### PR TITLE
Enhance localization of the getting-started package

### DIFF
--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { codicon, CommonCommands, Key, KeyCode, LabelProvider, Message, ReactWidget } from '@theia/core/lib/browser';
+import { codicon, CommonCommands, Key, KeyCode, LabelProvider, LocalizedMarkdown, Message, ReactWidget } from '@theia/core/lib/browser';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { CommandRegistry, environment, isOSX, Path, PreferenceService } from '@theia/core/lib/common';
@@ -26,6 +26,7 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import * as React from '@theia/core/shared/react';
 import { KeymapsCommands } from '@theia/keymaps/lib/browser';
 import { WorkspaceCommands, WorkspaceService } from '@theia/workspace/lib/browser';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 
 /**
  * Default implementation of the `GettingStartedWidget`.
@@ -108,6 +109,9 @@ export class GettingStartedWidget extends ReactWidget {
 
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
+
+    @inject(MarkdownRenderer)
+    protected readonly markdownRenderer: MarkdownRenderer;
 
     @postConstruct()
     protected init(): void {
@@ -422,7 +426,7 @@ export class GettingStartedWidget extends ReactWidget {
 
     protected renderNews(): React.ReactNode {
         return <div className='gs-section'>
-            <h3 className='gs-section-header'>🚀 AI Support in the Theia IDE is available (Beta Version)! ✨</h3>
+            <h3 className='gs-section-header'>🚀 {nls.localize('theia/getting-started/ai/header', 'AI Support in the Theia IDE is available (Beta Version)!')} ✨</h3>
             <div className='gs-action-container'>
                 <a
                     role={'button'}
@@ -430,7 +434,7 @@ export class GettingStartedWidget extends ReactWidget {
                     tabIndex={0}
                     onClick={() => this.doOpenAIChatView()}
                     onKeyDown={(e: React.KeyboardEvent) => this.doOpenAIChatViewEnter(e)}>
-                    {'Open the AI Chat View now to learn how to start! ✨'}
+                    {nls.localize('theia/getting-started/ai/openAIChatView', 'Open the AI Chat View now to learn how to start!')} ✨
                 </a>
             </div>
         </div>;
@@ -440,45 +444,25 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-container gs-aifeature-container'>
             <div className='flex-grid'>
                 <div className='col'>
-                    <h3 className='gs-section-header'> 🚀 AI Support in the Theia IDE is available (Beta Version)! ✨</h3>
-                    <div className='gs-action-container'>
-                        Theia IDE now contains AI support, which offers early access to cutting-edge AI capabilities within your IDE.
-                        <br />
-                        Please note that these features are disabled by default, ensuring that users can opt-in at their discretion.
-                        For those who choose to enable AI support, it is important to be aware that these may generate continuous
-                        requests to the language models (LLMs) you provide access to. This might incur costs that you need to monitor closely.
-                        <br />
-                        For more details, please visit &nbsp;
-                        <a
-                            role={'button'}
-                            tabIndex={0}
-                            onClick={() => this.doOpenExternalLink(this.userAIDocUrl)}
-                            onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.userAIDocUrl)}>
-                            {'the documentation'}
-                        </a>.
-                        <br />
-                        <br />
-                        🚧 Please note that this feature is currently in a beta state and may undergo changes.
-                        We welcome your feedback, contributions, and sponsorship! To support the ongoing development of the AI capabilities please visit the&nbsp;
-                        <a
-                            role={'button'}
-                            tabIndex={0}
-                            onClick={() => this.doOpenExternalLink(this.ghProjectUrl)}
-                            onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.ghProjectUrl)}>
-                            {'Github Project'}
-                        </a>.
-                        &nbsp;Thank you for being part of our community!
-                        <br />
-                        The AI features are built on the framework Theia AI. If you want to build a custom AI-powered tool or IDE, Theia AI has been published as stable release.
-                        Check out <a
-                            role={'button'}
-                            tabIndex={0}
-                            onClick={() => this.doOpenExternalLink(this.theiaAIDocUrl)}
-                            onKeyDown={(e: React.KeyboardEvent) => this.doOpenExternalLinkEnter(e, this.theiaAIDocUrl)}>
-                            {'the Theia AI documentation'}
-                        </a>!
-                    </div>
-                    <br />
+                    <h3 className='gs-section-header'> 🚀 {nls.localize('theia/getting-started/ai/header', 'AI Support in the Theia IDE is available (Beta Version)!')} ✨</h3>
+                    <LocalizedMarkdown className='gs-action-container'
+                        localizationKey='theia/getting-started/ai/features'
+                        defaultMarkdown={`
+Theia IDE now contains AI support, which offers early access to cutting-edge AI capabilities within your IDE.\\
+Please note that these features are disabled by default, ensuring that users can opt-in at their discretion.
+For those who choose to enable AI support, it is important to be aware that these may generate continuous
+requests to the language models (LLMs) you provide access to. This might incur costs that you need to monitor closely.\\
+For more details, please visit&nbsp;[the documentation]({0}).\\
+\\
+🚧 Please note that this feature is currently in a beta state and may undergo changes.
+We welcome your feedback, contributions, and sponsorship! To support the ongoing development of the AI capabilities please visit the&nbsp;[Github Project]({1}).&nbsp;
+Thank you for being part of our community!\\
+The AI features are built on the framework Theia AI. If you want to build a custom AI-powered tool or IDE, Theia AI has been published as stable release.
+Check out [the Theia AI documentation]({2})!
+`}
+                        args={[this.userAIDocUrl, this.ghProjectUrl, this.theiaAIDocUrl]}
+                        markdownRenderer={this.markdownRenderer}
+                    />
                     <div className='gs-action-container'>
                         <a
                             role={'button'}
@@ -486,7 +470,7 @@ export class GettingStartedWidget extends ReactWidget {
                             tabIndex={0}
                             onClick={() => this.doOpenAIChatView()}
                             onKeyDown={(e: React.KeyboardEvent) => this.doOpenAIChatViewEnter(e)}>
-                            {'Open the AI Chat View now to learn how to start! ✨'}
+                            {nls.localize('theia/getting-started/ai/openAIChatView', 'Open the AI Chat View now to learn how to start!')} ✨
                         </a>
                     </div>
                 </div>


### PR DESCRIPTION
#### What it does

This PR provides localization enhancements for the `getting-started` package.

#### How to test

The getting started widget should look and behave as before, except for external links in the AI Banner, which are now underlined and have tooltips. This is a side-effect of using the markdown renderer as part of the approach recommended in #16501. See also #16470 for a related discussion of localizing rich content in Theia.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
