### PR TITLE
feat: add fullOutput parameter to shell execution tool

### DIFF
--- a/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
+++ b/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
@@ -359,6 +359,15 @@ const ConfirmationUI: React.FC<ConfirmationUIProps> = ({
                         {formatDuration(input.timeout)}
                     </span>
                 )}
+                {input.fullOutput && (
+                    <span
+                        className="shell-execution-tool meta-item"
+                        title={nls.localize('theia/ai-terminal/fullOutput', 'Full output (no truncation)')}
+                    >
+                        <span className={codicon('unfold')} />
+                        {nls.localize('theia/ai-terminal/fullOutputLabel', 'Full Output')}
+                    </span>
+                )}
             </div>
 
             <ShellExecutionConfirmationActions
@@ -831,6 +840,11 @@ const CanceledUI: React.FC<CanceledUIProps> = ({
                             {input.cwd}
                         </MetaRow>
                     )}
+                    {input.fullOutput && (
+                        <MetaRow icon="unfold" label={nls.localize('theia/ai-terminal/fullOutput', 'Full output (no truncation)')}>
+                            {nls.localize('theia/ai-terminal/fullOutputLabel', 'Full Output')}
+                        </MetaRow>
+                    )}
                     {canceledResult?.output && (
                         <OutputBox
                             title={nls.localize('theia/ai-terminal/partialOutput', 'Partial Output')}
@@ -882,6 +896,11 @@ const FinishedUI: React.FC<FinishedUIProps> = ({
                     {(result?.cwd || input.cwd) && (
                         <MetaRow icon="folder" label={nls.localize('theia/ai-terminal/workingDirectory', 'Working directory')}>
                             {result?.cwd || input.cwd}
+                        </MetaRow>
+                    )}
+                    {input.fullOutput && (
+                        <MetaRow icon="unfold" label={nls.localize('theia/ai-terminal/fullOutput', 'Full output (no truncation)')}>
+                            {nls.localize('theia/ai-terminal/fullOutputLabel', 'Full Output')}
                         </MetaRow>
                     )}
                     {result?.error && (

--- a/packages/ai-terminal/src/common/shell-execution-input-parser.spec.ts
+++ b/packages/ai-terminal/src/common/shell-execution-input-parser.spec.ts
@@ -116,4 +116,32 @@ describe('parseShellExecutionInput', () => {
             expect(result.command).to.equal('cat file.txt | grep error > output.log');
         });
     });
+
+    describe('fullOutput', () => {
+        it('should parse fullOutput: true', () => {
+            const result = parseShellExecutionInput('{"command": "git diff", "fullOutput": true}');
+            expect(result.command).to.equal('git diff');
+            expect(result.fullOutput).to.be.true;
+        });
+
+        it('should parse fullOutput: false', () => {
+            const result = parseShellExecutionInput('{"command": "ls -la", "fullOutput": false}');
+            expect(result.command).to.equal('ls -la');
+            expect(result.fullOutput).to.be.false;
+        });
+
+        it('should have undefined fullOutput when not specified', () => {
+            const result = parseShellExecutionInput('{"command": "echo hello"}');
+            expect(result.command).to.equal('echo hello');
+            expect(result.fullOutput).to.be.undefined;
+        });
+
+        it('should parse fullOutput alongside other optional fields', () => {
+            const result = parseShellExecutionInput('{"command": "npm test", "cwd": "/tmp", "timeout": 60000, "fullOutput": true}');
+            expect(result.command).to.equal('npm test');
+            expect(result.cwd).to.equal('/tmp');
+            expect(result.timeout).to.equal(60000);
+            expect(result.fullOutput).to.be.true;
+        });
+    });
 });

--- a/packages/ai-terminal/src/common/shell-execution-input-parser.ts
+++ b/packages/ai-terminal/src/common/shell-execution-input-parser.ts
@@ -18,6 +18,7 @@ export interface ShellExecutionInput {
     command: string;
     cwd?: string;
     timeout?: number;
+    fullOutput?: boolean;
 }
 
 /**


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Add an optional `fullOutput` boolean parameter that bypasses output truncation when the LLM needs complete output (e.g. for diffs). When truncation occurs, the result now includes a summary showing how many characters were omitted so the LLM can decide whether to retry with full output.

Part of #16928

#### How to test

Instruct the LLM to run commands with large outputs, e.g. diffs.

Verify the full output is returned and the UI indicates that the full output was requested

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
