### PR TITLE
vscode api: Raise compatibility to webview content

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -199,9 +199,8 @@ globalThis.acquireVsCodeApi = (function() {
     };
 })();
 globalThis.acquireTheiaApi = acquireVsCodeApi;
-delete window.parent;
-delete window.top;
-delete window.frameElement;        
+window.parent = window;
+window.frameElement = null;
 `;
     }
 


### PR DESCRIPTION
#### What it does

The webview (or its  `acquireVsCodeApi` injector)
adds the vscode api but also deletes the properties `window.parent`, `window.top` and `window.frameElement`.

This voilates the HTML Spec and makes problems with some code like `if (window.parent === window)` to
detect if we are running in an iframe.

#### How to test

#### Follow-ups

#### Breaking changes

Yes, this affects [Hyrum's Law](https://www.hyrumslaw.com/) and https://xkcd.com/1172/ but detecting `acquireVsCodeApi` object itself feels to be cleaner anyway.

ref the similar PR in vscode https://github.com/microsoft/vscode/pull/253635

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
