### PR TITLE
Fix: Preserve multiple consecutive spaces in Theia UI elements

### DIFF
--- a/packages/core/src/browser/shell/tab-bars.ts
+++ b/packages/core/src/browser/shell/tab-bars.ts
@@ -644,8 +644,10 @@ export class TabBarRenderer extends TabBar.Renderer {
         } else if (title.caption) {
             const position = this.tabBar.orientation === 'horizontal' ? 'bottom' : 'right';
             const tooltip = ArrayUtils.coalesce([title.caption, ...this.getDecorationData(title, 'tooltip')]).join(' - ');
+            // Preserve multiple consecutive spaces by replacing with non-breaking spaces
+            const preservedTooltip = tooltip.replace(/ {2,}/g, match => '\u00A0'.repeat(match.length));
             this.hoverService.requestHover({
-                content: tooltip,
+                content: preservedTooltip,
                 target: event.currentTarget,
                 position
             });

--- a/packages/core/src/browser/style/breadcrumbs.css
+++ b/packages/core/src/browser/style/breadcrumbs.css
@@ -44,7 +44,7 @@
   display: flex;
   align-items: center;
   flex: 0 1 auto;
-  white-space: nowrap;
+  white-space: pre;
   align-self: center;
   height: 100%;
   color: var(--theia-breadcrumb-foreground);
@@ -118,7 +118,7 @@
   display: flex;
   align-items: center;
   flex: 0 1 auto;
-  white-space: nowrap;
+  white-space: pre;
   cursor: pointer;
   outline: none;
   padding: 0.25rem 0.25rem 0.25rem 0.25rem;

--- a/packages/core/src/browser/style/dialog.css
+++ b/packages/core/src/browser/style/dialog.css
@@ -70,6 +70,12 @@
   overflow-y: auto;
 }
 
+/* Preserve multiple consecutive spaces in dialog content */
+.lm-Widget.dialogOverlay .dialogContent li,
+.lm-Widget.dialogOverlay .dialogContent div {
+  white-space: pre-wrap;
+}
+
 .lm-Widget.dialogOverlay .dialogControl {
   padding: calc(var(--theia-ui-padding) * 2);
   display: flex;
@@ -118,7 +124,7 @@
 .theia-dialog-node-segment {
   flex-grow: 0;
   user-select: none;
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .theia-dialog-icon {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -115,7 +115,7 @@
   color: var(--theia-descriptionForeground);
   flex: 1 1 auto;
   overflow: hidden;
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .lm-TabBar-tail {
@@ -536,6 +536,7 @@
   font-weight: bolder;
   max-width: var(--theia-hover-preview-width);
   word-wrap: break-word;
+  white-space: pre-wrap !important;
   font-size: medium;
   margin: 0px 0px;
 }
@@ -544,6 +545,7 @@
   font-size: small;
   max-width: var(--theia-hover-preview-width);
   word-wrap: break-word;
+  white-space: pre-wrap !important;
   margin: 0px 0px;
   margin-top: 4px;
 }

--- a/packages/core/src/browser/style/tooltip.css
+++ b/packages/core/src/browser/style/tooltip.css
@@ -19,6 +19,7 @@
   background: var(--theia-editorHoverWidget-background) !important;
   border: 1px solid !important;
   border-color: var(--theia-editorHoverWidget-border) !important;
+  white-space: pre-wrap !important;
 }
 
 /* Hide tooltip arrow */

--- a/packages/core/src/browser/style/tree-decorators.css
+++ b/packages/core/src/browser/style/tree-decorators.css
@@ -15,12 +15,12 @@
  ********************************************************************************/
 
 .theia-caption-prefix {
-  white-space: nowrap;
+  white-space: pre;
   padding-right: 2px;
 }
 
 .theia-caption-suffix {
-  white-space: nowrap;
+  white-space: pre;
   padding: 0px 2px 0px 2px;
 }
 

--- a/packages/core/src/browser/style/tree.css
+++ b/packages/core/src/browser/style/tree.css
@@ -148,7 +148,7 @@
   align-items: center;
   flex-grow: 0;
   user-select: none;
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .theia-TreeNodeSegment.flex {
@@ -159,7 +159,7 @@
   flex-grow: 1 !important;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre;
 }
 
 .theia-TreeNodeTail {


### PR DESCRIPTION
#### What it does

Fixes multiple consecutive spaces being collapsed to single space in Theia UI elements (explorer tree, dialogs, breadcrumbs, and editor tab tooltips).


#### How to test

1. Create files/folders with multiple consecutive spaces in their names (e.g., `"test  file.txt"`, `"folder   name"`)
2. Verify in Explorer tree view that multiple spaces are preserved (not collapsed to single space)
3. Hover over editor tabs to see tooltips - verify file paths with multiple spaces display correctly
4. Open dialogs that display file names - verify spaces are preserved
5. Check breadcrumbs navigation - verify spaces in path segments are preserved

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
