### PR TITLE
[merge editor] Fix `Mark as Handled` having no effect in some cases

### DIFF
--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -451,6 +451,10 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
         this.toDispose.dispose();
     }
 
+    isDisposed(): boolean {
+        return this.toDispose.disposed;
+    }
+
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     trigger(source: string, handlerId: string, payload: any): void {
         this.editor.trigger(source, handlerId, payload);


### PR DESCRIPTION
#### What it does

Fixes #16857.

Previously, the `Mark as Handled` action was implemented by reapplying the base state for the merge conflict to the result editor to trigger a content change event that would cause the affected merge conflict [to be marked as handled](https://github.com/eclipse-theia/theia/blob/eb4f5a2dd92f793de3cf4f80c833bc29a6b236a5/packages/scm/src/browser/merge-editor/model/merge-editor-model.ts#L297-L334). That worked good enough, including properly restoring the cursor state on undo/redo, except for one case, as identified in #16857: when the base state is empty, no content change event is triggered, so the `Mark as Handled` action has no effect.

This PR reimplements the `Mark as Handled` action, so that it explicitly marks the merge conflict as handled and no longer relies on triggering a content change event.

#### How to test

Use the reproduction steps in #16857 to verify that the issue is fixed.

For more extensive testing, the following steps can be used.

Open the 3-way merge editor with the `Merge Editor (Dev): Open Merge Editor State from JSON command` (which is available in the command palette, `F1`) using the following JSON:

```json
{
  "base": "bar\nbaz",
  "input1": "foo1\nbar\nbaz1",
  "input2": "foo2\nbar\nbaz2",
  "result": "bar\nbaz"
}
```

Verify that clicking on `Mark as Handled` in the Result pane for the first merge conflict marks the merge conflict as handled. Resolve the second merge conflict by marking it as handled or in any other way. Try undoing (`Ctrl-Z`) these actions in the Result pane and redoing them.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
