### PR TITLE
feat(terminal): synchronize onOutput with buffer updates using onWriteParsed

### DIFF
--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -326,8 +326,6 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
             if (this._currentTerminalOutput.length > 0) {
                 const terminalOutput = this._currentTerminalOutput.join('');
                 this._currentTerminalOutput = [];
-                this.logger.debug(`Terminal output being emitted: ${terminalOutput}`);
-                this.logger.debug(`Terminal buffer state before onOutput event: ${this.buffer.getLines(0, this.buffer.length).join('\n')}`);
                 this.onOutputEmitter.fire(terminalOutput);
             }
         }));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
This implements the feature proposed in  #16874.

Previously, the onOutput event fired immediately when `write()` or `writeln()` was called. This change buffers the output data and defers the event emission until xterm fires `onWriteParsed`.

This prevents race conditions by ensuring the `onOutput` event fires only after xterm has fully parsed and synchronized the buffer, rather than immediately upon the method call.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Start theia with the flag --log-level=debug
2. Type anything in the terminal
3. Check in the browser console that the state of the terminal buffer that is logged is the same as the current terminal buffer
4. Check in the browser console that the payload of the event equals your input

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
