### PR TITLE
fix: prevent restart dialog on startup for empty windows

### DIFF
--- a/packages/workspace/src/browser/workspace-trust-service.ts
+++ b/packages/workspace/src/browser/workspace-trust-service.ts
@@ -394,12 +394,11 @@ export class WorkspaceTrustService {
                 this.storage.setData(STORAGE_TRUSTED, undefined);
             }
 
-            if (change.preferenceName === WORKSPACE_TRUST_ENABLED && this.isWorkspaceTrustResolved() && await this.confirmRestart()) {
-                this.windowService.setSafeToShutDown();
-                this.windowService.reload();
-            }
-
             if (change.preferenceName === WORKSPACE_TRUST_ENABLED) {
+                if (!await this.isEmptyWorkspace() && this.isWorkspaceTrustResolved() && await this.confirmRestart()) {
+                    this.windowService.setSafeToShutDown();
+                    this.windowService.reload();
+                }
                 this.resolveWorkspaceTrust();
             }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-16923

The restart dialog for workspace trust preference changes was incorrectly shown on startup when opening an empty window if the workspace trust enabled setting was overriden. The preference change handler now checks for empty workspaces before prompting to restart.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Set the `security.workspace.trust.enabled` manually to true via the settings UI or in the settings.json (e.g. for the browser example its default value is false, for the electron it is true)
2. If you have an opened workspace, expect a restart dialog as the setting has changed, you may skip the reload this time.
3. Close your current workspace if any or open a new empty window.
4. Verify the restart dialog due to settings changes does not appear on startup.
5. Verify the restart dialog appears as expected if you change the `security.workspace.trust.enabled` value again if you have an open workspace.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
