### PR TITLE
Fix preference imports that refer to 'common'

### DIFF
--- a/packages/core/src/common/preferences/injectable-preference-proxy.ts
+++ b/packages/core/src/common/preferences/injectable-preference-proxy.ts
@@ -15,13 +15,16 @@
 // *****************************************************************************
 
 import { inject, injectable, postConstruct } from 'inversify';
-import { PreferenceSchema } from '../../common/preferences/preference-schema';
-import { Disposable, DisposableCollection, Emitter, Event, isObject, MaybePromise, PreferenceScope } from '../../common';
+import { PreferenceSchema } from './preference-schema';
 import { PreferenceChangeEvent, PreferenceEventEmitter, PreferenceProxy, PreferenceProxyOptions, PreferenceRetrieval } from './preference-proxy';
 import { PreferenceChange, PreferenceChangeImpl, PreferenceChanges, PreferenceService } from './preference-service';
 import { JSONValue } from '@lumino/coreutils';
 import { PreferenceProviderDataChange } from './preference-provider';
-import { OverridePreferenceName } from '../../common/preferences/preference-language-override-service';
+import { OverridePreferenceName } from './preference-language-override-service';
+import { isObject, MaybePromise } from '../types';
+import { DisposableCollection } from '../disposable';
+import { Emitter, Event } from '../event';
+import { PreferenceScope } from './preference-scope';
 
 export const PreferenceProxySchema = Symbol('PreferenceProxySchema');
 export interface PreferenceProxyFactory {

--- a/packages/core/src/common/preferences/preference-configurations.ts
+++ b/packages/core/src/common/preferences/preference-configurations.ts
@@ -15,8 +15,8 @@
 // *****************************************************************************
 
 import { injectable, inject, named, interfaces } from 'inversify';
-import URI from '../../common/uri';
-import { ContributionProvider, bindRootContributionProvider } from '../../common/contribution-provider';
+import URI from '../uri';
+import { ContributionProvider, bindRootContributionProvider } from '../contribution-provider';
 
 export const PreferenceConfiguration = Symbol('PreferenceConfiguration');
 export interface PreferenceConfiguration {

--- a/packages/core/src/common/preferences/preference-provider-impl.ts
+++ b/packages/core/src/common/preferences/preference-provider-impl.ts
@@ -17,11 +17,14 @@
 import debounce = require('p-debounce');
 import { injectable } from 'inversify';
 import { JSONObject } from '@lumino/coreutils';
-import URI from '../../common/uri';
-import { DisposableCollection, Emitter, Event, isObject, PreferenceLanguageOverrideService } from '../../common';
-import { Deferred } from '../../common/promise-util';
+import URI from '../uri';
+import { Emitter, Event } from '../event';
+import { Deferred } from '../promise-util';
 import { PreferenceScope } from './preference-scope';
 import { PreferenceProvider, PreferenceProviderDataChange, PreferenceProviderDataChanges, PreferenceResolveResult } from './preference-provider';
+import { DisposableCollection } from '../disposable';
+import { PreferenceLanguageOverrideService } from './preference-language-override-service';
+import { isObject } from '../types';
 
 export abstract class PreferenceProviderBase {
 

--- a/packages/core/src/common/preferences/preference-proxy.ts
+++ b/packages/core/src/common/preferences/preference-proxy.ts
@@ -16,12 +16,14 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { Disposable, Event, isObject, MaybePromise } from '../../common';
 import { PreferenceService } from './preference-service';
 import { PreferenceScope } from './preference-scope';
-import { IJSONSchema } from '../../common/json-schema';
-import { isThenable } from '../../common/promise-util';
-import { OverridePreferenceName } from '../../common/preferences/preference-language-override-service';
+import { IJSONSchema } from '../json-schema';
+import { isThenable } from '../promise-util';
+import { OverridePreferenceName } from './preference-language-override-service';
+import { isObject, MaybePromise } from '../types';
+import { Event } from '../event';
+import { Disposable } from '../disposable';
 
 /**
  * It is worth explaining the type for `PreferenceChangeEvent`:

--- a/packages/core/src/common/preferences/preference-service.ts
+++ b/packages/core/src/common/preferences/preference-service.ts
@@ -18,14 +18,17 @@
 
 import { JSONValue } from '@lumino/coreutils';
 import { inject, injectable, postConstruct } from 'inversify';
-import { Disposable, DisposableCollection, Emitter, Event, deepFreeze, unreachable } from '../../common';
-import { Deferred } from '../../common/promise-util';
-import URI from '../../common/uri';
+import { Disposable, DisposableCollection } from '../disposable';
+import { Emitter, Event } from '../event';
+import { Deferred } from '../promise-util';
+import URI from '../uri';
 import { OverridePreferenceName, PreferenceLanguageOverrideService } from './preference-language-override-service';
 import { PreferenceProvider, PreferenceProviderDataChange, PreferenceProviderDataChanges, PreferenceResolveResult, PreferenceUtils } from './preference-provider';
 import { PreferenceSchemaService } from './preference-schema';
 import { PreferenceScope } from './preference-scope';
 import { PreferenceConfigurations } from './preference-configurations';
+import { deepFreeze } from '../objects';
+import { unreachable } from '../types';
 
 /**
  * Representation of a preference change. A preference value can be set to `undefined` for a specific scope.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Dating to their time on the `browser` side, many preference files still had imports structured as though they themselves did not live in `common`. Most were harmless, but those from the `common/index.ts` were viciously circular, because the preference material was also exported from the same file. This PR cleans up all references to `common` in the imports in the preference files.

Fixes #17114
Closes #17115

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Check that you can run the `packages/core/src/browser/preferences/preference-service.spec.ts` using the 'Run Mocha Tests' debug configuration and that the tests pass when you do.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
