### PR TITLE
feat(ai-chat-ui): show tool confirmation in collapsed delegation summary

### DIFF
--- a/.prompts/project-info.prompttemplate
+++ b/.prompts/project-info.prompttemplate
@@ -78,6 +78,15 @@ which bundles the frontend via webpack. Without this step, the running browser a
 
 To start Theia as a browser app to show something to the user or for UI testing use the launch config "Start Theia Default (Browser backend, no debug)"
 
+#### Building Applications
+
+Before running or testing the application UI, you must build the application:
+
+- **Browser application:** `npm run build:browser`
+- **Electron application:** `npm run build:electron`
+
+These commands bundle the frontend and must be run after any code changes before launching the application via debug configurations.
+
 ### Preferences
 
 Theia uses a preferences system for user/workspace settings. To add new preferences:

--- a/packages/ai-chat-ui/src/browser/chat-response-part-renderer.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-part-renderer.ts
@@ -22,4 +22,10 @@ export const ChatResponsePartRenderer = Symbol('ChatResponsePartRenderer');
 export interface ChatResponsePartRenderer<T extends ChatResponseContent> {
     canHandle(response: ChatResponseContent): number;
     render(response: T, parentNode: ResponseNode): ReactNode;
+    /**
+     * Optional method to render a compact confirmation/interaction view for this content type.
+     * Used by the delegation summary to show tool-specific confirmation UI in collapsed state.
+     * If not implemented, a generic fallback confirmation UI is used.
+     */
+    renderConfirmation?(response: T, parentNode: ResponseNode): ReactNode;
 }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -152,6 +152,7 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
     private subscribeToInvocation(invocation?: ChatRequestInvocation): void {
         this.toDispose.dispose();
         this.toDispose = new DisposableCollection();
+        this.trackedInteractionIds.clear();
         if (!invocation) {
             return;
         }
@@ -194,6 +195,7 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
 
     override componentWillUnmount(): void {
         this.toDispose.dispose();
+        this.trackedInteractionIds.clear();
     }
 
     private removeResolvedInteractions(): void {
@@ -285,6 +287,7 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
                                 <span className={`codicon ${statusIcon} delegation-status-icon`}></span>
                                 <span className='delegation-status-text'>{statusText}</span>
                             </span>
+                            <span className={`delegation-toggle-arrow${isOpen ? ' open' : ''}`} />
                         </div>
                         {showInteractionsInSummary && (
                             <div className='delegation-pending-confirmations'>

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -14,8 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable } from '@theia/core/shared/inversify';
-import { ChatRequestInvocation, ChatResponseContent, ChatResponseModel, ToolCallChatResponseContent } from '@theia/ai-chat';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { ChatRequestInvocation, ChatResponseContent, ChatResponseModel, InteractiveContent, ToolCallChatResponseContent } from '@theia/ai-chat';
 import { ChatAgentService } from '@theia/ai-chat/lib/common/chat-agent-service';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
 import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-core/lib/common/tool-constants';
@@ -26,7 +26,7 @@ import { ResponseNode } from '../chat-tree-view';
 import { SubChatWidgetFactory } from '../chat-tree-view/sub-chat-widget';
 import { withToolCallConfirmation } from './tool-confirmation';
 import { CompositeTreeNode, ContextMenuRenderer } from '@theia/core/lib/browser';
-import { DisposableCollection, nls } from '@theia/core';
+import { ContributionProvider, DisposableCollection, nls } from '@theia/core';
 import * as React from '@theia/core/shared/react';
 
 @injectable()
@@ -49,6 +49,9 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
 
     @inject(ContextMenuRenderer)
     protected contextMenuRenderer: ContextMenuRenderer;
+
+    @inject(ContributionProvider) @named(ChatResponsePartRenderer)
+    protected chatResponsePartRenderers: ContributionProvider<ChatResponsePartRenderer<ChatResponseContent>>;
 
     canHandle(response: ChatResponseContent): number {
         if (ToolCallChatResponseContent.is(response) && response.name === AGENT_DELEGATION_FUNCTION_ID) {
@@ -87,15 +90,21 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
             finished={response.finished}
             parentNode={parentNode}
             subChatWidgetFactory={this.subChatWidgetFactory}
+            contextMenuRenderer={this.contextMenuRenderer}
+            chatResponsePartRenderers={this.chatResponsePartRenderers}
             response={response}
             confirmationMode={confirmationMode}
             toolConfirmationManager={this.toolConfirmationManager}
             toolRequest={toolRequest}
             chatId={chatId}
             requestCanceled={parentNode.response.isCanceled}
-            contextMenuRenderer={this.contextMenuRenderer}
         />;
     }
+}
+
+interface PendingInteraction {
+    contentPart: InteractiveContent & ChatResponseContent;
+    id: string;
 }
 
 interface DelegatedChatProps {
@@ -105,19 +114,28 @@ interface DelegatedChatProps {
     finished?: boolean;
     parentNode: ResponseNode;
     subChatWidgetFactory: SubChatWidgetFactory;
+    contextMenuRenderer: ContextMenuRenderer;
+    chatResponsePartRenderers: ContributionProvider<ChatResponsePartRenderer<ChatResponseContent>>;
 }
 
 interface DelegatedChatState {
     node?: ResponseNode;
+    isOpen: boolean;
+    pendingInteractions: PendingInteraction[];
 }
 
 class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatState> {
     private widget: ReturnType<SubChatWidgetFactory>;
     private toDispose = new DisposableCollection();
+    private trackedInteractionIds = new Set<string>();
 
     constructor(props: DelegatedChatProps) {
         super(props);
-        this.state = { node: undefined };
+        this.state = {
+            node: undefined,
+            isOpen: false,
+            pendingInteractions: []
+        };
         this.widget = props.subChatWidgetFactory();
     }
 
@@ -143,9 +161,25 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
             this.setState({ node });
 
             const changeListener = () => {
+                this.removeResolvedInteractions();
                 this.forceUpdate();
             };
             this.toDispose.push(chatModel.onDidChange(changeListener));
+
+            // Subscribe to interactionNeeded for push-based interaction tracking
+            this.toDispose.push(chatModel.onInteractionNeeded(contentPart => {
+                const id = contentPart.interactionId;
+                if (id && !this.trackedInteractionIds.has(id)
+                    && this.findConfirmationRenderer(contentPart)) {
+                    this.trackedInteractionIds.add(id);
+                    this.setState(prevState => ({
+                        pendingInteractions: [
+                            ...prevState.pendingInteractions,
+                            { contentPart, id }
+                        ]
+                    }));
+                }
+            }));
         }).catch(error => {
             console.error('Failed to create delegated chat response:', error);
         });
@@ -160,6 +194,41 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
 
     override componentWillUnmount(): void {
         this.toDispose.dispose();
+    }
+
+    private removeResolvedInteractions(): void {
+        this.setState(prevState => ({
+            pendingInteractions: prevState.pendingInteractions.filter(p => !p.contentPart.isResolved)
+        }));
+    }
+
+    private findConfirmationRenderer(contentPart: ChatResponseContent): ChatResponsePartRenderer<ChatResponseContent> | undefined {
+        const renderer = this.props.chatResponsePartRenderers.getContributions().reduce<[number, ChatResponsePartRenderer<ChatResponseContent> | undefined]>(
+            (prev, current) => {
+                const prio = current.canHandle(contentPart);
+                if (prio > prev[0]) {
+                    return [prio, current];
+                }
+                return prev;
+            },
+            [-1, undefined])[1];
+        if (renderer && renderer.renderConfirmation) {
+            return renderer;
+        }
+        return undefined;
+    }
+
+    private handleToggle = (event: React.SyntheticEvent<HTMLDetailsElement>): void => {
+        const details = event.currentTarget;
+        this.setState({ isOpen: details.open });
+    };
+
+    private renderInteractionConfirmation(contentPart: ChatResponseContent, id: string): React.ReactNode {
+        const renderer = this.findConfirmationRenderer(contentPart);
+        if (renderer && this.state.node) {
+            return <React.Fragment key={id}>{renderer.renderConfirmation!(contentPart, this.state.node)}</React.Fragment>;
+        }
+        return undefined;
     }
 
     override render(): React.ReactNode {
@@ -193,19 +262,37 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
             statusText = nls.localize('theia/ai/chat-ui/delegation-response-renderer/status/starting', 'starting...');
         }
 
+        const { isOpen, pendingInteractions } = this.state;
+        const showInteractionsInSummary = !isOpen && pendingInteractions.length > 0;
+
         return (
             <div className='theia-delegation-container'>
-                <details className='delegation-response-details'>
+                <details className='delegation-response-details' onToggle={this.handleToggle}>
                     <summary className='delegation-summary'>
                         <div className='delegation-header'>
                             <span className='delegation-agent'>
                                 <span className='codicon codicon-copilot-large' /> {agentName}
                             </span>
                             <span className='delegation-status'>
+                                {showInteractionsInSummary && (
+                                    <span className='delegation-interaction-badge' title={nls.localize(
+                                        'theia/ai/chat-ui/delegation-response-renderer/interactionNeeded',
+                                        'User interaction needed'
+                                    )}>
+                                        <span className='codicon codicon-warning'></span>
+                                    </span>
+                                )}
                                 <span className={`codicon ${statusIcon} delegation-status-icon`}></span>
                                 <span className='delegation-status-text'>{statusText}</span>
                             </span>
                         </div>
+                        {showInteractionsInSummary && (
+                            <div className='delegation-pending-confirmations'>
+                                {pendingInteractions.map(({ contentPart, id }) =>
+                                    this.renderInteractionConfirmation(contentPart, id)
+                                )}
+                            </div>
+                        )}
                     </summary>
                     <div className='delegation-content'>
                         <div className='delegation-prompt-section'>

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/question-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/question-part-renderer.tsx
@@ -43,6 +43,13 @@ export class QuestionPartRenderer
         return <SingleSelectQuestion question={question} node={node} openerService={this.openerService} />;
     }
 
+    renderConfirmation(question: QuestionResponseContent, node: ResponseNode): ReactNode {
+        if (question.multiSelect) {
+            return <MultiSelectQuestion question={question} node={node} openerService={this.openerService} />;
+        }
+        return <SingleSelectQuestion question={question} node={node} openerService={this.openerService} />;
+    }
+
 }
 
 function isResolved(question: QuestionResponseContent): boolean {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -126,6 +126,32 @@ export function useToolConfirmationState(
     return { confirmationState, rejectionReason };
 }
 
+export function createConfirmationHandlers(
+    toolId: string | undefined,
+    response: ToolCallChatResponseContent,
+    toolConfirmationManager: ToolConfirmationManager,
+    chatId: string,
+    toolRequest?: ToolRequest
+): { handleAllow: (scope: ConfirmationScope) => void; handleDeny: (scope: ConfirmationScope, reason?: string) => void } {
+    const handleAllow = (scope: ConfirmationScope): void => {
+        if (scope === 'forever' && toolId) {
+            toolConfirmationManager.setConfirmationMode(toolId, ToolConfirmationPreferenceMode.ALWAYS_ALLOW, toolRequest);
+        } else if (scope === 'session' && toolId) {
+            toolConfirmationManager.setSessionConfirmationMode(toolId, ToolConfirmationPreferenceMode.ALWAYS_ALLOW, chatId);
+        }
+        response.confirm();
+    };
+    const handleDeny = (scope: ConfirmationScope, reason?: string): void => {
+        if (scope === 'forever' && toolId) {
+            toolConfirmationManager.setConfirmationMode(toolId, ToolConfirmationPreferenceMode.DISABLED);
+        } else if (scope === 'session' && toolId) {
+            toolConfirmationManager.setSessionConfirmationMode(toolId, ToolConfirmationPreferenceMode.DISABLED, chatId);
+        }
+        response.deny(reason);
+    };
+    return { handleAllow, handleDeny };
+}
+
 export interface ToolConfirmationCallbacks {
     toolRequest?: ToolRequest;
     onAllow: (scope: ConfirmationScope) => void;

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -21,7 +21,7 @@ import { ReactNode } from '@theia/core/shared/react';
 import { nls } from '@theia/core/lib/common/nls';
 import { codicon, ContextMenuRenderer, HoverService, OpenerService } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
-import { ToolConfirmation, useToolConfirmationState } from './tool-confirmation';
+import { createConfirmationHandlers, ToolConfirmation, useToolConfirmationState } from './tool-confirmation';
 import { ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ResponseNode } from '../chat-tree-view';
 import { useMarkdownRendering } from './markdown-part-renderer';
@@ -52,6 +52,22 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
             return 10;
         }
         return -1;
+    }
+
+    renderConfirmation(response: ToolCallChatResponseContent, parentNode: ResponseNode): ReactNode {
+        const chatId = parentNode.sessionId;
+        const toolRequest = response.name ? this.toolInvocationRegistry.getFunction(response.name) : undefined;
+        const { handleAllow, handleDeny } = createConfirmationHandlers(
+            response.name, response, this.toolConfirmationManager, chatId, toolRequest
+        );
+
+        return <ToolConfirmation
+            response={response}
+            toolRequest={toolRequest}
+            onAllow={handleAllow}
+            onDeny={handleDeny}
+            contextMenuRenderer={this.contextMenuRenderer}
+        />;
     }
 
     render(response: ToolCallChatResponseContent, parentNode: ResponseNode): ReactNode {
@@ -210,23 +226,10 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
         }
     };
 
-    const handleAllow = React.useCallback((mode: 'once' | 'session' | 'forever' = 'once') => {
-        if (mode === 'forever' && response.name) {
-            toolConfirmationManager.setConfirmationMode(response.name, ToolConfirmationMode.ALWAYS_ALLOW, toolRequest);
-        } else if (mode === 'session' && response.name) {
-            toolConfirmationManager.setSessionConfirmationMode(response.name, ToolConfirmationMode.ALWAYS_ALLOW, chatId);
-        }
-        response.confirm();
-    }, [response, toolConfirmationManager, chatId, toolRequest]);
-
-    const handleDeny = React.useCallback((mode: 'once' | 'session' | 'forever' = 'once', reason?: string) => {
-        if (mode === 'forever' && response.name) {
-            toolConfirmationManager.setConfirmationMode(response.name, ToolConfirmationMode.DISABLED);
-        } else if (mode === 'session' && response.name) {
-            toolConfirmationManager.setSessionConfirmationMode(response.name, ToolConfirmationMode.DISABLED, chatId);
-        }
-        response.deny(reason);
-    }, [response, toolConfirmationManager, chatId]);
+    const { handleAllow, handleDeny } = React.useMemo(
+        () => createConfirmationHandlers(response.name, response, toolConfirmationManager, chatId, toolRequest),
+        [response, toolConfirmationManager, chatId, toolRequest]
+    );
 
     const reasonText = formatReason(rejectionReason);
 

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1354,21 +1354,23 @@ div:last-child>.theia-ChatNode {
   background-color: var(--theia-toolbar-hoverBackground);
 }
 
-.delegation-summary::before {
+.delegation-toggle-arrow::before {
   content: "\25BC";
-  /* Down arrow */
-  position: absolute;
-  right: var(--theia-ui-padding);
-  top: var(--theia-ui-padding);
-  transform: translateY(25%);
   transition: transform 0.2s ease;
-  color: var(--theia-descriptionForeground);
-  font-size: var(--theia-ui-font-size1);
+  display: inline-block;
+  transform: rotate(-90deg);
 }
 
-.delegation-response-details:not([open]) .delegation-summary::before {
-  transform: translateY(25%) rotate(-90deg);
-  /* Right arrow when closed */
+.delegation-toggle-arrow.open::before {
+  transform: rotate(0deg);
+}
+
+.delegation-toggle-arrow {
+  color: var(--theia-descriptionForeground);
+  font-size: var(--theia-ui-font-size1);
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
 }
 
 .delegation-response-details:not([open]) .delegation-summary {
@@ -1407,8 +1409,6 @@ div:last-child>.theia-ChatNode {
   align-items: center;
   gap: var(--theia-ui-padding);
   font-size: var(--theia-ui-font-size1);
-  /* Leave space for the arrow */
-  margin-right: calc(var(--theia-ui-padding) * 3);
 }
 
 .delegation-status-icon {

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1359,15 +1359,15 @@ div:last-child>.theia-ChatNode {
   /* Down arrow */
   position: absolute;
   right: var(--theia-ui-padding);
-  top: 50%;
-  transform: translateY(-50%);
+  top: var(--theia-ui-padding);
+  transform: translateY(25%);
   transition: transform 0.2s ease;
   color: var(--theia-descriptionForeground);
   font-size: var(--theia-ui-font-size1);
 }
 
 .delegation-response-details:not([open]) .delegation-summary::before {
-  transform: translateY(-50%) rotate(-90deg);
+  transform: translateY(25%) rotate(-90deg);
   /* Right arrow when closed */
 }
 
@@ -1465,6 +1465,27 @@ div:last-child>.theia-ChatNode {
   display: block;
   margin-bottom: var(--theia-ui-padding);
   color: var(--theia-foreground);
+}
+
+.delegation-interaction-badge {
+  color: var(--theia-editorWarning-foreground);
+  display: flex;
+  align-items: center;
+}
+
+.delegation-pending-confirmations {
+  margin-top: var(--theia-ui-padding);
+  padding-top: var(--theia-ui-padding);
+  border-top: var(--theia-border-width) solid var(--theia-sideBarSectionHeader-border);
+}
+
+.delegation-pending-confirmations .theia-tool-confirmation {
+  margin: 0;
+  margin-bottom: var(--theia-ui-padding);
+}
+
+.delegation-pending-confirmations .theia-tool-confirmation:last-child {
+  margin-bottom: 0;
 }
 
 .delegation-response-placeholder {

--- a/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
@@ -56,7 +56,7 @@ function makeContextManager(): { addVariables: sinon.SinonStub; getVariables: si
 }
 
 function makeChangeSet(): { onDidChange: sinon.SinonStub } {
-    return { onDidChange: sinon.stub() };
+    return { onDidChange: sinon.stub().returns({ dispose: sinon.stub() }) };
 }
 
 function makeNewSession(contextManager = makeContextManager()): {
@@ -64,13 +64,15 @@ function makeNewSession(contextManager = makeContextManager()): {
     model: {
         context: ReturnType<typeof makeContextManager>;
         changeSet: ReturnType<typeof makeChangeSet>;
+        onDidChange: sinon.SinonStub;
     };
 } {
     return {
         id: 'new-session-id',
         model: {
             context: contextManager,
-            changeSet: makeChangeSet()
+            changeSet: makeChangeSet(),
+            onDidChange: sinon.stub().returns({ dispose: sinon.stub() })
         }
     };
 }

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { AGENT_DELEGATION_FUNCTION_ID, ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
+import { Disposable } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import {
     assertChatContext,
@@ -114,6 +115,7 @@ export class AgentDelegationTool implements ToolProvider {
             }
 
             let newSession;
+            let childModelDisposable: Disposable | undefined;
             try {
                 // FIXME: this creates a new conversation visible in the UI (Panel), which we don't want
                 // It is not possible to start a session without specifying a location (default=Panel)
@@ -148,6 +150,9 @@ export class AgentDelegationTool implements ToolProvider {
 
                 // Setup ChangeSet bubbling from delegated session to parent session
                 this.setupChangeSetBubbling(newSession, ctx.request.session);
+
+                // Setup parent-child model link for interactionNeeded event propagation
+                childModelDisposable = ctx.request.session.addChildModel(newSession.model as MutableChatModel);
             } catch (sessionError) {
                 const errorMsg = `Failed to create chat session for agent '${agentId}': ${sessionError instanceof Error ? sessionError.message : sessionError}`;
                 console.error(errorMsg, sessionError);
@@ -209,7 +214,8 @@ export class AgentDelegationTool implements ToolProvider {
                     const result = await response.responseCompleted;
                     const stringResult = result.response.asString();
 
-                    // Clean up the session after completion (no need to await)
+                    // Clean up the session and parent-child link after completion
+                    childModelDisposable?.dispose();
                     const chatService = this.getChatService();
                     chatService.deleteSession(newSession.id).catch(error => {
                         console.error('Failed to delete delegated session', error);

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -256,14 +256,13 @@ export class AgentDelegationTool implements ToolProvider {
         parentResponse: MutableChatResponseModel
     ): Disposable {
 
-        // Forward child session events to the parent response model so the UI can react:
-        // - interactionNeeded: displays confirmation dialogs in collapsed delegation summary
-        // - responseChanged: triggers cleanup of resolved interactions in the parent UI
+        // Forward interactionNeeded events to the parent response model
+        // so the UI (which subscribes to response.onInteractionNeeded) can display them.
+        // Also watch for each forwarded interaction's resolution to trigger cleanup.
         const eventForwarding = childModel.onDidChange(event => {
             if (ChatChangeEvent.isInteractionNeededEvent(event)) {
                 parentResponse.fireInteractionNeeded(event.contentPart);
-            } else if (event.kind === 'responseChanged') {
-                parentResponse.notifyChanged();
+                event.contentPart.whenResolved.then(() => parentResponse.notifyChanged());
             }
         });
 

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -21,13 +21,14 @@ import {
     assertChatContext,
     ChatAgentService,
     ChatAgentServiceFactory,
+    ChatChangeEvent,
     ChatRequest,
     ChatService,
     ChatServiceFactory,
     ChatToolContext,
     MutableChatModel,
     MutableChatRequestModel,
-    ChatSession,
+    MutableChatResponseModel,
     ChatRequestInvocation,
 } from '../common';
 import { TASK_CONTEXT_VARIABLE } from './task-context-variable';
@@ -148,11 +149,8 @@ export class AgentDelegationTool implements ToolProvider {
                     chatService.setActiveSession(currentActiveSession.id, { focus: false });
                 }
 
-                // Setup ChangeSet bubbling from delegated session to parent session
-                this.setupChangeSetBubbling(newSession, ctx.request.session);
-
-                // Setup parent-child model link for interactionNeeded event propagation
-                childModelDisposable = ctx.request.session.addChildModel(newSession.model as MutableChatModel);
+                // Setup bubbling of child session events to parent session
+                childModelDisposable = this.setupChildSessionBubbling(newSession.model as MutableChatModel, ctx.request.session, ctx.response);
             } catch (sessionError) {
                 const errorMsg = `Failed to create chat session for agent '${agentId}': ${sessionError instanceof Error ? sessionError.message : sessionError}`;
                 console.error(errorMsg, sessionError);
@@ -248,33 +246,38 @@ export class AgentDelegationTool implements ToolProvider {
     }
 
     /**
-     * Sets up monitoring of the ChangeSet in the delegated session and bubbles changes to the parent session.
-     * @param delegatedSession The session created for the delegated agent
-     * @param parentModel The parent session model that should receive the bubbled changes
+     * Sets up all event bubbling from a delegated child session to the parent session:
+     * - Interaction forwarding: child interactionNeeded events are forwarded to the parent response
+     * - ChangeSet bubbling: child changeset changes are forwarded to the parent model
      */
-    private setupChangeSetBubbling(
-        delegatedSession: ChatSession,
-        parentModel: MutableChatModel
-    ): void {
-        // Monitor ChangeSet for bubbling
-        delegatedSession.model.changeSet.onDidChange(_event => {
-            this.bubbleChangeSet(delegatedSession, parentModel);
-        });
-    }
+    private setupChildSessionBubbling(
+        childModel: MutableChatModel,
+        parentModel: MutableChatModel,
+        parentResponse: MutableChatResponseModel
+    ): Disposable {
 
-    /**
-     * Bubbles the ChangeSet from the delegated session to the parent session.
-     * @param delegatedSession The session from which to bubble changes
-     * @param parentModel The parent session model to receive the bubbled changes
-     */
-    private bubbleChangeSet(
-        delegatedSession: ChatSession,
-        parentModel: MutableChatModel
-    ): void {
-        const delegatedElements = delegatedSession.model.changeSet.getElements();
-        if (delegatedElements.length > 0) {
-            parentModel.changeSet.setTitle(delegatedSession.model.changeSet.title);
-            parentModel.changeSet.addElements(...delegatedElements);
-        }
+        // Forward interactionNeeded events to the parent response model
+        // so the UI (which subscribes to response.onInteractionNeeded) can display them
+        const interactionForwarding = childModel.onDidChange(event => {
+            if (ChatChangeEvent.isInteractionNeededEvent(event)) {
+                parentResponse.fireInteractionNeeded(event.contentPart);
+            }
+        });
+
+        // Bubble ChangeSet changes to the parent model
+        const changeSetForwarding = childModel.changeSet.onDidChange(() => {
+            const delegatedElements = childModel.changeSet.getElements();
+            if (delegatedElements.length > 0) {
+                parentModel.changeSet.setTitle(childModel.changeSet.title);
+                parentModel.changeSet.addElements(...delegatedElements);
+            }
+        });
+
+        return {
+            dispose: () => {
+                interactionForwarding.dispose();
+                changeSetForwarding.dispose();
+            }
+        };
     }
 }

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -256,11 +256,14 @@ export class AgentDelegationTool implements ToolProvider {
         parentResponse: MutableChatResponseModel
     ): Disposable {
 
-        // Forward interactionNeeded events to the parent response model
-        // so the UI (which subscribes to response.onInteractionNeeded) can display them
-        const interactionForwarding = childModel.onDidChange(event => {
+        // Forward child session events to the parent response model so the UI can react:
+        // - interactionNeeded: displays confirmation dialogs in collapsed delegation summary
+        // - responseChanged: triggers cleanup of resolved interactions in the parent UI
+        const eventForwarding = childModel.onDidChange(event => {
             if (ChatChangeEvent.isInteractionNeededEvent(event)) {
                 parentResponse.fireInteractionNeeded(event.contentPart);
+            } else if (event.kind === 'responseChanged') {
+                parentResponse.notifyChanged();
             }
         });
 
@@ -275,7 +278,7 @@ export class AgentDelegationTool implements ToolProvider {
 
         return {
             dispose: () => {
-                interactionForwarding.dispose();
+                eventForwarding.dispose();
                 changeSetForwarding.dispose();
             }
         };

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -43,7 +43,8 @@ export class FrontendChatToolRequestService extends ChatToolRequestService {
             ...toolRequest,
             handler: async (arg_string: string, ctx?: ToolInvocationContext) => {
                 const toolCallId = ctx?.toolCallId;
-                const confirmationMode = this.confirmationManager.getConfirmationMode(toolRequest.id, request.session.id, toolRequest);
+                const sessionId = request.session.rootSessionId ?? request.session.id;
+                const confirmationMode = this.confirmationManager.getConfirmationMode(toolRequest.id, sessionId, toolRequest);
 
                 switch (confirmationMode) {
                     case ToolConfirmationMode.DISABLED:

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -39,12 +39,11 @@ export class FrontendChatToolRequestService extends ChatToolRequestService {
     protected readonly preferences: ChatToolPreferences;
 
     protected override toChatToolRequest(toolRequest: ToolRequest, request: MutableChatRequestModel): ToolRequest {
-        const confirmationMode = this.confirmationManager.getConfirmationMode(toolRequest.id, request.session.id, toolRequest);
-
         return {
             ...toolRequest,
             handler: async (arg_string: string, ctx?: ToolInvocationContext) => {
                 const toolCallId = ctx?.toolCallId;
+                const confirmationMode = this.confirmationManager.getConfirmationMode(toolRequest.id, request.session.id, toolRequest);
 
                 switch (confirmationMode) {
                     case ToolConfirmationMode.DISABLED:

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -84,6 +84,7 @@ export class FrontendChatToolRequestService extends ChatToolRequestService {
                                 : this.preferences[TOOL_CONFIRMATION_TIMEOUT_PREFERENCE];
                             toolCallContent.confirmationTimeout = timeoutSeconds;
                             toolCallContent.requestUserConfirmation();
+                            request.response.fireInteractionNeeded(toolCallContent);
                             confirmed = await raceConfirmationWithTimeout(toolCallContent, timeoutSeconds);
                         }
 

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -78,7 +78,8 @@ export type ChatChangeEvent =
     | ChatEditCancelEvent
     | ChatEditSubmitEvent
     | ChatResponseChangedEvent
-    | ChatChangeHierarchyBranchEvent;
+    | ChatChangeHierarchyBranchEvent
+    | ChatInteractionNeededEvent;
 
 export interface ChatAddRequestEvent {
     kind: 'addRequest';
@@ -135,9 +136,17 @@ export interface ChatResponseChangedEvent {
     kind: 'responseChanged';
 }
 
+export interface ChatInteractionNeededEvent {
+    kind: 'interactionNeeded';
+    contentPart: InteractiveContent & ChatResponseContent;
+}
+
 export namespace ChatChangeEvent {
     export function isChangeSetEvent(event: ChatChangeEvent): event is ChatUpdateChangeSetEvent {
         return event.kind === 'updateChangeSet';
+    }
+    export function isInteractionNeededEvent(event: ChatChangeEvent): event is ChatInteractionNeededEvent {
+        return event.kind === 'interactionNeeded';
     }
 }
 
@@ -382,6 +391,26 @@ export interface ChatProgressMessage {
     content: string;
 }
 
+/**
+ * Interface for ChatResponseContent parts that require user interaction.
+ * Content parts that implement this interface can be tracked by the delegation
+ * renderer without content-type-specific checks.
+ */
+export interface InteractiveContent {
+    /** Stable identifier for deduplication in pending interaction tracking. */
+    readonly interactionId: string | undefined;
+    /** Whether the interaction has been resolved (e.g., confirmed/denied, option selected). */
+    readonly isResolved: boolean;
+}
+
+export namespace InteractiveContent {
+    export function is(content: unknown): content is InteractiveContent {
+        return typeof content === 'object' && !!content
+            && 'interactionId' in content
+            && 'isResolved' in content;
+    }
+}
+
 export interface ChatResponseContent {
     kind: string;
     /**
@@ -526,7 +555,7 @@ export interface HorizontalLayoutChatResponseContent extends ChatResponseContent
     content: ChatResponseContent[];
 }
 
-export interface ToolCallChatResponseContent extends Required<ChatResponseContent> {
+export interface ToolCallChatResponseContent extends Required<ChatResponseContent>, InteractiveContent {
     kind: 'toolCall';
     id?: string;
     name?: string;
@@ -803,7 +832,7 @@ export type MultiSelectQuestionResponseHandler = (
     selectedOptions: { text: string, value?: string }[],
 ) => void;
 
-export interface QuestionResponseContent extends ChatResponseContent {
+export interface QuestionResponseContent extends ChatResponseContent, InteractiveContent {
     kind: 'question';
     question: string;
     header?: string;
@@ -858,6 +887,11 @@ export interface ChatResponseModel {
      * Use this to be notified for any change in the response model
      */
     readonly onDidChange: Event<void>;
+    /**
+     * Fires when this response requires user interaction (e.g., tool confirmation, question response).
+     * The content part that needs interaction is provided as the event payload.
+     */
+    readonly onInteractionNeeded: Event<InteractiveContent & ChatResponseContent>;
     /**
      * The unique identifier of the response model
      */
@@ -1050,6 +1084,17 @@ export class MutableChatModel implements ChatModel, Disposable {
 
     setSettings(settings: ChatSessionSettings): void {
         this._settings = settings;
+    }
+
+    addChildModel(child: MutableChatModel): Disposable {
+        const disposable = new DisposableCollection();
+        disposable.push(child.onDidChange(event => {
+            if (ChatChangeEvent.isInteractionNeededEvent(event)) {
+                this._onDidChangeEmitter.fire(event);
+            }
+        }));
+        this.toDispose.push(disposable);
+        return disposable;
     }
 
     addRequest(parsedChatRequest: ParsedChatRequest, agentId?: string, context: ChatContext = { variables: [] }): MutableChatRequestModel {
@@ -1680,8 +1725,12 @@ export class MutableChatRequestModel implements ChatRequestModel, EditableChatRe
 
         // Wire response changes to propagate through request to session
         this._response.onDidChange(() => {
-            // Fire a generic addVariable event to propagate response changes
             this._onDidChangeEmitter.fire({ kind: 'responseChanged' });
+        }, this, this.toDispose);
+
+        // Wire interaction needed events to propagate through request to session
+        this._response.onInteractionNeeded(contentPart => {
+            this._onDidChangeEmitter.fire({ kind: 'interactionNeeded', contentPart });
         }, this, this.toDispose);
 
         this.toDispose.push(this._onDidChangeEmitter);
@@ -2236,7 +2285,7 @@ export class CodeChatResponseContentImpl implements CodeChatResponseContent {
     }
 }
 
-export class ToolCallChatResponseContentImpl implements ToolCallChatResponseContent {
+export class ToolCallChatResponseContentImpl implements ToolCallChatResponseContent, InteractiveContent {
     readonly kind = 'toolCall';
     protected _id?: string;
     protected _name?: string;
@@ -2296,6 +2345,14 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
 
     set confirmationTimeout(value: number | undefined) {
         this._confirmationTimeout = value;
+    }
+
+    get interactionId(): string | undefined {
+        return this._id;
+    }
+
+    get isResolved(): boolean {
+        return this.finished;
     }
 
     get confirmed(): Promise<boolean> {
@@ -2563,7 +2620,7 @@ export interface QuestionResponseContentOptions {
  * Default implementation for the QuestionResponseContent.
  * Can be created with or without handler/request for read-only (restored) mode.
  */
-export class QuestionResponseContentImpl implements QuestionResponseContent {
+export class QuestionResponseContentImpl implements QuestionResponseContent, InteractiveContent {
     readonly kind = 'question';
     public multiSelect?: boolean;
     public header?: string;
@@ -2596,10 +2653,21 @@ export class QuestionResponseContentImpl implements QuestionResponseContent {
         this.onSkip = questionOptions?.onSkip;
         this._selectedOptions = questionOptions?.selectedOptions ??
             (questionOptions?.selectedOption ? [questionOptions.selectedOption] : undefined);
+        if (!this.isReadOnly && this.request) {
+            this.request.response.fireInteractionNeeded(this);
+        }
     }
 
     get isReadOnly(): boolean {
         return !this.handler || !this.request;
+    }
+
+    get interactionId(): string | undefined {
+        return `question-${this.question}`;
+    }
+
+    get isResolved(): boolean {
+        return this.selectedOption !== undefined;
     }
 
     set selectedOption(option: { text: string; value?: string } | undefined) {
@@ -2765,6 +2833,9 @@ class ChatResponseImpl implements ChatResponse {
 export class MutableChatResponseModel implements ChatResponseModel {
     protected readonly _onDidChangeEmitter = new Emitter<void>();
     onDidChange: Event<void> = this._onDidChangeEmitter.event;
+
+    protected readonly _onInteractionNeededEmitter = new Emitter<InteractiveContent & ChatResponseContent>();
+    readonly onInteractionNeeded: Event<InteractiveContent & ChatResponseContent> = this._onInteractionNeededEmitter.event;
 
     data = {};
 
@@ -2950,6 +3021,10 @@ export class MutableChatResponseModel implements ChatResponseModel {
     stopWaitingForInput(): void {
         this._isWaitingForInput = false;
         this._onDidChangeEmitter.fire();
+    }
+
+    fireInteractionNeeded(contentPart: InteractiveContent & ChatResponseContent): void {
+        this._onInteractionNeededEmitter.fire(contentPart);
     }
 
     error(error: Error): void {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -401,13 +401,16 @@ export interface InteractiveContent {
     readonly interactionId: string | undefined;
     /** Whether the interaction has been resolved (e.g., confirmed/denied, option selected). */
     readonly isResolved: boolean;
+    /** Resolves when the interaction is resolved. Used for cleanup in delegation chains. */
+    readonly whenResolved: Promise<void>;
 }
 
 export namespace InteractiveContent {
     export function is(content: unknown): content is InteractiveContent {
         return typeof content === 'object' && !!content
             && 'interactionId' in content
-            && 'isResolved' in content;
+            && 'isResolved' in content
+            && 'whenResolved' in content;
     }
 }
 
@@ -1089,7 +1092,7 @@ export class MutableChatModel implements ChatModel, Disposable {
     addChildModel(child: MutableChatModel): Disposable {
         const disposable = new DisposableCollection();
         disposable.push(child.onDidChange(event => {
-            if (ChatChangeEvent.isInteractionNeededEvent(event) || event.kind === 'responseChanged') {
+            if (ChatChangeEvent.isInteractionNeededEvent(event)) {
                 this._onDidChangeEmitter.fire(event);
             }
         }));
@@ -2367,6 +2370,10 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
         return this._whenFinished;
     }
 
+    get whenResolved(): Promise<void> {
+        return this._whenFinished;
+    }
+
     createConfirmationPromise(): Promise<boolean> {
         if (!this._confirmationResolver) {
             this._confirmed = new Promise<boolean>((resolve, reject) => {
@@ -2626,6 +2633,8 @@ export class QuestionResponseContentImpl implements QuestionResponseContent, Int
     public header?: string;
     public onSkip?: () => void;
     protected _selectedOptions: { text: string; value?: string }[] | undefined;
+    protected _resolvedResolver?: () => void;
+    readonly whenResolved: Promise<void>;
 
     constructor(
         question: string,
@@ -2653,6 +2662,13 @@ export class QuestionResponseContentImpl implements QuestionResponseContent, Int
         this.onSkip = questionOptions?.onSkip;
         this._selectedOptions = questionOptions?.selectedOptions ??
             (questionOptions?.selectedOption ? [questionOptions.selectedOption] : undefined);
+        if (this._selectedOptions) {
+            this.whenResolved = Promise.resolve();
+        } else {
+            this.whenResolved = new Promise<void>(resolve => {
+                this._resolvedResolver = resolve;
+            });
+        }
         if (!this.isReadOnly && this.request) {
             this.request.response.fireInteractionNeeded(this);
         }
@@ -2672,6 +2688,7 @@ export class QuestionResponseContentImpl implements QuestionResponseContent, Int
 
     set selectedOption(option: { text: string; value?: string } | undefined) {
         this._selectedOptions = option ? [option] : undefined;
+        this._resolvedResolver?.();
         if (this.request) {
             this.request.response.response.responseContentChanged();
         }
@@ -2682,6 +2699,7 @@ export class QuestionResponseContentImpl implements QuestionResponseContent, Int
 
     set selectedOptions(options: { text: string; value?: string }[] | undefined) {
         this._selectedOptions = options;
+        this._resolvedResolver?.();
         if (this.request) {
             this.request.response.response.responseContentChanged();
         }

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -1089,7 +1089,7 @@ export class MutableChatModel implements ChatModel, Disposable {
     addChildModel(child: MutableChatModel): Disposable {
         const disposable = new DisposableCollection();
         disposable.push(child.onDidChange(event => {
-            if (ChatChangeEvent.isInteractionNeededEvent(event)) {
+            if (ChatChangeEvent.isInteractionNeededEvent(event) || event.kind === 'responseChanged') {
                 this._onDidChangeEmitter.fire(event);
             }
         }));
@@ -3025,6 +3025,10 @@ export class MutableChatResponseModel implements ChatResponseModel {
 
     fireInteractionNeeded(contentPart: InteractiveContent & ChatResponseContent): void {
         this._onInteractionNeededEmitter.fire(contentPart);
+    }
+
+    notifyChanged(): void {
+        this._onDidChangeEmitter.fire();
     }
 
     error(error: Error): void {

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -351,11 +351,12 @@ describe('ChatRequestParserImpl', () => {
                 id: 'session-1',
                 model: {
                     changeSet: {
-                        onDidChange: sinon.stub().returns({}),
+                        onDidChange: sinon.stub().returns({ dispose: sinon.stub() }),
                         getElements: sinon.stub().returns([]),
                         setTitle: sinon.stub(),
                         addElements: sinon.stub(),
-                    }
+                    },
+                    onDidChange: sinon.stub().returns({ dispose: sinon.stub() })
                 }
             }),
             sendRequest,
@@ -368,7 +369,7 @@ describe('ChatRequestParserImpl', () => {
             {
                 cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
                 request: {
-                    session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() }, addChildModel: sinon.stub().returns({ dispose: sinon.stub() }) },
+                    session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() } },
                 },
                 response: {
                     cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -323,6 +323,9 @@ describe('ChatRequestParserImpl', () => {
             invoke: async () => undefined,
         });
 
+        // Set up the parser's agent service so it can recognise agents during parsing
+        chatAgentService.getAgents.returns([createAgent('agentA'), createAgent('agentB')]);
+
         const tool = new AgentDelegationTool();
         (tool as unknown as { getChatAgentService: () => unknown }).getChatAgentService = () => ({
             getAgent: sinon.stub().withArgs('agentA').returns(createAgent('agentA')),
@@ -365,7 +368,7 @@ describe('ChatRequestParserImpl', () => {
             {
                 cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },
                 request: {
-                    session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() } },
+                    session: { changeSet: { setTitle: sinon.stub(), addElements: sinon.stub() }, addChildModel: sinon.stub().returns({ dispose: sinon.stub() }) },
                 },
                 response: {
                     cancellationToken: { isCancellationRequested: false, onCancellationRequested: sinon.stub() },

--- a/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
+++ b/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
@@ -69,6 +69,54 @@ export class ShellExecutionToolRenderer implements ChatResponsePartRenderer<Tool
         return -1;
     }
 
+    renderConfirmation(response: ToolCallChatResponseContent, parentNode: ResponseNode): ReactNode {
+        const chatId = parentNode.sessionId;
+        const toolRequest = this.toolInvocationRegistry.getFunction(SHELL_EXECUTION_FUNCTION_ID);
+        const input = parseShellExecutionInput(response.arguments);
+
+        const handleAllow = (patterns?: string[]) => {
+            if (patterns && patterns.length > 0) {
+                try {
+                    this.shellCommandPermissionService.addAllowlistPatterns(...patterns);
+                } catch (err) {
+                    console.warn('Failed to add allowlist patterns:', err);
+                }
+            }
+            response.confirm();
+        };
+        const handleDeny = (options?: { patterns?: string[]; reason?: string }) => {
+            if (options?.patterns && options.patterns.length > 0) {
+                try {
+                    this.shellCommandPermissionService.addDenylistPatterns(...options.patterns);
+                } catch (err) {
+                    console.warn('Failed to add denylist patterns:', err);
+                }
+            }
+            response.deny(options?.reason);
+        };
+        const handleAllowAllForever = () => {
+            this.toolConfirmationManager.setConfirmationMode(SHELL_EXECUTION_FUNCTION_ID, ToolConfirmationPreferenceMode.ALWAYS_ALLOW, toolRequest);
+            response.confirm();
+        };
+        const handleAllowAllSession = () => {
+            this.toolConfirmationManager.setSessionConfirmationMode(SHELL_EXECUTION_FUNCTION_ID, ToolConfirmationPreferenceMode.ALWAYS_ALLOW, chatId);
+            response.confirm();
+        };
+
+        return (
+            <ConfirmationUI
+                input={input}
+                shellCommandPermissionService={this.shellCommandPermissionService}
+                onAllow={handleAllow}
+                onAllowAllForever={handleAllowAllForever}
+                onAllowAllSession={handleAllowAllSession}
+                onDeny={handleDeny}
+                contextMenuRenderer={this.contextMenuRenderer}
+                response={response}
+            />
+        );
+    }
+
     render(response: ToolCallChatResponseContent, parentNode: ResponseNode): ReactNode {
         const chatId = parentNode.sessionId;
         const toolRequest = this.toolInvocationRegistry.getFunction(SHELL_EXECUTION_FUNCTION_ID);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
When a delegated agent requires tool confirmation, the confirmation UI now appears in the delegation summary when collapsed, allowing users to approve/deny without expanding the delegation section.

- Track open/closed state of delegation details element
- Scan response content for pending tool confirmations
- Render ToolConfirmation components in summary when collapsed
- Remove confirmations from summary after user action
- Fix arrow positioning to stay aligned with header row

Fixes #16922
Fixes #17050

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

In order to test you need to have tools that are not set to auto-allow. e.g change getfilecontent tool to confirm. ask universal agent to delegate to coder to summarize the readme in the root of the workspace and pass the delegateToAgent tool. 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

We have now multiple places with similar (partially identical) tool handler code. We should analyze them to eliminate code duplication across toolcall-part-renderer.tsx, delegation-response-renderer.tsx, and shell-execution-tool-renderer.tsx.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
