### PR TITLE
feat(ai-terminal): add shell command whitelist for auto-approval

### DIFF
--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -964,7 +964,8 @@ div:last-child > .theia-ChatNode {
   font-weight: bold;
 }
 
-.theia-toolCall-allowed .codicon-loading {
+.theia-toolCall-allowed .codicon-loading,
+.theia-toolCall-pending .codicon-loading {
   font-size: 1em;
 }
 

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -63,6 +63,20 @@ export class FrontendChatToolRequestService extends ChatToolRequestService {
                     case ToolConfirmationMode.CONFIRM:
                     default: {
                         const toolCallContent = this.findToolCallContent(toolRequest, arg_string, request, toolCallId);
+
+                        // Check for auto-action hook
+                        const autoAction = toolRequest.checkAutoAction?.(arg_string);
+
+                        if (autoAction?.action === 'allow') {
+                            toolCallContent.confirm();
+                        } else if (autoAction?.action === 'deny') {
+                            toolCallContent.deny(autoAction.reason);
+                            return toolCallContent.result;
+                        } else {
+                            // No auto-action — needs user confirmation
+                            toolCallContent.requestUserConfirmation();
+                        }
+
                         const confirmed = await toolCallContent.confirmed;
 
                         if (confirmed) {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -489,11 +489,15 @@ export interface ToolCallChatResponseContent extends Required<ChatResponseConten
     finished: boolean;
     result?: ToolCallResult;
     confirmed: Promise<boolean>;
+    /** Resolves when the tool call requires user confirmation (show Allow/Deny UI). */
+    needsUserConfirmation: Promise<void>;
     whenFinished: Promise<void>;
     data?: Record<string, string>;
     confirm(): void;
     deny(reason?: string): void;
     cancelConfirmation(reason?: unknown): void;
+    /** Signal that this tool call needs user confirmation. Resolves the needsUserConfirmation promise. */
+    requestUserConfirmation(): void;
     /**
      * Mark the tool call as completed with the given result.
      *
@@ -2172,6 +2176,8 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
     protected _finished?: boolean;
     protected _result?: ToolCallResult;
     protected _data?: Record<string, string>;
+    protected _needsUserConfirmation: Promise<void>;
+    protected _needsUserConfirmationResolver?: () => void;
     protected _confirmed: Promise<boolean>;
     protected _confirmationResolver?: (value: boolean) => void;
     protected _confirmationRejecter?: (reason?: unknown) => void;
@@ -2187,6 +2193,9 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
         this._data = data;
         this._confirmed = this.createConfirmationPromise();
         this._whenFinished = this.createFinishedPromise();
+        this._needsUserConfirmation = new Promise<void>(resolve => {
+            this._needsUserConfirmationResolver = resolve;
+        });
     }
 
     get id(): string | undefined {
@@ -2214,6 +2223,10 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
 
     get confirmed(): Promise<boolean> {
         return this._confirmed;
+    }
+
+    get needsUserConfirmation(): Promise<void> {
+        return this._needsUserConfirmation;
     }
 
     get whenFinished(): Promise<void> {
@@ -2257,6 +2270,13 @@ export class ToolCallChatResponseContentImpl implements ToolCallChatResponseCont
             this._result = { denied: true, reason };
             this._confirmationResolver(false);
             this.resolveFinished();
+        }
+    }
+
+    requestUserConfirmation(): void {
+        if (this._needsUserConfirmationResolver) {
+            this._needsUserConfirmationResolver();
+            this._needsUserConfirmationResolver = undefined;
         }
     }
 

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -93,6 +93,11 @@ export const isLanguageModelRequestMessage = (obj: unknown): obj is LanguageMode
         typeof (obj as { query: unknown }).query === 'string'
     );
 
+export interface AutoActionResult {
+    action: 'allow' | 'deny';
+    reason?: string;
+}
+
 export interface ToolRequestParameterProperty {
     type?: | 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array' | 'null';
     anyOf?: ToolRequestParameterProperty[];
@@ -145,6 +150,15 @@ export interface ToolRequest<TContext extends ToolInvocationContext = ToolInvoca
      */
     getArgumentsShortLabel?(args: string): { label: string; hasMore: boolean } | undefined;
 
+    /**
+     * Optional hook to determine automatic action for this tool invocation.
+     * @param argString - The JSON argument string passed to the tool
+     * @returns
+     *   - { action: 'allow' } - Auto-approve without confirmation
+     *   - { action: 'deny', reason } - Auto-deny without confirmation
+     *   - undefined - Show confirmation UI (default behavior)
+     */
+    checkAutoAction?: (argString: string) => AutoActionResult | undefined;
 }
 
 /**

--- a/packages/ai-ide/package.json
+++ b/packages/ai-ide/package.json
@@ -19,6 +19,7 @@
     "@theia/ai-chat-ui": "1.68.0",
     "@theia/ai-core": "1.68.0",
     "@theia/ai-mcp": "1.68.0",
+    "@theia/ai-terminal": "1.68.0",
     "@theia/core": "1.68.0",
     "@theia/debug": "1.68.0",
     "@theia/editor": "1.68.0",

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1352,3 +1352,58 @@
   color: var(--theia-descriptionForeground);
   font-style: italic;
 }
+
+/* Shell Command Permission List Section */
+.ai-shell-permission-list-section {
+  margin-top: calc(var(--theia-ui-padding) * 3);
+  padding-top: calc(var(--theia-ui-padding) * 2);
+  border-top: var(--theia-border-width) solid var(--theia-widget-border);
+}
+
+.ai-shell-permission-list-description {
+  color: var(--theia-descriptionForeground);
+  margin-bottom: var(--theia-ui-padding);
+}
+
+.ai-shell-permission-list-input-row {
+  display: flex;
+  gap: var(--theia-ui-padding);
+  margin-bottom: var(--theia-ui-padding);
+}
+
+.ai-shell-permission-list-input-row .theia-input {
+  flex: 1;
+}
+
+.ai-shell-permission-list-patterns {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ai-shell-permission-list-pattern-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: calc(var(--theia-ui-padding) / 2) var(--theia-ui-padding);
+  background-color: var(--theia-editor-background);
+  border: var(--theia-border-width) solid var(--theia-widget-border);
+  border-radius: 3px;
+  margin-bottom: calc(var(--theia-ui-padding) / 2);
+}
+
+.ai-shell-permission-list-pattern-item code {
+  font-family: var(--theia-code-font-family);
+  font-size: var(--theia-code-font-size);
+}
+
+.ai-shell-permission-list-empty {
+  color: var(--theia-descriptionForeground);
+  font-style: italic;
+}
+
+.ai-shell-permission-list-error {
+  color: var(--theia-errorForeground);
+  margin-top: calc(var(--theia-ui-padding) / 2);
+  margin-bottom: var(--theia-ui-padding);
+}

--- a/packages/ai-ide/tsconfig.json
+++ b/packages/ai-ide/tsconfig.json
@@ -25,6 +25,9 @@
       "path": "../ai-mcp"
     },
     {
+      "path": "../ai-terminal"
+    },
+    {
       "path": "../core"
     },
     {

--- a/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
@@ -17,7 +17,7 @@
 import { ChatResponsePartRenderer } from '@theia/ai-chat-ui/lib/browser/chat-response-part-renderer';
 import { Agent } from '@theia/ai-core/lib/common';
 import { bindToolProvider } from '@theia/ai-core/lib/common/tool-invocation-registry';
-import { CommandContribution, MenuContribution } from '@theia/core';
+import { CommandContribution, MenuContribution, PreferenceContribution } from '@theia/core';
 import { KeybindingContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { AiTerminalAgent } from './ai-terminal-agent';
@@ -25,6 +25,9 @@ import { AiTerminalCommandContribution } from './ai-terminal-contribution';
 import { ShellExecutionTool } from './shell-execution-tool';
 import { ShellExecutionToolRenderer } from './shell-execution-tool-renderer';
 import { ShellExecutionServer, shellExecutionPath } from '../common/shell-execution-server';
+import { ShellCommandPermissionService } from './shell-command-permission-service';
+import { shellCommandPreferences } from '../common/shell-command-preferences';
+import { DefaultShellCommandAnalyzer, ShellCommandAnalyzer } from '../common/shell-command-analyzer';
 
 import '../../src/browser/style/ai-terminal.css';
 import '../../src/browser/style/shell-execution-tool.css';
@@ -46,4 +49,10 @@ export default new ContainerModule(bind => {
     }).inSingletonScope();
 
     bind(ChatResponsePartRenderer).to(ShellExecutionToolRenderer).inSingletonScope();
+
+    bind(ShellCommandPermissionService).toSelf().inSingletonScope();
+
+    bind(PreferenceContribution).toConstantValue({ schema: shellCommandPreferences });
+
+    bind(ShellCommandAnalyzer).to(DefaultShellCommandAnalyzer).inSingletonScope();
 });

--- a/packages/ai-terminal/src/browser/index.ts
+++ b/packages/ai-terminal/src/browser/index.ts
@@ -1,0 +1,17 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './shell-command-permission-service';

--- a/packages/ai-terminal/src/browser/shell-command-permission-service.spec.ts
+++ b/packages/ai-terminal/src/browser/shell-command-permission-service.spec.ts
@@ -1,0 +1,626 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { ShellCommandPermissionService } from './shell-command-permission-service';
+import { SHELL_COMMAND_ALLOWLIST_PREFERENCE, SHELL_COMMAND_DENYLIST_PREFERENCE } from '../common/shell-command-preferences';
+import { PreferenceService } from '@theia/core/lib/common/preferences';
+import { DefaultShellCommandAnalyzer, ShellCommandAnalyzer } from '../common/shell-command-analyzer';
+
+describe('ShellCommandPermissionService', () => {
+    let service: ShellCommandPermissionService;
+    let preferenceServiceMock: sinon.SinonStubbedInstance<PreferenceService>;
+    let storedPatterns: string[];
+    let storedDenylistPatterns: string[];
+
+    beforeEach(() => {
+        storedPatterns = [];
+        storedDenylistPatterns = [];
+
+        preferenceServiceMock = {
+            get: sinon.stub().callsFake((key: string, defaultValue: string[]) => {
+                if (key === SHELL_COMMAND_ALLOWLIST_PREFERENCE) {
+                    return storedPatterns;
+                }
+                if (key === SHELL_COMMAND_DENYLIST_PREFERENCE) {
+                    return storedDenylistPatterns;
+                }
+                return defaultValue;
+            }),
+            updateValue: sinon.stub().callsFake((key: string, value: string[]) => {
+                if (key === SHELL_COMMAND_ALLOWLIST_PREFERENCE) {
+                    storedPatterns = value;
+                } else if (key === SHELL_COMMAND_DENYLIST_PREFERENCE) {
+                    storedDenylistPatterns = value;
+                }
+                return Promise.resolve();
+            })
+        } as unknown as sinon.SinonStubbedInstance<PreferenceService>;
+
+        service = new ShellCommandPermissionService();
+        (service as unknown as { preferenceService: PreferenceService }).preferenceService = preferenceServiceMock;
+        (service as unknown as { shellCommandAnalyzer: ShellCommandAnalyzer }).shellCommandAnalyzer = new DefaultShellCommandAnalyzer();
+    });
+
+    describe('addAllowlistPattern validation', () => {
+        describe('valid patterns', () => {
+            it('accepts exact match pattern', () => {
+                service.addAllowlistPattern('git log');
+                expect(storedPatterns).to.deep.equal(['git log']);
+            });
+
+            it('accepts trailing wildcard with space', () => {
+                service.addAllowlistPattern('git log *');
+                expect(storedPatterns).to.deep.equal(['git log *']);
+            });
+
+            it('accepts leading wildcard', () => {
+                service.addAllowlistPattern('* --version');
+                expect(storedPatterns).to.deep.equal(['* --version']);
+            });
+
+            it('accepts middle wildcard', () => {
+                service.addAllowlistPattern('git * main');
+                expect(storedPatterns).to.deep.equal(['git * main']);
+            });
+
+            it('accepts multiple wildcards with spaces', () => {
+                service.addAllowlistPattern('* * *');
+                expect(storedPatterns).to.deep.equal(['* * *']);
+            });
+
+            it('trims pattern before adding', () => {
+                service.addAllowlistPattern('  git log  ');
+                expect(storedPatterns).to.deep.equal(['git log']);
+            });
+
+            it('does not add duplicate pattern', () => {
+                storedPatterns = ['git log'];
+                service.addAllowlistPattern('git log');
+                expect(preferenceServiceMock.updateValue.called).to.be.false;
+            });
+        });
+
+        describe('invalid patterns', () => {
+            it('rejects empty pattern', () => {
+                expect(() => service.addAllowlistPattern('')).to.throw('Pattern cannot be empty or whitespace-only');
+            });
+
+            it('rejects whitespace-only pattern', () => {
+                expect(() => service.addAllowlistPattern('   ')).to.throw('Pattern cannot be empty or whitespace-only');
+            });
+
+            it('rejects * alone', () => {
+                expect(() => service.addAllowlistPattern('*')).to.throw(/too permissive/);
+            });
+
+            it('rejects wildcard without preceding space: git*', () => {
+                expect(() => service.addAllowlistPattern('git*')).to.throw(/must be preceded by a space/);
+            });
+
+            it('rejects wildcard without preceding space: git log*', () => {
+                expect(() => service.addAllowlistPattern('git log*')).to.throw(/must be preceded by a space/);
+            });
+
+            it('rejects wildcard in middle without space: git*log', () => {
+                expect(() => service.addAllowlistPattern('git*log')).to.throw(/must be preceded by a space/);
+            });
+
+            it('rejects wildcard after non-space: cmd* *', () => {
+                expect(() => service.addAllowlistPattern('cmd* *')).to.throw(/must be preceded by a space/);
+            });
+
+            it('rejects double wildcard **', () => {
+                expect(() => service.addAllowlistPattern('git log **')).to.throw(/must be preceded by a space/);
+            });
+
+            it('rejects triple wildcard ***', () => {
+                expect(() => service.addAllowlistPattern('git ***')).to.throw(/must be preceded by a space/);
+            });
+        });
+    });
+
+    describe('isCommandAllowed with Claude Code syntax', () => {
+        describe('exact match (no wildcard)', () => {
+            beforeEach(() => {
+                storedPatterns = ['git log'];
+            });
+
+            it('matches exact command', () => {
+                expect(service.isCommandAllowed('git log')).to.be.true;
+            });
+
+            it('does not match with additional args', () => {
+                expect(service.isCommandAllowed('git log --oneline')).to.be.false;
+            });
+
+            it('does not match partial command', () => {
+                expect(service.isCommandAllowed('git')).to.be.false;
+            });
+
+            it('does not match extended command', () => {
+                expect(service.isCommandAllowed('git logger')).to.be.false;
+            });
+
+            it('does not match with prefix', () => {
+                expect(service.isCommandAllowed('sudo git log')).to.be.false;
+            });
+        });
+
+        describe('trailing wildcard: "git log *"', () => {
+            beforeEach(() => {
+                storedPatterns = ['git log *'];
+            });
+
+            it('matches base command without args', () => {
+                expect(service.isCommandAllowed('git log')).to.be.true;
+            });
+
+            it('matches command with one arg', () => {
+                expect(service.isCommandAllowed('git log --oneline')).to.be.true;
+            });
+
+            it('matches command with multiple args', () => {
+                expect(service.isCommandAllowed('git log --oneline -n 5')).to.be.true;
+            });
+
+            it('does not match different base command', () => {
+                expect(service.isCommandAllowed('git status')).to.be.false;
+            });
+
+            it('does not match partial word extension', () => {
+                expect(service.isCommandAllowed('git logger')).to.be.false;
+            });
+
+            it('does not match with prefix', () => {
+                expect(service.isCommandAllowed('sudo git log')).to.be.false;
+            });
+        });
+
+        describe('leading wildcard: "* --version"', () => {
+            beforeEach(() => {
+                storedPatterns = ['* --version'];
+            });
+
+            it('matches command ending with --version', () => {
+                expect(service.isCommandAllowed('node --version')).to.be.true;
+            });
+
+            it('matches different command ending with --version', () => {
+                expect(service.isCommandAllowed('npm --version')).to.be.true;
+            });
+
+            it('matches complex command ending with --version', () => {
+                expect(service.isCommandAllowed('python3 --version')).to.be.true;
+            });
+
+            it('does not match --version alone (no prefix)', () => {
+                expect(service.isCommandAllowed('--version')).to.be.false;
+            });
+
+            it('does not match --version in middle', () => {
+                expect(service.isCommandAllowed('node --version extra')).to.be.false;
+            });
+
+            it('does not match similar but different suffix', () => {
+                expect(service.isCommandAllowed('node --versions')).to.be.false;
+            });
+        });
+
+        describe('middle wildcard: "git * main"', () => {
+            beforeEach(() => {
+                storedPatterns = ['git * main'];
+            });
+
+            it('matches with checkout', () => {
+                expect(service.isCommandAllowed('git checkout main')).to.be.true;
+            });
+
+            it('matches with merge', () => {
+                expect(service.isCommandAllowed('git merge main')).to.be.true;
+            });
+
+            it('matches with switch', () => {
+                expect(service.isCommandAllowed('git switch main')).to.be.true;
+            });
+
+            it('matches with complex middle', () => {
+                expect(service.isCommandAllowed('git checkout -b feature main')).to.be.true;
+            });
+
+            it('does not match without middle part', () => {
+                expect(service.isCommandAllowed('git main')).to.be.false;
+            });
+
+            it('does not match different ending', () => {
+                expect(service.isCommandAllowed('git checkout master')).to.be.false;
+            });
+
+            it('does not match with prefix', () => {
+                expect(service.isCommandAllowed('sudo git checkout main')).to.be.false;
+            });
+        });
+
+        describe('multiple wildcards: "cmd * * end"', () => {
+            beforeEach(() => {
+                storedPatterns = ['cmd * * end'];
+            });
+
+            it('matches command with required middle parts', () => {
+                expect(service.isCommandAllowed('cmd foo bar end')).to.be.true;
+            });
+
+            it('matches command with extra middle parts', () => {
+                expect(service.isCommandAllowed('cmd foo bar baz end')).to.be.true;
+            });
+
+            it('does not match without required ending', () => {
+                expect(service.isCommandAllowed('cmd foo bar')).to.be.false;
+            });
+
+            it('does not match without required start', () => {
+                expect(service.isCommandAllowed('foo bar end')).to.be.false;
+            });
+        });
+
+        describe('special regex characters in pattern', () => {
+            it('matches pattern with quotes literally', () => {
+                storedPatterns = ['echo "hello"'];
+                expect(service.isCommandAllowed('echo "hello"')).to.be.true;
+            });
+
+            it('does not treat quotes as special', () => {
+                storedPatterns = ['echo "hello"'];
+                expect(service.isCommandAllowed('echo hello')).to.be.false;
+            });
+
+            it('matches pattern with plus literally', () => {
+                storedPatterns = ['echo a+b'];
+                expect(service.isCommandAllowed('echo a+b')).to.be.true;
+                expect(service.isCommandAllowed('echo aXb')).to.be.false;
+            });
+
+            it('matches pattern with $ literally', () => {
+                storedPatterns = ['echo $HOME'];
+                expect(service.isCommandAllowed('echo $HOME')).to.be.true;
+            });
+
+            it('matches pattern with dot literally', () => {
+                storedPatterns = ['cat file.txt'];
+                expect(service.isCommandAllowed('cat file.txt')).to.be.true;
+                expect(service.isCommandAllowed('cat fileXtxt')).to.be.false;
+            });
+
+            it('matches pattern with brackets literally', () => {
+                storedPatterns = ['echo [test]'];
+                expect(service.isCommandAllowed('echo [test]')).to.be.true;
+            });
+
+            it('matches pattern with parentheses literally', () => {
+                storedPatterns = ['echo (test)'];
+                expect(service.isCommandAllowed('echo (test)')).to.be.true;
+            });
+        });
+
+        describe('edge cases', () => {
+            it('handles multiple spaces in command', () => {
+                storedPatterns = ['git log *'];
+                // Double space doesn't match - exact pattern requires single space
+                expect(service.isCommandAllowed('git  log')).to.be.false;
+            });
+
+            it('is case sensitive', () => {
+                storedPatterns = ['git log'];
+                expect(service.isCommandAllowed('Git Log')).to.be.false;
+                expect(service.isCommandAllowed('GIT LOG')).to.be.false;
+            });
+
+            it('returns false for empty allowlist', () => {
+                storedPatterns = [];
+                expect(service.isCommandAllowed('git log')).to.be.false;
+            });
+        });
+
+        describe('integration with dangerous pattern detection', () => {
+            it('blocks command substitution even when pattern matches', () => {
+                storedPatterns = ['git log *'];
+                expect(service.isCommandAllowed('git log $(whoami)')).to.be.false;
+            });
+
+            it('blocks backticks even when pattern matches', () => {
+                storedPatterns = ['echo *'];
+                expect(service.isCommandAllowed('echo `whoami`')).to.be.false;
+            });
+
+            it('blocks subshell even when pattern matches', () => {
+                storedPatterns = ['* *'];
+                expect(service.isCommandAllowed('(rm -rf /)')).to.be.false;
+            });
+        });
+
+        describe('combined sub-commands', () => {
+            beforeEach(() => {
+                storedPatterns = ['git log *', 'git status'];
+            });
+
+            it('allows when all sub-commands match', () => {
+                expect(service.isCommandAllowed('git log --oneline && git status')).to.be.true;
+            });
+
+            it('blocks when any sub-command does not match', () => {
+                expect(service.isCommandAllowed('git log --oneline && git push')).to.be.false;
+            });
+        });
+    });
+
+    describe('matchesPattern', () => {
+        it('matches exact pattern', () => {
+            expect(service.matchesPattern('git log', 'git log')).to.be.true;
+        });
+
+        it('does not match pattern with additional args without wildcard', () => {
+            expect(service.matchesPattern('git log --oneline', 'git log')).to.be.false;
+        });
+
+        it('matches trailing wildcard with args', () => {
+            expect(service.matchesPattern('git log --oneline', 'git log *')).to.be.true;
+        });
+
+        it('matches trailing wildcard without args', () => {
+            expect(service.matchesPattern('git log', 'git log *')).to.be.true;
+        });
+
+        it('does not match partial word', () => {
+            expect(service.matchesPattern('git logger', 'git log')).to.be.false;
+            expect(service.matchesPattern('git logger', 'git log *')).to.be.false;
+        });
+
+        it('does not match when pattern is not at start', () => {
+            expect(service.matchesPattern('sudo git log', 'git log')).to.be.false;
+        });
+    });
+
+    describe('getAllowlistPatterns', () => {
+        it('returns current patterns from preferences', () => {
+            storedPatterns = ['git log', 'npm test'];
+            const patterns = service.getAllowlistPatterns();
+            expect(patterns).to.deep.equal(['git log', 'npm test']);
+        });
+
+        it('returns empty array when no patterns configured', () => {
+            storedPatterns = [];
+            const patterns = service.getAllowlistPatterns();
+            expect(patterns).to.deep.equal([]);
+        });
+    });
+
+    describe('removeAllowlistPattern', () => {
+        it('removes existing pattern', () => {
+            storedPatterns = ['git log', 'npm test'];
+            service.removeAllowlistPattern('git log');
+            expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
+            expect(storedPatterns).to.deep.equal(['npm test']);
+        });
+
+        it('does not call updateValue when pattern does not exist', () => {
+            storedPatterns = ['git log'];
+            service.removeAllowlistPattern('npm test');
+            expect(preferenceServiceMock.updateValue.called).to.be.false;
+        });
+    });
+
+    describe('denylist functionality', () => {
+        describe('isCommandDenylisted', () => {
+            it('returns false when denylist is empty', () => {
+                storedDenylistPatterns = [];
+                expect(service.isCommandDenylisted('git push')).to.be.false;
+            });
+
+            it('returns true for exact match', () => {
+                storedDenylistPatterns = ['git push'];
+                expect(service.isCommandDenylisted('git push')).to.be.true;
+                expect(service.isCommandDenylisted('git push origin')).to.be.false;
+            });
+
+            it('returns true for wildcard match', () => {
+                storedDenylistPatterns = ['git push *'];
+                expect(service.isCommandDenylisted('git push')).to.be.true;
+                expect(service.isCommandDenylisted('git push origin main')).to.be.true;
+                expect(service.isCommandDenylisted('git pull')).to.be.false;
+            });
+
+            it('checks all sub-commands for denylist - returns true if ANY matches', () => {
+                storedDenylistPatterns = ['rm -rf /'];
+                expect(service.isCommandDenylisted('ls && rm -rf /')).to.be.true;
+            });
+        });
+
+        describe('denylist precedence over allowlist', () => {
+            it('denies command that matches both denylist and allowlist', () => {
+                storedPatterns = ['git *'];
+                storedDenylistPatterns = ['git push *'];
+                expect(service.isCommandAllowed('git log')).to.be.true;
+                expect(service.isCommandAllowed('git push origin')).to.be.false;
+            });
+        });
+
+        describe('getDenylistPatterns', () => {
+            it('returns empty array when no patterns', () => {
+                storedDenylistPatterns = [];
+                expect(service.getDenylistPatterns()).to.deep.equal([]);
+            });
+
+            it('returns stored patterns', () => {
+                storedDenylistPatterns = ['git push *', 'rm -rf /'];
+                expect(service.getDenylistPatterns()).to.deep.equal(['git push *', 'rm -rf /']);
+            });
+        });
+
+        describe('addDenylistPattern', () => {
+            it('adds valid pattern', () => {
+                service.addDenylistPattern('git push *');
+                expect(storedDenylistPatterns).to.deep.equal(['git push *']);
+            });
+
+            it('rejects empty pattern', () => {
+                expect(() => service.addDenylistPattern('')).to.throw('Pattern cannot be empty or whitespace-only');
+            });
+
+            it('rejects * alone', () => {
+                expect(() => service.addDenylistPattern('*')).to.throw(/too permissive/);
+            });
+
+            it('rejects invalid wildcard position (git push*)', () => {
+                expect(() => service.addDenylistPattern('git push*')).to.throw(/must be preceded by a space/);
+            });
+        });
+
+        describe('removeDenylistPattern', () => {
+            it('removes existing pattern', () => {
+                storedDenylistPatterns = ['git push *', 'rm -rf /'];
+                service.removeDenylistPattern('git push *');
+                expect(storedDenylistPatterns).to.deep.equal(['rm -rf /']);
+            });
+        });
+
+        describe('new default denylist entries', () => {
+            describe('command wrappers', () => {
+                it('xargs * blocks xargs rm -rf /', () => {
+                    storedDenylistPatterns = ['xargs *'];
+                    expect(service.isCommandDenylisted('xargs rm -rf /')).to.be.true;
+                });
+
+                it('nohup * blocks nohup rm -rf / &', () => {
+                    storedDenylistPatterns = ['nohup *'];
+                    expect(service.isCommandDenylisted('nohup rm -rf / &')).to.be.true;
+                });
+
+                it('timeout * blocks timeout 10 rm -rf /', () => {
+                    storedDenylistPatterns = ['timeout *'];
+                    expect(service.isCommandDenylisted('timeout 10 rm -rf /')).to.be.true;
+                });
+
+                it('nice * blocks nice -n 19 heavy-task', () => {
+                    storedDenylistPatterns = ['nice *'];
+                    expect(service.isCommandDenylisted('nice -n 19 heavy-task')).to.be.true;
+                });
+            });
+
+            describe('remote/repeated execution', () => {
+                it('ssh * blocks ssh user@host rm -rf /', () => {
+                    storedDenylistPatterns = ['ssh *'];
+                    expect(service.isCommandDenylisted('ssh user@host rm -rf /')).to.be.true;
+                });
+
+                it('watch * blocks watch cat /etc/shadow', () => {
+                    storedDenylistPatterns = ['watch *'];
+                    expect(service.isCommandDenylisted('watch cat /etc/shadow')).to.be.true;
+                });
+            });
+
+            describe('shell re-invocation', () => {
+                it('bash -c * blocks bash -c "rm -rf /"', () => {
+                    storedDenylistPatterns = ['bash -c *'];
+                    expect(service.isCommandDenylisted('bash -c "rm -rf /"')).to.be.true;
+                });
+
+                it('sh -c * blocks sh -c "malicious command"', () => {
+                    storedDenylistPatterns = ['sh -c *'];
+                    expect(service.isCommandDenylisted('sh -c "malicious command"')).to.be.true;
+                });
+            });
+
+            describe('interpreter execution', () => {
+                it('python -c * blocks python -c "import os; os.system(\'rm -rf /\')"', () => {
+                    storedDenylistPatterns = ['python -c *'];
+                    expect(service.isCommandDenylisted('python -c "import os; os.system(\'rm -rf /\')"')).to.be.true;
+                });
+
+                it('python3 -c * blocks python3 -c "print(\'pwned\')"', () => {
+                    storedDenylistPatterns = ['python3 -c *'];
+                    expect(service.isCommandDenylisted('python3 -c "print(\'pwned\')"')).to.be.true;
+                });
+
+                it('node -e * blocks node -e "require(\'child_process\').exec(\'rm -rf /\')"', () => {
+                    storedDenylistPatterns = ['node -e *'];
+                    expect(service.isCommandDenylisted('node -e "require(\'child_process\').exec(\'rm -rf /\')"')).to.be.true;
+                });
+
+                it('perl -e * blocks perl -e "system(\'rm -rf /\')"', () => {
+                    storedDenylistPatterns = ['perl -e *'];
+                    expect(service.isCommandDenylisted('perl -e "system(\'rm -rf /\')"')).to.be.true;
+                });
+
+                it('ruby -e * blocks ruby -e "system(\'rm -rf /\')"', () => {
+                    storedDenylistPatterns = ['ruby -e *'];
+                    expect(service.isCommandDenylisted('ruby -e "system(\'rm -rf /\')"')).to.be.true;
+                });
+            });
+
+            describe('removed entries are not denylisted', () => {
+                it('chmod 755 file.txt is not denylisted when chmod * is not in denylist', () => {
+                    storedDenylistPatterns = ['rm -rf /'];
+                    expect(service.isCommandDenylisted('chmod 755 file.txt')).to.be.false;
+                });
+
+                it('chown user:group file.txt is not denylisted when chown * is not in denylist', () => {
+                    storedDenylistPatterns = ['rm -rf /'];
+                    expect(service.isCommandDenylisted('chown user:group file.txt')).to.be.false;
+                });
+            });
+        });
+    });
+
+    describe('checkCommand', () => {
+        it('returns dangerous reason for dangerous commands', () => {
+            const result = service.checkCommand('echo $(whoami)');
+            expect(result.allowed).to.be.false;
+            expect(result.reason).to.equal('dangerous');
+        });
+
+        it('returns denied reason with matched pattern', () => {
+            storedDenylistPatterns = ['git push *'];
+            const result = service.checkCommand('git push origin');
+            expect(result.allowed).to.be.false;
+            expect(result.reason).to.equal('denied');
+            expect(result.matchedPattern).to.equal('git push *');
+        });
+
+        it('returns allowed for allowlisted commands', () => {
+            storedPatterns = ['git log *'];
+            const result = service.checkCommand('git log --oneline');
+            expect(result.allowed).to.be.true;
+            expect(result.reason).to.be.undefined;
+        });
+
+        it('returns not-allowed for unmatched commands', () => {
+            storedPatterns = [];
+            const result = service.checkCommand('some-command');
+            expect(result.allowed).to.be.false;
+            expect(result.reason).to.equal('not-allowed');
+        });
+
+        it('returns denied before allowed (precedence)', () => {
+            storedPatterns = ['git *'];
+            storedDenylistPatterns = ['git push *'];
+            const result = service.checkCommand('git push origin');
+            expect(result.allowed).to.be.false;
+            expect(result.reason).to.equal('denied');
+            expect(result.matchedPattern).to.equal('git push *');
+        });
+    });
+});

--- a/packages/ai-terminal/src/browser/shell-command-permission-service.ts
+++ b/packages/ai-terminal/src/browser/shell-command-permission-service.ts
@@ -1,0 +1,193 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PreferenceService } from '@theia/core/lib/common';
+import { SHELL_COMMAND_ALLOWLIST_PREFERENCE, SHELL_COMMAND_DENYLIST_PREFERENCE } from '../common/shell-command-preferences';
+import { ShellCommandAnalyzer } from '../common/shell-command-analyzer';
+
+export interface CommandCheckResult {
+    allowed: boolean;
+    reason?: 'denied' | 'dangerous' | 'not-allowed';
+    matchedPattern?: string;
+}
+
+@injectable()
+export class ShellCommandPermissionService {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(ShellCommandAnalyzer)
+    protected readonly shellCommandAnalyzer: ShellCommandAnalyzer;
+
+    /**
+     * Checks if a command is allowed based on the allowlist patterns.
+     * Returns false if the command contains dangerous patterns, is on the denylist, or if the allowlist is empty.
+     * Returns true only if ALL sub-commands match at least one allowlist pattern.
+     */
+    isCommandAllowed(command: string): boolean {
+        return this.checkCommand(command).allowed;
+    }
+
+    /** Returns true if ANY sub-command matches ANY denylist pattern. */
+    isCommandDenylisted(command: string): boolean {
+        return this.checkCommand(command).reason === 'denied';
+    }
+
+    /**
+     * Checks a command and returns detailed result with precedence:
+     * 1. Matches denylist → { allowed: false, reason: 'denied', matchedPattern }
+     * 2. Matches dangerous patterns → { allowed: false, reason: 'dangerous' }
+     * 3. Matches allowlist → { allowed: true }
+     * 4. Otherwise → { allowed: false, reason: 'not-allowed' }
+     */
+    checkCommand(command: string): CommandCheckResult {
+        const denylistPatterns = this.getDenylistPatterns();
+        const subCommands = this.shellCommandAnalyzer.parseCommand(command);
+
+        for (const subCommand of subCommands) {
+            for (const pattern of denylistPatterns) {
+                if (this.matchesPattern(subCommand, pattern)) {
+                    return { allowed: false, reason: 'denied', matchedPattern: pattern };
+                }
+            }
+        }
+
+        if (this.shellCommandAnalyzer.containsDangerousPatterns(command)) {
+            return { allowed: false, reason: 'dangerous' };
+        }
+
+        const allowlistPatterns = this.getAllowlistPatterns();
+        if (allowlistPatterns.length > 0 && subCommands.length > 0) {
+            const allAllowed = subCommands.every(subCommand =>
+                allowlistPatterns.some(pattern => this.matchesPattern(subCommand, pattern))
+            );
+            if (allAllowed) {
+                return { allowed: true };
+            }
+        }
+
+        return { allowed: false, reason: 'not-allowed' };
+    }
+
+    /**
+     * Checks if a sub-command matches an allowlist pattern using Claude Code compatible syntax.
+     * Supports * wildcards: trailing (optional args), leading (suffix match), middle (required match).
+     */
+    matchesPattern(subCommand: string, pattern: string): boolean {
+        let regexStr = '';
+        let i = 0;
+
+        while (i < pattern.length) {
+            const char = pattern[i];
+
+            if (char === '*') {
+                // Check if this is a trailing wildcard (at end, preceded by space)
+                if (i === pattern.length - 1 && i > 0 && pattern[i - 1] === ' ') {
+                    // Trailing " *" -> optional args: remove the space we added, add ( .*)?
+                    regexStr = regexStr.slice(0, -1) + '( .*)?';
+                } else {
+                    // Leading or middle wildcard -> required match
+                    regexStr += '.*';
+                }
+            } else if ('.+?^${}()|[]\\'.includes(char)) {
+                // Escape regex special char
+                regexStr += '\\' + char;
+            } else {
+                regexStr += char;
+            }
+            i++;
+        }
+
+        return new RegExp(`^${regexStr}$`).test(subCommand);
+    }
+
+    getAllowlistPatterns(): string[] {
+        return this.preferenceService.get<string[]>(SHELL_COMMAND_ALLOWLIST_PREFERENCE, []);
+    }
+
+    /**
+     * Adds a pattern to the allowlist.
+     * Rejects empty or whitespace-only patterns, "*" alone, and invalid wildcard positions.
+     * Trims the pattern before adding and avoids duplicates.
+     */
+    addAllowlistPattern(pattern: string): void {
+        this.addPatternToList(pattern, SHELL_COMMAND_ALLOWLIST_PREFERENCE, () => this.getAllowlistPatterns());
+    }
+
+    removeAllowlistPattern(pattern: string): void {
+        this.removePatternFromList(pattern, SHELL_COMMAND_ALLOWLIST_PREFERENCE, () => this.getAllowlistPatterns());
+    }
+
+    getDenylistPatterns(): string[] {
+        return this.preferenceService.get<string[]>(SHELL_COMMAND_DENYLIST_PREFERENCE, []);
+    }
+
+    /**
+     * Adds a pattern to the denylist.
+     * Uses the same validation as allowlist patterns.
+     */
+    addDenylistPattern(pattern: string): void {
+        this.addPatternToList(pattern, SHELL_COMMAND_DENYLIST_PREFERENCE, () => this.getDenylistPatterns());
+    }
+
+    removeDenylistPattern(pattern: string): void {
+        this.removePatternFromList(pattern, SHELL_COMMAND_DENYLIST_PREFERENCE, () => this.getDenylistPatterns());
+    }
+
+    /**
+     * Validates a pattern and returns the trimmed version.
+     * Throws an error if the pattern is invalid.
+     */
+    protected validatePattern(pattern: string): string {
+        const trimmed = pattern.trim();
+        if (!trimmed) {
+            throw new Error('Pattern cannot be empty or whitespace-only');
+        }
+        if (trimmed === '*') {
+            throw new Error('Pattern "*" is too permissive - it would match all commands');
+        }
+        // Check for * not preceded by space (unless at position 0)
+        // This regex finds * that is NOT at start AND NOT preceded by space
+        if (/(?<!^)(?<! )\*/.test(trimmed)) {
+            throw new Error('Wildcard * must be preceded by a space (e.g., "git log *" not "git log*")');
+        }
+        return trimmed;
+    }
+
+    protected addPatternToList(pattern: string, preferenceKey: string, getCurrentPatterns: () => string[]): void {
+        const trimmed = this.validatePattern(pattern);
+        const currentPatterns = getCurrentPatterns();
+        if (!currentPatterns.includes(trimmed)) {
+            this.preferenceService.updateValue(
+                preferenceKey,
+                [...currentPatterns, trimmed]
+            );
+        }
+    }
+
+    protected removePatternFromList(pattern: string, preferenceKey: string, getCurrentPatterns: () => string[]): void {
+        const currentPatterns = getCurrentPatterns();
+        const filtered = currentPatterns.filter(p => p !== pattern);
+        if (filtered.length !== currentPatterns.length) {
+            this.preferenceService.updateValue(
+                preferenceKey,
+                filtered
+            );
+        }
+    }
+}

--- a/packages/ai-terminal/src/common/index.ts
+++ b/packages/ai-terminal/src/common/index.ts
@@ -1,0 +1,18 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './shell-command-analyzer';
+export * from './shell-command-preferences';

--- a/packages/ai-terminal/src/common/shell-command-analyzer.spec.ts
+++ b/packages/ai-terminal/src/common/shell-command-analyzer.spec.ts
@@ -1,0 +1,231 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { DefaultShellCommandAnalyzer } from './shell-command-analyzer';
+
+describe('shell-command-analyzer', () => {
+    let analyzer: DefaultShellCommandAnalyzer;
+
+    beforeEach(() => {
+        analyzer = new DefaultShellCommandAnalyzer();
+    });
+
+    describe('parseCommand', () => {
+        it('should parse a single command', () => {
+            expect(analyzer.parseCommand('git log')).to.deep.equal(['git log']);
+        });
+
+        it('should split on AND operator (&&)', () => {
+            expect(analyzer.parseCommand('git status && git log')).to.deep.equal(['git status', 'git log']);
+        });
+
+        it('should split on OR operator (||)', () => {
+            expect(analyzer.parseCommand('cmd1 || cmd2')).to.deep.equal(['cmd1', 'cmd2']);
+        });
+
+        it('should split on semicolon (;)', () => {
+            expect(analyzer.parseCommand('cmd1 ; cmd2')).to.deep.equal(['cmd1', 'cmd2']);
+        });
+
+        it('should split on pipe (|)', () => {
+            expect(analyzer.parseCommand('cat file | grep pattern')).to.deep.equal(['cat file', 'grep pattern']);
+        });
+
+        it('should split on background operator (&)', () => {
+            expect(analyzer.parseCommand('echo test & cat /etc/passwd')).to.deep.equal(['echo test', 'cat /etc/passwd']);
+        });
+
+        it('should split on && without confusing with single &', () => {
+            expect(analyzer.parseCommand('cmd1 && cmd2')).to.deep.equal(['cmd1', 'cmd2']);
+        });
+
+        it('should handle mixed operators', () => {
+            expect(analyzer.parseCommand('cmd1 && cmd2 | cmd3 ; cmd4')).to.deep.equal(['cmd1', 'cmd2', 'cmd3', 'cmd4']);
+        });
+
+        it('should trim whitespace from sub-commands', () => {
+            expect(analyzer.parseCommand('  git log  &&  git status  ')).to.deep.equal(['git log', 'git status']);
+        });
+
+        it('should return empty array for empty command', () => {
+            expect(analyzer.parseCommand('')).to.deep.equal([]);
+        });
+
+        it('should return empty array for only operators', () => {
+            expect(analyzer.parseCommand('&& || ;')).to.deep.equal([]);
+        });
+
+        it('should split on pipe-with-stderr operator (|&)', () => {
+            expect(analyzer.parseCommand('bad_cmd |& cat /etc/passwd')).to.deep.equal(['bad_cmd', 'cat /etc/passwd']);
+        });
+
+        it('should not confuse |& with | followed by &', () => {
+            // |& is a single bash operator (pipe stderr+stdout), distinct from | then &
+            expect(analyzer.parseCommand('cmd1 |& cmd2')).to.deep.equal(['cmd1', 'cmd2']);
+        });
+    });
+
+    describe('containsDangerousPatterns', () => {
+        it('should return false for safe commands', () => {
+            expect(analyzer.containsDangerousPatterns('git log')).to.be.false;
+        });
+
+        it('should return true for command substitution with $(', () => {
+            expect(analyzer.containsDangerousPatterns('echo $(whoami)')).to.be.true;
+        });
+
+        it('should return true for backticks', () => {
+            expect(analyzer.containsDangerousPatterns('echo `whoami`')).to.be.true;
+        });
+
+        it('should return true when dangerous pattern is nested in argument', () => {
+            expect(analyzer.containsDangerousPatterns('git log $(malicious)')).to.be.true;
+        });
+
+        it('should return false for safe dollar sign (variable)', () => {
+            expect(analyzer.containsDangerousPatterns('echo $HOME')).to.be.false;
+        });
+
+        it('should return true for process substitution with <(', () => {
+            expect(analyzer.containsDangerousPatterns('cat <(ls)')).to.be.true;
+            expect(analyzer.containsDangerousPatterns('diff <(ls dir1) <(ls dir2)')).to.be.true;
+        });
+
+        it('should return true for process substitution with >(', () => {
+            expect(analyzer.containsDangerousPatterns('tee >(grep foo)')).to.be.true;
+        });
+
+        it('should return true for parameter expansion with ${', () => {
+            expect(analyzer.containsDangerousPatterns('echo ${PATH}')).to.be.true;
+            expect(analyzer.containsDangerousPatterns('echo ${var:-default}')).to.be.true;
+        });
+
+        it('should return true for subshell at command start', () => {
+            expect(analyzer.containsDangerousPatterns('(cd /tmp && ls)')).to.be.true;
+            expect(analyzer.containsDangerousPatterns('  (cd /tmp && ls)')).to.be.true; // with leading whitespace
+        });
+
+        it('should return false for safe parentheses in arguments', () => {
+            expect(analyzer.containsDangerousPatterns("grep '(pattern)' file")).to.be.false;
+            expect(analyzer.containsDangerousPatterns('echo "(hello)"')).to.be.false;
+        });
+
+        // Newlines as dangerous (shell treats \n as command separator)
+        it('should detect newline as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('echo safe\ncat /etc/passwd')).to.be.true;
+        });
+
+        it('should detect carriage return + newline as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('echo safe\r\ncat /etc/passwd')).to.be.true;
+        });
+
+        it('should detect carriage return as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('echo safe\rcat /etc/passwd')).to.be.true;
+        });
+
+        // Case statement attacks (;; and ;& and ;;& are case delimiters that enable multi-command execution)
+        it('should detect case statement with ;; as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('case x in *) cat /etc/passwd ;; esac')).to.be.true;
+        });
+
+        it('should detect case statement with ;& fallthrough as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('case x in *) echo ok ;& *) cat /etc/passwd ;; esac')).to.be.true;
+        });
+
+        it('should detect case statement with ;;& as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('case x in *) echo ok ;;& *) cat /etc/passwd ;; esac')).to.be.true;
+        });
+
+        it('should detect case statement with tab whitespace', () => {
+            expect(analyzer.containsDangerousPatterns('case\tx in *) cat /etc/passwd ;; esac')).to.be.true;
+        });
+
+        it('should detect brace group as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('{ cmd1; cmd2; }')).to.be.true;
+        });
+
+        it('should detect brace group with leading whitespace as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('  { echo safe; cat /etc/passwd; }')).to.be.true;
+        });
+
+        it('should detect coproc as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('coproc cat /etc/passwd')).to.be.true;
+        });
+
+        it('should detect coproc with tab whitespace as dangerous', () => {
+            expect(analyzer.containsDangerousPatterns('coproc\tcat /etc/passwd')).to.be.true;
+        });
+
+        it('should not flag commands containing coproc in arguments', () => {
+            expect(analyzer.containsDangerousPatterns('echo coproc')).to.be.false;
+        });
+
+        it('should not flag commands containing brace in arguments', () => {
+            expect(analyzer.containsDangerousPatterns('echo {a,b,c}')).to.be.false;
+        });
+
+        describe('-exec family detection', () => {
+            it('should detect find with -exec as dangerous', () => {
+                expect(analyzer.containsDangerousPatterns('find / -exec rm -rf {} \\;')).to.be.true;
+            });
+
+            it('should detect find with -execdir as dangerous', () => {
+                expect(analyzer.containsDangerousPatterns('find . -execdir cat {} \\;')).to.be.true;
+            });
+
+            it('should detect find with -ok as dangerous', () => {
+                expect(analyzer.containsDangerousPatterns('find . -ok rm {} \\;')).to.be.true;
+            });
+
+            it('should detect find with -okdir as dangerous', () => {
+                expect(analyzer.containsDangerousPatterns('find . -okdir rm {} \\;')).to.be.true;
+            });
+
+            it('should detect git rebase --exec= as dangerous', () => {
+                expect(analyzer.containsDangerousPatterns('git rebase --exec="make test" HEAD~3')).to.be.true;
+            });
+
+            it('should detect git rebase --exec (space-separated) as dangerous', () => {
+                expect(analyzer.containsDangerousPatterns('git rebase --exec make HEAD~3')).to.be.true;
+            });
+
+            it('should detect git bisect run --exec as dangerous', () => {
+                expect(analyzer.containsDangerousPatterns('git bisect run --exec test')).to.be.true;
+            });
+
+            it('should not flag "exec" embedded in a word like executable', () => {
+                expect(analyzer.containsDangerousPatterns('ls executable_file')).to.be.false;
+            });
+
+            it('should not flag --executor as it is not --exec', () => {
+                expect(analyzer.containsDangerousPatterns('echo --executor')).to.be.false;
+            });
+
+            it('should not flag exec in path/filename', () => {
+                expect(analyzer.containsDangerousPatterns('./my-exec-tool')).to.be.false;
+            });
+
+            it('should not flag exec at start of filename', () => {
+                expect(analyzer.containsDangerousPatterns('cat execfile.txt')).to.be.false;
+            });
+
+            it('should not flag -ok embedded in a larger flag', () => {
+                expect(analyzer.containsDangerousPatterns('echo -ok-result')).to.be.false;
+            });
+        });
+    });
+});

