### PR TITLE
fix: replace console.error with ILogger in hosted-instance-manager

### DIFF
--- a/packages/plugin-dev/src/node/hosted-instance-manager.ts
+++ b/packages/plugin-dev/src/node/hosted-instance-manager.ts
@@ -31,6 +31,7 @@ import { MetadataScanner } from '@theia/plugin-ext/lib/hosted/node/metadata-scan
 import { PluginDebugConfiguration } from '../common/plugin-dev-protocol';
 import { HostedPluginProcess } from '@theia/plugin-ext/lib/hosted/node/hosted-plugin-process';
 import { isENOENT } from '@theia/plugin-ext/lib/common/errors';
+import { ILogger } from '@theia/core/lib/common/logger';
 
 const DEFAULT_HOSTED_PLUGIN_PORT = 3030;
 
@@ -114,6 +115,9 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
 
     @inject(RequestService)
     protected readonly request: RequestService;
+
+    @inject(ILogger) @named('plugin-dev')
+    protected readonly logger: ILogger;
 
     isRunning(): boolean {
         return this.isPluginRunning;
@@ -233,10 +237,10 @@ export abstract class AbstractHostedInstanceManager implements HostedInstanceMan
             return true;
         } catch (err) {
             if (!isENOENT(err)) {
-                console.error(err);
+                this.logger.error('Failed to read plugin package.json', err);
             }
-            return false;
-        }
+        return false;
+}
     }
 
     protected async getStartCommand(port?: number, debugConfig?: PluginDebugConfiguration): Promise<string[]> {


### PR DESCRIPTION
## What it does
Replaces a raw `console.error()` call with the injected `ILogger` service 
in `AbstractHostedInstanceManager.isPluginValid()` in the `@theia/plugin-dev` package.

This ensures error messages go through Theia's standard logging infrastructure 
instead of bypassing it via console, making logs consistent with the rest of 
the codebase.

## How to test
1. Build and start the Electron example
2. Go to Run → Start Hosted Plugin Instance
3. Point it to an invalid/non-existent plugin path
4. Open View → Output panel
5. Verify the error "Failed to read plugin package.json" appears via 
   the logger instead of only in the raw console

Note: I tested that Theia builds and starts correctly with this change on 
the browser example. Full manual testing of the hosted plugin flow requires 
the Electron build which I was unable to complete in my environment.

## Breaking changes
No breaking changes.