### PR TITLE
feat(ai-chat): Implement session-based tool approval for Claude Code

### DIFF
--- a/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
@@ -322,7 +322,7 @@ export class ClaudeCodeChatAgent implements ChatAgent {
     }
 
     protected getSessionApprovedTools(request: MutableChatRequestModel): Set<string> {
-        let approvedTools = request.session.settings?.[CLAUDE_SESSION_APPROVED_TOOLS_KEY] as string[] | undefined;
+        const approvedTools = request.session.settings?.[CLAUDE_SESSION_APPROVED_TOOLS_KEY] as string[] | undefined;
         return new Set(approvedTools ?? []);
     }
 

--- a/packages/ai-claude-code/src/node/claude-code-service-impl.ts
+++ b/packages/ai-claude-code/src/node/claude-code-service-impl.ts
@@ -47,7 +47,6 @@ export class ClaudeCodeServiceImpl implements ClaudeCodeService {
     // Tools that don't require approval - they are safe and non-intrusive
     protected readonly autoApprovedTools = new Set(['AskUserQuestion']);
 
-
     setClient(client: ClaudeCodeClient): void {
         this.client = client;
     }


### PR DESCRIPTION
#### What it does

This pull request adds support for session-based tool approvals in the `ClaudeCodeChatAgent`, allowing users to approve a tool once for the duration of a chat session. The main changes introduce new session management logic, update the approval options, and ensure tools approved for the session are automatically allowed without prompting the user again.

**Session-based tool approval logic:**

* Added new constant `CLAUDE_SESSION_APPROVED_TOOLS_KEY` and updated approval options to include "Allow for this session".
* Introduced methods to get, set, and check session-approved tools (`getSessionApprovedTools`, `setSessionApprovedTools`, `isToolApprovedForSession`, `approveToolForSession`) in `ClaudeCodeChatAgent`.
* Modified the tool approval request handler to auto-approve tools that have already been approved for the current session, skipping the user prompt.
* Updated the approval response handler to track tools approved for the session and store them in session settings when "Allow for this session" is selected. [[1]](diffhunk://#diff-e0ddaa0f0b4e87ec5246185f342343f5e2b2ecff8861dfdaa29a59720483dc9cR390) [[2]](diffhunk://#diff-e0ddaa0f0b4e87ec5246185f342343f5e2b2ecff8861dfdaa29a59720483dc9cL362-R413)
* Auto approve for the AskUserQuestion tool

**Minor updates:**

* Added `MutableChatModel` import to support session settings mutation.<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

**This is how it looks:**

<img width="345" height="154" alt="image" src="https://github.com/user-attachments/assets/f446659a-6d18-4772-88ce-028517a562d9" />

And in a wider panel:

<img width="440" height="127" alt="image" src="https://github.com/user-attachments/assets/f8918969-88de-4bf2-a4cf-7be1f23f7857" />


#### How to test

- Use ClaudeCode agent
- Ask it to delete a file from the workspace
- It should use the Bash tool, and ask for permission as above
- Answer Approve for the current session
- Try the steps above again for a different file
- It will use the Bash tool again without asking the user



#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
