### PR TITLE
[AI] Fix FileDiagnosticProvider to not open an editor

### DIFF
--- a/.prompts/project-info.prompttemplate
+++ b/.prompts/project-info.prompttemplate
@@ -61,6 +61,9 @@ Use `npm` (not `yarn`) for all package management and script execution.
 If you want to compile something, run the linter or tests, prefer to execute them for changed packages first, as they will run faster. Only build the full project once you are
 done for a final validation. There are usually pre-defined tasks for all these operations, prefer to use these instead of npm directly.
 
+**Important:** Building a package only compiles TypeScript. Before any UI testing, you must also rebuild the browser example application (`examples/browser`),
+which bundles the frontend via webpack. Without this step, the running browser app will not include the latest code changes.
+
 ### Start Theia
 
 To start Theia as a browser app to show something to the user or for UI testing use the launch config "Start Theia Default (Browser backend, no debug)"

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -34,7 +34,6 @@ import { Container } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { URI } from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
-import { OpenerService } from '@theia/core/lib/browser';
 import { ProblemManager } from '@theia/markers/lib/browser';
 import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
@@ -91,8 +90,7 @@ describe('Workspace Functions Cancellation Tests', () => {
         };
 
         const mockMonacoWorkspace = {
-            // eslint-disable-next-line no-null/no-null
-            getTextDocument: () => null
+            getTextDocument: () => undefined
         } as unknown as MonacoWorkspace;
 
         const mockProblemManager = {
@@ -110,10 +108,6 @@ describe('Workspace Functions Cancellation Tests', () => {
             })
         } as unknown as MonacoTextModelService;
 
-        const mockOpenerService = {
-            open: async () => { }
-        };
-
         // Register mocks in the container
         container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
         container.bind(FileService).toConstantValue(mockFileService);
@@ -121,7 +115,6 @@ describe('Workspace Functions Cancellation Tests', () => {
         container.bind(MonacoWorkspace).toConstantValue(mockMonacoWorkspace);
         container.bind(ProblemManager).toConstantValue(mockProblemManager);
         container.bind(MonacoTextModelService).toConstantValue(mockMonacoTextModelService);
-        container.bind(OpenerService).toConstantValue(mockOpenerService);
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(GetWorkspaceDirectoryStructure).toSelf();
         container.bind(FileContentFunction).toSelf();
@@ -232,8 +225,7 @@ describe('FileContentFunction.getArgumentsShortLabel', () => {
         };
 
         const mockMonacoWorkspace = {
-            // eslint-disable-next-line no-null/no-null
-            getTextDocument: () => null
+            getTextDocument: () => undefined
         } as unknown as MonacoWorkspace;
 
         container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Currently the FileDiagnosticProvider open an editor to retrieve diagnostics, this is not necessary and confusing for the user.
Now this is not the case anymore.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
**Optionally:**
Open workspace-functions.ts in the editor
Add a line that triggers a linter/compiler warning (e.g. extra blank lines triggering eslint no-multiple-empty-lines)
Save the file, confirm warnings appear in the Problems panel
Close the editor tab

**main**:
Start with no editor tabs open
Open the AI Chat, send a message like `@Coder What are the errors and warnings in packages/ai-ide/src/browser/workspace-functions.ts?`
Wait for the getFileDiagnostics tool to be invoked
Before the fix: a workspace-functions.ts editor tab would open as a side effect
After the fix: no editor tab opens; diagnostics are retrieved silently



#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
