### PR TITLE
fix(core): change 'No reply handler' from throw to console.warn

### DIFF
--- a/packages/core/src/common/message-rpc/rpc-protocol.ts
+++ b/packages/core/src/common/message-rpc/rpc-protocol.ts
@@ -132,7 +132,9 @@ export class RpcProtocol {
             this.pendingRequests.delete(id);
             replyHandler.resolve(value);
         } else {
-            throw new Error(`No reply handler for reply with id: ${id}`);
+            // Late replies for cancelled/timed-out requests are non-critical - just warn
+            console.warn(`No reply handler for reply with id: ${id}`);
+            return;
         }
         this.disposeCancellationEventListener(id);
     }
@@ -143,7 +145,9 @@ export class RpcProtocol {
             this.pendingRequests.delete(id);
             replyHandler.reject(error);
         } else {
-            throw new Error(`No reply handler for error reply with id: ${id}`);
+            // Late error replies for cancelled/timed-out requests are non-critical - just warn
+            console.warn(`No reply handler for error reply with id: ${id}`);
+            return;
         }
         this.disposeCancellationEventListener(id);
     }


### PR DESCRIPTION
#### What it does

Changes `throw new Error` to `console.warn` in `handleReply` and `handleReplyErr` methods of `RpcProtocol`.

Late replies for cancelled or timed-out requests are non-critical conditions that should not crash the application. This can occur when:
- A request times out but the reply arrives later
- Network latency causes out-of-order message delivery
- Plugin host restarts while requests are pending

Fixes #16842

#### How to test

1. Start Theia with plugins that use RPC communication
2. Trigger scenarios where reply handlers may be missing (e.g., rapid plugin activation/deactivation)
3. Verify that warnings appear in console instead of crashes

#### Follow-ups

None identified.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of [es6kr](https://github.com/es6kr)

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)