### PR TITLE
[merge editor] Improve merge conflict revealing

### DIFF
--- a/packages/scm/src/browser/merge-editor/view/merge-editor-panes/merge-editor-pane.ts
+++ b/packages/scm/src/browser/merge-editor/view/merge-editor-panes/merge-editor-pane.ts
@@ -130,11 +130,11 @@ export abstract class MergeEditorPane extends BoxPanel {
 
     goToMergeRange(mergeRange: MergeRange, options?: { reveal?: boolean }): void {
         const { editor } = this;
-        const { startLineNumber, endLineNumberExclusive } = this.getLineRangeForMergeRange(mergeRange);
+        const { startLineNumber } = this.getLineRangeForMergeRange(mergeRange);
         editor.cursor = { line: startLineNumber, character: 0 };
         const reveal = options?.reveal ?? true;
         if (reveal) {
-            editor.getControl().revealLinesNearTop(startLineNumber + 1, endLineNumberExclusive + 1);
+            editor.getControl().setScrollTop(editor.getControl().getTopForLineNumber(startLineNumber + 1, true));
         }
     }
 


### PR DESCRIPTION
#### What it does

Currently, when navigating through merge conflicts with `Go to Next Unhandled Conflict`/`Go to Previous Unhandled Conflict`, a merge conflict is revealed near the top of the current pane of the merge editor (using the `revealLinesNearTop` API) rather than at the very top.

However, scroll-sync works by aligning *scrollTop* position between all merge editor panes, so the merge conflict revealed *near* the top can appear in different positions relative to the viewport top in the vertically split panes of the merge editor (e.g., there can be different number of visible lines above the merge conflict in the bottom pane and in the horizontally split panes).

This PR proposes to reveal a merge conflict exactly at the viewport top, which allows scroll-sync to precisely align it between all merge editor panes, and can improve UX, especially when navigating through more complex merge conflicts. Note that it works best together with improvements in scroll-sync implemented in #16947, although technically the change does not depend on that PR.

#### How to test

Navigate through multiple merge conflicts with `Go to Next Unhandled Conflict`/`Go to Previous Unhandled Conflict` and verify that the current merge conflict is now consistently revealed and precisely aligned at the very top of all merge editor panes.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
