### PR TITLE
fix(ui): debug console filter spellcheck and workspace trust dialog styles

### DIFF
--- a/packages/debug/src/browser/console/debug-console-contribution.tsx
+++ b/packages/debug/src/browser/console/debug-console-contribution.tsx
@@ -315,6 +315,7 @@ export class DebugConsoleContribution extends AbstractViewContribution<ConsoleWi
                     ref={ref => { this.filterInputRef = ref ?? undefined; }}
                     onChange={this.handleFilterInputChange}
                     onMouseEnter={this.handleFilterMouseEnter}
+                    spellCheck={false}
                 />
                 {this.currentFilterValue && <span
                     className="debug-console-filter-btn codicon codicon-close action-label"

--- a/packages/workspace/src/browser/style/index.css
+++ b/packages/workspace/src/browser/style/index.css
@@ -16,32 +16,32 @@
 
 /* Workspace Trust Dialog Styles */
 
-.workspace-trust-content {
+.workspace-trust-dialog .workspace-trust-content {
     display: flex;
     flex-direction: column;
     gap: calc(var(--theia-ui-padding) * 3);
     padding: calc(var(--theia-ui-padding) * 2);
 }
 
-.workspace-trust-header {
+.workspace-trust-dialog .workspace-trust-header {
     display: flex;
     align-items: center;
     gap: calc(var(--theia-ui-padding) * 2);
 }
 
-.workspace-trust-header i {
+.workspace-trust-dialog .workspace-trust-header i {
     font-size: calc(var(--theia-ui-font-size3) * 2.5) !important;
     color: var(--theia-button-background);
 }
 
-.workspace-trust-title {
+.workspace-trust-dialog .workspace-trust-title {
     font-size: var(--theia-ui-font-size2);
     font-weight: 600;
     line-height: var(--theia-content-line-height);
 }
 
-.workspace-trust-description,
-.workspace-trust-folder {
+.workspace-trust-dialog .workspace-trust-description,
+.workspace-trust-dialog .workspace-trust-folder {
     margin-left: calc(var(--theia-ui-font-size3) * 2.5 + var(--theia-ui-padding) * 2);
 }
 
@@ -51,17 +51,18 @@
     justify-content: flex-start !important;
 }
 
-.workspace-trust-description {
+.workspace-trust-dialog .dialogContent div.workspace-trust-description {
     color: var(--theia-descriptionForeground);
     line-height: var(--theia-content-line-height);
+    white-space: pre-line;
 }
 
-.workspace-trust-folder-list {
+.workspace-trust-dialog .workspace-trust-folder-list {
     padding-inline-start: 15px;
     margin-block: 0;
 }
 
-.workspace-trust-folder {
+.workspace-trust-dialog .workspace-trust-folder {
     font-family: var(--theia-code-font-family);
     font-size: var(--theia-code-font-size);
     color: var(--theia-foreground);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Disable spellcheck on the debug console filter input
- Scope workspace trust CSS selectors under `.workspace-trust-dialog` to prevent style leaking
- Add `white-space: pre-line` to workspace trust description to preserve Markdown indents

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Add an misspelled text to the debug console filter input and verify the spellcheck does not mark the text anymore
- Open an untrusted workspace and verify the text's indentation is correct and as expected.

Currently it looks like this below, due to recent css updates:
<img height="150" alt="image" src="https://github.com/user-attachments/assets/c8f1f376-1b1e-4c10-9f45-a5159ae384d1" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
