### PR TITLE
Handle multiple args to webview console

### DIFF
--- a/packages/plugin-ext/src/main/browser/webview/pre/main.js
+++ b/packages/plugin-ext/src/main/browser/webview/pre/main.js
@@ -154,29 +154,29 @@ globalThis.acquireVsCodeApi = (function() {
 
     let state = ${state ? `JSON.parse(${JSON.stringify(state)})` : undefined};
 
-    const forwardConsoleLog = (level, msg, args) => {
+    const forwardConsoleLog = (level, msg, ...args) => {
         let message, optionalParams;
         try {
             if (msg) {
                 message = JSON.stringify(msg) ?? null;
             }
-            if (args) {
+            if (args.length > 0) {
                 optionalParams = JSON.stringify(args) ?? null;
             }
         } catch (e) {
             // Log non serializable objects inside of view
-            originalConsole[level](msg, args);
+            originalConsole[level](msg, ...args);
             return;
         }
         originalPostMessage({ command: 'onconsole', data: { level, message, optionalParams } }, targetOrigin);
     };
 
-    console.log = (message, args) => forwardConsoleLog('log', message, args);
-    console.info = (message, args) => forwardConsoleLog('info', message, args);
-    console.warn = (message, args) => forwardConsoleLog('warn', message, args);
-    console.error = (message, args) => forwardConsoleLog('error', message, args);
-    console.debug = (message, args) => forwardConsoleLog('debug', message, args);
-    console.trace = (message, args) => forwardConsoleLog('trace', message, args);
+    console.log = (message, ...args) => forwardConsoleLog('log', message, ...args);
+    console.info = (message, ...args) => forwardConsoleLog('info', message, ...args);
+    console.warn = (message, ...args) => forwardConsoleLog('warn', message, ...args);
+    console.error = (message, ...args) => forwardConsoleLog('error', message, ...args);
+    console.debug = (message, ...args) => forwardConsoleLog('debug', message, ...args);
+    console.trace = (message, ...args) => forwardConsoleLog('trace', message, ...args);
 
     return () => {
         if (acquired) {

--- a/packages/plugin-ext/src/main/browser/webview/webview.ts
+++ b/packages/plugin-ext/src/main/browser/webview/webview.ts
@@ -475,7 +475,7 @@ export class WebviewWidget extends BaseWidget implements StatefulWidget, Extract
     protected forwardConsoleLog(log: WebviewConsoleLog): void {
         const message = `[webview: ${this.identifier.id}] ${log.message ? JSON.parse(log.message) : undefined}`;
         if (log.optionalParams !== undefined) {
-            console[log.level](message, JSON.parse(log.optionalParams));
+            console[log.level](message, ...JSON.parse(log.optionalParams));
         } else {
             console[log.level](message);
         }


### PR DESCRIPTION
In https://github.com/eclipse-theia/theia/pull/13084 we got handling
 of console log messages with one single argument.
 But the calls can have multiple parameters:
 ```ts
 console.info("Called with some %s or object %o", 'string', {foo:1});
 ```

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

On the `postMessage` transport layer it now packs and serializes all parameters an transfer it to the host.

There it is pushed all parameters into the existing Logger infrastructure which itself was capable of handling multiple parameters.


#### How to test
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Load a webview with 
```ts
console.error("Called with some %s or object %o", 'string', {foo:1});
```

This should give an output similar to

> 2026-03-04T10:42:42.123Z root ERROR [webview: f76e2e33-1e7c-4c16-90f1-8b47655a230f] Called with some string or object {foo: 1}

fixes #17119 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

none

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
