### PR TITLE
fix(ai-core): improve AI agent completion notifications

### DIFF
--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -158,6 +158,10 @@ export interface ChatAgent extends Agent {
     invoke(request: MutableChatRequestModel, chatAgentService?: ChatAgentService): Promise<void>;
 }
 
+export function isChatAgent(agent: Agent): agent is ChatAgent {
+    return 'locations' in agent && Array.isArray((agent as ChatAgent).locations) && 'invoke' in agent;
+}
+
 @injectable()
 export abstract class AbstractChatAgent implements ChatAgent {
     @inject(LanguageModelRegistry) protected languageModelRegistry: LanguageModelRegistry;

--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -20,6 +20,8 @@ import { interfaces } from '@theia/core/shared/inversify';
 import {
     NOTIFICATION_TYPES,
     NOTIFICATION_TYPE_OFF,
+    NOTIFICATION_TYPE_LABELS,
+    NOTIFICATION_TYPE_DESCRIPTIONS,
     NotificationType
 } from './notification-types';
 import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
@@ -129,13 +131,11 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
         [PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE]: {
             title: nls.localize('theia/ai/core/defaultNotification/title', 'Default Notification Type'),
             markdownDescription: nls.localize('theia/ai/core/defaultNotification/mdDescription',
-                'The default notification method used when an AI agent completes a task. Individual agents can override this setting.\n\
-                - `os-notification`: Show OS/system notifications\n\
-                - `message`: Show notifications in the status bar/message area\n\
-                - `blink`: Blink or highlight the UI\n\
-                - `off`: Disable all notifications'),
+                'The default notification method used when an AI agent completes a task. Individual agents can override this setting.'),
             type: 'string',
             enum: [...NOTIFICATION_TYPES],
+            enumItemLabels: NOTIFICATION_TYPES.map(type => NOTIFICATION_TYPE_LABELS[type]),
+            enumDescriptions: NOTIFICATION_TYPES.map(type => NOTIFICATION_TYPE_DESCRIPTIONS[type]),
             default: NOTIFICATION_TYPE_OFF
         },
         [PREFERENCE_NAME_SKILL_DIRECTORIES]: {

--- a/packages/ai-core/src/common/notification-types.ts
+++ b/packages/ai-core/src/common/notification-types.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { nls } from '@theia/core';
+
 export const NOTIFICATION_TYPE_OFF = 'off';
 export const NOTIFICATION_TYPE_OS_NOTIFICATION = 'os-notification';
 export const NOTIFICATION_TYPE_MESSAGE = 'message';
@@ -29,3 +31,17 @@ export const NOTIFICATION_TYPES: NotificationType[] = [
     NOTIFICATION_TYPE_MESSAGE,
     NOTIFICATION_TYPE_BLINK,
 ];
+
+export const NOTIFICATION_TYPE_LABELS: Record<NotificationType, string> = {
+    [NOTIFICATION_TYPE_OFF]: nls.localizeByDefault('Off'),
+    [NOTIFICATION_TYPE_OS_NOTIFICATION]: nls.localize('theia/ai/core/notification/osNotification', 'OS Notification'),
+    [NOTIFICATION_TYPE_MESSAGE]: nls.localizeByDefault('Message'),
+    [NOTIFICATION_TYPE_BLINK]: nls.localize('theia/ai/core/notification/windowBlink', 'Window Blink'),
+};
+
+export const NOTIFICATION_TYPE_DESCRIPTIONS: Record<NotificationType, string> = {
+    [NOTIFICATION_TYPE_OFF]: nls.localize('theia/ai/core/notification/off/description', 'Disable all notifications'),
+    [NOTIFICATION_TYPE_OS_NOTIFICATION]: nls.localize('theia/ai/core/notification/osNotification/description', 'Show native OS notifications'),
+    [NOTIFICATION_TYPE_MESSAGE]: nls.localize('theia/ai/core/notification/message/description', 'Show a notification message inside the application'),
+    [NOTIFICATION_TYPE_BLINK]: nls.localize('theia/ai/core/notification/windowBlink/description', 'Blink the application title to attract attention'),
+};

--- a/packages/ai-ide/src/browser/ai-configuration/components/agent-notification-settings.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/components/agent-notification-settings.tsx
@@ -1,0 +1,83 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import {
+    NotificationType,
+    NOTIFICATION_TYPES,
+    NOTIFICATION_TYPE_LABELS,
+    NOTIFICATION_TYPE_DESCRIPTIONS,
+} from '@theia/ai-core/lib/common';
+import { nls } from '@theia/core';
+import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
+import * as React from '@theia/core/shared/react';
+
+export interface AgentNotificationSettingsProps {
+    agentId: string;
+    currentNotificationType?: NotificationType;
+    onNotificationTypeChange: (agentId: string, notificationType: NotificationType | undefined) => Promise<void>;
+    onOpenNotificationSettings: () => void;
+}
+
+const DEFAULT_VALUE = 'default';
+
+const NOTIFICATION_SELECT_OPTIONS: SelectOption[] = [
+    {
+        value: DEFAULT_VALUE,
+        label: nls.localizeByDefault('Default'),
+        description: nls.localize('theia/ai/core/agentConfiguration/defaultNotificationDescription',
+            'Uses the global AI notification setting'),
+    },
+    ...NOTIFICATION_TYPES.map(type => ({
+        value: type,
+        label: NOTIFICATION_TYPE_LABELS[type],
+        description: NOTIFICATION_TYPE_DESCRIPTIONS[type],
+    })),
+];
+
+export const AgentNotificationSettings = ({ agentId, currentNotificationType, onNotificationTypeChange, onOpenNotificationSettings }: AgentNotificationSettingsProps) => {
+    const handleChange = (option: SelectOption, _index: number): void => {
+        const notificationType = option.value === DEFAULT_VALUE ? undefined : option.value as NotificationType;
+        onNotificationTypeChange(agentId, notificationType);
+    };
+
+    return (
+        <div className="ai-llm-requirement-item">
+            <div className="ai-configuration-value-row">
+                <label className="ai-configuration-value-row-label">
+                    {nls.localizeByDefault('Notifications')}:
+                </label>
+                <SelectComponent
+                    className="ai-configuration-select"
+                    options={NOTIFICATION_SELECT_OPTIONS}
+                    defaultValue={currentNotificationType ?? DEFAULT_VALUE}
+                    onChange={handleChange}
+                />
+            </div>
+            <NotificationDescription onOpenNotificationSettings={onOpenNotificationSettings} />
+        </div>
+    );
+};
+
+const NotificationDescription = ({ onOpenNotificationSettings }: { onOpenNotificationSettings: () => void }): React.ReactElement => {
+    const linkText = nls.localize('theia/ai/core/agentConfiguration/notificationSettingsLink', 'AI notification setting');
+    return (
+        <div className="ai-configuration-description">
+            {nls.localize('theia/ai/core/agentConfiguration/completionNotificationDescriptionPrefix',
+                'Select how you want to be notified when this agent completes its task. "Default" uses the ')}
+            <a href="#" onClick={e => { e.preventDefault(); onOpenNotificationSettings(); }}>{linkText}</a>.
+        </div>
+    );
+};

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -333,6 +333,7 @@
   color: var(--theia-foreground);
   text-align: left;
   padding-right: var(--theia-ui-padding);
+  line-height: 1.4;
 }
 
 .ai-configuration-value-row-value {
@@ -340,8 +341,28 @@
   word-break: break-word;
 }
 
