### PR TITLE
fix: prevent duplicate VSIX installations by using package.json ident…

### DIFF
--- a/packages/plugin-ext-vscode/src/node/local-vsix-file-plugin-deployer-resolver.ts
+++ b/packages/plugin-ext-vscode/src/node/local-vsix-file-plugin-deployer-resolver.ts
@@ -16,12 +16,11 @@
 
 import * as path from 'path';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { PluginDeployerResolverContext, PluginDeployerHandler } from '@theia/plugin-ext/lib/common/plugin-protocol';
+import { PluginDeployerResolverContext, PluginDeployerHandler, PluginIdentifiers } from '@theia/plugin-ext';
 import { LocalPluginDeployerResolver } from '@theia/plugin-ext/lib/main/node/resolvers/local-plugin-deployer-resolver';
 import { PluginVSCodeEnvironment } from '../common/plugin-vscode-environment';
 import { isVSCodePluginFile } from './plugin-vscode-file-handler';
 import { existsInDeploymentDir, unpackToDeploymentDir, extractExtensionIdentityFromVsix } from './plugin-vscode-utils';
-import { PluginIdentifiers } from '@theia/plugin-ext/lib/common/plugin-identifiers';
 
 @injectable()
 export class LocalVSIXFilePluginDeployerResolver extends LocalPluginDeployerResolver {
@@ -68,11 +67,11 @@ export class LocalVSIXFilePluginDeployerResolver extends LocalPluginDeployerReso
         const existingPlugins = this.pluginDeployerHandler.getDeployedPluginsById(unversionedId);
         if (existingPlugins.length > 0) {
             const existingVersions = existingPlugins.map(p => p.metadata.model.version);
-            // Throw an error with a user-facing message
-            throw new Error(
+            console.log(
                 'Extension ' + unversionedId + ' (version(s): ' + existingVersions.join(', ') + ') is already installed.\n' +
                 'Uninstall the existing extension before installing a new version from VSIX.'
             );
+            return;
         }
 
         // Check if the deployment directory already exists on disk

--- a/packages/plugin-ext-vscode/src/node/plugin-vscode-utils.ts
+++ b/packages/plugin-ext-vscode/src/node/plugin-vscode-utils.ts
@@ -29,11 +29,7 @@ import { PluginIdentifiers, PluginPackage } from '@theia/plugin-ext/lib/common/p
  * This function extracts only the `extension/package.json` file to read the extension metadata.
  *
  * @param vsixPath Path to the VSIX file
- * @returns The extension identity, or undefined if the package.json cannot be read or is invalid
- */
-/**
- * Extracts extension identity from a VSIX file by reading its package.json.
- * Returns PluginIdentifiers.Components (publisher?, name, version).
+ * @returns PluginIdentifiers.Components (publisher?, name, version), or undefined if the package.json cannot be read or is invalid
  */
 export async function extractExtensionIdentityFromVsix(vsixPath: string): Promise<PluginIdentifiers.Components | undefined> {
     try {
@@ -56,11 +52,8 @@ export async function extractExtensionIdentityFromVsix(vsixPath: string): Promis
             return undefined;
         }
 
-        // Use UNPUBLISHED as the default publisher for extensions without one
-        const publisher = packageJson.publisher ?? PluginIdentifiers.UNPUBLISHED;
-
         const components: PluginIdentifiers.Components = {
-            publisher,
+            publisher: packageJson.publisher,
             name: packageJson.name,
             version: packageJson.version
         };

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -266,8 +266,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
             await this.commandRegistry.executeCommand(VscodeCommands.INSTALL_EXTENSION_FROM_ID_OR_URI.id, fileURI);
             this.messageService.info(nls.localizeByDefault('Completed installing extension.', extensionName));
         } catch (e) {
-            const errorMessage = e instanceof Error ? e.message : String(e);
-            this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName) + ' ' + errorMessage);
+            this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName));
             console.warn(e);
         }
     }


### PR DESCRIPTION
#### What it does

Fixes #16845 - Prevents duplicate VSIX extension installations when the same extension is installed from VSIX files with different filenames.

**Problem:** Extensions installed via "Install from VSIX..." were identified by their **filename** rather than the actual extension identity from `package.json`. This allowed the same extension to be installed multiple times by simply renaming the VSIX file, resulting in:
- Multiple directories under `deployedPlugins`
- Only the first installed extension appearing in the IDE
- Contributions (commands) from later-installed VSIX files being silently ignored

**Solution:** Extract the true extension identity (`publisher.name@version`) from the VSIX's embedded `extension/package.json` instead of deriving it from the filename.

**Changes:**
- Added `extractExtensionIdentityFromVsix()` function in `plugin-vscode-utils.ts` that reads publisher, name, and version from the VSIX's package.json
- Modified `LocalVSIXFilePluginDeployerResolver.resolveFromLocalPath()` to:
  - Use package.json-based identity instead of filename for deployment directory naming
  - Check `getDeployedPluginsById()` to block duplicate installations of the same extension
  - Graceful fallback to filename-based ID if package.json cannot be read

#### How to test

1. Build a sample VSIX extension (e.g., Hello World sample)
2. Install it via `Extensions: Install from VSIX...`
3. Rename the VSIX file (e.g., `hello-0.0.1.vsix` → `hello-renamed.vsix`)
4. Attempt to install the renamed VSIX via `Extensions: Install from VSIX...`
5. **Expected:** Installation is blocked with a console message indicating the extension is already installed
6. **Before fix:** Both VSIX files would be installed, creating duplicate directories in `deployedPlugins`

#### Follow-ups

- Consider adding user-facing notification when duplicate installation is blocked (currently only logs to console)
- Potential enhancement: Allow version upgrades/downgrades via VSIX when different versions are detected

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution



#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

