### PR TITLE
fix: git actions and SCM tree selection in diff editors 

### DIFF
--- a/packages/monaco/src/browser/monaco-diff-editor.ts
+++ b/packages/monaco/src/browser/monaco-diff-editor.ts
@@ -117,7 +117,7 @@ export class MonacoDiffEditor extends MonacoEditor {
     }
 
     override getResourceUri(): URI {
-        return new URI(this.originalModel.uri);
+        return new URI(this.modifiedModel.uri);
     }
     override createMoveToUri(resourceUri: URI): URI {
         const [left, right] = DiffUris.decode(this.uri);

--- a/packages/scm/src/browser/decorations/scm-decorations-service.ts
+++ b/packages/scm/src/browser/decorations/scm-decorations-service.ts
@@ -89,9 +89,7 @@ export class ScmDecorationsService {
         const currentRepo = this.scmService.selectedRepository;
         if (currentRepo) {
             try {
-                // Currently, the uri used here is specific to vscode.git; other SCM providers are thus not supported.
-                // See https://github.com/eclipse-theia/theia/pull/13104#discussion_r1494540628 for a detailed discussion.
-                const query = { path: editor.uri['codeUri'].fsPath, ref: '~' };
+                const query = { path: editor.uri['codeUri'].fsPath, ref: '' };
                 const uri = editor.uri.withScheme(currentRepo.provider.id).withQuery(JSON.stringify(query));
                 const previousResource = await this.resourceProvider(uri);
                 try {

--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -358,7 +358,10 @@ class DirtyDiffPeekView extends MonacoEditorPeekViewWidget {
     private updateActions(): void {
         this.clearActions();
         const { contextKeyService, menuModelRegistry } = this.widget;
-        contextKeyService.with({ originalResourceScheme: this.widget.previousRevisionUri.scheme }, () => {
+        contextKeyService.with({
+            originalResourceScheme: this.widget.previousRevisionUri.scheme,
+            originalResource: this.widget.previousRevisionUri.toString(),
+        }, () => {
             for (const menuPath of [SCM_CHANGE_TITLE_MENU, PLUGIN_SCM_CHANGE_TITLE_MENU]) {
                 const menu = menuModelRegistry.getMenu(menuPath);
                 if (menu) {

--- a/packages/scm/src/browser/scm-tree-widget.tsx
+++ b/packages/scm/src/browser/scm-tree-widget.tsx
@@ -361,9 +361,15 @@ export class ScmTreeWidget extends TreeWidget {
     }
 
     selectNodeByUri(uri: URI): void {
-        for (const group of this.model.groups) {
-            const sourceUri = new URI(uri.path.toString());
-            const id = `${group.id}:${sourceUri.toString()}`;
+        // Use the URI as-is without coercing the scheme.
+        // Only URIs whose scheme matches the SCM resource sourceUri scheme (typically 'file')
+        // will find a matching node. Diff editors for staged changes (git: scheme) won't match,
+        // which is correct VS Code behavior. See https://github.com/eclipse-theia/theia/issues/16412
+        const uriString = uri.toString();
+        // Iterate backwards (last group first) to match VS Code behavior.
+        const groups = this.model.groups;
+        for (let i = groups.length - 1; i >= 0; i--) {
+            const id = `${groups[i].id}:${uriString}`;
             const node = this.model.getNode(id);
             if (SelectableTreeNode.is(node)) {
                 this.model.selectNode(node);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

fix: git actions and SCM tree selection in diff editors 

Resolves GH-16412
Part of GH-17020

- Set `originalResource` context key (full URI) in dirty diff peek view so vscode.git's `when` clause regex can match for scm/change/title menu items (stage/revert hunk buttons)
- Return modified (right) model URI from MonacoDiffEditor.getResourceUri() so `resourceScheme` context key is correct in diff editors (`file` for unstaged, `git` for staged)
- Stop coercing URI scheme in ScmTreeWidget.selectNodeByUri() and iterate groups backwards to match VS Code behavior, preventing staged diffs from incorrectly selecting the unstaged entry
- Change quick diff ref from '~' to '' in ScmDecorationsService to match the URI format expected by vscode.git's diffInformation lookups

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Please check the linked issues to test the fixes

Dirty diff peek view actions:
- Open a file with unstaged changes
- Click a gutter decoration to open the dirty diff peek view
- Verify Stage/Revert actions are visible in the peek view's action bar verify the change is staged/reverted successfully

SCM tree selection with staged + unstaged changes:
- Stage a file, then edit it again so it appears in both Changes and Staged Changes
- Click the unstaged entry in the SCM panel and verify the diff editor opens for the unstaged diff and the correct (unstaged) entry is selected
- Click the staged entry in the SCM panel and verify the staged diff opens and the staged entry is selected

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

GH-16994, GH-17153: These will improve also a few other parts of the diff editor experience (un/staging, revert via context menu entries).

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
