### PR TITLE
fix: Handle undefined parameters for prompt template discard command

### DIFF
--- a/packages/ai-core/src/browser/prompttemplate-contribution.ts
+++ b/packages/ai-core/src/browser/prompttemplate-contribution.ts
@@ -236,20 +236,23 @@ export class PromptTemplateContribution implements LanguageGrammarDefinitionCont
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(DISCARD_PROMPT_TEMPLATE_CUSTOMIZATIONS, {
-            isVisible: (widget: Widget) => this.isPromptTemplateWidget(widget),
-            isEnabled: (widget: EditorWidget) => this.canDiscard(widget),
+            isVisible: (widget: Widget | undefined) => this.isPromptTemplateWidget(widget),
+            isEnabled: (widget: Widget | undefined) => this.canDiscard(widget),
             execute: (widget: EditorWidget) => this.discard(widget)
         });
     }
 
-    protected isPromptTemplateWidget(widget: Widget): boolean {
+    protected isPromptTemplateWidget(widget: Widget | undefined): boolean {
         if (widget instanceof EditorWidget) {
             return PROMPT_TEMPLATE_LANGUAGE_ID === widget.editor.document.languageId;
         }
         return false;
     }
 
-    protected canDiscard(widget: EditorWidget): boolean {
+    protected canDiscard(widget: Widget | undefined): boolean {
+        if (!(widget instanceof EditorWidget)) {
+            return false;
+        }
         const resourceUri = widget.editor.uri;
         const id = this.promptService.getTemplateIDFromResource(resourceUri);
         if (id === undefined) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #16543

(Note: The branch name has a typo, the ticket referenced here is correct)

The `DISCARD_PROMPT_TEMPLATE_CUSTOMIZATION`'s command handler's `isEnabled` throwed an error when closing a prompt template editor because it got undefined as a parameter. This handles undefined parameters and ensures the parameter is actually an EditorWidget to guard against possible further error resulting from other Widget types being handed in.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Navigate to AI Configuration view
2. Select any Agent
3. Open the Prompt template for the selected agent using the Edit button
4. Close the opened prompt template file
5. Observe that no error is logged in contrast to the description in #16543

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
