### PR TITLE
Add gemini 3.0, remove older models

### DIFF
--- a/packages/ai-google/src/common/google-preferences.ts
+++ b/packages/ai-google/src/common/google-preferences.ts
@@ -36,7 +36,7 @@ export const GooglePreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/google/models/description', 'Official Google Gemini models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['gemini-1.5-flash', 'gemini-1.5-pro', 'gemini-2.0-flash', 'gemini-2.0-flash-lite', 'gemini-2.5-flash-preview-05-20', 'gemini-2.5-pro-preview-05-06'],
+            default: ['gemini-3-pro-preview', 'gemini-2.5-pro', 'gemini-2.5-flash'],
             items: {
                 type: 'string'
             }


### PR DESCRIPTION
#### What it does

Adds Gemini 3.0 and removes older models

#### How to test

Use Gemini 3.0, 2.5 and 2.5 flash

#### Follow-ups

Gemini 3.0 did not work well for me, it took a long time to do a simple change. It looks like something is wrong there, this should be debugged.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
