### PR TITLE
Add size limit to getFileContent (follow up of eclipse-theia/theia#17055)

### DIFF
--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -32,6 +32,7 @@ import {
 import { ToolInvocationContext } from '@theia/ai-core';
 import { Container } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
 import { URI } from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ProblemManager } from '@theia/markers/lib/browser';
@@ -253,6 +254,420 @@ describe('FileContentFunction.getArgumentsShortLabel', () => {
     it('returns undefined when file key is missing', () => {
         const result = getArgumentsShortLabel(JSON.stringify({ path: 'src/index.ts' }));
         expect(result).to.be.undefined;
+    });
+
+    it('returns hasMore true when offset is provided', () => {
+        const result = getArgumentsShortLabel(JSON.stringify({ file: 'src/index.ts', offset: 10 }));
+        expect(result).to.deep.equal({ label: 'src/index.ts', hasMore: true });
+    });
+
+    it('returns hasMore true when limit is provided', () => {
+        const result = getArgumentsShortLabel(JSON.stringify({ file: 'src/index.ts', limit: 50 }));
+        expect(result).to.deep.equal({ label: 'src/index.ts', hasMore: true });
+    });
+
+    it('returns hasMore true when both offset and limit are provided', () => {
+        const result = getArgumentsShortLabel(JSON.stringify({ file: 'src/index.ts', offset: 10, limit: 50 }));
+        expect(result).to.deep.equal({ label: 'src/index.ts', hasMore: true });
+    });
+});
+
+describe('FileContentFunction handler', () => {
+    let container: Container;
+    let fileContentFunction: FileContentFunction;
+    // Mutable delegates — tests reassign these directly instead of casting the mock object.
+    let mockResolve: () => Promise<unknown>;
+    let mockRead: () => Promise<unknown>;
+    let mockReadStream: () => Promise<unknown>;
+    let mockMonacoWorkspace: MonacoWorkspace;
+    let mockPreferenceService: { get: <T>(path: string, defaultValue: T) => T };
+
+    const makeMockStream = (content: string) => {
+        const handlers: Record<string, Function> = {};
+        // Use setTimeout so the macro-task fires after all pending microtasks
+        // (including the await continuation that registers the listeners).
+        setTimeout(() => {
+            handlers['data']?.(content);
+            handlers['end']?.();
+        }, 0);
+        return {
+            on(event: string, cb: Function): void { handlers[event] = cb; },
+            pause(): void { },
+            resume(): void { },
+            destroy(): void { },
+            removeListener(): void { }
+        };
+    };
+
+    let disableJSDOMInner: () => void;
+    before(() => {
+        disableJSDOMInner = enableJSDOM();
+    });
+    after(() => {
+        disableJSDOMInner();
+    });
+
+    beforeEach(() => {
+        container = new Container();
+
+        const mockWorkspaceService = {
+            roots: [{ resource: new URI('file:///workspace') }]
+        } as unknown as WorkspaceService;
+
+        mockResolve = async () => ({
+            isFile: true,
+            isDirectory: false,
+            size: 1024,
+            resource: new URI('file:///workspace/test.txt')
+        });
+
+        mockRead = async () => ({ value: 'line1\nline2\nline3\nline4\nline5' });
+
+        mockReadStream = async () => ({ value: makeMockStream('line1\nline2\nline3\nline4\nline5') });
+
+        // The mock object is stable across a test; individual methods delegate to
+        // the mutable variables above so tests can substitute behaviour without
+        // the fragile `(obj as unknown as {…}).method = …` double-cast pattern.
+        const mockFileService = {
+            exists: async () => true,
+            resolve: () => mockResolve(),
+            read: () => mockRead(),
+            readStream: () => mockReadStream(),
+        } as unknown as FileService;
+
+        mockPreferenceService = {
+            get: <T>(_path: string, defaultValue: T) => defaultValue
+        };
+
+        mockMonacoWorkspace = {
+            getTextDocument: () => undefined
+        } as unknown as MonacoWorkspace;
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(MonacoWorkspace).toConstantValue(mockMonacoWorkspace);
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(FileContentFunction).toSelf();
+
+        fileContentFunction = container.get(FileContentFunction);
+    });
+
+    it('returns file content when file is within size limit', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt' }), undefined);
+        expect(result).to.equal('line1\nline2\nline3\nline4\nline5');
+    });
+
+    it('rejects without reading when on-disk size exceeds limit', async () => {
+        // Stat reports 512 KB; default limit is 256 KB
+        let readCalled = false;
+        mockResolve = async () => ({
+            isFile: true,
+            isDirectory: false,
+            size: 512 * 1024,
+            resource: new URI('file:///workspace/big.txt')
+        });
+        mockRead = async () => {
+            readCalled = true;
+            return { value: 'should not be read' };
+        };
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'big.txt' }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.sizeKB).to.equal(512);
+        expect(readCalled).to.be.false;
+    });
+
+    it('returns editor content when file is open in editor and within size limit', async () => {
+        let resolveCalled = false;
+        mockResolve = async () => {
+            resolveCalled = true;
+            return { isFile: true, isDirectory: false, size: 1024, resource: new URI('file:///workspace/open.txt') };
+        };
+        mockMonacoWorkspace.getTextDocument = () => ({
+            getText: () => 'editor content'
+        } as unknown as ReturnType<MonacoWorkspace['getTextDocument']>);
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'open.txt' }), undefined);
+
+        expect(result).to.equal('editor content');
+        expect(resolveCalled).to.be.false;
+    });
+
+    it('rejects editor content when it exceeds the size limit', async () => {
+        const bigContent = 'x'.repeat(512 * 1024);
+        mockMonacoWorkspace.getTextDocument = () => ({
+            getText: () => bigContent
+        } as unknown as ReturnType<MonacoWorkspace['getTextDocument']>);
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'open.txt' }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.sizeKB).to.equal(512);
+    });
+
+    it('returns sliced content with header when offset and limit are provided', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', offset: 1, limit: 2 }), undefined);
+
+        expect(result).to.include('[Lines 2\u20133 of 5 total.');
+        expect(result).to.include('line2\nline3');
+    });
+
+    it('returns sliced editor content with header when file is open and offset/limit are provided', async () => {
+        mockMonacoWorkspace.getTextDocument = () => ({
+            getText: () => 'alpha\nbeta\ngamma\ndelta\nepsilon'
+        } as unknown as ReturnType<MonacoWorkspace['getTextDocument']>);
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'open.txt', offset: 1, limit: 2 }), undefined);
+
+        expect(result).to.include('[Lines 2\u20133 of 5 total.');
+        expect(result).to.include('beta\ngamma');
+    });
+
+    it('does not call resolve() or read() for paginated disk reads, uses readStream instead', async () => {
+        // Stat would report huge file, but the streaming path bypasses both stat and read
+        let resolveCalled = false;
+        let readCalled = false;
+        mockResolve = async () => {
+            resolveCalled = true;
+            return {
+                isFile: true,
+                isDirectory: false,
+                size: 512 * 1024,
+                resource: new URI('file:///workspace/big.txt')
+            };
+        };
+        mockRead = async () => {
+            readCalled = true;
+            return { value: 'should not be read' };
+        };
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'big.txt', offset: 0, limit: 3 }), undefined);
+
+        // resolve and read are NOT called in the streaming path
+        expect(resolveCalled).to.be.false;
+        expect(readCalled).to.be.false;
+        expect(result).to.include('line1\nline2\nline3');
+    });
+
+    it('rejects when the requested slice itself exceeds the size limit', async () => {
+        const bigLine = 'x'.repeat(1024);
+        const bigContent = Array.from({ length: 300 }, () => bigLine).join('\n');
+        mockReadStream = async () => ({ value: makeMockStream(bigContent) });
+
+        const handler = fileContentFunction.getTool().handler;
+        // Reading all 300 lines × 1 KB each = ~300 KB, over the 256 KB default limit
+        const result = await handler(JSON.stringify({ file: 'big.txt', offset: 0, limit: 300 }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.resultSizeKB).to.be.greaterThan(256);
+    });
+
+    it('returns File not found error when file does not exist', async () => {
+        mockResolve = async () => { throw new Error('File not found'); };
+        mockRead = async () => { throw new Error('File not found'); };
+        mockReadStream = async () => { throw new Error('File not found'); };
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'nonexistent.txt' }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.equal('File not found');
+    });
+
+    it('rejects negative offset', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', offset: -1 }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('non-negative integer');
+    });
+
+    it('rejects fractional offset', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', offset: 1.5 }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('non-negative integer');
+    });
+
+    it('rejects negative limit', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', limit: -1 }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('positive integer');
+    });
+
+    it('rejects zero limit', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', limit: 0 }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('positive integer');
+    });
+
+    it('returns content from offset to end when only offset is provided', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', offset: 2 }), undefined);
+
+        expect(result).to.include('[Lines 3\u20135 of 5 total.');
+        expect(result).to.include('line3\nline4\nline5');
+    });
+
+    it('returns last line when offset is at boundary', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', offset: 4, limit: 1 }), undefined);
+
+        expect(result).to.include('[Lines 5\u20135 of 5 total.');
+        expect(result).to.include('line5');
+    });
+
+    it('returns empty content when offset is beyond end of file', async () => {
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt', offset: 100, limit: 5 }), undefined);
+
+        // slice beyond end returns empty array → empty joined string
+        expect(result).to.include('[Lines 101\u2013100 of 5 total.');
+    });
+
+    it('uses custom preference value for size limit', async () => {
+        // Set a very small limit of 1 KB
+        mockPreferenceService.get = <T>(_path: string, _defaultValue: T) => 1 as unknown as T;
+
+        const content = 'x'.repeat(2 * 1024); // 2 KB
+        mockRead = async () => ({ value: content });
+        mockResolve = async () => ({
+            isFile: true,
+            isDirectory: false,
+            size: 2 * 1024,
+            resource: new URI('file:///workspace/test.txt')
+        });
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt' }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.maxSizeKB).to.equal(1);
+    });
+
+    it('falls back to streaming when stat.size is undefined and file is within limit', async () => {
+        // stat does not include a size — the code must not treat this as "0 KB"
+        // but instead stream the file and succeed when content is small.
+        let readCalled = false;
+        mockResolve = async () => ({
+            isFile: true,
+            isDirectory: false,
+            size: undefined,
+            resource: new URI('file:///workspace/test.txt')
+        });
+        mockRead = async () => {
+            readCalled = true;
+            return { value: 'should not be used' };
+        };
+        // mockReadStream already returns the small 5-line fixture from beforeEach
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt' }), undefined);
+
+        expect(readCalled).to.be.false;
+        expect(result).to.include('line1');
+        // Full-file streaming fallback must NOT include the [Lines...] header
+        expect(result).to.not.include('[Lines');
+    });
+
+    it('returns size-limit error (not "File not found") when stat.size is undefined and streamed content exceeds limit', async () => {
+        // stat does not include a size; the streamed content is larger than the limit.
+        mockResolve = async () => ({
+            isFile: true,
+            isDirectory: false,
+            size: undefined,
+            resource: new URI('file:///workspace/big.txt')
+        });
+        const bigLine = 'x'.repeat(1024);
+        const bigContent = Array.from({ length: 300 }, () => bigLine).join('\n'); // ~300 KB
+        mockReadStream = async () => ({ value: makeMockStream(bigContent) });
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'big.txt' }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.error).to.include('offset');
+        expect(parsed.error).not.to.equal('File not found');
+    });
+
+    it('returns size-limit error (not "File not found") when fileService.read throws FILE_TOO_LARGE', async () => {
+        // Simulate a file system provider that enforces its own hard size limit below maxSizeKB.
+        // stat.size is present and within our configured limit, but read() still throws.
+        mockResolve = async () => ({
+            isFile: true,
+            isDirectory: false,
+            size: 100 * 1024, // 100 KB — under the 256 KB default limit
+            resource: new URI('file:///workspace/test.txt')
+        });
+        mockRead = async () => {
+            throw new FileOperationError('File too large', FileOperationResult.FILE_TOO_LARGE);
+        };
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt' }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.error).to.include('offset');
+        expect(parsed.maxSizeKB).to.equal(256);
+    });
+
+    it('returns size-limit error (not "File not found") when fileService.read throws FILE_EXCEEDS_MEMORY_LIMIT', async () => {
+        mockResolve = async () => ({
+            isFile: true,
+            isDirectory: false,
+            size: 100 * 1024,
+            resource: new URI('file:///workspace/test.txt')
+        });
+        mockRead = async () => {
+            throw new FileOperationError('Exceeds memory limit', FileOperationResult.FILE_EXCEEDS_MEMORY_LIMIT);
+        };
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'test.txt' }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.error).to.include('offset');
+        expect(parsed.maxSizeKB).to.equal(256);
+    });
+
+    it('returns size-limit error (not "File not found") when readStream throws FILE_TOO_LARGE for paginated read', async () => {
+        // This is the key scenario: files.maxFileSizeMB is lower than the file size,
+        // but the caller is trying to read a chunk with offset/limit.
+        // Before the fix, readStream would throw FILE_TOO_LARGE and the catch block
+        // would return "File not found".
+        mockReadStream = async () => {
+            throw new FileOperationError('File too large', FileOperationResult.FILE_TOO_LARGE);
+        };
+
+        const handler = fileContentFunction.getTool().handler;
+        const result = await handler(JSON.stringify({ file: 'big.txt', offset: 0, limit: 50 }), undefined);
+
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('size limit');
+        expect(parsed.error).to.include('offset');
+        expect(parsed.error).not.to.equal('File not found');
+        expect(parsed.maxSizeKB).to.equal(256);
     });
 });
 

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -17,7 +17,7 @@ import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core
 import { CancellationToken, Disposable, PreferenceService, URI, Path } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { FileStat } from '@theia/filesystem/lib/common/files';
