### PR TITLE
fix(ai-chat-ui): Highlight referenced tools in users' chat messages

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -23,6 +23,7 @@ import {
     ChatService,
     EditableChatRequestModel,
     ParsedChatRequestAgentPart,
+    ParsedChatRequestFunctionPart,
     ParsedChatRequestVariablePart,
     type ChatRequest,
     type ChatHierarchyBranch,
@@ -808,7 +809,7 @@ const ChatRequestRender = (
         <div className="theia-RequestNode">
             <p>
                 {parts.map((part, index) => {
-                    if (part instanceof ParsedChatRequestAgentPart || part instanceof ParsedChatRequestVariablePart) {
+                    if (part instanceof ParsedChatRequestAgentPart || part instanceof ParsedChatRequestVariablePart || part instanceof ParsedChatRequestFunctionPart) {
                         let description = undefined;
                         let className = '';
                         if (part instanceof ParsedChatRequestAgentPart) {
@@ -817,6 +818,9 @@ const ChatRequestRender = (
                         } else if (part instanceof ParsedChatRequestVariablePart) {
                             description = variableService.getVariable(part.variableName)?.description;
                             className = 'theia-RequestNode-VariableLabel';
+                        } else if (part instanceof ParsedChatRequestFunctionPart) {
+                            description = part.toolRequest?.description;
+                            className = 'theia-RequestNode-FunctionLabel';
                         }
                         return (
                             <HoverableLabel

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -156,7 +156,8 @@ div:last-child > .theia-ChatNode {
 }
 
 .theia-RequestNode .theia-RequestNode-AgentLabel,
-.theia-RequestNode .theia-RequestNode-VariableLabel {
+.theia-RequestNode .theia-RequestNode-VariableLabel,
+.theia-RequestNode .theia-RequestNode-FunctionLabel {
   padding: calc(var(--theia-ui-padding) * 2 / 3);
   padding-top: 0px;
   padding-bottom: 0px;

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -22,7 +22,7 @@ import { ChatContext, ChatRequest } from './chat-model';
 import { expect } from 'chai';
 import { AIVariable, DefaultAIVariableService, ResolvedAIVariable, ToolInvocationRegistryImpl, ToolRequest } from '@theia/ai-core';
 import { ILogger, Logger } from '@theia/core';
-import { ParsedChatRequestTextPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
+import { ParsedChatRequestAgentPart, ParsedChatRequestFunctionPart, ParsedChatRequestTextPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
 
 describe('ChatRequestParserImpl', () => {
     const chatAgentService = sinon.createStubInstance(ChatAgentServiceImpl);
@@ -42,10 +42,11 @@ describe('ChatRequestParserImpl', () => {
         };
         const context: ChatContext = { variables: [] };
         const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
-        expect(result.parts).to.deep.contain({
-            text: 'What is the best pizza topping?',
-            range: { start: 0, endExclusive: 31 }
-        });
+        expect(result.parts.length).to.equal(1);
+        const part = result.parts[0] as ParsedChatRequestTextPart;
+        expect(part.kind).to.equal('text');
+        expect(part.text).to.equal('What is the best pizza topping?');
+        expect(part.range).to.deep.equal({ start: 0, endExclusive: 31 });
     });
 
     it('parses text with variable name', async () => {
@@ -54,19 +55,23 @@ describe('ChatRequestParserImpl', () => {
         };
         const context: ChatContext = { variables: [] };
         const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
-        expect(result).to.deep.contain({
-            parts: [{
-                text: 'What is the ',
-                range: { start: 0, endExclusive: 12 }
-            }, {
-                variableName: 'best',
-                variableArg: undefined,
-                range: { start: 12, endExclusive: 17 }
-            }, {
-                text: ' pizza topping?',
-                range: { start: 17, endExclusive: 32 }
-            }]
-        });
+        expect(result.parts.length).to.equal(3);
+
+        const textPart1 = result.parts[0] as ParsedChatRequestTextPart;
+        expect(textPart1.kind).to.equal('text');
+        expect(textPart1.text).to.equal('What is the ');
+        expect(textPart1.range).to.deep.equal({ start: 0, endExclusive: 12 });
+
+        const varPart = result.parts[1] as ParsedChatRequestVariablePart;
+        expect(varPart.kind).to.equal('var');
+        expect(varPart.variableName).to.equal('best');
+        expect(varPart.variableArg).to.be.undefined;
+        expect(varPart.range).to.deep.equal({ start: 12, endExclusive: 17 });
+
+        const textPart2 = result.parts[2] as ParsedChatRequestTextPart;
+        expect(textPart2.kind).to.equal('text');
+        expect(textPart2.text).to.equal(' pizza topping?');
+        expect(textPart2.range).to.deep.equal({ start: 17, endExclusive: 32 });
     });
 
     it('parses text with variable name with argument', async () => {
@@ -75,19 +80,23 @@ describe('ChatRequestParserImpl', () => {
         };
         const context: ChatContext = { variables: [] };
         const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
-        expect(result).to.deep.contain({
-            parts: [{
-                text: 'What is the ',
-                range: { start: 0, endExclusive: 12 }
-            }, {
-                variableName: 'best',
-                variableArg: 'by-poll',
-                range: { start: 12, endExclusive: 25 }
-            }, {
-                text: ' pizza topping?',
-                range: { start: 25, endExclusive: 40 }
-            }]
-        });
+        expect(result.parts.length).to.equal(3);
+
+        const textPart1 = result.parts[0] as ParsedChatRequestTextPart;
+        expect(textPart1.kind).to.equal('text');
+        expect(textPart1.text).to.equal('What is the ');
+        expect(textPart1.range).to.deep.equal({ start: 0, endExclusive: 12 });
+
+        const varPart = result.parts[1] as ParsedChatRequestVariablePart;
+        expect(varPart.kind).to.equal('var');
+        expect(varPart.variableName).to.equal('best');
+        expect(varPart.variableArg).to.equal('by-poll');
+        expect(varPart.range).to.deep.equal({ start: 12, endExclusive: 25 });
+
+        const textPart2 = result.parts[2] as ParsedChatRequestTextPart;
+        expect(textPart2.kind).to.equal('text');
+        expect(textPart2.text).to.equal(' pizza topping?');
+        expect(textPart2.range).to.deep.equal({ start: 25, endExclusive: 40 });
     });
 
     it('parses text with variable name with numeric argument', async () => {
@@ -264,5 +273,33 @@ describe('ChatRequestParserImpl', () => {
 
         const varPart = result.parts[0] as ParsedChatRequestVariablePart;
         expect(varPart.variableArg).to.equal('cmd|"arg with \\"quote\\"" other');
+    });
+
+    describe('parsed chat request part kind assignments', () => {
+        it('ParsedChatRequestTextPart has kind assigned at runtime', () => {
+            const part = new ParsedChatRequestTextPart({ start: 0, endExclusive: 5 }, 'hello');
+            expect(part.kind).to.equal('text');
+        });
+
+        it('ParsedChatRequestVariablePart has kind assigned at runtime', () => {
+            const part = new ParsedChatRequestVariablePart({ start: 0, endExclusive: 5 }, 'varName', undefined);
+            expect(part.kind).to.equal('var');
+        });
+
+        it('ParsedChatRequestFunctionPart has kind assigned at runtime', () => {
+            const toolRequest: ToolRequest = {
+                id: 'testTool',
+                name: 'Test Tool',
+                handler: async () => undefined,
+                parameters: { type: 'object', properties: {} }
+            };
+            const part = new ParsedChatRequestFunctionPart({ start: 0, endExclusive: 5 }, toolRequest);
+            expect(part.kind).to.equal('function');
+        });
+
+        it('ParsedChatRequestAgentPart has kind assigned at runtime', () => {
+            const part = new ParsedChatRequestAgentPart({ start: 0, endExclusive: 5 }, 'agentId', 'agentName');
+            expect(part.kind).to.equal('agent');
+        });
     });
 });

--- a/packages/ai-chat/src/common/parsed-chat-request.ts
+++ b/packages/ai-chat/src/common/parsed-chat-request.ts
@@ -59,7 +59,7 @@ export interface ParsedChatRequestPart {
 }
 
 export class ParsedChatRequestTextPart implements ParsedChatRequestPart {
-    readonly kind: 'text';
+    readonly kind = 'text';
 
     constructor(readonly range: OffsetRange, readonly text: string) { }
 
@@ -69,7 +69,7 @@ export class ParsedChatRequestTextPart implements ParsedChatRequestPart {
 }
 
 export class ParsedChatRequestVariablePart implements ParsedChatRequestPart {
-    readonly kind: 'var';
+    readonly kind = 'var';
 
     public resolution: ResolvedAIVariable;
 
@@ -86,7 +86,7 @@ export class ParsedChatRequestVariablePart implements ParsedChatRequestPart {
 }
 
 export class ParsedChatRequestFunctionPart implements ParsedChatRequestPart {
-    readonly kind: 'function';
+    readonly kind = 'function';
     constructor(readonly range: OffsetRange, readonly toolRequest: ToolRequest) { }
 
     get text(): string {
@@ -99,7 +99,7 @@ export class ParsedChatRequestFunctionPart implements ParsedChatRequestPart {
 }
 
 export class ParsedChatRequestAgentPart implements ParsedChatRequestPart {
-    readonly kind: 'agent';
+    readonly kind = 'agent';
     constructor(readonly range: OffsetRange, readonly agentId: string, readonly agentName: string) { }
 
     get text(): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Tool function references (~functionName) in chat messages are now displayed with badge styling matching agents and variables, with hover tooltips showing tool descriptions.

- Add rendering support for ParsedChatRequestFunctionPart in ChatRequestRender
- Extend CSS selector to include .theia-RequestNode-FunctionLabel
- Fix kind property assignments in ParsedChatRequest*Part classes
- Add tests for kind property runtime assignments

Fixes #16722

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Provide a tool as part of the user message. the tool label should be highlighted.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
