### PR TITLE
Do not copy preferences that are valid in folder scope

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -596,6 +596,8 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
         const workspaceData: WorkspaceData = { folders: [], settings: {} };
         if (!this.saved) {
             for (const p of Object.keys(this.schemaService.getJSONSchema(PreferenceScope.Workspace).properties!)) {
+                // The goal is to ensure that workspace-scoped preferences are preserved in the new workspace.
+                // Preferences valid in folder scope will take effect in their folders without being copied.
                 if (this.schemaService.isValidInScope(p, PreferenceScope.Folder)) {
                     continue;
                 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #16613

Credit to @sdirix for identifying the change.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open one folder as a single-folder workspace (I started with this repo)
2. Use the 'Add folder to workspace' command to add another folder.
3. There will be a prompt to save your new workspace as a workspace file.
4. Say yes and save the file.
5. Open the file. (e.g. by going to preferences, selecting workspace scope, then opening the JSON)
6. Observe that if it contains a `settings` field, those settings are only those from the original folder that are declared not to be valid in `folder` scope.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
