### PR TITLE
Updte vercel default models

### DIFF
--- a/packages/ai-vercel-ai/src/common/vercel-ai-preferences.ts
+++ b/packages/ai-vercel-ai/src/common/vercel-ai-preferences.ts
@@ -47,15 +47,17 @@ on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` t
             description: nls.localize('theia/ai/vercelai/models/description', 'Official models to use with Vercel AI SDK'),
             title: AI_CORE_PREFERENCES_TITLE,
             default: [
+                { id: 'vercel/openai/gpt-5.1', model: 'gpt-5.1', provider: 'openai' },
+                { id: 'vercel/openai/gpt-5', model: 'gpt-5', provider: 'openai' },
+                { id: 'vercel/openai/gpt-5-mini', model: 'gpt-5-mini', provider: 'openai' },
                 { id: 'vercel/openai/gpt-4.1', model: 'gpt-4.1', provider: 'openai' },
-                { id: 'vercel/openai/gpt-4.1-nano', model: 'gpt-4.1-nano', provider: 'openai' },
                 { id: 'vercel/openai/gpt-4.1-mini', model: 'gpt-4.1-mini', provider: 'openai' },
-                { id: 'vercel/openai/gpt-4-turbo', model: 'gpt-4-turbo', provider: 'openai' },
                 { id: 'vercel/openai/gpt-4o', model: 'gpt-4o', provider: 'openai' },
-                { id: 'vercel/openai/gpt-4o-mini', model: 'gpt-4o-mini', provider: 'openai' },
-                { id: 'vercel/anthropic/claude-3-7-sonnet-20250219', model: 'claude-3-7-sonnet-20250219', provider: 'anthropic' },
-                { id: 'vercel/anthropic/claude-3-5-haiku-20241022', model: 'claude-3-5-haiku-20241022', provider: 'anthropic' },
-                { id: 'vercel/anthropic/claude-3-opus-20240229', model: 'claude-3-opus-20240229', provider: 'anthropic' }
+                { id: 'vercel/anthropic/claude-sonnet-4-5', model: 'claude-sonnet-4-5', provider: 'anthropic' },
+                { id: 'vercel/anthropic/claude-sonnet-4-0', model: 'claude-sonnet-4-0', provider: 'anthropic' },
+                { id: 'vercel/anthropic/claude-3-7-sonnet-latest', model: 'claude-3-7-sonnet-latest', provider: 'anthropic' },
+                { id: 'vercel/anthropic/claude-opus-4-5', model: 'claude-opus-4-5', provider: 'anthropic' },
+                { id: 'vercel/anthropic/claude-opus-4-1', model: 'claude-opus-4-1', provider: 'anthropic' }
             ],
             items: {
                 type: 'object',


### PR DESCRIPTION
#### What it does

- Updates Vercel default models to the same as native providers

#### How to test

Use all default models

#### Follow-ups

@planger : GPT 5 and higher did not work for me with vercel. Could you maybe drive the decision on whether to fix this or whether to remove vercel or mark it as not compatible with >GPT 5 (ideally before mergeing this)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
