### PR TITLE
fix: prevent title bar shift when opening *.md in preview

### DIFF
--- a/packages/core/src/browser/style/index.css
+++ b/packages/core/src/browser/style/index.css
@@ -78,13 +78,13 @@
 
 html,
 body {
+    overflow: hidden;
     height: 100vh;
 }
 
 body {
     margin: 0;
     padding: 0;
-    overflow: hidden;
     font-family: var(--theia-ui-font-family);
     background: var(--theia-editor-background);
     color: var(--theia-foreground);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Menu bar shift: The html element was missing overflow: hidden, allowing the browser to auto-scroll it (~29px) when focus changes, dropdowns open, or scrollIntoView is triggered by tree widgets. This pushed the custom title bar / menu bar out of the visible viewport. The fix adds overflow: hidden to the shared html, body CSS rule in @theia/core.

Fixes GH-15804

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

-  Menu bar shift:
    1. Set window.titleBarStyle to custom, reload
    2. Open a .md file and click "Open Preview to the Side"
    3. Verify the menu bar stays visible (no upward shift)
    4. Open long context menus, toggle sidebar panels (Explorer, Extensions), open the Output channel dropdown and verify no layout shift in any case
    5. Confirm document.documentElement.scrollTop stays 0 in DevTools

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Edit: During the investigation of the duplicated preview button we discovered, the theia/preview package might be deprectated, see https://github.com/eclipse-theia/theia/issues/17143

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
