### PR TITLE
ci: set default values for scheduled publish-ci runs

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -30,15 +30,20 @@ jobs:
     name: Perform Publishing
     runs-on: ubuntu-22.04
     timeout-minutes: 60
+    env:
+      RELEASE_TYPE: ${{ inputs.release_type || 'next' }}
+      IS_PATCH_TO_PREVIOUS: ${{ inputs.is_patch_to_previous || false }}
     steps:
       - name: Validate Inputs
         shell: bash
         run: |
-          if [[ "${{ inputs.is_patch_to_previous }}" == "true" && "${{ inputs.release_type }}" != "patch" ]]; then
+          if [[ "${{ env.IS_PATCH_TO_PREVIOUS }}" == "true" && "${{ env.RELEASE_TYPE }}" != "patch" ]]; then
             echo "Error: When 'is_patch_to_previous' is enabled, release_type must be 'patch'"
             exit 1
           fi
           echo "Input validation passed"
+          echo "Release type: ${{ env.RELEASE_TYPE }}"
+          echo "Is patch to previous: ${{ env.IS_PATCH_TO_PREVIOUS }}"
 
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
@@ -69,25 +74,25 @@ jobs:
 
       - name: Publish to NPM (Latest)
         # We only publish minor or patch releases for the current version as latest, never for older patches or next versions.
-        if: ${{ (inputs.release_type == 'patch' || inputs.release_type == 'minor') && !inputs.is_patch_to_previous }}
+        if: ${{ (env.RELEASE_TYPE == 'patch' || env.RELEASE_TYPE == 'minor') && env.IS_PATCH_TO_PREVIOUS == 'false' }}
         shell: bash
         run: |
-          npm run publish:latest ${{ inputs.release_type }}
+          npm run publish:latest ${{ env.RELEASE_TYPE }}
           npm run publish:check
         env:
           NPM_CONFIG_PROVENANCE: "true"
 
       - name: Publish to NPM (Patch - To Previous Version)
-        if: ${{ inputs.release_type == 'patch' && inputs.is_patch_to_previous }}
+        if: ${{ env.RELEASE_TYPE == 'patch' && env.IS_PATCH_TO_PREVIOUS == 'true' }}
         shell: bash
         run: |
-          npm run publish:patch ${{ inputs.release_type }}
+          npm run publish:patch ${{ env.RELEASE_TYPE }}
           npm run publish:check
         env:
           NPM_CONFIG_PROVENANCE: "true"
       
       - name: Publish to NPM (Next)
-        if: ${{ inputs.release_type == 'next' }}
+        if: ${{ env.RELEASE_TYPE == 'next' }}
         shell: bash
         run: |
           npm run publish:next
@@ -95,7 +100,7 @@ jobs:
           NPM_CONFIG_PROVENANCE: "true"
 
       - name: Submit PR for package updates
-        if: ${{ inputs.release_type != 'next' }}
+        if: ${{ env.RELEASE_TYPE != 'next' }}
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The publish-ci workflow didn't pick up the default values from the inputs when running on a schedule. This change adds environment variables with fallback default values, ensuring the scheduled runs use 'next' as the release type by default.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

See scheduled publish run from yesterday morning:
https://github.com/eclipse-theia/theia/actions/runs/19807135019/job/56743064777

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
