### PR TITLE
Update default models for 1.70

### DIFF
--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -29,7 +29,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             id: 'default/code',
             defaultModelIds: [
                 'anthropic/claude-opus-4-6',
-                'openai/gpt-5.2',
+                'openai/gpt-5.4',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code/description', 'Optimized for code understanding and generation tasks.')
@@ -38,7 +38,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             id: 'default/universal',
             defaultModelIds: [
                 'anthropic/claude-opus-4-6',
-                'openai/gpt-5.2',
+                'openai/gpt-5.4',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/universal/description', 'Well-balanced for both code and general language use.')
@@ -46,8 +46,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code-completion',
             defaultModelIds: [
-                'openai/gpt-4.1',
-                'anthropic/claude-opus-4-6',
+                'anthropic/claude-sonnet-4-6',
+                'openai/gpt-5.4',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code-completion/description', 'Best suited for code autocompletion scenarios.')
@@ -56,7 +56,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             id: 'default/summarize',
             defaultModelIds: [
                 'anthropic/claude-opus-4-6',
-                'openai/gpt-5.2',
+                'openai/gpt-5.4',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/summarize/description', 'Models prioritized for summarization and condensation of content.')

--- a/packages/ai-google/src/common/google-preferences.ts
+++ b/packages/ai-google/src/common/google-preferences.ts
@@ -36,7 +36,7 @@ export const GooglePreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/google/models/description', 'Official Google Gemini models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['gemini-3.1-pro-preview', 'gemini-3-pro-preview', 'gemini-3-flash-preview'],
+            default: ['gemini-3.1-pro-preview', 'gemini-3-flash-preview'],
             items: {
                 type: 'string'
             }

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -36,9 +36,9 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             description: nls.localize('theia/ai/openai/models/description', 'Official OpenAI models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
             default: [
-                'gpt-5.2',
-                'gpt-5.2-pro',
-                'gpt-5-mini',
+                'gpt-5.4',
+                'gpt-5.4-pro',
+                'gpt-5.4-mini',
                 'gpt-4.1',
                 'gpt-4o'
             ],


### PR DESCRIPTION
#### What it does
Update default model list and model aliases

- remove Gemini 3 (deprecated
- Make GPT-5.4. new OpenAI default
- Replace code completion default with sonnet 4.6

#### How to test

Try all default models and aliases.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
