### PR TITLE
refactor: tree search box into React widget and enhance UX and styling

### DIFF
--- a/packages/core/src/browser/style/search-box.css
+++ b/packages/core/src/browser/style/search-box.css
@@ -15,109 +15,46 @@
  ********************************************************************************/
 
 :root {
-  --theia-search-box-padding: 3px;
   --theia-search-box-radius: 2px;
-  --theia-search-box-spacing: 4px;
   --theia-search-box-max-width: 500px;
 }
 
-.theia-search-box {
+.theia-search-box-widget {
   position: absolute;
-  display: flex;
-  top: var(--theia-search-box-spacing);
-  right: var(--theia-search-box-spacing);
-  box-shadow: var(--theia-border-width) var(--theia-border-width)
-    var(--theia-widget-shadow);
-  background-color: var(--theia-listFilterWidget-background);
+  top: 0;
+  right: var(--theia-scrollbar-width);
+  background-color: var(--theia-sideBar-background);
   z-index: calc(var(--theia-tabbar-toolbar-z-index) + 1);
   border-radius: var(--theia-search-box-radius);
-  padding: var(--theia-search-box-padding);
-  border: var(--theia-border-width) solid rgba(0, 0, 0, 0);
 }
 
-.theia-search-box.no-match {
-  border: var(--theia-border-width) solid
-    var(--theia-inputValidation-errorBorder);
+.theia-search-box-widget .theia-search-box {
+  display: flex;
+  padding: calc(var(--theia-ui-padding) / 2);
+  border: var(--theia-border-width) solid var(--theia-widget-border, var(--theia-list-hoverBackground));
 }
 
-.theia-search-input {
+.theia-search-box-widget .theia-search-box.no-match {
+  border: var(--theia-border-width) solid var(--theia-inputValidation-errorBorder);
+}
+
+.theia-search-box-widget .theia-search-input {
   flex-grow: 1;
   user-select: none;
+  background-color: var(--theia-input-background);
+  padding: calc(var(--theia-ui-padding) / 2);
 }
 
-.theia-search-box > .theia-search-buttons-wrapper {
-  max-width: 0px;
-  transition: max-width 0.2s ease-out;
+.theia-search-box-widget .theia-search-box>.theia-search-buttons-wrapper {
+  max-width: var(--theia-search-box-max-width);
   display: flex;
-  box-sizing: border-box;
   align-items: center;
 }
 
-.theia-search-box:hover > .theia-search-buttons-wrapper {
-  max-width: var(--theia-search-box-max-width);
-  transition: max-width 0.2s ease-in;
+.theia-search-box-widget .theia-search-button {
+  padding: 2px;
 }
 
-.theia-search-button {
-  min-width: 1rem;
-  text-align: center;
-  flex-grow: 0;
-  font-family: FontAwesome;
-  font-size: calc(var(--theia-content-font-size) * 0.8);
-  color: var(--theia-editorWidget-foreground);
-}
-
-.theia-search-button.codicon.codicon-filter {
-  color: var(--theia-editorWidget-foreground);
-  align-self: flex-end;
-  margin-left: var(--theia-search-box-spacing);
-}
-
-.theia-search-button.codicon-filter:not(.filter-active):before {
-  content: "\eb85";
-}
-
-.theia-search-button.codicon-filter.filter-active:before {
-  content: "\eb83";
-}
-
-.theia-search-button-next:before {
-  content: "\f107";
-}
-
-.theia-search-button-next:hover,
-.theia-search-button-previous:hover,
-.theia-search-button-close:hover,
-.theia-search-button.codicon-filter:hover {
-  cursor: pointer;
-}
-
-.theia-search-button-next:hover:before {
-  content: "\f107";
-}
-
-.theia-search-button-previous:before {
-  content: "\f106";
-}
-
-.theia-search-button-previous:hover:before {
-  content: "\f106";
-}
-
-.theia-search-button-close:before {
-  content: "\f00d";
-}
-
-.theia-search-button-close:hover:before {
-  content: "\f00d";
-}
-
-.theia-non-selectable {
-  -webkit-user-select: none;
-  -khtml-user-select: none;
-  -moz-user-select: none;
-  -ms-user-select: none;
-  -o-user-select: none;
-  user-select: none;
-  cursor: default;
+.theia-search-box-widget .theia-search-button.no-match {
+  opacity: var(--theia-mod-disabled-opacity);
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-16657

- Refactor SearchBox to a ReactWidget for improved state handling
- Update icons in the search box to use Codicons
- Update and simplify CSS rules

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Test the tree search box in different tree views, e.g. in explorer, outline, scm view
- Verify the behaviour described in the issue is fixed

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
