### PR TITLE
fix: respect agentId in delegateToAgent when prompt contains @mentions

### DIFF
--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -111,7 +111,7 @@ export class AgentDelegationTool implements ToolProvider {
 
                 newSession = chatService.createSession(
                     undefined,
-                    { focus: false, agentLocked: true },
+                    { focus: false },
                     agent
                 );
 
@@ -130,7 +130,7 @@ export class AgentDelegationTool implements ToolProvider {
 
             // Send the request
             const chatRequest: ChatRequest = {
-                text: prompt,
+                text: `@${agentId} ${prompt}`,
             };
 
             let response: ChatRequestInvocation | undefined;

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -17,12 +17,13 @@
 import * as sinon from 'sinon';
 import { ChatAgentServiceImpl } from './chat-agent-service';
 import { ChatRequestParserImpl } from './chat-request-parser';
-import { ChatAgentLocation } from './chat-agents';
+import { ChatAgent, ChatAgentLocation } from './chat-agents';
 import { ChatContext, ChatRequest } from './chat-model';
 import { expect } from 'chai';
 import { AIVariable, DefaultAIVariableService, ResolvedAIVariable, ToolInvocationRegistryImpl, ToolRequest } from '@theia/ai-core';
 import { ILogger, Logger } from '@theia/core';
 import { ParsedChatRequestAgentPart, ParsedChatRequestFunctionPart, ParsedChatRequestTextPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
+import { AgentDelegationTool } from '../browser/agent-delegation-tool';
 
 describe('ChatRequestParserImpl', () => {
     const chatAgentService = sinon.createStubInstance(ChatAgentServiceImpl);
@@ -273,6 +274,106 @@ describe('ChatRequestParserImpl', () => {
 
         const varPart = result.parts[0] as ParsedChatRequestVariablePart;
         expect(varPart.variableArg).to.equal('cmd|"arg with \\"quote\\"" other');
+    });
+
+    it('treats the first @agent mention as the selector and does not allow later mentions to override it', async () => {
+        const createAgent = (id: string): ChatAgent => ({
+            id,
+            name: id,
+            description: '',
+            tags: [],
+            variables: [],
+            prompts: [],
+            agentSpecificVariables: [],
+            functions: [],
+            languageModelRequirements: [],
+            locations: [ChatAgentLocation.Panel],
+            invoke: async () => undefined,
+        });
+        const req: ChatRequest = {
+            text: '@agentA do X @agentB do Y'
+        };
+        const context: ChatContext = { variables: [] };
+
+        chatAgentService.getAgents.returns([
+            createAgent('agentA'),
+            createAgent('agentB'),
+        ]);
+
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
+        const agentParts = result.parts.filter(p => p instanceof ParsedChatRequestAgentPart) as ParsedChatRequestAgentPart[];
+
+        expect(agentParts.length).to.equal(1);
+        expect(agentParts[0].agentId).to.equal('agentA');
+        expect(agentParts[0].agentName).to.equal('agentA');
+    });
+
+    it('delegateToAgent(agentId, prompt) composes a request that forces selecting agentId even if prompt mentions other agents', async () => {
+        const createAgent = (id: string): ChatAgent => ({
+            id,
+            name: id,
+            description: '',
+            tags: [],
+            variables: [],
+            prompts: [],
+            agentSpecificVariables: [],
+            functions: [],
+            languageModelRequirements: [],
+            locations: [ChatAgentLocation.Panel],
+            invoke: async () => undefined,
+        });
+
+        const tool = new AgentDelegationTool();
+        (tool as unknown as { getChatAgentService: () => unknown }).getChatAgentService = () => ({
+            getAgent: sinon.stub().withArgs('agentA').returns(createAgent('agentA')),
+            getAgents: sinon.stub().returns([createAgent('agentA')]),
+        });
+
+        const sendRequest = sinon.stub().callsFake(async (_sessionId: string, request: ChatRequest) => {
+            const parseResult = await parser.parseChatRequest(request, ChatAgentLocation.Panel, { variables: [] });
+            const agentParts = parseResult.parts.filter(p => p instanceof ParsedChatRequestAgentPart) as ParsedChatRequestAgentPart[];
+            expect(agentParts.length).to.equal(1);
+            expect(agentParts[0].agentId).to.equal('agentA');
+
+            return {
+                requestCompleted: Promise.resolve({ cancel: () => undefined }),
+                responseCompleted: Promise.resolve({ response: { asString: () => 'ok' } }),
+            };
+        });
+
+        (tool as unknown as { getChatService: () => unknown }).getChatService = () => ({
+            getActiveSession: sinon.stub().returns(undefined),
+            setActiveSession: sinon.stub(),
+            createSession: sinon.stub().returns({
+                id: 'session-1',
+                model: {
+                    changeSet: {
+                        onDidChange: sinon.stub().returns({}),
+                        getElements: sinon.stub().returns([]),
+                        setTitle: sinon.stub(),
+                        addElements: sinon.stub(),
+                    }
+                }
+            }),
+            sendRequest,
+            deleteSession: sinon.stub().resolves(undefined),
+        });
+
+        const toolRequest = tool.getTool();
+        await toolRequest.handler(
+            JSON.stringify({ agentId: 'agentA', prompt: 'do X @agentB do Y' }),
+            {
+                session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() } },
+                response: {
+                    cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
+                    response: { addContent: sinon.stub() },
+                },
+            } as unknown as Parameters<typeof toolRequest.handler>[1]
+        );
+
+        expect(sendRequest.calledOnce).to.be.true;
+        const delegatedChatRequest = sendRequest.firstCall.args[1] as ChatRequest;
+        expect(delegatedChatRequest.text).to.equal('@agentA do X @agentB do Y');
     });
 
     describe('parsed chat request part kind assignments', () => {

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -69,7 +69,6 @@ export interface ChatSession {
     model: ChatModel;
     isActive: boolean;
     pinnedAgent?: ChatAgent;
-    agentLocked?: boolean;
 }
 
 export interface ActiveSessionChangedEvent {
@@ -105,7 +104,6 @@ export function isSessionDeletedEvent(obj: unknown): obj is SessionDeletedEvent 
 
 export interface SessionOptions {
     focus?: boolean;
-    agentLocked?: boolean;
 }
 
 /**
@@ -220,8 +218,7 @@ export class ChatServiceImpl implements ChatService {
             lastInteraction: new Date(),
             model,
             isActive: true,
-            pinnedAgent,
-            agentLocked: options?.agentLocked
+            pinnedAgent
         };
         this._sessions.push(session);
         this.setupAutoSaveForSession(session);
@@ -392,16 +389,6 @@ export class ChatServiceImpl implements ChatService {
      * Check if an agent is pinned, and use it if no other agent is mentioned.
      */
     protected getPinnedAgent(parsedRequest: ParsedChatRequest, session: ChatSession, agent: ChatAgent | undefined): ChatAgent | undefined {
-        // When agent is locked, return pinned agent directly (skip mention check)
-        // This prevents @mentions in prompts from overriding explicitly delegated agents
-        if (session.agentLocked && session.pinnedAgent) {
-            const lockedAgent = this.chatAgentService.getAgent(session.pinnedAgent.id);
-            if (lockedAgent) {
-                return lockedAgent;
-            }
-            // If locked agent is no longer available, fall through to normal resolution
-        }
-
         const mentionedAgentPart = this.getMentionedAgent(parsedRequest);
         const mentionedAgent = mentionedAgentPart ? this.chatAgentService.getAgent(mentionedAgentPart.agentId) : undefined;
         if (mentionedAgent) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
When delegateToAgent passes a prompt containing @agentName to a target agent, the mentioned agent was incorrectly overriding the explicitly specified agentId. This broke delegation when prompts referenced other agents.

Added `agentLocked` flag to ChatSession that prevents @mentions from overriding the pinned agent in delegation scenarios. Regular user sessions are unaffected.

Fixes agent resolution in ChatServiceImpl.getPinnedAgent() to check the locked flag before extracting mentioned agents from prompt text.


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Ask an agent to use `delegateToAgent` and pass a prompt containing something like: `@Universal give me a short poem about Theia`.
See that without the fix instead of the agent you ask to use the agent mentioned is used.
The real world use case is asking the AppTester agent to test the AI-Chat. This often includes the message to pass to the chat.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
