### PR TITLE
Fix unread badge clearing all sessions when any chat is opened

### DIFF
--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1092,6 +1092,17 @@
   text-decoration: underline;
 }
 
+.theia-chat-session-badge-unread-tooltip {
+  font-size: var(--theia-ui-font-size0);
+  font-weight: 600;
+  color: var(--theia-activityBarBadge-foreground);
+  background-color: var(--theia-activityBarBadge-background);
+  border-radius: calc(var(--theia-ui-padding) * 0.75);
+  padding: 1px calc(var(--theia-ui-padding) * 0.75);
+  display: inline-block;
+  margin-bottom: var(--theia-ui-padding);
+}
+
 .theia-chat-session-tooltip-label {
   font-weight: 600;
   margin-bottom: calc(var(--theia-ui-padding) * 0.5);
@@ -1143,7 +1154,7 @@
   color: var(--theia-focusBorder);
 }
 
-.theia-chat-session-card-unread-badge {
+.theia-chat-session-badge-unread {
   position: absolute;
   top: calc(var(--theia-ui-padding) * 1.5);
   left: calc(var(--theia-ui-padding) * 1.5);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Move unread tracking from React useState (lost on unmount) into the  ChatSessionsWelcomeMessageProvider service so state persists across welcome screen mount/unmount cycles
- Only clear the unread flag for the specific session that is activated, not all sessions
- Show "Unread" badge in the session card hover tooltip
- Clean up unread state when a session is deleted

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Verify the unread state persists for the chat cards until it is actually read. Currently if you open an chat all unread states are  reset.
- Verify the chat card tooltip now also shows an unread badge if a chat has unread messages

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
