### PR TITLE
fix: set model for embedded diff editors immediately

### DIFF
--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -61,6 +61,11 @@ export class MonacoDiffEditor extends MonacoEditor {
         this.documents.add(originalModel);
         this.wordWrapOverride = options?.wordWrapOverride2;
         this._diffNavigator = diffNavigatorFactory.createdDiffNavigator(this._diffEditor);
+        if (parentEditor) {
+            // Embedded diff editors don't participate in visibility tracking (they're not wrapped in EditorWidget),
+            // so we need to set the model immediately since handleVisibilityChanged will never be called.
+            this.diffEditor.setModel(this.diffEditorModel);
+        }
     }
 
     get diffEditor(): monaco.editor.IStandaloneDiffEditor {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Resolves GH-16930.

This PR fixes the dirty diff indicator click functionality that broke in Theia 1.68.x after PR #16832 deferred Monaco model connections until editors become visible. While this works for regular editors wrapped in `EditorWidget` (which triggers handleVisibilityChanged(true) when shown), embedded diff editors used in the dirty diff peek view are created directly inside a peek view widget and never receive this visibility callback. As a result, their model was never set and no diff computation occurred.

The fix initializes the model immediately in the constructor for embedded diff editors, which is correct since they are always visible upon creation. Standalone diff editors (file compare, SCM diff view) continue to use deferred model loading as intended.

Additionally, this PR fixes a race condition where the peek view would not appear if the file was already open in another editor. In this case, the diff may compute before the onDidUpdateDiff listener is registered, so we now check whether the diff is already computed before waiting for the event.

#### How to test

Prerequisites:
- A git repository with at least one tracked file

Test steps:
1. Open a file that is tracked by git
2. Make a change to the file (add/modify/delete lines)
3. Observe the colored indicator appears in the left margin next to the line numbers (green for additions, blue for modifications, red arrow for deletions)
4. Click on the gutter indicator
5. Expected: A peek view opens showing the diff between the current content and the git HEAD version
6. Use the arrow buttons in the peek view header to navigate between changes
7. Close the peek view by clicking the X button or pressing Escape

Race condition test:
1. Open the same file in the SCM diff view
2. Click the dirty diff indicator in the first editor
3. Peek view opens as expected

Additional steps:
- Verify that regular diff editors (e.g., comparing two files via right-click → "Compare With...") still work correctly
- Verify that the SCM diff view (clicking a changed file in the Source Control panel) still works as expected

#### Follow-ups

None identified.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
