### PR TITLE
feat(ai): add generic capabilities selection UI for chat requests

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -66,6 +66,7 @@ import { ChatInputFocusService } from './chat-input-focus-service';
 import { ChatFocusContribution } from './chat-focus-contribution';
 import { ChatCapabilitiesService, ChatCapabilitiesServiceImpl } from './chat-capabilities-service';
 import { ChatInputCapabilitiesContribution } from './chat-input-capabilities-contribution';
+import { GenericCapabilitiesContribution, GenericCapabilitiesService, GenericCapabilitiesServiceImpl } from './generic-capabilities-service';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(AIChatNavigationService).toSelf().inSingletonScope();
@@ -91,6 +92,10 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(ChatCapabilitiesServiceImpl).toSelf().inSingletonScope();
     bind(ChatCapabilitiesService).toService(ChatCapabilitiesServiceImpl);
 
+    bindContributionProvider(bind, GenericCapabilitiesContribution);
+    bind(GenericCapabilitiesServiceImpl).toSelf().inSingletonScope();
+    bind(GenericCapabilitiesService).toService(GenericCapabilitiesServiceImpl);
+
     bind(ChatInputCapabilitiesContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(ChatInputCapabilitiesContribution);
     bind(KeybindingContribution).toService(ChatInputCapabilitiesContribution);
@@ -105,6 +110,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
         showContext: true,
         showPinnedAgent: true,
         showChangeSet: true,
+        showCapabilities: true,
         enablePromptHistory: true
     } satisfies AIChatInputConfiguration);
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
@@ -128,6 +134,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
             showPinnedAgent: true,
             showChangeSet: false,
             showSuggestions: false,
+            showCapabilities: true,
             enablePromptHistory: false
         } satisfies AIChatInputConfiguration);
         container.bind(AIChatTreeInputWidget).toSelf().inSingletonScope();

--- a/packages/ai-chat-ui/src/browser/chat-capabilities-panel.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-capabilities-panel.tsx
@@ -50,10 +50,6 @@ export const CapabilityChipsRow: React.FunctionComponent<CapabilityChipsRowProps
     // eslint-disable-next-line no-null/no-null
     const containerRef = React.useRef<HTMLDivElement>(null);
 
