### PR TITLE
[dirty diff] Call `handleVisibilityChanged` for embedded diff editor

### DIFF
--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -61,11 +61,6 @@ export class MonacoDiffEditor extends MonacoEditor {
         this.documents.add(originalModel);
         this.wordWrapOverride = options?.wordWrapOverride2;
         this._diffNavigator = diffNavigatorFactory.createdDiffNavigator(this._diffEditor);
-        if (parentEditor) {
-            // Embedded diff editors don't participate in visibility tracking (they're not wrapped in EditorWidget),
-            // so we need to set the model immediately since handleVisibilityChanged will never be called.
-            this.diffEditor.setModel(this.diffEditorModel);
-        }
     }
 
     get diffEditor(): monaco.editor.IStandaloneDiffEditor {


### PR DESCRIPTION
#### What it does

* Ensures that `handleVisibilityChanged` is properly called for the embedded diff editor in `DirtyDiffPeekView`
* Cleans up the relevant API and implementation in `DirtyDiffWidget`

This follows up on #16832 and #16940.

While #16940 does fix #16930 (thankfully), which #16832 caused initially (regretfully), it works a bit "by chance", since the assumption that embedded diff editors are always visible upon creation is not correct in general.

For example, when the embedded diff editor is created in the `DirtyDiffPeekView.create` method, its container node is not yet connected to the DOM (it gets connected only in the `show` method, while the `hide` method will disconnect it again).

Therefore, instead of connecting embedded diff editors to their model immediately in the `MonacoDiffEditor` constructor, it needs to be be ensured that they properly receive `handleVisibilityChanged` calls from their containing objects (`DirtyDiffPeekView` in this case), just as other editors.

#### How to test

Verify that #16930 is still fixed by using the steps provided in #16940. There should be no visible change in the behavior of the Dirty Diff Peek View.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
