### PR TITLE
Make Opus 4.6 default in model aliases

### DIFF
--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -28,7 +28,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code',
             defaultModelIds: [
-                'anthropic/claude-sonnet-4-6',
+                'anthropic/claude-opus-4-6',
                 'openai/gpt-5.2',
                 'google/gemini-3.1-pro-preview'
             ],
@@ -37,7 +37,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/universal',
             defaultModelIds: [
-                'anthropic/claude-sonnet-4-6',
+                'anthropic/claude-opus-4-6',
                 'openai/gpt-5.2',
                 'google/gemini-3.1-pro-preview'
             ],
@@ -47,7 +47,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             id: 'default/code-completion',
             defaultModelIds: [
                 'openai/gpt-4.1',
-                'anthropic/claude-sonnet-4-6',
+                'anthropic/claude-opus-4-6',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code-completion/description', 'Best suited for code autocompletion scenarios.')
@@ -55,7 +55,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/summarize',
             defaultModelIds: [
-                'anthropic/claude-sonnet-4-6',
+                'anthropic/claude-opus-4-6',
                 'openai/gpt-5.2',
                 'google/gemini-3.1-pro-preview'
             ],


### PR DESCRIPTION
#### What it does

Make Opus 4.6 default in model aliases, replacing Sonnet 4.6

#### How to test

Use the default aliases

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
