### PR TITLE
dev: improve clarity of sample contributions

### DIFF
--- a/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
@@ -109,8 +109,8 @@ Do not ask further questions once the text contains 5 or more "Question/Answer" 
  */
 @injectable()
 export class AskAndContinueChatAgent extends AbstractStreamParsingChatAgent {
-    id = 'AskAndContinue';
-    name = 'AskAndContinue';
+    id = 'AskAndContinueSample';
+    name = 'AskAndContinueSample';
     override description = 'This chat will ask questions related to the input and continues after that.';
     protected defaultLanguageModelPurpose = 'chat';
     override languageModelRequirements = [

--- a/examples/api-samples/src/browser/chat/change-set-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/change-set-chat-agent-contribution.ts
@@ -40,8 +40,8 @@ export function bindChangeSetChatAgentContribution(bind: interfaces.Bind): void 
  */
 @injectable()
 export class ChangeSetChatAgent extends AbstractStreamParsingChatAgent {
-    readonly id = 'ChangeSet';
-    readonly name = 'ChangeSet';
+    readonly id = 'ChangeSetSample';
+    readonly name = 'ChangeSetSample';
     readonly defaultLanguageModelPurpose = 'chat';
     override readonly description = 'This chat will create and modify a change set.';
     override languageModelRequirements: LanguageModelRequirement[] = [];

--- a/examples/api-samples/src/browser/chat/chat-node-toolbar-action-contribution.ts
+++ b/examples/api-samples/src/browser/chat/chat-node-toolbar-action-contribution.ts
@@ -31,7 +31,7 @@ export function bindChatNodeToolbarActionContribution(bind: interfaces.Bind): vo
                 return [{
                     commandId: 'sample-command',
                     icon: 'codicon codicon-feedback',
-                    tooltip: 'Example command'
+                    tooltip: 'API Samples: Example command'
                 }];
             } else {
                 return [];

--- a/examples/api-samples/src/browser/chat/custom-response-content-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/custom-response-content-agent-contribution.ts
@@ -240,7 +240,7 @@ export class CustomNonSerializableContentRenderer implements ChatResponsePartRen
 
 @injectable()
 export class CustomResponseContentRendererAgent extends AbstractStreamParsingChatAgent implements ChatAgent {
-    id = 'CustomContent';
+    id = 'CustomContentSample';
     name = this.id;
     override description = 'Demonstrates custom serializable and non-serializable chat response content';
     languageModelRequirements = [];

--- a/examples/api-samples/src/browser/chat/mode-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/mode-chat-agent-contribution.ts
@@ -36,8 +36,8 @@ export function bindModeChatAgentContribution(bind: interfaces.Bind): void {
  */
 @injectable()
 export class ModeChatAgent extends AbstractStreamParsingChatAgent {
-    readonly id = 'ModeTest';
-    readonly name = 'ModeTest';
+    readonly id = 'ModeTestSample';
+    readonly name = 'ModeTestSample';
     readonly defaultLanguageModelPurpose = 'chat';
     override readonly description = 'A test agent that demonstrates different response modes (concise vs detailed).';
     override languageModelRequirements: LanguageModelRequirement[] = [];

--- a/examples/api-samples/src/browser/chat/original-state-test-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/original-state-test-agent-contribution.ts
@@ -40,8 +40,8 @@ export function bindOriginalStateTestAgentContribution(bind: interfaces.Bind): v
  */
 @injectable()
 export class OriginalStateTestAgent extends AbstractStreamParsingChatAgent {
-    readonly id = 'OriginalStateTest';
-    readonly name = 'OriginalStateTest';
+    readonly id = 'OriginalStateTestSample';
+    readonly name = 'OriginalStateTestSample';
     readonly defaultLanguageModelPurpose = 'chat';
     override readonly description = 'This chat will test originalState functionality with sequential changes.';
     override languageModelRequirements: LanguageModelRequirement[] = [];

--- a/examples/api-samples/src/browser/contribution-filter/sample-filtered-command-contribution.ts
+++ b/examples/api-samples/src/browser/contribution-filter/sample-filtered-command-contribution.ts
@@ -19,17 +19,17 @@ import { injectable, interfaces } from '@theia/core/shared/inversify';
 
 export namespace SampleFilteredCommand {
 
-    const EXAMPLE_CATEGORY = 'Examples';
+    const API_SAMPLES_CATEGORY = 'API Samples';
 
     export const FILTERED: Command = {
         id: 'example_command.filtered',
-        category: EXAMPLE_CATEGORY,
+        category: API_SAMPLES_CATEGORY,
         label: 'This command should be filtered out'
     };
 
     export const FILTERED2: Command = {
         id: 'example_command.filtered2',
-        category: EXAMPLE_CATEGORY,
+        category: API_SAMPLES_CATEGORY,
         label: 'This command should be filtered out (2)'
     };
 }

--- a/examples/api-samples/src/browser/file-system/sample-file-system-capabilities.ts
+++ b/examples/api-samples/src/browser/file-system/sample-file-system-capabilities.ts
@@ -29,7 +29,8 @@ export class SampleFileSystemCapabilities implements CommandContribution {
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand({
             id: 'toggleFileSystemReadonly',
-            label: 'Toggle File System Readonly'
+            label: 'Toggle File System Readonly',
+            category: 'API Samples'
         }, {
             execute: () => {
                 const readonly = (this.remoteFileSystemProvider.capabilities & FileSystemProviderCapabilities.Readonly) !== 0;
@@ -43,7 +44,8 @@ export class SampleFileSystemCapabilities implements CommandContribution {
 
         commands.registerCommand({
             id: 'addFileSystemReadonlyMessage',
-            label: 'Add a File System ReadonlyMessage for readonly'
+            label: 'Add File System ReadonlyMessage',
+            category: 'API Samples'
         }, {
             execute: () => {
                 const readonlyMessage = new MarkdownStringImpl(`Added new **Markdown** string '+${Date.now()}`);
@@ -53,7 +55,8 @@ export class SampleFileSystemCapabilities implements CommandContribution {
 
         commands.registerCommand({
             id: 'removeFileSystemReadonlyMessage',
-            label: 'Remove File System ReadonlyMessage for readonly'
+            label: 'Remove File System ReadonlyMessage',
+            category: 'API Samples'
         }, {
             execute: () => {
                 this.remoteFileSystemProvider['setReadOnlyMessage'](undefined);

--- a/examples/api-samples/src/browser/file-watching/sample-file-watching-contribution.ts
+++ b/examples/api-samples/src/browser/file-watching/sample-file-watching-contribution.ts
@@ -14,10 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { postConstruct, injectable, inject, interfaces } from '@theia/core/shared/inversify';
+import { postConstruct, injectable, inject, interfaces, named } from '@theia/core/shared/inversify';
 import {
     FrontendApplicationContribution, LabelProvider,
 } from '@theia/core/lib/browser';
+import { ILogger } from '@theia/core/lib/common/logger';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { createPreferenceProxy, PreferenceService, PreferenceProxy, PreferenceContribution } from '@theia/core';
@@ -55,6 +56,9 @@ class SampleFileWatchingContribution implements FrontendApplicationContribution 
     @inject(FileWatchingPreferences)
     protected readonly fileWatchingPreferences: FileWatchingPreferences;
 
+    @inject(ILogger) @named('api-samples')
+    protected readonly logger: ILogger;
+
     @postConstruct()
     protected init(): void {
         this.verbose = this.fileWatchingPreferences['sample.file-watching.verbose'];
@@ -75,7 +79,7 @@ class SampleFileWatchingContribution implements FrontendApplicationContribution 
                 const workspace = roots.length > 0
                     ? roots.map(root => this.labelProvider.getLongName(root.resource)).join('+')
                     : '<no workspace>';
-                console.log(`Sample File Watching: ${event.changes.length} file(s) changed! ${workspace}`);
+                this.logger.info(`Sample File Watching: ${event.changes.length} file(s) changed! ${workspace}`);
             }
         });
     }

--- a/examples/api-samples/src/browser/label/sample-dynamic-label-provider-command-contribution.ts
+++ b/examples/api-samples/src/browser/label/sample-dynamic-label-provider-command-contribution.ts
@@ -20,10 +20,10 @@ import { FrontendApplicationContribution, LabelProviderContribution } from '@the
 import { SampleDynamicLabelProviderContribution } from './sample-dynamic-label-provider-contribution';
 
 export namespace ExampleLabelProviderCommands {
-    const EXAMPLE_CATEGORY = 'Examples';
+    const API_SAMPLES_CATEGORY = 'API Samples';
     export const TOGGLE_SAMPLE: Command = {
         id: 'example_label_provider.toggle',
-        category: EXAMPLE_CATEGORY,
+        category: API_SAMPLES_CATEGORY,
         label: 'Toggle Dynamically-Changing Labels'
     };
 }

--- a/examples/api-samples/src/browser/mcp/resolve-frontend-mcp-contribution.ts
+++ b/examples/api-samples/src/browser/mcp/resolve-frontend-mcp-contribution.ts
@@ -15,8 +15,9 @@
 // *****************************************************************************
 
 import { MCPFrontendService, RemoteMCPServerDescription } from '@theia/ai-mcp';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { FrontendApplicationContribution, QuickInputService } from '@theia/core/lib/browser';
+import { ILogger } from '@theia/core/lib/common/logger';
 
 @injectable()
 export class ResolveMcpFrontendContribution
@@ -28,12 +29,15 @@ export class ResolveMcpFrontendContribution
     @inject(QuickInputService)
     protected readonly quickInputService: QuickInputService;
 
+    @inject(ILogger) @named('api-samples')
+    protected readonly logger: ILogger;
+
     async onStart(): Promise<void> {
         const githubServer: RemoteMCPServerDescription = {
             name: 'github',
             serverUrl: 'https://api.githubcopilot.com/mcp/',
             resolve: async serverDescription => {
-                console.log('Resolving GitHub MCP server description');
+                this.logger.debug('Resolving GitHub MCP server description');
 
                 // Prompt user for authentication token
                 const authToken = await this.quickInputService.input({

--- a/examples/api-samples/src/browser/mcp/sample-frontend-mcp-contribution.ts
+++ b/examples/api-samples/src/browser/mcp/sample-frontend-mcp-contribution.ts
@@ -29,13 +29,13 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
-    @inject(ILogger) @named('SampleFrontendMCPContribution')
+    @inject(ILogger) @named('api-samples')
     protected readonly logger: ILogger;
 
     async getTools(): Promise<Tool[]> {
         return [
             {
-                name: 'workspace-info',
+                name: 'sample-workspace-info',
                 description: 'Get information about the current workspace',
                 inputSchema: {
                     type: 'object',
@@ -44,7 +44,7 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
                 }
             },
             {
-                name: 'workspace-files',
+                name: 'sample-workspace-files',
                 description: 'List files in the workspace',
                 inputSchema: {
                     type: 'object',
@@ -62,7 +62,7 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
 
     async getTool(name: string): Promise<ToolProvider | undefined> {
         switch (name) {
-            case 'workspace-info':
+            case 'sample-workspace-info':
                 return {
                     handler: async args => {
                         try {
@@ -82,7 +82,7 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
                     inputSchema: z.object({})
                 };
 
-            case 'workspace-files':
+            case 'sample-workspace-files':
                 return {
                     handler: async args => {
                         try {
@@ -136,8 +136,8 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
     async getResources(): Promise<Resource[]> {
         return [
             {
-                uri: 'workspace://info',
-                name: 'Workspace Information',
+                uri: 'sample-workspace://info',
+                name: 'Sample Workspace Information',
                 description: 'General information about the current workspace',
                 mimeType: 'application/json'
             }
@@ -145,7 +145,7 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
     }
 
     async readResource(uri: string): Promise<unknown> {
-        if (uri === 'workspace://info') {
+        if (uri === 'sample-workspace://info') {
             try {
                 const roots = await this.workspaceService.roots;
                 return {
@@ -169,7 +169,7 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
     async getPrompts(): Promise<Prompt[]> {
         return [
             {
-                name: 'workspace-context',
+                name: 'sample-workspace-context',
                 description: 'Generate context information about the workspace',
                 arguments: [
                     {
@@ -183,7 +183,7 @@ export class SampleFrontendMCPContribution implements MCPFrontendContribution {
     }
 
     async getPrompt(name: string, args: unknown): Promise<PromptMessage[]> {
-        if (name === 'workspace-context') {
+        if (name === 'sample-workspace-context') {
             try {
                 const parsedArgs = args as { includeFiles?: boolean };
                 const roots = await this.workspaceService.roots;

--- a/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
+++ b/examples/api-samples/src/browser/menu/sample-menu-contribution.ts
@@ -21,50 +21,62 @@ import {
     Command, CommandContribution, CommandMenu, CommandRegistry, ContextExpressionMatcher, MAIN_MENU_BAR,
     MenuContribution, MenuModelRegistry, MenuPath, MessageService
 } from '@theia/core/lib/common';
-import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { inject, injectable, interfaces, named } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { ReactNode } from '@theia/core/shared/react';
 
+const API_SAMPLES_CATEGORY = 'API Samples';
+
 const SampleCommand: Command = {
     id: 'sample-command',
-    label: 'Sample Command'
+    label: 'Command',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleCommand2: Command = {
     id: 'sample-command2',
-    label: 'Sample Command2'
+    label: 'Command 2',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleCommandConfirmDialog: Command = {
     id: 'sample-command-confirm-dialog',
-    label: 'Sample Confirm Dialog'
+    label: 'Confirm Dialog',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleComplexCommandConfirmDialog: Command = {
     id: 'sample-command-complex-confirm-dialog',
-    label: 'Sample Complex Confirm Dialog'
+    label: 'Complex Confirm Dialog',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleCommandWithProgressMessage: Command = {
     id: 'sample-command-with-progress',
-    label: 'Sample Command With Progress Message'
+    label: 'Command With Progress Message',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleCommandWithIndeterminateProgressMessage: Command = {
     id: 'sample-command-with-indeterminate-progress',
-    label: 'Sample Command With Indeterminate Progress Message'
+    label: 'Command With Indeterminate Progress Message',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleQuickInputCommand: Command = {
     id: 'sample-quick-input-command',
-    category: 'Quick Input',
-    label: 'Test Positive Integer'
+    label: 'Test Positive Integer',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleSelectDialog: Command = {
     id: 'sample-command-select-dialog',
-    label: 'Sample Select Component Dialog'
+    label: 'Select Component Dialog',
+    category: API_SAMPLES_CATEGORY
 };
 const SamplePersistentNotification: Command = {
     id: 'sample-persistent-notification',
-    label: 'Sample Persistent Notification (No Timeout)'
+    label: 'Persistent Notification (No Timeout)',
+    category: API_SAMPLES_CATEGORY
 };
 const SampleVanishingNotification: Command = {
     id: 'sample-vanishing-notification',
-    label: 'Sample Vanishing Notification (500ms Timeout)'
+    label: 'Vanishing Notification (500ms Timeout)',
+    category: API_SAMPLES_CATEGORY
 };
 
 @injectable()
@@ -76,13 +88,16 @@ export class SampleCommandContribution implements CommandContribution {
     @inject(MessageService)
     protected readonly messageService: MessageService;
 
+    @inject(ILogger) @named('api-samples')
+    protected readonly logger: ILogger;
+
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand({ id: 'create-quick-pick-sample', label: 'Internal QuickPick' }, {
+        commands.registerCommand({ id: 'create-quick-pick-sample', label: 'Internal QuickPick', category: API_SAMPLES_CATEGORY }, {
             execute: () => {
                 const pick = this.quickInputService.createQuickPick();
                 pick.items = [{ label: '1' }, { label: '2' }, { label: '3' }];
                 pick.onDidAccept(() => {
-                    console.log(`accepted: ${pick.selectedItems[0]?.label}`);
+                    this.logger.debug(`accepted: ${pick.selectedItems[0]?.label}`);
                     pick.hide();
                 });
                 pick.show();

--- a/examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts
+++ b/examples/api-samples/src/browser/monaco-editor-preferences/monaco-editor-preference-extractor.ts
@@ -92,7 +92,7 @@ export class MonacoEditorPreferenceSchemaExtractor implements CommandContributio
     @inject(MonacoEditorProvider) protected readonly monacoEditorProvider: MonacoEditorProvider;
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand({ id: 'check-for-unvalidated-editor-preferences', label: 'Check for unvalidated editor preferences in Monaco' }, {
+        commands.registerCommand({ id: 'check-for-unvalidated-editor-preferences', label: 'Check for unvalidated editor preferences in Monaco', category: 'API Samples' }, {
             execute: () => {
                 const firstRootUri = this.workspaceService.tryGetRoots()[0]?.resource;
                 if (firstRootUri) {
@@ -105,7 +105,7 @@ export class MonacoEditorPreferenceSchemaExtractor implements CommandContributio
                 }
             }
         });
-        commands.registerCommand({ id: 'extract-editor-preference-schema', label: 'Extract editor preference schema from Monaco' }, {
+        commands.registerCommand({ id: 'extract-editor-preference-schema', label: 'Extract editor preference schema from Monaco', category: 'API Samples' }, {
             execute: async () => {
                 const roots = this.workspaceService.tryGetRoots();
                 if (roots.length !== 1 || !(roots[0].resource.path.toString() ?? '').includes('theia')) {

--- a/examples/api-samples/src/browser/preferences/sample-preferences-contribution.ts
+++ b/examples/api-samples/src/browser/preferences/sample-preferences-contribution.ts
@@ -31,7 +31,7 @@ export class SamplePreferenceContribution implements CommandContribution {
     protected readonly preferencesService: SampleBackendPreferencesService;
 
     registerCommands(commands: CommandRegistry): void {
-        commands.registerCommand({ id: 'samplePreferences.get', label: 'Get Backend Preference' },
+        commands.registerCommand({ id: 'samplePreferences.get', label: 'Get Backend Preference', category: 'API Samples' },
             {
                 execute: async () => {
                     const key = await this.quickInputService.input({
@@ -51,7 +51,7 @@ export class SamplePreferenceContribution implements CommandContribution {
             }
         );
 
-        commands.registerCommand({ id: 'samplePreferences.inspect', label: 'Inspect Backend Preference' },
+        commands.registerCommand({ id: 'samplePreferences.inspect', label: 'Inspect Backend Preference', category: 'API Samples' },
             {
                 execute: async () => {
                     const key = await this.quickInputService.input({
@@ -71,20 +71,20 @@ export class SamplePreferenceContribution implements CommandContribution {
             }
         );
 
-        commands.registerCommand({ id: 'samplePreferences.set', label: 'Set Backend Preference' },
+        commands.registerCommand({ id: 'samplePreferences.set', label: 'Set Backend Preference', category: 'API Samples' },
             {
                 execute: async () => {
                     const key = await this.quickInputService.input({
-                        title: 'Inspect Backend Preference',
+                        title: 'Set Backend Preference',
                         prompt: 'Enter preference key'
                     });
                     if (key) {
                         const override = await this.quickInputService.input({
-                            title: 'Inspect Backend Preference',
+                            title: 'Set Backend Preference',
                             prompt: 'Enter override identifier'
                         });
                         const valueString = await this.quickInputService.input({
-                            title: 'Inspect Backend Preference',
+                            title: 'Set Backend Preference',
                             prompt: 'Enter JSON value'
                         });
                         if (valueString) {

--- a/examples/api-samples/src/browser/toolbar/sample-toolbar-contribution.tsx
+++ b/examples/api-samples/src/browser/toolbar/sample-toolbar-contribution.tsx
@@ -39,7 +39,7 @@ export const bindSampleToolbarContribution = (bind: interfaces.Bind, rebind: int
 
 export const FIND_IN_WORKSPACE_ROOT = {
     id: 'easy.search.find.in.workspace.root',
-    category: 'Search',
+    category: 'API Samples',
     label: 'Search Workspace Root for Text',
 };
 
@@ -104,7 +104,7 @@ export class SampleToolbarContribution extends AbstractToolbarContribution
                 className='icon-wrapper action-label item enabled codicon codicon-search'
                 id='easy-search-item-icon'
                 onClick={this.handleOnClick}
-                title='Search for files, text, commands, and more...'
+                title='API Samples: Search for files, text, commands, and more...'
             >
                 <div className='codicon codicon-triangle-down' />
             </div>);

--- a/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
+++ b/examples/api-samples/src/browser/view/sample-unclosable-view-contribution.ts
@@ -23,7 +23,8 @@ import { SampleViewUnclosableView } from './sample-unclosable-view';
 
 export const SampleToolBarCommand: Command = {
     id: 'sample.toggle.toolbarCommand',
-    iconClass: codicon('add')
+    iconClass: codicon('add'),
+    category: 'API Samples'
 };
 
 @injectable()
@@ -63,7 +64,7 @@ export class SampleUnclosableViewContribution extends AbstractViewContribution<S
         toolbarRegistry.registerItem({
             id: SampleToolBarCommand.id,
             command: SampleToolBarCommand.id,
-            tooltip: 'Click to Toggle Toolbar Item',
+            tooltip: 'API Samples: Click to Toggle Toolbar Item',
             priority: 0
         });
     }

--- a/examples/api-samples/src/browser/vsx/sample-vsx-command-contribution.ts
+++ b/examples/api-samples/src/browser/vsx/sample-vsx-command-contribution.ts
@@ -29,7 +29,8 @@ export class VSXCommandContribution implements CommandContribution {
 
     protected readonly command: Command = {
         id: 'vsx.echo-api-version',
-        label: 'VS Code API Version'
+        label: 'Show VS Code API Version',
+        category: 'API Samples'
     };
 
     registerCommands(commands: CommandRegistry): void {

--- a/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-contribution.ts
+++ b/examples/api-samples/src/electron-browser/updater/sample-updater-frontend-contribution.ts
@@ -32,7 +32,7 @@ import { SampleUpdater, UpdateStatus, SampleUpdaterClient } from '../../common/u
 
 export namespace SampleUpdaterCommands {
 
-    const category = 'Electron Updater Sample';
+    const category = 'API Samples';
 
     export const CHECK_FOR_UPDATES: Command = {
         id: 'electron-sample:check-for-updates',
@@ -49,13 +49,13 @@ export namespace SampleUpdaterCommands {
     // Mock
     export const MOCK_UPDATE_AVAILABLE: Command = {
         id: 'electron-sample:mock-update-available',
-        label: 'Mock - Available',
+        label: 'Mock Update - Available',
         category
     };
 
     export const MOCK_UPDATE_NOT_AVAILABLE: Command = {
         id: 'electron-sample:mock-update-not-available',
-        label: 'Mock - Not Available',
+        label: 'Mock Update - Not Available',
         category
     };
 
@@ -131,11 +131,11 @@ export class SampleUpdaterFrontendContribution implements CommandContribution, M
                     }
                     case UpdateStatus.NotAvailable: {
                         const { applicationName } = FrontendApplicationConfigProvider.get();
-                        this.messageService.info(`[Not Available]: You’re all good. You’ve got the latest version of ${applicationName}.`, { timeout: 3000 });
+                        this.messageService.info(`[Sample Updater - Not Available]: You're all good. You've got the latest version of ${applicationName}.`, { timeout: 3000 });
                         break;
                     }
                     case UpdateStatus.InProgress: {
-                        this.messageService.warn('[Downloading]: Work in progress...', { timeout: 3000 });
+                        this.messageService.warn('[Sample Updater - Downloading]: Work in progress...', { timeout: 3000 });
                         break;
                     }
                     default: throw new Error(`Unexpected status: ${status}`);
@@ -167,7 +167,7 @@ export class SampleUpdaterFrontendContribution implements CommandContribution, M
     }
 
     protected async handleUpdatesAvailable(): Promise<void> {
-        const answer = await this.messageService.info('[Available]: Found updates, do you want update now?', 'No', 'Yes');
+        const answer = await this.messageService.info('[Sample Updater - Available]: Found updates, do you want update now?', 'No', 'Yes');
         if (answer === 'Yes') {
             this.updater.onRestartToUpdateRequested();
         }

--- a/examples/api-samples/src/electron-main/update/sample-updater-impl.ts
+++ b/examples/api-samples/src/electron-main/update/sample-updater-impl.ts
@@ -33,7 +33,7 @@ export class SampleUpdaterImpl implements SampleUpdater, ElectronMainApplication
     }
 
     onRestartToUpdateRequested(): void {
-        console.info("'Update to Restart' was requested by the frontend.");
+        console.info("[api-samples] 'Update to Restart' was requested by the frontend.");
         // Here comes your install and restart implementation. For example: `autoUpdater.quitAndInstall();`
     }
 
@@ -66,9 +66,9 @@ export class SampleUpdaterImpl implements SampleUpdater, ElectronMainApplication
     setClient(client: SampleUpdaterClient | undefined): void {
         if (client) {
             this.clients.push(client);
-            console.info('Registered a new sample updater client.');
+            console.info('[api-samples] Registered a new sample updater client.');
         } else {
-            console.warn("Couldn't register undefined client.");
+            console.warn("[api-samples] Couldn't register undefined client.");
         }
     }
 
@@ -76,16 +76,16 @@ export class SampleUpdaterImpl implements SampleUpdater, ElectronMainApplication
         const index = this.clients.indexOf(client);
         if (index !== -1) {
             this.clients.splice(index, 1);
-            console.info('Disposed a sample updater client.');
+            console.info('[api-samples] Disposed a sample updater client.');
         } else {
-            console.warn("Couldn't dispose client; it was not registered.");
+            console.warn("[api-samples] Couldn't dispose client; it was not registered.");
         }
     }
 
     dispose(): void {
-        console.info('>>> Disposing sample updater service...');
+        console.info('[api-samples] >>> Disposing sample updater service...');
         this.clients.forEach(this.disconnectClient.bind(this));
-        console.info('>>> Disposed sample updater service.');
+        console.info('[api-samples] >>> Disposed sample updater service.');
     }
 
 }

--- a/examples/api-samples/src/node/sample-mock-open-vsx-server.ts
+++ b/examples/api-samples/src/node/sample-mock-open-vsx-server.ts
@@ -17,7 +17,8 @@
 import { BackendApplicationContribution } from '@theia/core/lib/node';
 import * as express from '@theia/core/shared/express';
 import * as fs from 'fs';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { ILogger } from '@theia/core/lib/common/logger';
 import { OVSXMockClient, VSXExtensionRaw } from '@theia/ovsx-client';
 import * as path from 'path';
 import { SampleAppInfo } from '../common/vsx/sample-app-info';
@@ -37,6 +38,9 @@ export class SampleMockOpenVsxServer implements BackendApplicationContribution {
 
     @inject(SampleAppInfo)
     protected appInfo: SampleAppInfo;
+
+    @inject(ILogger) @named('api-samples')
+    protected readonly logger: ILogger;
 
     protected mockClient: OVSXMockClient;
     protected staticFileHandlers: Map<string, express.RequestHandler<{
@@ -130,7 +134,7 @@ export class SampleMockOpenVsxServer implements BackendApplicationContribution {
         const url = new OVSXMockClient.UrlBuilder(baseUrl);
         const result = new Map<VersionedId, { path: string, data: VSXExtensionRaw }>();
         if (!await this.isDirectory(pluginsDbPath)) {
-            console.error(`ERROR: ${pluginsDbPath} is not a directory!`);
+            this.logger.error(`ERROR: ${pluginsDbPath} is not a directory!`);
             return result;
         }
         const namespaces = await fs.promises.readdir(pluginsDbPath);


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Clearly mark contributions of api-samples in UI and logs.
This is useful for Theia developers to easily separate between framework and api-samples behavior when testing.

- Use named logger 'api-samples' for consistent log identification
- Prefix console logs with [api-samples] in electron-main context
- Add 'Sample:' prefix to command labels for clear identification
- Append 'Sample' suffix to chat agent IDs and names
- Prefix MCP tool and resource names with 'sample-'
- Update notification messages to include 'Sample Updater' prefix

#### How to test

Run the example application(s) and check UI and logs

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
