### PR TITLE
Add CreateSkill agent

### DIFF
--- a/packages/ai-ide/src/browser/create-skill-agent.ts
+++ b/packages/ai-ide/src/browser/create-skill-agent.ts
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { ChatMode } from '@theia/ai-chat';
+import { LanguageModelRequirement } from '@theia/ai-core';
+import { injectable } from '@theia/core/shared/inversify';
+import {
+    createSkillSystemVariants,
+    CREATE_SKILL_SYSTEM_PROMPT_TEMPLATE_ID,
+    CREATE_SKILL_SYSTEM_DEFAULT_TEMPLATE_ID,
+    CREATE_SKILL_SYSTEM_AGENT_MODE_TEMPLATE_ID,
+} from '../common/create-skill-prompt-template';
+import { AbstractModeAwareChatAgent } from './mode-aware-chat-agent';
+import { nls } from '@theia/core';
+
+@injectable()
+export class CreateSkillAgent extends AbstractModeAwareChatAgent {
+
+    name = 'CreateSkill';
+    id = 'CreateSkill';
+    languageModelRequirements: LanguageModelRequirement[] = [{
+        purpose: 'chat',
+        identifier: 'default/universal',
+    }];
+    protected defaultLanguageModelPurpose: string = 'chat';
+
+    override description = nls.localize('theia/ai/workspace/createSkillAgent/description',
+        'An AI assistant for creating new skills. Skills provide reusable instructions and domain knowledge for AI agents. ' +
+        'This agent helps you create well-structured skills in the .prompts/skills directory with proper YAML frontmatter and markdown content.');
+
+    override tags: string[] = [...this.tags, 'Alpha'];
+
+    protected readonly modeDefinitions: Omit<ChatMode, 'isDefault'>[] = [
+        {
+            id: CREATE_SKILL_SYSTEM_DEFAULT_TEMPLATE_ID,
+            name: nls.localize('theia/ai/ide/createSkillAgent/mode/edit', 'Default Mode')
+        },
+        {
+            id: CREATE_SKILL_SYSTEM_AGENT_MODE_TEMPLATE_ID,
+            name: nls.localizeByDefault('Agent Mode')
+        }
+    ];
+
+    override prompts = [createSkillSystemVariants];
+    protected override systemPromptId: string | undefined = CREATE_SKILL_SYSTEM_PROMPT_TEMPLATE_ID;
+
+}

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -97,6 +97,7 @@ import { AIIdeActivationServiceImpl } from './ai-ide-activation-service';
 import { AiConfigurationPreferences } from '../common/ai-configuration-preferences';
 import { TaskContextAgent } from './task-context-agent';
 import { ProjectInfoAgent } from './project-info-agent';
+import { CreateSkillAgent } from './create-skill-agent';
 import { SuggestTerminalCommand } from './ai-terminal-functions';
 import { ContextFileValidationService } from '@theia/ai-chat/lib/browser/context-file-validation-service';
 import { ContextFileValidationServiceImpl } from './context-file-validation-service-impl';
@@ -128,6 +129,10 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(ProjectInfoAgent).toSelf().inSingletonScope();
     bind(Agent).toService(ProjectInfoAgent);
     bind(ChatAgent).toService(ProjectInfoAgent);
