### PR TITLE
feat(keymaps): capture physical keystrokes for keybindings

### DIFF
--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -898,7 +898,7 @@ class EditKeybindingDialog extends SingleTextInputDialog {
      */
     protected resetButton: HTMLButtonElement | undefined;
 
-    //Tracks resources that need to be disposed of when the dialog closes.
+    // Tracks resources that need to be disposed of when the dialog closes.
     protected readonly keystrokeDisposable = new DisposableCollection();
 
     constructor(
@@ -949,8 +949,8 @@ class EditKeybindingDialog extends SingleTextInputDialog {
             return;
         }
 
-        //Only letting Enter and Escape bypass the capture
-        if(event.key === 'Enter' || event.key === 'Escape'){
+        // Only letting Enter and Escape bypass the capture
+        if (event.key === 'Enter' || event.key === 'Escape') {
             return;
         }
 
@@ -959,13 +959,13 @@ class EditKeybindingDialog extends SingleTextInputDialog {
 
         const keyCode = KeyCode.createKeyCode(event);
 
-        if(keyCode.isModifierOnly()){
+        if (keyCode.isModifierOnly()) {
             return;
         }
 
         const inputField = target as HTMLInputElement;
         inputField.value = keyCode.toString();
-        inputField.dispatchEvent(new window.Event('input', { bubbles: true}))
+        inputField.dispatchEvent(new window.Event('input', { bubbles: true}));
     };
 
     /**

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -922,7 +922,7 @@ class EditKeybindingDialog extends SingleTextInputDialog {
         setTimeout(() => {
             const inputField = this.node.querySelector('input');
             if (inputField) {
-                inputField.placeholder = nls.localizeByDefault('Press desired key combination...');
+                inputField.placeholder = nls.localizeByDefault('Press any key to continue...');
             }
         }, 100);
     }
@@ -935,11 +935,11 @@ class EditKeybindingDialog extends SingleTextInputDialog {
     protected handleKeyDown = (event: KeyboardEvent): void => {
         const target = event.target as HTMLElement;
         if (target.tagName.toLowerCase() !== 'input') {
-            return; 
+            return;
         }
 
         if (event.key === 'Enter' || event.key === 'Escape' || event.key === 'Tab' || event.key === 'Backspace') {
-            return; 
+            return;
         }
 
         event.preventDefault();
@@ -950,16 +950,16 @@ class EditKeybindingDialog extends SingleTextInputDialog {
         if (event.ctrlKey) { keys.push('ctrl'); }
         if (event.shiftKey) { keys.push('shift'); }
         if (event.altKey) { keys.push('alt'); }
-        if (event.metaKey) { keys.push('cmd'); } 
+        if (event.metaKey) { keys.push('cmd'); }
 
         const keyName = event.key.toLowerCase();
         const isModifier = ['control', 'shift', 'alt', 'meta'].includes(keyName);
 
         if (!isModifier) {
             let finalKey = keyName;
-            
-            if (finalKey === ' ') { 
-                finalKey = 'space'; 
+
+            if (finalKey === ' ') {
+                finalKey = 'space';
             }
             finalKey = finalKey.replace('arrow', '');
 
@@ -967,10 +967,10 @@ class EditKeybindingDialog extends SingleTextInputDialog {
 
             const inputField = target as HTMLInputElement;
             inputField.value = keys.join('+');
-            
+
             inputField.dispatchEvent(new window.Event('input', { bubbles: true }));
         }
-    }
+    };
 
     /**
      * Add `Reset` action used to reset a custom keybinding, and close the dialog.

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -24,11 +24,11 @@ import { Keybinding } from '@theia/core/lib/common/keybinding';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import {
     KeybindingRegistry, SingleTextInputDialog, KeySequence, ConfirmDialog, Message, KeybindingScope,
-    SingleTextInputDialogProps, Key, ScopedKeybinding, codicon, StatefulWidget, Widget, ContextMenuRenderer, SELECTED_CLASS
+    SingleTextInputDialogProps, Key, ScopedKeybinding, codicon, StatefulWidget, Widget, ContextMenuRenderer, SELECTED_CLASS, KeyCode
 } from '@theia/core/lib/browser';
 import { KeymapsService } from './keymaps-service';
 import { AlertMessage } from '@theia/core/lib/browser/widgets/alert-message';
-import { DisposableCollection, isOSX, isObject } from '@theia/core';
+import { DisposableCollection, Disposable, isOSX, isObject } from '@theia/core';
 import { nls } from '@theia/core/lib/common/nls';
 
 /**
@@ -898,6 +898,9 @@ class EditKeybindingDialog extends SingleTextInputDialog {
      */
     protected resetButton: HTMLButtonElement | undefined;
 
+    //Tracks resources that need to be disposed of when the dialog closes.
+    protected readonly keystrokeDisposable = new DisposableCollection();
+
     constructor(
         @inject(SingleTextInputDialogProps) props: SingleTextInputDialogProps,
         @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
@@ -917,14 +920,22 @@ class EditKeybindingDialog extends SingleTextInputDialog {
             this.addResetAction(this.resetButton, 'click');
         }
 
-        this.node.addEventListener('keydown', this.handleKeyDown, true);
+        window.addEventListener('keydown', this.handleKeyDown, { capture: true });
+        this.keystrokeDisposable.push(Disposable.create(() => {
+            window.removeEventListener('keydown', this.handleKeyDown, { capture: true });
+        }));
 
         setTimeout(() => {
             const inputField = this.node.querySelector('input');
             if (inputField) {
-                inputField.placeholder = nls.localizeByDefault('Press any key to continue...');
+                inputField.placeholder = nls.localizeByDefault('Press desired key combination and then press ENTER.');
             }
         }, 100);
+    }
+
+    protected override onBeforeDetach(msg: Message): void {
+        super.onBeforeDetach(msg);
+        this.keystrokeDisposable.dispose();
     }
 
     /**
@@ -938,38 +949,23 @@ class EditKeybindingDialog extends SingleTextInputDialog {
             return;
         }
 
-        if (event.key === 'Enter' || event.key === 'Escape' || event.key === 'Tab' || event.key === 'Backspace') {
+        //Only letting Enter and Escape bypass the capture
+        if(event.key === 'Enter' || event.key === 'Escape'){
             return;
         }
 
         event.preventDefault();
         event.stopPropagation();
 
-        const keys: string[] = [];
+        const keyCode = KeyCode.createKeyCode(event);
 
-        if (event.ctrlKey) { keys.push('ctrl'); }
-        if (event.shiftKey) { keys.push('shift'); }
-        if (event.altKey) { keys.push('alt'); }
-        if (event.metaKey) { keys.push('cmd'); }
-
-        const keyName = event.key.toLowerCase();
-        const isModifier = ['control', 'shift', 'alt', 'meta'].includes(keyName);
-
-        if (!isModifier) {
-            let finalKey = keyName;
-
-            if (finalKey === ' ') {
-                finalKey = 'space';
-            }
-            finalKey = finalKey.replace('arrow', '');
-
-            keys.push(finalKey);
-
-            const inputField = target as HTMLInputElement;
-            inputField.value = keys.join('+');
-
-            inputField.dispatchEvent(new window.Event('input', { bubbles: true }));
+        if(keyCode.isModifierOnly()){
+            return;
         }
+
+        const inputField = target as HTMLInputElement;
+        inputField.value = keyCode.toString();
+        inputField.dispatchEvent(new window.Event('input', { bubbles: true}))
     };
 
     /**

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -722,11 +722,12 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
      */
     addKeybinding(item: KeybindingItem): void {
         const command = item.command.id;
-        const dialog = new SingleTextInputDialog({
+        const dialog = new EditKeybindingDialog({
             title: nls.localize('theia/keymaps/addKeybindingTitle', 'Add Keybinding for {0}', item.labels.command.value),
             maxWidth: 400,
             validate: newKeybinding => this.validateKeybinding(command, undefined, newKeybinding),
-        });
+        }, this.keymapsService, item, false);
+
         dialog.open().then(async keybinding => {
             if (keybinding) {
                 await this.keymapsService.setKeybinding({
@@ -880,6 +881,7 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
         }
     }
 }
+
 /**
  * Dialog used to edit keybindings, and reset custom keybindings.
  */
@@ -904,7 +906,6 @@ class EditKeybindingDialog extends SingleTextInputDialog {
     ) {
         super(props);
         this.item = item;
-        // Add the `Reset` button if the command currently has a custom keybinding.
         if (canReset) {
             this.appendResetButton();
         }
@@ -914,6 +915,60 @@ class EditKeybindingDialog extends SingleTextInputDialog {
         super.onAfterAttach(msg);
         if (this.resetButton) {
             this.addResetAction(this.resetButton, 'click');
+        }
+
+        this.node.addEventListener('keydown', this.handleKeyDown, true);
+
+        setTimeout(() => {
+            const inputField = this.node.querySelector('input');
+            if (inputField) {
+                inputField.placeholder = nls.localizeByDefault('Press desired key combination...');
+            }
+        }, 100);
+    }
+
+    /**
+     * Intercepts keystrokes to format them into the expected keybinding string representation.
+     * Prevents default browser text input for non-navigation keys.
+     * @param event the keyboard event.
+     */
+    protected handleKeyDown = (event: KeyboardEvent): void => {
+        const target = event.target as HTMLElement;
+        if (target.tagName.toLowerCase() !== 'input') {
+            return; 
+        }
+
+        if (event.key === 'Enter' || event.key === 'Escape' || event.key === 'Tab' || event.key === 'Backspace') {
+            return; 
+        }
+
+        event.preventDefault();
+        event.stopPropagation();
+
+        const keys: string[] = [];
+
+        if (event.ctrlKey) { keys.push('ctrl'); }
+        if (event.shiftKey) { keys.push('shift'); }
+        if (event.altKey) { keys.push('alt'); }
+        if (event.metaKey) { keys.push('cmd'); } 
+
+        const keyName = event.key.toLowerCase();
+        const isModifier = ['control', 'shift', 'alt', 'meta'].includes(keyName);
+
+        if (!isModifier) {
+            let finalKey = keyName;
+            
+            if (finalKey === ' ') { 
+                finalKey = 'space'; 
+            }
+            finalKey = finalKey.replace('arrow', '');
+
+            keys.push(finalKey);
+
+            const inputField = target as HTMLInputElement;
+            inputField.value = keys.join('+');
+            
+            inputField.dispatchEvent(new window.Event('input', { bubbles: true }));
         }
     }
 
@@ -935,10 +990,8 @@ class EditKeybindingDialog extends SingleTextInputDialog {
      * @returns the `Reset` button.
      */
     protected appendResetButton(): HTMLButtonElement {
-        // Create the `Reset` button.
         const resetButtonTitle = nls.localizeByDefault('Reset');
         this.resetButton = this.createButton(resetButtonTitle);
-        // Add the `Reset` button to the dialog control panel, before the `Accept` button.
         this.controlPanel.insertBefore(this.resetButton, this.acceptButton!);
         this.resetButton.title = nls.localizeByDefault('Reset Keybinding');
         this.resetButton.classList.add('secondary');

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -725,7 +725,7 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
         const dialog = new EditKeybindingDialog({
             title: nls.localize('theia/keymaps/addKeybindingTitle', 'Add Keybinding for {0}', item.labels.command.value),
             maxWidth: 400,
-            validate: (newKeybinding, mode) => mode === 'preview' && !newKeybinding ? '' : this.validateKeybinding(command, oldKeybinding?.keybinding, newKeybinding),
+            validate: (newKeybinding, mode) => mode === 'preview' && !newKeybinding ? '' : this.validateKeybinding(command, undefined, newKeybinding),
         }, this.keymapsService, item, false);
         dialog.open().then(async keybinding => {
             if (keybinding) {

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -898,6 +898,10 @@ class EditKeybindingDialog extends SingleTextInputDialog {
 
     // Tracks resources that need to be disposed of when the dialog closes.
     protected readonly keystrokeDisposable = new DisposableCollection();
+
+    protected chordPrefix: string | undefined;
+    protected chordTimeout: number | undefined;
+
     constructor(
         @inject(SingleTextInputDialogProps) props: SingleTextInputDialogProps,
         @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
@@ -959,7 +963,30 @@ class EditKeybindingDialog extends SingleTextInputDialog {
         }
 
         const inputField = target as HTMLInputElement;
-        inputField.value = keyCode.toString();
+        const keyString = keyCode.toString();
+
+        // Clear any existing timeout since a new key was pressed
+        if (this.chordTimeout !== undefined) {
+            window.clearTimeout(this.chordTimeout);
+            this.chordTimeout = undefined;
+        }
+
+        if (this.chordPrefix) {
+            // This is the second keystroke of a chord
+            inputField.value = `${this.chordPrefix} ${keyString}`;
+            this.chordPrefix = undefined; // Reset for the next full capture
+        } else {
+            // This is the first keystroke
+            inputField.value = keyString;
+            this.chordPrefix = keyString;
+
+            // Wait 2 seconds for a potential second keystroke to form a chord
+            this.chordTimeout = window.setTimeout(() => {
+                this.chordPrefix = undefined;
+                this.chordTimeout = undefined;
+            }, 2000);
+        }
+
         inputField.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
 

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -934,6 +934,10 @@ class EditKeybindingDialog extends SingleTextInputDialog {
     }
     protected override onBeforeDetach(msg: Message): void {
         super.onBeforeDetach(msg);
+        if (this.chordTimeout !== undefined) {
+            window.clearTimeout(this.chordTimeout);
+            this.chordTimeout = undefined;
+        }
         this.keystrokeDisposable.dispose();
     }
 

--- a/packages/keymaps/src/browser/keybindings-widget.tsx
+++ b/packages/keymaps/src/browser/keybindings-widget.tsx
@@ -673,7 +673,7 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
             title: nls.localize('theia/keymaps/editKeybindingTitle', 'Edit Keybinding for {0}', item.labels.command.value),
             maxWidth: 400,
             initialValue: oldKeybinding?.keybinding,
-            validate: newKeybinding => this.validateKeybinding(command, oldKeybinding?.keybinding, newKeybinding),
+            validate: (newKeybinding, mode) => mode === 'preview' && !newKeybinding ? '' : this.validateKeybinding(command, oldKeybinding?.keybinding, newKeybinding),
         }, this.keymapsService, item, this.canResetKeybinding(item));
         dialog.open().then(async keybinding => {
             if (keybinding && keybinding !== oldKeybinding?.keybinding) {
@@ -725,9 +725,8 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
         const dialog = new EditKeybindingDialog({
             title: nls.localize('theia/keymaps/addKeybindingTitle', 'Add Keybinding for {0}', item.labels.command.value),
             maxWidth: 400,
-            validate: newKeybinding => this.validateKeybinding(command, undefined, newKeybinding),
+            validate: (newKeybinding, mode) => mode === 'preview' && !newKeybinding ? '' : this.validateKeybinding(command, oldKeybinding?.keybinding, newKeybinding),
         }, this.keymapsService, item, false);
-
         dialog.open().then(async keybinding => {
             if (keybinding) {
                 await this.keymapsService.setKeybinding({
@@ -881,7 +880,6 @@ export class KeybindingWidget extends ReactWidget implements StatefulWidget {
         }
     }
 }
-
 /**
  * Dialog used to edit keybindings, and reset custom keybindings.
  */
@@ -900,7 +898,6 @@ class EditKeybindingDialog extends SingleTextInputDialog {
 
     // Tracks resources that need to be disposed of when the dialog closes.
     protected readonly keystrokeDisposable = new DisposableCollection();
-
     constructor(
         @inject(SingleTextInputDialogProps) props: SingleTextInputDialogProps,
         @inject(KeymapsService) protected readonly keymapsService: KeymapsService,
@@ -909,6 +906,7 @@ class EditKeybindingDialog extends SingleTextInputDialog {
     ) {
         super(props);
         this.item = item;
+        // Add the `Reset` button if the command currently has a custom keybinding.
         if (canReset) {
             this.appendResetButton();
         }
@@ -919,12 +917,10 @@ class EditKeybindingDialog extends SingleTextInputDialog {
         if (this.resetButton) {
             this.addResetAction(this.resetButton, 'click');
         }
-
         window.addEventListener('keydown', this.handleKeyDown, { capture: true });
         this.keystrokeDisposable.push(Disposable.create(() => {
             window.removeEventListener('keydown', this.handleKeyDown, { capture: true });
         }));
-
         setTimeout(() => {
             const inputField = this.node.querySelector('input');
             if (inputField) {
@@ -932,7 +928,6 @@ class EditKeybindingDialog extends SingleTextInputDialog {
             }
         }, 100);
     }
-
     protected override onBeforeDetach(msg: Message): void {
         super.onBeforeDetach(msg);
         this.keystrokeDisposable.dispose();
@@ -965,7 +960,7 @@ class EditKeybindingDialog extends SingleTextInputDialog {
 
         const inputField = target as HTMLInputElement;
         inputField.value = keyCode.toString();
-        inputField.dispatchEvent(new window.Event('input', { bubbles: true}));
+        inputField.dispatchEvent(new window.Event('input', { bubbles: true }));
     };
 
     /**
@@ -986,8 +981,10 @@ class EditKeybindingDialog extends SingleTextInputDialog {
      * @returns the `Reset` button.
      */
     protected appendResetButton(): HTMLButtonElement {
+        // Create the `Reset` button.
         const resetButtonTitle = nls.localizeByDefault('Reset');
         this.resetButton = this.createButton(resetButtonTitle);
+        // Add the `Reset` button to the dialog control panel, before the `Accept` button.
         this.controlPanel.insertBefore(this.resetButton, this.acceptButton!);
         this.resetButton.title = nls.localizeByDefault('Reset Keybinding');
         this.resetButton.classList.add('secondary');


### PR DESCRIPTION
#### What it does
Fixes #17194

This replaces the manual text-entry approach with a keystroke listener in the EditKeybindingDialog, significantly improving UX by capturing real keyboard events instead of requiring users to manually type out string representations.

Currently, users have to manually type out keybinding strings (e.g., "Ctrl+Alt+P") when reassigning a shortcut, which is prone to syntax typos.

This PR:

Intercepts keydown events during the capture phase when the EditKeybindingDialog is active.

Automatically parses modifier keys (ctrl, shift, alt, cmd) and standardizes special keys (like formatting ArrowUp to up and   to space).

Prevents the default browser text-input behavior for standard keys, while allowing navigation/control keys (Enter, Escape, Tab, Backspace) to pass through normally.

Automatically populates the input field with the correctly formatted string and triggers the underlying validation engine.

#### How to test

- Build and start the browser example (yarn start in examples/browser).
- Open the Keyboard Shortcuts widget from the command palette or menu.
- Click the edit (pencil) icon next to any command.
- Observe the new localized placeholder text: "Press desired key combination..."
- Press a physical key combination on your keyboard (e.g., Ctrl + Shift + L).
- Verify that the input box immediately captures the keystroke, formats it as ctrl+shift+l, and triggers the validation check.
- Verify that pressing Enter successfully saves the new keybinding, and pressing Escape cancels the dialog.

#### Follow-ups

- collision detection currently only flags USER-scope bindings (see KeybindingRegistry.containsKeybindingInScope); broadening it to default keybindings and improving the collision message

#### Breaking changes
- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the nls service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers
- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)