### PR TITLE
[merge editor] Fix `Go to Previous Unhandled Conflict` doing nothing

### DIFF
--- a/packages/scm/src/browser/merge-editor/merge-editor.ts
+++ b/packages/scm/src/browser/merge-editor/merge-editor.ts
@@ -440,9 +440,10 @@ export class MergeEditor extends BaseWidget implements StatefulWidget, SaveableS
 
     goToNextMergeRange(predicate: (mergeRange: MergeRange) => boolean = () => true): void {
         const pane = this.currentPane ?? this.resultPane;
-        const lineNumber = pane.cursorLine;
+        const { cursorLine } = pane;
+        const isAfterCursorLine = (mergeRange: MergeRange) => pane.getLineRangeForMergeRange(mergeRange).startLineNumber > cursorLine;
         const nextMergeRange =
-            this.model.mergeRanges.find(mergeRange => predicate(mergeRange) && pane.getLineRangeForMergeRange(mergeRange).startLineNumber > lineNumber) ||
+            this.model.mergeRanges.find(mergeRange => predicate(mergeRange) && isAfterCursorLine(mergeRange)) ||
             this.model.mergeRanges.find(mergeRange => predicate(mergeRange));
         if (nextMergeRange) {
             pane.goToMergeRange(nextMergeRange);
@@ -451,9 +452,13 @@ export class MergeEditor extends BaseWidget implements StatefulWidget, SaveableS
 
     goToPreviousMergeRange(predicate: (mergeRange: MergeRange) => boolean = () => true): void {
         const pane = this.currentPane ?? this.resultPane;
-        const lineNumber = pane.cursorLine;
+        const { cursorLine } = pane;
+        const isBeforeCursorLine = (mergeRange: MergeRange) => {
+            const lineRange = pane.getLineRangeForMergeRange(mergeRange);
+            return lineRange.isEmpty ? lineRange.startLineNumber < cursorLine : lineRange.endLineNumberExclusive <= cursorLine;
+        };
         const previousMergeRange =
-            ArrayUtils.findLast(this.model.mergeRanges, mergeRange => predicate(mergeRange) && pane.getLineRangeForMergeRange(mergeRange).endLineNumberExclusive <= lineNumber) ||
+            ArrayUtils.findLast(this.model.mergeRanges, mergeRange => predicate(mergeRange) && isBeforeCursorLine(mergeRange)) ||
             ArrayUtils.findLast(this.model.mergeRanges, mergeRange => predicate(mergeRange));
         if (previousMergeRange) {
             pane.goToMergeRange(previousMergeRange);


### PR DESCRIPTION
#### What it does

Fixes #16837.

- Fixes a bug in `MergeEditor.goToPreviousMergeRange`
- Aligns the implementation of `MergeEditor.goToNextMergeRange` with the new implementation of `goToPreviousMergeRange` (without changing its behavior)

#### How to test

Use the reproduction steps in #16837 to verify that the issue is fixed.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
