### PR TITLE
fix: use macOS symbols for menu shortcut labels in browser

### DIFF
--- a/packages/core/src/browser/menu/action-menu-node.ts
+++ b/packages/core/src/browser/menu/action-menu-node.ts
@@ -16,7 +16,7 @@
 
 import { KeybindingRegistry } from '../keybinding';
 import { ContextKeyService } from '../context-key-service';
-import { DisposableCollection, isObject, CommandRegistry, Emitter } from '../../common';
+import { DisposableCollection, isObject, CommandRegistry, Emitter, environment } from '../../common';
 import { CommandMenu, ContextExpressionMatcher, MenuAction, MenuPath } from '../../common/menu/menu-types';
 
 export interface AcceleratorSource {
@@ -86,7 +86,8 @@ export class ActionMenuNode implements CommandMenu {
         if (bindings.length) {
             const binding = bindings.find(b => this.keybindingRegistry.isEnabledInScope(b, context));
             if (binding) {
-                return this.keybindingRegistry.acceleratorFor(binding, '+', true);
+                const asciiOnly = environment.electron.is();
+                return this.keybindingRegistry.acceleratorFor(binding, '+', asciiOnly);
             }
         }
         return [];

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -17,7 +17,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import { inject, injectable, optional } from '@theia/core/shared/inversify';
-import { MenuPath, CommandRegistry, Disposable, DisposableCollection, nls, CommandMenu, AcceleratorSource, ContextExpressionMatcher } from '@theia/core';
+import { MenuPath, CommandRegistry, Disposable, DisposableCollection, nls, CommandMenu, AcceleratorSource, ContextExpressionMatcher, environment } from '@theia/core';
 import { MenuModelRegistry } from '@theia/core/lib/common';
 import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { DeployedPlugin, IconUrl, Menu } from '../../../common';
@@ -135,7 +135,8 @@ export class MenusContributionPointHandler {
                                         if (bindings.length) {
                                             const binding = bindings.find(b => this.keybindingRegistry.isEnabledInScope(b, context));
                                             if (binding) {
-                                                return this.keybindingRegistry.acceleratorFor(binding, '+', true);
+                                                const asciiOnly = environment.electron.is();
+                                                return this.keybindingRegistry.acceleratorFor(binding, '+', asciiOnly);
                                             }
                                         }
                                         return [];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Menu accelerator labels hardcoded asciiOnly=true, which is only needed for Electron's native menu API. Use environment.electron.is() so browser menus display ⌘, ⌥, ⇧, ⌃ on macOS.

fix: #15844
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

You need a mac :cry: 
then you should be able to open the menu and see icons in the browser.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
