### PR TITLE
fix: restrict clipboard/selectAll Monaco handlers to editor text focus

### DIFF
--- a/packages/monaco/src/browser/monaco-command.ts
+++ b/packages/monaco/src/browser/monaco-command.ts
@@ -44,6 +44,18 @@ export namespace MonacoCommands {
         ['editor.action.clipboardPasteAction', CommonCommands.PASTE.id]
     ]);
 
+    /**
+     * Actions that directly manipulate input content (clipboard, select all).
+     * These should only be handled when the editor's text area has focus,
+     * not when an overlay widget (e.g. find/replace) or an unrelated input has focus.
+     */
+    export const INPUT_ACTIONS = new Set([
+        'editor.action.selectAll',
+        'editor.action.clipboardCutAction',
+        'editor.action.clipboardCopyAction',
+        'editor.action.clipboardPasteAction'
+    ]);
+
     export const GO_TO_DEFINITION = 'editor.action.revealDefinition';
 
     export const EXCLUDE_ACTIONS = new Set([
@@ -138,13 +150,21 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
             if (MonacoCommands.EXCLUDE_ACTIONS.has(id)) {
                 continue;
             }
+            const isCommonAction = MonacoCommands.COMMON_ACTIONS.has(id);
+            const isInputAction = MonacoCommands.INPUT_ACTIONS.has(id);
             const handler: CommandHandler = {
                 execute: (...args) => {
                     /*
                      * We check monaco focused code editor first since they can contain inline like the debug console and embedded editors like in the peek reference.
                      * If there is not such then we check last focused editor tracked by us.
+                     * For input actions (clipboard, select all), we require the editor to have text focus
+                     * (not just widget focus). This avoids intercepting operations meant for native input
+                     * fields, including inputs inside Monaco's own overlay widgets like find/replace.
                      */
-                    const editor = codeEditorService.getFocusedCodeEditor() || codeEditorService.getActiveCodeEditor();
+                    const focusedEditor = codeEditorService.getFocusedCodeEditor();
+                    const editor = isInputAction
+                        ? (focusedEditor?.hasTextFocus() ? focusedEditor : undefined)
+                        : focusedEditor || codeEditorService.getActiveCodeEditor();
                     if (editorActions.has(id)) {
                         const action = editor && editor.getAction(id);
                         if (!action) {
@@ -161,13 +181,20 @@ export class MonacoEditorCommandHandlers implements CommandContribution {
                     );
                 },
                 isEnabled: () => {
-                    const editor = codeEditorService.getFocusedCodeEditor() || codeEditorService.getActiveCodeEditor();
+                    // For input actions (clipboard, select all), only claim enabled when the editor
+                    // has text focus (not just widget focus). This allows fallback handlers to handle
+                    // these actions in native inputs, including inputs inside Monaco's own overlay
+                    // widgets like the find/replace widget.
+                    const focusedEditor = codeEditorService.getFocusedCodeEditor();
+                    const editor = isInputAction
+                        ? (focusedEditor?.hasTextFocus() ? focusedEditor : undefined)
+                        : focusedEditor || codeEditorService.getActiveCodeEditor();
 
                     if (editorActions.has(id)) {
                         const action = editor && editor.getAction(id);
                         return !!action && action.isSupported();
                     }
-                    if (!!EditorExtensionsRegistry.getEditorCommand(id) || MonacoCommands.COMMON_ACTIONS.has(id)) {
+                    if (!!EditorExtensionsRegistry.getEditorCommand(id) || isCommonAction) {
                         return !!editor;
                     }
                     return true;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Follow-up of GH-17189

After the initial fix for the Ctrl+V paste of images in the AI input field, it surfaced that for other Theia inputs, like the search input, sometimes the paste stops  
  working. This was happening after switching between a Theia input and a Monaco editor.
                                                                                                                                                                         
  Additionally, paste/copy/cut/selectAll did not work in Monaco's own overlay widgets like the find/replace widget.                                                      
                                                     
  Root cause:                                                                                                                                                            
  - Monaco registers handlers for common actions (paste, copy, cut,                                        
    selectAll, find, replace) via COMMON_ACTIONS mapping
  - isEnabled check used getFocusedCodeEditor() || getActiveCodeEditor()
  - getActiveCodeEditor() returns the most recently active editor even                                                                                                   
    without focus, so the Monaco handler always claimed isEnabled when
    any editor was open                                                                                                                                                  
  - This prevented CommonFrontendContribution's native input handler                                       
    from ever running for these actions              
  - Clipboard operations in native input/textarea fields (e.g., search,
    rename) and Monaco overlay widget inputs (find/replace) were silently                                                                                                
    swallowed or routed to the editor                                                                                                                                    
                                                                                                                                                                         
  Fix: introduce INPUT_ACTIONS (clipboard, selectAll) that require                                                                                                       
  hasTextFocus() on the editor, not just widget focus. This ensures:                                       
  - Native inputs and overlay widget inputs (find/replace) handle                                                                                                        
    clipboard operations natively                                                                                                                                        
  - Find/replace commands retain the getActiveCodeEditor() fallback so                                                                                                   
    they still target the active editor from other panels   

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

  1. Open a Theia workspace with at least one file open in the editor                                                                                                    
  2. Put some text in your clipboard                                                                                                                                     
  3. Click into the Monaco editor, then click into a native input field (e.g., the search input via Ctrl+Shift+F), then back into the editor, then back into the input   
  4. With focus in the native input field, press Ctrl+V / Cmd+V and verify the text is pasted                                                                            
  5. Open the find/replace widget (Ctrl+H) in the editor, put the cursor in the find or replace input, and verify Ctrl+V pastes into that input (not into the editor)
  6. Verify Ctrl+A selects all text in the find input, not in the editor                                                                                                 
  7. Verify paste/copy/cut still work normally inside the Monaco editor when it is focused                                                                               
  8. Open the explorer, then press Ctrl+F and verify the find widget opens in the editor                                                                                 
  9. Right-click a file in the explorer, select "Rename", and verify Ctrl+V pastes into the rename input                                                                 
  10. Close all editors and repeat steps 3-4 to verify everything still works 

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
