### PR TITLE
Fix cannot configure tool confirmation mode if default is configured in package.json preferences

### DIFF
--- a/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
+++ b/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
@@ -77,15 +77,18 @@ export class ToolConfirmationManager {
      * @param toolRequest - Optional ToolRequest to check for confirmAlwaysAllow flag
      */
     setConfirmationMode(toolId: string, mode: ToolConfirmationMode, toolRequest?: ToolRequest): void {
+        const defaultPref = this.preferenceService.inspect(TOOL_CONFIRMATION_PREFERENCE)?.defaultValue as {
+            [toolId: string]: ToolConfirmationMode;
+        } || {};
         const current = this.preferences[TOOL_CONFIRMATION_PREFERENCE] || {};
         let starMode = current['*'];
         if (starMode === undefined) {
-            starMode = ToolConfirmationMode.ALWAYS_ALLOW;
+            starMode = defaultPref['*'] ?? ToolConfirmationMode.ALWAYS_ALLOW;
         }
         // For confirmAlwaysAllow tools, the effective default is CONFIRM, not ALWAYS_ALLOW
         const effectiveDefault = (toolRequest?.confirmAlwaysAllow && starMode === ToolConfirmationMode.ALWAYS_ALLOW)
             ? ToolConfirmationMode.CONFIRM
-            : starMode;
+            : defaultPref[toolId] ?? starMode;
         if (mode === effectiveDefault) {
             if (toolId in current) {
                 const { [toolId]: _, ...rest } = current;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fix not being able to change tool confirmation mode if it had a preference default.

The `ToolConfirmationManager` was not considering the default value when computing the effective default 
which caused it to incorrectly set the preference value.

Closes #16958 

#### How to test
- Update the config preferences of the package.json file in examples/browser with:
```
"ai-features.chat.toolConfirmation": {
  "getWorkspaceFileList": "confirm"
}
```
- Start the browser app.
- Go to the tool configuration tab.
- Try to set the confirmation mode of "getWorkspaceFileList" to something else than "Confirm".
- It should correctly set the confirmation mode.
- Try also with other tools which do not have a default in the preferences.


![feature](https://github.com/user-attachments/assets/f1431306-e2f1-448d-8ce3-57d59d840dc8)

#### Attribution

Contributed on behalf of Lonti.com Pty Ltd.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
