### PR TITLE
fix: allow reinstalling VSIX extension after uninstall

### DIFF
--- a/packages/plugin-ext-vscode/src/node/local-vsix-file-plugin-deployer-resolver.ts
+++ b/packages/plugin-ext-vscode/src/node/local-vsix-file-plugin-deployer-resolver.ts
@@ -16,7 +16,7 @@
 
 import * as path from 'path';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { PluginDeployerResolverContext, PluginDeployerHandler, PluginIdentifiers } from '@theia/plugin-ext';
+import { PluginDeployerResolverContext, PluginIdentifiers } from '@theia/plugin-ext';
 import { LocalPluginDeployerResolver } from '@theia/plugin-ext/lib/main/node/resolvers/local-plugin-deployer-resolver';
 import { PluginVSCodeEnvironment } from '../common/plugin-vscode-environment';
 import { isVSCodePluginFile } from './plugin-vscode-file-handler';
@@ -28,7 +28,6 @@ export class LocalVSIXFilePluginDeployerResolver extends LocalPluginDeployerReso
     static FILE_EXTENSION = '.vsix';
 
     @inject(PluginVSCodeEnvironment) protected readonly environment: PluginVSCodeEnvironment;
-    @inject(PluginDeployerHandler) protected readonly pluginDeployerHandler: PluginDeployerHandler;
 
     protected get supportedScheme(): string {
         return LocalVSIXFilePluginDeployerResolver.LOCAL_FILE;
@@ -60,24 +59,16 @@ export class LocalVSIXFilePluginDeployerResolver extends LocalPluginDeployerReso
             return;
         }
 
-        const unversionedId = PluginIdentifiers.componentsToUnversionedId(components);
         const versionedId = PluginIdentifiers.componentsToVersionedId(components);
-
-        // Check if an extension with this identity is already deployed in memory
-        const existingPlugins = this.pluginDeployerHandler.getDeployedPluginsById(unversionedId);
-        if (existingPlugins.length > 0) {
-            const existingVersions = existingPlugins.map(p => p.metadata.model.version);
-            const error = new Error(
-                `Extension ${unversionedId} is already installed (version(s): ${existingVersions.join(', ')}).`
-            );
-            error.name = 'DuplicateExtensionError';
-            throw error;
-        }
 
         // Check if the deployment directory already exists on disk
         if (await existsInDeploymentDir(this.environment, versionedId)) {
-            console.log(`[${pluginResolverContext.getOriginId()}]: Extension "${versionedId}" already exists in deployment dir`);
-            return;
+            const unversionedId = PluginIdentifiers.componentsToUnversionedId(components);
+            const error = new Error(
+                `Extension ${unversionedId} is already installed (version: ${components.version}).`
+            );
+            error.name = 'DuplicateExtensionError';
+            throw error;
         }
 
         const extensionDeploymentDir = await unpackToDeploymentDir(this.environment, localPath, versionedId);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes a regression introduced by #16963 where reinstalling a VSIX extension after uninstalling it (with reloads in between) would fail with a "duplicate extension" error.

The in-memory duplicate check via `getDeployedPluginsById` retained stale entries after uninstall because `uninstallPlugin` does not clear the `deployedBackendPlugins`/`deployedFrontendPlugins` maps (only `undeployPlugin` does). This caused a false `DuplicateExtensionError` on reinstall.

This PR replaces the in-memory check with a disk-based duplicate detection (`existsInDeploymentDir`) that throws `DuplicateExtensionError`, preserving the user-facing error notification from #17129. The disk-based check correctly reflects the actual state: the deployment directory is removed on uninstall so reinstalling succeeds, while true duplicates (e.g. same extension from differently-named VSIX files) are still detected.

#### How to test

1. Install an extension from a `.vsix` file
2. Reload the browser
3. Uninstall the extension
4. Reload the browser
5. Reinstall the same `.vsix` file
6. Verify the extension installs successfully
7. Try installing the same `.vsix` again without uninstalling — verify the duplicate error notification is shown

#### Follow-ups

None

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
