### PR TITLE
fix(ai-chat): forward change events for restored chat request models

### DIFF
--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -988,6 +988,11 @@ export class MutableChatModel implements ChatModel, Disposable {
                 respData
             );
             requestMap.set(requestModel.id, requestModel);
+            requestModel.onDidChange(event => {
+                if (!ChatChangeEvent.isChangeSetEvent(event)) {
+                    this._onDidChangeEmitter.fire(event);
+                }
+            }, this, this.toDispose);
         }
 
         // Restore the hierarchy structure with all alternatives


### PR DESCRIPTION
#### What it does

Fixes #16724
Fixes #17137

Restored chat sessions could not edit messages because restoreFromSerializedData() did not subscribe to onDidChange on request models, unlike addRequest(). Events like enableEdit were fired but never propagated to the tree widget for re-rendering.

#### How to test

1. Use the AI Chat and ask something
2. Restart Theia
3. Load the stored session via the "Show Chats..." button
4. Hover over the message and click the edit button
5. Observe: The message is editable
6. Click the cancel button (X)
7. Observe: The message is no longer editable
8. Click the edit button again, edit the message and send it
9. Observe: The edited request is processed as expected

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
