### PR TITLE
feat(ai-ide): add first-use confirmation for agent mode and make it the default

### DIFF
--- a/packages/ai-ide/src/browser/agent-mode-confirmation-service.ts
+++ b/packages/ai-ide/src/browser/agent-mode-confirmation-service.ts
@@ -1,0 +1,88 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import {
+    MarkdownChatResponseContentImpl,
+    MutableChatRequestModel,
+    QuestionResponseContentImpl
+} from '@theia/ai-chat/lib/common';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { nls, PreferenceService } from '@theia/core';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { PREFERENCE_NAME_AGENT_MODE_CONFIRMED } from '../common/ai-ide-preferences';
+
+export const AgentModeConfirmationService = Symbol('AgentModeConfirmationService');
+export interface AgentModeConfirmationService {
+    isAcknowledged(): boolean;
+    requestConfirmation(request: MutableChatRequestModel): Promise<boolean>;
+}
+
+@injectable()
+export class AgentModeConfirmationServiceImpl implements AgentModeConfirmationService {
+
+    @inject(PreferenceService) protected readonly preferenceService: PreferenceService;
+
+    isAcknowledged(): boolean {
+        return !!this.preferenceService.get<boolean>(PREFERENCE_NAME_AGENT_MODE_CONFIRMED, false);
+    }
+
+    async requestConfirmation(request: MutableChatRequestModel): Promise<boolean> {
+        const deferred = new Deferred<boolean>();
+
+        const confirmLabel = nls.localize('theia/ai/ide/agentModeConfirmation/confirm', 'Confirm');
+        const cancelLabel = nls.localizeByDefault('Cancel');
+
+        request.response.response.addContent(new MarkdownChatResponseContentImpl(
+            nls.localize('theia/ai/ide/agentModeConfirmation/msg',
+                'This agent uses an **agentic mode**. To enable autonomous flow, it is capable of directly writing to your workspace files without further confirmation.\n\n'
+                + 'It is recommended to use version control (e.g. Git) so you can review and revert changes.\n\n'
+                + 'You can switch to **Edit Mode** using the mode selector in the chat input area below, '
+                + 'or use the **Architect** agent for read-only planning.\n\n'
+                + 'This confirmation is saved for this workspace and won\'t be shown again. '
+                + 'To reset or configure it globally, look for `ai-features.agentMode.confirmed` in the Settings.')
+        ));
+
+        request.response.response.addContent(new QuestionResponseContentImpl(
+            nls.localize('theia/ai/ide/agentModeConfirmation/question', 'Do you want to proceed with Agent Mode?'),
+            [{ text: confirmLabel }, { text: cancelLabel }],
+            request,
+            async selectedOption => {
+                if (selectedOption.text === confirmLabel) {
+                    await this.preferenceService.set(PREFERENCE_NAME_AGENT_MODE_CONFIRMED, true);
+                    request.response.stopWaitingForInput();
+                    deferred.resolve(true);
+                } else {
+                    request.response.stopWaitingForInput();
+                    deferred.resolve(false);
+                }
+            }
+        ));
+
+        const progressMessage = request.response.addProgressMessage({
+            content: nls.localize('theia/ai/ide/agentModeConfirmation/waiting', 'Waiting for confirmation...'),
+            show: 'whileIncomplete'
+        });
+        request.response.waitForInput();
+
+        return deferred.promise.then(result => {
+            request.response.updateProgressMessage({ ...progressMessage, show: 'untilFirstContent', status: 'completed' });
+            if (result) {
+                request.response.response.clearContent();
+            }
+            return result;
+        });
+    }
+}

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -33,12 +33,14 @@ import { nls } from '@theia/core';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { AI_CHAT_NEW_CHAT_WINDOW_COMMAND, ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { AbstractModeAwareChatAgent } from './mode-aware-chat-agent';
+import { AgentModeConfirmationService } from './agent-mode-confirmation-service';
 
 export const CoderAgentId = 'Coder';
 
 @injectable()
 export class CoderAgent extends AbstractModeAwareChatAgent {
     @inject(ChatService) protected readonly chatService: ChatService;
+    @inject(AgentModeConfirmationService) protected readonly agentModeConfirmation: AgentModeConfirmationService;
     id: string = CoderAgentId;
     name = CoderAgentId;
     languageModelRequirements: LanguageModelRequirement[] = [{
@@ -73,10 +75,28 @@ export class CoderAgent extends AbstractModeAwareChatAgent {
         variants: [getCoderPromptTemplateEdit(), getCoderAgentModeNextPromptTemplate(), getCoderPromptTemplateEditNext()]
     }];
     protected override systemPromptId: string | undefined = CODER_SYSTEM_PROMPT_ID;
+
     override async invoke(request: MutableChatRequestModel): Promise<void> {
+        if (this.isAgentModeRequest(request) && !this.agentModeConfirmation.isAcknowledged()) {
+            const confirmed = await this.agentModeConfirmation.requestConfirmation(request);
+            if (!confirmed) {
+                request.response.complete();
+                return;
+            }
+        }
         await super.invoke(request);
         this.suggest(request);
     }
+
+    protected isAgentModeRequest(request: MutableChatRequestModel): boolean {
+        const modeId = request.request.modeId;
+        if (modeId) {
+            return modeId === CODER_AGENT_MODE_TEMPLATE_ID || modeId === CODER_AGENT_MODE_NEXT_TEMPLATE_ID;
+        }
+        const effectiveVariantId = this.getEffectiveVariantIdWithMode(undefined);
+        return effectiveVariantId === CODER_AGENT_MODE_TEMPLATE_ID || effectiveVariantId === CODER_AGENT_MODE_NEXT_TEMPLATE_ID;
+    }
+
     async suggest(context: ChatSession | ChatRequestModel): Promise<void> {
         const contextIsRequest = ChatRequestModel.is(context);
         const model = contextIsRequest ? context.session : context.model;

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -117,6 +117,7 @@ import { AppTesterCapabilityContribution } from './apptester-capability-contribu
 import { GitHubCapabilityContribution } from './github-capability-contribution';
 import { ShellExecutionCapabilityContribution } from './shell-execution-capability-contribution';
 import { JuniorAgent } from './junior-agent';
+import { AgentModeConfirmationService, AgentModeConfirmationServiceImpl } from './agent-mode-confirmation-service';
 
 import { ExploreAgent } from './explore-agent';
 import { CodeReviewerAgent } from './code-reviewer-agent';
@@ -128,6 +129,9 @@ import { JuniorPlanCapabilityContribution } from './junior-plan-capability-contr
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: aiIdePreferenceSchema });
     bind(PreferenceContribution).toConstantValue({ schema: WorkspacePreferencesSchema });
+
+    bind(AgentModeConfirmationServiceImpl).toSelf().inSingletonScope();
+    bind(AgentModeConfirmationService).toService(AgentModeConfirmationServiceImpl);
 
     bind(AIIdeActivationServiceImpl).toSelf().inSingletonScope();
     // rebinds the default implementation of '@theia/ai-core'

--- a/packages/ai-ide/src/common/ai-ide-preferences.ts
+++ b/packages/ai-ide/src/common/ai-ide-preferences.ts
@@ -20,7 +20,7 @@ import { nls, PreferenceSchema } from '@theia/core';
 // We reuse the context key for the preference name
 export const PREFERENCE_NAME_ENABLE_AI = 'ai-features.AiEnable.enableAI';
 export const PREFERENCE_NAME_ORCHESTRATOR_EXCLUSION_LIST = 'ai-features.orchestrator.excludedAgents';
-
+export const PREFERENCE_NAME_AGENT_MODE_CONFIRMED = 'ai-features.agentMode.confirmed';
 export const aiIdePreferenceSchema: PreferenceSchema = {
     properties: {
         [PREFERENCE_NAME_ENABLE_AI]: {
@@ -49,6 +49,15 @@ export const aiIdePreferenceSchema: PreferenceSchema = {
                 type: 'string'
             },
             default: ['ClaudeCode', 'Codex'],
+        },
+        [PREFERENCE_NAME_AGENT_MODE_CONFIRMED]: {
+            title: AI_CORE_PREFERENCES_TITLE,
+            markdownDescription: nls.localize('theia/ai/ide/agentMode/confirmed/mdDescription',
+                'Whether the user has confirmed the agent mode warning. '
+                + 'Agent mode allows autonomous file modifications without further confirmation. '
+                + 'Set to `false` to see the confirmation again on the next agent mode request.'),
+            type: 'boolean',
+            default: false,
         }
     }
 };


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17108

- Make agent mode the default for Coder
  - Switches the Coder agent's default prompt variant from Edit Mode to Agent Mode, so new users start with the full agentic experience. The first-use confirmation ensures users are informed before agent mode writes to their workspace.
- First-use confirmation for agent mode
  - When the Coder agent receives its first agentic mode request, it now shows an in-chat confirmation explaining that agent mode can directly write to workspace files without further confirmation. The user can click "I Understand, Continue" to proceed or "Cancel" to abort. The acknowledgment is persisted per workspace via StorageService so the prompt only appears once.
  - The confirmation logic is extracted into AgentModeConfirmationService (interface + symbol + implementation) so adopters can rebind it to customize or skip the confirmation flow.


<details>
<summary>Screenshots of the current flow</summary>

First use of the agentic mode:

<img width="500" height="542" alt="image" src="https://github.com/user-attachments/assets/344eba99-7b39-4c31-8f9e-bf51d042b002" />


Confirmed (user question was cleared from the history):

<img width="500" height="222" alt="image" src="https://github.com/user-attachments/assets/c67cf39f-2b4a-435b-9b08-1f2216dff7bc" />

<img width="494" height="256" alt="image" src="https://github.com/user-attachments/assets/be2d6c17-3fbd-4750-ae34-cd75c195b696" />


Writes the decision to a preference now:

<img width="1012" height="167" alt="image" src="https://github.com/user-attachments/assets/79c3f357-0752-46d3-a75e-b58a0c2a324a" />

If canceled, the request is aborted and the message stays:

<img width="501" height="532" alt="image" src="https://github.com/user-attachments/assets/e64611fb-c8a9-4e80-bfa0-41ea05730d2c" />




</details>

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the browser app with a fresh workspace (or clear workspace storage)                                                                                           
  2. Open the AI chat and send a message to `@Coder`                
  3. The first response should show a markdown explanation of agentig mode with "confirm" and "Cancel" buttons
  4. Click "Cancel": the request should complete without running the agent
  5. Send another message and the confirmation should appear again (not yet acknowledged)
  6. Click "Confirm" and the agent should proceed normally
  7. The setting `ai-features.agentMode.confirmed` is set to true for the workspace
  8. The user question is cleared from the conversation history
  9. Send another message and no confirmation should appear (acknowledged and persisted)
  10. Verify it also triggers when explicitly selecting "Agent Mode (Next)"
  11. Verify it does NOT trigger when selecting "Edit Mode"
  12. When using an agent that delegates to Coder (e.g. Junior), the confirmation will appear in the delegated Coder section.

Note: The delegate to agent section is not auto-expanded, so the user has to expand it to accept this (in case of another agent like Junior delegating to Coder) this UX issue is addressed separately in #16926

Note 2: This will prompt also users which already use agent mode as default once for each workspace.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

For the upcoming month it is planned to have a more explicit Onboarding agent (to help setup the AI configs). This might partly replace or integrate this confirmation.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
