### PR TITLE
fix: set workspace root as most recently used on unload

### DIFF
--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -19,12 +19,10 @@ import URI from '@theia/core/lib/common/uri';
 import { WorkspaceServer, UntitledWorkspaceService, WorkspaceFileService } from '../common';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { DEFAULT_WINDOW_HASH } from '@theia/core/lib/common/window';
-import {
-    FrontendApplicationContribution, LabelProvider
-} from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, LabelProvider, OnWillStopAction } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
-import { ILogger, Disposable, DisposableCollection, Emitter, Event, MaybePromise, MessageService, nls, ContributionProvider } from '@theia/core';
+import { ILogger, Disposable, DisposableCollection, Emitter, environment, Event, MaybePromise, MessageService, nls, ContributionProvider } from '@theia/core';
 import { WorkspacePreferences } from '../common/workspace-preferences';
 import * as jsoncparser from 'jsonc-parser';
 import * as Ajv from '@theia/core/shared/ajv';
@@ -340,9 +338,33 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
     }
 
     /**
-     * on unload, we set our workspace root as the last recently used on the backend.
+     * On unload, we set our workspace root as the last recently used on the backend.
+     *
+     * In the browser, we use `onStop` (fire-and-forget) because `onWillStop` actions
+     * are never executed during browser tab close and returning an `OnWillStopAction`
+     * would trigger an unwanted "Leave site?" confirmation dialog.
+     *
+     * In Electron, we use `onWillStop` so the workspace is persisted before the window closes.
      */
     onStop(): void {
+        if (!environment.electron.is()) {
+            this.setMostRecentlyUsedWorkspace();
+        }
+    }
+
+    onWillStop(): OnWillStopAction | undefined {
+        if (environment.electron.is() && this.workspace) {
+            return {
+                reason: 'Set workspace root as most recently used',
+                action: async () => {
+                    await this.setMostRecentlyUsedWorkspace();
+                    return true;
+                }
+            };
+        }
+    }
+
+    protected setMostRecentlyUsedWorkspace(): void {
         this.server.setMostRecentlyUsedWorkspace(this._workspace ? this._workspace.resource.toString() : '');
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes GH-16368

For the browser application it worked fine in the onStop hook, however not for the electron application (and hence also not in the Theia IDE). So I moved it to the onWillStop hook to ensure the most recently used workspace is saved.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the Electron example application and remeber the workspace
2. Open a new window and select some other workspace
3. Close the second workspace and then close the first workspace
4. Start the Electron example application again and verify the most recently used workspace (= our remembered first workspace, the last one closed) is opened.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
