### PR TITLE
fix: use undefined-safe deep equality check in preference updates

### DIFF
--- a/packages/core/src/common/preferences/preference-service.ts
+++ b/packages/core/src/common/preferences/preference-service.ts
@@ -16,7 +16,7 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { JSONExt, JSONValue } from '@lumino/coreutils';
+import { JSONValue } from '@lumino/coreutils';
 import { inject, injectable, postConstruct } from 'inversify';
 import { Disposable, DisposableCollection, Emitter, Event, deepFreeze, unreachable } from '../../common';
 import { Deferred } from '../../common/promise-util';
@@ -541,7 +541,7 @@ export class PreferenceServiceImpl implements PreferenceService {
                 || (
                     scopesToChange.length === 1
                     && scopesToChange[0] === PreferenceScope.User
-                    && inspection.defaultValue !== undefined && JSONExt.deepEqual(value, inspection.defaultValue)
+                    && PreferenceUtils.deepEqual(value, inspection.defaultValue)
                 );
             const effectiveValue = isDeletion ? undefined : value;
             await Promise.all(scopesToChange.map(scope => this.set(preferenceName, effectiveValue, scope, resourceUri)));
@@ -549,7 +549,7 @@ export class PreferenceServiceImpl implements PreferenceService {
     }
 
     protected getScopesToChange(inspection: PreferenceInspection<any>, intendedValue: any): PreferenceScope[] {
-        if (JSONExt.deepEqual(inspection.value, intendedValue)) {
+        if (PreferenceUtils.deepEqual(inspection.value, intendedValue)) {
             return [];
         }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Replace JSONExt.deepEqual with PreferenceUtils.deepEqual to ensure undefined inspect value can be handled, since undefined is not a valid JSON value, but preference values can frequently be undefined in practice.

PreferenceUtils.deepEqual properly handles undefined by checking for it explicitly before delegating to JSONExt.deepEqual.

Fixes GH-16708

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Please follow the steps mentioned in the issue

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
