### PR TITLE
fix: ensure active session is recreated after deletion

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -398,6 +398,8 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                     }
                 });
             } else if (context.button === AIChatContribution.REMOVE_CHAT_BUTTON) {
+                const activeSession = this.chatService.getActiveSession();
+
                 // Wait for deletion to complete before refreshing the list
                 this.chatService.deleteSession(context.item.id!).then(() => getItems()).then(items => {
                     quickPick.items = items;
@@ -406,6 +408,13 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                     }
                     // Update persisted sessions flag after deletion
                     this.checkPersistedSessions();
+
+                    if (activeSession && activeSession.id === context.item.id) {
+                        this.chatService.createSession(ChatAgentLocation.Panel, {
+                            // Auto-focus only when the quick pick is no longer visible
+                            focus: items.length === 0
+                        });
+                    }
                 }).catch(error => {
                     this.logger.error('Failed to delete chat session', error);
                     this.messageService.error(nls.localize('theia/ai/chat-ui/failedToDeleteSession', 'Failed to delete chat session'));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR ensures that when a chat session is deleted, a new active session is automatically created if the deleted session was the active one. This prevents the Chat UI from being left with an unusable active session after deletion.

Deleting the last item that is an active session from the quick pick will automatically set the focus on the Chat view.

![2025-12-04 00-09-12 2025-12-04 00_11_42](https://github.com/user-attachments/assets/3ed90519-0bc9-4183-ab0b-5ebc03075fff)

Fixes #16697

#### How to test

1. Create two chat sessions with messages so that they are visible in the chat history.
2. Click the **Show Chats...** button.
3. In the quick pick list, remove the active session. A new blank session should appear in the Chat view, and the focus should remain in the quick pick.
4. Click the remaining item in the quick pick to activate it.
5. Click the **Show Chats...** button again.
6. Remove the remaining item in the quick pick.
7. A new blank chat session should appear again, and the input in the chat view should be automatically focused.

#### Attribution

Contributed on behalf of [Lonti.com](http://lonti.com/) Pty Ltd

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
