### PR TITLE
fix(plugin): HostedPluginReader loads browser plugins relying on implicit .js resolution

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -80,10 +80,10 @@ export class HostedPluginReader implements BackendApplicationContribution {
 
     /**
      * Resolves a plugin file path with fallback to .js and .cjs extensions.
-     * 
+     *
      * This handles cases where plugins reference modules without extensions,
      * which is common in Node.js/CommonJS environments.
-     * 
+     *
      */
     protected async resolveFile(absolutePath: string): Promise<string | undefined> {
         const candidates = [absolutePath];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes: #16884

The change adds a fallback mechanism to resolve plugin files with .js and .cjs extensions when the exact file path doesn't exist. This is implemented through a new resolveFile() method.

This change fixes the `vscodevim.vim` extension and potentially other extensions that run into a similar issue.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. open theia in a browser
2. install vscodevim.vim extension

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
