### PR TITLE
Update node-pty to `1.2.0-beta.12`

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -55,6 +55,7 @@
     "source-map": "^0.6.1",
     "source-map-loader": "^2.0.1",
     "source-map-support": "^0.5.19",
+    "string-replace-loader": "^3.3.0",
     "style-loader": "^2.0.0",
     "tslib": "^2.6.2",
     "umd-compat-loader": "^2.1.2",

--- a/dev-packages/application-manager/src/generator/webpack-generator.ts
+++ b/dev-packages/application-manager/src/generator/webpack-generator.ts
@@ -478,8 +478,9 @@ const config = {
         'plugin-host': require.resolve('@theia/plugin-ext/lib/hosted/node/plugin-host'),`)}
         ${this.ifPackage('@theia/plugin-ext-headless', () => `// Theia Headless Plugin support:
         'plugin-host-headless': require.resolve('@theia/plugin-ext-headless/lib/hosted/node/plugin-host-headless'),`)}
-        ${this.ifPackage('@theia/process', () => `// Make sure the node-pty thread worker can be executed:
-        'worker/conoutSocketWorker': require.resolve('node-pty/lib/worker/conoutSocketWorker'),`)}        
+        ${this.ifPackage('@theia/process', () => `// Make sure the node-pty thread workers can be executed:
+        'worker/conoutSocketWorker': require.resolve('node-pty/lib/worker/conoutSocketWorker'),
+        'conpty_console_list_agent': require.resolve('node-pty/lib/conpty_console_list_agent'),`)}        
         ${this.ifElectron("'electron-main': require.resolve('./src-gen/backend/electron-main'),")}
         ${this.ifPackage('@theia/dev-container', () => `// VS Code Dev-Container communication:
         'dev-container-server': require.resolve('@theia/dev-container/lib/dev-container-server/dev-container-server'),`)}
@@ -503,6 +504,16 @@ const config = {
                 test: /\\.js$/,
                 enforce: 'pre',
                 loader: 'source-map-loader'
+            },
+            // node-pty uses a dynamic require which needs to be rewritten to work with webpack.
+            {
+                test: /node_modules[/\\\\]node-pty[/\\\\]lib[/\\\\]utils\.js$/,
+                loader: 'string-replace-loader',
+                options: {
+                    search: /require\\(/,
+                    replace: '__non_webpack_require__(',
+                    flags: 'g'
+                }
             },
             // jsonc-parser exposes its UMD implementation by default, which
             // confuses Webpack leading to missing js in the bundles.

--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -23,7 +23,6 @@ import type { Compiler } from 'webpack';
 const REQUIRE_RIPGREP = '@vscode/ripgrep';
 const REQUIRE_BINDINGS = 'bindings';
 const REQUIRE_PARCEL_WATCHER = './build/Release/watcher.node';
-const REQUIRE_NODE_PTY_CONPTY = '../build/Release/conpty.node';
 
 export interface NativeWebpackPluginOptions {
     out: string;
@@ -66,11 +65,6 @@ export class NativeWebpackPlugin {
                 [REQUIRE_BINDINGS]: bindingsFile,
                 [REQUIRE_PARCEL_WATCHER]: issuer => Promise.resolve(findNativeWatcherFile(issuer))
             };
-            if (process.platform !== 'win32') {
-                // The expected conpty.node file is not available on non-windows platforms during build.
-                // We need to provide a stub that will be replaced by the real file at runtime.
-                replacements[REQUIRE_NODE_PTY_CONPTY] = () => buildFile(directory, 'conpty.js', conhostWindowsReplacement());
-            }
         });
         compiler.hooks.normalModuleFactory.tap(
             NativeWebpackPlugin.name,
@@ -99,7 +93,7 @@ export class NativeWebpackPlugin {
                 await this.copyRipgrep(ripgrepIssuer, compiler);
             }
             if (this.options.pty && nodePtyIssuer) {
-                await this.copyNodePtySpawnHelper(nodePtyIssuer, compiler);
+                await this.copyNodePtyNativeDeps(nodePtyIssuer, compiler);
             }
         });
     }
@@ -111,19 +105,28 @@ export class NativeWebpackPlugin {
         await this.copyExecutable(sourceFile, targetFile);
     }
 
-    protected async copyNodePtySpawnHelper(issuer: string, compiler: Compiler): Promise<void> {
-        const targetDirectory = path.resolve(compiler.outputPath, '..', 'build', 'Release');
+    protected async copyNodePtyNativeDeps(issuer: string, compiler: Compiler): Promise<void> {
+        const dist = `${process.platform}-${process.arch}`;
+        const src = `node-pty/prebuilds/${dist}`;
+        const targetDirectory = path.resolve(compiler.outputPath, '..', 'prebuilds', dist);
+
+        const copyFile = async (source: string): Promise<void> => {
+            const file = require.resolve(`${src}/${source}`, { paths: [issuer] });
+            const targetFile = path.join(targetDirectory, source);
+            await this.copyExecutable(file, targetFile);
+        };
+
         if (process.platform === 'win32') {
-            const agentFile = require.resolve('node-pty/build/Release/winpty-agent.exe', { paths: [issuer] });
-            const targetAgentFile = path.join(targetDirectory, 'winpty-agent.exe');
-            await this.copyExecutable(agentFile, targetAgentFile);
-            const dllFile = require.resolve('node-pty/build/Release/winpty.dll', { paths: [issuer] });
-            const targetDllFile = path.join(targetDirectory, 'winpty.dll');
-            await this.copyExecutable(dllFile, targetDllFile);
+            await copyFile('conpty.node');
+            await copyFile('conpty_console_list.node');
+            await copyFile('conpty/conpty.dll');
+            await copyFile('conpty/OpenConsole.exe');
         } else if (process.platform === 'darwin') {
-            const sourceFile = require.resolve('node-pty/build/Release/spawn-helper', { paths: [issuer] });
-            const targetFile = path.join(targetDirectory, 'spawn-helper');
-            await this.copyExecutable(sourceFile, targetFile);
+            await copyFile('spawn-helper');
+        }
+        // On non-windows platforms
+        if (process.platform !== 'win32') {
+            await copyFile('pty.node');
         }
     }
 
@@ -208,7 +211,3 @@ ${cases.join(os.EOL)}
     throw new Error(\`unhandled module: "\${jsModule}"\`);
 }`.trim();
 };
