### PR TITLE
fix(ai-chat): validate request has content before sending to LLM

### DIFF
--- a/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
@@ -223,6 +223,15 @@ export class ClaudeCodeChatAgent implements ChatAgent {
                 prompt = prompt.replace(agentAddress, '').trim();
             }
 
+            // Check if prompt is empty after removing agent address
+            if (prompt.length === 0) {
+                request.response.response.addContent(
+                    new MarkdownChatResponseContentImpl(nls.localize('theia/ai/chat/emptyRequest', 'Please provide a message or question.'))
+                );
+                request.response.complete();
+                return;
+            }
+
             const shouldFork = claudeSessionId !== undefined && this.isEditRequest(request);
 
             const streamResult = await this.claudeCode.send({

--- a/packages/ai-codex/src/browser/codex-chat-agent.ts
+++ b/packages/ai-codex/src/browser/codex-chat-agent.ts
@@ -105,6 +105,15 @@ export class CodexChatAgent implements ChatAgent {
                 prompt = prompt.replace(agentAddress, '').trim();
             }
 
+            // Check if prompt is empty after removing agent address
+            if (prompt.length === 0) {
+                request.response.response.addContent(
+                    new MarkdownChatResponseContentImpl(nls.localize('theia/ai/chat/emptyRequest', 'Please provide a message or question.'))
+                );
+                request.response.complete();
+                return;
+            }
+
             const sessionId = request.session.id;
             const sandboxMode = this.extractSandboxMode(request.request.modeId);
             const streamResult = await this.codexService.send(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-16941

- Add validation in AbstractChatAgent.invoke() to check for text or image content
- Add validation in CodexChatAgent and ClaudeCodeChatAgent after stripping agent address
- Return user-friendly message when request is empty instead of LLM API error

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Send a message via the AI Chat using different agents without any prompt or only a trailing whitespace
   - e.g. `@Coder ` or only `@Architect`
   - In the theia example application you can also trigger other test agents that do not expect a prompt like ModeTester, they should still work.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
