### PR TITLE
Fix whitespace collapsing in Explorer file/folder names

### DIFF
--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -118,7 +118,9 @@
 }
 
 .theia-Tree:focus-within .theia-TreeNode.theia-mod-focus,
-.theia-Tree .ReactVirtualized__List:focus-within .theia-TreeNode.theia-mod-focus {
+.theia-Tree
+  .ReactVirtualized__List:focus-within
+  .theia-TreeNode.theia-mod-focus {
   outline-width: 1px;
   outline-style: solid;
   outline-offset: -1px;
@@ -148,7 +150,7 @@
   align-items: center;
   flex-grow: 0;
   user-select: none;
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .theia-TreeNodeSegment.flex {
@@ -159,7 +161,7 @@
   flex-grow: 1 !important;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .theia-TreeNodeTail {
@@ -169,10 +171,10 @@
 }
 
 .open-editors-node-row .theia-TreeNode .theia-TreeNodeContent .noWrapInfo > * {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    display: inline;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: inline;
 }
 
 .theia-TreeNodeSegment mark {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #16865

Multiple consecutive spaces in file and folder names were being collapsed to single spaces in the Explorer tree view due to default HTML whitespace handling.

Added 'white-space: pre' CSS property to .theia-TreeNodeSegment to preserve exact spacing in file and folder names.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

See issue description

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