+.ai-configuration-select {
+  max-width: 400px;
+}
+
 .ai-configuration-value-row-value.ai-alias-evaluates-to-unresolved {
   color: var(--theia-descriptionForeground);
+}
+
+.ai-configuration-description {
+  color: var(--theia-descriptionForeground);
+  font-size: var(--theia-ui-font-size1);
+  margin-top: calc(var(--theia-ui-padding) * 1.5);
+}
+
+.ai-configuration-description a {
+  color: var(--theia-textLink-foreground);
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.ai-configuration-description a:hover {
+  text-decoration: underline;
 }
 
 .settings-section-subcategory-title {
@@ -378,8 +399,17 @@
 .variable-references,
 .function-references {
   list-style: none;
-  padding: 0;
+  padding: calc(var(--theia-ui-padding) * 1.5) 0;
   margin: 0;
+  border-top: var(--theia-border-width) solid var(--theia-widget-border);
+  border-bottom: var(--theia-border-width) solid var(--theia-widget-border);
+}
+
+/* Agent-specific variables already have per-item borders, remove the list-level ones */
+.variable-references:has(.ai-agent-specific-variable-item) {
+  border-top: none;
+  border-bottom: none;
+  padding: 0;
 }
 
 .variable-reference,


### PR DESCRIPTION
#### What it does

Resolves https://github.com/eclipse-theia/theia/issues/15894

- Suppress completion notifications only when the user is actively viewing the same chat session, not when any chat widget is focused
- Fix title blinking in Electron with custom titlebar by updating the custom title element directly
- Blink secondary window titles alongside the main window title
- Add per-agent notification type setting in the AI Configuration view using Theia's `SelectComponent` with descriptions
- Focus the corresponding chat session when clicking an OS or message notification
- Use `enumItemLabels` and `enumDescriptions` for the default notification type preference
- Guard against concurrent title blink animations
- Extract notification settings UI into a separate component
- Strengthen `isChatAgent` type guard with `Array.isArray` check

#### How to test

Setup: Configure a default notification type in preferences (`ai-features.notifications.default`) or set a per-agent notification type in the AI Configuration view (Agents > select agent > Notification Settings).

Triggering notifications: Start a chat with an agent, then immediately either:
  - Open a new/different chat session, or
  - Switch to another view in the same area (e.g., if the chat is in the right sidebar, switch to the Outline view)

This ensures the chat session is not focused when the agent completes, so the notification is not suppressed.

- Electron: Verify title blink correctly for both titlebar settings (native/custom)
- Browser app: Verify title blinks correctly in the browser tab
- Secondary windows: Extract a widget to a secondary window, trigger a notification, and verify both the main and secondary window titles blink
- OS notifications: Verify native OS notifications appear and clicking them focuses the correct chat session
- Message notifications: Verify in-app message notifications appear with a "Show Chat" action that navigates to the correct session
- Per-agent setting: In the AI Configuration view, set a specific notification type for one agent and verify it overrides the global default
- Default suppression: Verify notifications are suppressed when the user is actively viewing the same chat session that completed

#### Follow-ups

- Use `SelectComponent` throughout the AI Configuration view (not only for the notification setting) for a consistent look and feel
- Add reset to default options for settings in the Agent configuration view
- General AI Configuration view facelift to better align the different configuration tabs (Agents, Variables, Model Aliases, etc.)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
