### PR TITLE
fix: remote MCP server state and improve UX

### DIFF
--- a/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ReactWidget } from '@theia/core/lib/browser';
+import { codicon, ReactWidget } from '@theia/core/lib/browser';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { HoverService } from '@theia/core/lib/browser/hover-service';
@@ -148,8 +148,8 @@ export class AIMCPConfigurationWidget extends ReactWidget {
 
     protected renderServerHeader(server: MCPServerDescription): React.ReactNode {
         const isStoppable = server.status === MCPServerStatus.Running
-            || server.status === MCPServerStatus.Connected
-            || server.status === MCPServerStatus.Starting
+            || server.status === MCPServerStatus.Connected;
+        const isStarting = server.status === MCPServerStatus.Starting
             || server.status === MCPServerStatus.Connecting;
         const isStartable = server.status === MCPServerStatus.NotRunning
             || server.status === MCPServerStatus.NotConnected
@@ -157,10 +157,14 @@ export class AIMCPConfigurationWidget extends ReactWidget {
 
         const isRemote = isRemoteMCPServerDescription(server);
         const startIcon = isRemote ? 'plug' : 'play';
-        const stopIcon = isRemote ? 'debug-disconnect' : 'close';
+        const startingIcon = 'loading';
+        const stopIcon = isRemote ? 'debug-disconnect' : 'debug-stop';
         const startLabel = isRemote
             ? nls.localize('theia/ai/mcpConfiguration/connectServer', 'Connect')
             : nls.localizeByDefault('Start Server');
+        const startingLabel = isRemote
+            ? nls.localize('theia/ai/mcpConfiguration/connectingServer', 'Connecting...')
+            : nls.localizeByDefault('Starting...');
         const stopLabel = isRemote
             ? nls.localizeByDefault('Disconnect')
             : nls.localizeByDefault('Stop Server');
@@ -172,14 +176,21 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                     {this.renderStatusBadge(server)}
                     {isStartable && (
                         <button
-                            className={`mcp-action-button codicon codicon-${startIcon}`}
+                            className={`mcp-action-button ${codicon(startIcon)}`}
                             onClick={() => this.handleStartServer(server.name)}
                             title={startLabel}
                         />
                     )}
+                    {isStarting && (
+                        <button
+                            className={`mcp-action-button ${codicon(startingIcon)} theia-animation-spin`}
+                            disabled
+                            title={startingLabel}
+                        />
+                    )}
                     {isStoppable && (
                         <button
-                            className={`mcp-action-button codicon codicon-${stopIcon}`}
+                            className={`mcp-action-button ${codicon(stopIcon)}`}
                             onClick={() => this.handleStopServer(server.name)}
                             title={stopLabel}
                         />

--- a/packages/ai-ide/src/browser/style/widgets/mcp-configuration.css
+++ b/packages/ai-ide/src/browser/style/widgets/mcp-configuration.css
@@ -103,6 +103,14 @@
   font-size: var(--theia-ui-font-size2);
 }
 
+.mcp-action-button:disabled {
+  cursor: default;
+}
+
+.mcp-action-button:disabled:hover {
+  background: inherit;
+}
+
 .mcp-action-button:hover {
   background-color: var(--theia-list-hoverBackground);
 }

--- a/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
+++ b/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
@@ -39,7 +39,7 @@ export class MCPServerManagerImpl implements MCPServerManager {
     async getRunningServers(): Promise<string[]> {
         const runningServers: string[] = [];
         for (const [name, server] of this.servers.entries()) {
-            if (server.isRunnning()) {
+            if (server.isRunning()) {
                 runningServers.push(name);
             }
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Suppress error callback when remote server is already stopped, to avoid faulty error state if connection was aborted
- Add spinning loading indicator during server start/connect
- Disable action button while server is starting or connecting

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Start and stop remote and local MCP servers manually and check if the UI behaves as expected (showing the correct states and icons)
  - When stopping a remote MCP server it should now also stop correctly and not show an error after stopping.
- Test an error case that it still shows if the MCP could not be started correctly (e.g. wrong url or command)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
