### PR TITLE
fix: allow clicking into hover tooltips to select and copy content

### DIFF
--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -260,9 +260,11 @@ export class HoverService {
      * For interactive hovers, the hover remains visible to allow interaction with its elements.
      */
     protected listenForMouseClick(request: HoverRequest): void {
-        const handleMouseDown = (_e: MouseEvent) => {
-            const isInteractive = request.interactive;
-            if (!isInteractive) {
+        const handleMouseDown = (e: MouseEvent) => {
+            if (this.hoverHost.contains(e.target as Node)) {
+                return;
+            }
+            if (!request.interactive) {
                 this.cancelHover();
             }
         };

--- a/packages/core/src/browser/style/hover-service.css
+++ b/packages/core/src/browser/style/hover-service.css
@@ -29,6 +29,7 @@
   border: 1px solid var(--theia-editorHoverWidget-border);
   padding: var(--theia-ui-padding);
   max-width: var(--theia-hover-max-width);
+  user-select: text;
 }
 
 /* overwrite potentially different default user agent styles */


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-15986

- Check if mousedown target is inside the hover host before canceling, so clicks within the tooltip no longer dismiss it
- Add user-select: text to the hover CSS to ensure text is selectable

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Hover over an element that shows a static tooltip (e.g. title of any sidebar view like Explorer)
2. Click and drag or doubleclick to select text inside the tooltip, verify text selection works and content can be copied
3. Click outside the tooltip and verify it dismisses as expected
4. Hover over an element that shows an interactive tooltip (e.g. the language status bar item `{ }`)
5. Click an action in the hover tooltip, verify it stays open and does not dismiss

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
