### PR TITLE
ci: work around broken dash-licenses download URL temporarily

### DIFF
--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -51,4 +51,17 @@ jobs:
         shell: bash
         run: |
           npm ci
+          # Workaround: pre-download dash-licenses JAR since the @eclipse-dash/nodejs-wrapper
+          # uses a broken Nexus 2 URL after the repo.eclipse.org upgrade to Nexus 3.
+          # We use 1.1.1-SNAPSHOT because 1.0.2 and 1.1.0 incorrectly flag internal
+          # workspace packages (link:true with no version) as restricted.
+          # See: https://github.com/eclipse-dash/nodejs-wrapper/issues/7
+          # See: https://github.com/eclipse-dash/dash-licenses/issues/534
+          # TODO: remove this workaround once the nodejs-wrapper is updated (GH-17168)
+          DASH_JAR="node_modules/@eclipse-dash/nodejs-wrapper/download/dash-licenses.jar"
+          mkdir -p "$(dirname "$DASH_JAR")"
+          # Resolve the latest 1.1.1-SNAPSHOT timestamped JAR from the Maven metadata
+          SNAP_BASE="https://repo.eclipse.org/repository/dash-maven2-snapshots/org/eclipse/dash/org.eclipse.dash.licenses/1.1.1-SNAPSHOT"
+          SNAP_JAR=$(curl -s "$SNAP_BASE/maven-metadata.xml" | grep -oP '(?<=<value>)1\.1\.1-[^<]+' | tail -1)
+          curl -L "$SNAP_BASE/org.eclipse.dash.licenses-$SNAP_JAR.jar" -o "$DASH_JAR"
           npm run license:check


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Works around the broken `@eclipse-dash/nodejs-wrapper` download URL in the license check CI workflow. The wrapper uses a Nexus 2 redirect endpoint that stopped working after the `repo.eclipse.org` upgrade to Nexus 3.x, causing the JAR download to fail.

The fix pre-downloads the dash-licenses JAR using the correct Nexus 3 URL before invoking the wrapper.

Upstream issues:
- https://github.com/eclipse-dash/nodejs-wrapper/issues/7
- https://github.com/eclipse-dash/dash-licenses/issues/534
- https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7272

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The second commit triggers the license check CI by touching `package-lock.json`. Verify that the license check job can run the license check as the Jar is downloaded beforehand. 
Note: The second commit will be dropped before merging.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

GH-17168: Remove the workaround once the upstream `@eclipse-dash/nodejs-wrapper` is updated with the correct URL

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)