### PR TITLE
fix: handle notification timeout correctly when set to 0

### DIFF
--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -58,6 +58,14 @@ const SampleSelectDialog: Command = {
     id: 'sample-command-select-dialog',
     label: 'Sample Select Component Dialog'
 };
+const SamplePersistentNotification: Command = {
+    id: 'sample-persistent-notification',
+    label: 'Sample Persistent Notification (No Timeout)'
+};
+const SampleVanishingNotification: Command = {
+    id: 'sample-vanishing-notification',
+    label: 'Sample Vanishing Notification (500ms Timeout)'
+};
 
 @injectable()
 export class SampleCommandContribution implements CommandContribution {
@@ -216,6 +224,22 @@ export class SampleCommandContribution implements CommandContribution {
                         }, 6000);
                         window.setTimeout(() => progress.cancel(), 7000);
                     });
+            }
+        });
+        commands.registerCommand(SamplePersistentNotification, {
+            execute: () => {
+                this.messageService.info(
+                    'This notification will stay visible until you dismiss it manually.',
+                    { timeout: 0 }
+                );
+            }
+        });
+        commands.registerCommand(SampleVanishingNotification, {
+            execute: () => {
+                this.messageService.info(
+                    'This notification will stay visible for 500ms.',
+                    { timeout: 500 }
+                );
             }
         });
     }

--- a/packages/messages/src/browser/notifications-manager.spec.ts
+++ b/packages/messages/src/browser/notifications-manager.spec.ts
@@ -1,0 +1,112 @@
+// *****************************************************************************
+// Copyright (C) 2026 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { Message } from '@theia/core/lib/common';
+import { NotificationManager } from './notifications-manager';
+import { NotificationPreferences } from '../common/notification-preferences';
+import { NotificationContentRenderer } from './notification-content-renderer';
+
+disableJSDOM();
+
+describe('NotificationManager', () => {
+
+    const DEFAULT_TIMEOUT = 30000;
+
+    class TestableNotificationManager extends NotificationManager {
+        public testGetTimeout(plainMessage: Message): number {
+            return this.getTimeout(plainMessage);
+        }
+    }
+
+    function createNotificationManager(preferenceTimeout: number = DEFAULT_TIMEOUT): TestableNotificationManager {
+        const manager = new TestableNotificationManager();
+        (manager as unknown as { preferences: Partial<NotificationPreferences> }).preferences = {
+            'notification.timeout': preferenceTimeout
+        };
+        (manager as unknown as { contentRenderer: NotificationContentRenderer }).contentRenderer = new NotificationContentRenderer();
+        return manager;
+    }
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    describe('getTimeout', () => {
+
+        let manager: TestableNotificationManager = createNotificationManager();
+
+        it('should return preference timeout when no options are provided', () => {
+            const message: Message = { text: 'Test message' };
+            expect(manager.testGetTimeout(message)).to.equal(DEFAULT_TIMEOUT);
+        });
+
+        it('should return preference timeout when options are provided without timeout', () => {
+            const message: Message = { text: 'Test message', options: {} };
+            expect(manager.testGetTimeout(message)).to.equal(DEFAULT_TIMEOUT);
+        });
+
+        it('should return explicit timeout when provided', () => {
+            const message: Message = { text: 'Test message', options: { timeout: 5000 } };
+            expect(manager.testGetTimeout(message)).to.equal(5000);
+        });
+
+        it('should return 0 when timeout is explicitly set to 0', () => {
+            const message: Message = { text: 'Test message', options: { timeout: 0 } };
+            expect(manager.testGetTimeout(message)).to.equal(0);
+        });
+
+        it('should return 0 when actions are present regardless of timeout', () => {
+            const message: Message = { text: 'Test message', actions: ['OK'], options: { timeout: 5000 } };
+            expect(manager.testGetTimeout(message)).to.equal(0);
+        });
+
+        it('should return 0 when actions are present and no timeout is set', () => {
+            const message: Message = { text: 'Test message', actions: ['OK', 'Cancel'] };
+            expect(manager.testGetTimeout(message)).to.equal(0);
+        });
+
+        it('should return negative timeout when explicitly set', () => {
+            const message: Message = { text: 'Test message', options: { timeout: -1 } };
+            expect(manager.testGetTimeout(message)).to.equal(-1);
+        });
+
+        it('should return explicit timeout even if custom preference timeout is available', () => {
+            const customTimeout = 60000;
+            manager = createNotificationManager(customTimeout);
+            const message: Message = { text: 'Test message', options: { timeout: 5000 } };
+            expect(manager.testGetTimeout(message)).to.equal(5000);
+        });
+
+        it('should return custom preference timeout if no timeout is set', () => {
+            const customTimeout = 60000;
+            manager = createNotificationManager(customTimeout);
+            const message: Message = { text: 'Test message' };
+            expect(manager.testGetTimeout(message)).to.equal(customTimeout);
+        });
+
+    });
+
+});

--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -229,7 +229,7 @@ export class NotificationManager extends MessageClient {
             // Ignore the timeout if at least one action is set, and we wait for user interaction.
             return 0;
         }
-        return plainMessage.options && plainMessage.options.timeout || this.preferences['notification.timeout'];
+        return plainMessage.options?.timeout !== undefined ? plainMessage.options.timeout : this.preferences['notification.timeout'];
     }
     protected isExpandable(message: string, source: string | undefined, actions: string[]): boolean {
         if (!actions.length && source) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Fix timeout logic to properly handle explicit timeout of 0
- Change condition from falsy check to undefined check to preserve 0 value if set explicitly
- Add unit tests for getTimeout method covering various timeout scenarios
- Add sample commands demonstrating persistent and vanishing notifications

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Test the different commands with either 0ms, 500ms or default notification timeout:
   - `Sample Persistent Notification` (No Timeout)
   - `Sample Vanishing Notification` (500ms Timeout)
   - `Test Positive Integer` (default timeout: 30000ms, unless overridden in the settings `notification.timeout`)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
