### PR TITLE
fix: refactor tool handler context types for type safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - [scm] refactored some of the methods pertaining to the 3-way Merge Editor implementation as part of [#16867](https://github.com/eclipse-theia/theia/pull/16867)
   - removed the `MergeEditorModel.findMergeRanges` method
   - renamed the `RangeUtils.isBeforeOrTouching` method to `isBefore`
+- [ai-chat, ai-core] refactored tool handler context types [#16899](https://github.com/eclipse-theia/theia/issues/16899): Tool handlers now receive `ToolInvocationContext` (with `cancellationToken`) instead of `MutableChatRequestModel`. Chat-bound tools should use `assertChatContext(ctx)` to access `ChatToolContext` with `request` and `response` properties.
 
 ## 1.67.0 - 12/10/2025
 

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -17,7 +17,7 @@
 import { ToolInvocationContext, ToolRequest } from '@theia/ai-core';
 import { ILogger } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
-import { ChatToolRequestService, ChatToolRequest } from '../common/chat-tool-request-service';
+import { ChatToolRequestService } from '../common/chat-tool-request-service';
 import { MutableChatRequestModel, ToolCallChatResponseContent } from '../common/chat-model';
 import { ToolConfirmationMode, ChatToolPreferences } from '../common/chat-tool-preferences';
 import { ToolConfirmationManager } from './chat-tool-preference-bindings';
@@ -37,13 +37,13 @@ export class FrontendChatToolRequestService extends ChatToolRequestService {
     @inject(ChatToolPreferences)
     protected readonly preferences: ChatToolPreferences;
 
-    protected override toChatToolRequest(toolRequest: ToolRequest, request: MutableChatRequestModel): ChatToolRequest {
+    protected override toChatToolRequest(toolRequest: ToolRequest, request: MutableChatRequestModel): ToolRequest {
         const confirmationMode = this.confirmationManager.getConfirmationMode(toolRequest.id, request.session.id, toolRequest);
 
         return {
             ...toolRequest,
-            handler: async (arg_string: string, ctx?: unknown) => {
-                const toolCallId = ToolInvocationContext.getToolCallId(ctx);
+            handler: async (arg_string: string, ctx?: ToolInvocationContext) => {
+                const toolCallId = ctx?.toolCallId;
 
                 switch (confirmationMode) {
                     case ToolConfirmationMode.DISABLED:

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -66,7 +66,7 @@ import {
     ErrorChatResponseContent,
     InformationalChatResponseContent,
 } from './chat-model';
-import { ChatToolRequest, ChatToolRequestService } from './chat-tool-request-service';
+import { ChatToolRequestService } from './chat-tool-request-service';
 import { parseContents } from './parse-contents';
 import { DefaultResponseContentFactory, ResponseContentMatcher, ResponseContentMatcherProvider } from './response-content-matcher';
 import { ImageContextVariable } from './image-context-variable';
@@ -356,9 +356,9 @@ export abstract class AbstractChatAgent implements ChatAgent {
     /**
      * Deduplicate tools by name (falling back to id) while preserving the first occurrence and order.
      */
-    protected deduplicateTools(toolRequests: ChatToolRequest[]): ChatToolRequest[] {
+    protected deduplicateTools(toolRequests: ToolRequest[]): ToolRequest[] {
         const seen = new Set<string>();
-        const deduped: ChatToolRequest[] = [];
+        const deduped: ToolRequest[] = [];
         for (const tool of toolRequests) {
             const key = tool.name ?? tool.id;
             if (!seen.has(key)) {
@@ -372,7 +372,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
     protected async sendLlmRequest(
         request: MutableChatRequestModel,
         messages: LanguageModelMessage[],
-        toolRequests: ChatToolRequest[],
+        toolRequests: ToolRequest[],
         languageModel: LanguageModel
     ): Promise<LanguageModelResponse> {
         const agentSettings = this.getLlmSettings();

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -363,12 +363,13 @@ describe('ChatRequestParserImpl', () => {
         await toolRequest.handler(
             JSON.stringify({ agentId: 'agentA', prompt: 'do X @agentB do Y' }),
             {
+                cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
                 request: {
                     session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() } },
-                    response: {
-                        cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
-                        response: { addContent: sinon.stub() },
-                    },
+                },
+                response: {
+                    cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
+                    response: { addContent: sinon.stub() },
                 },
             } as unknown as Parameters<typeof toolRequest.handler>[1]
         );

--- a/packages/ai-ide/src/browser/ai-terminal-functions.ts
+++ b/packages/ai-ide/src/browser/ai-terminal-functions.ts
@@ -14,8 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { MutableChatRequestModel } from '@theia/ai-chat';
-import { ToolProvider, ToolRequest } from '@theia/ai-core';
+import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { SUGGEST_TERMINAL_COMMAND_ID } from '../common/ai-terminal-functions';
@@ -56,8 +55,8 @@ export class SuggestTerminalCommand implements ToolProvider {
                 },
                 required: ['command']
             },
-            handler: async (args: string, ctx: MutableChatRequestModel): Promise<string> => {
-                if (ctx?.response?.cancellationToken?.isCancellationRequested) {
+            handler: async (args: string, ctx?: ToolInvocationContext): Promise<string> => {
+                if (ctx?.cancellationToken?.isCancellationRequested) {
                     return JSON.stringify({ error: 'Operation cancelled by user' });
                 }
                 // Ensure that there is a workspace

--- a/packages/ai-ide/src/browser/context-functions.spec.ts
+++ b/packages/ai-ide/src/browser/context-functions.spec.ts
@@ -20,7 +20,7 @@ FrontendApplicationConfigProvider.set({});
 import { expect } from 'chai';
 import { ListChatContext, ResolveChatContext, AddFileToChatContext } from './context-functions';
 import { CancellationTokenSource } from '@theia/core';
-import { ChatContextManager, MutableChatModel, MutableChatRequestModel, MutableChatResponseModel } from '@theia/ai-chat';
+import { ChatContextManager, ChatToolContext, MutableChatModel, MutableChatRequestModel, MutableChatResponseModel } from '@theia/ai-chat';
 import { fail } from 'assert';
 import { AIVariableResolutionRequest, ResolvedAIContextVariable } from '@theia/ai-core';
 import { ContextFileValidationService, FileValidationState } from '@theia/ai-chat/lib/browser/context-file-validation-service';
@@ -28,7 +28,7 @@ disableJSDOM();
 
 describe('Context Functions Cancellation Tests', () => {
     let cancellationTokenSource: CancellationTokenSource;
-    let mockCtx: Partial<MutableChatRequestModel>;
+    let mockCtx: ChatToolContext;
 
     before(() => {
         disableJSDOM = enableJSDOM();
@@ -42,12 +42,9 @@ describe('Context Functions Cancellation Tests', () => {
         cancellationTokenSource = new CancellationTokenSource();
         const context: Partial<ChatContextManager> = {
             addVariables: () => { },
-            getVariables: () => mockCtx.context?.variables as ResolvedAIContextVariable[]
+            getVariables: () => mockCtx.request.context?.variables as ResolvedAIContextVariable[]
         };
-        mockCtx = {
-            response: {
-                cancellationToken: cancellationTokenSource.token
-            } as MutableChatResponseModel,
+        const mockRequest = {
             context: {
                 variables: [{
                     variable: { id: 'file1', name: 'File' },
@@ -58,6 +55,11 @@ describe('Context Functions Cancellation Tests', () => {
             session: {
                 context
             } as MutableChatModel
+        } as unknown as MutableChatRequestModel;
+        mockCtx = {
+            cancellationToken: cancellationTokenSource.token,
+            request: mockRequest,
+            response: {} as MutableChatResponseModel
         };
     });
 
@@ -103,7 +105,7 @@ describe('Context Functions Cancellation Tests', () => {
 });
 
 describe('AddFileToChatContext Validation Tests', () => {
-    let mockCtx: Partial<MutableChatRequestModel>;
+    let mockCtx: ChatToolContext;
     let addedFiles: AIVariableResolutionRequest[];
 
     before(() => {
@@ -121,16 +123,18 @@ describe('AddFileToChatContext Validation Tests', () => {
             },
             getVariables: () => []
         };
-        mockCtx = {
-            response: {
-                cancellationToken: new CancellationTokenSource().token
-            } as MutableChatResponseModel,
+        const mockRequest = {
             context: {
                 variables: []
             },
             session: {
                 context
             } as MutableChatModel
+        } as unknown as MutableChatRequestModel;
+        mockCtx = {
+            cancellationToken: new CancellationTokenSource().token,
+            request: mockRequest,
+            response: {} as MutableChatResponseModel
         };
     });
 

--- a/packages/ai-ide/src/browser/file-changeset-function.spec.ts
+++ b/packages/ai-ide/src/browser/file-changeset-function.spec.ts
@@ -19,7 +19,7 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 FrontendApplicationConfigProvider.set({});
 
-import { MutableChatRequestModel } from '@theia/ai-chat';
+import { ChatToolContext, MutableChatRequestModel, MutableChatResponseModel } from '@theia/ai-chat';
 import { Container } from '@theia/core/shared/inversify';
 import { expect } from 'chai';
 import { DefaultFileChangeSetTitleProvider } from './file-changeset-functions';
@@ -42,9 +42,12 @@ describe('DefaultFileChangeSetTitleProvider', () => {
     });
 
     it('should provide the title', () => {
-        const ctx = {
-            agentId: 'test-agent',
-        } as MutableChatRequestModel;
+        const ctx: ChatToolContext = {
+            request: {
+                agentId: 'test-agent',
+            } as MutableChatRequestModel,
+            response: {} as MutableChatResponseModel
+        };
 
         const title = provider.getChangeSetTitle(ctx);
         expect(title).to.equal('Changes proposed');

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -28,7 +28,7 @@ import {
     FileDiagnosticProvider,
     WorkspaceFunctionScope
 } from './workspace-functions';
-import { MutableChatRequestModel, MutableChatResponseModel } from '@theia/ai-chat';
+import { ToolInvocationContext } from '@theia/ai-core';
 import { Container } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { URI } from '@theia/core/lib/common/uri';
@@ -42,7 +42,7 @@ disableJSDOM();
 
 describe('Workspace Functions Cancellation Tests', () => {
     let cancellationTokenSource: CancellationTokenSource;
-    let mockCtx: Partial<MutableChatRequestModel>;
+    let mockCtx: ToolInvocationContext;
     let container: Container;
 
     before(() => {
@@ -58,9 +58,7 @@ describe('Workspace Functions Cancellation Tests', () => {
 
         // Setup mock context
         mockCtx = {
-            response: {
-                cancellationToken: cancellationTokenSource.token
-            } as MutableChatResponseModel
+            cancellationToken: cancellationTokenSource.token
         };
 
         // Create a new container for each test
@@ -139,7 +137,7 @@ describe('Workspace Functions Cancellation Tests', () => {
         cancellationTokenSource.cancel();
 
         const handler = getDirectoryStructure.getTool().handler;
-        const result = await handler(JSON.stringify({}), mockCtx as MutableChatRequestModel);
+        const result = await handler(JSON.stringify({}), mockCtx);
 
         const jsonResponse = typeof result === 'string' ? JSON.parse(result) : result;
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
@@ -150,7 +148,7 @@ describe('Workspace Functions Cancellation Tests', () => {
         cancellationTokenSource.cancel();
 
         const handler = fileContentFunction.getTool().handler;
-        const result = await handler(JSON.stringify({ file: 'test.txt' }), mockCtx as MutableChatRequestModel);
+        const result = await handler(JSON.stringify({ file: 'test.txt' }), mockCtx);
 
         const jsonResponse = JSON.parse(result as string);
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
@@ -161,7 +159,7 @@ describe('Workspace Functions Cancellation Tests', () => {
         cancellationTokenSource.cancel();
 
         const handler = getWorkspaceFileList.getTool().handler;
-        const result = await handler(JSON.stringify({ path: '' }), mockCtx as MutableChatRequestModel);
+        const result = await handler(JSON.stringify({ path: '' }), mockCtx);
 
         expect(result).to.include('Operation cancelled by user');
     });
@@ -181,7 +179,7 @@ describe('Workspace Functions Cancellation Tests', () => {
         };
 
         const handler = getWorkspaceFileList.getTool().handler;
-        const result = await handler(JSON.stringify({ path: '' }), mockCtx as MutableChatRequestModel);
+        const result = await handler(JSON.stringify({ path: '' }), mockCtx);
 
         expect(result).to.include('Operation cancelled by user');
     });
@@ -191,7 +189,7 @@ describe('Workspace Functions Cancellation Tests', () => {
         cancellationTokenSource.cancel();
 
         const handler = fileDiagnosticProvider.getTool().handler;
-        const result = await handler(JSON.stringify({ file: 'test.txt' }), mockCtx as MutableChatRequestModel);
+        const result = await handler(JSON.stringify({ file: 'test.txt' }), mockCtx);
 
         const jsonResponse = JSON.parse(result as string);
         expect(jsonResponse.error).to.equal('Operation cancelled by user');

--- a/packages/ai-ide/src/browser/workspace-launch-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-launch-provider.ts
@@ -14,14 +14,13 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ToolProvider, ToolRequest } from '@theia/ai-core';
+import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
+import { CancellationToken } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { DebugConfigurationManager } from '@theia/debug/lib/browser/debug-configuration-manager';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
 import { DebugSessionOptions } from '@theia/debug/lib/browser/debug-session-options';
 import { DebugSession } from '@theia/debug/lib/browser/debug-session';
-import { MutableChatRequestModel } from '@theia/ai-chat';
-import { CancellationToken } from '@theia/core';
 import {
     LIST_LAUNCH_CONFIGURATIONS_FUNCTION_ID,
     RUN_LAUNCH_CONFIGURATION_FUNCTION_ID,
@@ -105,7 +104,7 @@ export class LaunchRunnerProvider implements ToolProvider {
                 },
                 required: ['configurationName']
             },
-            handler: async (argString: string, ctx: MutableChatRequestModel) => this.handleRunLaunchConfiguration(argString, ctx?.response?.cancellationToken)
+            handler: async (argString: string, ctx?: ToolInvocationContext) => this.handleRunLaunchConfiguration(argString, ctx?.cancellationToken)
         };
     }
 

--- a/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { CancellationTokenSource, PreferenceService } from '@theia/core';
 import { WorkspaceSearchProvider } from './workspace-search-provider';
-import { MutableChatRequestModel, MutableChatResponseModel } from '@theia/ai-chat';
+import { ToolInvocationContext } from '@theia/ai-core';
 import { Container } from '@theia/core/shared/inversify';
 import { SearchInWorkspaceService, SearchInWorkspaceCallbacks } from '@theia/search-in-workspace/lib/browser/search-in-workspace-service';
 import { WorkspaceFunctionScope } from './workspace-functions';
@@ -27,7 +27,7 @@ import { SearchInWorkspaceOptions } from '@theia/search-in-workspace/lib/common/
 
 describe('Workspace Search Provider Cancellation Tests', () => {
     let cancellationTokenSource: CancellationTokenSource;
-    let mockCtx: Partial<MutableChatRequestModel>;
+    let mockCtx: ToolInvocationContext;
     let container: Container;
     let searchService: SearchInWorkspaceService;
 
@@ -36,9 +36,7 @@ describe('Workspace Search Provider Cancellation Tests', () => {
 
         // Setup mock context
         mockCtx = {
-            response: {
-                cancellationToken: cancellationTokenSource.token
-            } as MutableChatResponseModel
+            cancellationToken: cancellationTokenSource.token
         };
 
         // Create a new container for each test
@@ -94,7 +92,7 @@ describe('Workspace Search Provider Cancellation Tests', () => {
         const handler = searchProvider.getTool().handler;
         const result = await handler(
             JSON.stringify({ query: 'test', useRegExp: false }),
-            mockCtx as MutableChatRequestModel
+            mockCtx
         );
 
         const jsonResponse = JSON.parse(result as string);

--- a/packages/ai-ide/src/browser/workspace-search-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.ts
@@ -14,8 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { MutableChatRequestModel } from '@theia/ai-chat';
-import { ToolProvider, ToolRequest } from '@theia/ai-core';
+import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
 import { inject, injectable } from '@theia/core/shared/inversify';
@@ -82,7 +81,7 @@ export class WorkspaceSearchProvider implements ToolProvider {
                 },
                 required: ['query', 'useRegExp']
             },
-            handler: (argString, ctx: MutableChatRequestModel) => this.handleSearch(argString, ctx?.response?.cancellationToken)
+            handler: (argString, ctx?: ToolInvocationContext) => this.handleSearch(argString, ctx?.cancellationToken)
         };
     }
 

--- a/packages/ai-ide/src/browser/workspace-task-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-task-provider.spec.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { CancellationTokenSource } from '@theia/core';
 import { TaskListProvider, TaskRunnerProvider } from './workspace-task-provider';
-import { MutableChatRequestModel, MutableChatResponseModel } from '@theia/ai-chat';
+import { ToolInvocationContext } from '@theia/ai-core';
 import { Container } from '@theia/core/shared/inversify';
 import { TaskService } from '@theia/task/lib/browser/task-service';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
@@ -26,7 +26,7 @@ import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget
 
 describe('Workspace Task Provider Cancellation Tests', () => {
     let cancellationTokenSource: CancellationTokenSource;
-    let mockCtx: Partial<MutableChatRequestModel>;
+    let mockCtx: ToolInvocationContext;
     let container: Container;
     let mockTaskService: TaskService;
     let mockTerminalService: TerminalService;
@@ -36,9 +36,7 @@ describe('Workspace Task Provider Cancellation Tests', () => {
 
         // Setup mock context
         mockCtx = {
-            response: {
-                cancellationToken: cancellationTokenSource.token
-            } as MutableChatResponseModel
+            cancellationToken: cancellationTokenSource.token
         };
 
         // Create a new container for each test
@@ -105,7 +103,7 @@ describe('Workspace Task Provider Cancellation Tests', () => {
         cancellationTokenSource.cancel();
 
         const handler = taskListProvider.getTool().handler;
-        const result = await handler(JSON.stringify({ filter: '' }), mockCtx as MutableChatRequestModel);
+        const result = await handler(JSON.stringify({ filter: '' }), mockCtx);
 
         const jsonResponse = JSON.parse(result as string);
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
@@ -116,7 +114,7 @@ describe('Workspace Task Provider Cancellation Tests', () => {
         cancellationTokenSource.cancel();
 
         const handler = taskRunnerProvider.getTool().handler;
-        const result = await handler(JSON.stringify({ taskName: 'build' }), mockCtx as MutableChatRequestModel);
+        const result = await handler(JSON.stringify({ taskName: 'build' }), mockCtx);
 
         const jsonResponse = JSON.parse(result as string);
         expect(jsonResponse.error).to.equal('Operation cancelled by user');

--- a/packages/ai-ide/src/browser/workspace-task-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-task-provider.ts
@@ -14,12 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ToolProvider, ToolRequest } from '@theia/ai-core';
+import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
+import { CancellationToken } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { TaskService } from '@theia/task/lib/browser/task-service';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { MutableChatRequestModel } from '@theia/ai-chat';
-import { CancellationToken } from '@theia/core';
 import { LIST_TASKS_FUNCTION_ID, RUN_TASK_FUNCTION_ID } from '../common/workspace-functions';
 
 @injectable()
@@ -49,8 +48,8 @@ export class TaskListProvider implements ToolProvider {
                 },
                 required: ['filter']
             },
-            handler: async (argString: string, ctx: MutableChatRequestModel) => {
-                if (ctx?.response?.cancellationToken?.isCancellationRequested) {
+            handler: async (argString: string, ctx?: ToolInvocationContext) => {
+                if (ctx?.cancellationToken?.isCancellationRequested) {
                     return JSON.stringify({ error: 'Operation cancelled by user' });
                 }
                 const filterArgs: { filter: string } = JSON.parse(argString);
@@ -98,7 +97,7 @@ export class TaskRunnerProvider implements ToolProvider {
                 },
                 required: ['taskName']
             },
-            handler: async (argString: string, ctx: MutableChatRequestModel) => this.handleRunTask(argString, ctx?.response?.cancellationToken)
+            handler: async (argString: string, ctx?: ToolInvocationContext) => this.handleRunTask(argString, ctx?.cancellationToken)
 
         };
     }


### PR DESCRIPTION
Many chat tools were broken by a refactoring of tool parameters. The type system did not catch that as we used `unknown` in the base interface and narrowed the type within the tools without any type checking.

#### What it does

This PR fixes the issue and cleans the architecture:
- We now express via the type system that there are tools which are chat dependent and tools which are not
- We do not force this into the framework, i.e. the tools check themselves whether they are in the correct context and throw errors if not. This allows adopters to easily avoid these checks if they are always in a specific context for their tools.
- Lifts the generic "cancellationSupport" out of the chat context (although it only works within the chat context by default).
- Any change in the interface will now immediately produce type errors if tools will be broken by it

Fixes #16899

#### How to test

Make sure all tool calls, especially the ones related to chat context and file manipulation, work.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [X] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

Technically the breaking change was introduced earlier, but now we handle it correctly.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
