### PR TITLE
Add remember command

### DIFF
--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -98,6 +98,7 @@ import { ProjectInfoAgent } from './project-info-agent';
 import { SuggestTerminalCommand } from './ai-terminal-functions';
 import { ContextFileValidationService } from '@theia/ai-chat/lib/browser/context-file-validation-service';
 import { ContextFileValidationServiceImpl } from './context-file-validation-service-impl';
+import { RememberCommandContribution } from './remember-command-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: aiIdePreferenceSchema });
@@ -275,4 +276,6 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(ContextFileValidationServiceImpl).toSelf().inSingletonScope();
     bind(ContextFileValidationService).toService(ContextFileValidationServiceImpl);
+
+    bind(FrontendApplicationContribution).to(RememberCommandContribution);
 });

--- a/packages/ai-ide/src/browser/remember-command-contribution.ts
+++ b/packages/ai-ide/src/browser/remember-command-contribution.ts
@@ -1,0 +1,105 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PromptService } from '@theia/ai-core/lib/common';
+import { nls } from '@theia/core';
+import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+
+/**
+ * Contribution that registers the `/remember` slash command for AI chat agents.
+ *
+ * This command allows Architect and Coder agents to extract important topics
+ * from the current conversation and delegate to the ProjectInfo agent to update
+ * the persistent project context file.
+ */
+@injectable()
+export class RememberCommandContribution implements FrontendApplicationContribution {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    onStart(): void {
+        this.registerRememberCommand();
+    }
+
+    protected registerRememberCommand(): void {
+        const commandTemplate = this.buildCommandTemplate();
+
+        this.promptService.addBuiltInPromptFragment({
+            id: 'remember-conversation-context',
+            template: commandTemplate,
+            isCommand: true,
+            commandName: 'remember',
+            commandDescription: nls.localize(
+                'theia/ai-ide/rememberCommand/description',
+                'Extract topics from conversation and update project info'
+            ),
+            commandArgumentHint: nls.localize(
+                'theia/ai-ide/rememberCommand/argumentHint',
+                '[topic-hint]'
+            ),
+            commandAgents: ['Architect', 'Coder']
+        });
+    }
+
+    protected buildCommandTemplate(): string {
+        return `You have been asked to extract and remember important information from the current conversation.
+
+    ## Task Overview
+    Review the conversation history and identify specific information that should be added to the persistent project context.
+
+    ## Focus Area
+    $ARGUMENTS
+
+    ## What to Extract
+    **If a focus area is provided above**: ONLY extract information related to that specific focus area. Ignore all other topics.
+
+    **If no focus area is provided**: Look specifically for information where the user had to correct you or provide clarification:
+    - **User corrections**: When the user corrected your assumptions about the codebase, architecture, or processes
+    - **User-provided context**: Information the user explicitly provided that you couldn't discover yourself
+    - **Project-specific knowledge**: Details about the project that the user shared when you made incorrect assumptions
+
+    **Do NOT extract**:
+    - General information you discovered through code analysis
+    - Standard coding practices you identified yourself
+    - Information you found by exploring the codebase
+    - Common knowledge or widely-known patterns
+    - Details that are already well-documented in the code
+
+    ## Instructions
+    1. **Analyze the conversation**: Review messages for the specific criteria above
+    2. **Extract only relevant information**: For each qualifying item, prepare a clear description that captures:
+    - What the user corrected or clarified
+    - Why your initial understanding was incomplete
+    - The specific project context that was provided
+    3. **Delegate to ProjectInfo agent**: Use the ~{${AGENT_DELEGATION_FUNCTION_ID}} tool to send the extracted information to the ProjectInfo agent:
+    - Agent ID: 'ProjectInfo'
+    - Prompt: Ask the ProjectInfo agent to review the extracted information and update the project information file
+
+    ## Example Delegation
+    \`\`\`
+    Please review and incorporate the following user corrections/clarifications into the project context:
+
+    [Your extracted corrections and user-provided context here]
+
+    Update /.prompts/project-info.prompttemplate by adding this information to the appropriate sections. Focus on information that prevents future misunderstandings.
+    \`\`\`
+
+    Remember: Only extract information that prevents future AI agents from making the same mistakes or assumptions you made that were corrected by the user.`;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR introduces a new /remember slash command for AI chat agents that enables the extraction and persistence of important conversation context to improve future AI interactions.

Key Features:

- Slash Command Registration: Adds a /remember command available to Architect and Coder agents
- Conversation Analysis: Analyzes chat history to identify user corrections and clarifications that should be preserved
- Intelligent Filtering: Focuses on extracting only information where users corrected AI assumptions or provided project-specific context
- Agent Delegation: Automatically delegates to the ProjectInfo agent to update the persistent project information file
- Focused Extraction: Supports optional topic hints (as a command argument) to extract information about specific areas only

#### How to test

1. Have a conversation where you correct the AI agent about project-specific details (goo example is to generate a prompt or another command, as it will often miss the file length limit)
2. Run /remember and verify it delegates to the ProjectInfo agent
3. Check that the .prompts/project-info.prompttemplate file gets updated with relevant corrections

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
