### PR TITLE
Fix dropdown

### DIFF
--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -60,6 +60,7 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
     protected mountedListeners: Map<string, EventListenerOrEventListenerObject> = new Map();
     protected optimalWidth = 0;
     protected optimalHeight = 0;
+    protected resizeObserver: ResizeObserver | undefined;
 
     constructor(props: SelectComponentProps) {
         super(props);
@@ -148,14 +149,16 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         return optimal + 20; // Just to be safe, add another 20 pixels here
     }
 
-    protected attachListeners(): void {
-        const hide = (event: MouseEvent) => {
+   protected attachListeners(): void {
+        const hide = (event: Event) => {
             if (!this.dropdownRef.current?.contains(event.target as Node)) {
                 this.hide();
             }
         };
+        const hideOnResize = () => this.hide();
         this.mountedListeners.set('scroll', hide);
         this.mountedListeners.set('wheel', hide);
+        this.mountedListeners.set('resize', hideOnResize);
 
         let parent = this.fieldRef.current?.parentElement;
         while (parent) {
@@ -170,9 +173,43 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         for (const [key, listener] of this.mountedListeners.entries()) {
             window.addEventListener(key, listener);
         }
+
+        // Catch Lumino sash drags globally - observe the closest lm-Widget panel
+        const fieldEl = this.fieldRef.current;
+        const resizablePanel = fieldEl?.closest('.lm-Widget') ?? fieldEl?.parentElement;
+
+        if (resizablePanel && typeof ResizeObserver !== 'undefined') {
+            let lastWidth = 0;
+            let lastHeight = 0;
+            let isFirstFire = true;
+
+            this.resizeObserver = new ResizeObserver(entries => {
+                for (const entry of entries) {
+                    const { width, height } = entry.contentRect;
+
+                    // Ignore the initial automatic fire when the observer attaches
+                    if (isFirstFire) {
+                        lastWidth = width;
+                        lastHeight = height;
+                        isFirstFire = false;
+                        continue;
+                    }
+
+                    // Only hide if the panel dimensions actually changed by more than 2 pixels
+                    if (this.state.dimensions && (Math.abs(width - lastWidth) > 2 || Math.abs(height - lastHeight) > 2)) {
+                        this.hide();
+                    }
+
+                    lastWidth = width;
+                    lastHeight = height;
+                }
+            });
+            this.resizeObserver.observe(resizablePanel);
+        }
     }
 
     override componentWillUnmount(): void {
+        this.resizeObserver?.disconnect();
         if (this.mountedListeners.size > 0) {
             const eventListener = this.mountedListeners.get('scroll')!;
             let parent = this.fieldRef.current?.parentElement;


### PR DESCRIPTION
#### What it does
Fixes the preference select dropdown staying open and mispositioned when the browser window is resized or when the Lumino split-panel sash is dragged (which shifts the layout but does not fire a standard window resize event).

Closes #12619

#### How to test
1. Open **Settings** (File → Preferences → Open Settings UI)
2. Search for `editor.wordWrap`
3. Click the dropdown to open it
4. **Resize the browser window** by dragging its edge → dropdown should close ✅
5. Repeat steps 2-3, then **drag the sidebar sash** to shift the layout → dropdown should close ✅

#### Follow-ups
The fix uses `(this.selectComponent.current as any).hide()` to call the protected `hide()` method on `SelectComponent` without modifying the core widget. A potential follow-up would be to expose a public `close()` method on `SelectComponent` to avoid this cast. A technical debt issue could be created for this.

#### Breaking changes
- [ ] This PR introduces breaking changes and requires careful review.

#### Attribution
<!-- N/A -->

#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the `nls` service (no user-facing text introduced in this PR)

#### Reminder for reviewers
- As a reviewer, I agree to behave in accordance with the review guidelines