### PR TITLE
fix: workbench.startupEditor and scm.defaultViewMode reset behavior

### DIFF
--- a/packages/core/src/common/preferences/preference-provider.ts
+++ b/packages/core/src/common/preferences/preference-provider.ts
@@ -27,6 +27,10 @@ export interface PreferenceProviderDataChange {
     readonly preferenceName: string;
     /**
      * The new value of the changed preference.
+     * Can be `undefined` for multiple reasons:
+     * - The preference has been reset to its default value.
+     * - The preference has been reset and has no value explicitly stored.
+     * If `undefined`, use the preference service to determine the effective new value if needed.
      */
     readonly newValue?: JSONValue;
     /**

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -637,7 +637,7 @@ function WelcomePreferences(props: PreferencesProps): JSX.Element {
     React.useEffect(() => {
         const prefListener = props.preferenceService.onPreferenceChanged(change => {
             if (change.preferenceName === 'workbench.startupEditor') {
-                const prefValue = change.newValue as string;
+                const prefValue = change.newValue as string ?? props.preferenceService.get<string>('workbench.startupEditor');
                 setStartupEditor(prefValue);
             }
         });

--- a/packages/scm/src/browser/scm-widget.tsx
+++ b/packages/scm/src/browser/scm-widget.tsx
@@ -89,7 +89,8 @@ export class ScmWidget extends BaseWidget implements StatefulWidget {
         this.toDispose.push(this.scmPreferences.onPreferenceChanged(
             e => {
                 if (e.preferenceName === 'scm.defaultViewMode') {
-                    this.updateViewMode(e.newValue);
+                    const newValue = e.newValue as 'tree' | 'list' ?? this.scmPreferences.get('scm.defaultViewMode');
+                    this.updateViewMode(newValue);
                 }
             }));
         this.toDispose.push(this.shell.onDidChangeCurrentWidget(({ newValue }) => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes GH-16617

- Fix preference reset behavior for workbench.startupEditor and scm.defaultViewMode
- Update PreferenceProviderDataChange#newValue documentation to clarify the undefined newValue case

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Test the behavior of the `Show welcome page on startup` on the welcome page as mentioned in GH-16617
2. Test the updates/resets of the `scm.defaultViewMode` preference and verify the scm view updates to one of the two view modes in any case.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- GH-16645

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
