### PR TITLE
fix: search-in-workspace replace all fails for unopened files

### DIFF
--- a/packages/monaco/src/browser/monaco-editor.ts
+++ b/packages/monaco/src/browser/monaco-editor.ts
@@ -631,11 +631,25 @@ export class MonacoEditor extends MonacoEditorServices implements TextEditor {
                 text: param.text
             };
         });
+        // If the editor doesn't have a model set (e.g., widget not visible),
+        // apply edits directly to the document's underlying model.
+        // This ensures text replacements work even when the editor widget is not attached to the shell.
+        if (!this.editor.getModel()) {
+            this.document.textEditorModel.applyEdits(edits);
+            return true;
+        }
         return this.editor.executeEdits(params.source, edits);
     }
 
     executeEdits(edits: TextEdit[]): boolean {
-        return this.editor.executeEdits('MonacoEditor', this.p2m.asTextEdits(edits) as monaco.editor.IIdentifiedSingleEditOperation[]);
+        const monacoEdits = this.p2m.asTextEdits(edits) as monaco.editor.IIdentifiedSingleEditOperation[];
+        // If the editor doesn't have a model set (e.g., widget not visible),
+        // apply edits directly to the document's underlying model.
+        if (!this.editor.getModel()) {
+            this.document.textEditorModel.applyEdits(monacoEdits);
+            return true;
+        }
+        return this.editor.executeEdits('MonacoEditor', monacoEdits);
     }
 
     storeViewState(): object {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes "Replace All" in search-in-workspace failing silently for files that are not currently open in an editor.
When triggering "Replace All", the editor widget is created via getOrCreateByUri but not made visible. Due to the visibility workaround for #14880, the Monaco editor's model is only set when the widget becomes visible, causing editor.executeEdits() to silently fail.

This PR adds a fallback in replaceText and executeEdits to apply edits directly to the document's textEditorModel when the editor has no model set.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a workspace with multiple files containing a common string (e.g., "TODO")
2. Open the search widget and search for that string
3. Ensure none of the result files are open in an editor
4. Enter a replacement term and click "Replace All" right next to the replace string input
5. Verify the replacements are actually applied to the files (check scm view or re-run search)
6. Also verify the other replace actions (per hit or per file in the search results) still work

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

A Monaco editor uplift is planned for this month (#16401). We will review other potential issues related to the visibility workaround to ensure a comprehensive fix.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
