### PR TITLE
fix: blur focused element before activating next widget on close #17010

### DIFF
--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -589,6 +589,23 @@ export class ApplicationShell extends Widget {
         dockPanel.id = MAIN_AREA_ID;
         dockPanel.widgetAdded.connect((_, widget) => this.fireDidAddWidget(widget));
         dockPanel.widgetRemoved.connect((_, widget) => this.fireDidRemoveWidget(widget));
+        dockPanel.widgetRemoved.connect((_, widget) => {
+            if (widget.id === this.lastActiveWidgetId) {
+                this.lastActiveWidgetId = undefined;
+                const tabBar = this.lastActiveTabBar;
+                this.lastActiveTabBar = undefined;
+
+                // Lumino already auto-selected the next tab when the old one was removed.
+                // We just need to wait for the DOM to update, then force focus onto the new tab.
+                if (tabBar && tabBar.currentTitle) {
+                    const nextWidget = tabBar.currentTitle.owner;
+                    window.requestAnimationFrame(() => {
+                        this.activateWidget(nextWidget.id);
+                        nextWidget.activate();
+                    });
+                }
+            }
+        });
 
         const openUri = async (fileUri: URI) => {
             try {
@@ -1198,7 +1215,8 @@ export class ApplicationShell extends Widget {
     private onCurrentChanged(sender: FocusTracker<Widget>, args: FocusTracker.IChangedArgs<Widget>): void {
         this.onDidChangeCurrentWidgetEmitter.fire(args);
     }
-
+    protected lastActiveWidgetId: string | undefined;
+    protected lastActiveTabBar: TabBar<Widget> | undefined;
     protected readonly toDisposeOnActiveChanged = new DisposableCollection();
 
     /**
@@ -1207,6 +1225,13 @@ export class ApplicationShell extends Widget {
     private onActiveChanged(sender: FocusTracker<Widget>, args: FocusTracker.IChangedArgs<Widget>): void {
         this.toDisposeOnActiveChanged.dispose();
         const { newValue, oldValue } = args;
+
+        // Track the active widget and its tab bar before it gets closed
+        if (newValue) {
+            this.lastActiveWidgetId = newValue.id;
+            this.lastActiveTabBar = this.getTabBarFor(newValue) as TabBar<Widget> | undefined;
+        }
+
         if (oldValue) {
             let w: Widget | null = oldValue;
             while (w) {
@@ -1237,27 +1262,6 @@ export class ApplicationShell extends Widget {
                 panel.markAsCurrent(widget!.title);
             }
 
-            // activate another widget if an active widget will be closed
-            const onCloseRequest = newValue['onCloseRequest'];
-            newValue['onCloseRequest'] = msg => {
-                const currentTabBar = this.currentTabBar;
-                if (currentTabBar) {
-                    const recentlyUsedInTabBar = currentTabBar['_previousTitle'] as TabBar<Widget>['currentTitle'];
-                    if (recentlyUsedInTabBar && recentlyUsedInTabBar.owner !== newValue) {
-                        currentTabBar.currentIndex = ArrayExt.firstIndexOf(currentTabBar.titles, recentlyUsedInTabBar);
-                        if (currentTabBar.currentTitle) {
-                            this.activateWidget(currentTabBar.currentTitle.owner.id);
-                        }
-                    } else if (!this.activateNextTabInTabBar(currentTabBar)) {
-                        if (!this.activatePreviousTabBar(currentTabBar)) {
-                            this.activateNextTabBar(currentTabBar);
-                        }
-                    }
-                }
-                newValue['onCloseRequest'] = onCloseRequest;
-                newValue['onCloseRequest'](msg);
-            };
-            this.toDisposeOnActiveChanged.push(Disposable.create(() => newValue['onCloseRequest'] = onCloseRequest));
             if (PreviewableWidget.is(newValue)) {
                 newValue.loaded = true;
             }

--- a/packages/core/src/browser/widgets/widget.ts
+++ b/packages/core/src/browser/widgets/widget.ts
@@ -156,6 +156,12 @@ export class BaseWidget extends Widget implements PreviewableWidget {
     }
 
     protected override onBeforeDetach(msg: Message): void {
+        // If the focused element is inside this widget, explicitly blur it
+        // before the DOM node is destroyed so the browser doesn't force a focus reset.
+        if (this.node.contains(document.activeElement)) {
+            (document.activeElement as HTMLElement).blur();
+        }
+
         this.toDisposeOnDetach.dispose();
         super.onBeforeDetach(msg);
     }

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -222,7 +222,7 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
 
     protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
-        this.focusInputField();
+        window.requestAnimationFrame(() => this.focusInputField());
     }
 
     /**


### PR DESCRIPTION
What it does
When closing a widget that contains a focused element (e.g. an input field in Settings), the next widget in the tab bar did not receive onActivateRequest properly.
The previous fix using onCloseRequest was incomplete because closeWithSaving calls widget[close]() using the internal lumino close symbol, bypassing the onCloseRequest override entirely.
Fixed by:

Tracking the last active widget ID in a new lastActiveWidgetId property, updated in onActiveChanged
Listening to the widgetRemoved event on the main panel and activating the next appropriate widget there — this works regardless of how the widget is closed (X button, keybinding, or closeWithSaving)
Wrapping focusInputField in requestAnimationFrame in keybindings-widget.tsx to ensure the DOM is ready before attempting to focus the search input

Fixes #17010
How to test

Open Keyboard Shortcuts (Ctrl+Shift+P → Open Keyboard Shortcuts)
Open Settings (Ctrl+,)
Change a setting (e.g. Files: Auto Save → afterDelay)
Close the Settings widget using the X button or View: Close Tab command
Verify that Keyboard Shortcuts becomes properly activated
Run View: Close Tab again — Keyboard Shortcuts should close successfully

Follow-ups
None
Breaking changes

 This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the changelog has been updated.

Attribution
N/A
Review checklist

 As an author, I have thoroughly tested my changes and carefully followed the review guidelines
 User-facing text is internationalized using the nls service