### PR TITLE
Fix deletion of disabled source breakpoints

### DIFF
--- a/packages/debug/src/browser/model/debug-source-breakpoint.tsx
+++ b/packages/debug/src/browser/model/debug-source-breakpoint.tsx
@@ -52,7 +52,9 @@ export class DebugSourceBreakpoint extends DebugBreakpoint<SourceBreakpoint> imp
     setEnabled(enabled: boolean): void {
         const { uri, raw } = this;
         let shouldUpdate = false;
-        let breakpoints = raw && this.doRemove(this.origins.filter(origin => !(origin.raw.line === raw.line && origin.raw.column === raw.column)));
+        const originLine = this.origin.raw.line;
+        const originColumn = this.origin.raw.column;
+        let breakpoints = raw && this.doRemove(this.origins.filter(origin => !(origin.raw.line === originLine && origin.raw.column === originColumn)));
         // Check for breakpoints array with at least one entry
         if (breakpoints && breakpoints.length) {
             shouldUpdate = true;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Closes #16770

The bug was caused by a confusion of sources of location data for a breakpoint. The old logic was using the verified location of a given breakpoint to identify itself, but that didn't match the metadata available the rest of the debug session, which was using the original location (e.g. just 'line 6' rather than 'line 6, column 3' provided by the debug adapter). This resulted in the breakpoint removing itself.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Create a debug session and hit a breakpoint in a certain file.
2. Disable that breakpoint and other breakpoints in the same file.
3. They should remain in the UI, but be shown as disabled and should not be hit.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