-    if (capabilities.length === 0) {
-        return undefined;
-    }
-
     const handleKeyDown = (e: React.KeyboardEvent): void => {
         if (disabled) {
             return;
@@ -128,7 +124,7 @@ interface CapabilityChipProps {
  * option buttons (match case, regex). Uses inputOption theme colors
  * when enabled, transparent when disabled.
  */
-const CapabilityChip = React.memo<CapabilityChipProps>(function CapabilityChip({
+export const CapabilityChip = React.memo<CapabilityChipProps>(function CapabilityChip({
     fragmentId,
     name,
     description,

--- a/packages/ai-chat-ui/src/browser/chat-capabilities-service.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-capabilities-service.spec.ts
@@ -1,0 +1,177 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { ChatCapabilitiesServiceImpl } from './chat-capabilities-service';
+
+disableJSDOM();
+
+describe('ChatCapabilitiesServiceImpl', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    describe('extractUsedGenericCapabilities', () => {
+        let service: ChatCapabilitiesServiceImpl;
+
+        // Helper to access the protected method for testing
+        type ExtractFn = (template: string) => import('@theia/ai-core').GenericCapabilitySelections;
+        const extract = (template: string): import('@theia/ai-core').GenericCapabilitySelections =>
+            (service as unknown as { extractUsedGenericCapabilities: ExtractFn }).extractUsedGenericCapabilities(template);
+
+        beforeEach(() => {
+            // Create a minimal instance to test the extraction logic
+            service = new ChatCapabilitiesServiceImpl();
+        });
+
+        it('extracts functions from template', () => {
+            const template = `
+        You have access to these tools:
+        ~{myFunction}
+        ~{anotherFunction}
+            `;
+
+            const result = extract(template);
+
+            expect(result.functions).to.deep.equal(['myFunction', 'anotherFunction']);
+        });
+
+        it('extracts MCP functions without distinguishing from regular functions', () => {
+            const template = `
+        You have access to MCP tools:
+        ~{mcp_server1_tool1}
+        ~{mcp_server2_tool2}
+        ~{regularFunction}
+            `;
+
+            const result = extract(template);
+
+            expect(result.functions).to.deep.equal(['mcp_server1_tool1', 'mcp_server2_tool2', 'regularFunction']);
+        });
+
+        it('extracts prompt fragment variable names', () => {
+            const template = `
+        Include these fragments:
+        {{prompt:fragment1}}
+        {{prompt:another-fragment}}
+            `;
+
+            const result = extract(template);
+
+            expect(result.variables).to.include('prompt');
+        });
+
+        it('extracts skill variable names', () => {
+            const template = `
+        Load skills:
+        {{skill:git-best-practices}}
+        {{skill:code-review}}
+            `;
+
+            const result = extract(template);
+
+            expect(result.variables).to.include('skill');
+        });
+
+        it('extracts regular variables from template', () => {
+            const template = `
+        Use these variables:
+        {{today}}
+        {{file:src/index.ts}}
+        {{someVariable}}
+            `;
+
+            const result = extract(template);
+
+            expect(result.variables).to.include('today');
+            expect(result.variables).to.include('file');
+            expect(result.variables).to.include('someVariable');
+        });
+
+        it('excludes capability variables', () => {
+            const template = `
+{{capability:some-capability default on}}
+{{someVariable}}
+            `;
+
+            const result = extract(template);
+
+            expect(result.variables).to.not.include('capability');
+            expect(result.variables).to.include('someVariable');
+        });
+
+        it('excludes selected_* variables', () => {
+            const template = `
+{{selected_skills}}
+{{selected_functions}}
+{{someVariable}}
+            `;
+
+            const result = extract(template);
+
+            expect(result.variables).to.not.include('selected_skills');
+            expect(result.variables).to.not.include('selected_functions');
+            expect(result.variables).to.include('someVariable');
+        });
+
+        it('excludes {{skills}} variable as a meta-variable', () => {
+            const template = `
+        {{skills}}
+            `;
+
+            const result = extract(template);
+
+            // The {{skills}} variable lists all skills, so it's excluded
+            expect(result.variables).to.not.include('skills');
+        });
+
+        it('handles mixed content correctly', () => {
+            const template = `
+        # System Prompt
+
+        Use the following:
+        ~{myFunction}
+        ~{mcp_server1_tool}
+        {{prompt:my-fragment}}
+        {{skill:test-skill}}
+        {{today}}
+        {{capability:some-cap default on}}
+            `;
+
+            const result = extract(template);
+
+            expect(result.functions).to.deep.equal(['myFunction', 'mcp_server1_tool']);
+            expect(result.variables).to.include('prompt');
+            expect(result.variables).to.include('skill');
+            expect(result.variables).to.include('today');
+            expect(result.variables).to.not.include('capability');
+        });
+
+        it('returns empty arrays for template with no capabilities', () => {
+            const template = 'Just some plain text without any capabilities.';
+
+            const result = extract(template);
+
+            expect(result.functions).to.deep.equal([]);
+            expect(result.variables).to.deep.equal([]);
+        });
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-input-capabilities-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-capabilities-contribution.ts
@@ -41,7 +41,7 @@ export class ChatInputCapabilitiesContribution implements CommandContribution, K
         keybindings.registerKeybinding({
             command: CHAT_INPUT_TOGGLE_CAPABILITIES_COMMAND.id,
             keybinding: 'ctrlcmd+shift+.',
-            when: 'chatInputFocus && chatInputHasCapabilities'
+            when: 'chatInputFocus'
         });
     }
 

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -15,13 +15,13 @@
 // *****************************************************************************
 import { CommandService, ContributionProvider, deepClone, Emitter, Event, MessageService, PreferenceService, URI } from '@theia/core';
 import { ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings, isActiveSessionChangedEvent, MutableChatModel } from '@theia/ai-chat';
+import { GenericCapabilitySelections, AIVariableResolutionRequest } from '@theia/ai-core';
 import { BaseWidget, codicon, ExtractableWidget, Message, PanelLayout, StatefulWidget } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { AIChatInputWidget } from './chat-input-widget';
 import { ChatViewTreeWidget, ChatWelcomeMessageProvider } from './chat-tree-view/chat-view-tree-widget';
 import { AIActivationService } from '@theia/ai-core/lib/browser/ai-activation-service';
-import { AIVariableResolutionRequest } from '@theia/ai-core';
 import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
 import { FrontendVariableService } from '@theia/ai-core/lib/browser';
 import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
@@ -235,12 +235,17 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         return this.onStateChangedEmitter.event;
     }
 
-    protected async onQuery(query?: string | ChatRequest, modeId?: string, capabilityOverrides?: Record<string, boolean>): Promise<void> {
+    protected async onQuery(
+        query?: string | ChatRequest,
+        modeId?: string,
+        capabilityOverrides?: Record<string, boolean>,
+        genericCapabilitySelections?: GenericCapabilitySelections
+    ): Promise<void> {
         const chatRequest: ChatRequest = !query
             ? { text: '' }
             : typeof query === 'string'
-                ? { text: query, modeId, capabilityOverrides }
-                : { ...query, capabilityOverrides };
+                ? { text: query, modeId, capabilityOverrides, genericCapabilitySelections }
+                : { ...query, capabilityOverrides, genericCapabilitySelections };
         if (chatRequest.text.length === 0) { return; }
 
         if (this.chatSession.model.isEmpty()) {

--- a/packages/ai-chat-ui/src/browser/generic-capabilities-section.tsx
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-section.tsx
@@ -1,0 +1,81 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+import { GenericCapabilitySelections } from '@theia/ai-core';
+import { AvailableGenericCapabilities } from './generic-capabilities-service';
+import { GenericCapabilitiesTree } from './generic-capabilities-tree';
+
+export interface GenericCapabilitiesSectionProps {
+    /** Current generic capability selections */
+    genericCapabilities: GenericCapabilitySelections;
+    /** Called when a capability type's selection changes */
+    onGenericCapabilityChange: (type: keyof GenericCapabilitySelections, ids: string[]) => void;
+    /** Available capabilities to select from */
+    availableCapabilities: AvailableGenericCapabilities;
+    /** Items already in the agent prompt that should be disabled/greyed */
+    disabledCapabilities: GenericCapabilitySelections;
+    /** Whether the section is disabled */
+    disabled?: boolean;
+    /** Hover service for tooltips */
+    hoverService: HoverService;
+}
+
+/**
+ * Section component displaying generic capabilities in a tree layout.
+ * Shows a unified multi-level tree with all capability types as roots,
+ * groups as intermediate nodes, and items as leaves.
+ * Includes a search bar for filtering capabilities.
+ */
+export const GenericCapabilitiesSection: React.FunctionComponent<GenericCapabilitiesSectionProps> = ({
+    genericCapabilities,
+    onGenericCapabilityChange,
+    availableCapabilities,
+    disabledCapabilities,
+    disabled,
+    hoverService
+}) => {
+    // Check if we have any available capabilities to show
+    const hasAvailableCapabilities =
+        availableCapabilities.skills.length > 0 ||
+        availableCapabilities.mcpFunctions.length > 0 ||
+        availableCapabilities.functions.length > 0 ||
+        availableCapabilities.promptFragments.length > 0 ||
+        availableCapabilities.agentDelegation.length > 0 ||
+        availableCapabilities.variables.length > 0;
+
+    if (!hasAvailableCapabilities) {
+        return undefined;
+    }
+
+    return (
+        <div className="theia-ChatInput-GenericCapabilitiesSection">
+            <div className="theia-ChatInput-GenericCapabilitiesSection-heading">
+                {nls.localize('theia/ai/chat-ui/genericCapabilities', 'Generic Capabilities')}
+            </div>
+            <GenericCapabilitiesTree
+                genericCapabilities={genericCapabilities}
+                onGenericCapabilityChange={onGenericCapabilityChange}
+                availableCapabilities={availableCapabilities}
+                disabledCapabilities={disabledCapabilities}
+                disabled={disabled}
+                hoverService={hoverService}
+            />
+        </div>
+    );
+};

--- a/packages/ai-chat-ui/src/browser/generic-capabilities-service.ts
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-service.ts
@@ -1,0 +1,248 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, named, optional, postConstruct } from '@theia/core/shared/inversify';
+import { ContributionProvider, Disposable, DisposableCollection, Emitter, Event } from '@theia/core';
+import { SkillService } from '@theia/ai-core/lib/browser';
+import {
+    AIVariable,
+    CapabilityType,
+    GenericCapabilitiesContribution,
+    GenericCapabilityGroup,
+    GenericCapabilityItem,
+    GENERIC_CAPABILITIES_PROMPT_PREFIX,
+    GENERIC_CAPABILITIES_VARIABLE_PREFIX,
+    PromptFragment,
+    PromptService,
+    ToolInvocationRegistry,
+    AIVariableService
+} from '@theia/ai-core';
+import { ChatAgentService } from '@theia/ai-chat';
+import debounce = require('@theia/core/shared/lodash.debounce');
+
+// Re-export types from ai-core for backward compatibility
+export { GenericCapabilityItem, GenericCapabilityGroup, GenericCapabilitiesContribution };
+
+/**
+ * Represents the available generic capabilities aggregated from all sources.
+ * Used by the UI to populate capability selection dropdowns.
+ */
+export interface AvailableGenericCapabilities {
+    skills: GenericCapabilityItem[];
+    mcpFunctions: GenericCapabilityGroup[];
+    functions: GenericCapabilityGroup[];
+    promptFragments: GenericCapabilityItem[];
+    agentDelegation: GenericCapabilityItem[];
+    variables: GenericCapabilityItem[];
+}
+
+export const GenericCapabilitiesService = Symbol('GenericCapabilitiesService');
+
+/**
+ * Service to provide lists of available generic capabilities for selection in the UI.
+ * Aggregates capabilities from various sources (skills, MCP, functions, etc.)
+ * and provides change notifications when available capabilities change.
+ */
+export interface GenericCapabilitiesService {
+    /** Event fired when the list of available capabilities changes */
+    readonly onDidChangeAvailableCapabilities: Event<void>;
+
+    /** Get all available skills */
+    getAvailableSkills(): GenericCapabilityItem[];
+
+    /** Get all available MCP functions grouped by server */
+    getAvailableMCPFunctions(): Promise<GenericCapabilityGroup[]>;
+
+    /** Get all available functions (non-MCP) grouped by provider */
+    getAvailableFunctions(): GenericCapabilityGroup[];
+
+    /** Get all available prompt fragments */
+    getAvailablePromptFragments(): GenericCapabilityItem[];
+
+    /** Get all available agents for delegation, optionally excluding a specific agent */
+    getAvailableAgents(excludeAgentId?: string): GenericCapabilityItem[];
+
+    /** Get all available variables */
+    getAvailableVariables(): GenericCapabilityItem[];
+}
+
+@injectable()
+export class GenericCapabilitiesServiceImpl implements GenericCapabilitiesService, Disposable {
+
+    @inject(SkillService) @optional()
+    protected readonly skillService: SkillService | undefined;
+
+    @inject(ToolInvocationRegistry) @optional()
+    protected readonly toolInvocationRegistry: ToolInvocationRegistry | undefined;
+
+    @inject(PromptService) @optional()
+    protected readonly promptService: PromptService | undefined;
+
+    @inject(ChatAgentService) @optional()
+    protected readonly chatAgentService: ChatAgentService | undefined;
+
+    @inject(AIVariableService) @optional()
+    protected readonly variableService: AIVariableService | undefined;
+
+    @inject(ContributionProvider) @named(GenericCapabilitiesContribution) @optional()
+    protected readonly contributions: ContributionProvider<GenericCapabilitiesContribution> | undefined;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChangeAvailableCapabilities: Event<void> = this.onDidChangeEmitter.event;
+
+    protected readonly fireChangeDebounced = debounce(() => {
+        this.onDidChangeEmitter.fire();
+    }, 50);
+
+    @postConstruct()
+    protected init(): void {
+        // Subscribe to change events from all relevant services
+        if (this.skillService) {
+            this.toDispose.push(this.skillService.onSkillsChanged(() => this.fireChangeDebounced()));
+        }
+        if (this.toolInvocationRegistry) {
+            this.toDispose.push(this.toolInvocationRegistry.onDidChange(() => this.fireChangeDebounced()));
+        }
+        if (this.promptService) {
+            this.toDispose.push(this.promptService.onPromptsChange(() => this.fireChangeDebounced()));
+        }
+        if (this.variableService) {
+            this.toDispose.push(this.variableService.onDidChangeVariables(() => this.fireChangeDebounced()));
+        }
+        // Subscribe to change events from external contributions
+        if (this.contributions) {
+            for (const contribution of this.contributions.getContributions()) {
+                if (contribution.onDidChange) {
+                    this.toDispose.push(contribution.onDidChange(() => this.fireChangeDebounced()));
+                }
+            }
+        }
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    getAvailableSkills(): GenericCapabilityItem[] {
+        if (!this.skillService) {
+            return [];
+        }
+
+        return this.skillService.getSkills().map(skill => ({
+            id: skill.name,
+            name: skill.name,
+            description: skill.description
+        }));
+    }
+
+    async getAvailableMCPFunctions(): Promise<GenericCapabilityGroup[]> {
+        return this.getContributedCapabilities('mcpFunctions');
+    }
+
+    protected async getContributedCapabilities(type: CapabilityType): Promise<GenericCapabilityGroup[]> {
+        if (!this.contributions) {
+            return [];
+        }
+        const results: GenericCapabilityGroup[] = [];
+        for (const contribution of this.contributions.getContributions()) {
+            if (contribution.capabilityType === type) {
+                const groups = await contribution.getAvailableCapabilities();
+                results.push(...groups);
+            }
+        }
+        return results;
+    }
+
+    getAvailableFunctions(): GenericCapabilityGroup[] {
+        if (!this.toolInvocationRegistry) {
+            return [];
+        }
+
+        const allFunctions = this.toolInvocationRegistry.getAllFunctions();
+        const groupMap = new Map<string, GenericCapabilityItem[]>();
+
+        for (const fn of allFunctions) {
+            // Skip MCP functions - they are handled separately
+            if (fn.providerName?.startsWith('mcp_')) {
+                continue;
+            }
+
+            const groupName = fn.providerName || 'Other';
+            if (!groupMap.has(groupName)) {
+                groupMap.set(groupName, []);
+            }
+
+            groupMap.get(groupName)!.push({
+                id: fn.id,
+                name: fn.name || fn.id,
+                group: groupName,
+                description: fn.description
+            });
+        }
+
+        const groups: GenericCapabilityGroup[] = [];
+        for (const [name, items] of groupMap) {
+            groups.push({ name, items });
+        }
+
+        return groups;
+    }
+
+    getAvailablePromptFragments(): GenericCapabilityItem[] {
+        if (!this.promptService) {
+            return [];
+        }
+
+        const fragments = this.promptService.getActivePromptFragments();
+        return fragments
+            .filter((fragment: PromptFragment) => !fragment.id.startsWith(GENERIC_CAPABILITIES_PROMPT_PREFIX))
+            .map((fragment: PromptFragment) => ({
+                id: fragment.id,
+                name: fragment.id,
+                description: fragment.template.substring(0, 100).replace(/\n/g, ' ') +
+                    (fragment.template.length > 100 ? '...' : '')
+            }));
+    }
+
+    getAvailableAgents(excludeAgentId?: string): GenericCapabilityItem[] {
+        if (!this.chatAgentService) {
+            return [];
+        }
+
+        return this.chatAgentService.getAgents()
+            .filter(agent => agent.id !== excludeAgentId)
+            .map(agent => ({
+                id: agent.id,
+                name: agent.name,
+                description: agent.description
+            }));
+    }
+
+    getAvailableVariables(): GenericCapabilityItem[] {
+        if (!this.variableService) {
+            return [];
+        }
+
+        return this.variableService.getVariables()
+            .filter((variable: Readonly<AIVariable>) => !variable.name.startsWith(GENERIC_CAPABILITIES_VARIABLE_PREFIX))
+            .map((variable: Readonly<AIVariable>) => ({
+                id: variable.name,
+                name: variable.name,
+                description: variable.description
+            }));
+    }
+}

--- a/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
@@ -1,0 +1,681 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+import { CAPABILITY_TYPE_PROMPT_MAP, GenericCapabilitySelections } from '@theia/ai-core';
+import { AvailableGenericCapabilities, GenericCapabilityItem, GenericCapabilityGroup } from './generic-capabilities-service';
+
+export interface GenericCapabilitiesTreeProps {
+    /** Current generic capability selections */
+    genericCapabilities: GenericCapabilitySelections;
+    /** Called when a capability type's selection changes */
+    onGenericCapabilityChange: (type: keyof GenericCapabilitySelections, ids: string[]) => void;
+    /** Available capabilities to select from */
+    availableCapabilities: AvailableGenericCapabilities;
+    /** Items already in the agent prompt that should be disabled/greyed */
+    disabledCapabilities: GenericCapabilitySelections;
+    /** Whether the section is disabled */
+    disabled?: boolean;
+    /** Hover service for tooltips */
+    hoverService: HoverService;
+}
+
+// Root node descriptions for tooltips
+const ROOT_DESCRIPTIONS: Record<string, () => string> = {
+    skills: () => nls.localize('theia/ai/chat-ui/skillsDescription', 'Reusable skill instructions that can be added to the conversation'),
+    variables: () => nls.localize('theia/ai/chat-ui/variablesDescription', 'Dynamic variables that provide context information'),
+    mcpFunctions: () => nls.localize('theia/ai/chat-ui/mcpFunctionsDescription', 'Model Context Protocol (MCP) functions from connected servers'),
+    functions: () => nls.localize('theia/ai/chat-ui/functionsDescription', 'Built-in functions provided by Theia extensions'),
+    promptFragments: () => nls.localize('theia/ai/chat-ui/promptFragmentsDescription', 'Custom prompt fragments to include in the conversation'),
+    agentDelegation: () => nls.localize('theia/ai/chat-ui/agentDelegationDescription', 'Other AI agents that can be delegated to')
+};
+
+type CapabilityType = keyof GenericCapabilitySelections;
+
+interface TreeNodeData {
+    id: string;
+    type: 'root' | 'group' | 'item';
+    name: string;
+    capabilityType?: CapabilityType;
+    groupName?: string;
+    description?: string;
+    selected?: boolean;
+    disabled?: boolean;
+    expanded?: boolean;
+    children?: TreeNodeData[];
+    /** The original capability item ID (for leaf items only) */
+    itemId?: string;
+}
+
+type CheckboxState = 'checked' | 'unchecked' | 'indeterminate';
+
+/** Props for the parent node checkbox component */
+interface ParentCheckboxProps {
+    checkboxState: CheckboxState;
+    name: string;
+    onClick: (e: React.MouseEvent) => void;
+    hoverService: HoverService;
+}
+
+/** Component for rendering parent node checkbox with indeterminate state support */
+const ParentCheckbox: React.FC<ParentCheckboxProps> = ({ checkboxState, name, onClick, hoverService }) => {
+    // eslint-disable-next-line no-null/no-null
+    const checkboxRef = React.useRef<HTMLInputElement>(null);
+
+    // Update indeterminate state via ref (can't be set via attribute)
+    React.useEffect(() => {
+        if (checkboxRef.current) {
+            checkboxRef.current.indeterminate = checkboxState === 'indeterminate';
+        }
+    }, [checkboxState]);
+
+    return (
+        <input
+            ref={checkboxRef}
+            type="checkbox"
+            className="theia-input theia-GenericCapabilities-TreeNode-Checkbox"
+            checked={checkboxState === 'checked'}
+            aria-label={name}
+            onChange={() => { /* handled by onClick */ }}
+            onClick={onClick}
+            tabIndex={-1}
+            onMouseEnter={e => {
+                hoverService.requestHover({
+                    content: checkboxState === 'checked' || checkboxState === 'indeterminate'
+                        ? nls.localize('theia/ai/chat-ui/unselectAllInCategory', 'Unselect all in this category')
+                        : nls.localize('theia/ai/chat-ui/selectAllInCategory', 'Select all in this category'),
+                    target: e.currentTarget as HTMLElement,
+                    position: 'bottom'
+                });
+            }}
+        />
+    );
+};
+
+/**
+ * A unified tree component for selecting generic capabilities.
+ * Shows all capability types as root nodes, with groups and items as children.
+ * Includes search functionality and keyboard navigation.
+ */
+export const GenericCapabilitiesTree: React.FunctionComponent<GenericCapabilitiesTreeProps> = ({
+    genericCapabilities,
+    onGenericCapabilityChange,
+    availableCapabilities,
+    disabledCapabilities,
+    disabled,
+    hoverService
+}) => {
+    const [searchQuery, setSearchQuery] = React.useState('');
+    const [expandedNodes, setExpandedNodes] = React.useState<Set<string>>(new Set());
+    const [focusedNodeId, setFocusedNodeId] = React.useState<string | undefined>(undefined);
+    // eslint-disable-next-line no-null/no-null
+    const treeRef = React.useRef<HTMLDivElement>(null);
+    // eslint-disable-next-line no-null/no-null
+    const searchInputRef = React.useRef<HTMLInputElement>(null);
+
+    // Build the tree data structure
+    // Order: Skills, MCP, Agents, Functions, Prompts, Variables
+    const treeData = React.useMemo((): TreeNodeData[] => {
+        const buildFlatRootNode = (
+            rootId: string,
+            label: string,
+            capabilityType: CapabilityType,
+            items: GenericCapabilityItem[]
+        ): TreeNodeData | undefined => {
+            if (items.length === 0) {
+                return undefined;
+            }
+            const selected = new Set(genericCapabilities[capabilityType] || []);
+            const disabledIds = new Set(disabledCapabilities[capabilityType] || []);
+            return {
+                id: `root-${rootId}`,
+                type: 'root',
+                name: label,
+                capabilityType,
+                children: items.map(item => ({
+                    id: `item-${rootId}-${item.id}`,
+                    type: 'item' as const,
+                    name: item.name,
+                    description: item.description,
+                    capabilityType,
+                    itemId: item.id,
+                    selected: selected.has(item.id) || disabledIds.has(item.id),
+                    disabled: disabledIds.has(item.id)
+                }))
+            };
+        };
+
+        const buildGroupedRootNode = (
+            rootId: string,
+            label: string,
+            capabilityType: CapabilityType,
+            groups: GenericCapabilityGroup[]
+        ): TreeNodeData | undefined => {
+            if (groups.length === 0) {
+                return undefined;
+            }
+            const selected = new Set(genericCapabilities[capabilityType] || []);
+            const disabledIds = new Set(disabledCapabilities[capabilityType] || []);
+            return {
+                id: `root-${rootId}`,
+                type: 'root',
+                name: label,
+                capabilityType,
+                children: groups.map(group => ({
+                    id: `group-${rootId}-${group.name}`,
+                    type: 'group' as const,
+                    name: group.name,
+                    groupName: group.name,
+                    capabilityType,
+                    children: group.items.map(item => ({
+                        id: `item-${rootId}-${item.id}`,
+                        type: 'item' as const,
+                        name: item.name,
+                        description: item.description,
+                        capabilityType,
+                        groupName: group.name,
+                        itemId: item.id,
+                        selected: selected.has(item.id) || disabledIds.has(item.id),
+                        disabled: disabledIds.has(item.id)
+                    }))
+                }))
+            };
+        };
+
+        return [
+            buildFlatRootNode('skills', nls.localizeByDefault('Skills'), 'skills', availableCapabilities.skills),
+            buildGroupedRootNode('mcp', nls.localize('theia/ai/chat-ui/mcpFunctions', 'MCP'), 'mcpFunctions', availableCapabilities.mcpFunctions),
+            buildFlatRootNode('agents', nls.localizeByDefault('Agents'), 'agentDelegation', availableCapabilities.agentDelegation),
+            buildGroupedRootNode('functions', nls.localize('theia/ai/chat-ui/functions', 'Functions'), 'functions', availableCapabilities.functions),
+            buildFlatRootNode('prompts', nls.localize('theia/ai/chat-ui/promptFragments', 'Prompts'), 'promptFragments', availableCapabilities.promptFragments),
+            buildFlatRootNode('variables', nls.localizeByDefault('Variables'), 'variables', availableCapabilities.variables),
+        ].filter((node): node is TreeNodeData => node !== undefined);
+    }, [availableCapabilities, genericCapabilities, disabledCapabilities]);
+
+    // Filter tree based on search query
+    const filteredTree = React.useMemo((): TreeNodeData[] => {
+        if (!searchQuery.trim()) {
+            return treeData;
+        }
+
+        const query = searchQuery.toLowerCase();
+
+        const filterNode = (node: TreeNodeData): TreeNodeData | undefined => {
+            const nameMatches = node.name.toLowerCase().includes(query);
+            const descMatches = node.description?.toLowerCase().includes(query) || false;
+
+            if (node.children && node.children.length > 0) {
+                const filteredChildren = node.children
+                    .map(child => filterNode(child))
+                    .filter((child): child is TreeNodeData => child !== undefined);
+
+                // If any children match or this node itself matches, include it
+                if (filteredChildren.length > 0 || nameMatches || descMatches) {
+                    return {
+                        ...node,
+                        // If node matches, show all children; otherwise show only filtered children
+                        children: (nameMatches || descMatches) ? node.children : filteredChildren
+                    };
+                }
+            } else if (nameMatches || descMatches) {
+                return node;
+            }
+
+            return undefined;
+        };
+
+        return treeData
+            .map(node => filterNode(node))
+            .filter((node): node is TreeNodeData => node !== undefined);
+    }, [treeData, searchQuery]);
+
+    // Track previous search query to detect actual search changes vs other re-renders
+    const prevSearchQueryRef = React.useRef(searchQuery);
+
+    // Auto-expand when searching; collapse only when search transitions from non-empty to empty
+    React.useEffect(() => {
+        const prev = prevSearchQueryRef.current;
+        prevSearchQueryRef.current = searchQuery;
+
+        if (searchQuery.trim()) {
+            const allIds = new Set<string>();
+            const collectIds = (nodes: TreeNodeData[]): void => {
+                for (const node of nodes) {
+                    allIds.add(node.id);
+                    if (node.children) {
+                        collectIds(node.children);
+                    }
+                }
+            };
+            collectIds(filteredTree);
+            setExpandedNodes(allIds);
+
+            if (focusedNodeId && !allIds.has(focusedNodeId)) {
+                setFocusedNodeId(undefined);
+            }
+        } else if (prev.trim()) {
+            // Only collapse when search was cleared, not on every re-render
+            setExpandedNodes(new Set());
+        }
+    }, [searchQuery, filteredTree, focusedNodeId]);
+
+    // Get all visible node IDs for keyboard navigation
+    const getVisibleNodeIds = React.useCallback((): string[] => {
+        const ids: string[] = [];
+        const collect = (nodes: TreeNodeData[]): void => {
+            for (const node of nodes) {
+                ids.push(node.id);
+                if (node.children && expandedNodes.has(node.id)) {
+                    collect(node.children);
+                }
+            }
+        };
+        collect(filteredTree);
+        return ids;
+    }, [filteredTree, expandedNodes]);
+
+    const toggleExpand = (nodeId: string): void => {
+        setExpandedNodes(prev => {
+            const next = new Set(prev);
+            if (next.has(nodeId)) {
+                next.delete(nodeId);
+            } else {
+                next.add(nodeId);
+            }
+            return next;
+        });
+    };
+
+    // Calculate checkbox state for parent nodes (root or group)
+    // Disabled items are completely ignored - they don't affect parent checkbox state
+    const getParentCheckboxState = (node: TreeNodeData): CheckboxState => {
+        if (!node.children || node.children.length === 0) {
+            return 'unchecked';
+        }
+
+        const allItems = getAllLeafItems(node);
+        // Only consider enabled items for checkbox state
+        const enabledItems = allItems.filter(item => !item.disabled);
+
+        if (enabledItems.length === 0) {
+            // All items are disabled, show unchecked
+            return 'unchecked';
+        }
+
+        const enabledSelectedCount = enabledItems.filter(item => item.selected).length;
+
+        if (enabledSelectedCount === enabledItems.length) {
+            return 'checked';
+        } else if (enabledSelectedCount > 0) {
+            return 'indeterminate';
+        }
+        return 'unchecked';
+    };
+
+    // Get all leaf items under a node
+    const getAllLeafItems = (node: TreeNodeData): TreeNodeData[] => {
+        const items: TreeNodeData[] = [];
+        const collect = (n: TreeNodeData): void => {
+            if (n.type === 'item') {
+                items.push(n);
+            } else if (n.children) {
+                n.children.forEach(collect);
+            }
+        };
+        collect(node);
+        return items;
+    };
+
+    // Toggle all items under a parent node (for checkbox click)
+    const handleParentCheckboxToggle = (node: TreeNodeData, e?: React.MouseEvent): void => {
+        e?.stopPropagation();
+        if (!node.capabilityType) {
+            return;
+        }
+
+        const checkboxState = getParentCheckboxState(node);
+        const current = new Set(getCapabilityIds(node.capabilityType));
+        const disabledIds = new Set(getDisabledIds(node.capabilityType));
+        const itemsToToggle = getAvailableItemIds(node.capabilityType, node.groupName);
+
+        if (checkboxState === 'checked' || checkboxState === 'indeterminate') {
+            // Uncheck all (except disabled items)
+            for (const id of itemsToToggle) {
+                if (!disabledIds.has(id)) {
+                    current.delete(id);
+                }
+            }
+        } else {
+            // Check all (except disabled items)
+            for (const id of itemsToToggle) {
+                if (!disabledIds.has(id)) {
+                    current.add(id);
+                }
+            }
+        }
+
+        onGenericCapabilityChange(node.capabilityType, Array.from(current));
+    };
+
+    const handleResetAll = (): void => {
+        // Clear all selections across all capability types (except disabled items)
+        for (const { type } of CAPABILITY_TYPE_PROMPT_MAP) {
+            const disabledIds = new Set(getDisabledIds(type));
+            const currentIds = getCapabilityIds(type);
+            // Keep only disabled items that are selected
+            const remaining = currentIds.filter(id => disabledIds.has(id));
+            if (remaining.length !== currentIds.length) {
+                onGenericCapabilityChange(type, remaining);
+            }
+        }
+        // Also collapse all and clear search
+        setExpandedNodes(new Set());
+        setSearchQuery('');
+    };
+
+    const handleItemToggle = (capabilityType: CapabilityType, itemId: string): void => {
+        const current = new Set(getCapabilityIds(capabilityType));
+        const disabledIds = new Set(getDisabledIds(capabilityType));
+
+        if (disabledIds.has(itemId)) {
+            return; // Can't toggle disabled items
+        }
+
+        if (current.has(itemId)) {
+            current.delete(itemId);
+        } else {
+            current.add(itemId);
+        }
+
+        onGenericCapabilityChange(capabilityType, Array.from(current));
+    };
+
+    const getIdsForType = (source: GenericCapabilitySelections, type: CapabilityType): string[] =>
+        source[type] || [];
+
+    const getCapabilityIds = (type: CapabilityType): string[] =>
+        getIdsForType(genericCapabilities, type);
+
+    const getDisabledIds = (type: CapabilityType): string[] =>
+        getIdsForType(disabledCapabilities, type);
+
+    const getAvailableItemIds = (type: CapabilityType, groupName?: string): string[] => {
+        const getItems = (items: GenericCapabilityItem[]): string[] => items.map(i => i.id);
+        const getGroupItems = (groups: GenericCapabilityGroup[], filterGroup?: string): string[] => {
+            const filtered = filterGroup ? groups.filter(g => g.name === filterGroup) : groups;
+            return filtered.flatMap(g => g.items.map(i => i.id));
+        };
+
+        switch (type) {
+            case 'skills': return getItems(availableCapabilities.skills);
+            case 'variables': return getItems(availableCapabilities.variables);
+            case 'mcpFunctions': return getGroupItems(availableCapabilities.mcpFunctions, groupName);
+            case 'functions': return getGroupItems(availableCapabilities.functions, groupName);
+            case 'promptFragments': return getItems(availableCapabilities.promptFragments);
+            case 'agentDelegation': return getItems(availableCapabilities.agentDelegation);
+            default: return [];
+        }
+    };
+
+    const findNode = (nodes: TreeNodeData[], id: string): TreeNodeData | undefined => {
+        for (const node of nodes) {
+            if (node.id === id) {
+                return node;
+            }
+            if (node.children) {
+                const found = findNode(node.children, id);
+                if (found) {
+                    return found;
+                }
+            }
+        }
+        return undefined;
+    };
+
+    // Keyboard navigation
+    const handleKeyDown = (e: React.KeyboardEvent): void => {
+        if (disabled) {
+            return;
+        }
+
+        const visibleIds = getVisibleNodeIds();
+        const currentIndex = focusedNodeId ? visibleIds.indexOf(focusedNodeId) : -1;
+
+        switch (e.key) {
+            case 'ArrowDown':
+                e.preventDefault();
+                if (currentIndex < visibleIds.length - 1) {
+                    setFocusedNodeId(visibleIds[currentIndex + 1]);
+                } else if (visibleIds.length > 0) {
+                    setFocusedNodeId(visibleIds[0]);
+                }
+                break;
+            case 'ArrowUp':
+                e.preventDefault();
+                if (currentIndex > 0) {
+                    setFocusedNodeId(visibleIds[currentIndex - 1]);
+                } else if (visibleIds.length > 0) {
+                    setFocusedNodeId(visibleIds[visibleIds.length - 1]);
+                }
+                break;
+            case 'ArrowRight':
+                if (focusedNodeId && !expandedNodes.has(focusedNodeId)) {
+                    e.preventDefault();
+                    toggleExpand(focusedNodeId);
+                }
+                break;
+            case 'ArrowLeft':
+                if (focusedNodeId && expandedNodes.has(focusedNodeId)) {
+                    e.preventDefault();
+                    toggleExpand(focusedNodeId);
+                }
+                break;
+            case 'Enter':
+            case ' ':
+                if (focusedNodeId) {
+                    e.preventDefault();
+                    const foundNode = findNode(filteredTree, focusedNodeId);
+                    if (foundNode) {
+                        if (foundNode.type === 'item' && foundNode.capabilityType && foundNode.itemId && !foundNode.disabled) {
+                            handleItemToggle(foundNode.capabilityType, foundNode.itemId);
+                        } else if ((foundNode.type === 'root' || foundNode.type === 'group') && foundNode.capabilityType) {
+                            // Toggle checkbox for parent nodes on Enter/Space
+                            handleParentCheckboxToggle(foundNode);
+                        }
+                    }
+                }
+                break;
+            case 'Home':
+                e.preventDefault();
+                if (visibleIds.length > 0) {
+                    setFocusedNodeId(visibleIds[0]);
+                }
+                break;
+            case 'End':
+                e.preventDefault();
+                if (visibleIds.length > 0) {
+                    setFocusedNodeId(visibleIds[visibleIds.length - 1]);
+                }
+                break;
+        }
+    };
+
+    // Scroll focused node into view
+    React.useEffect(() => {
+        if (focusedNodeId && treeRef.current) {
+            const focusedElement = treeRef.current.querySelector(`[data-node-id="${focusedNodeId}"]`);
+            if (focusedElement) {
+                focusedElement.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+            }
+        }
+    }, [focusedNodeId]);
+
+    const renderNode = (node: TreeNodeData, depth: number = 0): React.ReactNode => {
+        const isExpanded = expandedNodes.has(node.id);
+        const isFocused = focusedNodeId === node.id;
+
+        if (node.type === 'item') {
+            return (
+                <div
+                    key={node.id}
+                    data-node-id={node.id}
+                    className={`theia-GenericCapabilities-TreeItem${node.disabled ? ' theia-mod-disabled' : ''}${isFocused ? ' theia-mod-selected' : ''}`}
+                    style={{ '--tree-indent': `${(depth * 12) + 8}px` } as React.CSSProperties}
+                    onClick={() => node.capabilityType && node.itemId && handleItemToggle(node.capabilityType, node.itemId)}
+                    onMouseDown={() => setFocusedNodeId(node.id)}
+                    role="treeitem"
+                    aria-selected={isFocused}
+                    aria-checked={node.selected}
+                    aria-disabled={node.disabled}
+                    onMouseEnter={e => {
+                        hoverService.requestHover({
+                            content: node.description || node.name,
+                            target: e.currentTarget as HTMLElement,
+                            position: 'bottom'
+                        });
+                    }}
+                >
+                    <input
+                        type="checkbox"
+                        className="theia-input theia-GenericCapabilities-TreeItem-Checkbox"
+                        checked={node.selected}
+                        disabled={node.disabled}
+                        aria-label={node.name}
+                        onChange={() => { /* handled by parent div onClick */ }}
+                        tabIndex={-1}
+                    />
+                    <span className="theia-GenericCapabilities-TreeItem-Name">{node.name}</span>
+                </div>
+            );
+        }
+
+        // Root or group node
+        const isRoot = node.type === 'root';
+        const checkboxState = getParentCheckboxState(node);
+
+        return (
+            <div key={node.id} className={`theia-GenericCapabilities-TreeNode${isRoot ? ' root' : ' group'}`}>
+                <div
+                    data-node-id={node.id}
+                    className={`theia-GenericCapabilities-TreeNodeHeader${isFocused ? ' theia-mod-selected' : ''}`}
+                    style={{ '--tree-indent': `${(depth * 12) + 4}px` } as React.CSSProperties}
+                    onClick={() => toggleExpand(node.id)}
+                    onMouseDown={() => setFocusedNodeId(node.id)}
+                    role="treeitem"
+                    aria-expanded={isExpanded}
+                >
+                    <ParentCheckbox
+                        checkboxState={checkboxState}
+                        name={node.name}
+                        onClick={e => handleParentCheckboxToggle(node, e)}
+                        hoverService={hoverService}
+                    />
+                    <span className={`codicon ${isExpanded ? 'codicon-chevron-down' : 'codicon-chevron-right'} theia-GenericCapabilities-TreeNode-Chevron`} />
+                    <span
+                        className="theia-GenericCapabilities-TreeNode-Name"
+                        onMouseEnter={isRoot && node.capabilityType ? e => {
+                            const description = ROOT_DESCRIPTIONS[node.capabilityType!]?.() || node.name;
+                            hoverService.requestHover({
+                                content: `${node.name}: ${description}`,
+                                target: e.currentTarget as HTMLElement,
+                                position: 'bottom'
+                            });
+                        } : undefined}
+                    >{node.name}</span>
+                </div>
+                {isExpanded && node.children && (
+                    <div className="theia-GenericCapabilities-TreeNodeChildren" role="group">
+                        {node.children.map(child => renderNode(child, depth + 1))}
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    if (filteredTree.length === 0 && !searchQuery.trim()) {
+        return undefined;
+    }
+
+    return (
+        <div className={`theia-GenericCapabilities-Tree${disabled ? ' disabled' : ''}`}>
+            <div className="theia-GenericCapabilities-Tree-SearchContainer">
+                <input
+                    ref={searchInputRef}
+                    type="text"
+                    className="theia-input theia-GenericCapabilities-Tree-SearchInput"
+                    placeholder={nls.localize('theia/ai/chat-ui/searchCapabilities', 'Search capabilities...')}
+                    value={searchQuery}
+                    onChange={e => setSearchQuery(e.target.value)}
+                    aria-label={nls.localize('theia/ai/chat-ui/searchCapabilities', 'Search capabilities')}
+                    autoFocus
+                />
+                <div className="theia-GenericCapabilities-Tree-SearchActions">
+                    <button
+                        className="theia-GenericCapabilities-Tree-SearchAction"
+                        onClick={handleResetAll}
+                        aria-label={nls.localize('theia/ai/chat-ui/clearAllSelections', 'Clear search string and capability selections')}
+                        onMouseEnter={e => {
+                            hoverService.requestHover({
+                                content: nls.localize('theia/ai/chat-ui/clearAllSelections', 'Clear search string and capability selections'),
+                                target: e.currentTarget as HTMLElement,
+                                position: 'bottom'
+                            });
+                        }}
+                    >
+                        <span className="codicon codicon-clear-all" />
+                    </button>
+                    <button
+                        className="theia-GenericCapabilities-Tree-SearchAction"
+                        onClick={() => setExpandedNodes(new Set())}
+                        aria-label={nls.localize('theia/ai/chat-ui/collapseAll', 'Collapse all')}
+                        onMouseEnter={e => {
+                            hoverService.requestHover({
+                                content: nls.localize('theia/ai/chat-ui/collapseAll', 'Collapse all'),
+                                target: e.currentTarget as HTMLElement,
+                                position: 'bottom'
+                            });
+                        }}
+                    >
+                        <span className="codicon codicon-collapse-all" />
+                    </button>
+                </div>
+            </div>
+            <div
+                ref={treeRef}
+                className="theia-GenericCapabilities-Tree-Content"
+                role="tree"
+                aria-label={nls.localize('theia/ai/chat-ui/genericCapabilities', 'Generic Capabilities')}
+                tabIndex={0}
+                onKeyDown={handleKeyDown}
+                onFocus={() => {
+                    if (!focusedNodeId && filteredTree.length > 0) {
+                        setFocusedNodeId(filteredTree[0].id);
+                    }
+                }}
+            >
+                {filteredTree.length > 0 ? (
+                    filteredTree.map(node => renderNode(node, 0))
+                ) : (
+                    <div className="theia-GenericCapabilities-Tree-Empty">
+                        {nls.localize('theia/ai/chat-ui/noMatchingCapabilities', 'No matching capabilities')}
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -205,11 +205,11 @@ div:last-child>.theia-ChatNode {
 }
 
 .theia-ChatInput {
-  margin-top: 16px;
+  margin-top: calc(var(--theia-ui-padding) * 8 / 3);
   position: relative;
   width: 100%;
   box-sizing: border-box;
-  gap: 4px;
+  gap: calc(var(--theia-ui-padding) * 2 / 3);
 }
 
 .theia-ChatInput[data-ai-disabled="true"] {
@@ -536,11 +536,11 @@ div:last-child>.theia-ChatNode {
 }
 
 .theia-ChatInput-Editor-Box {
-  margin: 0 16px 16px 16px;
-  padding: 2px;
+  margin: 0 var(--theia-ui-padding) var(--theia-ui-padding) var(--theia-ui-padding);
+  padding: calc(var(--theia-ui-padding) / 3);
   height: auto;
   border: var(--theia-border-width) solid var(--theia-dropdown-border);
-  border-radius: 4px;
+  border-radius: calc(var(--theia-ui-padding) * 2 / 3);
   background-color: var(--theia-editor-background);
   display: flex;
   flex-direction: column;
@@ -569,7 +569,7 @@ div:last-child>.theia-ChatNode {
 .theia-ChatInput-Editor-Placeholder {
   position: absolute;
   top: var(--theia-ui-padding);
-  left: 8px;
+  left: calc(var(--theia-ui-padding) * 4 / 3);
   right: 0;
   display: flex;
   align-items: center;
@@ -595,7 +595,7 @@ div:last-child>.theia-ChatNode {
 .theia-ChatInput-Editor .monaco-editor .margin,
 .theia-ChatInput-Editor .monaco-editor .monaco-editor-background,
 .theia-ChatInput-Editor .monaco-editor .inputarea.ime-input {
-  padding-left: 8px !important;
+  padding-left: calc(var(--theia-ui-padding) * 4 / 3) !important;
 }
 
 .theia-ChatInput-ImagePreview-Item {
@@ -627,8 +627,8 @@ div:last-child>.theia-ChatNode {
 .theia-ChatInputOptions {
   width: 100%;
   height: 25px;
-  padding-left: 3px;
-  padding-right: 6px;
+  padding-left: calc(var(--theia-ui-padding) / 2);
+  padding-right: var(--theia-ui-padding);
   display: flex;
   justify-content: space-between;
   color: var(--theia-foreground);
@@ -646,30 +646,30 @@ div:last-child>.theia-ChatNode {
 }
 
 .theia-ChatInputOptions .theia-ChatInputOptions-right {
-  margin-right: 8px;
+  margin-right: calc(var(--theia-ui-padding) * 4 / 3);
 }
 
 .theia-ChatInputOptions .option {
-  min-width: 21px;
-  height: 21px;
-  padding: 2px;
+  min-width: calc(var(--theia-icon-size) + var(--theia-ui-padding) - 1px);
+  height: calc(var(--theia-icon-size) + var(--theia-ui-padding) - 1px);
+  padding: calc(var(--theia-ui-padding) / 3);
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 2px;
+  gap: calc(var(--theia-ui-padding) / 3);
   box-sizing: border-box;
   user-select: none;
   background-repeat: no-repeat;
   background-position: center;
-  border-radius: 5px;
+  border-radius: calc(var(--theia-ui-padding) * 5 / 6);
   border: var(--theia-border-width) solid transparent;
   cursor: pointer;
   outline: none;
 }
 
 .theia-ChatInputOptions .option:focus-visible {
-  outline: 1px solid var(--theia-focusBorder);
-  outline-offset: -1px;
+  outline: var(--theia-border-width) solid var(--theia-focusBorder);
+  outline-offset: calc(-1 * var(--theia-border-width));
 }
 
 .theia-ChatInputOptions .option.disabled {
@@ -691,14 +691,14 @@ div:last-child>.theia-ChatNode {
 .theia-ChatInput-ModeSelector.theia-select-component {
   min-width: unset;
   min-height: unset;
-  height: 21px;
+  height: calc(var(--theia-icon-size) + var(--theia-ui-padding) - 1px);
   padding: 0 calc(var(--theia-ui-padding) * 2 / 3);
   border: var(--theia-border-width) solid transparent;
   box-sizing: border-box;
   background: var(--theia-editor-background);
   font-family: var(--theia-ui-font-family);
   font-size: var(--theia-content-font-size);
-  border-radius: 5px;
+  border-radius: calc(var(--theia-ui-padding) * 5 / 6);
   max-width: 150px;
   outline: none;
 }
@@ -1429,13 +1429,14 @@ div:last-child>.theia-ChatNode {
 
 /* Collapsible Section — subtle separator-label for config area sections */
 .theia-ChatInput-CapabilitiesSection {
-  border-top: 1px solid color-mix(in srgb, var(--theia-panel-border) 50%, transparent);
+  border-top: var(--theia-border-width) solid color-mix(in srgb, var(--theia-panel-border) 50%, transparent);
   margin-top: var(--theia-ui-padding);
   padding-top: calc(var(--theia-ui-padding) / 3);
 }
 
 .theia-ChatInput-CapabilitiesSection-heading {
-  padding: calc(var(--theia-ui-padding) / 3) calc(var(--theia-ui-padding) * 4 / 3);
+  padding: calc(var(--theia-ui-padding) / 2) calc(var(--theia-ui-padding) / 3);
+  padding-bottom: var(--theia-ui-padding);
   color: var(--theia-descriptionForeground);
   font-size: var(--theia-ui-font-size1);
   font-family: var(--theia-ui-font-family);
@@ -1466,6 +1467,7 @@ div:last-child>.theia-ChatNode {
   user-select: none;
   outline: none;
   white-space: nowrap;
+  margin: 1px 0px;
 }
 
 .theia-ChatInput-CapabilityChip.checked {
@@ -1497,4 +1499,348 @@ div:last-child>.theia-ChatNode {
   pointer-events: none;
 }
 
-/* Capabilities chevron toggle — first item in toolbar left section */
+.theia-ChatInputOptions .option.toggled {
+  border: var(--theia-border-width) var(--theia-inputOption-activeBorder) solid;
+  background-color: var(--theia-inputOption-activeBackground);
+}
+
+.theia-ChatInputOptions .option {
+  position: relative;
+}
+
+.theia-capabilities-badge-dot {
+  position: absolute;
+  top: var(--theia-border-width);
+  right: var(--theia-border-width);
+  width: var(--theia-ui-padding);
+  height: var(--theia-ui-padding);
+  border-radius: 50%;
+  background-color: var(--theia-activityBarBadge-background);
+  pointer-events: none;
+}
+
+/* Generic Capabilities Section */
+.theia-ChatInput-GenericCapabilitiesSection {
+  border-top: var(--theia-border-width) solid color-mix(in srgb, var(--theia-panel-border) 50%, transparent);
+  margin-top: var(--theia-ui-padding);
+  padding-top: calc(var(--theia-ui-padding) / 3);
+}
+
+.theia-ChatInput-GenericCapabilitiesSection-heading {
+  padding: calc(var(--theia-ui-padding) / 2) calc(var(--theia-ui-padding) / 3);
+  padding-bottom: var(--theia-ui-padding);
+  color: var(--theia-descriptionForeground);
+  font-size: var(--theia-ui-font-size1);
+  font-family: var(--theia-ui-font-family);
+  user-select: none;
+}
+
+/* Generic Capabilities Tree — fixed height so filtering doesn't grow the panel */
+.theia-GenericCapabilities-Tree {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  height: 250px;
+}
+
+.theia-GenericCapabilities-Tree.disabled {
+  opacity: var(--theia-mod-disabled-opacity);
+  pointer-events: none;
+}
+
+/* Search/filter bar — replicates settings search input (preferences-searchbar-widget) */
+.theia-GenericCapabilities-Tree-SearchContainer {
+  display: flex;
+  align-items: center;
+  position: relative;
+  margin-bottom: calc(var(--theia-ui-padding) / 2);
+  flex-shrink: 0;
+}
+
+.theia-GenericCapabilities-Tree-SearchInput {
+  flex: 1;
+  text-indent: calc(var(--theia-ui-padding) + 2px);
+  padding: 2px 0;
+  min-height: 22px;
+  box-sizing: border-box;
+  border: var(--theia-border-width) solid var(--theia-dropdown-border);
+}
+
+/* Hide native clear button */
+.theia-GenericCapabilities-Tree-SearchInput::-webkit-search-decoration,
+.theia-GenericCapabilities-Tree-SearchInput::-webkit-search-cancel-button {
+  display: none;
+}
+
+.theia-GenericCapabilities-Tree-SearchActions {
+  height: 20px;
+  align-items: center;
+  position: absolute;
+  z-index: 1;
+  right: calc(var(--theia-ui-padding) + 3px);
+  display: flex;
+}
+
+.theia-GenericCapabilities-Tree-SearchAction {
+  width: 18px;
+  height: 18px;
+  margin: 0 1px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: border-box;
+  user-select: none;
+  border: var(--theia-border-width) solid transparent;
+  opacity: 0.7;
+  cursor: pointer;
+  appearance: none;
+  background-color: transparent;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+}
+
+.theia-GenericCapabilities-Tree-SearchAction:hover {
+  background-color: var(--theia-toolbar-hoverBackground);
+  opacity: 1;
+}
+
+/* Tree content */
+.theia-GenericCapabilities-Tree-Content {
+  flex: 1;
+  overflow-y: auto;
+  outline: none;
+}
+
+.theia-GenericCapabilities-Tree-Content:focus-visible {
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: -1px;
+}
+
+.theia-GenericCapabilities-Tree-Empty {
+  padding: var(--theia-ui-padding);
+  color: var(--theia-descriptionForeground);
+  font-style: italic;
+  text-align: center;
+}
+
+/* Tree node (root or group) */
+.theia-GenericCapabilities-TreeNode {
+  user-select: none;
+}
+
+.theia-GenericCapabilities-TreeNode.root {
+  border-bottom: var(--theia-border-width) solid var(--theia-dropdown-border);
+}
+
+.theia-GenericCapabilities-TreeNode.root:last-child {
+  border-bottom: none;
+}
+
+.theia-GenericCapabilities-TreeNodeHeader {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding) / 2);
+  padding: calc(var(--theia-ui-padding) / 2) var(--theia-ui-padding);
+  padding-left: var(--tree-indent, var(--theia-ui-padding));
+  cursor: pointer;
+  outline: none;
+}
+
+.theia-GenericCapabilities-TreeNode.root>.theia-GenericCapabilities-TreeNodeHeader {
+  background-color: var(--theia-sideBarSectionHeader-background);
+}
+
+.theia-GenericCapabilities-TreeNode.group>.theia-GenericCapabilities-TreeNodeHeader {
+  background-color: color-mix(in srgb, var(--theia-sideBarSectionHeader-background) 50%, transparent);
+  font-size: var(--theia-ui-font-size1);
+}
+
+.theia-GenericCapabilities-TreeNodeHeader:hover {
+  background: var(--theia-list-hoverBackground);
+  color: var(--theia-list-hoverForeground);
+}
+
+/* Selected (focused) header — active when tree has focus */
+.theia-GenericCapabilities-Tree-Content:focus-within .theia-GenericCapabilities-TreeNodeHeader.theia-mod-selected {
+  background: var(--theia-list-activeSelectionBackground);
+  color: var(--theia-list-activeSelectionForeground);
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: -1px;
+}
+
+/* Selected header — inactive when tree lacks focus */
+.theia-GenericCapabilities-TreeNodeHeader.theia-mod-selected {
+  background: var(--theia-list-inactiveSelectionBackground);
+  color: var(--theia-list-inactiveSelectionForeground);
+}
+
+.theia-GenericCapabilities-TreeNode-Chevron {
+  flex-shrink: 0;
+  font-size: var(--theia-ui-font-size1);
+}
+
+.theia-GenericCapabilities-TreeNode-Name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--theia-ui-font-size1);
+}
+
+.theia-GenericCapabilities-TreeNodeChildren {
+  /* Children container */
+}
+
+/* Tree item (leaf) */
+.theia-GenericCapabilities-TreeItem {
+  display: flex;
+  align-items: center;
+  gap: var(--theia-ui-padding);
+  padding: calc(var(--theia-ui-padding) / 2) var(--theia-ui-padding);
+  padding-left: var(--tree-indent, var(--theia-ui-padding));
+  cursor: pointer;
+  user-select: none;
+  outline: none;
+}
+
+.theia-GenericCapabilities-TreeItem:hover:not(.theia-mod-disabled) {
+  background: var(--theia-list-hoverBackground);
+  color: var(--theia-list-hoverForeground);
+}
+
+/* Selected (focused) item — active when tree has focus */
+.theia-GenericCapabilities-Tree-Content:focus-within .theia-GenericCapabilities-TreeItem.theia-mod-selected {
+  background: var(--theia-list-activeSelectionBackground);
+  color: var(--theia-list-activeSelectionForeground);
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: -1px;
+}
+
+/* Selected item — inactive when tree lacks focus */
+.theia-GenericCapabilities-TreeItem.theia-mod-selected {
+  background: var(--theia-list-inactiveSelectionBackground);
+  color: var(--theia-list-inactiveSelectionForeground);
+}
+
+.theia-GenericCapabilities-TreeItem.theia-mod-disabled {
+  opacity: var(--theia-mod-disabled-opacity);
+  cursor: default;
+}
+
+.theia-GenericCapabilities-TreeItem-Checkbox {
+  flex-shrink: 0;
+}
+
+.theia-GenericCapabilities-TreeItem-Name {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--theia-ui-font-size1);
+  padding-bottom: 1px;
+  margin-bottom: -1px;
+}
+
+/* Two-column capabilities panel layout */
+.theia-ChatInput-CapabilitiesPanel {
+  display: flex;
+  flex-direction: row;
+  gap: var(--theia-ui-padding);
+  border-bottom: 1px solid color-mix(in srgb, var(--theia-panel-border) 50%, transparent);
+  padding: var(--theia-ui-padding);
+}
+
+.theia-ChatInput-CapabilitiesPanel-Left {
+  flex: 0 0 auto;
+  min-width: 120px;
+  max-width: 200px;
+}
+
+.theia-ChatInput-CapabilitiesPanel-Divider {
+  width: 1px;
+  background-color: var(--theia-panel-border);
+  margin: 0 calc(var(--theia-ui-padding) / 2);
+}
+
+.theia-ChatInput-CapabilitiesPanel-Right {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Override chip layout to be vertical in left panel */
+.theia-ChatInput-CapabilitiesPanel-Left .theia-ChatInput-CapabilitiesSection {
+  border-top: none;
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.theia-ChatInput-CapabilitiesPanel-Left .theia-ChatInput-CapabilityChips {
+  flex-direction: column;
+  max-height: 280px;
+  padding: 0;
+}
+
+/* Override generic capabilities section in right panel */
+.theia-ChatInput-CapabilitiesPanel-Right .theia-ChatInput-GenericCapabilitiesSection {
+  border-top: none;
+  margin-top: 0;
+  padding-top: 0;
+}
+
+.theia-ChatInput-CapabilitiesPanel-Right .theia-GenericCapabilities-Tree {
+  height: 280px;
+}
+
+/* Tree checkbox styling - use native inputs aligned with settings checkboxes */
+.theia-GenericCapabilities-TreeNode-Checkbox,
+.theia-GenericCapabilities-TreeItem-Checkbox {
+  flex-shrink: 0;
+  margin: 0;
+  cursor: pointer;
+}
+
+.theia-GenericCapabilities-Tree-SearchAction:focus-visible {
+  border-color: var(--theia-focusBorder);
+  opacity: 1;
+}
+
+/* Capabilities Collapsed Bar - horizontal scrollable chip row */
+.theia-capabilities-collapsed-bar {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: calc(var(--theia-ui-padding) / 2) calc(var(--theia-ui-padding) * 4 / 3);
+  min-width: 0;
+}
+
+/* Capabilities quick bar - horizontal scrollable chip container */
+.theia-capabilities-collapsed-scrollbar {
+  flex: 1;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  gap: calc(var(--theia-ui-padding) * 2 / 3);
+  min-width: 0;
+  overflow-x: scroll;
+  overflow-y: hidden;
+  min-height: calc(var(--theia-content-line-height) + var(--theia-ui-padding) / 3);
+}
+
+/* Thin overlay scrollbar, always reserves space but thumb only visible on hover */
+.theia-capabilities-collapsed-scrollbar::-webkit-scrollbar {
+  height: calc(var(--theia-ui-padding) / 2);
+}
+
+.theia-capabilities-collapsed-scrollbar::-webkit-scrollbar-thumb {
+  background-color: transparent;
+  border-radius: calc(var(--theia-ui-padding) / 2);
+}
+
+.theia-capabilities-collapsed-scrollbar:hover::-webkit-scrollbar-thumb {
+  background-color: var(--theia-scrollbarSlider-background);
+}
+
+.theia-capabilities-collapsed-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--theia-scrollbarSlider-hoverBackground);
+}

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
+import { AGENT_DELEGATION_FUNCTION_ID, ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import {
     assertChatContext,
@@ -30,8 +30,6 @@ import {
     ChatRequestInvocation,
 } from '../common';
 import { DelegationResponseContent } from './delegation-response-content';
-
-export const AGENT_DELEGATION_FUNCTION_ID = 'delegateToAgent';
 
 @injectable()
 export class AgentDelegationTool implements ToolProvider {

--- a/packages/ai-chat/src/common/chat-model-serialization.ts
+++ b/packages/ai-chat/src/common/chat-model-serialization.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { GenericCapabilitySelections } from '@theia/ai-core';
 import { ChatAgentLocation } from './chat-agents';
 
 export interface SerializableChangeSetElement {
@@ -104,6 +105,11 @@ export interface SerializableChatRequestData {
      * Maps capability fragment IDs to enabled/disabled state.
      */
     capabilityOverrides?: Record<string, boolean>;
+    /**
+     * Generic capability selections for this request.
+     * Contains user-selected skills, functions, MCP tools, etc.
+     */
+    genericCapabilitySelections?: GenericCapabilitySelections;
 }
 
 export interface SerializableChatResponseContentData<T = unknown> {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -21,6 +21,7 @@
 
 import {
     AIVariableResolutionRequest,
+    GenericCapabilitySelections,
     LanguageModelMessage,
     ResolvedAIContextVariable,
     ResolvedAIVariable,
@@ -295,6 +296,13 @@ export interface ChatRequest {
      * Only includes capabilities that differ from their default value.
      */
     readonly capabilityOverrides?: Record<string, boolean>;
+
+    /**
+     * Generic capability selections for this request.
+     * Contains user-selected skills, functions, MCP tools, etc.
+     * from the capabilities panel dropdowns.
+     */
+    readonly genericCapabilitySelections?: GenericCapabilitySelections;
 }
 
 export interface ChatContext {
@@ -1672,7 +1680,8 @@ export class MutableChatRequestModel implements ChatRequestModel, EditableChatRe
         this._id = reqData.id;
         this._request = {
             text: reqData.text,
-            capabilityOverrides: reqData.capabilityOverrides
+            capabilityOverrides: reqData.capabilityOverrides,
+            genericCapabilitySelections: reqData.genericCapabilitySelections
         };
         this._agentId = reqData.agentId;
         this._data = {};
@@ -1915,7 +1924,8 @@ export class MutableChatRequestModel implements ChatRequestModel, EditableChatRe
                 elements: this._changeSet.getElements().map(elem => elem.toSerializable?.()).filter((elem): elem is SerializableChangeSetElement => elem !== undefined)
             } : undefined,
             parsedRequest: this.message ? ParsedChatRequest.toSerializable(this.message) : undefined,
-            capabilityOverrides: this.request.capabilityOverrides
+            capabilityOverrides: this.request.capabilityOverrides,
+            genericCapabilitySelections: this.request.genericCapabilitySelections
         };
     }
 

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -288,7 +288,8 @@ export class ChatServiceImpl implements ChatService {
 
         const resolutionContext: ChatSessionContext = {
             model: session.model,
-            capabilityOverrides: request.capabilityOverrides
+            capabilityOverrides: request.capabilityOverrides,
+            genericCapabilitySelections: request.genericCapabilitySelections
         };
         const resolvedContext = await this.resolveChatContext(request.variables ?? session.model.context.getVariables(), resolutionContext);
         const parsedRequest = await this.chatRequestParser.parseChatRequest(request, session.model.location, resolvedContext);

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -73,8 +73,10 @@ import { AISettingsService } from '../common/settings-service';
 import { DefaultSkillService, SkillService } from './skill-service';
 import { SkillPromptCoordinator } from './skill-prompt-coordinator';
 import { AiCoreCommandContribution } from './ai-core-command-contribution';
-import { PromptVariableContribution } from '../common/prompt-variable-contribution';
+import { PromptVariableContribution } from './prompt-variable-contribution';
 import { CapabilityVariableContribution } from '../common/capability-variable-contribution';
+import { GenericCapabilitiesVariableContribution } from './generic-capabilities-variable-contribution';
+import { GenericCapabilitiesPromptFragmentContribution } from './generic-capabilities-prompt-fragment-contribution';
 import { LanguageModelService } from '../common/language-model-service';
 import { FrontendLanguageModelServiceImpl } from './frontend-language-model-service';
 import { TokenUsageFrontendService } from './token-usage-frontend-service';
@@ -141,13 +143,22 @@ export default new ContainerModule(bind => {
     bind(TheiaVariableContribution).toSelf().inSingletonScope();
     bind(AIVariableContribution).toService(TheiaVariableContribution);
 
-    bind(AIVariableContribution).to(PromptVariableContribution).inSingletonScope();
+    bind(PromptVariableContribution).toSelf().inSingletonScope();
+    bind(AIVariableContribution).toService(PromptVariableContribution);
     bind(AIVariableContribution).to(TodayVariableContribution).inSingletonScope();
     bind(AIVariableContribution).to(FileVariableContribution).inSingletonScope();
-    bind(AIVariableContribution).to(AgentsVariableContribution).inSingletonScope();
+    bind(AgentsVariableContribution).toSelf().inSingletonScope();
+    bind(AIVariableContribution).toService(AgentsVariableContribution);
     bind(AIVariableContribution).to(OpenEditorsVariableContribution).inSingletonScope();
-    bind(AIVariableContribution).to(SkillsVariableContribution).inSingletonScope();
+    bind(SkillsVariableContribution).toSelf().inSingletonScope();
+    bind(AIVariableContribution).toService(SkillsVariableContribution);
     bind(AIVariableContribution).to(CapabilityVariableContribution).inSingletonScope();
+
+    bind(GenericCapabilitiesVariableContribution).toSelf().inSingletonScope();
+    bind(AIVariableContribution).toService(GenericCapabilitiesVariableContribution);
+
+    bind(GenericCapabilitiesPromptFragmentContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(GenericCapabilitiesPromptFragmentContribution);
 
     bind(FrontendApplicationContribution).to(AICoreFrontendApplicationContribution).inSingletonScope();
 

--- a/packages/ai-core/src/browser/generic-capabilities-prompt-fragment-contribution.ts
+++ b/packages/ai-core/src/browser/generic-capabilities-prompt-fragment-contribution.ts
@@ -1,0 +1,87 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { PromptService } from '../common/prompt-service';
+import {
+    GENERIC_CAPABILITIES_SKILLS_PROMPT_ID,
+    GENERIC_CAPABILITIES_MCP_FUNCTIONS_PROMPT_ID,
+    GENERIC_CAPABILITIES_FUNCTIONS_PROMPT_ID,
+    GENERIC_CAPABILITIES_PROMPT_FRAGMENTS_PROMPT_ID,
+    GENERIC_CAPABILITIES_AGENT_DELEGATION_PROMPT_ID,
+    GENERIC_CAPABILITIES_VARIABLES_PROMPT_ID
+} from '../common/capability-utils';
+import { AGENT_DELEGATION_FUNCTION_ID } from '../common';
+
+const SKILLS_TEMPLATE = `## Skills
+The following skills are available. Evaluate which skills apply to the current context and load applicable skills using getSkillFileContent before proceeding.
+{{selected_skills}}`;
+
+const MCP_FUNCTIONS_TEMPLATE = `## MCP Functions
+{{selected_mcp_functions}}`;
+
+const FUNCTIONS_TEMPLATE = `## Functions
+{{selected_functions}}`;
+
+const PROMPT_FRAGMENTS_TEMPLATE = `## Prompt Fragments
+{{selected_prompt_fragments}}`;
+
+const AGENT_DELEGATION_TEMPLATE = `## Agent Delegation
+You can use ~{${AGENT_DELEGATION_FUNCTION_ID}} to delegate to the following agents:
+{{selected_agent_delegation}}`;
+
+const VARIABLES_TEMPLATE = `## Variables
+{{selected_variables}}`;
+
+/**
+ * Contribution that registers prompt fragments for each generic capability type.
+ * These fragments are dynamically added to agent prompts based on user selections
+ * from the chat UI dropdowns.
+ */
+@injectable()
+export class GenericCapabilitiesPromptFragmentContribution implements FrontendApplicationContribution {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    onStart(): void {
+        this.promptService.addBuiltInPromptFragment({
+            id: GENERIC_CAPABILITIES_SKILLS_PROMPT_ID,
+            template: SKILLS_TEMPLATE,
+        });
+        this.promptService.addBuiltInPromptFragment({
+            id: GENERIC_CAPABILITIES_MCP_FUNCTIONS_PROMPT_ID,
+            template: MCP_FUNCTIONS_TEMPLATE,
+        });
+        this.promptService.addBuiltInPromptFragment({
+            id: GENERIC_CAPABILITIES_FUNCTIONS_PROMPT_ID,
+            template: FUNCTIONS_TEMPLATE,
+        });
+        this.promptService.addBuiltInPromptFragment({
+            id: GENERIC_CAPABILITIES_PROMPT_FRAGMENTS_PROMPT_ID,
+            template: PROMPT_FRAGMENTS_TEMPLATE,
+        });
+        this.promptService.addBuiltInPromptFragment({
+            id: GENERIC_CAPABILITIES_AGENT_DELEGATION_PROMPT_ID,
+            template: AGENT_DELEGATION_TEMPLATE,
+        });
+        this.promptService.addBuiltInPromptFragment({
+            id: GENERIC_CAPABILITIES_VARIABLES_PROMPT_ID,
+            template: VARIABLES_TEMPLATE,
+        });
+    }
+}

--- a/packages/ai-core/src/browser/generic-capabilities-variable-contribution.spec.ts
+++ b/packages/ai-core/src/browser/generic-capabilities-variable-contribution.spec.ts
@@ -1,0 +1,136 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { Container } from 'inversify';
+import {
+    GenericCapabilitiesVariableContribution,
+    SELECTED_SKILLS_VARIABLE,
+    SELECTED_FUNCTIONS_VARIABLE,
+    SELECTED_VARIABLES_VARIABLE
+} from './generic-capabilities-variable-contribution';
+import { CapabilityAwareContext } from '../common/capability-utils';
+
+disableJSDOM();
+
+describe('GenericCapabilitiesVariableContribution', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+    let contribution: GenericCapabilitiesVariableContribution;
+    let container: Container;
+
+    beforeEach(() => {
+        container = new Container();
+        container.bind<GenericCapabilitiesVariableContribution>(GenericCapabilitiesVariableContribution).toSelf().inSingletonScope();
+        contribution = container.get<GenericCapabilitiesVariableContribution>(GenericCapabilitiesVariableContribution);
+    });
+
+    describe('canResolve', () => {
+        it('returns 1 for selected_skills variable', () => {
+            const result = contribution.canResolve(
+                { variable: SELECTED_SKILLS_VARIABLE },
+                {}
+            );
+            expect(result).to.equal(1);
+        });
+
+        it('returns 1 for selected_functions variable', () => {
+            const result = contribution.canResolve(
+                { variable: SELECTED_FUNCTIONS_VARIABLE },
+                {}
+            );
+            expect(result).to.equal(1);
+        });
+
+        it('returns 1 for selected_variables variable', () => {
+            const result = contribution.canResolve(
+                { variable: SELECTED_VARIABLES_VARIABLE },
+                {}
+            );
+            expect(result).to.equal(1);
+        });
+
+        it('returns -1 for unknown variables', () => {
+            const result = contribution.canResolve(
+                { variable: { id: 'unknown', name: 'unknown', description: 'unknown' } },
+                {}
+            );
+            expect(result).to.equal(-1);
+        });
+    });
+
+    describe('resolve', () => {
+        it('returns empty string when no selections exist', async () => {
+            const context: CapabilityAwareContext = {};
+
+            const result = await contribution.resolve(
+                { variable: SELECTED_SKILLS_VARIABLE },
+                context
+            );
+
+            expect(result?.value).to.equal('');
+        });
+
+        it('returns empty string when selections array is empty', async () => {
+            const context: CapabilityAwareContext = {
+                genericCapabilitySelections: {
+                    skills: []
+                }
+            };
+
+            const result = await contribution.resolve(
+                { variable: SELECTED_SKILLS_VARIABLE },
+                context
+            );
+
+            expect(result?.value).to.equal('');
+        });
+
+        it('returns empty string for skills when skillService is not available', async () => {
+            const context: CapabilityAwareContext = {
+                genericCapabilitySelections: {
+                    skills: ['skill1', 'skill2']
+                }
+            };
+
+            const result = await contribution.resolve(
+                { variable: SELECTED_SKILLS_VARIABLE },
+                context
+            );
+
+            // Without skillService, it returns empty
+            expect(result?.value).to.equal('');
+        });
+
+        it('returns correct variable in result', async () => {
+            const context: CapabilityAwareContext = {};
+
+            const result = await contribution.resolve(
+                { variable: SELECTED_SKILLS_VARIABLE },
+                context
+            );
+
+            expect(result?.variable).to.deep.equal(SELECTED_SKILLS_VARIABLE);
+        });
+    });
+});

--- a/packages/ai-core/src/browser/generic-capabilities-variable-contribution.ts
+++ b/packages/ai-core/src/browser/generic-capabilities-variable-contribution.ts
@@ -1,0 +1,254 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, optional } from '@theia/core/shared/inversify';
+import { MaybePromise } from '@theia/core';
+import {
+    AIVariable,
+    AIVariableArg,
+    AIVariableContext,
+    AIVariableContribution,
+    AIVariableResolutionRequest,
+    AIVariableResolverWithVariableDependencies,
+    AIVariableService,
+    ResolvedAIVariable,
+    CapabilityAwareContext,
+    AgentService,
+    AgentsVariableContribution
+} from '../common';
+import { PromptVariableContribution } from './prompt-variable-contribution';
+import { SkillService } from './skill-service';
+import { SkillsVariableContribution } from './skills-variable-contribution';
+
+/**
+ * Variable IDs for generic capability selections.
+ * These variables resolve to lists of selected items from the chat UI dropdowns.
+ */
+export const SELECTED_SKILLS_VARIABLE: AIVariable = {
+    id: 'selected_skills',
+    name: 'selected_skills',
+    description: 'Returns the list of user-selected skills from the capabilities panel'
+};
+
+export const SELECTED_MCP_FUNCTIONS_VARIABLE: AIVariable = {
+    id: 'selected_mcp_functions',
+    name: 'selected_mcp_functions',
+    description: 'Returns the list of user-selected MCP functions from the capabilities panel'
+};
+
+export const SELECTED_FUNCTIONS_VARIABLE: AIVariable = {
+    id: 'selected_functions',
+    name: 'selected_functions',
+    description: 'Returns the list of user-selected functions from the capabilities panel'
+};
+
+export const SELECTED_PROMPT_FRAGMENTS_VARIABLE: AIVariable = {
+    id: 'selected_prompt_fragments',
+    name: 'selected_prompt_fragments',
+    description: 'Returns the list of user-selected prompt fragments from the capabilities panel'
+};
+
+export const SELECTED_AGENT_DELEGATION_VARIABLE: AIVariable = {
+    id: 'selected_agent_delegation',
+    name: 'selected_agent_delegation',
+    description: 'Returns the list of user-selected agents for delegation from the capabilities panel'
+};
+
+export const SELECTED_VARIABLES_VARIABLE: AIVariable = {
+    id: 'selected_variables',
+    name: 'selected_variables',
+    description: 'Returns the list of user-selected variables from the capabilities panel'
+};
+
+const GENERIC_CAPABILITY_VARIABLES = [
+    SELECTED_SKILLS_VARIABLE,
+    SELECTED_MCP_FUNCTIONS_VARIABLE,
+    SELECTED_FUNCTIONS_VARIABLE,
+    SELECTED_PROMPT_FRAGMENTS_VARIABLE,
+    SELECTED_AGENT_DELEGATION_VARIABLE,
+    SELECTED_VARIABLES_VARIABLE
+];
+
+/**
+ * Contribution that registers variables for resolving user-selected generic capabilities.
+ * These variables read from the genericCapabilitySelections field in the context
+ * and delegate resolution to the respective variable contributions.
+ */
+@injectable()
+export class GenericCapabilitiesVariableContribution implements AIVariableContribution, AIVariableResolverWithVariableDependencies {
+
+    @inject(SkillsVariableContribution) @optional()
+    protected readonly skillsContribution: SkillsVariableContribution | undefined;
+
+    @inject(SkillService) @optional()
+    protected readonly skillService: SkillService | undefined;
+
+    @inject(AIVariableService) @optional()
+    protected readonly variableService: AIVariableService | undefined;
+
+    @inject(AgentService) @optional()
+    protected readonly agentService: AgentService | undefined;
+
+    @inject(AgentsVariableContribution) @optional()
+    protected readonly agentsContribution: AgentsVariableContribution | undefined;
+
+    @inject(PromptVariableContribution) @optional()
+    protected readonly promptContribution: PromptVariableContribution | undefined;
+
+    registerVariables(service: AIVariableService): void {
+        for (const variable of GENERIC_CAPABILITY_VARIABLES) {
+            service.registerResolver(variable, this);
+        }
+    }
+
+    canResolve(request: AIVariableResolutionRequest, _context: AIVariableContext): MaybePromise<number> {
+        if (GENERIC_CAPABILITY_VARIABLES.some(v => v.name === request.variable.name)) {
+            return 1;
+        }
+        return -1;
+    }
+
+    async resolve(
+        request: AIVariableResolutionRequest,
+        context: AIVariableContext,
+        resolveDependency?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<ResolvedAIVariable | undefined> {
+        const selections = CapabilityAwareContext.is(context) ? context.genericCapabilitySelections : undefined;
+
+        if (!selections) {
+            return { variable: request.variable, value: '' };
+        }
+
+        switch (request.variable.name) {
+            case SELECTED_SKILLS_VARIABLE.name:
+                return this.resolveSelectedSkills(request.variable, selections.skills);
+            case SELECTED_MCP_FUNCTIONS_VARIABLE.name:
+                return this.resolveSelectedFunctions(request.variable, selections.mcpFunctions);
+            case SELECTED_FUNCTIONS_VARIABLE.name:
+                return this.resolveSelectedFunctions(request.variable, selections.functions);
+            case SELECTED_PROMPT_FRAGMENTS_VARIABLE.name:
+                return this.resolveSelectedPromptFragments(request.variable, selections.promptFragments, context, resolveDependency);
+            case SELECTED_AGENT_DELEGATION_VARIABLE.name:
+                return this.resolveSelectedAgentDelegation(request.variable, selections.agentDelegation);
+            case SELECTED_VARIABLES_VARIABLE.name:
+                return this.resolveSelectedVariables(request.variable, selections.variables, context, resolveDependency);
+            default:
+                return undefined;
+        }
+    }
+
+    /**
+     * Resolves selected skills using SkillsVariableContribution.resolveSkillsVariable().
+     */
+    protected resolveSelectedSkills(variable: AIVariable, skillIds: string[] | undefined): ResolvedAIVariable {
+        if (!skillIds || skillIds.length === 0 || !this.skillService || !this.skillsContribution) {
+            return { variable, value: '' };
+        }
+
+        const skills = skillIds
+            .map(skillId => this.skillService!.getSkill(skillId))
+            .filter((skill): skill is NonNullable<typeof skill> => skill !== undefined);
+
+        return this.skillsContribution.resolveSkillsVariable(skills, variable);
+    }
+
+    /**
+     * Resolves selected functions by outputting ~{functionId} syntax.
+     * The chat request parser will pick these up and add them to the toolRequests map.
+     */
+    protected resolveSelectedFunctions(variable: AIVariable, functionIds: string[] | undefined): ResolvedAIVariable {
+        if (!functionIds || functionIds.length === 0) {
+            return { variable, value: '' };
+        }
+
+        // Output function references in ~{id} format so the chat parser picks them up
+        const functionRefs = functionIds.map(id => `~{${id}}`).join('\n');
+        return { variable, value: functionRefs };
+    }
+
+    /**
+     * Resolves selected prompt fragments using PromptVariableContribution.resolvePromptFragments().
+     */
+    protected async resolveSelectedPromptFragments(
+        variable: AIVariable,
+        fragmentIds: string[] | undefined,
+        context: AIVariableContext,
+        resolveDependency?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<ResolvedAIVariable> {
+        if (!fragmentIds || fragmentIds.length === 0 || !this.promptContribution) {
+            return { variable, value: '', allResolvedDependencies: [] };
+        }
+
+        return this.promptContribution.resolvePromptFragments(fragmentIds, variable, context, resolveDependency);
+    }
+
+    /**
+     * Resolves selected agents for delegation using AgentsVariableContribution.resolveAgentsVariable().
+     */
+    protected resolveSelectedAgentDelegation(variable: AIVariable, agentIds: string[] | undefined): ResolvedAIVariable {
+        if (!agentIds || agentIds.length === 0 || !this.agentService || !this.agentsContribution) {
+            return { variable, value: '' };
+        }
+
+        const allAgents = this.agentService.getAgents();
+        const agents = agentIds
+            .map(agentId => allAgents.find(a => a.id === agentId))
+            .filter((agent): agent is NonNullable<typeof agent> => agent !== undefined);
+
+        return this.agentsContribution.resolveAgentsVariable(agents, variable);
+    }
+
+    /**
+     * Resolves selected variables using AIVariableService.resolveVariable().
+     */
+    protected async resolveSelectedVariables(
+        variable: AIVariable,
+        variableNames: string[] | undefined,
+        context: AIVariableContext,
+        resolveDependency?: (variable: AIVariableArg) => Promise<ResolvedAIVariable | undefined>
+    ): Promise<ResolvedAIVariable> {
+        if (!variableNames || variableNames.length === 0 || !this.variableService) {
+            return { variable, value: '', allResolvedDependencies: [] };
+        }
+
+        const resolvedValues: string[] = [];
+        const allDependencies: ResolvedAIVariable[] = [];
+
+        for (const variableName of variableNames) {
+            const aiVariable = this.variableService.getVariable(variableName);
+            if (aiVariable) {
+                // Use resolveDependency if provided (for proper caching), otherwise use variableService directly
+                const resolved = resolveDependency
+                    ? await resolveDependency({ variable: aiVariable.name })
+                    : await this.variableService.resolveVariable({ variable: aiVariable }, context);
+
+                if (resolved && resolved.value) {
+                    resolvedValues.push(`### ${aiVariable.name}\n${resolved.value}`);
+                    allDependencies.push(resolved);
+                    if (resolved.allResolvedDependencies) {
+                        allDependencies.push(...resolved.allResolvedDependencies);
+                    }
+                }
+            }
+        }
+
+        return {
+            variable,
+            value: resolvedValues.join('\n\n'),
+            allResolvedDependencies: allDependencies
+        };
+    }
+}

--- a/packages/ai-core/src/browser/index.ts
+++ b/packages/ai-core/src/browser/index.ts
@@ -36,3 +36,6 @@ export * from './skill-prompt-coordinator';
 export * from './frontend-variable-service';
 export * from './ai-core-command-contribution';
 export * from '../common/language-model-service';
+export * from './generic-capabilities-variable-contribution';
+export * from './generic-capabilities-prompt-fragment-contribution';
+export * from './prompt-variable-contribution';

--- a/packages/ai-core/src/browser/prompt-variable-contribution.spec.ts
+++ b/packages/ai-core/src/browser/prompt-variable-contribution.spec.ts
@@ -25,8 +25,8 @@ import * as sinon from 'sinon';
 import { Container } from 'inversify';
 import { CommandService, ILogger, Logger } from '@theia/core';
 import { PromptVariableContribution, PROMPT_VARIABLE } from './prompt-variable-contribution';
-import { PromptService, PromptServiceImpl } from './prompt-service';
-import { DefaultAIVariableService, AIVariableService } from './variable-service';
+import { PromptService, PromptServiceImpl } from '../common/prompt-service';
+import { DefaultAIVariableService, AIVariableService } from '../common/variable-service';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 
 disableJSDOM();

--- a/packages/ai-core/src/browser/skills-variable-contribution.ts
+++ b/packages/ai-core/src/browser/skills-variable-contribution.ts
@@ -80,21 +80,21 @@ export class SkillsVariableContribution implements AIVariableContribution, AIVar
 
         // Handle plural skills variable
         if (request.variable.name === SKILLS_VARIABLE.name) {
-            const skills = this.skillService.getSkills();
-            this.logger.debug(`SkillsVariableContribution: Resolving skills variable, found ${skills.length} skills`);
-
-            const skillSummaries: SkillSummary[] = skills.map(skill => ({
-                name: skill.name,
-                description: skill.description,
-                location: skill.location
-            }));
-
-            const xmlValue = this.generateSkillsXML(skillSummaries);
-            this.logger.debug(`SkillsVariableContribution: Generated XML:\n${xmlValue}`);
-
-            return { variable: SKILLS_VARIABLE, skills: skillSummaries, value: xmlValue };
+            return this.resolveSkillsVariable(this.skillService.getSkills(), SKILLS_VARIABLE);
         }
         return undefined;
+    }
+
+    /**
+     * Resolves skills into a ResolvedSkillsVariable with XML format.
+     */
+    resolveSkillsVariable(includedSkills: SkillSummary[], variable: AIVariable): ResolvedSkillsVariable {
+        this.logger.debug(`SkillsVariableContribution: Resolving skills variable, found ${includedSkills.length} skills`);
+
+        const xmlValue = this.generateSkillsXML(includedSkills);
+        this.logger.debug(`SkillsVariableContribution: Generated XML:\n${xmlValue}`);
+
+        return { variable, skills: includedSkills, value: xmlValue };
     }
 
     protected async resolveSingleSkill(request: AIVariableResolutionRequest): Promise<ResolvedAIVariable | undefined> {
@@ -127,8 +127,9 @@ export class SkillsVariableContribution implements AIVariableContribution, AIVar
     /**
      * Generates XML representation of skills.
      * XML format follows the Agent Skills spec for structured skill representation.
+     * This method is public to allow reuse by GenericCapabilitiesVariableContribution.
      */
-    protected generateSkillsXML(skills: SkillSummary[]): string {
+    generateSkillsXML(skills: SkillSummary[]): string {
         if (skills.length === 0) {
             return '<available_skills>\n</available_skills>';
         }

--- a/packages/ai-core/src/common/agents-variable-contribution.ts
+++ b/packages/ai-core/src/common/agents-variable-contribution.ts
@@ -17,6 +17,7 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { AIVariable, AIVariableContext, AIVariableContribution, AIVariableResolutionRequest, AIVariableResolver, AIVariableService, ResolvedAIVariable } from './variable-service';
 import { MaybePromise, nls } from '@theia/core';
 import { AgentService } from './agent-service';
+import { Agent } from './agent';
 
 export const AGENTS_VARIABLE: AIVariable = {
     id: 'agents',
@@ -53,12 +54,16 @@ export class AgentsVariableContribution implements AIVariableContribution, AIVar
 
     async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAgentsVariable | undefined> {
         if (request.variable.name === AGENTS_VARIABLE.name) {
-            const agents = this.agentService.getAgents().map(agent => ({
-                id: agent.id,
-                name: agent.name,
-                description: agent.description
-            }));
-            return { variable: AGENTS_VARIABLE, agents, value: JSON.stringify(agents) };
+            return this.resolveAgentsVariable(this.agentService.getAgents(), AGENTS_VARIABLE);
         }
+    }
+
+    resolveAgentsVariable(includedAgents: Agent[], variable: AIVariable): ResolvedAgentsVariable {
+        const agents = includedAgents.map(agent => ({
+            id: agent.id,
+            name: agent.name,
+            description: agent.description
+        }));
+        return { variable, agents, value: JSON.stringify(agents) };
     }
 }

--- a/packages/ai-core/src/common/capability-utils.ts
+++ b/packages/ai-core/src/common/capability-utils.ts
@@ -13,7 +13,109 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
+import { Event, MaybePromise } from '@theia/core';
 import { AIVariableContext } from './variable-service';
+
+/** Prompt fragment IDs for each generic capability type */
+export const GENERIC_CAPABILITIES_SKILLS_PROMPT_ID = 'generic-capabilities-skills';
+export const GENERIC_CAPABILITIES_MCP_FUNCTIONS_PROMPT_ID = 'generic-capabilities-mcp-functions';
+export const GENERIC_CAPABILITIES_FUNCTIONS_PROMPT_ID = 'generic-capabilities-functions';
+export const GENERIC_CAPABILITIES_PROMPT_FRAGMENTS_PROMPT_ID = 'generic-capabilities-prompt-fragments';
+export const GENERIC_CAPABILITIES_AGENT_DELEGATION_PROMPT_ID = 'generic-capabilities-agent-delegation';
+export const GENERIC_CAPABILITIES_VARIABLES_PROMPT_ID = 'generic-capabilities-variables';
+
+export type CapabilityType = keyof GenericCapabilitySelections;
+
+/** Prefix used by internal prompt fragments for generic capabilities */
+export const GENERIC_CAPABILITIES_PROMPT_PREFIX = 'generic-capabilities-';
+
+/** Prefix used by internal variables for generic capability selections */
+export const GENERIC_CAPABILITIES_VARIABLE_PREFIX = 'selected_';
+
+/**
+ * Represents a single capability item that can be selected.
+ */
+export interface GenericCapabilityItem {
+    /** Unique identifier for this capability */
+    id: string;
+    /** Display name for the capability */
+    name: string;
+    /** Optional group name for grouping related items */
+    group?: string;
+    /** Optional description */
+    description?: string;
+}
+
+/**
+ * Represents a group of capability items.
+ */
+export interface GenericCapabilityGroup {
+    /** Group name */
+    name: string;
+    /** Items in this group */
+    items: GenericCapabilityItem[];
+}
+
+export const GenericCapabilitiesContribution = Symbol('GenericCapabilitiesContribution');
+
+/**
+ * Contribution point for external packages to provide additional generic capabilities.
+ * For example, the MCP package can contribute MCP tool functions without
+ * creating coupling between unrelated packages.
+ */
+export interface GenericCapabilitiesContribution {
+    /** The capability type this contribution provides items for */
+    readonly capabilityType: CapabilityType;
+    /** Event fired when available capabilities from this contribution change */
+    readonly onDidChange?: Event<void>;
+    /** Returns available capability groups for this type */
+    getAvailableCapabilities(): MaybePromise<GenericCapabilityGroup[]>;
+}
+
+/**
+ * Static mapping of capability types to their corresponding prompt fragment IDs.
+ * This is the single source of truth for the enumeration of capability types,
+ * reducing DRY violations across the codebase.
+ */
+export const CAPABILITY_TYPE_PROMPT_MAP: ReadonlyArray<{ type: CapabilityType; promptId: string }> = [
+    { type: 'skills', promptId: GENERIC_CAPABILITIES_SKILLS_PROMPT_ID },
+    { type: 'mcpFunctions', promptId: GENERIC_CAPABILITIES_MCP_FUNCTIONS_PROMPT_ID },
+    { type: 'functions', promptId: GENERIC_CAPABILITIES_FUNCTIONS_PROMPT_ID },
+    { type: 'promptFragments', promptId: GENERIC_CAPABILITIES_PROMPT_FRAGMENTS_PROMPT_ID },
+    { type: 'agentDelegation', promptId: GENERIC_CAPABILITIES_AGENT_DELEGATION_PROMPT_ID },
+    { type: 'variables', promptId: GENERIC_CAPABILITIES_VARIABLES_PROMPT_ID },
+];
+
+/**
+ * Represents user-selected generic capabilities to be included in chat requests.
+ * These are capabilities selected via dropdown menus in the chat UI.
+ */
+export interface GenericCapabilitySelections {
+    /** Selected skill IDs */
+    skills?: string[];
+    /** Selected MCP function IDs (format: "servername_toolname") */
+    mcpFunctions?: string[];
+    /** Selected function IDs */
+    functions?: string[];
+    /** Selected prompt fragment IDs */
+    promptFragments?: string[];
+    /** Selected agent IDs for delegation */
+    agentDelegation?: string[];
+    /** Selected variable names */
+    variables?: string[];
+}
+
+export namespace GenericCapabilitySelections {
+    /**
+     * Checks if the selections object has any non-empty arrays.
+     */
+    export function hasSelections(selections: GenericCapabilitySelections | undefined): boolean {
+        if (!selections) {
+            return false;
+        }
+        return CAPABILITY_TYPE_PROMPT_MAP.some(({ type }) => (selections[type]?.length ?? 0) > 0);
+    }
+}
 
 /**
  * An extended variable resolution context that includes capability override information.
@@ -21,6 +123,13 @@ import { AIVariableContext } from './variable-service';
  * This context is used during prompt template resolution to determine which capability
  * fragments should be enabled or disabled, allowing dynamic customization of agent behavior.
  */
+export namespace CapabilityAwareContext {
+    export function is(candidate: unknown): candidate is CapabilityAwareContext {
+        return typeof candidate === 'object' && !!candidate
+            && ('capabilityOverrides' in candidate || 'genericCapabilitySelections' in candidate);
+    }
+}
+
 export interface CapabilityAwareContext extends AIVariableContext {
     /**
      * Optional mapping of capability fragment IDs to their enabled/disabled state.
@@ -30,6 +139,13 @@ export interface CapabilityAwareContext extends AIVariableContext {
      * present in this map, the capability's default state is used.
      */
     capabilityOverrides?: Record<string, boolean>;
+
+    /**
+     * Optional generic capability selections from dropdown menus.
+     * These selections are used to dynamically include additional capabilities
+     * (skills, functions, MCP tools, etc.) in the agent's prompt.
+     */
+    genericCapabilitySelections?: GenericCapabilitySelections;
 }
 
 /**

--- a/packages/ai-core/src/common/index.ts
+++ b/packages/ai-core/src/common/index.ts
@@ -24,6 +24,7 @@ export * from './language-model';
 export * from './language-model-alias';
 export * from './prompt-service';
 export * from './prompt-service-util';
+
 export * from './prompt-text';
 export * from './protocol';
 export * from './today-variable-contribution';
@@ -36,3 +37,4 @@ export * from './configurable-in-memory-resources';
 export * from './notification-types';
 export * from './skill';
 export * from './capability-utils';
+export * from './tool-constants';

--- a/packages/ai-core/src/common/tool-constants.ts
+++ b/packages/ai-core/src/common/tool-constants.ts
@@ -1,0 +1,21 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * The function ID for the agent delegation tool.
+ * This tool allows agents to delegate tasks to other specialized agents.
+ */
+export const AGENT_DELEGATION_FUNCTION_ID = 'delegateToAgent';

--- a/packages/ai-editor/src/browser/ai-editor-frontend-module.ts
+++ b/packages/ai-editor/src/browser/ai-editor-frontend-module.ts
@@ -48,7 +48,8 @@ export default new ContainerModule(bind => {
             showContext: true,
             showPinnedAgent: true,
             showChangeSet: false,
-            showSuggestions: false
+            showSuggestions: false,
+            showCapabilities: false
         } satisfies AskAIInputConfiguration);
         container.bind(AskAIInputWidget).toSelf().inSingletonScope();
         return container.get(AskAIInputWidget);

--- a/packages/ai-ide/src/browser/address-pr-review-command-contribution.ts
+++ b/packages/ai-ide/src/browser/address-pr-review-command-contribution.ts
@@ -18,7 +18,7 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { PromptService } from '@theia/ai-core/lib/common';
 import { nls } from '@theia/core';
-import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-core';
 import { GitHubChatAgentId } from './github-chat-agent';
 
 @injectable()

--- a/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/mcp-configuration-widget.tsx
@@ -29,7 +29,7 @@ import {
     RemoteMCPServerDescription
 } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MessageService, nls, PreferenceScope, PreferenceService } from '@theia/core';
-import { PROMPT_VARIABLE } from '@theia/ai-core/lib/common/prompt-variable-contribution';
+import { PROMPT_VARIABLE } from '@theia/ai-core/lib/browser/prompt-variable-contribution';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
 import { DialogProps } from '@theia/core/lib/browser/dialogs';

--- a/packages/ai-ide/src/browser/analyze-gh-ticket-command-contribution.ts
+++ b/packages/ai-ide/src/browser/analyze-gh-ticket-command-contribution.ts
@@ -18,7 +18,7 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { PromptService } from '@theia/ai-core/lib/common';
 import { nls } from '@theia/core';
-import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-core';
 import { GitHubChatAgentId } from './github-chat-agent';
 
 @injectable()

--- a/packages/ai-ide/src/browser/apptester-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/apptester-capability-contribution.ts
@@ -16,8 +16,7 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { PromptService } from '@theia/ai-core/lib/common';
-import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+import { AGENT_DELEGATION_FUNCTION_ID, PromptService } from '@theia/ai-core';
 import { RUN_TASK_FUNCTION_ID } from '../common/workspace-functions';
 import { nls } from '@theia/core';
 

--- a/packages/ai-ide/src/browser/github-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/github-capability-contribution.ts
@@ -16,8 +16,7 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { PromptService } from '@theia/ai-core/lib/common';
-import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+import { AGENT_DELEGATION_FUNCTION_ID, PromptService } from '@theia/ai-core';
 import { GitHubChatAgentId } from './github-chat-agent';
 import { nls } from '@theia/core';
 

--- a/packages/ai-ide/src/browser/implement-gh-ticket-command-contribution.ts
+++ b/packages/ai-ide/src/browser/implement-gh-ticket-command-contribution.ts
@@ -18,7 +18,7 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { PromptService } from '@theia/ai-core/lib/common';
 import { nls } from '@theia/core';
-import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-core';
 import { GitHubChatAgentId } from './github-chat-agent';
 
 @injectable()

--- a/packages/ai-ide/src/browser/remember-command-contribution.ts
+++ b/packages/ai-ide/src/browser/remember-command-contribution.ts
@@ -18,7 +18,7 @@ import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { PromptService } from '@theia/ai-core/lib/common';
 import { nls } from '@theia/core';
-import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-core';
 
 /**
  * Contribution that registers the `/remember` slash command for AI chat agents.

--- a/packages/ai-mcp/src/browser/mcp-frontend-module.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-module.ts
@@ -28,6 +28,8 @@ import { MCPFrontendNotificationServiceImpl } from './mcp-frontend-notification-
 import { MCPServerManagerServerClientImpl } from './mcp-server-manager-server-client';
 import { MCPServerManagerServer, MCPServerManagerServerClient, MCPServerManagerServerPath } from '../common/mcp-protocol';
 import { WorkspaceRestrictionContribution } from '@theia/workspace/lib/browser/workspace-trust-service';
+import { GenericCapabilitiesContribution } from '@theia/ai-core';
+import { MCPGenericCapabilitiesContribution } from './mcp-generic-capabilities-contribution';
 
 export default new ContainerModule(bind => {
     bind(McpFrontendApplicationContribution).toSelf().inSingletonScope();
@@ -35,6 +37,9 @@ export default new ContainerModule(bind => {
     bind(WorkspaceRestrictionContribution).toService(McpFrontendApplicationContribution);
     bind(MCPFrontendService).to(MCPFrontendServiceImpl).inSingletonScope();
     bind(MCPFrontendNotificationService).to(MCPFrontendNotificationServiceImpl).inSingletonScope();
+
+    bind(MCPGenericCapabilitiesContribution).toSelf().inSingletonScope();
+    bind(GenericCapabilitiesContribution).toService(MCPGenericCapabilitiesContribution);
     bind(MCPServerManagerServerClient).to(MCPServerManagerServerClientImpl).inSingletonScope();
 
     bind(MCPServerManagerServer).toDynamicValue(ctx => {

--- a/packages/ai-mcp/src/browser/mcp-generic-capabilities-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-generic-capabilities-contribution.ts
@@ -1,0 +1,67 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Event } from '@theia/core';
+import {
+    CapabilityType,
+    GenericCapabilitiesContribution,
+    GenericCapabilityGroup,
+    GenericCapabilityItem
+} from '@theia/ai-core';
+import { MCPFrontendService, MCPFrontendNotificationService } from '../common/mcp-server-manager';
+
+/**
+ * Contributes MCP tool functions as generic capabilities for selection in the chat UI.
+ */
+@injectable()
+export class MCPGenericCapabilitiesContribution implements GenericCapabilitiesContribution {
+
+    readonly capabilityType: CapabilityType = 'mcpFunctions';
+
+    @inject(MCPFrontendService)
+    protected readonly mcpFrontendService: MCPFrontendService;
+
+    @inject(MCPFrontendNotificationService)
+    protected readonly mcpNotificationService: MCPFrontendNotificationService;
+
+    get onDidChange(): Event<void> {
+        return this.mcpNotificationService.onDidUpdateMCPServers;
+    }
+
+    async getAvailableCapabilities(): Promise<GenericCapabilityGroup[]> {
+        const groups: GenericCapabilityGroup[] = [];
+        const startedServers = await this.mcpFrontendService.getStartedServers();
+
+        for (const serverName of startedServers) {
+            const tools = await this.mcpFrontendService.getTools(serverName);
+            if (tools?.tools && tools.tools.length > 0) {
+                const items: GenericCapabilityItem[] = tools.tools.map(tool => ({
+                    id: `mcp_${serverName}_${tool.name}`,
+                    name: tool.name,
+                    group: serverName,
+                    description: tool.description
+                }));
+                groups.push({
+                    name: serverName,
+                    items
+                });
+            }
+        }
+
+        return groups;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Allows users to dynamically select additional AI capabilities per chat request via a new expandable panel in the chat input widget. The panel is toggled with a toolbar button or `Ctrl+Shift+.` (`Cmd+Shift+.` on Mac).

Capability types supported: Skills, MCP functions (grouped by server), built-in Functions (grouped by provider), Prompt Fragments, Agent Delegation, and Variables.

Key features:
- Searchable tree with expand/collapse, keyboard navigation (arrow keys, Enter/Space to toggle, Home/End), and tri-state parent checkboxes (checked/unchecked/indeterminate)
- Items already referenced in the agent's prompt template are auto-detected and shown as disabled to prevent duplication
- Selected capabilities are resolved into prompt text and appended to the agent's system message at request time (via `generic-capabilities-*` prompt fragments and `selected_*` variables)
- Collapsed state shows agent-specific capability chips as a horizontally scrollable row; expanded state shows the full panel with chips on the left and the generic capabilities tree on the right
- MCP integration: MCP servers contribute their tools as selectable capabilities, updated live when servers start/stop
- Accessibility: proper ARIA roles (`tree`, `treeitem`, `group`, `switch`), `aria-checked`, `aria-expanded`, `aria-disabled`, labels on all interactive elements, and hover tooltips throughout
- Capabilities panel state (open/closed, selections) resets properly on session switch; restored from the last request's serialized data when switching back
- Blue dot badge on the tools icon indicates active selections when the panel is closed      
- Pinned agent's capabilities are preserved after sending a message (instead of resetting to the default agent's capabilities)
- genericCapabilitySelections are serialized alongside capabilityOverrides in session data


#### How to test

1. Basic flow: Open the Chat view. Select an agent (e.g. one with a minimal prompt). Click the wrench/capabilities icon in the chat input toolbar (or press `Ctrl+Shift+.`). The capabilities panel should expand above the editor.
2. Generic capabilities tree: In the expanded panel, verify the right side shows a tree with capability types as roots (Skills, MCP, Agents, Functions, Prompts, Variables: only those with available items). Expand nodes, check/uncheck items, and verify parent checkboxes reflect the selection state (indeterminate when partially selected).
3. Search: Type in the search box and the tree should auto-expand and filter to matching items. Clear the search and the tree should collapse back.
4. Keyboard navigation: Focus the tree content area. Use Arrow Up/Down to navigate, Arrow Right/Left to expand/collapse, Enter/Space to toggle items, Home/End to jump to first/last node.
5. Disabled items: If the agent's prompt already references certain functions or variables (via `~{functionId}` or `{{variableName}}`), those should appear greyed out and non-toggleable in the tree.
6. Send and verify: Select some capabilities, send a message, then open the AI History view. The system prompt should contain additional sections (e.g. `## Skills`, `## MCP Functions`) with the selected items resolved into the prompt text.
7. Collapsed bar: Close the panel. If the agent has capability chips (from `{{capability:...}}` syntax in its prompt), they should appear as a scrollable chip row below the panel area.
8. MCP capabilities: If you have MCP servers configured, start them and verify their tools appear grouped by server name in the tree under the MCP root.
9. Mode cycling: Agents with multiple modes press `Shift+Tab` in the editor to cycle through modes and verify the updated capabilties (e.g. for Coder currently)
10. Session switch: Open capabilities, select some items, then switch to a different chat session. The panel should close and selections should reset.
  Switch back — the selections from the last sent message should be restored.
11. Badge dot: Select some capabilities, close the panel. A small blue dot should appear on the tools icon. Open the panel again — the dot disappears.
12. Pinned agent after send: Pin an agent (e.g. Universal), open capabilities, select items, send a message. After the response completes, the capabilities should still show the pinned agent's items (not reset to the default agent like Coder).

#### Follow-ups

- Keyboard navigation from editor into the capabilities panel (Shift+Tab) and back (Tab) needs further design for interaction with mode cycling shortcut (which is currently Shift+Tab also)
- Also remaining follow ups from #16985

Edit: extracted to GH-17069

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
