### PR TITLE
fix(debug): variables made expandable when they should not

### DIFF
--- a/packages/debug/src/browser/console/debug-console-items.tsx
+++ b/packages/debug/src/browser/console/debug-console-items.tsx
@@ -56,7 +56,7 @@ export class ExpressionContainer implements CompositeConsoleItem {
     }
 
     get hasElements(): boolean {
-        return this.variablesReference !== undefined;
+        return !!this.variablesReference;
     }
 
     protected elements: Promise<ExpressionContainer[]> | undefined;


### PR DESCRIPTION
#### What it does

Fixes #16683 by restoring the implementation of `ExpressionContainer.hasElements` that was changed in #16505.

#### How to test

Please use the steps to reproduce listed in #16683 to verify that the issue is now fixed.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
