### PR TITLE
feat: preserve LSP Diagnostic.data in markers

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -210,6 +210,8 @@ export interface MarkerData {
     endColumn: number;
     relatedInformation?: RelatedInformation[];
     tags?: MarkerTag[];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    data?: any;
 }
 
 export interface RelatedInformation {

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -1283,7 +1283,8 @@ function reviveMarker(marker: MarkerData): vst.Diagnostic {
         range: reviveRange(marker.startLineNumber, marker.startColumn, marker.endLineNumber, marker.endColumn),
         message: marker.message,
         source: marker.source,
-        relatedInformation: undefined
+        relatedInformation: undefined,
+        data: marker.data
     };
 
     if (marker.relatedInformation) {

--- a/packages/plugin-ext/src/plugin/type-converters.ts
+++ b/packages/plugin-ext/src/plugin/type-converters.ts
@@ -362,7 +362,8 @@ export function convertDiagnosticToMarkerData(diagnostic: theia.Diagnostic): mod
         endLineNumber: diagnostic.range.end.line + 1,
         endColumn: diagnostic.range.end.character + 1,
         relatedInformation: convertRelatedInformation(diagnostic.relatedInformation),
-        tags: convertTags(diagnostic.tags)
+        tags: convertTags(diagnostic.tags),
+        data: diagnostic.data,
     };
 }
 

--- a/packages/plugin/src/theia-extra.d.ts
+++ b/packages/plugin/src/theia-extra.d.ts
@@ -390,6 +390,13 @@ export module '@theia/plugin' {
     export namespace window {
         export function registerTerminalObserver(observer: TerminalObserver): Disposable;
     }
+
+    export interface Diagnostic {
+        /**
+         * A data entry field that is preserved between diagnostics and code actions.
+         */
+        data?: any;
+    }
 }
 
 /**


### PR DESCRIPTION
#### What it does

Implemented conversion for the data field in the diagnostic <-> marker lifecycle by updating convertDiagnosticToMarkerData and reviveMarker, enabling ProblemManager markers to carry the data payload. The data field is an opaque, server-defined payload used to attach metadata to a diagnostic and must be preserved by the client. This field is defined on the Diagnostic interface in the vscode-languageserver-protocol package as below:

<img width="1021" height="949" alt="image" src="https://github.com/user-attachments/assets/6bf58663-fb87-4cad-8a0f-53beb1562b23" />

#### How to test

1. Prepare an LSP server or mock that publishes diagnostics including a data property (LSP 3.16+).
2. Open a workspace/file that receives those diagnostics.
3. Verify that ProblemManager exposes markers whose data field is present and matches the published diagnostic data. 
4. Inspect markers via the UI or programmatic API that uses MarkerManager.findMarkers() and check marker.data.data contains the expected value.

<img width="575" height="395" alt="image" src="https://github.com/user-attachments/assets/7623e320-ac48-41fb-94d6-2e1cb2b2c050" />

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
