### PR TITLE
[merge editor] Improve UX for merge conflict actions in special cases

### DIFF
--- a/packages/scm/src/browser/merge-editor/view/merge-range-actions.ts
+++ b/packages/scm/src/browser/merge-editor/view/merge-range-actions.ts
@@ -59,14 +59,14 @@ export class MergeRangeActions {
         const sideTitle = side === 1 ? side1Title : side2Title;
         const state = model.getMergeRangeResultState(mergeRange);
 
-        if (state !== 'Unrecognized' && !state.includes('Side' + side)) {
-            if (state !== 'Base' || mergeRange.getChanges(side).length) {
-                result.push({
-                    text: nls.localizeByDefault('Accept {0}', sideTitle),
-                    tooltip: nls.localizeByDefault('Accept {0} in the result document.', sideTitle),
-                    run: () => this.applyMergeRangeAcceptedState(mergeRange, MergeRangeAcceptedState.addSide(state, side))
-                });
-            }
+        if (state !== 'Unrecognized' && !state.includes('Side' + side) && mergeRange.getChanges(side).length &&
+            (state === 'Base' || !(mergeRange.isEqualChange || mergeRange.getModifiedRange(side).isEmpty))
+        ) {
+            result.push({
+                text: nls.localizeByDefault('Accept {0}', sideTitle),
+                tooltip: nls.localizeByDefault('Accept {0} in the result document.', sideTitle),
+                run: () => this.applyMergeRangeAcceptedState(mergeRange, MergeRangeAcceptedState.addSide(state, side))
+            });
 
             if (mergeRange.canBeSmartCombined(side)) {
                 result.push({
@@ -114,6 +114,15 @@ export class MergeRangeActions {
                     run: () => this.markMergeRangeAsHandled(mergeRange)
                 });
             }
+        } else if (mergeRange.isEqualChange) {
+            result.push({
+                text: side1Title + ' = ' + side2Title
+            });
+            result.push({
+                text: nls.localizeByDefault('Reset to base'),
+                tooltip: nls.localizeByDefault('Reset this conflict to the common ancestor of both the right and left changes.'),
+                run: () => this.applyMergeRangeAcceptedState(mergeRange, 'Base')
+            });
         } else {
             const labels: string[] = [];
             const stateToggles: MergeRangeAction[] = [];


### PR DESCRIPTION
#### What it does

* Currently, the merge editor shows the same set of actions for (auto-resolved) merge conflicts with equal left and right sides as it does for ordinary merge conflicts:

   <img width="937" height="281" alt="Image" src="https://github.com/user-attachments/assets/3dfe6d9e-e1d4-4dce-b572-ffee73481b93" />

   Although not incorrect technically, the UX is not optimal, as e.g. removing the left side and then accepting the right side in this case will still show the left side as accepted, together with the action to accept the right side again (like on the screenshot above), which does not make much sense.

* This PR adds special handling for this case that makes the merge editor show the merge conflict state more precisely (e.g. `Left = Right` instead of just `Left`), together with a set of actions specifically tailored to that state (e.g. `Reset to base` instead of `Remove Left`):

  <img width="939" height="278" alt="Image" src="https://github.com/user-attachments/assets/ff49a9a3-3ea0-46d5-9f08-af6cab6c1561" />

* Also, this PR makes the merge editor hide the action for accepting a conflict side in cases when it would make no sense (e.g. when the other side has already been accepted and both sides are equal, or when it would result in no change).

#### How to test

1. Open the 3-way merge editor with the `Merge Editor (Dev): Open Merge Editor State from JSON` command (which is available in the command palette, `F1`) using the following JSON:

   ```json
   {
     "base": "foo",
     "input1": "bar",
     "input2": "bar",
     "result": "bar"
   }
   ```

   This corresponds to a merge conflict with equal left and right sides:

   <img width="939" height="278" alt="Image" src="https://github.com/user-attachments/assets/ff49a9a3-3ea0-46d5-9f08-af6cab6c1561" />

   Verify that the merge conflict state is shown as `Left = Right` instead of just `Left`, the `Reset to base` action is shown instead of `Remove Left`, and neither `Accept Left` *nor* `Accept Right` actions are shown. Try resetting the merge conflict to base and verify that both `Accept Left` and `Accept Right` actions are now shown and work as expected.
 
2. Open the merge editor using the following JSON:

   ```json
   {
     "base": "foo",
     "input1": "bar",
     "input2": "foo",
     "result": "bar"
   }
   ```

   This corresponds to a merge conflict with the right side that is equal to base:

   <img width="938" height="282" alt="Image" src="https://github.com/user-attachments/assets/4a171577-9eb7-4094-9bb5-0c1eec9474c1" />

   Verify that neither `Accept Left` *nor* `Accept Right` actions are shown. Try removing the left side and verify that the `Accept Left` action is now shown, while the `Accept Right` action is still hidden.
 
3. Open the merge editor using the following JSON:

   ```json
   {
     "base": "foo\nbaz",
     "input1": "bar\nbaz",
     "input2": "baz",
     "result": "bar\nbaz"
   }
   ```

   This corresponds to a merge conflict with the empty right side:

   <img width="938" height="283" alt="Image" src="https://github.com/user-attachments/assets/8bd8a462-fbc2-4175-a5a6-c5768ee93074" />

   Verify that neither `Accept Left` *nor* `Accept Right` actions are shown. Try removing the left side and verify that both `Accept Left` and `Accept Right` actions are now shown and work as expected.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