--- a/packages/ai-terminal/src/common/shell-command-analyzer.ts
+++ b/packages/ai-terminal/src/common/shell-command-analyzer.ts
@@ -1,0 +1,106 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+
+/**
+ * Pattern to match command concatenation operators: &&, &, ||, |&, |, ;
+ * Note: Single `&` uses negative lookaround `(?<!&)&(?!&)` to explicitly
+ * prevent matching when adjacent to another `&`, rather than relying on
+ * alternation ordering.
+ * `|&` must appear before `|` in the alternation to be matched first.
+ */
+const COMMAND_SEPARATOR_PATTERN = /\s*(?:&&|(?<!&)&(?!&)|\|\||\|&|\||;)\s*/;
+
+/**
+ * Pattern to detect dangerous shell patterns:
+ * - $( - command substitution
+ * - ` - backtick command substitution
+ * - <( - process substitution (input)
+ * - >( - process substitution (output)
+ * - ${ - parameter expansion with braces (can execute code via ${var:-$(cmd)})
+ * - \n, \r - newlines (shell treats them as command separators)
+ *
+ * Note: `-exec` family flags (e.g., `find -exec`, `git rebase --exec`) are
+ * detected separately in `containsDangerousPatterns` via EXEC_FLAG_PATTERN.
+ */
+const DANGEROUS_PATTERN = /\$\(|`|<\(|>\(|\$\{|\n|\r/;
+
+/**
+ * Pattern to detect `-exec` family argument flags that allow arbitrary command execution.
+ * Matches: -exec, --exec, -execdir, --execdir, -ok, -okdir
+ * These are used by commands like `find -exec rm {} \;` or `git rebase --exec="make test"`.
+ * The pattern requires word boundaries (start-of-string or whitespace before, whitespace/=/end after)
+ * to avoid false positives on words like "executable" or "--executor".
+ */
+const EXEC_FLAG_PATTERN = /(?:^|\s)(?:--?exec(?:dir)?|-ok(?:dir)?)(?:\s|=|$)/;
+
+export const ShellCommandAnalyzer = Symbol('ShellCommandAnalyzer');
+
+export interface ShellCommandAnalyzer {
+    /**
+     * Checks if a command contains dangerous patterns that could indicate
+     * bypass attacks. Detects:
+     * - Command substitution via $() or backticks
+     * - Process substitution via <() or >()
+     * - Parameter expansion with braces via ${}
+     * - Subshell execution when command starts with (
+     *
+     * @param command The shell command to analyze
+     * @returns true if the command contains dangerous patterns, false otherwise
+     */
+    containsDangerousPatterns(command: string): boolean;
+
+    /**
+     * Parses a shell command string into individual sub-commands by splitting
+     * on concatenation operators (&&, ||, ;, |).
+     *
+     * @param command The shell command to parse
+     * @returns Array of trimmed sub-commands with empty entries filtered out
+     */
+    parseCommand(command: string): string[];
+}
+
+@injectable()
+export class DefaultShellCommandAnalyzer implements ShellCommandAnalyzer {
+
+    containsDangerousPatterns(command: string): boolean {
+        const trimmed = command.trimStart();
+        if (trimmed.startsWith('(')) {
+            return true;
+        }
+        if (/^case\s/.test(trimmed)) {
+            return true;
+        }
+        if (trimmed.startsWith('{')) {
+            return true;
+        }
+        if (/^coproc\s/.test(trimmed)) {
+            return true;
+        }
+        if (EXEC_FLAG_PATTERN.test(command)) {
+            return true;
+        }
+        return DANGEROUS_PATTERN.test(command);
+    }
+
+    parseCommand(command: string): string[] {
+        return command
+            .split(COMMAND_SEPARATOR_PATTERN)
+            .map(cmd => cmd.trim())
+            .filter(cmd => cmd.length > 0);
+    }
+}

--- a/packages/ai-terminal/src/common/shell-command-preferences.ts
+++ b/packages/ai-terminal/src/common/shell-command-preferences.ts
@@ -1,0 +1,96 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { PreferenceSchema } from '@theia/core/lib/common/preferences';
+import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
+
+export const SHELL_COMMAND_ALLOWLIST_PREFERENCE = 'ai-features.terminal.shellCommandAllowlist';
+export const SHELL_COMMAND_DENYLIST_PREFERENCE = 'ai-features.terminal.shellCommandDenylist';
+
+export const shellCommandPreferences: PreferenceSchema = {
+    properties: {
+        [SHELL_COMMAND_ALLOWLIST_PREFERENCE]: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [],
+            description: nls.localize(
+                'theia/ai-terminal/shellCommandAllowlist/description',
+                'List of shell command patterns. Use * as wildcard: "git log" (exact match), ' +
+                '"git log *" (with optional arguments), "* --version" (any command ending with --version). ' +
+                'Wildcard must be preceded by space. Commands with dangerous patterns ($, backticks) are never auto-allowed.'
+            ),
+            title: AI_CORE_PREFERENCES_TITLE,
+        },
+        [SHELL_COMMAND_DENYLIST_PREFERENCE]: {
+            type: 'array',
+            items: { type: 'string' },
+            default: [
+                // Shell execution control — these commands can execute arbitrary code,
+                // bypass static analysis, or alter the shell's execution environment
+                'eval *',
+                'exec *',
+                'source *',
+                '. *',
+                'trap *',
+                // Indirect execution — can bypass denylist pattern matching
+                // e.g., "command eval ..." or "env sudo ..."
+                'command *',
+                'builtin *',
+                'env *',
+                // Privilege escalation
+                'sudo *',
+                'su *',
+                // Destructive operations
+                'rm -rf /',
+                'mkfs *',
+                'dd *',
+                // System control
+                'shutdown *',
+                'reboot *',
+                'halt *',
+                'poweroff *',
+                // Command wrappers — execute their arguments as commands
+                'xargs *',
+                'nohup *',
+                'timeout *',
+                'nice *',
+                // Remote/repeated execution
+                'ssh *',
+                'watch *',
+                // Shell re-invocation
+                'bash -c *',
+                'sh -c *',
+                'zsh -c *',
+                'dash -c *',
+                'ksh -c *',
+                // Interpreter execution
+                'python -c *',
+                'python3 -c *',
+                'node -e *',
+                'perl -e *',
+                'ruby -e *',
+            ],
+            description: nls.localize(
+                'theia/ai-terminal/shellCommandDenylist/description',
+                'List of shell command patterns that should always be denied. Commands matching these patterns will be auto-rejected without confirmation. ' +
+                'Uses pattern syntax: "git push" (exact match) or "git push *" (with any arguments). ' +
+                'Ships with default patterns for dangerous commands (eval, exec, sudo, rm -rf, etc.).'
+            ),
+            title: AI_CORE_PREFERENCES_TITLE,
+        }
+    }
+};


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Adds command-level analysis and pattern-based whitelist for the shellExecute tool, allowing users to auto-approve specific commands while requiring confirmation for others.

Key features:

- Pattern-based whitelist with word-boundary prefix matching
- Commands with dangerous patterns ($() or backticks) are never auto-approved
- Concatenated commands (&&, ||, ;, |) require ALL sub-commands to match
- UI section in AI Configuration → Tools tab for managing patterns
- Patterns persist via preferences

Additional changes:

- Introduces shouldAutoApprove hook on ToolRequest interface, allowing tools to control their own auto-approval logic without hardcoding tool IDs in the chat service.
- Adds ShellCommandAnalyzer for parsing shell commands and detecting dangerous patterns like command substitution.
- Adds ShellCommandWhitelistService for managing whitelist patterns with word-boundary prefix matching (e.g., "git log" matches "git log --oneline" but not "git logger" or "sudo git log").
- Empty or whitespace-only patterns are rejected to prevent accidental match-all configurations.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Set shellExecute to `Confirm`. Then add 2 commands that should be auto-approved. then ask the shell execute to execute those. alone, combined and combined with not approved tools. 
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
