### PR TITLE
feat(ai-claude-code): add session forking support

### DIFF
--- a/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
@@ -223,6 +223,8 @@ export class ClaudeCodeChatAgent implements ChatAgent {
                 prompt = prompt.replace(agentAddress, '').trim();
             }
 
+            const shouldFork = claudeSessionId !== undefined && this.isEditRequest(request);
+
             const streamResult = await this.claudeCode.send({
                 prompt,
                 options: {
@@ -232,7 +234,8 @@ export class ClaudeCodeChatAgent implements ChatAgent {
                         append: systemPromptAppendix?.text
                     },
                     permissionMode: this.getClaudePermissionMode(request),
-                    resume: claudeSessionId
+                    resume: claudeSessionId,
+                    forkSession: shouldFork
                 }
             }, request.response.cancellationToken);
 
@@ -390,6 +393,10 @@ export class ClaudeCodeChatAgent implements ChatAgent {
 
     protected getClaudeSessionId(request: MutableChatRequestModel): string | undefined {
         return request.getDataByKey(CLAUDE_SESSION_ID_KEY);
+    }
+
+    protected isEditRequest(request: MutableChatRequestModel): boolean {
+        return request.request.referencedRequestId !== undefined;
     }
 
     protected setClaudeSessionId(request: MutableChatRequestModel, sessionId: string): void {

--- a/packages/ai-claude-code/src/common/claude-code-service.ts
+++ b/packages/ai-claude-code/src/common/claude-code-service.ts
@@ -237,6 +237,7 @@ export interface ClaudeCodeOptions {
     executableArgs?: string[];
     extraArgs?: Record<string, string | null>;
     fallbackModel?: string;
+    forkSession?: boolean;
     maxThinkingTokens?: number;
     maxTurns?: number;
     model?: string;


### PR DESCRIPTION
#### What it does

Add automatic session forking when users edit requests in Claude Code chat. This allows exploring alternative conversation paths while preserving the original conversation thread.

Implementation:
- Add forkSession option to ClaudeCodeOptions interface
- Add isEditRequest() helper to detect edited requests via referencedRequestId
- Automatically fork sessions when editing requests with existing session IDs
- Maintain backward compatibility: normal continuations use same session

The feature leverages Theia's existing chat hierarchy infrastructure where referencedRequestId is set when users edit requests. When both a previous session ID exists and the request is an edit, the Claude Agent SDK's forkSession option is enabled to create a new session branch.

Fixes #16502

#### How to test

https://github.com/user-attachments/assets/3403c30f-1fe5-4762-9133-831f45b90cfc

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
