### PR TITLE
Enhance and Refine capabilities

### DIFF
--- a/packages/ai-ide/src/browser/apptester-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/apptester-capability-contribution.ts
@@ -21,25 +21,19 @@ import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-d
 import { RUN_TASK_FUNCTION_ID } from '../common/workspace-functions';
 
 @injectable()
-export class WithAppTesterContribution implements FrontendApplicationContribution {
+export class AppTesterCapabilityContribution implements FrontendApplicationContribution {
 
     @inject(PromptService)
     protected readonly promptService: PromptService;
 
     onStart(): void {
-        this.registerWithAppTesterCommand();
-    }
-
-    protected registerWithAppTesterCommand(): void {
-        const commandTemplate = this.buildCommandTemplate();
-
         this.promptService.addBuiltInPromptFragment({
-            id: 'with-apptester',
-            template: commandTemplate
+            id: 'apptester',
+            template: this.buildTemplate()
         });
     }
 
-    protected buildCommandTemplate(): string {
+    protected buildTemplate(): string {
         return `After implementing the changes, delegate to the AppTester agent to test the implementation. The changes need to be applied and built.
 
     Use the ~{${AGENT_DELEGATION_FUNCTION_ID}} tool to delegate to the AppTester agent.

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -113,7 +113,9 @@ import { CreateTaskContextFunction, GetTaskContextFunction, EditTaskContextFunct
 import { FixGitHubTicketCommandContribution } from './implement-gh-ticket-command-contribution';
 import { AnalyzesGhTicketCommandContribution } from './analyze-gh-ticket-command-contribution';
 import { AddressGhReviewCommandContribution } from './address-pr-review-command-contribution';
-import { WithAppTesterContribution } from './with-apptester-contribution';
+import { AppTesterCapabilityContribution } from './apptester-capability-contribution';
+import { GitHubCapabilityContribution } from './github-capability-contribution';
+import { ShellExecutionCapabilityContribution } from './shell-execution-capability-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: aiIdePreferenceSchema });
@@ -319,5 +321,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(FrontendApplicationContribution).to(FixGitHubTicketCommandContribution);
     bind(FrontendApplicationContribution).to(AddressGhReviewCommandContribution);
     bind(FrontendApplicationContribution).to(AnalyzesGhTicketCommandContribution);
-    bind(FrontendApplicationContribution).to(WithAppTesterContribution);
+    bind(FrontendApplicationContribution).to(AppTesterCapabilityContribution);
+    bind(FrontendApplicationContribution).to(GitHubCapabilityContribution);
+    bind(FrontendApplicationContribution).to(ShellExecutionCapabilityContribution);
 });

--- a/packages/ai-ide/src/browser/github-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/github-capability-contribution.ts
@@ -1,0 +1,78 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PromptService } from '@theia/ai-core/lib/common';
+import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
+import { GitHubChatAgentId } from './github-chat-agent';
+
+@injectable()
+export class GitHubCapabilityContribution implements FrontendApplicationContribution {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    onStart(): void {
+        this.promptService.addBuiltInPromptFragment({
+            id: 'github',
+            template: this.buildTemplate()
+        });
+    }
+
+    protected buildTemplate(): string {
+        return `## GitHub
+
+You can interact with GitHub (issues, pull requests, repositories, etc.) by delegating to the GitHub agent \
+using the ~{${AGENT_DELEGATION_FUNCTION_ID}} tool.
+
+**Agent ID:** '${GitHubChatAgentId}'
+
+### When to use GitHub delegation
+
+Use this when the task requires reading from or writing to GitHub, for example:
+- Retrieving issue or pull request details
+- Creating or updating issues and pull requests
+- Listing repository contents, branches, or commits
+- Posting comments on issues or pull requests
+
+### How to delegate effectively
+
+The quality of the result depends entirely on the precision of the prompt you provide. Always include:
+- **What to do**: the exact GitHub operation (e.g., "retrieve", "create", "comment on")
+- **What to act on**: the specific resource (e.g., issue #42, PR #7, repository owner/repo)
+- **What to return**: the exact fields or information you need back (e.g., title, body, all comments, labels)
+
+#### Example — retrieving an issue:
+\`\`\`
+Please retrieve all details for issue #123 in the current repository, including:
+- Title, body, labels, state, assignees
+- All comments in full
+- Any referenced issues or pull requests
+\`\`\`
+
+#### Example — creating an issue:
+\`\`\`
+Please create a new issue in the current repository with:
+- Title: "Fix null pointer in FooService"
+- Body: "When calling FooService.bar() with a null argument, a NullPointerException is thrown. ..."
+- Labels: bug
+\`\`\`
+
+**IMPORTANT:** Be explicit and complete in your delegation prompt. Vague prompts lead to incomplete results \
+and require follow-up delegations.`;
+    }
+}

--- a/packages/ai-ide/src/browser/shell-execution-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/shell-execution-capability-contribution.ts
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PromptService } from '@theia/ai-core/lib/common';
+import { SHELL_EXECUTION_FUNCTION_ID } from '@theia/ai-terminal/lib/common/shell-execution-server';
+import { LIST_TASKS_FUNCTION_ID, RUN_TASK_FUNCTION_ID } from '../common/workspace-functions';
+
+@injectable()
+export class ShellExecutionCapabilityContribution implements FrontendApplicationContribution {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    onStart(): void {
+        this.promptService.addBuiltInPromptFragment({
+            id: 'shell-execution',
+            template: this.buildTemplate()
+        });
+    }
+
+    protected buildTemplate(): string {
+        return `## Shell Execution
+
+You have access to the ~{${SHELL_EXECUTION_FUNCTION_ID}} tool, which lets you run arbitrary shell commands on the host system and capture their output.
+
+### When to use shell execution
+
+Use ~{${SHELL_EXECUTION_FUNCTION_ID}} **only when no better-suited tool exists** for the task:
+
+- **Prefer tasks over shell execution** for compiling, building, linting, testing, or any operation that has a corresponding workspace task. \
+Always check available tasks with ~{${LIST_TASKS_FUNCTION_ID}} first and run them with ~{${RUN_TASK_FUNCTION_ID}} instead of invoking the build tool directly.
+- **Prefer dedicated tools** for file reading, searching, or editing — use the file and search tools provided rather than \`cat\`, \`grep\`, or \`sed\` for workspace files.
+
+Appropriate use cases for ~{${SHELL_EXECUTION_FUNCTION_ID}}:
+- Running a command for which no workspace task exists (e.g., a one-off script, \`git\` operations, installing a dependency)
+- Efficient bulk operations that are impractical with the file editing tools (e.g., \`sed\`/\`awk\` for mass search-and-replace across many files)
+- Querying system or environment information (e.g., checking installed tool versions, environment variables)
+- Running scripts (bash, python, node, etc.) that are part of the task
+
+### Important constraints
+
+- **Do not start long-running or blocking processes** (e.g., dev servers, file watchers) with this tool — use launch configurations instead.
+- Commands require **user approval** before execution. The user sees the exact command and can approve, deny, or cancel it.
+- Output is truncated for large results; use filters (\`grep\`, \`head\`, \`tail\`) to keep output focused.`;
+    }
+}

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -171,6 +171,12 @@ Use the todo tool for complex multi-step tasks to:
 - Show the user what you're working on
 - Track completed and remaining steps
 
+{{capability:shell-execution default off}}
+
+{{capability:github default off}}
+
+{{capability:apptester default off}}
+
 # Workflow
 
 ## 1. Understand the Task
@@ -260,8 +266,6 @@ You are an autonomous AI agent. Do not stop until:
 - New tests are created if needed
 - No security vulnerabilities are introduced
 - No further action is required
-
-{{capability:with-apptester default off}}
 `;
 }
 


### PR DESCRIPTION
#### What it does

Introduces three opt-in capabilities for the Coder agent (agent mode), each disabled by default and toggled via the capability mechanism (`{{capability:<id> default off}}`):

- **`shell-execution`** — grants the agent access to the `shellExecute` tool for running arbitrary shell commands. The capability fragment instructs the agent to prefer workspace tasks (via `listTasks`/`runTask`) and dedicated file/search tools over shell execution, and to use `shellExecute` only when no better-suited tool exists. Long-running processes must still be started via launch configurations.

- **`github`** — enables GitHub interactions by delegating to the `GitHub` agent via the `agentDelegation` tool. The fragment explains when to delegate (reading/writing issues, PRs, repositories, etc.) and how to write precise delegation prompts, including concrete examples.

- **`apptester`** — enables post-implementation UI testing by delegating to the `AppTester` agent. This was previously wired up under the internal id `with-apptester`; it is now consistently named `apptester`.

All three capabilities are surfaced as subsections inside the **Tools Reference** section of the coder agent-mode prompt, alongside the existing tool documentation.

The corresponding contribution classes are renamed for clarity: `WithAppTesterContribution` → `AppTesterCapabilityContribution`, `WithShellExecutionContribution` → `ShellExecutionCapabilityContribution`, with the new `GitHubCapabilityContribution` following the same pattern.

#### How to test

1. Open the Coder agent in agent mode.
2. Verify that none of the three capabilities appear in the prompt by default (all are off).
3. Enable the `shell-execution` capability and confirm the agent uses `listTasks`/`runTask` first, only falling back to `shellExecute` for tasks without a corresponding workspace task.
4. Enable the `github` capability and ask the Coder agent to retrieve or create a GitHub issue; confirm it delegates to the `GitHub` agent with a precise prompt.
5. Enable the `apptester` capability and implement a small change; confirm the agent delegates to the `AppTester` agent after completing the implementation.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
