### PR TITLE
[Ollama] Yield ToolCallResponsePart before calling the tool handler

### DIFF
--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -162,7 +162,7 @@ export class OllamaModel implements LanguageModel {
                             tool_calls: toolCalls
                         });
 
-                        // Create tool call message parts and yield them. 
+                        // Create tool call message parts and yield them.
                         // This is required because when calling a tool, Theia AI expects the corresponding message part to exist.
                         const toolCallsForResponse = that.createToolCalls(toolCalls, lastUpdated);
                         yield { tool_calls: toolCallsForResponse };


### PR DESCRIPTION
### What it does

Fixes #16969 by creating and yielding a `ToolCallResponsePart` before calling the tool handler, and then updating the `ToolCallResponsePart` with the tool call result.

#### How to test

1. Configure Ollama with a tool-capable model (e.g. glm-4.7-flash)
2. Ask the Architect Agent to describe the workspace contents
3. Inspect the tool calls in the chat by expanding them

The tool call should succeed (it does not reliably without this fix).

#### Follow-ups

-

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
