### PR TITLE
ai-ide: Add getWorkspaceRoot MCP tool

### DIFF
--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -28,6 +28,7 @@ import {
     FindFilesByPattern,
     GetWorkspaceDirectoryStructure,
     GetWorkspaceFileList,
+    GetWorkspaceRoot,
     WorkspaceFunctionScope
 } from './workspace-functions';
 import { WorkspaceSearchProvider } from './workspace-search-provider';
@@ -158,6 +159,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindToolProvider(GetWorkspaceDirectoryStructure, bind);
     bindToolProvider(FileDiagnosticProvider, bind);
     bindToolProvider(FindFilesByPattern, bind);
+    bindToolProvider(GetWorkspaceRoot, bind);
     bind(WorkspaceFunctionScope).toSelf().inSingletonScope();
     bindToolProvider(WorkspaceSearchProvider, bind);
 

--- a/packages/ai-ide/src/common/workspace-functions.ts
+++ b/packages/ai-ide/src/common/workspace-functions.ts
@@ -24,3 +24,4 @@ export const RUN_TASK_FUNCTION_ID = 'runTask';
 export const LIST_LAUNCH_CONFIGURATIONS_FUNCTION_ID = 'listLaunchConfigurations';
 export const RUN_LAUNCH_CONFIGURATION_FUNCTION_ID = 'runLaunchConfiguration';
 export const STOP_LAUNCH_CONFIGURATION_FUNCTION_ID = 'stopLaunchConfiguration';
+export const GET_WORKSPACE_ROOT_FUNCTION_ID = 'getWorkspaceRoot';


### PR DESCRIPTION
Currently untested, looking for early feedback.

Add a new tool provider that returns the absolute filesystem path of the workspace root directory. This is useful for tools that require absolute paths to interact with the workspace.

The tool returns:
- workspaceRoots: Array of all workspace root paths
- primaryRoot: The first/primary workspace root

Includes unit tests for successful retrieval and error handling when no workspace is open.

Assisted-by: Claude

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
