### PR TITLE
Fix default model for theia-dev

### DIFF
--- a/.prompts/customAgents.yml
+++ b/.prompts/customAgents.yml
@@ -3,10 +3,10 @@
   description: A software architect and coordinator
   prompt: >-
     {{!-- Placeholder--}}
-  defaultLLM: anthropic/claude-sonnet-4-5-20250929
+  defaultLLM: anthropic/claude-sonnet-4-5
 - id: theia_dev_coder
   name: TheiaDevCoder
   description: A specialized coder that listenes to the TheiaDev architect and produces detailed software designs
   prompt: >-
     {{!-- Placeholder--}}
-  defaultLLM: anthropic/claude-sonnet-4-5-20250929
+  defaultLLM: anthropic/claude-sonnet-4-5


### PR DESCRIPTION
#### What it does

Change the default model form Sonnet with date to Sonnet alias. The id with the date is not in the defaults anymore.

#### How to test

Use the Theia Dev agent.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
