### PR TITLE
refactor: update debug frame decoration logic

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -176,7 +176,7 @@ export class DebugEditorModel implements Disposable {
 
         const decorations: monaco.editor.IModelDeltaDecoration[] = [];
         const isTopFrameInEditor = topFrame.source && new URI(topFrame.source.uri.toString()).isEqual(this.uri);
-        const isCurrentFrameInEditor = currentFrame.source && new URI(currentFrame.source.uri.toString()).isEqual(this.uri);
+        const isCurrentFrameInEditor = this.sessionManager.isCurrentEditorFrame(this.uri);
 
         if (isTopFrameInEditor) {
             const columnUntilEOLRange = new monaco.Range(topFrame.raw.line, topFrame.raw.column, topFrame.raw.line, 1 << 30);


### PR DESCRIPTION
Fixes #16840 


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

This PR decouples the logic for rendering the "Top Stack Frame" (execution pointer) and the "Current Stack Frame" in the editor. Previously, the debugger would only render decorations if the selected frame matched the open editor, causing the execution pointer to disappear from the source file when navigating the call stack to other files.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Create a file with a function and a call to the function:
```
function test() {
    a =1;
}
test();
```
2. Set a breakpoint at the function call
3. Run the file
4. Step into the function
5. Select main call stack level

#### Screenshot and Video demo

<img width="963" height="352" alt="Screenshot 2026-02-15 at 3 03 00 AM" src="https://github.com/user-attachments/assets/d047f70e-57aa-49c5-8c1d-174f839a8de4" />


https://github.com/user-attachments/assets/2db4b590-ab83-4955-8737-022df1520ec1




#### Follow-ups
None
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
