### PR TITLE
Remove confusing escpaing comment from function

### DIFF
--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -252,8 +252,7 @@ export class ReplaceContentInFileFunctionHelper {
                         properties: replacementProperties,
                         required: ['oldContent', 'newContent']
                     },
-                    description: `An array of replacement objects, each containing oldContent and newContent strings.
-                    Ensure these strings are valid JSON string values, escaping quotes only as required.`
+                    description: 'An array of replacement objects, each containing oldContent and newContent strings.'
                 },
                 reset: {
                     type: 'boolean',


### PR DESCRIPTION
#### What it does

Removed a confusing comment about escaping from the replaceContent tool function.
This leads to Anthropic models often escaping `

#### How to test

1. Create a MD file with the content <<replace `this` with a short poem>>
2. Press CTRL+I and task coder agent mode next to "do it"
3. Check that it used the replace function and not writes the full file (otherwise add this to the prompt)
4. Replacement should work on the first try (and not without the fix)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
