### PR TITLE
fix(electron): revive skipped electron smoke test

### DIFF
--- a/examples/electron/test/basic-example.espec.ts
+++ b/examples/electron/test/basic-example.espec.ts
@@ -16,27 +16,71 @@
 
 import * as chai from 'chai';
 import * as path from 'path';
+import * as http from 'http';
+import { AddressInfo } from 'net';
 import { app, BrowserWindow } from 'electron';
 
 const expect = chai.expect;
 
-describe.skip('basic-example-spec', () => {
+const electronExampleDir = path.resolve(__dirname, '..', '..', '..');
 
-    const mainWindow: Electron.BrowserWindow = new BrowserWindow({ show: false });
-    mainWindow.on('ready-to-show', () => mainWindow.show());
+describe('basic-example-spec', function (): void {
+    this.timeout(60_000);
 
-    describe('01 #start example app', () => {
-        it('should start the electron example app', async () => {
-            if (!app.isReady()) {
-                await new Promise(resolve => app.on('ready', resolve));
-            }
+    let server: http.Server | undefined;
+    let mainWindow: BrowserWindow | undefined;
 
-            require('../src-gen/backend/main'); // start the express server
+    after(async () => {
+        if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.destroy();
+        }
+        if (server) {
+            await new Promise<void>(resolve => server!.close(() => resolve()));
+        }
+        // Remove all 'exit' listeners to prevent BackendApplication.onStop from
+        // calling terminateProcessTree, which crashes Chromium's GPU process on shutdown.
+        process.removeAllListeners('exit');
+        process.exit(0);
+    });
 
-            mainWindow.webContents.openDevTools();
-            mainWindow.loadURL(`file://${path.join(__dirname, 'index.html')}`);
+    it('should start the backend server', async () => {
+        if (!app.isReady()) {
+            await app.whenReady();
+        }
 
-            expect(mainWindow.isVisible()).to.be.true;
+        // Set the backend config before loading the server module, matching what main.js does
+        const { BackendApplicationConfigProvider } = require('@theia/core/lib/node/backend-application-config-provider');
+        BackendApplicationConfigProvider.set({
+            singleInstance: false,
+            configurationFolder: '.theia'
         });
+
+        // eslint-disable-next-line import/no-dynamic-require
+        const serverModule = require(path.join(electronExampleDir, 'src-gen', 'backend', 'server'));
+        server = await serverModule(0, 'localhost');
+        expect(server).to.not.be.undefined;
+
+        const address = server!.address() as AddressInfo;
+        expect(address).to.not.be.null;
+        expect(address.port).to.be.a('number').and.to.be.greaterThan(0);
+    });
+
+    it('should load the frontend in an Electron window', async () => {
+        expect(server).to.not.be.undefined;
+        const address = server!.address() as AddressInfo;
+
+        mainWindow = new BrowserWindow({
+            show: false,
+            webPreferences: {
+                nodeIntegration: false,
+                contextIsolation: true
+            }
+        });
+
+        const url = `http://localhost:${address.port}`;
+        await mainWindow.loadURL(url);
+
+        const title = mainWindow.webContents.getTitle();
+        expect(title).to.include('Theia Electron Example');
     });
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The electron example test has been skipped via `describe.skip` since 2017 and never updated to match the current architecture. This rewrites it to:

- Start the backend server on a random port using the generated server module
- Load the Theia frontend in a BrowserWindow and verify the window title
- Properly clean up server and window resources on teardown
- Handle Chromium GPU process shutdown gracefully in CI environments

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check the CI check

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
