### PR TITLE
Return command by name if not found by ID

### DIFF
--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -565,6 +565,10 @@ export class PromptServiceImpl implements PromptService {
         return this._builtInFragments.find(fragment => fragment.id === fragmentId);
     }
 
+    protected findBuiltInFragmentByName(fragmentName: string): BasePromptFragment | undefined {
+        return this._builtInFragments.find(fragment => fragment.commandName === fragmentName);
+    }
+
     getRawPromptFragment(fragmentId: string): PromptFragment | undefined {
         if (this.customizationService?.isPromptFragmentCustomized(fragmentId)) {
             const customizedFragment = this.customizationService.getActivePromptFragmentCustomization(fragmentId);
@@ -576,7 +580,7 @@ export class PromptServiceImpl implements PromptService {
     }
 
     getBuiltInRawPrompt(fragmentId: string): PromptFragment | undefined {
-        return this.findBuiltInFragmentById(fragmentId);
+        return this.findBuiltInFragmentById(fragmentId) ?? this.findBuiltInFragmentByName(fragmentId);
     }
 
     getPromptFragment(fragmentId: string): PromptFragment | undefined {
@@ -941,7 +945,7 @@ export class PromptServiceImpl implements PromptService {
         if (promptFragment.isCommand && promptFragment.commandName) {
             const commandName = promptFragment.commandName;
             const duplicates = this._builtInFragments.filter(
-                f => f.isCommand && f.commandName === commandName && f.id !== promptFragment.id
+                f => f.isCommand && f.commandName === commandName
             );
             if (duplicates.length > 0) {
                 this.logger.warn(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #16596, but I'd appreciate some input from @planger about what you think should happen in this case.

<!-- Include relevant issues and describe how they are addressed. -->

The proximal cause of #16596 was that, in the prompt variable resolver, if the arguments to the _variable_ include arguments to the _command_, then the _command_ is retrieved by name, and if not, it's retrieved by ID:

https://github.com/eclipse-theia/theia/blob/9b2e07fb7d4d8937fdc11da2903931098907145c/packages/ai-core/src/common/prompt-variable-contribution.ts#L75-L88

i.e. something like 

```
@Architect /hello|Colin
```
Is translated to `prompt:hello|Colin`, then parsed as `name: hello, args: Colin`, then retrieved by name `hello`, and that works.

Whereas something like the problem case

```
@Architect /hello
```

is translated to `prompt:hello`, then parsed as `name: hello, args: ''`, and then we try to look it up by ID, but the ID of [that command](https://github.com/eclipse-theia/theia/blob/9b2e07fb7d4d8937fdc11da2903931098907145c/examples/api-samples/src/browser/chat/sample-chat-command-contribution.ts#L45-L52) is `sample-hello`, so the lookup under `hello` fails.

There are two questions that follow from this:

1. What should happen narrowly in the problem case. This PR falls back to looking things up by name in the `getBuiltinRawPrompt` implementation, since the name is what the user will have used, but maybe we want to do something else if something we thought should have had arguments ended up not having them. (And maybe our variable completions should reflect that?)
2. What should happen if, after we try resolving everything, we end up with an empty user message? Probably we should throw our own error and say that we ended up with an empty message. One tricky part of this idea is that we actually defer the decision how a parsed message gets translated into content to the agent invocation, and at that point, we're dealing with an array of messages and we've (kind of) lost the view of what the 'current' message is.


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
