### PR TITLE
Improve Variables view state preservation across debugger pauses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ old behavior and the new view. Default is the old behavior. [#16604](https://git
 
 - [core] `CommonCommands` has been extracted from `common-frontend-contribution.ts` into its own file `common-commands.ts`. This only affects code using deep imports: imports of `CommonCommands` from `@theia/core/lib/browser/common-frontend-contribution` should be updated to use the standard barrel export `@theia/core/lib/browser` instead.
 - [core] `CommonMenus` has been extracted from `common-frontend-contribution.ts` into its own file `common-menus.ts`. This only affects code using deep imports: imports of `CommonMenus` from `@theia/core/lib/browser/common-frontend-contribution` should be updated to use the standard barrel export `@theia/core/lib/browser` instead.
+- [debug] refactored some of the debug model elements as part of [#16689](https://github.com/eclipse-theia/theia/pull/16689):
+  - added required `id` parameter to `DebugStackFrame` and `DebugScope` constructors
+  - changed type of keys in the `DebugThread._frames` map from `number` to `string`
+  - added required `startFrame` parameter to `DebugThread.doUpdateFrames` method
 - [plugin-ext] `$setBadge` method removed from `WebviewsMain` interface and `WebviewsMainImpl`; badge-related fields removed from `WebviewView` interface and implementation; badge-related fields removed from `PluginViewWidget`; badge-related fields removed from `WebviewWidget`. Use the `BadgeService` instead of `BadgeWidget` interface implementation to show extension badges. [#16518](https://github.com/eclipse-theia/theia/pull/16518)
 - [scm] `ScmTabBarDecorator` and bindings removed. `ScmWidget` now contributes badge decorations via the `BadgeService`. [#16518](https://github.com/eclipse-theia/theia/pull/16518)
 - [ai-core] objects returned by `AiSettingsService` settings retrievals marked readonly. To mutate a settings object, make a copy. [#16612](https://github.com/eclipse-theia/theia/pull/16612)

--- a/packages/debug/src/browser/view/debug-watch-expression.tsx
+++ b/packages/debug/src/browser/view/debug-watch-expression.tsx
@@ -23,7 +23,7 @@ import { nls } from '@theia/core';
 
 export class DebugWatchExpression extends ExpressionItem {
 
-    readonly id: number;
+    override readonly id: number;
     protected isError: boolean;
     protected isNotAvailable: boolean;
 
@@ -34,8 +34,7 @@ export class DebugWatchExpression extends ExpressionItem {
         remove: () => void,
         onDidChange: () => void
     }) {
-        super(options.expression, options.session);
-        this.id = options.id;
+        super(options.expression, options.session, options.id);
     }
 
     override async evaluate(): Promise<void> {


### PR DESCRIPTION
#### What it does

Fixes #16665. Fixes #16641.

This PR improves Variables view state preservation across debugger pauses by giving stable ids to `DebugVariable` and `DebugScope` elements, and storing/restoring the `DebugVariablesWidget` state for a stack frame when the current stack frame changes, similarly to how it is implemented in VS Code.

#### How to test

This can be tested e.g. using a simple Node.JS program:

```js
const person = {
	email: 'foo@example.bar'
}
const email = person.email;
await sleep(1000);
console.log(email);

function sleep(ms) {
    return new Promise(resolve => setTimeout(resolve, ms));
}
```

1. Set breakpoints at lines `const email = person.email;` and `console.log(email);`, and launch the program.
2. After the first breakpoint is hit, expand the `person` variable in the Debug Variables view.
    <img width="1049" height="675" src="https://github.com/user-attachments/assets/96bff94a-e535-4d4b-80a4-5f0924e30cc8" />
3. Step Over. Verify that expansion state in the Variables view is preserved.
    <img width="1049" height="675" src="https://github.com/user-attachments/assets/8be84622-d0cb-4b14-bb01-c97507d314d7" />
4. Continue execution until the second breakpoint is hit. Verify that expansion state in the Variables view is preserved.
    <img width="1049" height="675" alt="Screenshot 2025-12-01 at 20 39 00" src="https://github.com/user-attachments/assets/5ac1b766-e2b6-4538-a816-cc31ede7108d" />

Also, the steps to reproduce #16641 can be used for testing that the issue is now fixed, but please make sure to use the corrected version of the initially provided test program, as explained in https://github.com/eclipse-theia/theia/issues/16641#issuecomment-3597910459, and test expansion state preservation only in the Variables view, as explained in https://github.com/eclipse-theia/theia/issues/16641#issuecomment-3598652771.

#### Follow-ups

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
