### PR TITLE
Add support for "lazy" debug variables

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -16,7 +16,7 @@
 
 import * as React from '@theia/core/shared/react';
 import { DebugProtocol } from '@vscode/debugprotocol/lib/debugProtocol';
-import { SingleTextInputDialog } from '@theia/core/lib/browser';
+import { codicon, SingleTextInputDialog } from '@theia/core/lib/browser';
 import { ConsoleItem, CompositeConsoleItem } from '@theia/console/lib/browser/console-session';
 import { DebugSession, formatMessage } from '../debug-session';
 import { Severity } from '@theia/core/lib/common/severity';
@@ -38,6 +38,7 @@ export class ExpressionContainer implements CompositeConsoleItem {
     protected variablesReference: number;
     protected namedVariables: number | undefined;
     protected indexedVariables: number | undefined;
+    protected presentationHint: DebugProtocol.VariablePresentationHint | undefined;
     protected readonly startOfVariables: number;
 
     constructor(options: ExpressionContainer.Options) {
@@ -47,6 +48,10 @@ export class ExpressionContainer implements CompositeConsoleItem {
         this.namedVariables = options.namedVariables;
         this.indexedVariables = options.indexedVariables;
         this.startOfVariables = options.startOfVariables || 0;
+        this.presentationHint = options.presentationHint;
+        if (this.lazy) {
+            (this as CompositeConsoleItem).expandByDefault = () => !this.lazy && !this.session?.autoExpandLazyVariables;
+        }
     }
 
     render(): React.ReactNode {
@@ -58,7 +63,31 @@ export class ExpressionContainer implements CompositeConsoleItem {
     }
 
     get hasElements(): boolean {
-        return !!this.variablesReference;
+        return !!this.variablesReference && !this.lazy;
+    }
+
+    get lazy(): boolean {
+        return !!this.presentationHint?.lazy;
+    }
+
+    async resolveLazy(): Promise<void> {
+        const { session, variablesReference, lazy } = this;
+        if (!session || !variablesReference || !lazy) {
+            return;
+        }
+        const response = await session.sendRequest('variables', { variablesReference });
+        const { variables } = response.body;
+        if (variables.length !== 1) {
+            return;
+        }
+        this.handleResolvedLazy(variables[0]);
+    }
+
+    protected handleResolvedLazy(resolved: DebugProtocol.Variable): void {
+        this.variablesReference = resolved.variablesReference;
+        this.namedVariables = resolved.namedVariables;
+        this.indexedVariables = resolved.indexedVariables;
+        this.presentationHint = resolved.presentationHint;
     }
 
     protected elements: Promise<ExpressionContainer[]> | undefined;
@@ -109,14 +138,23 @@ export class ExpressionContainer implements CompositeConsoleItem {
     protected fetch(result: ConsoleItem[], filter: 'indexed', start: number, count?: number): Promise<void>;
     protected async fetch(result: ConsoleItem[], filter: 'indexed' | 'named', start?: number, count?: number): Promise<void> {
         try {
-            const { variablesReference } = this;
-            const response = await this.session!.sendRequest('variables', { variablesReference, filter, start, count });
-            const { variables } = response.body;
-            const names = new Set<string>();
-            for (const variable of variables) {
-                if (!names.has(variable.name)) {
-                    result.push(new DebugVariable(this.sessionProvider, variable, this));
-                    names.add(variable.name);
+            const { session } = this;
+            if (session) {
+                const { variablesReference } = this;
+                const response = await session.sendRequest('variables', { variablesReference, filter, start, count });
+                const { variables } = response.body;
+                const names = new Set<string>();
+                const debugVariables: DebugVariable[] = [];
+                for (const variable of variables) {
+                    if (!names.has(variable.name)) {
+                        const v = new DebugVariable(this.sessionProvider, variable, this);
+                        debugVariables.push(v);
+                        result.push(v);
+                        names.add(variable.name);
+                    }
+                }
+                if (session.autoExpandLazyVariables) {
+                    await Promise.all(debugVariables.map(v => v.lazy && v.resolveLazy()));
                 }
             }
         } catch (e) {
@@ -137,6 +175,7 @@ export namespace ExpressionContainer {
         namedVariables?: number
         indexedVariables?: number
         startOfVariables?: number
+        presentationHint?: DebugProtocol.VariablePresentationHint
     }
 }
 
@@ -155,7 +194,8 @@ export class DebugVariable extends ExpressionContainer {
             id: `${parent.id}:${variable.name}`,
             variablesReference: variable.variablesReference,
             namedVariables: variable.namedVariables,
-            indexedVariables: variable.indexedVariables
+            indexedVariables: variable.indexedVariables,
+            presentationHint: variable.presentationHint
         });
     }
 
@@ -175,16 +215,19 @@ export class DebugVariable extends ExpressionContainer {
     }
 
     get readOnly(): boolean {
-        return this.variable.presentationHint?.attributes?.includes('readOnly') ?? false;
+        return this.presentationHint?.attributes?.includes('readOnly') || this.lazy;
     }
 
     override render(): React.ReactNode {
-        const { type, value, name } = this;
+        const { type, value, name, lazy } = this;
         return <div className={this.variableClassName}>
-            <span title={type || name} className='name' ref={this.setNameRef}>{name}{!!value && ': '}</span>
-            <span title={value} ref={this.setValueRef}>{value}</span>
+            <span title={type || name} className='name' ref={this.setNameRef}>{name}{(value || lazy) && ': '}</span>
+            {lazy && <span title={nls.localizeByDefault('Click to expand')} className={codicon('eye') + ' lazy-button'} onClick={this.handleLazyButtonClick} />}
+            <span title={value} className='value' ref={this.setValueRef}>{value}</span>
         </div>;
     }
+
+    private readonly handleLazyButtonClick = () => this.resolveLazy();
 
     protected get variableClassName(): string {
         const { type, value } = this;
@@ -199,6 +242,13 @@ export class DebugVariable extends ExpressionContainer {
             classNames.push('string');
         }
         return classNames.join(' ');
+    }
+
+    protected override handleResolvedLazy(resolved: DebugProtocol.Variable): void {
+        this._value = resolved.value;
+        this._type = resolved.type || this._type;
+        super.handleResolvedLazy(resolved);
+        this.session?.['onDidResolveLazyVariableEmitter'].fire(this);
     }
 
     get supportSetVariable(): boolean {
@@ -340,7 +390,7 @@ export class ExpressionItem extends ExpressionContainer {
         </div>;
     }
 
-    async evaluate(context: string = 'repl'): Promise<void> {
+    async evaluate(context: string = 'repl', resolveLazy = true): Promise<void> {
         const session = this.session;
         if (!session?.currentFrame) {
             this.setResult(undefined, ExpressionItem.notAvailable);
@@ -350,6 +400,9 @@ export class ExpressionItem extends ExpressionContainer {
         try {
             const body = await session.evaluate(this._expression, context);
             this.setResult(body);
+            if (this.lazy && resolveLazy) {
+                await this.resolveLazy();
+            }
         } catch (err) {
             this.setResult(undefined, err.message);
         }
@@ -363,6 +416,7 @@ export class ExpressionItem extends ExpressionContainer {
             this.variablesReference = body.variablesReference;
             this.namedVariables = body.namedVariables;
             this.indexedVariables = body.indexedVariables;
+            this.presentationHint = body.presentationHint;
             this.severity = Severity.Log;
         } else {
             this._value = error;
@@ -371,11 +425,17 @@ export class ExpressionItem extends ExpressionContainer {
             this.variablesReference = 0;
             this.namedVariables = undefined;
             this.indexedVariables = undefined;
+            this.presentationHint = undefined;
             this.severity = Severity.Error;
         }
         this.elements = undefined;
     }
 
+    protected override handleResolvedLazy(resolved: DebugProtocol.Variable): void {
+        this._value = resolved.value;
+        this._type = resolved.type || this._type;
+        super.handleResolvedLazy(resolved);
+    }
 }
 
 export class DebugScope extends ExpressionContainer {

--- a/packages/debug/src/browser/console/debug-console-session.ts
+++ b/packages/debug/src/browser/console/debug-console-session.ts
@@ -85,6 +85,7 @@ export class DebugConsoleSession extends ConsoleSession {
             triggerCharacters: ['.'],
             provideCompletionItems: (model, position) => this.completions(model, position),
         }));
+        this.toDispose.push(this.sessionManager.onDidResolveLazyVariable(() => this.fireDidChange()));
     }
 
     getElements(): IterableIterator<ConsoleItem> {

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -146,7 +146,9 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
             this.messages,
             this.fileService,
             this.debugContributionProvider,
-            this.workspaceService);
+            this.workspaceService,
+            this.debugPreferences
+        );
     }
 
     protected getTraceOutputChannel(): OutputChannel | undefined {

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -25,7 +25,7 @@ import { EditorManager } from '@theia/editor/lib/browser';
 import { CompositeTreeElement } from '@theia/core/lib/browser/source-tree';
 import { DebugSessionConnection, DebugRequestTypes, DebugEventTypes } from './debug-session-connection';
 import { DebugThread, StoppedDetails, DebugThreadData } from './model/debug-thread';
-import { DebugScope } from './console/debug-console-items';
+import { DebugScope, DebugVariable } from './console/debug-console-items';
 import { DebugStackFrame } from './model/debug-stack-frame';
 import { DebugSource } from './model/debug-source';
 import { DebugBreakpoint, DebugBreakpointOptions } from './model/debug-breakpoint';
@@ -47,6 +47,7 @@ import { nls } from '@theia/core';
 import { TestService, TestServices } from '@theia/test/lib/browser/test-service';
 import { DebugSessionManager } from './debug-session-manager';
 import { DebugDataBreakpoint } from './model/debug-data-breakpoint';
+import { DebugPreferences } from '../common/debug-preferences';
 
 export enum DebugState {
     Inactive,
@@ -103,6 +104,9 @@ export class DebugSession implements CompositeTreeElement {
         this.onDidChangeBreakpointsEmitter.fire(uri);
     }
 
+    protected readonly onDidResolveLazyVariableEmitter = new Emitter<DebugVariable>();
+    readonly onDidResolveLazyVariable: Event<DebugVariable> = this.onDidResolveLazyVariableEmitter.event;
+
     protected readonly childSessions = new Map<string, DebugSession>();
     protected readonly toDispose = new DisposableCollection();
 
@@ -124,6 +128,7 @@ export class DebugSession implements CompositeTreeElement {
         protected readonly fileService: FileService,
         protected readonly debugContributionProvider: ContributionProvider<DebugContribution>,
         protected readonly workspaceService: WorkspaceService,
+        protected readonly debugPreferences: DebugPreferences,
         /**
          * Number of millis after a `stop` request times out. It's 5 seconds by default.
          */
@@ -157,7 +162,10 @@ export class DebugSession implements CompositeTreeElement {
         this.connection.onDidClose(() => this.toDispose.dispose());
         this.toDispose.pushAll([
             this.onDidChangeEmitter,
+            this.onDidFocusStackFrameEmitter,
+            this.onDidFocusThreadEmitter,
             this.onDidChangeBreakpointsEmitter,
+            this.onDidResolveLazyVariableEmitter,
             Disposable.create(() => {
                 this.clearBreakpoints();
                 this.doUpdateThreads([]);
@@ -184,6 +192,10 @@ export class DebugSession implements CompositeTreeElement {
     protected _capabilities: DebugProtocol.Capabilities = {};
     get capabilities(): DebugProtocol.Capabilities {
         return this._capabilities;
+    }
+
+    get autoExpandLazyVariables(): boolean {
+        return this.debugPreferences['debug.autoExpandLazyVariables'] === 'on';
     }
 
     protected readonly sources = new Map<string, DebugSource>();

--- a/packages/debug/src/browser/editor/debug-hover-source.tsx
+++ b/packages/debug/src/browser/editor/debug-hover-source.tsx
@@ -18,7 +18,7 @@ import * as React from '@theia/core/shared/react';
 import { TreeSource, TreeElement } from '@theia/core/lib/browser/source-tree';
 import { ExpressionContainer, ExpressionItem, DebugVariable } from '../console/debug-console-items';
 import { DebugSessionManager } from '../debug-session-manager';
-import { injectable, inject } from '@theia/core/shared/inversify';
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 
 @injectable()
 export class DebugHoverSource extends TreeSource {
@@ -34,6 +34,11 @@ export class DebugHoverSource extends TreeSource {
     protected elements: TreeElement[] = [];
     getElements(): IterableIterator<TreeElement> {
         return this.elements[Symbol.iterator]();
+    }
+
+    @postConstruct()
+    init(): void {
+        this.toDispose.push(this.sessions.onDidResolveLazyVariable(() => this.fireDidChange()));
     }
 
     protected renderTitle(element: ExpressionItem | DebugVariable): React.ReactNode {
@@ -101,5 +106,4 @@ export class DebugHoverSource extends TreeSource {
             return this.doFindVariable(variables[0], namesToFind.slice(1));
         }
     }
-
 }

--- a/packages/debug/src/browser/editor/debug-inline-value-decorator.ts
+++ b/packages/debug/src/browser/editor/debug-inline-value-decorator.ts
@@ -194,7 +194,7 @@ export class DebugInlineValueDecorator implements FrontendApplicationContributio
                                     }
                                     if (expr) {
                                         const expression = new ExpressionItem(expr, () => stackFrame.thread.session);
-                                        await expression.evaluate('watch');
+                                        await expression.evaluate('watch', false);
                                         if (expression.available) {
                                             text = this.formatInlineValue(expr, expression.value);
                                         }

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -187,6 +187,7 @@
 }
 
 .theia-debug-console-variable {
+  display: flex;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -210,6 +211,22 @@
 
 .theia-debug-console-variable .name {
   color: var(--theia-variable-name-color);
+}
+
+.theia-debug-console-variable .lazy-button {
+  margin-left: 3px;
+  border-radius: 5px;
+  cursor: pointer;
+  align-self: center;
+  color: var(--theia-icon-foreground);
+}
+
+.theia-debug-console-variable .lazy-button:hover {
+  background-color: var(--theia-toolbar-hoverBackground);
+}
+
+.theia-debug-console-variable .value {
+  margin-left: 6px;
 }
 
 .theia-TreeNode:not(:hover) .theia-debug-console-variable .action-label {

--- a/packages/debug/src/browser/view/debug-variables-source.ts
+++ b/packages/debug/src/browser/view/debug-variables-source.ts
@@ -30,6 +30,7 @@ export class DebugVariablesSource extends TreeSource {
     protected init(): void {
         this.refresh();
         this.toDispose.push(this.model.onDidChange(() => this.refresh()));
+        this.toDispose.push(this.model.onDidResolveLazyVariable(() => this.fireDidChange()));
     }
 
     protected readonly refresh = debounce(() => this.fireDidChange(), 400);

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -39,6 +39,7 @@ export class DebugWatchExpression extends ExpressionItem {
 
     override async evaluate(): Promise<void> {
         await super.evaluate('watch');
+        this.options.onDidChange();
     }
 
     protected override setResult(body?: DebugProtocol.EvaluateResponse['body'], error?: string): void {
@@ -55,14 +56,13 @@ export class DebugWatchExpression extends ExpressionItem {
             super.setResult(body, error);
             this.isError = !!error;
         }
-        this.options.onDidChange();
     }
 
     override render(): React.ReactNode {
         const valueClass = this.valueClass();
         return <div className='theia-debug-console-variable theia-debug-watch-expression'>
             <div className={TREE_NODE_SEGMENT_GROW_CLASS}>
-                <span title={this.type || this._expression} className='name'>{this._expression}: </span>
+                <span title={this.type || this._expression} className='name'>{this._expression}:</span>
                 <span title={this._value} ref={this.setValueRef} className={valueClass}>{this._value}</span>
             </div>
             <div className={codicon('close', true)} title={nls.localizeByDefault('Remove Expression')} onClick={this.options.remove} />
@@ -76,7 +76,7 @@ export class DebugWatchExpression extends ExpressionItem {
         if (this.isNotAvailable) {
             return 'watch-not-available';
         }
-        return '';
+        return 'value';
     }
 
     async open(): Promise<void> {

--- a/packages/debug/src/browser/view/debug-watch-source.ts
+++ b/packages/debug/src/browser/view/debug-watch-source.ts
@@ -30,6 +30,7 @@ export class DebugWatchSource extends TreeSource {
     protected init(): void {
         this.refresh();
         this.toDispose.push(this.model.onDidChangeWatchExpressions(() => this.refresh()));
+        this.toDispose.push(this.model.onDidResolveLazyVariable(() => this.refresh()));
     }
 
     protected readonly refresh = debounce(() => this.fireDidChange(), 100);

--- a/packages/debug/src/common/debug-preferences.ts
+++ b/packages/debug/src/common/debug-preferences.ts
@@ -64,7 +64,17 @@ export const debugPreferencesSchema: PreferenceSchema = {
             description: nls.localizeByDefault('Show Source Code in Disassembly View.'),
             type: 'boolean',
             default: true,
-        }
+        },
+        'debug.autoExpandLazyVariables': {
+            type: 'string',
+            enum: ['on', 'off'],
+            default: 'off',
+            enumDescriptions: [
+                nls.localizeByDefault('Always automatically expand lazy variables.'),
+                nls.localizeByDefault('Never automatically expand lazy variables.')
+            ],
+            description: nls.localizeByDefault('Controls whether variables that are lazily resolved, such as getters, are automatically resolved and expanded by the debugger.')
+        },
     }
 };
 
@@ -76,6 +86,7 @@ export class DebugConfiguration {
     'debug.showInStatusBar': 'never' | 'always' | 'onFirstSessionStart';
     'debug.confirmOnExit': 'never' | 'always';
     'debug.disassemblyView.showSourceCode': boolean;
+    'debug.autoExpandLazyVariables': 'on' | 'off';
 }
 
 export const DebugPreferenceContribution = Symbol('DebugPreferenceContribution');

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -52,10 +52,11 @@ export class PluginDebugSession extends DebugSession {
         protected override readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
         protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>,
-        protected override readonly workspaceService: WorkspaceService) {
+        protected override readonly workspaceService: WorkspaceService,
+        debugPreferences: DebugPreferences) {
         super(id, options, parentSession, testService, testRun, sessionManager, connection, terminalServer, editorManager, breakpoints,
             labelProvider, messages, fileService, debugContributionProvider,
-            workspaceService);
+            workspaceService, debugPreferences);
     }
 
     protected override async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
@@ -110,6 +111,7 @@ export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
             this.terminalOptionsExt,
             this.debugContributionProvider,
             this.workspaceService,
+            this.debugPreferences,
         );
     }
 }


### PR DESCRIPTION
#### What it does

Closes #16591.

As described in #16591, debug adapters can return "lazy" variables, such as getters, which will not have their real value retrieved until the user clicks a button. Currently, Theia ignores the lazy flag and does not provide special UI for such variables. They are presented in a generic way as "placeholder" variables that the user needs to expand to see the child "resolved" variable. Such indirection can make it difficult to grasp the effective data structure:

<img width="1049" height="675" src="https://github.com/user-attachments/assets/cfb07063-b70f-4e5f-9f79-b325fab1d6d4" />

This PR implements special support for "lazy" debug variables similarly to how it is done in VS Code.

Instead of expanding such variables, the user will need to click on a special button (`codicon-eye`) on the right hand side of the variable name. The button will disappear after clicking it, and the variable will be resolved. If the result is a simple variable, its value will be shown in place of the initial ("placeholder") value of the lazy variable. If the result is a structured variable, its value will be shown in place of the initial ("placeholder") value and its children will be revealed by auto-expanding the lazy variable.

This feature is supported in all Debug views where a variable can appear (Variables, Watch, Debug Console, Debug Hover):

<img width="1049" height="675" src="https://github.com/user-attachments/assets/982b8cc2-4c60-473a-8703-1d97e04787e4" />

Also, this PR adds support for the `debug.autoExpandLazyVariables` preference (also present in VS Code), which controls whether "lazy" variables are automatically resolved by the debugger (turned off by default).

#### How to test

This can be tested e.g. using a simple Node.JS program:

```js
class Foo {
  get bar() {
    return new Bar();
  }
  get x() {
    return 1;
  }
}
class Bar {
  a = 'a';
  b = 'b';
}
const foo = new Foo();
console.log(foo);

```

1. Set a breakpoint at line `console.log(foo);` and launch the program.
2. Expand the `foo` variable in the Debug Variables view.
3. Click on the resolve (eye) button on the right hand side of the name of the `bar` variable inside `foo`. The variable should be automatically expanded to reveal its resolved structure.
4. Click on the resolve (eye) button on the right hand side of the name of the `x` variable inside `foo`. The resolved value of the variable should be shown.
5. Add the `foo` variable to Watch, and repeat steps 3-4.
6. Evaluate `foo` in Debug Console, and repeat steps 3-4.
7. Repeat steps 3-4 in Debug Hover for `foo`.
8. Turn on the `debug.autoExpandLazyVariables` preference and relaunch the program. Verify that `bar` and `x` variables are now automatically resolved inside `foo`, and no resolve (eye) button is shown for them in Variables, Watch, Debug Console, and Debug Hover.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
