### PR TITLE
Enhance localization of the terminal-manager package

### DIFF
--- a/packages/terminal-manager/src/browser/terminal-manager-frontend-view-contribution.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-frontend-view-contribution.ts
@@ -23,7 +23,7 @@ import {
     MAXIMIZED_CLASS,
     Widget,
 } from '@theia/core/lib/browser';
-import { CommandRegistry, Event, MenuModelRegistry } from '@theia/core';
+import { CommandRegistry, Event, MenuModelRegistry, nls } from '@theia/core';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { BOTTOM_AREA_ID } from '@theia/core/lib/browser/shell/theia-dock-panel';
 import { TerminalManagerCommands, TerminalManagerTreeTypes, TERMINAL_MANAGER_TREE_CONTEXT_MENU } from './terminal-manager-types';
@@ -38,7 +38,7 @@ export class TerminalManagerFrontendViewContribution extends AbstractViewContrib
     constructor() {
         super({
             widgetId: TerminalManagerWidget.ID,
-            widgetName: 'Terminal Manager',
+            widgetName: nls.localize('theia/terminal-manager', 'Terminal Manager'),
             defaultWidgetOptions: {
                 area: 'bottom',
             },
@@ -143,10 +143,12 @@ export class TerminalManagerFrontendViewContribution extends AbstractViewContrib
             isVisible: widget => widget instanceof TerminalManagerWidget,
             execute: async widget => {
                 if (widget instanceof TerminalManagerWidget) {
-                    const PRIMARY_BUTTON = 'Reset Layout';
+                    const PRIMARY_BUTTON = nls.localize('theia/terminal-manager/resetLayout', 'Reset Layout');
                     const dialogResponse = await this.confirmUserAction({
-                        title: 'Do you want to reset the terminal manager layout?',
-                        message: 'Once the layout is reset, it cannot be restored. Are you sure you would like to clear the layout?',
+                        title: nls.localize('theia/terminal-manager/resetLayoutPrompt', 'Do you want to reset the terminal manager layout?'),
+                        message: nls.localize(
+                            'theia/terminal-manager/resetLayoutMessage',
+                            'Once the layout is reset, it cannot be restored. Are you sure you would like to clear the layout?'),
                         primaryButtonText: PRIMARY_BUTTON,
                     });
                     if (dialogResponse === PRIMARY_BUTTON) {

--- a/packages/terminal-manager/src/browser/terminal-manager-preferences.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-preferences.ts
@@ -21,7 +21,7 @@ export const TerminalManagerPreferenceSchema: PreferenceSchema = {
         'terminal.grouping.treeViewLocation': {
             'type': 'string',
             'enum': ['left', 'right'],
-            'description': nls.localize('theia/terminalManager/treeViewLocation', 'The location of the terminal manager\'s tree view.'
+            'description': nls.localize('theia/terminal-manager/treeViewLocation', 'The location of the terminal manager\'s tree view.'
                 + ' Only applies when \'terminal.grouping.mode\' is set to \'tree\'.'),
             'default': 'left',
             'scope': PreferenceScope.Workspace,
@@ -29,7 +29,7 @@ export const TerminalManagerPreferenceSchema: PreferenceSchema = {
         'terminal.grouping.mode': {
             'type': 'string',
             'enum': ['tabbed', 'tree'],
-            'description': nls.localize('theia/terminalManager/tabsDisplay',
+            'description': nls.localize('theia/terminal-manager/tabsDisplay',
                 'Controls how terminals are displayed. \'tree\' shows multiple terminals in a single view with a tree view for management,'
                 + '\'tabbed\' shows each terminal in its own view in a separate tab.'),
             'default': 'tabbed',

--- a/packages/terminal-manager/src/browser/terminal-manager-tree-model.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-tree-model.ts
@@ -16,7 +16,7 @@
 
 import { injectable, postConstruct } from '@theia/core/shared/inversify';
 import { TreeModelImpl, CompositeTreeNode, SelectableTreeNode, DepthFirstTreeIterator } from '@theia/core/lib/browser';
-import { Emitter } from '@theia/core';
+import { Emitter, nls } from '@theia/core';
 import { TerminalManagerTreeTypes } from './terminal-manager-types';
 
 @injectable()
@@ -94,7 +94,7 @@ export class TerminalManagerTreeModel extends TreeModelImpl {
         const currentPageNumber = this.getNextPageCounter();
         return {
             id: pageId,
-            label: `Page(${currentPageNumber})`,
+            label: `${nls.localize('theia/terminal-manager/page', 'Page')} (${currentPageNumber})`,
             parent: undefined,
             selected: false,
             children: [],
@@ -149,7 +149,7 @@ export class TerminalManagerTreeModel extends TreeModelImpl {
         const currentGroupNum = this.getNextGroupCounterForPage(pageId);
         return {
             id: groupId,
-            label: `Group(${currentGroupNum})`,
+            label: `${nls.localize('theia/terminal-manager/group', 'Group')} (${currentGroupNum})`,
             parent: undefined,
             selected: false,
             children: [],
@@ -212,7 +212,7 @@ export class TerminalManagerTreeModel extends TreeModelImpl {
     ): TerminalManagerTreeTypes.TerminalNode {
         return {
             id: terminalId,
-            label: 'Terminal',
+            label: nls.localizeByDefault('Terminal'),
             parent: undefined,
             children: [],
             selected: false,

--- a/packages/terminal-manager/src/browser/terminal-manager-types.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-types.ts
@@ -26,81 +26,80 @@ import {
 import { TerminalWidgetFactoryOptions, TerminalWidgetImpl } from '@theia/terminal/lib/browser/terminal-widget-impl';
 
 export namespace TerminalManagerCommands {
-    export const MANAGER_NEW_TERMINAL_GROUP = Command.toDefaultLocalizedCommand({
+    export const MANAGER_NEW_TERMINAL_GROUP = Command.toLocalizedCommand({
         id: 'terminal:new-in-manager-toolbar',
         category: 'Terminal Manager',
         label: 'Create New Terminal Group',
         iconClass: codicon('split-horizontal'),
-    });
-    export const MANAGER_DELETE_TERMINAL = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/createNewTerminalGroup');
+    export const MANAGER_DELETE_TERMINAL = Command.toLocalizedCommand({
         id: 'terminal:delete-terminal',
         category: 'Terminal Manager',
         label: 'Delete Terminal',
         iconClass: codicon('trash'),
-    });
-    export const MANAGER_RENAME_TERMINAL = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/deleteTerminal');
+    export const MANAGER_RENAME_TERMINAL = Command.toLocalizedCommand({
         id: 'terminal: rename-terminal',
         category: 'Terminal Manager',
-        label: 'Rename...',
+        label: 'Rename',
         iconClass: codicon('edit'),
-    });
-    export const MANAGER_NEW_PAGE_BOTTOM_TOOLBAR = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/rename');
+    export const MANAGER_NEW_PAGE_BOTTOM_TOOLBAR = Command.toLocalizedCommand({
         id: 'terminal:new-manager-page',
         category: 'Terminal Manager',
         label: 'Create New Terminal Page',
         iconClass: codicon('new-file'),
-    });
-    export const MANAGER_DELETE_PAGE = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/createNewTerminalPage');
+    export const MANAGER_DELETE_PAGE = Command.toLocalizedCommand({
         id: 'terminal:delete-page',
         category: 'Terminal Manager',
         label: 'Delete Page',
         iconClass: codicon('trash'),
-    });
-    export const MANAGER_ADD_TERMINAL_TO_GROUP = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/deletePage');
+    export const MANAGER_ADD_TERMINAL_TO_GROUP = Command.toLocalizedCommand({
         id: 'terminal:manager-split-horizontal',
         category: 'Terminal Manager',
         label: 'Add terminal to group',
         iconClass: codicon('split-vertical'),
-    });
-    export const MANAGER_DELETE_GROUP = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/addTerminalToGroup');
+    export const MANAGER_DELETE_GROUP = Command.toLocalizedCommand({
         id: 'terminal:manager-delete-group',
         category: 'Terminal Manager',
-        label: 'Delete Group...',
+        label: 'Delete Group',
         iconClass: codicon('trash'),
-    });
-    export const MANAGER_SHOW_TREE_TOOLBAR = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/deleteGroup');
+    export const MANAGER_SHOW_TREE_TOOLBAR = Command.toLocalizedCommand({
         id: 'terminal:manager-toggle-tree',
         category: 'Terminal Manager',
         label: 'Toggle Tree View',
         iconClass: codicon('list-tree'),
-    });
-
-    export const MANAGER_MAXIMIZE_BOTTOM_PANEL_TOOLBAR = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/toggleTreeView');
+    export const MANAGER_MAXIMIZE_BOTTOM_PANEL_TOOLBAR = Command.toLocalizedCommand({
         id: 'terminal:manager-maximize-bottom-panel',
         category: 'Terminal Manager',
         label: 'Maximize Bottom Panel',
-    });
-    export const MANAGER_MINIMIZE_BOTTOM_PANEL_TOOLBAR = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/maximizeBottomPanel');
+    export const MANAGER_MINIMIZE_BOTTOM_PANEL_TOOLBAR = Command.toLocalizedCommand({
         id: 'terminal:manager-minimize-bottom-panel',
         category: 'Terminal Manager',
         label: 'Minimize Bottom Panel',
-    });
-    export const MANAGER_CLEAR_ALL = Command.toDefaultLocalizedCommand({
+    }, 'theia/terminal-manager/minimizeBottomPanel');
+    export const MANAGER_CLEAR_ALL = Command.toLocalizedCommand({
         id: 'terminal:manager-clear-all',
         category: 'Terminal Manager',
-        label: 'Reset Terminal Manager layout',
+        label: 'Reset Terminal Manager Layout',
         iconClass: codicon('trash'),
-    });
-    export const MANAGER_OPEN_VIEW: Command = {
+    }, 'theia/terminal-manager/resetTerminalManagerLayout');
+    export const MANAGER_OPEN_VIEW = Command.toLocalizedCommand({
         id: 'terminal:open-manager',
         category: 'View',
         label: 'Open Terminal Manager',
-    };
-    export const MANAGER_CLOSE_VIEW: Command = {
+    }, 'theia/terminal-manager/openTerminalManager');
+    export const MANAGER_CLOSE_VIEW = Command.toLocalizedCommand({
         id: 'terminal:close-manager',
         category: 'View',
         label: 'Close Terminal Manager',
-    };
+    }, 'theia/terminal-manager/closeTerminalManager');
 }
 
 export const TERMINAL_MANAGER_TREE_CONTEXT_MENU = ['terminal-manager-tree-context-menu'];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- TerminalManagerCommands did use toDefaultLocalizeCommand which logged a lot of warnings on startup as the 'Terminal Manager' is not a default category in VS Code, so we use custom localization for those now.
- add localization for remaining user facing text
- use the same localizationKey prefix for this package

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- verify the warnings on startup are gone:
   - e.g. `Could not find translation key for default value: "Create New Terminal Group"`
- for the remaining changes code review should be enough, as we have no translations for those new strings yet (will be generated with next release)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
