### PR TITLE
fix: prevent Chat UI crash when tool call returns a primitive value

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -76,8 +76,9 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
         if (!result) {
             return undefined;
         }
-        if (typeof result === 'string') {
-            return <pre>{JSON.stringify(result, undefined, 2)}</pre>;
+        // eslint-disable-next-line no-null/no-null
+        if (typeof result !== 'object' || result === null) {
+            return <pre>{String(result)}</pre>;
         }
         if ('content' in result) {
             return <div className='theia-toolCall-response-content'>


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Guard against non-object values (numbers, booleans, etc.) before using the `in` operator in `renderResult`, fixing a TypeError when a tool call result is parsed into a primitive by `JSON.parse`.

Fixes #17202

#### How to test

1. Create a file whose content is just the number 3
2. Ask an agent in the chat view to retrieve the content of the file
3. The getFileContent just returns the content of the file, which, when parsed, is converted to the number 3
4. Observe that the chat ui still works and no error is printed in the console

#### Follow-ups

No direct follow ups. We could consider adapting our tall calls to always return object results. However for defense-in-depth we need to be able to handle non-object results anyway.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