-
-const conhostWindowsReplacement = (nativePath: string = '.'): string => `
-module.exports = __non_webpack_require__('${nativePath}/native/conpty.node');
-`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -98,6 +98,7 @@
         "source-map": "^0.6.1",
         "source-map-loader": "^2.0.1",
         "source-map-support": "^0.5.19",
+        "string-replace-loader": "^3.3.0",
         "style-loader": "^2.0.0",
         "tslib": "^2.6.2",
         "umd-compat-loader": "^2.1.2",
@@ -21170,9 +21171,9 @@
       }
     },
     "node_modules/node-pty": {
-      "version": "1.1.0-beta27",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.1.0-beta27.tgz",
-      "integrity": "sha512-r0nRVgunspo/cBmf/eR+ultBrclxqldaL6FhiTLEmC4VcyKJxhluRK5d8EtbHYPLt8DqPKMnCakJDxreQynpnw==",
+      "version": "1.2.0-beta.12",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.2.0-beta.12.tgz",
+      "integrity": "sha512-uExTCG/4VmSJa4+TjxFwPXv8BfacmfFEBL6JpxCMDghcwqzvD0yTcGmZ1fKOK6HY33tp0CelLblqTECJizc+Yw==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -26404,6 +26405,91 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-replace-loader": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/string-replace-loader/-/string-replace-loader-3.3.0.tgz",
+      "integrity": "sha512-AZ3y7ktSHhd/Ebipczkp6vdfp01d2kQVwFujCGAgmogTB8t4dRhbsRGDKnyZAYqBbIA9QW7+D/IsACVJOOpcBg==",
+      "license": "MIT",
+      "dependencies": {
+        "schema-utils": "^4"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "webpack": "^5"
+      }
+    },
+    "node_modules/string-replace-loader/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/string-replace-loader/node_modules/ajv-formats": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/string-replace-loader/node_modules/ajv-keywords": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz",
+      "integrity": "sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3"
+      },
+      "peerDependencies": {
+        "ajv": "^8.8.2"
+      }
+    },
+    "node_modules/string-replace-loader/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/string-replace-loader/node_modules/schema-utils": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+      "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "ajv": "^8.9.0",
+        "ajv-formats": "^2.1.1",
+        "ajv-keywords": "^5.1.0"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/string-width": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
@@ -31179,7 +31265,7 @@
         "lodash.clonedeep": "^4.5.0",
         "macaddress": "^0.5.3",
         "mime": "^2.4.4",
-        "node-pty": "1.1.0-beta27",
+        "node-pty": "1.2.0-beta.12",
         "semver": "^7.5.4",
         "tslib": "^2.6.2",
         "vhost": "^3.0.2",
@@ -31331,7 +31417,7 @@
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@theia/core": "1.69.0",
-        "node-pty": "1.1.0-beta27",
+        "node-pty": "1.2.0-beta.12",
         "string-argv": "^0.1.1",
         "tslib": "^2.6.2"
       },

--- a/packages/plugin-ext/package.json
+++ b/packages/plugin-ext/package.json
@@ -45,7 +45,7 @@
     "lodash.clonedeep": "^4.5.0",
     "macaddress": "^0.5.3",
     "mime": "^2.4.4",
-    "node-pty": "1.1.0-beta27",
+    "node-pty": "1.2.0-beta.12",
     "semver": "^7.5.4",
     "tslib": "^2.6.2",
     "vhost": "^3.0.2",

--- a/packages/process/package.json
+++ b/packages/process/package.json
@@ -4,7 +4,7 @@
   "description": "Theia process support.",
   "dependencies": {
     "@theia/core": "1.69.0",
-    "node-pty": "1.1.0-beta27",
+    "node-pty": "1.2.0-beta.12",
     "string-argv": "^0.1.1",
     "tslib": "^2.6.2"
   },

--- a/scripts/zip-native-dependencies.js
+++ b/scripts/zip-native-dependencies.js
@@ -27,7 +27,7 @@ async function run() {
     const nativeDependencies = await glob('lib/backend/native/**', {
         cwd: browserAppPath
     });
-    const buildDependencies = await glob('lib/build/Release/**', {
+    const prebuildsDependencies = await glob('lib/prebuilds/**', {
         cwd: browserAppPath
     });
     const trashDependencies = await glob('lib/backend/{windows-trash.exe,macos-trash}', {
@@ -38,7 +38,7 @@ async function run() {
     archive.pipe(output);
     for (const file of [
         ...nativeDependencies,
-        ...buildDependencies,
+        ...prebuildsDependencies,
         ...trashDependencies
     ]) {
         const filePath = path.join(browserAppPath, file);


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/12733

*Simply* updates node-pty to its currently latest version. This is unfortunately a bit more involved, and involves a bunch of changes to the backend bundling. However, it should now work quite a bit better on all platforms.

#### How to test

The terminals should work as expected. Opening/closing especially.

I would recommend testing on debug mode in Windows, as that has previously crashed the backend. Now it works fine.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
