### PR TITLE
fix: support image paste and fix clipboard in input fields

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -62,6 +62,7 @@ import { SubChatWidget, SubChatWidgetFactory } from './chat-tree-view/sub-chat-w
 import { ChatInputHistoryService } from './chat-input-history';
 import { ChatInputHistoryContribution } from './chat-input-history-contribution';
 import { ChatInputModeContribution } from './chat-input-mode-contribution';
+import { ChatInputPasteContribution } from './chat-input-paste-contribution';
 import { ChatInputFocusService } from './chat-input-focus-service';
 import { ChatFocusContribution } from './chat-focus-contribution';
 import { ChatCapabilitiesService, ChatCapabilitiesServiceImpl } from './chat-capabilities-service';
@@ -84,6 +85,10 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(ChatInputModeContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(ChatInputModeContribution);
     bind(KeybindingContribution).toService(ChatInputModeContribution);
+
+    bind(ChatInputPasteContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(ChatInputPasteContribution);
+    bind(KeybindingContribution).toService(ChatInputPasteContribution);
 
     bind(ChatFocusContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(ChatFocusContribution);

--- a/packages/ai-chat-ui/src/browser/chat-input-paste-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-paste-contribution.ts
@@ -1,0 +1,74 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Command, CommandContribution, CommandRegistry } from '@theia/core';
+import { CommonCommands, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { ChatInputFocusService } from './chat-input-focus-service';
+
+/**
+ * Handles Ctrl+V / Cmd+V in the chat input to paste images from the clipboard.
+ *
+ * In Electron, Theia's global paste command uses `document.execCommand('paste')`,
+ * which does not produce a DOM paste event for image clipboard content.
+ * In the browser, Monaco 1.108+'s EditContext API handles Ctrl+V internally
+ * without firing a DOM paste event.
+ *
+ * This contribution registers a higher-priority keybinding (scoped to `chatInputFocus`)
+ * that reads images from the clipboard via the async Clipboard API.
+ * For non-image clipboard content, it falls through to the default paste behavior.
+ */
+export const CHAT_INPUT_PASTE_COMMAND = Command.toLocalizedCommand({
+    id: 'chat-input:paste-with-image-support',
+    label: 'Paste (with image support)'
+}, 'theia/ai/chat-ui/chatInput/pasteWithImageSupport');
+
+@injectable()
+export class ChatInputPasteContribution implements CommandContribution, KeybindingContribution {
+
+    @inject(ChatInputFocusService)
+    protected readonly chatInputFocusService: ChatInputFocusService;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(CHAT_INPUT_PASTE_COMMAND, {
+            execute: () => this.execute(),
+            isEnabled: () => !!this.chatInputFocusService.getFocused()
+        });
+    }
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: CHAT_INPUT_PASTE_COMMAND.id,
+            keybinding: 'ctrlcmd+v',
+            when: 'chatInputFocus'
+        });
+    }
+
+    protected async execute(): Promise<void> {
+        const widget = this.chatInputFocusService.getFocused();
+        if (!widget) {
+            return;
+        }
+        const imagesPasted = await widget.pasteFromClipboard();
+        if (!imagesPasted) {
+            // No images found — trigger the default paste for text content
+            this.commandRegistry.executeCommand(CommonCommands.PASTE.id);
+        }
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -1036,38 +1036,79 @@ export class AIChatInputWidget extends ReactWidget {
     }
 
     protected onPaste(event: ClipboardEvent): void {
+        // Check synchronously whether the clipboard contains images.
+        // If so, prevent the default paste to avoid Monaco also inserting
+        // the text representation of the clipboard alongside our image reference.
+        const hasImages = this.clipboardDataHasImages(event.clipboardData);
+        if (hasImages) {
+            event.preventDefault();
+        }
         this.variableService.getPasteResult(event, { type: 'ai-chat-input-widget' }).then(result => {
-            const position = this.editorRef?.getControl().getPosition();
-            const textsToInsert: string[] = [];
+            this.processPasteResult(result);
+        });
+    }
 
-            result.variables.forEach(variable => {
-                if (ImageContextVariable.isImageContextRequest(variable)) {
-                    // Register with short ID and insert short reference at cursor position
-                    const shortId = this.registerPendingImage(variable);
-                    textsToInsert.push(`#${variable.variable.name}:${shortId}`);
-                } else {
-                    this.addContext(variable);
-                }
-            });
+    /**
+     * Paste images from the clipboard using the async Clipboard API.
+     * Called from the keybinding contribution when Ctrl+V is pressed in the chat input,
+     * because Electron/Theia's paste command (document.execCommand('paste')) does not
+     * produce a DOM paste event for image clipboard content.
+     * @returns true if images were found and pasted, false otherwise.
+     */
+    async pasteFromClipboard(): Promise<boolean> {
+        const result = await this.variableService.getPasteResult(
+            new ClipboardEvent('paste'), { type: 'ai-chat-input-widget' }
+        );
+        const hasImages = result.variables.some(v => ImageContextVariable.isImageContextRequest(v));
+        if (hasImages) {
+            this.processPasteResult(result);
+        }
+        return hasImages;
+    }
 
-            // Insert any text from the paste result
-            if (result.text) {
-                textsToInsert.push(result.text);
-            }
+    protected processPasteResult(result: { variables: AIVariableResolutionRequest[], text?: string }): void {
+        const position = this.editorRef?.getControl().getPosition();
+        const textsToInsert: string[] = [];
 
-            // Insert all collected text at cursor position
-            if (position && textsToInsert.length > 0) {
-                this.editorRef?.getControl().executeEdits('paste', [{
-                    range: {
-                        startLineNumber: position.lineNumber,
-                        startColumn: position.column,
-                        endLineNumber: position.lineNumber,
-                        endColumn: position.column
-                    },
-                    text: textsToInsert.join(' ')
-                }]);
+        result.variables.forEach(variable => {
+            if (ImageContextVariable.isImageContextRequest(variable)) {
+                // Register with short ID and insert short reference at cursor position
+                const shortId = this.registerPendingImage(variable);
+                textsToInsert.push(`#${variable.variable.name}:${shortId}`);
+            } else {
+                this.addContext(variable);
             }
         });
+
+        // Insert any text from the paste result
+        if (result.text) {
+            textsToInsert.push(result.text);
+        }
+
+        // Insert all collected text at cursor position
+        if (position && textsToInsert.length > 0) {
+            this.editorRef?.getControl().executeEdits('paste', [{
+                range: {
+                    startLineNumber: position.lineNumber,
+                    startColumn: position.column,
+                    endLineNumber: position.lineNumber,
+                    endColumn: position.column
+                },
+                text: textsToInsert.join(' ')
+            }]);
+        }
+    }
+
+    protected clipboardDataHasImages(clipboardData: DataTransfer | null): boolean {
+        if (!clipboardData?.items) {
+            return false;
+        }
+        for (const item of clipboardData.items) {
+            if (item.type.startsWith('image/')) {
+                return true;
+            }
+        }
+        return false;
     }
 
     protected onEscape(): void {

--- a/packages/ai-chat/src/browser/image-context-variable-contribution.ts
+++ b/packages/ai-chat/src/browser/image-context-variable-contribution.ts
@@ -209,44 +209,69 @@ export class ImageContextVariableContribution implements AIVariableContribution,
         return variable?.wsRelativePath ? this.makeAbsolute(variable.wsRelativePath) : undefined;
     }
 
-    async handlePaste(event: ClipboardEvent, context: AIVariableContext): Promise<AIVariablePasteResult | undefined> {
-        if (!event.clipboardData?.items) { return undefined; }
+    async handlePaste(event: ClipboardEvent, _context: AIVariableContext): Promise<AIVariablePasteResult | undefined> {
+        // Try event.clipboardData first (works with legacy textarea-based Monaco input),
+        // then fall back to navigator.clipboard.read() (works with EditContext-based input
+        // in Monaco 1.108+ where clipboardData may not contain image items).
+        const variables = await this.extractImagesFromClipboardData(event) ?? await this.extractImagesFromClipboardAPI();
+        return variables && variables.length > 0 ? { variables } : undefined;
+    }
+
+    protected async extractImagesFromClipboardData(event: ClipboardEvent): Promise<AIVariableResolutionRequest[] | undefined> {
+        if (!event.clipboardData?.items) {
+            return undefined;
+        }
 
         const variables: AIVariableResolutionRequest[] = [];
-
         for (const item of event.clipboardData.items) {
             if (item.type.startsWith('image/')) {
                 const blob = item.getAsFile();
                 if (blob) {
                     try {
-                        const dataUrl = await this.readFileAsDataURL(blob);
-                        // Extract the base64 data by removing the data URL prefix
-                        // Format is like: data:image/png;base64,BASE64DATA
-                        const imageData = dataUrl.substring(dataUrl.indexOf(',') + 1);
+                        const base64Data = await this.blobToBase64(blob);
                         variables.push(ImageContextVariable.createRequest({
-                            data: imageData,
+                            data: base64Data,
                             name: blob.name || `pasted-image-${Date.now()}.png`,
-                            mimeType: blob.type
+                            mimeType: blob.type || item.type
                         }));
                     } catch (error) {
-                        console.error('Failed to process pasted image:', error);
+                        this.logger.error('Failed to process pasted image from clipboardData:', error);
                     }
                 }
             }
         }
-
-        return variables.length > 0 ? { variables } : undefined;
+        return variables.length > 0 ? variables : undefined;
     }
 
-    private readFileAsDataURL(blob: Blob): Promise<string> {
+    protected async extractImagesFromClipboardAPI(): Promise<AIVariableResolutionRequest[] | undefined> {
+        try {
+            const clipboardItems = await navigator.clipboard.read();
+            const variables: AIVariableResolutionRequest[] = [];
+            for (const item of clipboardItems) {
+                const imageType = item.types.find(type => type.startsWith('image/'));
+                if (imageType) {
+                    const blob = await item.getType(imageType);
+                    const base64Data = await this.blobToBase64(blob);
+                    variables.push(ImageContextVariable.createRequest({
+                        data: base64Data,
+                        name: `pasted-image-${Date.now()}.${imageType.split('/')[1]}`,
+                        mimeType: imageType
+                    }));
+                }
+            }
+            return variables.length > 0 ? variables : undefined;
+        } catch (error) {
+            this.logger.error('Failed to read image from clipboard API:', error);
+            return undefined;
+        }
+    }
+
+    protected blobToBase64(blob: Blob): Promise<string> {
         return new Promise((resolve, reject) => {
             const reader = new FileReader();
-            reader.onload = e => {
-                if (!e.target?.result) {
-                    reject(new Error('Failed to read file as data URL'));
-                    return;
-                }
-                resolve(e.target.result as string);
+            reader.onload = () => {
+                const dataUrl = reader.result as string;
+                resolve(dataUrl.substring(dataUrl.indexOf(',') + 1));
             };
             reader.onerror = () => reject(reader.error);
             reader.readAsDataURL(blob);

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -159,7 +159,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     protected readonly undoRedoHandlerService: UndoRedoHandlerService;
 
     protected pinnedKey: ContextKey<boolean>;
-    protected inputFocus: ContextKey<boolean>;
 
     async configure(app: FrontendApplication): Promise<void> {
         // FIXME: This request blocks valuable startup time (~200ms).
@@ -174,9 +173,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         this.contextKeyService.createKey<boolean>('isMac', OS.type() === OS.Type.OSX);
         this.contextKeyService.createKey<boolean>('isWindows', OS.type() === OS.Type.Windows);
         this.contextKeyService.createKey<boolean>('isWeb', !this.isElectron());
-        this.inputFocus = this.contextKeyService.createKey<boolean>('inputFocus', false);
-        this.updateInputFocus();
-        browser.onDomEvent(document, 'focusin', () => this.updateInputFocus());
+        // Note: the 'inputFocus' context key is tracked by Monaco's ContextKeyService
+        // which sets it for <input>, <textarea>, and elements with EditContext (Monaco editors).
+        // We no longer track it separately to avoid race conditions between two focusin listeners.
 
         this.pinnedKey = this.contextKeyService.createKey<boolean>('activeEditorIsPinned', false);
         this.updatePinnedKey();
@@ -231,15 +230,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         document.body.classList.remove('theia-editor-highlightModifiedTabs');
         if (this.preferences['workbench.editor.highlightModifiedTabs']) {
             document.body.classList.add('theia-editor-highlightModifiedTabs');
-        }
-    }
-
-    protected updateInputFocus(): void {
-        const activeElement = document.activeElement;
-        if (activeElement) {
-            const isInput = activeElement.tagName?.toLowerCase() === 'input'
-                || activeElement.tagName?.toLowerCase() === 'textarea';
-            this.inputFocus.set(isInput);
         }
     }
 
@@ -498,7 +488,18 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         commandRegistry.registerCommand(CommonCommands.CUT, {
             execute: () => {
                 if (supportCut) {
-                    document.execCommand('cut');
+                    const active = document.activeElement;
+                    if (environment.electron.is() && (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement)) {
+                        const start = active.selectionStart ?? 0;
+                        const end = active.selectionEnd ?? 0;
+                        const selectedText = active.value.substring(start, end);
+                        if (selectedText) {
+                            this.clipboardService.writeText(selectedText);
+                            document.execCommand('insertText', false, '');
+                        }
+                    } else {
+                        document.execCommand('cut');
+                    }
                 } else {
                     this.messageService.warn(nls.localize('theia/core/cutWarn', "Please use the browser's cut command or shortcut."));
                 }
@@ -507,16 +508,34 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         commandRegistry.registerCommand(CommonCommands.COPY, {
             execute: () => {
                 if (supportCopy) {
-                    document.execCommand('copy');
+                    const active = document.activeElement;
+                    if (environment.electron.is() && (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement)) {
+                        const start = active.selectionStart ?? 0;
+                        const end = active.selectionEnd ?? 0;
+                        const selectedText = active.value.substring(start, end);
+                        if (selectedText) {
+                            this.clipboardService.writeText(selectedText);
+                        }
+                    } else {
+                        document.execCommand('copy');
+                    }
                 } else {
                     this.messageService.warn(nls.localize('theia/core/copyWarn', "Please use the browser's copy command or shortcut."));
                 }
             }
         });
         commandRegistry.registerCommand(CommonCommands.PASTE, {
-            execute: () => {
+            execute: async () => {
                 if (supportPaste) {
-                    document.execCommand('paste');
+                    const active = document.activeElement;
+                    if (environment.electron.is() && (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement)) {
+                        const text = await this.clipboardService.readText();
+                        if (text) {
+                            document.execCommand('insertText', false, text);
+                        }
+                    } else {
+                        document.execCommand('paste');
+                    }
                 } else {
                     this.messageService.warn(nls.localize('theia/core/pasteWarn', "Please use the browser's paste command or shortcut."));
                 }

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -345,7 +345,15 @@ export class DynamicMenuWidget extends MenuWidget {
                     const enabled = node.isEnabled(nodePath, ...(this.args || []));
                     const toggled = node.isToggled ? !!node.isToggled(nodePath, ...(this.args || [])) : false;
                     phCommandRegistry.addCommand(id, {
-                        execute: () => { node.run(nodePath, ...(this.args || [])); },
+                        execute: () => {
+                            // Restore focus to the previously focused element before executing
+                            // the command so that focus-dependent commands like clipboard
+                            // operations target the correct element instead of the menu.
+                            if (this.previousFocusedElement) {
+                                this.previousFocusedElement.focus({ preventScroll: true });
+                            }
+                            node.run(nodePath, ...(this.args || []));
+                        },
                         isEnabled: () => enabled,
                         isToggled: () => toggled,
                         isVisible: () => true,

--- a/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
+++ b/packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
@@ -233,12 +233,10 @@ export class ElectronMainMenuFactory extends BrowserMainMenuFactory {
                 }
             };
 
-            if (isOSX) {
-                const role = this.roleFor(menu.id);
-                if (role) {
-                    menuItem.role = role;
-                    delete menuItem.execute;
-                }
+            const role = this.roleFor(menu.id);
+            if (role) {
+                menuItem.role = role;
+                delete menuItem.execute;
             }
             parentItems.push(menuItem);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes GH-17179

Fixes clipboard-related regressions in Electron since the Monaco 1.108 upgrade (#17140), which uses the native EditContext API instead of a hidden textarea.

- Image paste in AI chat input (Ctrl+V)
   - With EditContext, Ctrl+V is handled internally by Monaco without firing a DOM `paste` event, so the chat input's image paste handler never triggers. Add a `ChatInputPasteContribution` with a keybinding scoped to `chatInputFocus` that reads images via the async Clipboard API and falls through to default paste for text. Also refactor `ImageContextVariableContribution` to fall back to `navigator.clipboard.read()` when `event.clipboardData` has no images.

- Clipboard shortcuts (Ctrl+V/X/C) in Electron input fields
   - Theia's global clipboard keybindings intercepted the event and called `document.execCommand('paste')`, which no longer works reliably with EditContext. Register passthrough keybindings when `inputFocus` is true so the browser handles clipboard natively. Remove Theia's redundant `inputFocus` tracking to avoid race conditions with Monaco's ContextKeyService which already tracks it.

- Context menu clipboard in Electron
   - Custom title bar: Restore focus to the previously focused element in `DynamicMenuWidget` before executing commands, and use Electron's clipboard API with `insertText` for native inputs.
   - Native title bar: Apply Electron menu roles (paste, cut, copy, etc.) on all platforms, not just macOS.

#### How to test

1. Image paste: Copy an image, focus the AI chat input, press Ctrl+V and verify image is attached
2. Clipboard shortcuts: In search or other input fields, verify Ctrl+C/V/X work reliably
3. Context menu (Electron): Right-click a native input field, select Paste and test with both native and custom title bar styles

#### Follow-ups

- Pasting images via the context menu in the AI chat input does not resolve them properly in browser app/custom title bar electron app (the context menu goes through `core.paste` instead of the image-aware paste contribution)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)