### PR TITLE
Set deepl auth header

### DIFF
--- a/dev-packages/localization-manager/src/deepl-api.ts
+++ b/dev-packages/localization-manager/src/deepl-api.ts
@@ -40,7 +40,7 @@ export async function deepl(
         const parameterCopy: DeeplParameters = { ...parameters, text: chunk };
         const url = `https://${sub_domain}.deepl.com/v2/translate`;
         const buffer = Buffer.from(toFormData(parameterCopy));
-        return postWithRetry(url, buffer, 1);
+        return postWithRetry(url, parameters.auth_key, buffer, 1);
     }));
     const mergedResponse: DeeplResponse = { translations: [] };
     for (const response of responses) {
@@ -52,17 +52,18 @@ export async function deepl(
     return mergedResponse;
 }
 
-async function postWithRetry(url: string, buffer: Buffer, attempt: number): Promise<DeeplResponse> {
+async function postWithRetry(url: string, key: string, buffer: Buffer, attempt: number): Promise<DeeplResponse> {
     try {
         await rateLimiter.removeTokens(Math.min(attempt, 10));
         const response = await post(url, buffer, {
             'Content-Type': 'application/x-www-form-urlencoded',
-            'User-Agent': 'Theia-Localization-Manager'
+            'User-Agent': 'Theia-Localization-Manager',
+            'Authorization': 'DeepL-Auth-Key ' + key
         });
         return response;
     } catch (e) {
         if ('message' in e && typeof e.message === 'string' && e.message.includes('Too Many Requests')) {
-            return postWithRetry(url, buffer, attempt + 1);
+            return postWithRetry(url, key, buffer, attempt + 1);
         }
         throw e;
     }


### PR DESCRIPTION
#### What it does

Fixes the recent 403 translation errors. It looks like DeepL no longer requires to set the key in the body, but instead in the request header (which makes more sense to be honest). I'll clean up the deepl request code in a separate PR. This is just to fix the immediate issue.

#### How to test

Run the localization script locally. It should work as expected (after setting a key).

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
