### PR TITLE
fix: Quick command panel not closing when pressing escape

### DIFF
--- a/packages/monaco/src/browser/monaco-quick-input-service.ts
+++ b/packages/monaco/src/browser/monaco-quick-input-service.ts
@@ -116,8 +116,8 @@ export class MonacoQuickInputImplementation implements IQuickInputService {
         window.addEventListener('resize', () => this.updateLayout());
 
         // Make sure "Escape" key closes the quick input view when it is open.
-        document.addEventListener("keydown", (event) => {
-            if (event.key === "Escape" && event.target instanceof Element && this.container.contains(event.target)) {
+        document.addEventListener('keydown', event => {
+            if (event.key === 'Escape' && event.target instanceof Element && this.container.contains(event.target)) {
                 event.stopImmediatePropagation();
                 this.hide();
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Ensures that the handler for hiding the quick input container has precedence over any other event handler (e.g. those registered via keybindings).
- fixes #16660 
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open the notification overlay (click the bell). 
2. Open quickCommandPalette (F1)
3. Press Escape -> The quickCommandPallete should close

Or with playwright:
```ts
    test('should close the quickCommandPalette when there are open notifications and escape is pressed', async () => {
        const notifIndicator = new TheiaNotificationIndicator(app);
        const notifOverlay = new TheiaNotificationOverlay(app, notifIndicator);
        const commandPalette = new TheiaQuickCommandPalette(app);

        // Preconditions: has notifications opened or the overlay is opened
        await notifOverlay.activate();
        expect(await notifOverlay.isVisible()).toBe(true);

        // Open commandPalette and close it by pressing escape
        await commandPalette.open();
        expect(await commandPalette.isOpen()).toBe(true);
        await app.page.keyboard.press('Escape');

        // Expect commandPalette is closed and notifications overlay stays open
        expect(await commandPalette.isOpen()).toBe(false);
        expect(await notifOverlay.isVisible()).toBe(true);
    })
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
