### PR TITLE
ai-copilot: UX improvements for GitHub Copilot integration

### DIFF
--- a/packages/ai-copilot/src/browser/copilot-auth-dialog.tsx
+++ b/packages/ai-copilot/src/browser/copilot-auth-dialog.tsx
@@ -62,7 +62,7 @@ export class CopilotAuthDialog extends ReactDialog<boolean> {
 
     @postConstruct()
     protected init(): void {
-        this.titleNode.textContent = nls.localize('theia/ai/copilot/auth/title', 'Sign in to GitHub Copilot');
+        this.titleNode.textContent = this.props.title;
         this.appendAcceptButton(nls.localize('theia/ai/copilot/auth/authorize', 'I have authorized'));
         this.appendCloseButton(nls.localizeByDefault('Cancel'));
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Part of GH-17058

- Add confirmation dialog before signing out of GitHub Copilot
- Hide Copilot status bar item when AI features are disabled
- Hide Copilot commands from palette when AI features are disabled
- Show "Sign in to GitHub Copilot" in status bar when not authenticated
- Consolidate duplicate localization keys for sign-in dialog title
- Remove unused CopilotAuthDialogProps constant binding

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Disable AI features `ai-features.AiEnable.enableAI` to verify the copilot status bar item is not shown
- Verify the confirmation dialog pops up before signing out the user
- Check if the status bar item's naming is more intuitive

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
