### PR TITLE
feat: FileService - onDidChangeFile - Implement file change buffering to deduplicate events (solution 1)

### DIFF
--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -39,7 +39,7 @@ import { ContributionProvider } from '@theia/core/lib/common/contribution-provid
 import { TernarySearchTree } from '@theia/core/lib/common/ternary-search-tree';
 import {
     ensureFileSystemProviderError, etag, ETAG_DISABLED,
-    FileChangesEvent,
+    FileChange, FileChangeType, FileChangesEvent,
     FileOperation, FileOperationError,
     FileOperationEvent, FileOperationResult, FileSystemProviderCapabilities,
     FileSystemProviderErrorCode, FileType, hasFileFolderCopyCapability, hasOpenReadWriteCloseCapability, hasReadWriteCapability,
@@ -374,7 +374,7 @@ export class FileService {
         this.onDidChangeFileSystemProviderRegistrationsEmitter.fire({ added: true, scheme, provider });
 
         const providerDisposables = new DisposableCollection();
-        providerDisposables.push(provider.onDidChangeFile(changes => this.onDidFilesChangeEmitter.fire(new FileChangesEvent(changes))));
+        providerDisposables.push(provider.onDidChangeFile(changes => this.bufferFileChanges(changes)));
         providerDisposables.push(provider.onFileWatchError(() => this.handleFileWatchError()));
         providerDisposables.push(provider.onDidChangeCapabilities(() => this.onDidChangeFileSystemProviderCapabilitiesEmitter.fire({ provider, scheme })));
         if (ReadOnlyMessageFileSystemProvider.is(provider)) {
@@ -1429,6 +1429,87 @@ export class FileService {
      */
     get onDidFilesChange(): Event<FileChangesEvent> {
         return this.onDidFilesChangeEmitter.event;
+    }
+
+    private static readonly FILE_CHANGES_DEBOUNCE_MS = 100;
+    private pendingFileChanges = new Map<string, FileChange[]>();
+    private pendingFileChangesTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    /**
+     * Buffer incoming file changes and deduplicate by URI before emitting.
+     * Multiple overlapping watchers may report the same file change independently;
+     * this ensures consumers only see one consolidated event per debounce window.
+     */
+    private bufferFileChanges(changes: readonly FileChange[]): void {
+        for (const change of changes) {
+            const uriStr = change.resource.toString();
+            const existing = this.pendingFileChanges.get(uriStr) || [];
+            this.normalizeFileChange(existing, change);
+            this.pendingFileChanges.set(uriStr, existing);
+        }
+        if (this.pendingFileChangesTimeout !== undefined) {
+            clearTimeout(this.pendingFileChangesTimeout);
+        }
+        this.pendingFileChangesTimeout = setTimeout(() => this.flushPendingFileChanges(), FileService.FILE_CHANGES_DEBOUNCE_MS);
+    }
+
+    /**
+     * Normalize a new change into the existing changes for the same URI.
+     *
+     * Rules (same as FileChangeCollection):
+     * - ADDED + ADDED => ADDED
+     * - ADDED + UPDATED => ADDED
+     * - ADDED + DELETED => [ADDED, DELETED]
+     * - UPDATED + ADDED => UPDATED
+     * - UPDATED + UPDATED => UPDATED
+     * - UPDATED + DELETED => DELETED
+     * - DELETED + ADDED => UPDATED
+     * - DELETED + UPDATED => UPDATED
+     * - DELETED + DELETED => DELETED
+     */
+    private normalizeFileChange(changes: FileChange[], change: FileChange): void {
+        let currentType: FileChangeType | undefined;
+        let nextType: FileChangeType | [FileChangeType, FileChangeType] = change.type;
+        do {
+            const current = changes.pop();
+            currentType = current?.type;
+            nextType = this.reduceFileChangeType(currentType, nextType);
+        } while (!Array.isArray(nextType) && currentType !== undefined && currentType !== nextType);
+
+        const resource = change.resource;
+        if (Array.isArray(nextType)) {
+            changes.push(...nextType.map(type => ({ resource, type })));
+        } else {
+            changes.push({ resource, type: nextType });
+        }
+    }
+
+    private reduceFileChangeType(current: FileChangeType | undefined, change: FileChangeType): FileChangeType | [FileChangeType, FileChangeType] {
+        if (current === undefined) {
+            return change;
+        }
+        if (current === FileChangeType.ADDED) {
+            if (change === FileChangeType.DELETED) {
+                return [FileChangeType.ADDED, FileChangeType.DELETED];
+            }
+            return FileChangeType.ADDED;
+        }
+        if (change === FileChangeType.DELETED) {
+            return FileChangeType.DELETED;
+        }
+        return FileChangeType.UPDATED;
+    }
+
+    private flushPendingFileChanges(): void {
+        this.pendingFileChangesTimeout = undefined;
+        const allChanges: FileChange[] = [];
+        for (const changes of this.pendingFileChanges.values()) {
+            allChanges.push(...changes);
+        }
+        this.pendingFileChanges.clear();
+        if (allChanges.length > 0) {
+            this.onDidFilesChangeEmitter.fire(new FileChangesEvent(allChanges));
+        }
     }
 
     private activeWatchers = new Map<string, { disposable: Disposable, count: number }>();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

First solution to the issue below (simple with overhead: 100ms latency on every file change event + extra complexity):

Fixes: https://github.com/eclipse-theia/theia/issues/16520

Brief summary: 
Deduplicate at the FileService event emission — centralized, prevents all consumers from seeing duplicates

See comment for details:
https://github.com/eclipse-theia/theia/issues/16520#issuecomment-3919615528

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
