### PR TITLE
fix: correctly assert path for windows and linux tests

### DIFF
--- a/packages/ai-codex/src/browser/codex-frontend-service.spec.ts
+++ b/packages/ai-codex/src/browser/codex-frontend-service.spec.ts
@@ -18,6 +18,7 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 FrontendApplicationConfigProvider.set({});
+import * as path from 'path';
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';
@@ -206,7 +207,8 @@ describe('CodexFrontendService', () => {
             await service.send({ prompt: 'test prompt', sessionId: 'session-1' });
 
             const backendRequest = (mockBackendService.send as sinon.SinonStub).firstCall.args[0];
-            expect(backendRequest.options?.workingDirectory).to.include('test/workspace');
+            const expectedPath = path.join('test', 'workspace');
+            expect(backendRequest.options?.workingDirectory).to.include(expectedPath);
         });
 
         it('should pass prompt to backend', async () => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Correctly handle path assert so it works for windows and linux.

fixes #16619
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
