### PR TITLE
[merge editor] Improve scroll state preservation

### DIFF
--- a/packages/scm/src/browser/merge-editor/view/merge-editor-scroll-sync.ts
+++ b/packages/scm/src/browser/merge-editor/view/merge-editor-scroll-sync.ts
@@ -94,16 +94,16 @@ export class MergeEditorScrollSync implements Disposable {
     }
 
     storeScrollState(): unknown {
-        return this.mergeEditor.side1Pane.editor.getControl().getScrollTop();
+        return ScrollState.get(this.mergeEditor.resultPane.editor);
     }
 
     restoreScrollState(state: unknown): void {
-        if (typeof state === 'number') {
-            const scrollTop = this.mergeEditor.side1Pane.editor.getControl().getScrollTop();
-            if (state !== scrollTop) {
-                this.mergeEditor.side1Pane.editor.getControl().setScrollTop(state);
-            } else {
+        if (state instanceof ScrollState) {
+            const { editor } = this.mergeEditor.resultPane;
+            if (state.isEqual(ScrollState.get(editor))) {
                 this.update();
+            } else {
+                state.restore(editor);
             }
         }
     }
@@ -114,8 +114,8 @@ export class MergeEditorScrollSync implements Disposable {
         }
         this.isSyncing = true;
         try {
-            const scrollTop = this.mergeEditor.side1Pane.editor.getControl().getScrollTop();
-            this.handleSide1ScrollTopChanged(scrollTop);
+            const scrollTop = this.mergeEditor.resultPane.editor.getControl().getScrollTop();
+            this.handleResultScrollTopChanged(scrollTop);
         } finally {
             this.isSyncing = false;
         }
@@ -238,4 +238,37 @@ export class MergeEditorScrollSync implements Disposable {
 
         return targetScrollTop;
     }
+}
+
+class ScrollState {
+
+    static get(editor: MonacoEditor): ScrollState {
+        const visibleRanges = editor.getVisibleRanges();
+        if (visibleRanges.length === 0) {
+            return new ScrollState(0, 0);
+        }
+        const scrollTop = editor.getControl().getScrollTop();
+        let topLineNumber = visibleRanges[0].start.line;
+        if (topLineNumber > 0 && scrollTop < editor.getControl().getTopForLineNumber(topLineNumber + 1, true)) {
+            --topLineNumber;
+        }
+        return new ScrollState(scrollTop, topLineNumber);
+    }
+
+    restore(editor: MonacoEditor): void {
+        editor.getControl().setScrollTop(this.scrollTop);
+        if (this.topLineNumber !== ScrollState.get(editor).topLineNumber) { // this.scrollTop no longer corresponds to this.topLineNumber e.g. due to view zones having been changed
+            // make sure that the top line position is restored, even if not precisely
+            editor.getControl().setScrollTop(editor.getControl().getTopForLineNumber(this.topLineNumber + 1));
+        }
+    }
+
+    isEqual(other: ScrollState): boolean {
+        return this.scrollTop === other.scrollTop && this.topLineNumber === other.topLineNumber;
+    }
+
+    private constructor(
+        private readonly scrollTop: number,
+        private readonly topLineNumber: number
+    ) { }
 }


### PR DESCRIPTION
#### What it does

Fixes #16959.

#### How to test

Use the reproduction steps in #16959 to verify that the issue is fixed.

Note that it works best together with improvements in scroll-sync implemented in #16947, although technically the change does not depend on that PR.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
