### PR TITLE
Allow Theia Coder Agent Mode to launch Apps

### DIFF
--- a/.prompts/project-info.prompttemplate
+++ b/.prompts/project-info.prompttemplate
@@ -61,6 +61,10 @@ Use `npm` (not `yarn`) for all package management and script execution.
 If you want to compile something, run the linter or tests, prefer to execute them for changed packages first, as they will run faster. Only build the full project once you are
 done for a final validation. There are usually pre-defined tasks for all these operations, prefer to use these instead of npm directly.
 
+### Start Theia
+
+To start Theia as a browser app to show something to the user or for UI testing use the launch config "Start Theia Default (Browser backend, no debug)"
+
 ### Preferences
 
 Theia uses a preferences system for user/workspace settings. To add new preferences:

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -67,6 +67,18 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Start Theia Default (Browser backend, no debug)",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": [
+        "run",
+        "start:browser"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Launch Browser Backend",
       "program": "${workspaceFolder}/examples/browser/lib/backend/main.js",
       "cwd": "${workspaceFolder}/examples/browser",

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -18,7 +18,10 @@ import {
     SEARCH_IN_WORKSPACE_FUNCTION_ID,
     FIND_FILES_BY_PATTERN_FUNCTION_ID,
     LIST_TASKS_FUNCTION_ID,
-    RUN_TASK_FUNCTION_ID
+    RUN_TASK_FUNCTION_ID,
+    LIST_LAUNCH_CONFIGURATIONS_FUNCTION_ID,
+    RUN_LAUNCH_CONFIGURATION_FUNCTION_ID,
+    STOP_LAUNCH_CONFIGURATION_FUNCTION_ID
 } from './workspace-functions';
 import { TODO_WRITE_FUNCTION_ID } from './todo-tool';
 import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from './context-variables';
@@ -150,6 +153,15 @@ If no relevant tests exist for your changes:
 - Create new test files using ~{${WRITE_FILE_REPLACEMENTS_ID}} or ~{${WRITE_FILE_CONTENT_ID}}
 - Follow patterns from existing tests in the codebase
 - Ensure new tests validate the new behavior and prevent regressions
+
+## Running Applications
+Running tasks will not return until a task is done. To launch an application so that the user \
+or an agent can test it or interact with it continuously, use launch configurations instead.
+- ~{${LIST_LAUNCH_CONFIGURATIONS_FUNCTION_ID}} — list all available launch configs and their state (running or not)
+- ~{${RUN_LAUNCH_CONFIGURATION_FUNCTION_ID}} — start a launch configuration (returns immediately, app runs in background)
+- ~{${STOP_LAUNCH_CONFIGURATION_FUNCTION_ID}} — stop a running launch configuration
+
+Launch configurations are defined in \`.vscode/launch.json\`. If none exist or you need to inspect/modify them, read or create this file.
 
 ## Progress Tracking
 - ~{${TODO_WRITE_FUNCTION_ID}} — track task progress with a todo list visible to the user


### PR DESCRIPTION
#### What it does

Adds launch configuration support to the AI Coder agent, enabling it to start and manage long-running applications for testing and user interaction.

- Added launch configuration functions (`listLaunchConfigurations`, `runLaunchConfiguration`, `stopLaunchConfiguration`) to the coder agent's toolset
- Added "Start Theia Default (Browser backend, no debug)" launch config that the agent can reliably identify and use
- Updated project-info prompt to reference the new launch config

#### How to test

1. Start Theia and open the AI chat
2. Ask the Coder agent to start the application
3. Verify the agent uses launch configurations instead of blocking tasks

#### Follow-ups

Check the new AppTester and /with-app-testing for consistency @sgraband 
(Is tested it once, it seems to work, but please check)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
