### PR TITLE
Improve function descriptions

### DIFF
--- a/packages/ai-ide/src/browser/context-functions.ts
+++ b/packages/ai-ide/src/browser/context-functions.ts
@@ -104,16 +104,19 @@ export class AddFileToChatContext implements ToolProvider {
                 properties: {
                     filesToAdd: {
                         type: 'array',
-                        description: 'The paths of files to add to the context of the current chat, relative to the workspace root.',
+                        description: 'Array of relative file paths to bookmark (e.g., ["src/index.ts", "package.json"]). Paths are relative to the workspace root.',
                         items: { type: 'string' }
                     }
                 },
                 required: ['filesToAdd']
             },
-            description: 'Adds one or more files to the context of the current chat session. ' +
+            description: 'Adds one or more files to the context of the current chat session for future reference. ' +
+                'Use this to bookmark important files that you\'ll need to reference multiple times during the conversation - ' +
+                'this is more efficient than re-reading files repeatedly. ' +
                 'Only files that exist within the workspace boundaries will be added. ' +
                 'Files outside the workspace or non-existent files will be rejected. ' +
-                'Returns a detailed status for each file, including which were successfully added and which were rejected with reasons.',
+                'Returns a detailed status for each file, including which were successfully added and which were rejected with reasons. ' +
+                'Note: Adding a file to context does NOT read its contents - use getFileContent to read the actual content.',
             handler: async (arg: string, ctx: MutableChatRequestModel): Promise<string> => {
                 if (ctx?.response?.cancellationToken?.isCancellationRequested) {
                     return JSON.stringify({ error: 'Operation cancelled by user' });

--- a/packages/ai-ide/src/browser/workspace-search-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.ts
@@ -46,12 +46,16 @@ export class WorkspaceSearchProvider implements ToolProvider {
         return {
             id: SEARCH_IN_WORKSPACE_FUNCTION_ID,
             name: SEARCH_IN_WORKSPACE_FUNCTION_ID,
-            description: 'Searches the content of files within the workspace for lines matching the given search term (`query`). \
-            The search uses case-insensitive string matching or regular expressions (controlled by the `useRegExp` parameter). \
-            It returns a list of matching files, including the file path (URI), the line number, and the full text content of each matching line. \
-            Multi-word patterns must match exactly (including spaces, case-insensitively). \
-            For best results, use specific search terms and consider filtering by file extensions or limiting to specific subdirectories to avoid overwhelming results. \
-            For complex searches, prefer multiple simpler queries over one complex query or regular expression.',
+            description: 'Searches file contents within the workspace for lines matching the given search term. ' +
+            'Returns up to 30 matching results by default (configurable via preferences). If results are truncated, ' +
+            'refine your search with fileExtensions or subDirectoryPath filters. ' +
+            'The search uses case-insensitive string matching or regular expressions (controlled by the `useRegExp` parameter). ' +
+            'Returns a list of matches including: file path, line number, and the matching line content. ' +
+            'Multi-word patterns must match exactly (including spaces, case-insensitively). ' +
+            'For best results, use specific search terms and filter by file extensions or subdirectories. ' +
+            'For complex searches, prefer multiple simpler queries over one complex regex. ' +
+            'Use this for finding code patterns, function usages, or text across the codebase. ' +
+            'Do NOT use this for finding files by name - use findFilesByPattern instead.',
             parameters: {
                 type: 'object',
                 properties: {

--- a/packages/ai-ide/src/browser/workspace-task-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-task-provider.ts
@@ -32,13 +32,19 @@ export class TaskListProvider implements ToolProvider {
         return {
             id: LIST_TASKS_FUNCTION_ID,
             name: LIST_TASKS_FUNCTION_ID,
-            description: 'Lists available tool tasks in the workspace, such as build, run, test. Tasks can be filtered by name.',
+            description: 'Lists available tasks in the workspace that can be executed with runTask. Returns an array ' +
+                'of task labels (strings). Common task types include npm scripts, shell tasks, and build tasks. ' +
+                'Use the filter parameter with an empty string "" to retrieve all tasks, or provide a substring ' +
+                'to filter (e.g., "test" returns tasks containing "test" in the name). ' +
+                'Example return: ["npm: build", "npm: test", "npm: lint"]. ' +
+                'Always call this before runTask to discover exact task names.',
             parameters: {
                 type: 'object',
                 properties: {
                     filter: {
                         type: 'string',
-                        description: 'Filter to apply on task names (empty string to retrieve all tasks).'
+                        description: 'Substring filter for task names. Use "" (empty string) to retrieve all tasks, ' +
+                            'or a keyword like "build", "test", "lint" to filter results.'
                     }
                 },
                 required: ['filter']
@@ -75,13 +81,19 @@ export class TaskRunnerProvider implements ToolProvider {
         return {
             id: RUN_TASK_FUNCTION_ID,
             name: RUN_TASK_FUNCTION_ID,
-            description: 'Executes a specified task.',
+            description: 'Executes a specified task by name and waits for completion. Returns the terminal output ' +
+                '(first and last 50 lines if output exceeds this limit). The task must exist in the workspace ' +
+                '(use listTasks to discover available tasks). Common task types include: build tasks ' +
+                '(e.g., "npm: build"), test tasks (e.g., "npm: test"), and lint tasks (e.g., "npm: lint"). ' +
+                'If the task fails, the error output is included in the response. Tasks may take significant ' +
+                'time to complete (builds can take minutes). The operation can be cancelled by the user. ' +
+                'Do NOT use this for tasks you haven\'t discovered via listTasks first.',
             parameters: {
                 type: 'object',
                 properties: {
                     taskName: {
                         type: 'string',
-                        description: 'The name of the task to execute.'
+                        description: 'The exact name/label of the task to execute, as returned by listTasks.'
                     }
                 },
                 required: ['taskName']


### PR DESCRIPTION
 Improves AI tool descriptions to provide better guidance for the Coder agent, hopefully resulting in more effective tool usage and fewer errors.

  Key improvements:
  - runTask/listTasks: Added output format details, examples, and cross-references
  - *FileReplacements: Added failure recovery guidance explaining "Expected 1 found X" errors
  - searchInWorkspace: Made 30-result limit prominent, added "when NOT to use" guidance
  - getFileDiagnostics: Documented severity filtering (Error/Warning only) and language service timing
  - findFilesByPattern: Added performance warning and subdirectory optimization advice
  - All tools: Standardized parameter descriptions with examples and added "when to use" alternatives

 #### How to test

  1. Use the Coder agent in agent mode
  2. Verify the agent makes better tool choices (e.g., uses findFilesByPattern for file discovery, searchInWorkspace for content search)
  3. Verify the agent recovers better from replacement failures by re-reading files and adjusting oldContent


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
