### PR TITLE
Make next replacer function default

### DIFF
--- a/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
@@ -25,14 +25,14 @@ import {
     SuggestFileContent,
     WriteFileContent,
     SuggestFileReplacements,
+    SuggestFileReplacements_Simple,
     WriteFileReplacements,
     ClearFileChanges,
     GetProposedFileState,
     ReplaceContentInFileFunctionHelper,
     FileChangeSetTitleProvider,
     DefaultFileChangeSetTitleProvider,
-    ReplaceContentInFileFunctionHelperV2,
-    SuggestFileReplacements_Next
+    ReplaceContentInFileFunctionHelperV2
 } from './file-changeset-functions';
 import { MutableChatRequestModel, MutableChatResponseModel, ChangeSet, ChangeSetElement, MutableChatModel } from '@theia/ai-chat';
 import { Container } from '@theia/core/shared/inversify';
@@ -106,12 +106,12 @@ describe('File Changeset Functions Cancellation Tests', () => {
         container.bind(ReplaceContentInFileFunctionHelper).toSelf();
         container.bind(SuggestFileContent).toSelf();
         container.bind(WriteFileContent).toSelf();
+        container.bind(SuggestFileReplacements_Simple).toSelf();
         container.bind(SuggestFileReplacements).toSelf();
         container.bind(WriteFileReplacements).toSelf();
         container.bind(ClearFileChanges).toSelf();
         container.bind(GetProposedFileState).toSelf();
         container.bind(ReplaceContentInFileFunctionHelperV2).toSelf();
-        container.bind(SuggestFileReplacements_Next).toSelf();
     });
 
     afterEach(() => {
@@ -140,11 +140,11 @@ describe('File Changeset Functions Cancellation Tests', () => {
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
     });
 
-    it('SuggestFileReplacements should respect cancellation token', async () => {
-        const suggestFileReplacements = container.get(SuggestFileReplacements);
+    it('SuggestFileReplacements_Simple should respect cancellation token', async () => {
+        const suggestFileReplacementsSimple = container.get(SuggestFileReplacements_Simple);
         cancellationTokenSource.cancel();
 
-        const handler = suggestFileReplacements.getTool().handler;
+        const handler = suggestFileReplacementsSimple.getTool().handler;
         const result = await handler(
             JSON.stringify({
                 path: 'test.txt',
@@ -214,11 +214,11 @@ describe('File Changeset Functions Cancellation Tests', () => {
 
     });
 
-    it('SuggestFileReplacements_Next should respect cancellation token', async () => {
-        const suggestFileReplacementsNext = container.get(SuggestFileReplacements_Next);
+    it('SuggestFileReplacements should respect cancellation token with V2 implementation', async () => {
+        const suggestFileReplacements = container.get(SuggestFileReplacements);
         cancellationTokenSource.cancel();
 
-        const handler = suggestFileReplacementsNext.getTool().handler;
+        const handler = suggestFileReplacements.getTool().handler;
         const result = await handler(
             JSON.stringify({
                 path: 'test.txt',
@@ -231,9 +231,9 @@ describe('File Changeset Functions Cancellation Tests', () => {
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
     });
 
-    it('SuggestFileReplacements_Next should have correct ID', () => {
-        const suggestFileReplacementsNext = container.get(SuggestFileReplacements_Next);
-        expect(SuggestFileReplacements_Next.ID).to.equal('suggestFileReplacements_Next');
-        expect(suggestFileReplacementsNext.getTool().id).to.equal('suggestFileReplacements_Next');
+    it('SuggestFileReplacements should have correct ID', () => {
+        const suggestFileReplacements = container.get(SuggestFileReplacements);
+        expect(SuggestFileReplacements.ID).to.equal('suggestFileReplacements');
+        expect(suggestFileReplacements.getTool().id).to.equal('suggestFileReplacements');
     });
 });

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -31,7 +31,7 @@ import {
     SUGGEST_FILE_REPLACEMENTS_ID,
     WRITE_FILE_CONTENT_ID,
     WRITE_FILE_REPLACEMENTS_ID,
-    SUGGEST_FILE_REPLACEMENTS_NEXT_ID
+    SUGGEST_FILE_REPLACEMENTS_SIMPLE_ID
 } from '../common/file-changeset-function-ids';
 
 export const FileChangeSetTitleProvider = Symbol('FileChangeSetTitleProvider');
@@ -492,16 +492,16 @@ export class SimpleWriteFileReplacements implements ToolProvider {
 }
 
 @injectable()
-export class SuggestFileReplacements implements ToolProvider {
-    static ID = SUGGEST_FILE_REPLACEMENTS_ID;
+export class SuggestFileReplacements_Simple implements ToolProvider {
+    static ID = SUGGEST_FILE_REPLACEMENTS_SIMPLE_ID;
     @inject(ReplaceContentInFileFunctionHelper)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelper;
 
     getTool(): ToolRequest {
         const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata(true);
         return {
-            id: SuggestFileReplacements.ID,
-            name: SuggestFileReplacements.ID,
+            id: SuggestFileReplacements_Simple.ID,
+            name: SuggestFileReplacements_Simple.ID,
             description: metadata.description,
             parameters: metadata.parameters,
             handler: async (args: string, ctx: MutableChatRequestModel): Promise<string> => {
@@ -611,8 +611,8 @@ export class ReplaceContentInFileFunctionHelperV2 extends ReplaceContentInFileFu
 }
 
 @injectable()
-export class SuggestFileReplacements_Next implements ToolProvider {
-    static ID = SUGGEST_FILE_REPLACEMENTS_NEXT_ID;
+export class SuggestFileReplacements implements ToolProvider {
+    static ID = SUGGEST_FILE_REPLACEMENTS_ID;
 
     @inject(ReplaceContentInFileFunctionHelperV2)
     protected readonly replaceContentInFileFunctionHelper: ReplaceContentInFileFunctionHelperV2;
@@ -620,8 +620,8 @@ export class SuggestFileReplacements_Next implements ToolProvider {
     getTool(): ToolRequest {
         const metadata = this.replaceContentInFileFunctionHelper.getToolMetadata(true);
         return {
-            id: SuggestFileReplacements_Next.ID,
-            name: SuggestFileReplacements_Next.ID,
+            id: SuggestFileReplacements.ID,
+            name: SuggestFileReplacements.ID,
             description: `Proposes to replace sections of content in an existing file by providing a list of replacements.
             Each replacement consists of oldContent to be matched and newContent to insert in its place.
             By default, a single occurrence of each oldContent is expected. If the 'multiple' flag is set to true, all occurrences will be replaced.

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -50,6 +50,7 @@ import {
     GetProposedFileState,
     ReplaceContentInFileFunctionHelper,
     SuggestFileReplacements,
+    SuggestFileReplacements_Simple,
     SimpleSuggestFileReplacements,
     SuggestFileContent,
     WriteFileContent,
@@ -57,8 +58,7 @@ import {
     SimpleWriteFileReplacements,
     FileChangeSetTitleProvider,
     DefaultFileChangeSetTitleProvider,
-    ReplaceContentInFileFunctionHelperV2,
-    SuggestFileReplacements_Next
+    ReplaceContentInFileFunctionHelperV2
 } from './file-changeset-functions';
 import { OrchestratorChatAgent, OrchestratorChatAgentId } from '../common/orchestrator-chat-agent';
 import { UniversalChatAgent, UniversalChatAgentId } from '../common/universal-chat-agent';
@@ -167,10 +167,10 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindToolProvider(LaunchStopProvider, bind);
     bind(ReplaceContentInFileFunctionHelper).toSelf().inSingletonScope();
     bind(FileChangeSetTitleProvider).to(DefaultFileChangeSetTitleProvider).inSingletonScope();
-    bindToolProvider(SuggestFileReplacements, bind);
-    bindToolProvider(WriteFileReplacements, bind);
     bind(ReplaceContentInFileFunctionHelperV2).toSelf().inSingletonScope();
-    bindToolProvider(SuggestFileReplacements_Next, bind);
+    bindToolProvider(SuggestFileReplacements, bind);
+    bindToolProvider(SuggestFileReplacements_Simple, bind);
+    bindToolProvider(WriteFileReplacements, bind);
     bindToolProvider(ListChatContext, bind);
     bindToolProvider(ResolveChatContext, bind);
     bind(AIConfigurationSelectionService).toSelf().inSingletonScope();

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -28,8 +28,7 @@ import {
     SUGGEST_FILE_REPLACEMENTS_ID,
     WRITE_FILE_REPLACEMENTS_ID,
     CLEAR_FILE_CHANGES_ID,
-    GET_PROPOSED_CHANGES_ID,
-    SUGGEST_FILE_REPLACEMENTS_NEXT_ID
+    GET_PROPOSED_CHANGES_ID
 } from './file-changeset-function-ids';
 
 export const CODER_SYSTEM_PROMPT_ID = 'coder-system';
@@ -161,7 +160,7 @@ You are an autonomous AI agent. Do not stop until:
     };
 }
 
-function getCoderEditPromptTemplate(suggestFileReplacementsId: string): string {
+function getCoderEditPromptTemplate(): string {
     return `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
 Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
@@ -189,9 +188,9 @@ This also applies for newly created files!
 - **Always Retrieve Current Content**: Use getFileContent to get the original content of the target file.
 - **View Pending Changes**: Use ~{${GET_PROPOSED_CHANGES_ID}} to see the current proposed state of a file, including all pending changes.
 - **Change Content**: Use one of these methods to propose changes:
-  - ~{${suggestFileReplacementsId}}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
-  - ~{${SUGGEST_FILE_CONTENT_ID}}: For complete file rewrites when you need to replace the entire content. 
-  - If ~{${suggestFileReplacementsId}} continuously fails use ~{${SUGGEST_FILE_CONTENT_ID}}.
+  - ~{${SUGGEST_FILE_REPLACEMENTS_ID}}: For targeted replacements of specific text sections. Multiple calls will merge changes unless you set the reset parameter to true.
+  - ~{${SUGGEST_FILE_CONTENT_ID}}: For complete file rewrites when you need to replace the entire content.
+  - If ~{${SUGGEST_FILE_REPLACEMENTS_ID}} continuously fails use ~{${SUGGEST_FILE_CONTENT_ID}}.
   - ~{${CLEAR_FILE_CHANGES_ID}}: To clear all pending changes for a file and start fresh.
 
 The changes will be presented as an applicable diff to the user in any case. The user can then accept or reject each change individually. Before you run tasks that depend on the \
@@ -235,14 +234,14 @@ You have previously proposed changes for the following files. Some suggestions m
 export function getCoderPromptTemplateEdit(): BasePromptFragment {
     return {
         id: CODER_EDIT_TEMPLATE_ID,
-        template: getCoderEditPromptTemplate(SUGGEST_FILE_REPLACEMENTS_ID)
+        template: getCoderEditPromptTemplate()
     };
 }
-
+// Currently, the next template is identical to the regular edit prompt
 export function getCoderPromptTemplateEditNext(): BasePromptFragment {
     return {
         id: CODER_EDIT_NEXT_TEMPLATE_ID,
-        template: getCoderEditPromptTemplate(SUGGEST_FILE_REPLACEMENTS_NEXT_ID),
+        template: getCoderEditPromptTemplate(),
         ...({ variantOf: CODER_EDIT_TEMPLATE_ID })
     };
 }

--- a/packages/ai-ide/src/common/file-changeset-function-ids.ts
+++ b/packages/ai-ide/src/common/file-changeset-function-ids.ts
@@ -16,8 +16,22 @@
 
 export const SUGGEST_FILE_CONTENT_ID = 'suggestFileContent';
 export const WRITE_FILE_CONTENT_ID = 'writeFileContent';
+
+/**
+ * Default function ID for suggesting file replacements.
+ * Uses the improved content replacer implementation (V2) with better matching and error handling.
+ * This replaced the previous simpler implementation which is now available as SUGGEST_FILE_REPLACEMENTS_SIMPLE_ID.
+ */
 export const SUGGEST_FILE_REPLACEMENTS_ID = 'suggestFileReplacements';
+
+/**
+ * Legacy function ID for suggesting file replacements.
+ * Uses the original content replacer implementation (V1).
+ * @deprecated This is the older implementation. Consider using SUGGEST_FILE_REPLACEMENTS_ID (default) instead.
+ * This implementation may be removed in a future version.
+ */
+export const SUGGEST_FILE_REPLACEMENTS_SIMPLE_ID = 'suggestFileReplacements_Simple';
+
 export const WRITE_FILE_REPLACEMENTS_ID = 'writeFileReplacements';
 export const CLEAR_FILE_CHANGES_ID = 'clearFileChanges';
 export const GET_PROPOSED_CHANGES_ID = 'getProposedFileState';
-export const SUGGEST_FILE_REPLACEMENTS_NEXT_ID = 'suggestFileReplacements_Next';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Make the next replacer function default for suggest file changes
- Keep Coder next prompt, but make it "identical" to edit prompt for now
- Kepp old function as "_simple" variant for no, but mark it deprecated

#### How to test

Test Theia Coder or any agent using the replace function (such as project info)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
