### PR TITLE
fix: Electron startup crash on Wayland

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -616,6 +616,7 @@ export class ElectronMainApplication {
         // On Wayland, screen.getCursorScreenPoint() causes a native crash (SIGSEGV)
         // before any window is opened. Detect Wayland and use primary display instead.
         if (this.isWaylandSession()) {
+            console.debug('Running under Wayland, using primary display for new window.');
             return screen.getPrimaryDisplay();
         }
         try {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

When Electron is running in a pure Wayland environment, certain API calls lead to a native Electron crash which is not catchable.

Adds detection for this environment and avoids the problematic API calls compromising on the initial size and position of the Theia window.

Fixes #16582

#### How to test

Build and run the Electron application in a pure Wayland without a preconfigured fallback to X11. For example Ubuntu 25 and Ubuntu 24 (Wayland) on the latest patch levels.

---

Note that if the window data was stored before, then the problematic code path is not entered when only creating a single window. This explains why for some users Theia Electron continues to work although they are on Wayland.

To clear your local Electron storage you can use `rm -rf ~/.config/Theia\ Electron\ Example`

I added a debug message when we go through the new fallback. Check the logs whether you actually went through the problematic case.

#### Follow-ups

Find an alternative way to determine the initial position and size on a Wayland system.

Note that we already store the position and size of the window, however within Wayland we always receive 0,0 for the x and y positions. Even when setting some x,y, the (first) window is still created in seemingly arbitrary locations. This needs a more detailed treatment than what is done in this PR.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
