### PR TITLE
fix: create proper type instances in toSymbolInformation

### DIFF
--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -707,6 +707,24 @@ export namespace SymbolKind {
         }
         return model.SymbolKind.Property;
     }
+
+    // lstypes.SymbolKind is 1-26, but Theia/model SymbolKind is 0–25.
+    // We convert by adding or subtracting 1 to keep the enum indices aligned.
+    export function fromLspSymbolKind(kind: lstypes.SymbolKind): theia.SymbolKind {
+        const n = Number(kind);
+        if (n >= 1 && n <= 26) {
+            return (n - 1) as theia.SymbolKind;
+        }
+        return fromLspSymbolKind(lstypes.SymbolKind.Property);
+    }
+
+    export function toLspSymbolKind(kind: model.SymbolKind): lstypes.SymbolKind {
+        const n = Number(kind);
+        if (n >= 0 && n <= 25) {
+            return (n + 1) as lstypes.SymbolKind;
+        }
+        return lstypes.SymbolKind.Property;
+    }
 }
 
 export function toCodeActionTriggerKind(triggerKind: model.CodeActionTriggerKind): types.CodeActionTriggerKind {
@@ -1185,14 +1203,14 @@ export function fromSymbolInformation(symbolInformation: theia.SymbolInformation
     if (symbolInformation.location && symbolInformation.location.range) {
         const p1 = lstypes.Position.create(symbolInformation.location.range.start.line, symbolInformation.location.range.start.character);
         const p2 = lstypes.Position.create(symbolInformation.location.range.end.line, symbolInformation.location.range.end.character);
-        return lstypes.SymbolInformation.create(symbolInformation.name, symbolInformation.kind++ as lstypes.SymbolKind, lstypes.Range.create(p1, p2),
+        return lstypes.SymbolInformation.create(symbolInformation.name, SymbolKind.toLspSymbolKind(symbolInformation.kind), lstypes.Range.create(p1, p2),
             symbolInformation.location.uri.toString(), symbolInformation.containerName);
     }
 
     return {
         name: symbolInformation.name,
         containerName: symbolInformation.containerName,
-        kind: symbolInformation.kind++ as lstypes.SymbolKind,
+        kind: SymbolKind.toLspSymbolKind(symbolInformation.kind),
         location: {
             uri: symbolInformation.location.uri.toString(),
             range: symbolInformation.location.range,
@@ -1205,15 +1223,21 @@ export function toSymbolInformation(symbolInformation: lstypes.SymbolInformation
         return undefined;
     }
 
-    return <theia.SymbolInformation>{
+    const lspRange: lstypes.Range = symbolInformation.location.range;
+    const range = new types.Range(
+        lspRange.start.line,
+        lspRange.start.character,
+        lspRange.end.line,
+        lspRange.end.character
+    );
+
+    const theiaSymbolInformation: theia.SymbolInformation = {
         name: symbolInformation.name,
-        containerName: symbolInformation.containerName,
-        kind: symbolInformation.kind,
-        location: {
-            uri: URI.parse(symbolInformation.location.uri),
-            range: symbolInformation.location.range
-        }
+        containerName: symbolInformation.containerName || '',
+        kind: SymbolKind.fromLspSymbolKind(symbolInformation.kind),
+        location: new types.Location(URI.parse(symbolInformation.location.uri), range)
     };
+    return theiaSymbolInformation;
 }
 
 export function fromSelectionRange(selectionRange: theia.SelectionRange): model.SelectionRange {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-16726

- Use proper SymbolInformation, Location and Range constructors instead of plain objects with forced casts.
- Fix SymbolKind conversion between LSP and theia enums by adding an explicit conversion helper

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- For testing with the Theia examples, install the java plugins Extension Pack for Java (`vscjava.vscode-java-pack`) and vscjava.vscode-java-dependency (`vscjava.vscode-java-dependency`).
- Follow the steps in GH-16726
- Now that the SymbolKind values are correctly mapped, the kind indicated by the icon should also be accurate (you can compare it with the outline, for example).
  <img width="1448" height="244" alt="image" src="https://github.com/user-attachments/assets/6e68f09b-798a-4537-9588-e9787d818730" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
