### PR TITLE
fix: align input heights in preferences UI

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -134,6 +134,11 @@ blockquote {
     white-space: nowrap;
 }
 
+.theia-input[type="checkbox"],
+.theia-input[type="radio"] {
+    min-height: unset;
+}
+
 .theia-input::placeholder {
     color: var(--theia-input-placeholderForeground);
     overflow: hidden;

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -78,10 +78,6 @@
   margin-left: var(--theia-ui-padding);
 }
 
-.theia-source-breakpoint > .theia-input {
-  min-height: auto;
-}
-
 .theia-debug-session .status,
 .theia-debug-thread .status {
   text-transform: uppercase;

--- a/packages/preferences/src/browser/style/index.css
+++ b/packages/preferences/src/browser/style/index.css
@@ -502,7 +502,7 @@
 /** Select component */
 
 .theia-settings-container .theia-select-component {
-  height: 26px;
+  height: 28px;
   width: 100%;
   max-width: 320px;
 }

--- a/packages/preferences/src/browser/style/preference-file.css
+++ b/packages/preferences/src/browser/style/preference-file.css
@@ -26,6 +26,5 @@
 }
 
 .theia-settings-container .preference-file-button {
-  margin-left: 0px;
-  height: calc(var(--theia-content-line-height) + 4px);
+  margin-left: var(--theia-ui-padding);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Remove min-height from checkbox and radio inputs
- Remove now redundant min-height override in debug breakpoint styles
- Adjust select component height to 28px in preferences
- Use theia-ui-padding for preference file button margin and remove height

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Pure css style change: check the UI settings view if checkboxes, inputs (like text, number, file etc) are well aligned.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
