### PR TITLE
fix: pass toolCallId across RPC and normalize empty tool arguments

### DIFF
--- a/packages/ai-chat/src/common/chat-tool-request-service.spec.ts
+++ b/packages/ai-chat/src/common/chat-tool-request-service.spec.ts
@@ -1,0 +1,97 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { isEmptyToolArgs, normalizeToolArgs } from './chat-tool-request-service';
+
+describe('Tool Arguments Utilities', () => {
+
+    describe('isEmptyToolArgs', () => {
+        it('should return true for undefined', () => {
+            expect(isEmptyToolArgs(undefined)).to.be.true;
+        });
+
+        it('should return true for empty string', () => {
+            expect(isEmptyToolArgs('')).to.be.true;
+        });
+
+        it('should return true for empty JSON object', () => {
+            expect(isEmptyToolArgs('{}')).to.be.true;
+        });
+
+        it('should return true for empty JSON object with whitespace', () => {
+            expect(isEmptyToolArgs('{ }')).to.be.true;
+            expect(isEmptyToolArgs('{  }')).to.be.true;
+            expect(isEmptyToolArgs('{\n}')).to.be.true;
+            expect(isEmptyToolArgs('{ \n }')).to.be.true;
+        });
+
+        it('should return false for non-empty JSON object', () => {
+            expect(isEmptyToolArgs('{"key": "value"}')).to.be.false;
+            expect(isEmptyToolArgs('{"file": "test.ts"}')).to.be.false;
+        });
+
+        it('should return false for JSON array', () => {
+            expect(isEmptyToolArgs('[]')).to.be.false;
+            expect(isEmptyToolArgs('[1, 2, 3]')).to.be.false;
+        });
+
+        it('should return false for invalid JSON', () => {
+            expect(isEmptyToolArgs('not json')).to.be.false;
+            expect(isEmptyToolArgs('{')).to.be.false;
+            expect(isEmptyToolArgs('{"truncated')).to.be.false;
+        });
+
+        it('should return false for JSON primitives', () => {
+            expect(isEmptyToolArgs('null')).to.be.false;
+            expect(isEmptyToolArgs('true')).to.be.false;
+            expect(isEmptyToolArgs('42')).to.be.false;
+            expect(isEmptyToolArgs('"string"')).to.be.false;
+        });
+    });
+
+    describe('normalizeToolArgs', () => {
+        it('should normalize undefined to empty string', () => {
+            expect(normalizeToolArgs(undefined)).to.equal('');
+        });
+
+        it('should normalize empty string to empty string', () => {
+            expect(normalizeToolArgs('')).to.equal('');
+        });
+
+        it('should normalize empty JSON object to empty string', () => {
+            expect(normalizeToolArgs('{}')).to.equal('');
+            expect(normalizeToolArgs('{ }')).to.equal('');
+        });
+
+        it('should preserve non-empty JSON arguments', () => {
+            const args = '{"file": "test.ts"}';
+            expect(normalizeToolArgs(args)).to.equal(args);
+        });
+
+        it('should preserve invalid JSON as-is', () => {
+            const args = 'not json';
+            expect(normalizeToolArgs(args)).to.equal(args);
+        });
+
+        it('should allow matching empty arguments from different representations', () => {
+            const fromStream = '{}';
+            const fromHandler = '';
+
+            expect(normalizeToolArgs(fromStream)).to.equal(normalizeToolArgs(fromHandler));
+        });
+    });
+});

--- a/packages/ai-chat/src/common/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/common/chat-tool-request-service.ts
@@ -19,6 +19,30 @@ import { injectable } from '@theia/core/shared/inversify';
 import { MutableChatRequestModel, MutableChatResponseModel } from './chat-model';
 
 /**
+ * Checks if the given arguments string represents empty tool arguments.
+ * Handles different representations: '', undefined, '{}', '{ }', etc.
+ */
+export function isEmptyToolArgs(args: string | undefined): boolean {
+    if (!args) {
+        return true;
+    }
+    try {
+        const parsed = JSON.parse(args);
+        return typeof parsed === 'object' && !!parsed && !Array.isArray(parsed) && Object.keys(parsed).length === 0;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Normalizes tool arguments for comparison purposes.
+ * Empty arguments (undefined, '', '{}') are normalized to '' for consistent comparison.
+ */
+export function normalizeToolArgs(args: string | undefined): string {
+    return isEmptyToolArgs(args) ? '' : args!;
+}
+
+/**
  * Context object passed to tool handlers when invoked within a chat session.
  * Extends ToolInvocationContext to include chat-specific information.
  */

--- a/packages/ai-core/src/common/language-model-delegate.ts
+++ b/packages/ai-core/src/common/language-model-delegate.ts
@@ -22,7 +22,7 @@ import {
 
 export const LanguageModelDelegateClient = Symbol('LanguageModelDelegateClient');
 export interface LanguageModelDelegateClient {
-    toolCall(requestId: string, toolId: string, args_string: string): Promise<ToolCallResult>;
+    toolCall(requestId: string, toolId: string, args_string: string, toolCallId?: string): Promise<ToolCallResult>;
     send(id: string, token: LanguageModelStreamResponsePart | undefined): void;
     error(id: string, error: Error): void;
 }

--- a/packages/ai-core/src/node/language-model-frontend-delegate.ts
+++ b/packages/ai-core/src/node/language-model-frontend-delegate.ts
@@ -80,7 +80,7 @@ export class LanguageModelFrontendDelegateImpl implements LanguageModelFrontendD
             );
         }
         request.tools?.forEach(tool => {
-            tool.handler = async args_string => this.frontendDelegateClient.toolCall(requestId, tool.id, args_string);
+            tool.handler = async (args_string, ctx) => this.frontendDelegateClient.toolCall(requestId, tool.id, args_string, ctx?.toolCallId);
         });
         if (cancellationToken) {
             const tokenSource = new CancellationTokenSource();


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Pass toolCallId from backend to frontend via RPC for proper tool call matching
- Normalize empty arguments ('', '{}') for comparison

The `toolCallId` was not passed via the RCP gap, which means that it could not be used for tool call matching. This is now fixed.

Also fixes an issue with the fallback of tool call id matching, which is name + arguments matching. The arguments are not consistent in case of empty parameter tool calls, comparing {} to ''. They are now normalized to fix this issue too.

#### How to test

Execute tool calls without parameters, e.g. `getWorkspaceDirectoryStructure` with an Anthropic model and observe that there are no warnings in the console

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
