### PR TITLE
Improve the skill slash commands

### DIFF
--- a/packages/ai-core/src/browser/skill-prompt-coordinator.ts
+++ b/packages/ai-core/src/browser/skill-prompt-coordinator.ts
@@ -57,7 +57,7 @@ export class SkillPromptCoordinator implements FrontendApplicationContribution {
             if (!this.registeredSkillCommands.has(skill.name)) {
                 this.promptService.addBuiltInPromptFragment({
                     id: `skill-command-${skill.name}`,
-                    template: `{{skill:${skill.name}}}`,
+                    template: `Load the skill ${skill.name} using ~{getSkillFileContent}.`,
                     isCommand: true,
                     commandName: skill.name,
                     commandDescription: skill.description


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Instead of pasting the skills content actually let the LLM load the Skill. This has the advantage that it is clear to the LLM what is user prompt and what is Skill. This might be relevant for certain user messages.

@eneufeld Please let me know if you see any issues with this approach.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Add a skill via / to your user prompt.
See that the Skill gets loaded via tool call and that the AI History user message does not contain the full prompt.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
