### PR TITLE
fix: correct the failing test

### DIFF
--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -363,10 +363,12 @@ describe('ChatRequestParserImpl', () => {
         await toolRequest.handler(
             JSON.stringify({ agentId: 'agentA', prompt: 'do X @agentB do Y' }),
             {
-                session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() } },
-                response: {
-                    cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
-                    response: { addContent: sinon.stub() },
+                request: {
+                    session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() } },
+                    response: {
+                        cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
+                        response: { addContent: sinon.stub() },
+                    },
                 },
             } as unknown as Parameters<typeof toolRequest.handler>[1]
         );


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fixes the failing test case after merging delegateToAgent fixes.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
