### PR TITLE
fix: small improvements in AI agent config view

### DIFF
--- a/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -166,7 +166,7 @@ export class AIAgentConfigurationWidget extends AIListDetailConfigurationWidget<
                 className={
                     `agent-status-indicator ${enabled ? `agent-enabled ${codicon('circle-filled')}` : `agent-disabled ${codicon('circle')}`}`
                 }
-                title={enabled ? 'Enabled' : 'Disabled'}
+                title={enabled ? nls.localizeByDefault('Enabled') : nls.localizeByDefault('Disabled')}
             >
             </span>
         );
@@ -239,7 +239,7 @@ export class AIAgentConfigurationWidget extends AIListDetailConfigurationWidget<
 
         const agentNameWithTags = <>
             {agent.name}
-            {agent.tags?.length && <span>{agent.tags.map(tag => <span key={tag} className='agent-tag'>{tag}</span>)}</span>}
+            {agent.tags && agent.tags.length > 0 && <span>{agent.tags.map(tag => <span key={tag} className='agent-tag'>{tag}</span>)}</span>}
         </>;
 
         return <div key={agent.id}>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Use boolean comparison instead of truthy length check to avoid rendering stringified 0 for empty tags array
- Localize two missing user-facing strings

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open the AI Configuration View and select the Chat Session Summary agent. Verify the detail page heading does not render a trailing0
  - Without this fix it looks like this: <img  height="40" alt="image" src="https://github.com/user-attachments/assets/a1cb4748-49d6-43df-909b-f9dff3f5de3c" />
- Switch the application language and hover the status indicator in the agent list and verify the tooltip is localized now.
  <img width="252" height="91" alt="image" src="https://github.com/user-attachments/assets/3fe5f773-9654-44cc-a9b4-87eb98667de4" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
