### PR TITLE
Improve task context variable description

### DIFF
--- a/packages/ai-ide/src/browser/task-background-summary-variable.ts
+++ b/packages/ai-ide/src/browser/task-background-summary-variable.ts
@@ -58,7 +58,19 @@ export class TaskContextSummaryVariableContribution implements AIVariableContrib
         const allSummaryRequests = context.model.context.getVariables().filter(candidate => candidate.variable.id === TASK_CONTEXT_VARIABLE.id);
         if (!allSummaryRequests.length) { return { ...request, value: '' }; }
         const allSummaries = await Promise.all(allSummaryRequests.map(summaryRequest => resolveDependency(summaryRequest).then(resolved => resolved?.value)));
-        const value = `# Current Task Context\n\n${allSummaries.map((content, index) => `## Task ${index + 1}\n\n${content}`).join('\n\n')}`;
+        const value = `# Current Task Context
+
+The following task context defines the task you are expected to work on. It was explicitly provided by the user and represents your primary objective.
+This context is authoritative: follow it unless you identify issues (e.g., outdated assumptions, technical conflicts, or unclear steps).
+The task context may contain errors or outdated assumptions. You are expected to identify and report these, not blindly execute incorrect instructions.
+Note: This context is a snapshot from the start of the conversation and will not update during this run.
+When deviating from the plan:
+- Explain the deviation and your reasoning before proceeding
+- Summarize all deviations at the end of your response, and suggest updates to the task context if the plan needs revision
+
+---
+
+${allSummaries.map((content, index) => `## Task ${index + 1}\n\n${content}`).join('\n\n')}`;
         return {
             ...request,
             value


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Improves the description of the task context summary variable to explain to the agent what the task context is and how to handle this information.

#### How to test

In general, it should just better follow and manage task contexts. I tested this with ~ 10 runs with good results. One particular test case is to run the attached task context and observe that it does not implement one step and report this at the end.
[File-Changeset-Functions-Simplificatio.md](https://github.com/user-attachments/files/24545875/File-Changeset-Functions-Simplificatio.md)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

