### PR TITLE
Make debug toolbar actions command-based and display their keybindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ old behavior and the new view. Default is the old behavior. [#16604](https://git
   - added required `id` parameter to `DebugStackFrame` and `DebugScope` constructors
   - changed type of keys in the `DebugThread._frames` map from `number` to `string`
   - added required `startFrame` parameter to `DebugThread.doUpdateFrames` method
+- [debug] some of the fields and methods of `DebugToolBar` have been removed in [#16719](https://github.com/eclipse-theia/theia/pull/16719)
 - [plugin-ext] `$setBadge` method removed from `WebviewsMain` interface and `WebviewsMainImpl`; badge-related fields removed from `WebviewView` interface and implementation; badge-related fields removed from `PluginViewWidget`; badge-related fields removed from `WebviewWidget`. Use the `BadgeService` instead of `BadgeWidget` interface implementation to show extension badges. [#16518](https://github.com/eclipse-theia/theia/pull/16518)
 - [scm] `ScmTabBarDecorator` and bindings removed. `ScmWidget` now contributes badge decorations via the `BadgeService`. [#16518](https://github.com/eclipse-theia/theia/pull/16518)
 - [ai-core] objects returned by `AiSettingsService` settings retrievals marked readonly. To mutate a settings object, make a copy. [#16612](https://github.com/eclipse-theia/theia/pull/16612)

--- a/packages/debug/src/browser/debug-commands.ts
+++ b/packages/debug/src/browser/debug-commands.ts
@@ -71,6 +71,7 @@ export namespace DebugCommands {
         id: 'workbench.action.debug.restart',
         category: DEBUG_CATEGORY,
         label: 'Restart',
+        iconClass: codicon('debug-restart')
     });
 
     export const OPEN_CONFIGURATIONS = Command.toDefaultLocalizedCommand({

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -200,7 +200,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
 
     override registerMenus(menus: MenuModelRegistry): void {
         super.registerMenus(menus);
-        const registerMenuActions = (menuPath: string[], ...commands: (Command & { order?: string })[]) => {
+        const registerMenuActions = (menuPath: string[], ...commands: (Command & { order?: string, when?: string })[]) => {
             for (const [index, command] of commands.entries()) {
                 const label = command.label;
                 const debug = `${DebugCommands.DEBUG_CATEGORY}:`;
@@ -208,6 +208,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
                     commandId: command.id,
                     label: label && label.startsWith(debug) && label.slice(debug.length).trimStart() || label,
                     icon: command.iconClass,
+                    when: command.when,
                     order: command.order || String.fromCharCode('a'.charCodeAt(0) + index)
                 });
             }
@@ -350,6 +351,15 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         menus.linkCompoundMenuNode({ newParentPath: EDITOR_LINENUMBER_CONTEXT_MENU, submenuPath: DebugEditorModel.CONTEXT_MENU });
 
         menus.registerSubmenu(DebugToolBar.MENU, nls.localize('theia/debug/debugToolbarMenu', 'Debug Toolbar Menu'));
+        registerMenuActions(DebugToolBar.CONTROLS,
+            { ...DebugCommands.CONTINUE, when: 'debugState == stopped' },
+            { ...DebugCommands.PAUSE, when: 'debugState != stopped' },
+            DebugCommands.STEP_OVER,
+            DebugCommands.STEP_INTO,
+            DebugCommands.STEP_OUT,
+            DebugCommands.RESTART,
+            DebugCommands.STOP
+        );
     }
 
     override registerCommands(registry: CommandRegistry): void {

--- a/packages/debug/src/browser/view/debug-action.tsx
+++ b/packages/debug/src/browser/view/debug-action.tsx
@@ -21,7 +21,7 @@ import { MenuPath } from '@theia/core';
 export class DebugAction extends React.Component<DebugAction.Props> {
 
     override render(): React.ReactNode {
-        const { enabled, label, iconClass } = this.props;
+        const { enabled, label, tooltip, iconClass } = this.props;
         const classNames = ['debug-action'];
         if (iconClass) {
             classNames.push(...codiconArray(iconClass, true));
@@ -31,7 +31,7 @@ export class DebugAction extends React.Component<DebugAction.Props> {
         }
         return <span tabIndex={0}
             className={classNames.join(' ')}
-            title={label}
+            title={tooltip || label}
             onClick={() => { this.props.run([]); }}
             ref={this.setRef} >
             {!iconClass && <div>{label}</div>}
@@ -51,6 +51,7 @@ export class DebugAction extends React.Component<DebugAction.Props> {
 export namespace DebugAction {
     export interface Props {
         label: string
+        tooltip?: string
         iconClass: string
         run: (effectiveMenuPath: MenuPath) => void
         enabled?: boolean

--- a/packages/debug/src/browser/view/debug-session-widget.ts
+++ b/packages/debug/src/browser/view/debug-session-widget.ts
@@ -100,11 +100,6 @@ export class DebugSessionWidget extends BaseWidget implements StatefulWidget, Ap
         layout.addWidget(this.viewContainer);
     }
 
-    protected override onActivateRequest(msg: Message): void {
-        super.onActivateRequest(msg);
-        this.toolbar.focus();
-    }
-
     protected override onAfterShow(msg: Message): void {
         super.onAfterShow(msg);
         this.getTrackableWidgets().forEach(w => w.update());


### PR DESCRIPTION
#### What it does

Closes #16674.

Currently, actions in debug toolbar are not based on commands. They execute code that is functionally equivalent to the code that would be executed by corresponding debug commands, such as `workbench.action.debug.stepOver`, but the respective code paths are not identical. This explains why actions in debug toolbar don't currently display keybindings (#16674). It is debug commands that have keybindings, not actions in debug toolbar, which don't even invoke the corresponding debug commands currently.

This PR makes debug toolbar actions be based on the corresponding debug commands and display their keybindings.

#### How to test

Debug toolbar should look and act as before, except for it should now display keybindings, i.e. #16674 should now be fixed.

<img width="756" height="290" src="https://github.com/user-attachments/assets/fcf67827-ba24-407d-b4d6-3fdd879739a6" />

#### Follow-ups

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
