### PR TITLE
fix(filesystem): normalize Windows paths for OPFS compatibility

### DIFF
--- a/packages/filesystem/src/browser-only/opfs-filesystem-provider.ts
+++ b/packages/filesystem/src/browser-only/opfs-filesystem-provider.ts
@@ -36,7 +36,7 @@ import { OPFSFileSystem, WatchEventType, type FileStat, type OPFSError, type Wat
 import { OPFSInitialization } from './opfs-filesystem-initialization';
 import { ReadableStreamEvents, newWriteableStream } from '@theia/core/lib/common/stream';
 import { readFileIntoStream } from '../common/io';
-import { FileUri } from '@theia/core/lib/common/file-uri';
+import { Path } from '@theia/core/lib/common/path';
 
 @injectable()
 export class OPFSFileSystemProvider implements Disposable,
@@ -515,10 +515,14 @@ export class OPFSFileSystemProvider implements Disposable,
 }
 
 /**
- * Formats a URI or string resource to a file system path
+ * Formats a URI or string resource to a file system path.
+ *
+ * For browser-only mode with OPFS we always want POSIX-style paths,
+ * regardless of the underlying platform.
  */
 function formatPath(resource: URI | string): string {
-    return FileUri.fsPath(resource);
+    const uri = typeof resource === 'string' ? new URI(resource) : resource;
+    return uri.path.fsPath(Path.Format.Posix);
 }
 
 /**


### PR DESCRIPTION
#### What it does

Fix: #17111

This pull request fixes an issue in **browser-only** mode on **Windows** where the OPFS-based filesystem fails due to Windows-style paths being passed down to the underlying OPFS implementation.

Currently, `OPFSFileSystemProvider` uses:

```ts
function formatPath(resource: URI | string): string {
    return FileUri.fsPath(resource);
}
```

On Windows, `FileUri.fsPath` returns Windows-style paths such as `\workspace` or `C:\workspace`. These values are then forwarded to the `OPFSFileSystem` (from `opfs-worker`) and ultimately to the browser’s OPFS APIs (`getFileHandle`), which interpret them as invalid names and throw:

`TypeError: Failed to execute 'getFileHandle' on 'FileSystemDirectoryHandle': Name is not allowed.`

The PR modifies `formatPath` in `OPFSFileSystemProvider` so that, on Windows, it normalizes the path to a **POSIX-style path** before passing it to OPFS. This makes browser-only + OPFS work correctly on Windows without changing behavior on POSIX platforms.

The change addresses a bug where browser-only cannot reliably open a workspace (for example `#/workspace`) on Windows and workspace-related commands (including “Open Workspace”) fail or behave unexpectedly.

#### How to test

1. On **Windows**, clone the Theia repository and install dependencies:
   - `yarn` (or `npm install`)

2. Build and start the browser-only example:
   - `yarn build:browser-only`
   - `yarn start:browser-only`

3. In a Chromium-based browser (for example Chrome or Edge), open:
   - `http://localhost:3000/#/workspace`

4. Open the browser devtools **Console** and verify:
   - Before the fix (current behavior on master), you see an error like:
     - `TypeError: Failed to execute 'getFileHandle' on 'FileSystemDirectoryHandle': Name is not allowed.`
   - After applying this PR:
     - The error no longer appears.
     - If you add a temporary log in `OPFSFileSystemProvider.exists`:

       ```ts
       console.log('[OPFSFileSystemProvider.exists] path =', formatPath(resource));
       ```

       you should see POSIX-style paths such as:

       ```text
       "/workspace"
       ```

       instead of Windows-style `\workspace` or `C:\workspace`.

5. Functionally verify browser-only:
   - The application starts successfully on Windows.
   - Opening a workspace (for example `#/workspace`) works without OPFS errors.
   - Workspace-related commands (such as “Open Workspace” and file dialogs) function as expected.

#### Follow-ups

- None identified at this time.
- If desired, follow-up work could:
  - Add automated tests around OPFS path handling on Windows.
  - Document Windows-specific notes for browser-only + OPFS in the Theia documentation.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the changelog has been updated.

This change is not intended to be breaking. It only adjusts how paths are formatted for OPFS on Windows and should be transparent for existing consumers.

#### Attribution

N/A.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines.
- [ ] User-facing text is internationalized using the `nls` service (not applicable for this PR as it does not introduce new user-facing strings).

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with the review guidelines.