+import { FileStat, FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import {
     FILE_CONTENT_FUNCTION_ID, GET_FILE_DIAGNOSTICS_ID,
@@ -26,7 +26,7 @@ import {
 } from '../common/workspace-functions';
 import ignore from 'ignore';
 import { Minimatch } from 'minimatch';
-import { CONSIDER_GITIGNORE_PREF, USER_EXCLUDE_PATTERN_PREF } from '../common/workspace-preferences';
+import { CONSIDER_GITIGNORE_PREF, FILE_CONTENT_MAX_SIZE_KB_PREF, USER_EXCLUDE_PATTERN_PREF } from '../common/workspace-preferences';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { ProblemManager } from '@theia/markers/lib/browser';
@@ -280,7 +280,12 @@ export class FileContentFunction implements ToolProvider {
                 'If the file is currently open in an editor with unsaved changes, returns the editor\'s current content (not the saved file on disk). ' +
                 'Binary files may not be readable and will return an error. ' +
                 'Use this tool to read file contents before making any edits with replacement functions. ' +
-                'Do NOT use this for files you haven\'t located yet - use findFilesByPattern or searchInWorkspace first.',
+                'Do NOT use this for files you haven\'t located yet - use findFilesByPattern or searchInWorkspace first. ' +
+                'Files exceeding the configured size limit will return an error. ' +
+                'It is recommended to read the whole file by not providing offset or limit parameters, ' +
+                'unless you expect it to be very large. ' +
+                'If the size limit is hit, do NOT attempt to read the full file in chunks using offset and limit — ' +
+                'this wastes context window. Use searchInWorkspace to find the specific content you need instead.',
             parameters: {
                 type: 'object',
                 properties: {
@@ -288,20 +293,30 @@ export class FileContentFunction implements ToolProvider {
                         type: 'string',
                         description: 'The relative path to the target file within the workspace (e.g., "src/index.ts", "package.json"). ' +
                             'Must be relative to the workspace root. Absolute paths and paths outside the workspace will result in an error.',
+                    },
+                    offset: {
+                        type: 'number',
+                        description: 'Zero-based line offset to start reading from (default: 0). ' +
+                            'Use together with limit to page through large files.'
+                    },
+                    limit: {
+                        type: 'number',
+                        description: 'Maximum number of lines to return. Defaults to the rest of the file.'
                     }
                 },
                 required: ['file']
             },
             handler: (arg_string: string, ctx?: ToolInvocationContext) => {
-                const file = this.parseArg(arg_string);
-                return this.getFileContent(file, ctx?.cancellationToken);
+                const { file, offset, limit } = this.parseArg(arg_string);
+                return this.getFileContent(file, ctx?.cancellationToken, offset, limit);
             },
             providerName: undefined,
             getArgumentsShortLabel: (args: string): { label: string; hasMore: boolean } | undefined => {
                 try {
                     const parsed = JSON.parse(args);
                     if (parsed && typeof parsed === 'object' && 'file' in parsed) {
-                        return { label: String(parsed.file), hasMore: false };
+                        const hasMore = 'offset' in parsed || 'limit' in parsed;
+                        return { label: String(parsed.file), hasMore };
                     }
                 } catch {
                     // ignore parse errors
@@ -320,14 +335,24 @@ export class FileContentFunction implements ToolProvider {
     @inject(MonacoWorkspace)
     protected readonly monacoWorkspace: MonacoWorkspace;
 
-    private parseArg(arg_string: string): string {
+    @inject(PreferenceService)
+    protected readonly preferences: PreferenceService;
+
+    private parseArg(arg_string: string): { file: string; offset?: number; limit?: number } {
         const result = JSON.parse(arg_string);
-        return result.file;
+        return { file: result.file, offset: result.offset, limit: result.limit };
     }
 
-    private async getFileContent(file: string, cancellationToken?: CancellationToken): Promise<string> {
+    private async getFileContent(file: string, cancellationToken?: CancellationToken, offset?: number, limit?: number): Promise<string> {
         if (cancellationToken?.isCancellationRequested) {
             return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+
+        if (offset !== undefined && (!Number.isInteger(offset) || offset < 0)) {
+            return JSON.stringify({ error: 'offset must be a non-negative integer.' });
+        }
+        if (limit !== undefined && (!Number.isInteger(limit) || limit <= 0)) {
+            return JSON.stringify({ error: 'limit must be a positive integer.' });
         }
 
         let targetUri: URI | undefined;
@@ -339,21 +364,174 @@ export class FileContentFunction implements ToolProvider {
             return JSON.stringify({ error: error.message });
         }
 
+        if (cancellationToken?.isCancellationRequested) {
+            return JSON.stringify({ error: 'Operation cancelled by user' });
+        }
+
+        const openEditorValue = this.monacoWorkspace.getTextDocument(targetUri.toString())?.getText();
+        const maxSizeKB = this.preferences.get<number>(FILE_CONTENT_MAX_SIZE_KB_PREF, 256);
+        const isEditorOpen = openEditorValue !== undefined;
+        const isPaginated = offset !== undefined || limit !== undefined;
+
+        if (isEditorOpen) {
+            return this.handleEditorContent(openEditorValue!, maxSizeKB, offset, limit);
+        } else if (isPaginated) {
+            return this.readStreamedSlice(targetUri, maxSizeKB, offset, limit);
+        } else {
+            return this.handleFullDiskRead(targetUri, maxSizeKB);
+        }
+    }
+
+    private handleEditorContent(content: string, maxSizeKB: number, offset?: number, limit?: number): string {
+        if (offset === undefined && limit === undefined) {
+            const sizeKB = this.sizeInKB(content);
+            if (sizeKB > maxSizeKB) {
+                return this.buildFileSizeLimitError(sizeKB, maxSizeKB);
+            }
+            return content;
+        }
+
+        const lines = content.split('\n');
+        const startOffset = offset ?? 0;
+        const sliced = limit !== undefined ? lines.slice(startOffset, startOffset + limit) : lines.slice(startOffset);
+        const result = sliced.join('\n');
+        const resultSizeKB = this.sizeInKB(result);
+        if (resultSizeKB > maxSizeKB) {
+            return this.buildSliceSizeLimitError(resultSizeKB, maxSizeKB);
+        }
+        const startLine = startOffset + 1;
+        const endLine = startOffset + sliced.length;
+        const header = `[Lines ${startLine}\u2013${endLine} of ${lines.length} total. Use offset and limit to read other ranges.]`;
+        return `${header}\n${result}`;
+    }
+
+    private async handleFullDiskRead(targetUri: URI, maxSizeKB: number): Promise<string> {
         try {
-            if (cancellationToken?.isCancellationRequested) {
-                return JSON.stringify({ error: 'Operation cancelled by user' });
+            const stat = await this.fileService.resolve(targetUri);
+            if (stat.size !== undefined) {
+                const statSizeKB = Math.round(stat.size / 1024);
+                if (statSizeKB > maxSizeKB) {
+                    return this.buildFileSizeLimitError(statSizeKB, maxSizeKB);
+                }
+            } else {
+                // Size is unknown from stat; use the streaming path to avoid loading
+                // an arbitrarily large file into memory, with a post-read size check.
+                return this.readStreamedSlice(targetUri, maxSizeKB);
             }
 
-            const openEditorValue = this.monacoWorkspace.getTextDocument(targetUri.toString())?.getText();
-            if (openEditorValue !== undefined) {
-                return openEditorValue;
+            const rawContent = (await this.fileService.read(targetUri)).value;
+            const sizeKB = this.sizeInKB(rawContent);
+            if (sizeKB > maxSizeKB) {
+                return this.buildFileSizeLimitError(sizeKB, maxSizeKB);
             }
-
-            const fileContent = await this.fileService.read(targetUri);
-            return fileContent.value;
+            return rawContent;
         } catch (error) {
+            if (error instanceof FileOperationError) {
+                if (error.fileOperationResult === FileOperationResult.FILE_TOO_LARGE ||
+                    error.fileOperationResult === FileOperationResult.FILE_EXCEEDS_MEMORY_LIMIT) {
+                    return this.buildFileSizeLimitError(undefined, maxSizeKB);
+                }
+            }
             return JSON.stringify({ error: 'File not found' });
         }
+    }
+
+    private async readStreamedSlice(
+        targetUri: URI, maxSizeKB: number, startLine?: number, limit?: number
+    ): Promise<string> {
+        const isPaginated = startLine !== undefined || limit !== undefined;
+        const effectiveStartLine = startLine ?? 0;
+
+        let streamValue: Awaited<ReturnType<typeof this.fileService.readStream>>['value'];
+        try {
+            // Bypass the files.maxFileSizeMB preference: the streaming path never loads the
+            // full file into memory, so the OS-level size cap is not appropriate here.
+            // Our own per-result maxSizeKB check still applies to the collected slice.
+            streamValue = (await this.fileService.readStream(targetUri, { limits: { size: Number.MAX_SAFE_INTEGER } })).value;
+        } catch (e) {
+            if (e instanceof FileOperationError &&
+                (e.fileOperationResult === FileOperationResult.FILE_TOO_LARGE ||
+                 e.fileOperationResult === FileOperationResult.FILE_EXCEEDS_MEMORY_LIMIT)) {
+                return JSON.stringify({
+                    error: 'File exceeds the configured ' + maxSizeKB + 'KB size limit. ' +
+                        'Use the \'offset\' (0-based) and \'limit\' parameters to read specific line ranges, ' +
+                        'or use searchInWorkspace to find specific content.',
+                    maxSizeKB
+                });
+            }
+            return JSON.stringify({ error: 'File not found' });
+        }
+
+        return new Promise<string>(resolve => {
+            let pending = '';
+            let lineIndex = 0;
+            const sliceLines: string[] = [];
+
+            streamValue.on('data', (chunk: string) => {
+                const parts = (pending + chunk).split('\n');
+                pending = parts.pop()!;
+                for (const line of parts) {
+                    if (lineIndex >= effectiveStartLine && (limit === undefined || lineIndex < effectiveStartLine + limit)) {
+                        sliceLines.push(line);
+                    }
+                    lineIndex++;
+                }
+            });
+
+            streamValue.on('end', () => {
+                if (pending.length > 0) {
+                    if (lineIndex >= effectiveStartLine && (limit === undefined || lineIndex < effectiveStartLine + limit)) {
+                        sliceLines.push(pending);
+                    }
+                    lineIndex++;
+                }
+                const result = sliceLines.join('\n');
+                const resultSizeKB = this.sizeInKB(result);
+                if (resultSizeKB > maxSizeKB) {
+                    const sizeError = isPaginated
+                        ? this.buildSliceSizeLimitError(resultSizeKB, maxSizeKB)
+                        : this.buildFileSizeLimitError(resultSizeKB, maxSizeKB);
+                    resolve(sizeError);
+                    return;
+                }
+                if (isPaginated) {
+                    const header =
+                        `[Lines ${effectiveStartLine + 1}\u2013${effectiveStartLine + sliceLines.length} of ${lineIndex} total. ` +
+                        'Use offset and limit to read other ranges.]';
+                    resolve(`${header}\n${result}`);
+                } else {
+                    resolve(result);
+                }
+            });
+
+            streamValue.on('error', () => resolve(JSON.stringify({ error: 'File not found' })));
+        });
+    }
+
+    private sizeInKB(content: string): number {
+        return Math.round(Buffer.byteLength(content, 'utf8') / 1024);
+    }
+
+    private buildFileSizeLimitError(sizeKB: number | undefined, maxSizeKB: number): string {
+        const sizeInfo = sizeKB !== undefined ? ` (${sizeKB}KB)` : '';
+        const result: Record<string, unknown> = {
+            error: `File exceeds the configured ${maxSizeKB}KB size limit${sizeInfo}. ` +
+                'Use the \'offset\' (0-based) and \'limit\' parameters to read specific line ranges, or use searchInWorkspace to find specific content.',
+            maxSizeKB
+        };
+        if (sizeKB !== undefined) {
+            result.sizeKB = sizeKB;
+        }
+        return JSON.stringify(result);
+    }
+
+    private buildSliceSizeLimitError(resultSizeKB: number, maxSizeKB: number): string {
+        return JSON.stringify({
+            error: 'Requested range exceeds the configured ' + maxSizeKB + 'KB size limit (' + resultSizeKB + 'KB). ' +
+                'Use a smaller limit to read fewer lines at a time.',
+            resultSizeKB,
+            maxSizeKB
+        });
     }
 }
 

--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -23,6 +23,7 @@ export const PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF = 'ai-features.promptTem
 export const PROMPT_TEMPLATE_ADDITIONAL_EXTENSIONS_PREF = 'ai-features.promptTemplates.TemplateExtensions';
 export const PROMPT_TEMPLATE_WORKSPACE_FILES_PREF = 'ai-features.promptTemplates.WorkspaceTemplateFiles';
 export const TASK_CONTEXT_STORAGE_DIRECTORY_PREF = 'ai-features.promptTemplates.taskContextStorageDirectory';
+export const FILE_CONTENT_MAX_SIZE_KB_PREF = 'ai-features.workspaceFunctions.fileContentMaxSizeKB';
 
 const CONFLICT_RESOLUTION_DESCRIPTION = 'When templates with the same ID (filename) exist in multiple locations, conflicts are resolved by priority: specific template files \
 (highest) > workspace directories > global directories (lowest).';
@@ -91,6 +92,16 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
                 ' If set to empty value, generated task contexts will be stored in memory rather than on disk.'
             ),
             default: '.prompts/task-contexts'
+        },
+        [FILE_CONTENT_MAX_SIZE_KB_PREF]: {
+            type: 'number',
+            title: nls.localize('theia/ai/workspace/fileContentMaxSizeKB/title', 'File Content Max Size (KB)'),
+            description: nls.localize('theia/ai/workspace/fileContentMaxSizeKB/description',
+                'Maximum size in kilobytes of the content returned by the getFileContent tool. ' +
+                'When reading a full file (no offset/limit), files exceeding this limit return an error. ' +
+                'When using offset and limit, only the requested range is checked against this limit.'),
+            default: 256,
+            minimum: 1
         }
     }
 };


### PR DESCRIPTION
#### What it does

Adds five commits to address review comments on the PR eclipse-theia/theia#17055 and issues I found in my own testing of it.

1. Implement fixes for critical issues from review: two correctness fixes
   - rewrote the preference description to accurately distinguish that full-file reads check the whole file size while offset/limit reads check only the requested range;
   - replaced .length / 1024 (UTF-16 code units) with new Blob([content]).size / 1024 (actual UTF-8 bytes) for accurate KB measurements on files with multi-byte characters.
3. Implement fixes for significant issues from review:
   - refactoring and robustness: extracted buildFileSizeLimitError / buildSliceSizeLimitError helper methods (DRY)
   - replaced a live preferences.get() call in the tool description with static text
   - added input validation
   - added tests for edge cases
5. Fix brittle mocking issue: cleaned up test mocks to preserve TypeScript type information instead of casting it away, so the compiler can detect API changes that would silently break the mocks.
6. Stream file contents for paginated reads: when the LLM provides offset/limit and the source is an on-disk file, read it via readStream instead of read so that only the requested lines are ever loaded into memory.
7. Fix file-not-found errors on too-large files: when FileService refused to read a file because it exceeded the files.maxFileSizeMB preference, the getFileContent tool was returning a misleading "File not found" error to the LLM rather than the pagination suggestion. Fixed by bypassing the files.maxFileSizeMB cap in the streaming path (since streaming never loads the full file into memory) and by properly recognising FILE_TOO_LARGE / FILE_EXCEEDS_MEMORY_LIMIT errors in catch blocks to return the correct guidance.

The latter two commits actually are key for the original motivation of the upstream PR: the original scenario required the LLM to analyze the format of very large files in order to compose scripts intended to process the data that they contain. This would never have worked without a streaming solution because these files are too large for the FileService to read in one shot anyways, so the original PR is effectively moot without streaming support.

#### How to test

According to the upstream PR description. Also, run the new tests in this PR and try asking an agent to analyze the structure of a file of 300 MB size or greater.

#### Follow-ups

None identified for this PR; they would all be upstream.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
