### PR TITLE
When the terminal was inputting with a Chinese input method, the text that had already been input was covered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31028,6 +31028,15 @@
         "xterm": "^5.0.0"
       }
     },
+    "node_modules/xterm-addon-webgl": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/xterm-addon-webgl/-/xterm-addon-webgl-0.16.0.tgz",
+      "integrity": "sha512-E8cq1AiqNOv0M/FghPT+zPAEnvIQRDbAbkb04rRYSxUym69elPWVJ4sv22FCLBqM/3LcrmBLl/pELnBebVFKgA==",
+      "deprecated": "This package is now deprecated. Move to @xterm/addon-webgl instead.",
+      "peerDependencies": {
+        "xterm": "^5.0.0"
+      }
+    },
     "node_modules/y-protocols": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.6.tgz",
@@ -33058,7 +33067,8 @@
         "tslib": "^2.6.2",
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0",
-        "xterm-addon-search": "^0.13.0"
+        "xterm-addon-search": "^0.13.0",
+        "xterm-addon-webgl": "^0.16.0"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.66.0"

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -13,7 +13,8 @@
     "tslib": "^2.6.2",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0",
-    "xterm-addon-search": "^0.13.0"
+    "xterm-addon-search": "^0.13.0",
+    "xterm-addon-webgl": "^0.16.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -16,6 +16,7 @@
 
 import { Terminal } from 'xterm';
 import { FitAddon } from 'xterm-addon-fit';
+import { WebglAddon } from 'xterm-addon-webgl';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { ContributionProvider, Disposable, Event, Emitter, ILogger, DisposableCollection, Channel, OS, generateUuid } from '@theia/core';
 import {
@@ -95,6 +96,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     protected _terminalId = -1;
     protected readonly onTermDidClose = new Emitter<TerminalWidget>();
     protected fitAddon: FitAddon;
+    protected webglAddon: WebglAddon;
     protected term: Terminal;
     protected searchBox: TerminalSearchWidget;
     protected restored = false;
@@ -208,6 +210,9 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
         this.fitAddon = new FitAddon();
         this.term.loadAddon(this.fitAddon);
+
+        this.webglAddon = new WebglAddon();
+        this.term.loadAddon(this.webglAddon);
 
         this.initializeLinkHover();
 
@@ -850,6 +855,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             this.enhancedPreviewNode = undefined;
         }
         this.styleElement?.remove();
+        this.webglAddon?.dispose();
         super.dispose();
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #16584

I added webgl-addon to enable the terminal to render using canvas

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open a terminal

2. Enter a piece of Chinese, and then enter a Chinese comma or period

3. Keep inputting and keep the input method displayed

4. After entering multiple Chinese commas or periods, the cursor position is inaccurate when calling up the input method

<img width="1215" height="495" alt="image" src="https://github.com/user-attachments/assets/8efe68a0-d776-4dae-bf7f-0ffeecac1027" />


<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

1. xterm-webgl-addon has been added in packages/terminal/package.json(line 17)
2. import WebglAddon in packages/terminal/src/browser/terminal-widget-impl.ts (line 19)
3. load webglAddon for the terminal in packages/terminal/src/browser/terminal-widget-impl.ts(line 217)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
