### PR TITLE
feat: Added support for displaying and handling deprecated VSX extensions

### DIFF
--- a/dev-packages/ovsx-client/src/ovsx-types.ts
+++ b/dev-packages/ovsx-client/src/ovsx-types.ts
@@ -183,6 +183,7 @@ export interface VSXSearchEntry {
      * `false` or `undefined`.
      */
     allVersions?: VSXAllVersions[];
+    deprecated?: boolean;
 }
 
 export type VSXExtensionNamespaceAccess = 'public' | 'restricted';
@@ -251,6 +252,7 @@ export interface VSXExtensionRaw {
     engines?: {
         [engine: string]: string;
     };
+    deprecated?: boolean;
 }
 
 export interface VSXBadge {

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -78,10 +78,7 @@
 .theia-vsx-extensions-search-bar {
   display: flex;
   align-content: center;
-  padding: var(--theia-ui-padding) 
-           max(var(--theia-scrollbar-width), var(--theia-ui-padding)) 
-           var(--theia-ui-padding) 
-           calc(var(--theia-ui-padding) * 3);
+  padding: var(--theia-ui-padding) max(var(--theia-scrollbar-width), var(--theia-ui-padding)) var(--theia-ui-padding) calc(var(--theia-ui-padding) * 3);
 }
 
 .theia-vsx-extensions-search-bar .theia-input {
@@ -217,10 +214,7 @@
 
 .theia-vsx-extension-editor .header {
   display: flex;
-  padding: calc(var(--theia-ui-padding) * 3)
-           max(var(--theia-ui-padding), var(--theia-scrollbar-width))
-           calc(var(--theia-ui-padding) * 3)
-           calc(var(--theia-ui-padding) * 3);
+  padding: calc(var(--theia-ui-padding) * 3) max(var(--theia-ui-padding), var(--theia-scrollbar-width)) calc(var(--theia-ui-padding) * 3) calc(var(--theia-ui-padding) * 3);
   flex-shrink: 0;
   border-bottom: 1px solid hsla(0, 0%, 50%, 0.5);
   width: 100%;
@@ -356,6 +350,35 @@
   font-size: var(--theia-ui-font-size0);
   font-style: italic;
   margin-left: calc(var(--theia-ui-padding) * 5 / 3);
+}
+
+.theia-vsx-extension-deprecated {
+  background: var(--theia-statusBarItem-warningBackground, #cc6633);
+  color: var(--theia-statusBarItem-warningForeground, #ffffff);
+  border-radius: 2px;
+  padding: 0 5px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+.theia-vsx-extension-deprecation-notice {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  margin: 0px 24px;
+  background: var(--theia-inputValidation-warningBackground);
+  border: 1px solid var(--theia-inputValidation-warningBorder);
+  color: var(--theia-foreground);
+  font-size: 12px;
+}
+
+.theia-vsx-extension-name-deprecated {
+  text-decoration: line-through;
+  opacity: 0.8;
 }
 
 .theia-vsx-extension-editor .header .details .subtitle {

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -64,6 +64,7 @@ export class VSXExtensionData {
     readonly verified?: boolean;
     readonly namespaceAccess?: VSXExtensionNamespaceAccess;
     readonly publishedBy?: VSXUser;
+    readonly deprecated?: boolean;
     static KEYS: Set<(keyof VSXExtensionData)> = new Set([
         'version',
         'iconUrl',
@@ -82,7 +83,8 @@ export class VSXExtensionData {
         'preview',
         'verified',
         'namespaceAccess',
-        'publishedBy'
+        'publishedBy',
+        'deprecated'
     ]);
 }
 
@@ -292,6 +294,10 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
 
     get preview(): boolean | undefined {
         return this.getData('preview');
+    }
+
+    get deprecated(): boolean | undefined {
+        return this.getData('deprecated');
     }
 
     get verified(): boolean | undefined {
@@ -508,7 +514,7 @@ export abstract class AbstractVSXExtensionComponent<Props extends AbstractVSXExt
                 !builtin && installed && !uninstalled && <button className="theia-button action" onClick={this.uninstall}>{nls.localizeByDefault('Uninstall')}</button>
             }
             {
-                !builtin && !installed && <button className="theia-button prominent action" onClick={this.install}>{nls.localizeByDefault('Install')}</button>
+                !builtin && !installed && <button className={`theia-button prominent action${this.props.extension.deprecated ? ' theia-mod-disabled' : ''}`} disabled={this.props.extension.deprecated} onClick={this.install}>{nls.localizeByDefault('Install')}</button>
             }
             <div className="codicon codicon-settings-gear action" tabIndex={tabIndex} onClick={this.manage}></div>
         </div>;
@@ -560,9 +566,14 @@ export class VSXExtensionComponent<Props extends VSXExtensionComponent.Props = V
             <div className='theia-vsx-extension-content'>
                 <div className='title'>
                     <div className='noWrapInfo'>
-                        <span className='name'>{displayName}</span>&nbsp;
+                        <span className={`name${this.props.extension.deprecated ? ' theia-vsx-extension-name-deprecated' : ''}`}>{displayName}</span>&nbsp;
                         <span className='version'>{VSXExtension.formatVersion(version)}&nbsp;
                         </span>{disabled && installed && <span className='disabled'>({nls.localizeByDefault('disabled')})</span>}
+                        {this.props.extension.deprecated && (
+                            <span className='theia-vsx-extension-tag theia-vsx-extension-deprecated' title='This extension is deprecated'>
+                                Deprecated
+                            </span>
+                        )}
                     </div>
                     <div className='stat'>
                         {!!downloadCount && <span className='download-count'><i className={codicon('cloud-download')} />{downloadCompactFormatter.format(downloadCount)}</span>}
@@ -613,10 +624,11 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                     <div className='icon-container placeholder' />}
                 <div className='details'>
                     <div className='title'>
-                        <span title='Extension name' className='name' onClick={this.openExtension}>{displayName}</span>
+                        <span title='Extension name' className={`name${this.props.extension.deprecated ? ' theia-vsx-extension-name-deprecated' : ''}`} onClick={this.openExtension}>{displayName}</span>
                         <span title='Extension identifier' className='identifier'>{id}</span>
                         {preview && <span className='preview'>Preview</span>}
                         {builtin && <span className='builtin'>Built-in</span>}
+                        {this.props.extension.deprecated && <span className='theia-vsx-extension-tag theia-vsx-extension-deprecated' title='This extension is deprecated'>Deprecated</span>}
                     </div>
                     <div className='subtitle'>
                         <span title='Publisher name' className='publisher' onClick={this.searchPublisher}>
@@ -637,6 +649,12 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                     {this.renderAction()}
                 </div>
             </div>
+            {this.props.extension.deprecated && (
+                <div className='theia-vsx-extension-deprecation-notice'>
+                    <i className='codicon codicon-warning' />
+                    This extension has been deprecated.
+                </div>
+            )}
             {
                 sanitizedReadme &&
                 <div className='scroll-container'

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -514,7 +514,15 @@ export abstract class AbstractVSXExtensionComponent<Props extends AbstractVSXExt
                 !builtin && installed && !uninstalled && <button className="theia-button action" onClick={this.uninstall}>{nls.localizeByDefault('Uninstall')}</button>
             }
             {
-                !builtin && !installed && <button className={`theia-button prominent action${this.props.extension.deprecated ? ' theia-mod-disabled' : ''}`} disabled={this.props.extension.deprecated} onClick={this.install}>{nls.localizeByDefault('Install')}</button>
+                !builtin && !installed && (
+                    <button
+                        className={`theia-button prominent action${this.props.extension.deprecated ? ' theia-mod-disabled' : ''}`}
+                        disabled={this.props.extension.deprecated}
+                        onClick={this.install}
+                    >
+                        {nls.localizeByDefault('Install')}
+                    </button>
+                )
             }
             <div className="codicon codicon-settings-gear action" tabIndex={tabIndex} onClick={this.manage}></div>
         </div>;
@@ -624,11 +632,24 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                     <div className='icon-container placeholder' />}
                 <div className='details'>
                     <div className='title'>
-                        <span title='Extension name' className={`name${this.props.extension.deprecated ? ' theia-vsx-extension-name-deprecated' : ''}`} onClick={this.openExtension}>{displayName}</span>
+                        <span
+                            title='Extension name'
+                            className={`name${this.props.extension.deprecated ? ' theia-vsx-extension-name-deprecated' : ''}`}
+                            onClick={this.openExtension}
+                        >
+                            {displayName}
+                        </span>
                         <span title='Extension identifier' className='identifier'>{id}</span>
                         {preview && <span className='preview'>Preview</span>}
                         {builtin && <span className='builtin'>Built-in</span>}
-                        {this.props.extension.deprecated && <span className='theia-vsx-extension-tag theia-vsx-extension-deprecated' title='This extension is deprecated'>Deprecated</span>}
+                        {this.props.extension.deprecated && (
+                            <span
+                                className='theia-vsx-extension-tag theia-vsx-extension-deprecated'
+                                title='This extension is deprecated'
+                            >
+                                Deprecated
+                            </span>
+                        )}
                     </div>
                     <div className='subtitle'>
                         <span title='Publisher name' className='publisher' onClick={this.searchPublisher}>


### PR DESCRIPTION
Fixes #17007 

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR introduces visual indicators to the VSX Extension Registry UI to clearly identify when an extension has been deprecated. By parsing the deprecated flag from the OpenVSX API, the UI now displays a "Deprecated" badge, applies a strikethrough effect to the extension's name, and disables the "Install" button in both the list and detailed editor views to prevent accidental installations. Additionally, a prominent warning banner is added beneath the header in the detailed view to explicitly inform users of the deprecation status.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. look for `davidgomes.platformio-ide-cursor` or `platformio` extension
2. notice that it mention this is marked as deprecated. ([vsx-link](https://open-vsx.org/extension/davidgomes/platformio-ide-cursor/reviews))

#### Screenshot

<img width="1414" height="347" alt="Screenshot 2026-02-20 at 10 32 08 PM" src="https://github.com/user-attachments/assets/12ca42ff-7405-47b3-ad25-155b209521ed" />

#### Follow-ups
None
<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
