### PR TITLE
Import `PreferenceProvider` directly from definition module

### DIFF
--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { interfaces } from 'inversify';
-import { bindRootContributionProvider, PreferenceProvider } from '../../common';
+import { bindRootContributionProvider } from '../../common';
 import { PreferenceScope, ValidPreferenceScopes } from '../../common/preferences/preference-scope';
 import { FrontendApplicationConfig } from '@theia/application-package/lib/application-props';
 import { isObject } from '../../common/types';
@@ -25,6 +25,7 @@ import { DefaultsPreferenceProvider } from '../../common/preferences/defaults-pr
 import { PreferenceLanguageOverrideService } from '../../common/preferences/preference-language-override-service';
 import { FrontendConfigPreferenceContribution } from './frontend-config-preference-contributions';
 import { bindPreferenceConfigurations } from '../../common/preferences/preference-configurations';
+import { PreferenceProvider } from '../../common/preferences/preference-provider';
 
 export function bindPreferenceSchemaProvider(bind: interfaces.Bind): void {
     bindPreferenceConfigurations(bind);


### PR DESCRIPTION
Fixes #17114

When importing via `common`, the symbol `PreferenceProvider` is undefined.


#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups
#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution
#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
