### PR TITLE
fix: resolve TypeScript compilation errors with Node 22 and @types/ex…

### DIFF
--- a/packages/notebook/src/browser/contributions/notebook-label-provider-contribution.ts
+++ b/packages/notebook/src/browser/contributions/notebook-label-provider-contribution.ts
@@ -19,11 +19,14 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { CellKind, CellUri } from '../../common';
 import { NotebookService } from '../service/notebook-service';
 import { NotebookCellOutlineNode } from './notebook-outline-contribution';
-import type Token = require('markdown-it/lib/token');
 import markdownit = require('@theia/core/shared/markdown-it');
 import * as markdownitemoji from '@theia/core/shared/markdown-it-emoji';
 import { NotebookCellModel } from '../view-model/notebook-cell-model';
 import { URI } from '@theia/core';
+
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Token = any;
 
 @injectable()
 export class NotebookLabelProviderContribution implements LabelProviderContribution {

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -44,8 +44,8 @@ export class HostedPluginReader implements BackendApplicationContribution {
 
     configure(app: express.Application): void {
         app.get('/hostedPlugin/:pluginId/:path(*)', async (req, res) => {
-            const pluginId = req.params.pluginId;
-            const filePath = req.params.path;
+            const pluginId = String(req.params.pluginId);
+            const filePath = String((req.params as any)['path(*)'] ?? (req.params as any).path);
 
             const localPath = this.pluginsIdsFiles.get(pluginId);
             if (localPath) {
@@ -109,7 +109,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
     }
 
     protected async handleMissingResource(req: express.Request, res: express.Response): Promise<void> {
-        const pluginId = req.params.pluginId;
+        const pluginId = String(req.params.pluginId);
         res.status(404).send(`The plugin with id '${escape_html(pluginId)}' does not exist.`);
     }
 


### PR DESCRIPTION
## Summary
Fixes TypeScript compilation errors when building Theia on Node 22 with @types/express v5.

## Changes
- `packages/plugin-ext/src/hosted/node/plugin-reader.ts` — cast `req.params` to string to handle the new `string | string[]` return type in express v5
- `packages/notebook/src/browser/contributions/notebook-label-provider-contribution.ts` — replace broken `markdown-it/lib/token` import (removed in v14) with a local `type Token = any` alias

## Testing
Successfully compiled all 90 packages with Node 22.22.0 and Yarn 1.22.22.