### PR TITLE
fix: file dialog path input on Windows

### DIFF
--- a/packages/filesystem/src/browser/location/location-renderer.spec.ts
+++ b/packages/filesystem/src/browser/location/location-renderer.spec.ts
@@ -19,6 +19,7 @@ let disableJSDOM = enableJSDOM();
 
 import URI from '@theia/core/lib/common/uri';
 import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
 import type { FileDialogModel } from '../file-dialog/file-dialog-model';
 import { LocationListRenderer } from './location-renderer';
 import type { LocationService } from './location-service';
@@ -37,6 +38,10 @@ class TestableLocationListRenderer extends LocationListRenderer {
 
     testTryRenderFirstMatch(inputElement: HTMLInputElement, children: string[]): void {
         this.tryRenderFirstMatch(inputElement, children);
+    }
+
+    testRenderSelectInput(): React.ReactNode {
+        return this.renderSelectInput();
     }
 }
 
@@ -157,6 +162,37 @@ describe('LocationListRenderer', () => {
             r.testTryRenderFirstMatch(input, children);
 
             expect(input.value).to.equal('/home/user/xyz');
+            r.dispose();
+        });
+    });
+
+    describe('renderSelectInput', () => {
+        it('should render select with value matching the current service location', () => {
+            const host = document.createElement('div');
+            const service = createMockService();
+            const location = URI.fromFilePath('/home/user/folder');
+            service.location = location;
+            const r = new TestableLocationListRenderer({ model: service as unknown as FileDialogModel, host });
+
+            const selectElement = r.testRenderSelectInput() as React.ReactElement;
+
+            expect(selectElement.props.value).to.equal(location.toString());
+            r.dispose();
+        });
+
+        it('should update select value when service location changes across drives', () => {
+            const host = document.createElement('div');
+            const service = createMockService();
+            service.location = URI.fromFilePath('/d:/Projects/theia');
+            const r = new TestableLocationListRenderer({ model: service as unknown as FileDialogModel, host });
+
+            // Simulate the model navigating to a different drive
+            const newLocation = URI.fromFilePath('/c:/Users');
+            service.location = newLocation;
+
+            const selectElement = r.testRenderSelectInput() as React.ReactElement;
+
+            expect(selectElement.props.value).to.equal(newLocation.toString());
             r.dispose();
         });
     });

--- a/packages/filesystem/src/browser/location/location-renderer.tsx
+++ b/packages/filesystem/src/browser/location/location-renderer.tsx
@@ -209,6 +209,7 @@ export class LocationListRenderer extends ReactRenderer {
         const options = this.collectLocations().map(value => this.renderLocation(value));
         return (
             <select className={`theia-select ${LocationListRenderer.Styles.LOCATION_LIST_CLASS}`}
+                value={this.service.location?.toString() ?? ''}
                 onChange={this.handleLocationChanged}>
                 {...options}
             </select>


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The location text input in the browser file dialog used `new URI(path)` to convert user-typed paths to URIs. On Windows, this treats the drive letter (e.g. `C:`) as a URI scheme instead of creating a proper `file://` URI, causing Enter key navigation to silently fail.

Use `URI.fromFilePath()` which correctly handles both Unix and Windows paths. Also fix autocomplete to recognize Windows drive-letter paths.

Fixes #17132

#### How to test

On Windows:

1. Open File > Open Workspace from File (or any action that opens the browser file dialog)
2. In the file dialog, click the pencil icon next to the location dropdown to switch to text input mode
3. Type a valid Windows path, e.g. C:\Users or D:\Projects
4. Press Enter
5. Expected: The file tree navigates to the typed directory and the input switches back to the
dropdown showing the new location
6. Previously: The edit was silently ignored; the location did not change

Also:
- Test autocomplete
- Make sure that there are no regressions on Linux / Mac

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
