### PR TITLE
fix incorrect argument passing to StatusBarEntry

### DIFF
--- a/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/status-bar-message-registry-main.ts
@@ -53,16 +53,11 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
         tooltip: string | MarkdownString | true | undefined,
         command: string | undefined,
         accessibilityInformation: types.AccessibilityInformation,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        args: any[] | undefined): Promise<void> {
-        const ariaLabel = accessibilityInformation?.label;
-        const role = accessibilityInformation?.role;
+        args: unknown[] | undefined): Promise<void> {
 
-        const entry = {
+        const entry: StatusBarEntry = {
             name,
             text: text || '',
-            ariaLabel,
-            role,
             priority,
             alignment: alignment === types.StatusBarAlignment.Left ? StatusBarAlignment.LEFT : StatusBarAlignment.RIGHT,
             color: color && (this.colorRegistry.getCurrentColor(color) || color),
@@ -72,7 +67,7 @@ export class StatusBarMessageRegistryMainImpl implements StatusBarMessageRegistr
             tooltip: tooltip === true ? (token: CancellationToken) => this.proxy.$getMessage(id, token) : tooltip,
             command,
             accessibilityInformation,
-            args
+            arguments: args
         };
 
         const isNewEntry = !this.entries.has(id);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes GH-16624

Ensure command arguments are passed correctly to the StatusBarEntry by typing the entry correctly. Remove outdated properties ariaLabel and role as they are now contained in accessibilityInformation.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Follow the steps of GH-16624

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
