### PR TITLE
fix: surface duplicate VSIX installation error to user notification

### DIFF
--- a/packages/plugin-ext-vscode/src/node/local-vsix-file-plugin-deployer-resolver.ts
+++ b/packages/plugin-ext-vscode/src/node/local-vsix-file-plugin-deployer-resolver.ts
@@ -67,11 +67,11 @@ export class LocalVSIXFilePluginDeployerResolver extends LocalPluginDeployerReso
         const existingPlugins = this.pluginDeployerHandler.getDeployedPluginsById(unversionedId);
         if (existingPlugins.length > 0) {
             const existingVersions = existingPlugins.map(p => p.metadata.model.version);
-            console.log(
-                'Extension ' + unversionedId + ' (version(s): ' + existingVersions.join(', ') + ') is already installed.\n' +
-                'Uninstall the existing extension before installing a new version from VSIX.'
+            const error = new Error(
+                `Extension ${unversionedId} is already installed (version(s): ${existingVersions.join(', ')}).`
             );
-            return;
+            error.name = 'DuplicateExtensionError';
+            throw error;
         }
 
         // Check if the deployment directory already exists on disk

--- a/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
+++ b/packages/plugin-ext/src/main/node/plugin-deployer-impl.ts
@@ -181,6 +181,7 @@ export class PluginDeployerImpl implements PluginDeployer {
         const hasBeenVisited = (id: string) => visited.has(id) || (visited.add(id), false);
         const pluginsToDeploy = new Map<PluginIdentifiers.VersionedId, PluginDeployerEntry>();
         const unversionedIdsHandled = new Map<PluginIdentifiers.UnversionedId, string[]>();
+        const errors: Error[] = [];
 
         const queue: UnresolvedPluginEntry[] = [...plugins];
         while (queue.length) {
@@ -215,6 +216,7 @@ export class PluginDeployerImpl implements PluginDeployer {
                     }
                 } catch (e) {
                     console.error(`Failed to resolve plugins from '${entry.id}'`, e);
+                    errors.push(e instanceof Error ? e : new Error(String(e)));
                 }
             }));
             queue.length = 0;
@@ -228,6 +230,9 @@ export class PluginDeployerImpl implements PluginDeployer {
                     }
                 }
             }
+        }
+        if (pluginsToDeploy.size === 0 && errors.length > 0) {
+            throw errors[0];
         }
         return [...pluginsToDeploy.values()];
     }

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -266,7 +266,15 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
             await this.commandRegistry.executeCommand(VscodeCommands.INSTALL_EXTENSION_FROM_ID_OR_URI.id, fileURI);
             this.messageService.info(nls.localizeByDefault('Completed installing extension.', extensionName));
         } catch (e) {
-            this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName));
+            if (e instanceof Error && e.name === 'DuplicateExtensionError') {
+                this.messageService.error(
+                    nls.localize('theia/vsx-registry/duplicateVSIX',
+                        'Failed to install {0} from VSIX. The extension is already installed. Uninstall the existing extension before installing a new version from VSIX.',
+                        extensionName)
+                );
+            } else {
+                this.messageService.error(nls.localize('theia/vsx-registry/failedInstallingVSIX', 'Failed to install {0} from VSIX.', extensionName));
+            }
             console.warn(e);
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Follow-up to #16963

- Throw `DuplicateExtensionError` from the resolver instead of silently returning
- Propagate resolver errors through `resolvePlugins` when no plugins were resolved
- Show a localized user-facing notification when a duplicate VSIX install is detected

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- See steps in #16963

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
