### PR TITLE
feat: implement textEditorDiffInformation proposed API

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -1075,6 +1075,35 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                 await open(this.openerService, uri, options);
             }
         });
+
+        // Temporary workaround: opens a single diff editor for the revealed resource.
+        // TODO: GH-16280 implement a proper MultiDiffEditor widget.
+        commands.registerCommand({ id: '_workbench.openMultiDiffEditor' }, {
+            execute: async (options: {
+                title: string;
+                resources?: { originalUri: UriComponents; modifiedUri: UriComponents }[];
+                reveal?: { modifiedUri: UriComponents };
+            }): Promise<void> => {
+                if (!options.resources?.length) {
+                    return;
+                }
+                const revealModified = options.reveal?.modifiedUri;
+                const revealStr = revealModified ? URI.revive(revealModified)?.toString() : undefined;
+                const target = revealStr
+                    ? options.resources.find(r => URI.revive(r.modifiedUri)?.toString() === revealStr)
+                    : undefined;
+                const resource = target ?? options.resources[0];
+                const left = URI.revive(resource.originalUri);
+                const right = URI.revive(resource.modifiedUri);
+                if (left && right) {
+                    await commands.executeCommand(VscodeCommands.DIFF.id, left, right, options.title);
+                } else if (right) {
+                    await commands.executeCommand(VscodeCommands.OPEN.id, right);
+                } else if (left) {
+                    await commands.executeCommand(VscodeCommands.OPEN.id, left);
+                }
+            },
+        });
     }
 
     private async deployPlugin(uri: TheiaURI | UriComponents): Promise<void> {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1248,9 +1248,22 @@ export interface TextEditorPositionData {
     [id: string]: EditorPosition;
 }
 
+export interface TextEditorDiffInformationDto {
+    readonly documentVersion: number;
+    readonly original: UriComponents | undefined;
+    readonly modified: UriComponents;
+    readonly changes: readonly {
+        readonly original: { readonly startLineNumber: number; readonly endLineNumberExclusive: number };
+        readonly modified: { readonly startLineNumber: number; readonly endLineNumberExclusive: number };
+        readonly kind: number;
+    }[];
+    readonly isStale: boolean;
+}
+
 export interface TextEditorsExt {
     $acceptEditorPropertiesChanged(id: string, props: EditorChangedPropertiesData): void;
     $acceptEditorPositionData(data: TextEditorPositionData): void;
+    $acceptEditorDiffInformation(id: string, diffInformation: TextEditorDiffInformationDto[] | undefined): void;
 }
 
 export interface SingleEditOperation {

--- a/packages/plugin-ext/src/main/browser/text-editor-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editor-main.ts
@@ -147,6 +147,10 @@ export class TextEditorMain implements Disposable {
         return this.editor.diffInformation;
     }
 
+    getDiffEditor(): MonacoDiffEditor | undefined {
+        return this.editor instanceof MonacoDiffEditor ? this.editor : undefined;
+    }
+
     setSelections(selections: Selection[]): void {
         if (this.editor) {
             this.editor.getControl().setSelections(selections);

--- a/packages/plugin-ext/src/main/browser/text-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/text-editors-main.ts
@@ -49,6 +49,11 @@ import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/stan
 import { ICodeEditorService } from '@theia/monaco-editor-core/esm/vs/editor/browser/services/codeEditorService';
 import { type ILineChange } from '@theia/monaco-editor-core/esm/vs/editor/common/diff/legacyLinesDiffComputer';
 import { ArrayUtils, URI } from '@theia/core';
+import { DiffUris } from '@theia/core/lib/browser/diff-uris';
+import { TextEditorChangeKind } from '../../plugin/types-impl';
+import { Change } from '@theia/scm/lib/browser/dirty-diff/diff-computer';
+import { DirtyDiffUpdate } from '@theia/scm/lib/browser/dirty-diff/dirty-diff-decorator';
+import { ScmDecorationsService } from '@theia/scm/lib/browser/decorations/scm-decorations-service';
 import { toNotebookWorspaceEdit } from './notebooks/notebooks-main';
 import { interfaces } from '@theia/core/shared/inversify';
 import { NotebookService } from '@theia/notebook/lib/browser';
@@ -62,6 +67,7 @@ export class TextEditorsMainImpl implements TextEditorsMain, Disposable {
 
     private readonly bulkEditService: MonacoBulkEditService;
     private readonly notebookService: NotebookService;
+    private readonly scmDecorationsService: ScmDecorationsService;
 
     constructor(
         private readonly editorsAndDocuments: EditorsAndDocumentsMain,
@@ -73,10 +79,12 @@ export class TextEditorsMainImpl implements TextEditorsMain, Disposable {
 
         this.bulkEditService = container.get(MonacoBulkEditService);
         this.notebookService = container.get(NotebookService);
+        this.scmDecorationsService = container.get(ScmDecorationsService);
 
         this.toDispose.push(editorsAndDocuments);
         this.toDispose.push(editorsAndDocuments.onTextEditorAdd(editors => editors.forEach(this.onTextEditorAdd, this)));
         this.toDispose.push(editorsAndDocuments.onTextEditorRemove(editors => editors.forEach(this.onTextEditorRemove, this)));
+        this.toDispose.push(this.scmDecorationsService.onDirtyDiffUpdate(update => this.onDirtyDiffUpdate(update)));
     }
 
     dispose(): void {
@@ -93,6 +101,130 @@ export class TextEditorsMainImpl implements TextEditorsMain, Disposable {
         );
         this.editorsToDispose.set(id, toDispose);
         this.toDispose.push(toDispose);
+
+        const diffEditor = editor.getDiffEditor();
+        if (diffEditor) {
+            const pushDiffEditorInfo = () => this.pushDiffEditorDiffInformation(id, editor);
+            toDispose.push(diffEditor.diffEditor.onDidUpdateDiff(pushDiffEditorInfo));
+            pushDiffEditorInfo();
+        }
+    }
+
+    private onDirtyDiffUpdate(update: DirtyDiffUpdate): void {
+        const editorUri = update.editor.uri.toString();
+        const editorIds = this.findEditorIdsByUri(editorUri, true);
+        if (editorIds.length === 0) {
+            return;
+        }
+
+        const originalUri = update.previousRevisionUri?.toComponents();
+
+        const changes = update.changes.map(change => {
+            let kind: TextEditorChangeKind;
+            if (Change.isAddition(change)) {
+                kind = TextEditorChangeKind.Addition;
+            } else if (Change.isRemoval(change)) {
+                kind = TextEditorChangeKind.Deletion;
+            } else {
+                kind = TextEditorChangeKind.Modification;
+            }
+            return {
+                original: {
+                    startLineNumber: change.previousRange.start + 1,
+                    endLineNumberExclusive: change.previousRange.end + 1
+                },
+                modified: {
+                    startLineNumber: change.currentRange.start + 1,
+                    endLineNumberExclusive: change.currentRange.end + 1
+                },
+                kind
+            };
+        });
+
+        // Push diff information to all editors with this URI (regular editors and diff editor modified sides).
+        for (const editorId of editorIds) {
+            const editor = this.editorsAndDocuments.getEditor(editorId);
+            if (!editor) {
+                continue;
+            }
+            const model = editor.getModel();
+            const modifiedUri = URI.fromComponents(model.uri).toComponents();
+            this.proxy.$acceptEditorDiffInformation(editorId, [{
+                documentVersion: model.getVersionId(),
+                original: originalUri,
+                modified: modifiedUri,
+                changes,
+                isStale: false
+            }]);
+        }
+    }
+
+    private pushDiffEditorDiffInformation(id: string, editor: TextEditorMain): void {
+        const diffEditor = editor.getDiffEditor();
+        if (!diffEditor) {
+            return;
+        }
+
+        let originalUri: UriComponents | undefined;
+        let modifiedUri: UriComponents;
+
+        try {
+            const [left, right] = DiffUris.decode(diffEditor.uri);
+            originalUri = left.toComponents();
+            modifiedUri = right.toComponents();
+        } catch {
+            // Not a valid DiffUri; fall back to model URIs
+            originalUri = new URI(diffEditor.originalModel.uri).toComponents();
+            modifiedUri = new URI(diffEditor.modifiedModel.uri).toComponents();
+        }
+
+        const lineChanges = diffEditor.diffInformation;
+
+        const changes = lineChanges.map(change => {
+            let kind: TextEditorChangeKind;
+            if (change.originalEndLineNumber === 0) {
+                kind = TextEditorChangeKind.Addition;
+            } else if (change.modifiedEndLineNumber === 0) {
+                kind = TextEditorChangeKind.Deletion;
+            } else {
+                kind = TextEditorChangeKind.Modification;
+            }
+
+            // ILineChange uses 1-based lines where 0 means empty range.
+            // TextEditorLineRange uses 1-based startLineNumber and endLineNumberExclusive.
+            const toLineRange = (start: number, end: number) => end === 0
+                ? { startLineNumber: start + 1, endLineNumberExclusive: start + 1 }
+                : { startLineNumber: start, endLineNumberExclusive: end + 1 };
+
+            return {
+                original: toLineRange(change.originalStartLineNumber, change.originalEndLineNumber),
+                modified: toLineRange(change.modifiedStartLineNumber, change.modifiedEndLineNumber),
+                kind
+            };
+        });
+
+        const model = editor.getModel();
+        this.proxy.$acceptEditorDiffInformation(id, [{
+            documentVersion: model.getVersionId(),
+            original: originalUri,
+            modified: modifiedUri,
+            changes,
+            isStale: false
+        }]);
+    }
+
+    private findEditorIdsByUri(uri: string, excludeDiffEditors = false): string[] {
+        const ids: string[] = [];
+        for (const id of this.editorsToDispose.keys()) {
+            const editor = this.editorsAndDocuments.getEditor(id);
+            if (editor && editor.getModel().uri.toString() === uri) {
+                if (excludeDiffEditors && editor.getDiffEditor()) {
+                    continue;
+                }
+                ids.push(id);
+            }
+        }
+        return ids;
     }
 
     private onTextEditorRemove(id: string): void {

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -22,10 +22,11 @@ import * as theia from '@theia/plugin';
 import * as model from '../common/plugin-api-rpc-model';
 import { CommandRegistryExt, PLUGIN_RPC_CONTEXT as Ext, CommandRegistryMain } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
-import { Disposable } from './types-impl';
+import { Disposable, URI } from './types-impl';
 import { DisposableCollection } from '@theia/core';
 import { KnownCommands } from './known-commands';
 import { ArgumentProcessor } from '../common/commands';
+import { isUriComponents } from './type-converters';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Handler = <T>(...args: any[]) => T | PromiseLike<T | undefined>;
@@ -42,6 +43,16 @@ export class CommandRegistryImpl implements CommandRegistryExt {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
         this.argumentProcessors = [];
         this.commandsConverter = new CommandsConverter(this);
+        this.registerArgumentProcessor({
+            processArgument: arg => {
+                // Revive URI-like plain objects that lost their class identity during RPC/JSON serialization
+                // (e.g. command arguments from markdown links parsed by CommandOpenHandler)
+                if (isUriComponents(arg) && !(arg instanceof URI)) {
+                    return URI.revive(arg);
+                }
+                return arg;
+            }
+        });
     }
 
     get converter(): CommandsConverter {

--- a/packages/plugin-ext/src/plugin/text-editors.ts
+++ b/packages/plugin-ext/src/plugin/text-editors.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { TextEditorsExt, EditorChangedPropertiesData, TextEditorPositionData, TextEditorsMain, PLUGIN_RPC_CONTEXT } from '../common/plugin-api-rpc';
+import { TextEditorsExt, EditorChangedPropertiesData, TextEditorPositionData, TextEditorsMain, PLUGIN_RPC_CONTEXT, TextEditorDiffInformationDto } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
 import * as theia from '@theia/plugin';
 import { Emitter, Event } from '@theia/core/lib/common/event';
@@ -120,7 +120,7 @@ export class TextEditorsExtImpl implements TextEditorsExt {
         return activeEditor.getDiffInformation();
     }
 
-    $acceptEditorDiffInformation(id: string, diffInformation: theia.TextEditorDiffInformation[] | undefined): void {
+    $acceptEditorDiffInformation(id: string, diffInformation: TextEditorDiffInformationDto[] | undefined): void {
         const textEditor = this.editorsAndDocuments.getEditor(id);
         if (!textEditor) {
             throw new Error('unknown text editor');


### PR DESCRIPTION
#### What it does

Resolves https://github.com/eclipse-theia/theia/issues/17153
Resolves https://github.com/eclipse-theia/theia/issues/16994

Implements the `textEditorDiffInformation` proposed API (#17153), which provides plugins with diff information for text editors. This also fixes the broken "Stage/Unstage Selected Range" context menu commands in the SCM diff editor (#16994), as the builtin git extension relies on `editor.diffInformation` to determine which hunks to stage.

- Adds `TextEditorDiffInformationDto` to the RPC protocol and wires up `$acceptEditorDiffInformation` from Main to Ext side
- Pushes dirty diff changes from `ScmDecorationsService` to regular editors, excluding diff editors which receive their own updates
- Pushes diff information from diff editors via `onDidUpdateDiff` with original/modified URIs from the `DiffUri`
- Registers a URI-reviving `ArgumentProcessor` in `CommandRegistryImpl` to fix "e.with is not a function" when command arguments lose URI class identity during JSON serialization
- Adds `_workbench.openMultiDiffEditor` stub as a single-file diff workaround until a proper MultiDiffEditor is implemented (#16280)

#### How to test

1. Make changes to a tracked file, open the SCM diff editor
2. Select a range, right-click and verify "Stage Selected Range" / "Unstage Selected Range" / "Revert Selected Range" work correctly
3. Verify that `vscode.window.activeTextEditor.diffInformation` is populated in both regular editors (dirty diff) and diff editors
4. Verify that the git blame status bar item and editor decorations work as described in #17153

#### Follow-ups

- #16280: Implement a proper MultiDiffEditor widget (currently stubbed as single-file diff)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