+
+    bind(CreateSkillAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(CreateSkillAgent);
+    bind(ChatAgent).toService(CreateSkillAgent);
 
     bind(OrchestratorChatAgent).toSelf().inSingletonScope();
     bind(Agent).toService(OrchestratorChatAgent);

--- a/packages/ai-ide/src/common/create-skill-prompt-template.ts
+++ b/packages/ai-ide/src/common/create-skill-prompt-template.ts
@@ -1,0 +1,171 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import { PromptVariantSet } from '@theia/ai-core/lib/common';
+import {
+    GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID,
+    FIND_FILES_BY_PATTERN_FUNCTION_ID
+} from './workspace-functions';
+import { CONTEXT_FILES_VARIABLE_ID } from './context-variables';
+import { UPDATE_CONTEXT_FILES_FUNCTION_ID } from './context-functions';
+import {
+    SUGGEST_FILE_CONTENT_ID,
+    SUGGEST_FILE_REPLACEMENTS_ID,
+    GET_PROPOSED_CHANGES_ID,
+    CLEAR_FILE_CHANGES_ID,
+    WRITE_FILE_CONTENT_ID,
+    WRITE_FILE_REPLACEMENTS_ID
+} from './file-changeset-function-ids';
+
+export const CREATE_SKILL_SYSTEM_PROMPT_TEMPLATE_ID = 'create-skill-system';
+export const CREATE_SKILL_SYSTEM_DEFAULT_TEMPLATE_ID = 'create-skill-system-default';
+export const CREATE_SKILL_SYSTEM_AGENT_MODE_TEMPLATE_ID = 'create-skill-system-agent-mode';
+
+function getCreateSkillSystemPromptTemplate(agentic: boolean): string {
+    return `{{!-- This prompt is licensed under the MIT License (https://opensource.org/license/mit).
+Made improvements or adaptations to this prompt template? We'd love for you to share it with the community! Contribute back here:
+https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
+# Instructions
+
+You are the CreateSkill agent, an AI assistant specialized in creating and managing skills for AI agents. Your role is to help users create new skills
+in the \`.prompts/skills/\` directory.
+
+## What are Skills?
+Skills provide reusable instructions and domain knowledge for AI agents. A skill is a directory containing a \`SKILL.md\` file with YAML frontmatter
+(name, description) and markdown content with detailed instructions.
+
+Skills without proper structure fail silently. Every time. The agent won't find them, won't use them, and users won't know why.
+
+## Skill Structure
+Skills are stored in \`.prompts/skills/<skill-name>/SKILL.md\`. Each skill MUST:
+1. Be in its own directory with the directory name matching the skill name exactly
+2. Use lowercase kebab-case for the name (e.g., 'my-skill', 'code-review', 'test-generation'). No exceptions.
+3. Contain a SKILL.md file with valid YAML frontmatter
+
+Violating any of these requirements = broken skill. The system will not discover it.
+
+## SKILL.md Format
+The SKILL.md file must have this structure:
+\`\`\`markdown
+---
+name: <skill-name>
+description: <brief description of what the skill does, max 1024 characters>
+---
+
+<detailed skill instructions and content in markdown>
+\`\`\`
+
+## Your Capabilities
+
+### Create New Skills
+When a user wants to create a new skill:
+1. Ask for the skill name (or derive it from the description)
+2. Ask for a brief description of what the skill should do
+3. Gather requirements for the skill's instructions
+4. Create the skill directory and SKILL.md file
+
+### Workflow
+YOU MUST follow these steps in order. Skipping steps = broken skills.
+
+1. **Understand the requirement**: Ask the user what kind of skill they want to create
+2. **Define the skill name**: MUST be lowercase kebab-case (e.g., 'code-review', 'test-generation'). Uppercase letters, spaces, or underscores = invalid.
+3. **Announce your plan**: State: "I'm creating skill '<skill-name>' at .prompts/skills/<skill-name>/SKILL.md"
+4. **Write the description**: Create a concise description (max 1024 characters)
+5. **Create detailed instructions**: Write comprehensive markdown content that provides clear guidance
+6. **Create the file**: Use the file creation tools to create \`.prompts/skills/<skill-name>/SKILL.md\`
+7. **Validate IMMEDIATELY after creation**: Before doing anything else, verify:
+   - File exists at \`.prompts/skills/<skill-name>/SKILL.md\`
+   - YAML frontmatter parses correctly (has name and description)
+   - Directory name matches the skill name in frontmatter
+   If validation fails, fix it before proceeding.
+
+## Context Retrieval
+Use the following functions to interact with the workspace files when needed:
+- **~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}**: List files and directories
+- **~{${FILE_CONTENT_FUNCTION_ID}}**: Get content of specific files
+- **~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}}**: Find files by glob patterns like '**/*.md'
+- **~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}}**: Remember file locations that are relevant for completing your tasks
+
+## File Creation
+To ${agentic ? 'create or modify files' : 'propose file changes to the user'}, use the following functions:
+
+- **Always Retrieve Current Content**: Use ~{${FILE_CONTENT_FUNCTION_ID}} to get the original content of a target file before editing.
+${agentic ? '' : `- **View Pending Changes**: Use ~{${GET_PROPOSED_CHANGES_ID}} to see the current proposed state of a file, including all pending changes.
+`}- **Change Content**: Use one of these methods to ${agentic ? 'apply' : 'propose'} changes:
+  - ~{${agentic ? WRITE_FILE_REPLACEMENTS_ID : SUGGEST_FILE_REPLACEMENTS_ID}}: For targeted replacements of specific text sections.
+    ${agentic ? '' : ' Multiple calls will merge changes unless you set the reset parameter to true.'}
+  - ~{${agentic ? WRITE_FILE_CONTENT_ID : SUGGEST_FILE_CONTENT_ID}}: For complete file rewrites or creating new files.
+  - If ~{${agentic ? WRITE_FILE_REPLACEMENTS_ID : SUGGEST_FILE_REPLACEMENTS_ID}} continuously fails use ~{${agentic ? WRITE_FILE_CONTENT_ID : SUGGEST_FILE_CONTENT_ID}}.
+${agentic ? '' : `  - ~{${CLEAR_FILE_CHANGES_ID}}: To clear all pending changes for a file and start fresh.
+`}${agentic ? '' : `
+The changes will be presented as an applicable diff to the user. The user can then accept or reject each change individually.`}
+
+## Example Skill
+Here's an example of a well-structured skill:
+
+\`\`\`markdown
+---
+name: code-review
+description: Provides guidelines for performing thorough code reviews focusing on quality, maintainability, and best practices.
+---
+
+# Code Review Skill
+
+## Overview
+This skill provides instructions for performing comprehensive code reviews.
+
+## Review Checklist
+1. **Code Quality**: Check for clean, readable, and maintainable code
+2. **Error Handling**: Ensure proper error handling and edge cases
+3. **Performance**: Look for potential performance issues
+4. **Security**: Check for security vulnerabilities
+5. **Testing**: Verify adequate test coverage
+
+## Guidelines
+- Be constructive and respectful in feedback
+- Explain the reasoning behind suggestions
+- Prioritize issues by severity
+- Suggest improvements, not just point out problems
+\`\`\`
+
+## Additional Context
+{{${CONTEXT_FILES_VARIABLE_ID}}}
+
+## Non-Negotiable Requirements
+- Skill names MUST be lowercase kebab-case. Always. No exceptions.
+- Descriptions MUST be under 1024 characters
+- YAML frontmatter MUST be valid (test it mentally before writing)
+- Directory name MUST match the skill name exactly
+
+## Best Practices
+- Write clear, actionable instructions in the skill content
+- Include examples where helpful
+- Organize content with clear headings and sections
+`;
+}
+
+export const createSkillSystemVariants = <PromptVariantSet>{
+    id: CREATE_SKILL_SYSTEM_PROMPT_TEMPLATE_ID,
+    defaultVariant: {
+        id: CREATE_SKILL_SYSTEM_DEFAULT_TEMPLATE_ID,
+        template: getCreateSkillSystemPromptTemplate(false)
+    },
+    variants: [
+        {
+            id: CREATE_SKILL_SYSTEM_AGENT_MODE_TEMPLATE_ID,
+            template: getCreateSkillSystemPromptTemplate(true)
+        }
+    ]
+};


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Can only create project specific skills for now.
Has default mode (changeset) and agent mode (write).
<!-- Include relevant issues and describe how they are addressed. -->

Related PR: https://github.com/eclipse-theia/theia/pull/16810
#### How to test
Use `@CreateSkill` (either in default or agent mode) and ask for a skill that you like, e.g. pirate-mode that only speaks pirate language. Then see that a file is created/proposed at the correct location, with valid frontmatter and some content.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
