### PR TITLE
Switch writeFileReplacement to V2 Replacer

### DIFF
--- a/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
@@ -27,6 +27,7 @@ import {
     SuggestFileReplacements,
     SuggestFileReplacements_Simple,
     WriteFileReplacements,
+    WriteFileReplacements_Simple,
     ClearFileChanges,
     GetProposedFileState,
     ReplaceContentInFileFunctionHelper,
@@ -108,6 +109,7 @@ describe('File Changeset Functions Cancellation Tests', () => {
         container.bind(WriteFileContent).toSelf();
         container.bind(SuggestFileReplacements_Simple).toSelf();
         container.bind(SuggestFileReplacements).toSelf();
+        container.bind(WriteFileReplacements_Simple).toSelf();
         container.bind(WriteFileReplacements).toSelf();
         container.bind(ClearFileChanges).toSelf();
         container.bind(GetProposedFileState).toSelf();
@@ -157,11 +159,11 @@ describe('File Changeset Functions Cancellation Tests', () => {
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
     });
 
-    it('WriteFileReplacements should respect cancellation token', async () => {
-        const writeFileReplacements = container.get(WriteFileReplacements);
+    it('WriteFileReplacements_Simple should respect cancellation token', async () => {
+        const writeFileReplacementsSimple = container.get(WriteFileReplacements_Simple);
         cancellationTokenSource.cancel();
 
-        const handler = writeFileReplacements.getTool().handler;
+        const handler = writeFileReplacementsSimple.getTool().handler;
         const result = await handler(
             JSON.stringify({
                 path: 'test.txt',
@@ -172,6 +174,29 @@ describe('File Changeset Functions Cancellation Tests', () => {
 
         const jsonResponse = typeof result === 'string' ? JSON.parse(result) : result;
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
+    });
+
+    it('WriteFileReplacements should respect cancellation token with V2 implementation', async () => {
+        const writeFileReplacements = container.get(WriteFileReplacements);
+        cancellationTokenSource.cancel();
+
+        const handler = writeFileReplacements.getTool().handler;
+        const result = await handler(
+            JSON.stringify({
+                path: 'test.txt',
+                replacements: [{ oldContent: 'old', newContent: 'new', multiple: true }]
+            }),
+            mockCtx as MutableChatRequestModel
+        );
+
+        const jsonResponse = typeof result === 'string' ? JSON.parse(result) : result;
+        expect(jsonResponse.error).to.equal('Operation cancelled by user');
+    });
+
+    it('WriteFileReplacements should have correct ID', () => {
+        const writeFileReplacements = container.get(WriteFileReplacements);
+        expect(WriteFileReplacements.ID).to.equal('writeFileReplacements');
+        expect(writeFileReplacements.getTool().id).to.equal('writeFileReplacements');
     });
 
     it('ClearFileChanges should respect cancellation token', async () => {

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -55,6 +55,7 @@ import {
     SuggestFileContent,
     WriteFileContent,
     WriteFileReplacements,
+    WriteFileReplacements_Simple,
     SimpleWriteFileReplacements,
     FileChangeSetTitleProvider,
     DefaultFileChangeSetTitleProvider,
@@ -174,6 +175,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindToolProvider(SuggestFileReplacements, bind);
     bindToolProvider(SuggestFileReplacements_Simple, bind);
     bindToolProvider(WriteFileReplacements, bind);
+    bindToolProvider(WriteFileReplacements_Simple, bind);
     bindToolProvider(ListChatContext, bind);
     bindToolProvider(ResolveChatContext, bind);
     bind(AIConfigurationSelectionService).toSelf().inSingletonScope();

--- a/packages/ai-ide/src/common/file-changeset-function-ids.ts
+++ b/packages/ai-ide/src/common/file-changeset-function-ids.ts
@@ -32,6 +32,19 @@ export const SUGGEST_FILE_REPLACEMENTS_ID = 'suggestFileReplacements';
  */
 export const SUGGEST_FILE_REPLACEMENTS_SIMPLE_ID = 'suggestFileReplacements_Simple';
 
+/**
+ * Default function ID for writing file replacements.
+ * Uses the improved content replacer implementation (V2) with better matching and error handling.
+ * This replaced the previous simpler implementation which is now available as WRITE_FILE_REPLACEMENTS_SIMPLE_ID.
+ */
 export const WRITE_FILE_REPLACEMENTS_ID = 'writeFileReplacements';
+
+/**
+ * Legacy function ID for writing file replacements.
+ * Uses the original content replacer implementation (V1).
+ * @deprecated This is the older implementation. Consider using WRITE_FILE_REPLACEMENTS_ID (default) instead.
+ * This implementation may be removed in a future version.
+ */
+export const WRITE_FILE_REPLACEMENTS_SIMPLE_ID = 'writeFileReplacements_Simple';
 export const CLEAR_FILE_CHANGES_ID = 'clearFileChanges';
 export const GET_PROPOSED_CHANGES_ID = 'getProposedFileState';


### PR DESCRIPTION
#### What it does

Use the V2 Replacer for "writeFileReplacement" function. The new replacer was already used for the "suggestFileReplacement" for quite a while and works more efficiently.

#### How to test

Use Theia Coder agent mode and observe the file replacement function calls. They should generally work. It will be hard to identify a difference while testing probably.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
