### PR TITLE
Enable markd down syntax for prompt template files

### DIFF
--- a/packages/ai-core/data/prompttemplate.tmLanguage.json
+++ b/packages/ai-core/data/prompttemplate.tmLanguage.json
@@ -97,6 +97,9 @@
           "match": "[a-zA-Z_][a-zA-Z0-9_\\-]*"
         }
       ]
+    },
+    {
+      "include": "text.html.markdown"
     }
   ],
   "repository": {},


### PR DESCRIPTION
#### What it does

Includes the markdown syntax for prompt template files.

#### How to test

- Open any prompt template file (either manually or via the agent settings)
- Check that mark down is highlighted
- Check that the existing syntax still works

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
