### PR TITLE
feat(core): add locale and no-translate attributes to html element on startup

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -291,8 +291,14 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     }
 
     onStart(): void {
+        this.setupHtmlLanguageAttributes(document.documentElement);
         this.storageService.getData<{ recent: Command[] }>(RECENT_COMMANDS_STORAGE_KEY, { recent: [] })
             .then(tasks => this.commandRegistry.recent = tasks.recent);
+    }
+
+    protected setupHtmlLanguageAttributes(element: HTMLElement): void {
+        nls.setHtmlLang(element);
+        nls.setHtmlNoTranslate(element);
     }
 
     onStop(): void {

--- a/packages/core/src/browser/secondary-window-handler.ts
+++ b/packages/core/src/browser/secondary-window-handler.ts
@@ -23,6 +23,7 @@ import { Emitter } from '../common/event';
 import { isSecondaryWindow, SecondaryWindowRootWidget, SecondaryWindowService } from './window/secondary-window-service';
 import { KeybindingRegistry } from './keybinding';
 import { MAIN_AREA_ID, TheiaDockPanel } from './shell/theia-dock-panel';
+import { nls } from '../common/nls';
 
 /** Widgets to be contained inside a DockPanel in the secondary window. */
 class SecondaryWindowDockPanelWidget extends SecondaryWindowRootWidget {
@@ -180,6 +181,8 @@ export class SecondaryWindowHandler {
             // See https://html.spec.whatwg.org/multipage/dom.html#document.title
             newWindow.document.title = `${widget.title.label} — ${mainWindowTitle}`;
 
+            this.setupHtmlLanguageAttributes(newWindow.document.documentElement);
+
             const element = newWindow.document.getElementById('widget-host');
             if (!element) {
                 console.error('Could not find dom element to attach to in secondary window');
@@ -216,6 +219,11 @@ export class SecondaryWindowHandler {
             });
             widget.activate();
         });
+    }
+
+    protected setupHtmlLanguageAttributes(element: HTMLElement): void {
+        nls.setHtmlLang(element);
+        nls.setHtmlNoTranslate(element);
     }
 
     private onWidgetRemove(widget: Widget, newWindow: Window, rootWidget: SecondaryWindowRootWidget): void {

--- a/packages/core/src/common/nls.ts
+++ b/packages/core/src/common/nls.ts
@@ -68,6 +68,31 @@ export namespace nls {
     export function setLocale(id: string): void {
         window.localStorage.setItem(localeId, id);
     }
+
+    /**
+     * Sets the 'lang' attribute on the given HTML element based on the current locale.
+     * If no locale is set, defaults to 'en' (English).
+     * Typically used with document.documentElement (the <html> tag) to set the page language.
+     *
+     * @param element The HTML element to set the language attribute on
+     */
+    export function setHtmlLang(element: HTMLElement): void {
+        const lang = locale?.split('_').at(0) || 'en';
+        element.setAttribute('lang', lang);
+    }
+
+    /**
+     * Sets the 'translate' attribute to 'no' and adds the 'notranslate' class
+     * to the given HTML element. This prevents translation tools from translating
+     * the content of the element.
+     * Typically used with document.documentElement (the <html> tag) to disable page translation.
+     *
+     * @param element The HTML element to set translation attributes on
+     */
+    export function setHtmlNoTranslate(element: HTMLElement): void {
+        element.setAttribute('translate', 'no');
+        element.classList.add('notranslate');
+    }
 }
 
 interface NlsKeys {


### PR DESCRIPTION
Modify html tag attributes on startup


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does


- Set 'lang' attribute based on detected locale.
- Prevent auto-translation by setting 'translate="no"' and adding 'notranslate' class.

This ensures better i18n support and avoids issues with unintended UI translation.

fixes #16968 
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

Open web application and check that html element in devtools has the right attributes respecting locale saved to localstorage via nls
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
