### PR TITLE
[merge editor] Fix manual resolution not detected in some cases

### DIFF
--- a/packages/scm/src/browser/merge-editor/model/merge-editor-model.ts
+++ b/packages/scm/src/browser/merge-editor/model/merge-editor-model.ts
@@ -338,7 +338,12 @@ export class MergeEditorModel implements Disposable {
 
     protected computeMergeRangeStateFromResult(mergeRange: MergeRange): MergeRangeResultState {
 
-        const resultRange = this.getLineRangeInResult(mergeRange);
+        const { originalRange: baseRange, modifiedRange: resultRange } = this.getResultLineRangeMapping(mergeRange);
+
+        if (!mergeRange.baseRange.equals(baseRange)) {
+            return 'Unrecognized';
+        }
+
         const existingLines = resultRange.getLines(this.resultDocument);
 
         const states: MergeRangeAcceptedState[] = [


### PR DESCRIPTION
#### What it does

Fixes #16868.

#### How to test

Use the reproduction steps in #16868 to verify that the issue is fixed.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
