### PR TITLE
fix: hoist @lumino/widgets and @lumino/dragdrop to root node_modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4603,6 +4603,16 @@
       "integrity": "sha512-naYGUQn3e0CLtz/tjKOZP8SOBg0SW7EguhkxLpNUXlVUvx7rVsfr0VI22FVL+jgI0FbxXpEkxpSMxtK73jxJAg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@lumino/dragdrop": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-2.1.8.tgz",
+      "integrity": "sha512-5sBYkTka598+XsgjY2tWOC+WYCh9NEgx8RhLvQ3x+V182YhcpEXw38RWGQZyNpQ4m4vtQWKv42A26q+ae6sMwg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lumino/coreutils": "^2.2.2",
+        "@lumino/disposable": "^2.1.5"
+      }
+    },
     "node_modules/@lumino/keyboard": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@lumino/keyboard/-/keyboard-2.0.4.tgz",
@@ -4642,6 +4652,25 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lumino/algorithm": "^2.0.4"
+      }
+    },
+    "node_modules/@lumino/widgets": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-2.7.5.tgz",
+      "integrity": "sha512-i11PlbTsZYIvC/uhcC4FeeLnu/7vveG8WzXFbxPunjT1yGjleqQIPlpMOAJ5d4PwCKqeM8LYttYke6ZOXvXDLA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@lumino/algorithm": "^2.0.4",
+        "@lumino/commands": "^2.3.3",
+        "@lumino/coreutils": "^2.2.2",
+        "@lumino/disposable": "^2.1.5",
+        "@lumino/domutils": "^2.0.4",
+        "@lumino/dragdrop": "^2.1.8",
+        "@lumino/keyboard": "^2.0.4",
+        "@lumino/messaging": "^2.0.4",
+        "@lumino/properties": "^2.0.4",
+        "@lumino/signaling": "^2.1.5",
+        "@lumino/virtualdom": "^2.0.4"
       }
     },
     "node_modules/@malept/cross-spawn-promise": {
@@ -31241,35 +31270,6 @@
         "@theia/electron": {
           "optional": true
         }
-      }
-    },
-    "packages/core/node_modules/@lumino/dragdrop": {
-      "version": "2.1.8",
-      "resolved": "https://registry.npmjs.org/@lumino/dragdrop/-/dragdrop-2.1.8.tgz",
-      "integrity": "sha512-5sBYkTka598+XsgjY2tWOC+WYCh9NEgx8RhLvQ3x+V182YhcpEXw38RWGQZyNpQ4m4vtQWKv42A26q+ae6sMwg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lumino/coreutils": "^2.2.2",
-        "@lumino/disposable": "^2.1.5"
-      }
-    },
-    "packages/core/node_modules/@lumino/widgets": {
-      "version": "2.7.5",
-      "resolved": "https://registry.npmjs.org/@lumino/widgets/-/widgets-2.7.5.tgz",
-      "integrity": "sha512-i11PlbTsZYIvC/uhcC4FeeLnu/7vveG8WzXFbxPunjT1yGjleqQIPlpMOAJ5d4PwCKqeM8LYttYke6ZOXvXDLA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lumino/algorithm": "^2.0.4",
-        "@lumino/commands": "^2.3.3",
-        "@lumino/coreutils": "^2.2.2",
-        "@lumino/disposable": "^2.1.5",
-        "@lumino/domutils": "^2.0.4",
-        "@lumino/dragdrop": "^2.1.8",
-        "@lumino/keyboard": "^2.0.4",
-        "@lumino/messaging": "^2.0.4",
-        "@lumino/properties": "^2.0.4",
-        "@lumino/signaling": "^2.1.5",
-        "@lumino/virtualdom": "^2.0.4"
       }
     },
     "packages/core/node_modules/linkify-it": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does                                                                                                                                             
                                                                                                                                                                
Hoists `@lumino/widgets` and `@lumino/dragdrop` from nested `packages/core/node_modules/` to root `node_modules/` in package-lock.json. The packages were incorrectly nested after the v1.69.0 release, causing the `@lumino/widgets` patch to fail. This has no reall effect on the build, but the example applications currently do not apply the patch and hence would not have the needed lumino changes for secondary window support.

#### How to test

Run `npm install` and check the build log for the patch applying successfully:
```
    patch-package 8.0.1
    Applying patches...
    @lumino/widgets@2.7.5 ✔
```
It should NOT show the error `Error: Patch file found for package widgets which is not present at node_modules/@lumino/widgets`, e.g. like on current master build: https://github.com/eclipse-theia/theia/actions/runs/22619840954/job/65541838812#step:5:3419


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
