### PR TITLE
Add ./prompts/skills default to preference description

### DIFF
--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -141,7 +141,7 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
         [PREFERENCE_NAME_SKILL_DIRECTORIES]: {
             description: nls.localize('theia/ai/core/skillDirectories/description',
                 'Additional directories containing skill definitions (SKILL.md files). Skills provide reusable instructions that can be referenced by AI agents. ' +
-                'The default skills directory in your product\'s configuration folder is always included.'),
+                'The .prompts/skills directory in your workspace and the skills directory in your product\'s configuration folder are always included.'),
             type: 'array',
             items: {
                 type: 'string'


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Documents both default skill directories in the preference description. Previously only the config folder default (`~/.theia/skills`) was mentioned, but the workspace default (`.prompts/skills`) was missing.

#### How to test

Open settings and search for `skillDirectories`. Verify the description mentions both default locations.

#### Follow-ups

- Support workspace-relative paths in the `skillDirectories` preference (similar to prompt templates)
@sgraband If you agree to this, could you create a ticket, please?

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
