### PR TITLE
fix(core): restore tree expansion state preservation in SourceTreeWidget

### DIFF
--- a/packages/core/src/browser/source-tree/source-tree-widget.tsx
+++ b/packages/core/src/browser/source-tree/source-tree-widget.tsx
@@ -89,19 +89,4 @@ export class SourceTreeWidget extends TreeWidget {
         return [TREE_NODE_SEGMENT_GROW_CLASS];
     }
 
-    override storeState(): object {
-        // no-op
-        return {};
-    }
-    protected superStoreState(): object {
-        return super.storeState();
-    }
-    override restoreState(state: object): void {
-        // no-op
-    }
-    protected superRestoreState(state: object): void {
-        super.restoreState(state);
-        return;
-    }
-
 }


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
The SourceTreeWidget was overriding storeState() and restoreState() methods with no-op implementations, which disabled the built-in tree state management from the parent TreeWidget class. This caused expansion states to be lost when the tree refreshed during debug sessions.

By removing these override methods, SourceTreeWidget now inherits the full state management capabilities from TreeWidget, which automatically preserves and restores tree expansion states across refreshes.

Fixes expansion state loss in Debug Variables view when stepping through breakpoints or continuing execution, bringing behavior in line with VS Code.

Part of #16641

_Note:_ I am not sure on why this behaviour was removed in the first place. With some testing i was not able to find any performance impacts or weird behaviors, but i certainly cannot rule it out.

@ndoschek imho we could either include this in tomorrows release to get a lot of feedback via the preview phase, or wait and test this out in the next phase (however it is a long one). Let me know what you prefer.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
See the instructions in #16641 for the issue and observe that this does no longer happen.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
