### PR TITLE
feat: introduce AI Tool Sketchpad for runtime tool prototyping in custom agents

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -46,6 +46,7 @@
     "@theia/ai-registry": "1.73.0",
     "@theia/ai-scanoss": "1.73.0",
     "@theia/ai-terminal": "1.73.0",
+    "@theia/ai-tool-sketchpad": "1.73.0",
     "@theia/api-provider-sample": "1.73.0",
     "@theia/api-samples": "1.73.0",
     "@theia/bulk-edit": "1.73.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -78,6 +78,9 @@
       "path": "../../packages/ai-terminal"
     },
     {
+      "path": "../../packages/ai-tool-sketchpad"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -50,6 +50,7 @@
     "@theia/ai-registry": "1.73.0",
     "@theia/ai-scanoss": "1.73.0",
     "@theia/ai-terminal": "1.73.0",
+    "@theia/ai-tool-sketchpad": "1.73.0",
     "@theia/api-provider-sample": "1.73.0",
     "@theia/api-samples": "1.73.0",
     "@theia/bulk-edit": "1.73.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -81,6 +81,9 @@
       "path": "../../packages/ai-terminal"
     },
     {
+      "path": "../../packages/ai-tool-sketchpad"
+    },
+    {
       "path": "../../packages/bulk-edit"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -564,6 +564,7 @@
         "@theia/ai-registry": "1.73.0",
         "@theia/ai-scanoss": "1.73.0",
         "@theia/ai-terminal": "1.73.0",
+        "@theia/ai-tool-sketchpad": "1.73.0",
         "@theia/api-provider-sample": "1.73.0",
         "@theia/api-samples": "1.73.0",
         "@theia/bulk-edit": "1.73.0",
@@ -709,6 +710,7 @@
         "@theia/ai-registry": "1.73.0",
         "@theia/ai-scanoss": "1.73.0",
         "@theia/ai-terminal": "1.73.0",
+        "@theia/ai-tool-sketchpad": "1.73.0",
         "@theia/api-provider-sample": "1.73.0",
         "@theia/api-samples": "1.73.0",
         "@theia/bulk-edit": "1.73.0",
@@ -7392,6 +7394,10 @@
     },
     "node_modules/@theia/ai-terminal": {
       "resolved": "packages/ai-terminal",
+      "link": true
+    },
+    "node_modules/@theia/ai-tool-sketchpad": {
+      "resolved": "packages/ai-tool-sketchpad",
       "link": true
     },
     "node_modules/@theia/ai-vercel-ai": {
@@ -32518,6 +32524,21 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/ai-tool-sketchpad": {
+      "name": "@theia/ai-tool-sketchpad",
+      "version": "1.73.0",
+      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "dependencies": {
+        "@theia/ai-core": "1.73.0",
+        "@theia/core": "1.73.0",
+        "@theia/filesystem": "1.73.0",
+        "js-yaml": "^4.1.0",
+        "tslib": "^2.6.2"
+      },
+      "devDependencies": {
+        "@theia/ext-scripts": "1.73.0"
       }
     },
     "packages/ai-vercel-ai": {

--- a/packages/ai-tool-sketchpad/.eslintrc.js
+++ b/packages/ai-tool-sketchpad/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/ai-tool-sketchpad/README.md
+++ b/packages/ai-tool-sketchpad/README.md
@@ -1,0 +1,44 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - AI TOOL SKETCHPAD EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/ai-tool-sketchpad` extension lets you prototype LLM tools at runtime without writing or rebuilding any code.
+
+When designing custom AI agents, most aspects of agent behavior (system prompts, LLMs, skills, MCPs) can already be adjusted at runtime. Custom tools were the remaining gap. This extension closes it by letting you define _sketched tools_ declaratively: name, description, input parameters, and return behavior. The tool implementation is deliberately left out.
+
+## Usage
+
+Open the **AI Tool Sketchpad** view (available once AI features are enabled) to create, edit, and delete sketched tools. Each tool defines:
+
+- **Name** and **Description** exposed to the LLM.
+- **Parameters**, including nested object and array parameters.
+- A **Return Mode**:
+  - `Static Return Value` always returns a fixed string.
+  - `Ask At Runtime` opens a quick input at invocation time so you can supply the return value on the fly.
+
+Sketched tools are registered in the `ToolInvocationRegistry` and become immediately available to any AI agent or chat session. Definitions are persisted as YAML and reloaded live when edited externally.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+<https://www.eclipse.org/theia>

--- a/packages/ai-tool-sketchpad/package.json
+++ b/packages/ai-tool-sketchpad/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@theia/ai-tool-sketchpad",
+  "version": "1.73.0",
+  "description": "Theia - AI Tool Sketchpad for defining ad-hoc LLM tools",
+  "dependencies": {
+    "@theia/ai-core": "1.73.0",
+    "@theia/core": "1.73.0",
+    "@theia/filesystem": "1.73.0",
+    "js-yaml": "^4.1.0",
+    "tslib": "^2.6.2"
+  },
+  "main": "lib/common",
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.73.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-tool-sketchpad/src/browser/frontend-module.ts
+++ b/packages/ai-tool-sketchpad/src/browser/frontend-module.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/frontend-module.ts
+++ b/packages/ai-tool-sketchpad/src/browser/frontend-module.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import '../../src/browser/style/index.css';
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { FrontendApplicationContribution, WidgetFactory, bindViewContribution } from '@theia/core/lib/browser';
+import { SketchedToolService } from '../common';
+import { SketchedToolServiceImpl } from './sketched-tool-service';
+import { SketchedToolWidget } from './sketched-tool-widget';
+import { SketchedToolViewContribution } from './sketched-tool-contribution';
+
+export default new ContainerModule(bind => {
+    // Service
+    bind(SketchedToolServiceImpl).toSelf().inSingletonScope();
+    bind(SketchedToolService).toService(SketchedToolServiceImpl);
+    bind(FrontendApplicationContribution).toService(SketchedToolServiceImpl);
+
+    // Widget
+    bind(SketchedToolWidget).toSelf();
+    bind(WidgetFactory)
+        .toDynamicValue(ctx => ({
+            id: SketchedToolWidget.ID,
+            createWidget: () => ctx.container.get(SketchedToolWidget)
+        }))
+        .inSingletonScope();
+
+    // View contribution
+    bindViewContribution(bind, SketchedToolViewContribution);
+});

--- a/packages/ai-tool-sketchpad/src/browser/frontend-module.ts
+++ b/packages/ai-tool-sketchpad/src/browser/frontend-module.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/index.ts
+++ b/packages/ai-tool-sketchpad/src/browser/index.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/index.ts
+++ b/packages/ai-tool-sketchpad/src/browser/index.ts
@@ -1,0 +1,19 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './sketched-tool-service';
+export * from './sketched-tool-widget';
+export * from './sketched-tool-contribution';

--- a/packages/ai-tool-sketchpad/src/browser/index.ts
+++ b/packages/ai-tool-sketchpad/src/browser/index.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-contribution.ts
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-contribution.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-contribution.ts
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-contribution.ts
@@ -1,0 +1,37 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { AIViewContribution } from '@theia/ai-core/lib/browser';
+import { SketchedToolWidget } from './sketched-tool-widget';
+
+export const SKETCHED_TOOL_TOGGLE_COMMAND_ID = 'aiToolSketchpad:toggle';
+
+@injectable()
+export class SketchedToolViewContribution extends AIViewContribution<SketchedToolWidget> {
+
+    constructor() {
+        super({
+            widgetId: SketchedToolWidget.ID,
+            widgetName: SketchedToolWidget.LABEL,
+            defaultWidgetOptions: {
+                area: 'main',
+                rank: 200
+            },
+            toggleCommandId: SKETCHED_TOOL_TOGGLE_COMMAND_ID
+        });
+    }
+}

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-contribution.ts
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-contribution.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-service.ts
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-service.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-service.ts
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-service.ts
@@ -1,0 +1,255 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { DisposableCollection, Emitter, Event, nls, URI } from '@theia/core';
+import { FrontendApplicationContribution, QuickInputService } from '@theia/core/lib/browser';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
+import {
+    ToolInvocationRegistry,
+    ToolRequest,
+    ToolRequestParameters,
+    ToolRequestParameterProperty
+} from '@theia/ai-core';
+import { dump, load } from 'js-yaml';
+import {
+    SketchedToolDefinition,
+    SketchedToolParameterDefinition,
+    SketchedToolService,
+    SKETCHED_TOOLS_PROVIDER_NAME
+} from '../common';
+
+const SKETCHED_TOOLS_FILENAME = 'sketchedTools.yml';
+
+@injectable()
+export class SketchedToolServiceImpl implements SketchedToolService, FrontendApplicationContribution {
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(EnvVariablesServer)
+    protected readonly envVariablesServer: EnvVariablesServer;
+
+    @inject(ToolInvocationRegistry)
+    protected readonly toolInvocationRegistry: ToolInvocationRegistry;
+
+    @inject(QuickInputService)
+    protected readonly quickInputService: QuickInputService;
+
+    protected tools: SketchedToolDefinition[] = [];
+    protected fileUri: URI | undefined;
+    protected readonly toDispose = new DisposableCollection();
+    protected loading = false;
+
+    protected readonly onDidChangeSketchedToolsEmitter = new Emitter<void>();
+    readonly onDidChangeSketchedTools: Event<void> = this.onDidChangeSketchedToolsEmitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.onDidChangeSketchedToolsEmitter);
+    }
+
+    async onStart(): Promise<void> {
+        this.fileUri = await this.resolveFileUri();
+        await this.loadFromDisk();
+        this.watchFile();
+    }
+
+    getSketchedTools(): SketchedToolDefinition[] {
+        return [...this.tools];
+    }
+
+    async addSketchedTool(tool: SketchedToolDefinition): Promise<void> {
+        this.tools.push(tool);
+        this.registerAllTools();
+        await this.persistToDisk();
+        this.onDidChangeSketchedToolsEmitter.fire();
+    }
+
+    async updateSketchedTool(tool: SketchedToolDefinition): Promise<void> {
+        const index = this.tools.findIndex(t => t.id === tool.id);
+        if (index >= 0) {
+            this.tools[index] = tool;
+        } else {
+            this.tools.push(tool);
+        }
+        this.registerAllTools();
+        await this.persistToDisk();
+        this.onDidChangeSketchedToolsEmitter.fire();
+    }
+
+    async removeSketchedTool(toolId: string): Promise<void> {
+        this.tools = this.tools.filter(t => t.id !== toolId);
+        this.registerAllTools();
+        await this.persistToDisk();
+        this.onDidChangeSketchedToolsEmitter.fire();
+    }
+
+    protected async resolveFileUri(): Promise<URI> {
+        const configDirUri = await this.envVariablesServer.getConfigDirUri();
+        return new URI(configDirUri).resolve('prompt-templates').resolve(SKETCHED_TOOLS_FILENAME);
+    }
+
+    protected async loadFromDisk(): Promise<void> {
+        if (!this.fileUri) {
+            return;
+        }
+        this.loading = true;
+        try {
+            const exists = await this.fileService.exists(this.fileUri);
+            if (!exists) {
+                this.tools = [];
+                this.registerAllTools();
+                return;
+            }
+            const fileContent = await this.fileService.read(this.fileUri, { encoding: 'utf-8' });
+            const doc = load(fileContent.value);
+            if (Array.isArray(doc) && doc.every(entry => SketchedToolDefinition.is(entry))) {
+                this.tools = (doc as SketchedToolDefinition[]).map(SketchedToolDefinition.normalize);
+            } else {
+                console.debug('Invalid sketchedTools.yml content, ignoring.');
+                this.tools = [];
+            }
+            this.registerAllTools();
+            this.onDidChangeSketchedToolsEmitter.fire();
+        } catch (e) {
+            console.debug(`Error loading ${SKETCHED_TOOLS_FILENAME}: ${e.message}`, e);
+        } finally {
+            this.loading = false;
+        }
+    }
+
+    onStop(): void {
+        this.toDispose.dispose();
+    }
+
+    protected async persistToDisk(): Promise<void> {
+        if (!this.fileUri) {
+            return;
+        }
+        try {
+            const yamlContent = dump(this.tools, { lineWidth: -1 });
+            const buffer = BinaryBuffer.fromString(yamlContent);
+            if (await this.fileService.exists(this.fileUri)) {
+                await this.fileService.writeFile(this.fileUri, buffer);
+            } else {
+                await this.fileService.createFile(this.fileUri, buffer);
+            }
+        } catch (e) {
+            console.error(`Error persisting ${SKETCHED_TOOLS_FILENAME}: ${e.message}`, e);
+        }
+    }
+
+    protected watchFile(): void {
+        if (!this.fileUri) {
+            return;
+        }
+        const parentUri = this.fileUri.parent;
+        this.toDispose.push(this.fileService.watch(parentUri));
+        const listener = this.fileService.onDidFilesChange((event: FileChangesEvent) => {
+            if (this.fileUri && event.contains(this.fileUri) && !this.loading) {
+                this.loadFromDisk();
+            }
+        });
+        this.toDispose.push(listener);
+    }
+
+    protected registerAllTools(): void {
+        this.toolInvocationRegistry.unregisterAllTools(SKETCHED_TOOLS_PROVIDER_NAME);
+        for (const def of this.tools) {
+            const toolRequest = this.toToolRequest(def);
+            this.toolInvocationRegistry.registerTool(toolRequest);
+        }
+    }
+
+    protected toToolRequest(def: SketchedToolDefinition): ToolRequest {
+        const parameters = this.convertParameters(def.parameters);
+        return {
+            id: def.id,
+            name: def.name,
+            description: def.description,
+            providerName: SKETCHED_TOOLS_PROVIDER_NAME,
+            parameters,
+            handler: async (argString: string) => {
+                if (def.returnMode === 'askAtRuntime') {
+                    return this.askUserForReturnValue(def.name, argString);
+                }
+                return def.staticReturn;
+            }
+        };
+    }
+
+    protected async askUserForReturnValue(toolName: string, argString: string): Promise<string> {
+        const result = await this.quickInputService.input({
+            prompt: nls.localize('theia/ai-tool-sketchpad/askReturnPrompt',
+                'Tool "{0}" was called with: {1}', toolName, argString),
+            placeHolder: nls.localize('theia/ai-tool-sketchpad/askReturnPlaceholder',
+                'Enter the return value for this tool call...')
+        });
+        return result ?? '';
+    }
+
+    protected convertParameters(params: SketchedToolParameterDefinition[]): ToolRequestParameters {
+        const properties: Record<string, ToolRequestParameterProperty> = {};
+        const required: string[] = [];
+
+        for (const param of params) {
+            properties[param.name] = this.convertParameterProperty(param);
+            if (param.required) {
+                required.push(param.name);
+            }
+        }
+
+        return {
+            type: 'object',
+            properties,
+            ...(required.length > 0 ? { required } : {})
+        };
+    }
+
+    protected convertParameterProperty(param: SketchedToolParameterDefinition): ToolRequestParameterProperty {
+        const prop: ToolRequestParameterProperty = {
+            type: param.type,
+            description: param.description
+        };
+
+        if (param.type === 'object' && param.properties && param.properties.length > 0) {
+            const nested = this.convertParameters(param.properties);
+            prop.properties = nested.properties;
+            if (nested.required && nested.required.length > 0) {
+                prop.required = nested.required;
+            }
+        }
+
+        if (param.type === 'array' && param.itemType) {
+            if (param.itemType === 'object' && param.itemProperties && param.itemProperties.length > 0) {
+                const nested = this.convertParameters(param.itemProperties);
+                prop.items = {
+                    type: 'object',
+                    properties: nested.properties,
+                    ...(nested.required && nested.required.length > 0 ? { required: nested.required } : {})
+                };
+            } else {
+                prop.items = { type: param.itemType };
+            }
+        }
+
+        return prop;
+    }
+}

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-service.ts
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-service.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -56,6 +56,8 @@ export class SketchedToolServiceImpl implements SketchedToolService, FrontendApp
     protected fileUri: URI | undefined;
     protected readonly toDispose = new DisposableCollection();
     protected loading = false;
+    /** The content we last wrote to disk, used to ignore file-watch events triggered by our own writes. */
+    protected lastPersistedContent: string | undefined;
 
     protected readonly onDidChangeSketchedToolsEmitter = new Emitter<void>();
     readonly onDidChangeSketchedTools: Event<void> = this.onDidChangeSketchedToolsEmitter.event;
@@ -119,11 +121,21 @@ export class SketchedToolServiceImpl implements SketchedToolService, FrontendApp
                 return;
             }
             const fileContent = await this.fileService.read(this.fileUri, { encoding: 'utf-8' });
+            if (fileContent.value === this.lastPersistedContent) {
+                // This change was triggered by our own write; the in-memory state is already up to date.
+                return;
+            }
             const doc = load(fileContent.value);
-            if (Array.isArray(doc) && doc.every(entry => SketchedToolDefinition.is(entry))) {
-                this.tools = (doc as SketchedToolDefinition[]).map(SketchedToolDefinition.normalize);
+            if (Array.isArray(doc)) {
+                // Skip invalid entries rather than discarding all tools if one entry is malformed.
+                const valid = doc.filter(entry => SketchedToolDefinition.is(entry)) as SketchedToolDefinition[];
+                const skipped = doc.length - valid.length;
+                if (skipped > 0) {
+                    console.debug(`Skipped ${skipped} invalid entr${skipped === 1 ? 'y' : 'ies'} in ${SKETCHED_TOOLS_FILENAME}.`);
+                }
+                this.tools = valid.map(SketchedToolDefinition.normalize);
             } else {
-                console.debug('Invalid sketchedTools.yml content, ignoring.');
+                console.debug(`Invalid ${SKETCHED_TOOLS_FILENAME} content, ignoring.`);
                 this.tools = [];
             }
             this.registerAllTools();
@@ -151,6 +163,7 @@ export class SketchedToolServiceImpl implements SketchedToolService, FrontendApp
             } else {
                 await this.fileService.createFile(this.fileUri, buffer);
             }
+            this.lastPersistedContent = yamlContent;
         } catch (e) {
             console.error(`Error persisting ${SKETCHED_TOOLS_FILENAME}: ${e.message}`, e);
         }
@@ -172,23 +185,37 @@ export class SketchedToolServiceImpl implements SketchedToolService, FrontendApp
 
     protected registerAllTools(): void {
         this.toolInvocationRegistry.unregisterAllTools(SKETCHED_TOOLS_PROVIDER_NAME);
+        // Guard against invalid or duplicate names in hand-edited YAML: the name is the registered id,
+        // so an invalid name is uncallable and a duplicate would collide. Register the first valid one.
+        const registeredNames = new Set<string>();
         for (const def of this.tools) {
-            const toolRequest = this.toToolRequest(def);
-            this.toolInvocationRegistry.registerTool(toolRequest);
+            const name = def.name.trim();
+            if (!SketchedToolDefinition.NAME_PATTERN.test(name)) {
+                console.warn(`Skipping sketched tool "${def.name}": name is empty or contains invalid characters.`);
+                continue;
+            }
+            if (registeredNames.has(name)) {
+                console.warn(`Skipping sketched tool "${name}": another tool with the same name is already registered.`);
+                continue;
+            }
+            registeredNames.add(name);
+            this.toolInvocationRegistry.registerTool(this.toToolRequest(def, name));
         }
     }
 
-    protected toToolRequest(def: SketchedToolDefinition): ToolRequest {
+    protected toToolRequest(def: SketchedToolDefinition, name: string): ToolRequest {
         const parameters = this.convertParameters(def.parameters);
         return {
-            id: def.id,
-            name: def.name,
+            // The readable name doubles as the id so chat completions insert a meaningful reference;
+            // the internal UUID (def.id) remains the persistence key, keeping renames lossless.
+            id: name,
+            name,
             description: def.description,
             providerName: SKETCHED_TOOLS_PROVIDER_NAME,
             parameters,
             handler: async (argString: string) => {
                 if (def.returnMode === 'askAtRuntime') {
-                    return this.askUserForReturnValue(def.name, argString);
+                    return this.askUserForReturnValue(name, argString);
                 }
                 return def.staticReturn;
             }

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-widget.tsx
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-widget.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-widget.tsx
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-widget.tsx
@@ -1,0 +1,700 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { codicon, ConfirmDialog, ReactWidget } from '@theia/core/lib/browser';
+import { nls } from '@theia/core';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import * as React from '@theia/core/shared/react';
+import { generateUuid } from '@theia/core/lib/common/uuid';
+import { SketchedToolDefinition, SketchedToolParameterDefinition, SketchedToolParameterType, SketchedToolReturnMode, SketchedToolService } from '../common';
+
+const PARAMETER_TYPES: SketchedToolParameterType[] = ['string', 'number', 'integer', 'boolean', 'object', 'array'];
+const ITEM_TYPES: Array<'string' | 'number' | 'integer' | 'boolean' | 'object'> = ['string', 'number', 'integer', 'boolean', 'object'];
+const MAX_NESTING_DEPTH = 2;
+
+function toolDisplayName(tool: SketchedToolDefinition): string {
+    return tool.name.trim() || nls.localize('theia/ai-tool-sketchpad/untitledTool', 'Untitled tool');
+}
+
+function returnModeLabel(mode: SketchedToolReturnMode): string {
+    return mode === 'askAtRuntime'
+        ? nls.localize('theia/ai-tool-sketchpad/returnModeAskShort', 'Ask at runtime')
+        : nls.localize('theia/ai-tool-sketchpad/returnModeStaticShort', 'Static');
+}
+
+/** Renders a tool as a call signature, e.g. `getWeather(city, units?)`. Optional parameters get a trailing `?`. */
+function toolSignature(tool: SketchedToolDefinition): string {
+    const name = tool.name.trim() || 'tool';
+    const args = tool.parameters
+        .map(param => `${param.name.trim() || 'arg'}${param.required ? '' : '?'}`)
+        .join(', ');
+    return `${name}(${args})`;
+}
+
+function toolSummary(tool: SketchedToolDefinition): string {
+    const count = tool.parameters.length;
+    const params = count === 1
+        ? nls.localize('theia/ai-tool-sketchpad/oneParameter', '1 parameter')
+        : nls.localize('theia/ai-tool-sketchpad/nParameters', '{0} parameters', count);
+    return `${params} · ${returnModeLabel(tool.returnMode ?? 'static')}`;
+}
+
+interface ToolListItemProps {
+    tool: SketchedToolDefinition;
+    isSelected: boolean;
+    onSelect: (tool: SketchedToolDefinition) => void;
+    onDelete: (id: string) => void;
+}
+
+function ToolListItem({ tool, isSelected, onSelect, onDelete }: ToolListItemProps): React.ReactElement {
+    const handleClick = React.useCallback(() => onSelect(tool), [tool, onSelect]);
+    const handleDelete = React.useCallback((e: React.MouseEvent): void => {
+        e.stopPropagation();
+        onDelete(tool.id);
+    }, [tool.id, onDelete]);
+    return (
+        <li
+            className={`theia-TreeNode ai-sketchpad-list-item${isSelected ? ' theia-mod-selected' : ''}`}
+            onClick={handleClick}
+            title={toolSignature(tool)}
+        >
+            <i className={`ai-sketchpad-list-item-icon ${codicon('symbol-method')}`} />
+            <div className='ai-sketchpad-list-item-text'>
+                <span className='ai-sketchpad-list-item-label'>{toolDisplayName(tool)}</span>
+                <span className='ai-sketchpad-list-item-meta'>{toolSummary(tool)}</span>
+            </div>
+            <span
+                className={`ai-sketchpad-delete-icon ${codicon('trash')}`}
+                title={nls.localizeByDefault('Delete')}
+                onClick={handleDelete}
+            />
+        </li>
+    );
+}
+
+interface ToolDetailFormProps {
+    tool: SketchedToolDefinition;
+    onSave: (tool: SketchedToolDefinition) => void;
+    onDelete: (id: string) => void;
+}
+
+function ToolDetailForm({ tool: initialTool, onSave, onDelete }: ToolDetailFormProps): React.ReactElement {
+    const [tool, setTool] = React.useState<SketchedToolDefinition>(deepCopy(initialTool));
+    const [isDirty, setIsDirty] = React.useState(false);
+
+    React.useEffect(() => {
+        setTool(deepCopy(initialTool));
+        setIsDirty(false);
+    }, [initialTool.id]);
+
+    const updateField = (field: 'name' | 'description' | 'staticReturn', value: string): void => {
+        setTool(prev => ({ ...prev, [field]: value }));
+        setIsDirty(true);
+    };
+
+    const updateReturnMode = (mode: SketchedToolReturnMode): void => {
+        setTool(prev => ({ ...prev, returnMode: mode }));
+        setIsDirty(true);
+    };
+
+    const getParamsAtPath = (params: SketchedToolParameterDefinition[], path: number[]): SketchedToolParameterDefinition[] | undefined => {
+        let current = params;
+        for (const index of path) {
+            if (index < 0 || index >= current.length) {
+                return undefined;
+            }
+            const param = current[index];
+            if (!param.properties) {
+                param.properties = [];
+            }
+            current = param.properties;
+        }
+        return current;
+    };
+
+    const getItemPropertiesAtPath = (params: SketchedToolParameterDefinition[], path: number[]): SketchedToolParameterDefinition[] | undefined => {
+        let current = params;
+        for (let i = 0; i < path.length - 1; i++) {
+            const index = path[i];
+            if (index < 0 || index >= current.length) {
+                return undefined;
+            }
+            const parent = current[index];
+            if (!parent.properties) {
+                parent.properties = [];
+            }
+            current = parent.properties;
+        }
+        const lastIndex = path[path.length - 1];
+        if (lastIndex < 0 || lastIndex >= current.length) {
+            return undefined;
+        }
+        const param = current[lastIndex];
+        if (!param.itemProperties) {
+            param.itemProperties = [];
+        }
+        return param.itemProperties;
+    };
+
+    const updateParameter = (path: number[], field: string, value: unknown): void => {
+        if (path.length === 0) {
+            return;
+        }
+        setTool(prev => {
+            const next = deepCopy(prev);
+            const parentPath = path.slice(0, -1);
+            const index = path[path.length - 1];
+            const params = getParamsAtPath(next.parameters, parentPath);
+            if (params && index >= 0 && index < params.length) {
+                const param = { ...params[index], [field]: value };
+                if (field === 'type' && value === 'object' && !param.properties) {
+                    param.properties = [];
+                }
+                if (field === 'type' && value === 'array' && !param.itemType) {
+                    param.itemType = 'string';
+                }
+                if (field === 'itemType' && value === 'object' && !param.itemProperties) {
+                    param.itemProperties = [];
+                }
+                params[index] = param;
+            }
+            return next;
+        });
+        setIsDirty(true);
+    };
+
+    const handleAddParameter = (path: number[]): void => {
+        const newParam: SketchedToolParameterDefinition = {
+            name: '',
+            description: '',
+            type: 'string'
+        };
+        setTool(prev => {
+            const next = deepCopy(prev);
+            const params = getParamsAtPath(next.parameters, path);
+            if (params) {
+                params.push(newParam);
+            }
+            return next;
+        });
+        setIsDirty(true);
+    };
+
+    const handleAddItemProperty = (path: number[]): void => {
+        const newParam: SketchedToolParameterDefinition = {
+            name: '',
+            description: '',
+            type: 'string'
+        };
+        setTool(prev => {
+            const next = deepCopy(prev);
+            const itemProps = getItemPropertiesAtPath(next.parameters, path);
+            if (itemProps) {
+                itemProps.push(newParam);
+            }
+            return next;
+        });
+        setIsDirty(true);
+    };
+
+    const handleRemoveParameter = (path: number[]): void => {
+        if (path.length === 0) {
+            return;
+        }
+        setTool(prev => {
+            const next = deepCopy(prev);
+            const parentPath = path.slice(0, -1);
+            const index = path[path.length - 1];
+            const params = getParamsAtPath(next.parameters, parentPath);
+            if (params && index >= 0 && index < params.length) {
+                params.splice(index, 1);
+            }
+            return next;
+        });
+        setIsDirty(true);
+    };
+
+    const handleRemoveItemProperty = (paramPath: number[], propertyIndex: number): void => {
+        setTool(prev => {
+            const next = deepCopy(prev);
+            const itemProps = getItemPropertiesAtPath(next.parameters, paramPath);
+            if (itemProps && propertyIndex >= 0 && propertyIndex < itemProps.length) {
+                itemProps.splice(propertyIndex, 1);
+            }
+            return next;
+        });
+        setIsDirty(true);
+    };
+
+    const handleSave = (): void => {
+        if (tool.name.trim()) {
+            onSave(tool);
+            setIsDirty(false);
+        }
+    };
+
+    const renderParameters = (params: SketchedToolParameterDefinition[], path: number[], depth: number): React.ReactNode => {
+        if (params.length === 0) {
+            return (
+                <div className='ai-sketchpad-no-params'>
+                    {nls.localize('theia/ai-tool-sketchpad/noParameters', 'No parameters defined.')}
+                </div>
+            );
+        }
+        return (
+            <div className='ai-sketchpad-param-list'>
+                {params.map((param, index) => renderParameterRow(param, [...path, index], depth))}
+            </div>
+        );
+    };
+
+    const renderItemProperties = (params: SketchedToolParameterDefinition[], paramPath: number[], depth: number): React.ReactNode => {
+        if (params.length === 0) {
+            return (
+                <div className='ai-sketchpad-no-params'>
+                    {nls.localize('theia/ai-tool-sketchpad/noItemProperties', 'No item properties defined.')}
+                </div>
+            );
+        }
+        return (
+            <div className='ai-sketchpad-param-list'>
+                {params.map((param, index) => renderItemPropertyRow(param, paramPath, index, depth))}
+            </div>
+        );
+    };
+
+    const renderItemPropertyRow = (param: SketchedToolParameterDefinition, paramPath: number[], propertyIndex: number, depth: number): React.ReactNode => {
+        const key = `${paramPath.join('-')}-item-${propertyIndex}`;
+        const depthClass = depth > 0 ? ` ai-sketchpad-param-depth-${depth}` : '';
+        return (
+            <div key={key} className={`ai-sketchpad-param-item${depthClass}`}>
+                <div className='ai-sketchpad-param-row'>
+                    <input
+                        className='theia-input ai-sketchpad-param-name'
+                        value={param.name}
+                        placeholder={nls.localizeByDefault('Name')}
+                        onChange={e => updateItemProperty(paramPath, propertyIndex, 'name', e.target.value)}
+                    />
+                    <input
+                        className='theia-input ai-sketchpad-param-desc'
+                        value={param.description}
+                        placeholder={nls.localizeByDefault('Description')}
+                        onChange={e => updateItemProperty(paramPath, propertyIndex, 'description', e.target.value)}
+                    />
+                    <select
+                        className='theia-select ai-sketchpad-param-type'
+                        value={param.type}
+                        onChange={e => updateItemProperty(paramPath, propertyIndex, 'type', e.target.value)}
+                    >
+                        {ITEM_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                    </select>
+                    <label className='ai-sketchpad-param-required'>
+                        <input
+                            type='checkbox'
+                            checked={param.required ?? false}
+                            onChange={e => updateItemProperty(paramPath, propertyIndex, 'required', e.target.checked)}
+                        />
+                        <span>{nls.localize('theia/ai-tool-sketchpad/required', 'Required')}</span>
+                    </label>
+                    <span
+                        className={`ai-sketchpad-param-delete ${codicon('close')}`}
+                        title={nls.localizeByDefault('Remove')}
+                        onClick={() => handleRemoveItemProperty(paramPath, propertyIndex)}
+                    />
+                </div>
+            </div>
+        );
+    };
+
+    const updateItemProperty = (paramPath: number[], propertyIndex: number, field: string, value: unknown): void => {
+        setTool(prev => {
+            const next = deepCopy(prev);
+            const itemProps = getItemPropertiesAtPath(next.parameters, paramPath);
+            if (itemProps && propertyIndex >= 0 && propertyIndex < itemProps.length) {
+                itemProps[propertyIndex] = { ...itemProps[propertyIndex], [field]: value };
+            }
+            return next;
+        });
+        setIsDirty(true);
+    };
+
+    const renderParameterRow = (param: SketchedToolParameterDefinition, path: number[], depth: number): React.ReactNode => {
+        const key = path.join('-');
+        const depthClass = depth > 0 ? ` ai-sketchpad-param-depth-${depth}` : '';
+        return (
+            <div key={key} className={`ai-sketchpad-param-item${depthClass}`}>
+                <div className='ai-sketchpad-param-row'>
+                    <input
+                        className='theia-input ai-sketchpad-param-name'
+                        value={param.name}
+                        placeholder={nls.localizeByDefault('Name')}
+                        onChange={e => updateParameter(path, 'name', e.target.value)}
+                    />
+                    <input
+                        className='theia-input ai-sketchpad-param-desc'
+                        value={param.description}
+                        placeholder={nls.localizeByDefault('Description')}
+                        onChange={e => updateParameter(path, 'description', e.target.value)}
+                    />
+                    <select
+                        className='theia-select ai-sketchpad-param-type'
+                        value={param.type}
+                        onChange={e => updateParameter(path, 'type', e.target.value)}
+                    >
+                        {PARAMETER_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                    </select>
+                    <label className='ai-sketchpad-param-required'>
+                        <input
+                            type='checkbox'
+                            checked={param.required ?? false}
+                            onChange={e => updateParameter(path, 'required', e.target.checked)}
+                        />
+                        <span>{nls.localize('theia/ai-tool-sketchpad/required', 'Required')}</span>
+                    </label>
+                    <span
+                        className={`ai-sketchpad-param-delete ${codicon('close')}`}
+                        title={nls.localizeByDefault('Remove')}
+                        onClick={() => handleRemoveParameter(path)}
+                    />
+                </div>
+                {param.type === 'object' && depth < MAX_NESTING_DEPTH && (
+                    <div className='ai-sketchpad-param-nested'>
+                        {renderParameters(param.properties ?? [], path, depth + 1)}
+                        <button
+                            className='theia-button secondary ai-sketchpad-add-nested-btn'
+                            onClick={() => handleAddParameter(path)}
+                        >
+                            <i className={codicon('add')} />&nbsp;
+                            {nls.localize('theia/ai-tool-sketchpad/addProperty', 'Add Property')}
+                        </button>
+                    </div>
+                )}
+                {param.type === 'array' && (
+                    <div className='ai-sketchpad-param-array-type'>
+                        <label>{nls.localize('theia/ai-tool-sketchpad/itemType', 'Item Type:')}</label>
+                        <select
+                            className='theia-select'
+                            value={param.itemType ?? 'string'}
+                            onChange={e => updateParameter(path, 'itemType', e.target.value)}
+                        >
+                            {ITEM_TYPES.map(t => <option key={t} value={t}>{t}</option>)}
+                        </select>
+                    </div>
+                )}
+                {param.type === 'array' && param.itemType === 'object' && depth < MAX_NESTING_DEPTH && (
+                    <div className='ai-sketchpad-param-nested'>
+                        {renderItemProperties(param.itemProperties ?? [], path, depth + 1)}
+                        <button
+                            className='theia-button secondary ai-sketchpad-add-nested-btn'
+                            onClick={() => handleAddItemProperty(path)}
+                        >
+                            <i className={codicon('add')} />&nbsp;
+                            {nls.localize('theia/ai-tool-sketchpad/addItemProperty', 'Add Item Property')}
+                        </button>
+                    </div>
+                )}
+            </div>
+        );
+    };
+
+    return (
+        <div className='ai-sketchpad-detail'>
+            <div className='ai-sketchpad-form'>
+                <div className='ai-sketchpad-tool-header'>
+                    <div className='ai-sketchpad-tool-title'>
+                        <i className={`ai-sketchpad-tool-title-icon ${codicon('symbol-method')}`} />
+                        <span className='ai-sketchpad-tool-title-name'>{toolDisplayName(tool)}</span>
+                        <span className='ai-sketchpad-mode-badge'>{returnModeLabel(tool.returnMode ?? 'static')}</span>
+                    </div>
+                    <code className='ai-sketchpad-tool-signature'>{toolSignature(tool)}</code>
+                </div>
+
+                <div className='ai-sketchpad-form-field'>
+                    <label>{nls.localize('theia/ai-tool-sketchpad/toolName', 'Tool Name')}</label>
+                    <input
+                        className='theia-input'
+                        value={tool.name}
+                        placeholder={nls.localize('theia/ai-tool-sketchpad/toolNamePlaceholder', 'e.g. getWeather')}
+                        onChange={e => updateField('name', e.target.value)}
+                    />
+                </div>
+
+                <div className='ai-sketchpad-form-field'>
+                    <label>{nls.localizeByDefault('Description')}</label>
+                    <textarea
+                        className='theia-input ai-sketchpad-textarea'
+                        value={tool.description}
+                        placeholder={nls.localize('theia/ai-tool-sketchpad/descriptionPlaceholder', 'Describe what the tool does...')}
+                        onChange={e => updateField('description', e.target.value)}
+                        rows={3}
+                    />
+                </div>
+
+                <div className='ai-sketchpad-form-field'>
+                    <label>{nls.localize('theia/ai-tool-sketchpad/parameters', 'Parameters')}</label>
+                    {renderParameters(tool.parameters, [], 0)}
+                    <button className='theia-button secondary ai-sketchpad-add-param-btn' onClick={() => handleAddParameter([])}>
+                        <i className={codicon('add')} />&nbsp;
+                        {nls.localize('theia/ai-tool-sketchpad/addParameter', 'Add Parameter')}
+                    </button>
+                </div>
+
+                <div className='ai-sketchpad-form-field'>
+                    <label>{nls.localize('theia/ai-tool-sketchpad/returnMode', 'Return Mode')}</label>
+                    <select
+                        className='theia-select'
+                        value={tool.returnMode ?? 'static'}
+                        onChange={e => updateReturnMode(e.target.value as SketchedToolReturnMode)}
+                    >
+                        <option value='static'>
+                            {nls.localize('theia/ai-tool-sketchpad/returnModeStatic', 'Static Return Value')}
+                        </option>
+                        <option value='askAtRuntime'>
+                            {nls.localize('theia/ai-tool-sketchpad/returnModeAskAtRuntime', 'Ask At Runtime')}
+                        </option>
+                    </select>
+                </div>
+
+                {tool.returnMode !== 'askAtRuntime' && (
+                    <div className='ai-sketchpad-form-field'>
+                        <label>{nls.localize('theia/ai-tool-sketchpad/staticReturn', 'Static Return Value')}</label>
+                        <textarea
+                            className='theia-input ai-sketchpad-textarea ai-sketchpad-textarea-code'
+                            value={tool.staticReturn}
+                            placeholder={nls.localize('theia/ai-tool-sketchpad/staticReturnPlaceholder',
+                                'The value returned when this tool is invoked (e.g. JSON string)')}
+                            onChange={e => updateField('staticReturn', e.target.value)}
+                            rows={4}
+                        />
+                        <span className='ai-sketchpad-hint'>
+                            {nls.localize('theia/ai-tool-sketchpad/staticReturnHint',
+                                'This static value is returned every time the tool is called, regardless of the input arguments.')}
+                        </span>
+                    </div>
+                )}
+
+                {tool.returnMode === 'askAtRuntime' && (
+                    <div className='ai-sketchpad-form-field'>
+                        <span className='ai-sketchpad-hint'>
+                            {nls.localize('theia/ai-tool-sketchpad/askAtRuntimeHint',
+                                'When the LLM calls this tool, a quick input will open asking you to provide the return value.')}
+                        </span>
+                    </div>
+                )}
+
+                <div className='ai-sketchpad-actions'>
+                    <button className='theia-button secondary' onClick={() => onDelete(tool.id)}>
+                        {nls.localizeByDefault('Delete')}
+                    </button>
+                    <button
+                        className='theia-button main'
+                        onClick={handleSave}
+                        disabled={!isDirty || !tool.name.trim()}
+                    >
+                        {nls.localizeByDefault('Save')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+function deepCopy<T>(obj: T): T {
+    return JSON.parse(JSON.stringify(obj));
+}
+
+@injectable()
+export class SketchedToolWidget extends ReactWidget {
+
+    static readonly ID = 'ai-tool-sketchpad';
+    static readonly LABEL = nls.localize('theia/ai-tool-sketchpad/label', 'AI Tool Sketchpad');
+
+    @inject(SketchedToolService)
+    protected readonly sketchedToolService: SketchedToolService;
+
+    protected tools: SketchedToolDefinition[] = [];
+    protected selectedToolId: string | undefined;
+    protected editingTool: SketchedToolDefinition | undefined;
+    protected isNewUnsavedTool = false;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = SketchedToolWidget.ID;
+        this.title.label = SketchedToolWidget.LABEL;
+        this.title.caption = SketchedToolWidget.LABEL;
+        this.title.closable = true;
+        this.title.iconClass = codicon('beaker');
+        this.addClass('ai-sketchpad-widget');
+
+        this.loadTools();
+
+        this.toDispose.push(
+            this.sketchedToolService.onDidChangeSketchedTools(() => {
+                this.loadTools();
+            })
+        );
+    }
+
+    protected loadTools(): void {
+        this.tools = this.sketchedToolService.getSketchedTools();
+        if (this.selectedToolId) {
+            const stillExists = this.tools.find(t => t.id === this.selectedToolId);
+            if (!stillExists) {
+                // Preserve a new tool that hasn't been saved to the service yet
+                if (!this.isNewUnsavedTool) {
+                    this.selectedToolId = undefined;
+                    this.editingTool = undefined;
+                }
+            } else {
+                this.isNewUnsavedTool = false;
+                this.editingTool = deepCopy(stillExists);
+            }
+        }
+        this.update();
+    }
+
+    protected render(): React.ReactNode {
+        return (
+            <div className='ai-sketchpad-container'>
+                {this.renderList()}
+                {this.renderDetail()}
+            </div>
+        );
+    }
+
+    protected renderList(): React.ReactNode {
+        return (
+            <div className='ai-sketchpad-list theia-TreeContainer'>
+                {this.tools.length === 0 ? (
+                    <div className='ai-sketchpad-list-empty'>
+                        {nls.localize('theia/ai-tool-sketchpad/noTools', 'No tools yet.')}
+                    </div>
+                ) : (
+                    <ul>
+                        {this.tools.map(tool => (
+                            <ToolListItem
+                                key={tool.id}
+                                tool={tool}
+                                isSelected={this.selectedToolId === tool.id}
+                                onSelect={this.handleSelectTool}
+                                onDelete={this.handleDeleteTool}
+                            />
+                        ))}
+                    </ul>
+                )}
+                <div className='ai-sketchpad-add-button'>
+                    <button className='theia-button main' onClick={this.handleAddTool}>
+                        <i className={codicon('add')} />&nbsp;
+                        {nls.localize('theia/ai-tool-sketchpad/addTool', 'Add Tool')}
+                    </button>
+                </div>
+            </div>
+        );
+    }
+
+    protected renderDetail(): React.ReactNode {
+        if (!this.editingTool) {
+            return (
+                <div className='ai-sketchpad-detail'>
+                    <div className='ai-sketchpad-empty-state'>
+                        <i className={`ai-sketchpad-empty-icon ${codicon('beaker')}`} />
+                        <span className='ai-sketchpad-empty-message'>
+                            {nls.localize('theia/ai-tool-sketchpad/selectTool', 'Select a tool to edit, or add a new one to start sketching.')}
+                        </span>
+                    </div>
+                </div>
+            );
+        }
+
+        return (
+            <ToolDetailForm
+                key={this.editingTool.id}
+                tool={this.editingTool}
+                onSave={this.handleSave}
+                onDelete={this.handleDeleteTool}
+            />
+        );
+    }
+
+    // --- Event Handlers (arrow functions per coding guidelines) ---
+
+    protected handleSelectTool = (tool: SketchedToolDefinition): void => {
+        this.selectedToolId = tool.id;
+        this.editingTool = deepCopy(tool);
+        this.update();
+    };
+
+    protected handleAddTool = (): void => {
+        const newTool: SketchedToolDefinition = {
+            id: generateUuid(),
+            name: '',
+            description: '',
+            parameters: [],
+            returnMode: 'static',
+            staticReturn: ''
+        };
+        this.selectedToolId = newTool.id;
+        this.editingTool = newTool;
+        this.isNewUnsavedTool = true;
+        this.update();
+    };
+
+    protected handleDeleteTool = async (toolId: string): Promise<void> => {
+        const existing = this.tools.find(t => t.id === toolId);
+        if (existing) {
+            const confirmed = await new ConfirmDialog({
+                title: nls.localizeByDefault('Delete'),
+                msg: nls.localize('theia/ai-tool-sketchpad/confirmDelete',
+                    'Are you sure you want to delete the tool "{0}"?', existing.name || existing.id),
+                ok: nls.localizeByDefault('Delete'),
+                cancel: nls.localizeByDefault('Cancel')
+            }).open();
+            if (!confirmed) {
+                return;
+            }
+            this.clearSelectionIfMatches(toolId);
+            await this.sketchedToolService.removeSketchedTool(toolId);
+            // loadTools() will be triggered via onDidChangeSketchedTools and call update()
+        } else {
+            // New unsaved tool not yet in the service — just discard and refresh the UI
+            this.clearSelectionIfMatches(toolId);
+            this.update();
+        }
+    };
+
+    protected clearSelectionIfMatches(toolId: string): void {
+        if (this.selectedToolId === toolId) {
+            this.selectedToolId = undefined;
+            this.editingTool = undefined;
+            this.isNewUnsavedTool = false;
+        }
+    }
+
+    protected handleSave = async (tool: SketchedToolDefinition): Promise<void> => {
+        if (!tool.name.trim()) {
+            return;
+        }
+        this.editingTool = tool;
+        this.isNewUnsavedTool = false;
+        const existing = this.tools.find(t => t.id === tool.id);
+        if (existing) {
+            await this.sketchedToolService.updateSketchedTool(tool);
+        } else {
+            await this.sketchedToolService.addSketchedTool(tool);
+        }
+        // loadTools() is triggered via onDidChangeSketchedTools and calls update()
+    };
+}

--- a/packages/ai-tool-sketchpad/src/browser/sketched-tool-widget.tsx
+++ b/packages/ai-tool-sketchpad/src/browser/sketched-tool-widget.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -87,13 +87,16 @@ function ToolListItem({ tool, isSelected, onSelect, onDelete }: ToolListItemProp
 
 interface ToolDetailFormProps {
     tool: SketchedToolDefinition;
+    existingTools: SketchedToolDefinition[];
     onSave: (tool: SketchedToolDefinition) => void;
     onDelete: (id: string) => void;
 }
 
-function ToolDetailForm({ tool: initialTool, onSave, onDelete }: ToolDetailFormProps): React.ReactElement {
+function ToolDetailForm({ tool: initialTool, existingTools, onSave, onDelete }: ToolDetailFormProps): React.ReactElement {
     const [tool, setTool] = React.useState<SketchedToolDefinition>(deepCopy(initialTool));
     const [isDirty, setIsDirty] = React.useState(false);
+
+    const nameError = SketchedToolDefinition.validateName(tool.name, existingTools, tool.id);
 
     React.useEffect(() => {
         setTool(deepCopy(initialTool));
@@ -240,8 +243,8 @@ function ToolDetailForm({ tool: initialTool, onSave, onDelete }: ToolDetailFormP
     };
 
     const handleSave = (): void => {
-        if (tool.name.trim()) {
-            onSave(tool);
+        if (!nameError) {
+            onSave({ ...tool, name: tool.name.trim() });
             setIsDirty(false);
         }
     };
@@ -425,11 +428,14 @@ function ToolDetailForm({ tool: initialTool, onSave, onDelete }: ToolDetailFormP
                 <div className='ai-sketchpad-form-field'>
                     <label>{nls.localize('theia/ai-tool-sketchpad/toolName', 'Tool Name')}</label>
                     <input
-                        className='theia-input'
+                        className={`theia-input${isDirty && nameError ? ' ai-sketchpad-input-error' : ''}`}
                         value={tool.name}
                         placeholder={nls.localize('theia/ai-tool-sketchpad/toolNamePlaceholder', 'e.g. getWeather')}
                         onChange={e => updateField('name', e.target.value)}
                     />
+                    {isDirty && nameError && (
+                        <span className='ai-sketchpad-error'>{nameError}</span>
+                    )}
                 </div>
 
                 <div className='ai-sketchpad-form-field'>
@@ -502,7 +508,7 @@ function ToolDetailForm({ tool: initialTool, onSave, onDelete }: ToolDetailFormP
                     <button
                         className='theia-button main'
                         onClick={handleSave}
-                        disabled={!isDirty || !tool.name.trim()}
+                        disabled={!isDirty || !!nameError}
                     >
                         {nls.localizeByDefault('Save')}
                     </button>
@@ -623,6 +629,7 @@ export class SketchedToolWidget extends ReactWidget {
             <ToolDetailForm
                 key={this.editingTool.id}
                 tool={this.editingTool}
+                existingTools={this.tools}
                 onSave={this.handleSave}
                 onDelete={this.handleDeleteTool}
             />
@@ -684,7 +691,7 @@ export class SketchedToolWidget extends ReactWidget {
     }
 
     protected handleSave = async (tool: SketchedToolDefinition): Promise<void> => {
-        if (!tool.name.trim()) {
+        if (SketchedToolDefinition.validateName(tool.name, this.tools, tool.id)) {
             return;
         }
         this.editingTool = tool;

--- a/packages/ai-tool-sketchpad/src/browser/style/index.css
+++ b/packages/ai-tool-sketchpad/src/browser/style/index.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2025 EclipseSource GmbH.
+ * Copyright (C) 2026 EclipseSource GmbH.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/browser/style/index.css
+++ b/packages/ai-tool-sketchpad/src/browser/style/index.css
@@ -1,0 +1,376 @@
+/********************************************************************************
+ * Copyright (C) 2025 EclipseSource GmbH.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* ===== Main Layout ===== */
+.ai-sketchpad-widget {
+    height: 100%;
+}
+
+.ai-sketchpad-container {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+    overflow: hidden;
+}
+
+/* ===== List Panel ===== */
+.ai-sketchpad-list {
+    width: 240px;
+    min-width: 180px;
+    max-width: 320px;
+    border-right: var(--theia-border-width) solid var(--theia-widget-border);
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.ai-sketchpad-list ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    flex: 1;
+    overflow-y: auto;
+}
+
+.ai-sketchpad-list-empty {
+    flex: 1;
+    padding: var(--theia-ui-padding);
+    color: var(--theia-descriptionForeground);
+    font-style: italic;
+}
+
+.ai-sketchpad-list .theia-TreeNode {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) * 0.75);
+    padding: calc(var(--theia-ui-padding) * 0.75) var(--theia-ui-padding);
+    cursor: pointer;
+    user-select: none;
+}
+
+.ai-sketchpad-list .theia-TreeNode:hover {
+    background-color: var(--theia-list-hoverBackground);
+}
+
+.ai-sketchpad-list .theia-TreeNode.theia-mod-selected {
+    background-color: var(--theia-list-activeSelectionBackground);
+    color: var(--theia-list-activeSelectionForeground);
+}
+
+.ai-sketchpad-list-item-icon {
+    flex: 0 0 auto;
+    color: var(--theia-icon-foreground);
+    opacity: 0.8;
+}
+
+.ai-sketchpad-list-item-text {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-width: 0;
+    line-height: 1.3;
+}
+
+.ai-sketchpad-list-item-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.ai-sketchpad-list-item-meta {
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-descriptionForeground);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Keep icon and meta legible against the selection highlight. */
+.ai-sketchpad-list .theia-TreeNode.theia-mod-selected .ai-sketchpad-list-item-icon,
+.ai-sketchpad-list .theia-TreeNode.theia-mod-selected .ai-sketchpad-list-item-meta {
+    color: inherit;
+    opacity: 0.75;
+}
+
+.ai-sketchpad-delete-icon {
+    opacity: 0;
+    cursor: pointer;
+    color: var(--theia-icon-foreground);
+    padding: calc(var(--theia-ui-padding) / 3);
+    border-radius: calc(var(--theia-ui-padding) / 2);
+    transition: opacity 0.15s, background-color 0.15s;
+}
+
+.ai-sketchpad-list .theia-TreeNode:hover .ai-sketchpad-delete-icon {
+    opacity: 0.6;
+}
+
+.ai-sketchpad-list .theia-TreeNode:hover .ai-sketchpad-delete-icon:hover {
+    opacity: 1;
+    background-color: var(--theia-list-hoverBackground);
+    color: var(--theia-errorForeground);
+}
+
+.ai-sketchpad-add-button {
+    padding: var(--theia-ui-padding);
+    border-top: var(--theia-border-width) solid var(--theia-widget-border);
+}
+
+.ai-sketchpad-add-button button {
+    width: 100%;
+    margin-left: 0;
+}
+
+/* ===== Detail Panel ===== */
+.ai-sketchpad-detail {
+    flex: 1;
+    overflow-y: auto;
+    padding: calc(var(--theia-ui-padding) * 2);
+    min-width: 0;
+}
+
+.ai-sketchpad-empty-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: var(--theia-ui-padding);
+    height: 100%;
+    text-align: center;
+}
+
+.ai-sketchpad-empty-icon {
+    font-size: 32px;
+    color: var(--theia-descriptionForeground);
+    opacity: 0.5;
+}
+
+.ai-sketchpad-empty-message {
+    max-width: 260px;
+    color: var(--theia-descriptionForeground);
+    font-style: italic;
+}
+
+/* ===== Form ===== */
+.ai-sketchpad-form {
+    max-width: 700px;
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--theia-ui-padding) * 2);
+}
+
+/* ===== Detail header (live tool signature) ===== */
+.ai-sketchpad-tool-header {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--theia-ui-padding) * 0.75);
+    padding-bottom: calc(var(--theia-ui-padding) * 1.5);
+    border-bottom: var(--theia-border-width) solid var(--theia-widget-border);
+}
+
+.ai-sketchpad-tool-title {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) * 0.75);
+    min-width: 0;
+}
+
+.ai-sketchpad-tool-title-icon {
+    flex: 0 0 auto;
+    font-size: var(--theia-ui-font-size3);
+    color: var(--theia-icon-foreground);
+}
+
+.ai-sketchpad-tool-title-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: var(--theia-ui-font-size3);
+    font-weight: 600;
+}
+
+.ai-sketchpad-mode-badge {
+    flex: 0 0 auto;
+    margin-left: auto;
+    padding: 1px calc(var(--theia-ui-padding) * 0.75);
+    border-radius: 999px;
+    font-size: var(--theia-ui-font-size0);
+    white-space: nowrap;
+    background-color: var(--theia-badge-background);
+    color: var(--theia-badge-foreground);
+}
+
+.ai-sketchpad-tool-signature {
+    overflow-x: auto;
+    white-space: pre;
+    padding: calc(var(--theia-ui-padding) * 0.5) calc(var(--theia-ui-padding) * 0.75);
+    border-left: 2px solid var(--theia-focusBorder);
+    border-radius: calc(var(--theia-ui-padding) / 2);
+    font-family: var(--theia-code-font-family);
+    font-size: var(--theia-code-font-size);
+    color: var(--theia-descriptionForeground);
+    background-color: var(--theia-textCodeBlock-background);
+}
+
+.ai-sketchpad-form-field {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--theia-ui-padding) * 0.5);
+}
+
+.ai-sketchpad-form-field > label {
+    font-weight: 600;
+    font-size: var(--theia-ui-font-size2);
+    color: var(--theia-foreground);
+}
+
+.ai-sketchpad-textarea {
+    resize: vertical;
+    min-height: 60px;
+}
+
+.ai-sketchpad-textarea-code {
+    font-family: var(--theia-code-font-family);
+    font-size: var(--theia-code-font-size);
+}
+
+.ai-sketchpad-hint {
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-descriptionForeground);
+    font-style: italic;
+    margin-top: calc(var(--theia-ui-padding) * 0.25);
+}
+
+/* ===== Parameters ===== */
+.ai-sketchpad-no-params {
+    color: var(--theia-descriptionForeground);
+    font-style: italic;
+    padding: calc(var(--theia-ui-padding) * 0.5) 0;
+}
+
+.ai-sketchpad-param-list {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--theia-ui-padding) * 0.5);
+}
+
+.ai-sketchpad-param-item {
+    border: var(--theia-border-width) solid var(--theia-widget-border);
+    border-radius: calc(var(--theia-ui-padding) * 2 / 3);
+    padding: calc(var(--theia-ui-padding) * 0.75);
+    background-color: var(--theia-editor-background);
+}
+
+.ai-sketchpad-param-row {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) * 0.5);
+    flex-wrap: wrap;
+}
+
+.ai-sketchpad-param-name {
+    flex: 1;
+    min-width: 100px;
+    max-width: 160px;
+}
+
+.ai-sketchpad-param-desc {
+    flex: 2;
+    min-width: 120px;
+}
+
+.ai-sketchpad-param-type {
+    width: 100px;
+    height: stretch;
+}
+
+.ai-sketchpad-param-required {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) * 2 / 3);
+    padding-left: var(--theia-ui-padding);
+    cursor: pointer;
+    user-select: none;
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-descriptionForeground);
+    white-space: nowrap;
+}
+
+.ai-sketchpad-param-required input[type="checkbox"] {
+    margin: 0;
+}
+
+.ai-sketchpad-param-delete {
+    cursor: pointer;
+    color: var(--theia-icon-foreground);
+    padding: calc(var(--theia-ui-padding) / 3);
+    border-radius: calc(var(--theia-ui-padding) / 2);
+    transition: background-color 0.15s;
+}
+
+.ai-sketchpad-param-delete:hover {
+    background-color: var(--theia-list-hoverBackground);
+    color: var(--theia-errorForeground);
+}
+
+/* ===== Nested Parameters ===== */
+.ai-sketchpad-param-nested {
+    margin-top: calc(var(--theia-ui-padding) * 0.5);
+    padding-left: calc(var(--theia-ui-padding) * 1.5);
+    border-left: calc(var(--theia-border-width) * 2) solid var(--theia-widget-border);
+}
+
+.ai-sketchpad-param-depth-1 {
+    margin-left: calc(var(--theia-ui-padding) * 3);
+}
+
+.ai-sketchpad-param-depth-2 {
+    margin-left: calc(var(--theia-ui-padding) * 6);
+}
+
+.ai-sketchpad-add-nested-btn {
+    margin-top: calc(var(--theia-ui-padding) * 0.5);
+    align-self: flex-start;
+}
+
+.ai-sketchpad-add-param-btn {
+    margin-top: calc(var(--theia-ui-padding) * 0.5);
+    align-self: flex-start;
+}
+
+/* ===== Array Item Type ===== */
+.ai-sketchpad-param-array-type {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) * 0.5);
+    margin-top: calc(var(--theia-ui-padding) * 0.5);
+    padding-left: calc(var(--theia-ui-padding) * 1.5);
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-descriptionForeground);
+}
+
+.ai-sketchpad-param-array-type select {
+    width: 100px;
+}
+
+/* ===== Actions ===== */
+.ai-sketchpad-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: var(--theia-ui-padding);
+    padding-top: var(--theia-ui-padding);
+    border-top: var(--theia-border-width) solid var(--theia-widget-border);
+}

--- a/packages/ai-tool-sketchpad/src/browser/style/index.css
+++ b/packages/ai-tool-sketchpad/src/browser/style/index.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2026 EclipseSource GmbH.
+ * Copyright (C) 2026 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -364,6 +364,17 @@
 
 .ai-sketchpad-param-array-type select {
     width: 100px;
+}
+
+/* ===== Validation ===== */
+.ai-sketchpad-input-error {
+    border-color: var(--theia-inputValidation-errorBorder) !important;
+}
+
+.ai-sketchpad-error {
+    margin-top: calc(var(--theia-ui-padding) * 0.5);
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-errorForeground);
 }
 
 /* ===== Actions ===== */

--- a/packages/ai-tool-sketchpad/src/common/index.ts
+++ b/packages/ai-tool-sketchpad/src/common/index.ts
@@ -1,0 +1,17 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export * from './sketched-tool';

--- a/packages/ai-tool-sketchpad/src/common/index.ts
+++ b/packages/ai-tool-sketchpad/src/common/index.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/common/sketched-tool.ts
+++ b/packages/ai-tool-sketchpad/src/common/sketched-tool.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/common/sketched-tool.ts
+++ b/packages/ai-tool-sketchpad/src/common/sketched-tool.ts
@@ -1,0 +1,89 @@
+// *****************************************************************************
+// Copyright (C) 2025 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core';
+
+export type SketchedToolParameterType = 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array';
+
+export type SketchedToolReturnMode = 'static' | 'askAtRuntime';
+
+export interface SketchedToolParameterDefinition {
+    name: string;
+    description: string;
+    type: SketchedToolParameterType;
+    required?: boolean;
+    /** For type 'object': nested properties (max 2 levels) */
+    properties?: SketchedToolParameterDefinition[];
+    /** For type 'array': item type */
+    itemType?: 'string' | 'number' | 'integer' | 'boolean' | 'object';
+    /** For type 'array' with itemType 'object': properties of the item object */
+    itemProperties?: SketchedToolParameterDefinition[];
+}
+
+export interface SketchedToolDefinition {
+    id: string;
+    name: string;
+    description: string;
+    parameters: SketchedToolParameterDefinition[];
+    returnMode: SketchedToolReturnMode;
+    staticReturn: string;
+}
+
+export namespace SketchedToolDefinition {
+    export function is(obj: unknown): obj is SketchedToolDefinition {
+        // eslint-disable-next-line no-null/no-null
+        if (typeof obj !== 'object' || obj === null) {
+            return false;
+        }
+        const candidate = obj as Record<string, unknown>;
+        if (typeof candidate.id !== 'string' || typeof candidate.name !== 'string') {
+            return false;
+        }
+        if (typeof candidate.description !== 'string') {
+            return false;
+        }
+        if (!Array.isArray(candidate.parameters)) {
+            return false;
+        }
+        if (candidate.returnMode !== undefined && candidate.returnMode !== 'static' && candidate.returnMode !== 'askAtRuntime') {
+            return false;
+        }
+        // returnMode and staticReturn are optional here; normalize() fills in defaults.
+        if (candidate.staticReturn !== undefined && typeof candidate.staticReturn !== 'string') {
+            return false;
+        }
+        return true;
+    }
+
+    export function normalize(obj: SketchedToolDefinition): SketchedToolDefinition {
+        return {
+            ...obj,
+            returnMode: obj.returnMode ?? 'static',
+            staticReturn: obj.staticReturn ?? ''
+        };
+    }
+}
+
+export const SKETCHED_TOOLS_PROVIDER_NAME = 'ai-tool-sketchpad';
+
+export const SketchedToolService = Symbol('SketchedToolService');
+export interface SketchedToolService {
+    getSketchedTools(): SketchedToolDefinition[];
+    addSketchedTool(tool: SketchedToolDefinition): Promise<void>;
+    updateSketchedTool(tool: SketchedToolDefinition): Promise<void>;
+    removeSketchedTool(toolId: string): Promise<void>;
+    onDidChangeSketchedTools: Event<void>;
+}

--- a/packages/ai-tool-sketchpad/src/common/sketched-tool.ts
+++ b/packages/ai-tool-sketchpad/src/common/sketched-tool.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Event } from '@theia/core';
+import { Event, nls } from '@theia/core';
 
 export type SketchedToolParameterType = 'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array';
 
@@ -74,6 +74,35 @@ export namespace SketchedToolDefinition {
             returnMode: obj.returnMode ?? 'static',
             staticReturn: obj.staticReturn ?? ''
         };
+    }
+
+    /**
+     * Pattern accepted as a tool name by most LLM providers (e.g. OpenAI, Anthropic).
+     * The name is also used as the id under which the tool is registered, so it must be unique.
+     */
+    export const NAME_PATTERN = /^[a-zA-Z0-9_-]{1,128}$/;
+
+    /**
+     * Validates a tool name for use as a registered tool id.
+     *
+     * @param name the name to validate
+     * @param existingTools the currently defined tools, used to check for name collisions
+     * @param selfId the id of the tool being edited, so it is not compared against itself
+     * @returns a localized error message if the name is invalid, otherwise `undefined`
+     */
+    export function validateName(name: string, existingTools: SketchedToolDefinition[], selfId?: string): string | undefined {
+        const trimmed = name.trim();
+        if (!trimmed) {
+            return nls.localize('theia/ai-tool-sketchpad/nameEmpty', 'Tool name must not be empty.');
+        }
+        if (!NAME_PATTERN.test(trimmed)) {
+            return nls.localize('theia/ai-tool-sketchpad/nameInvalid',
+                'Tool name may only contain letters, digits, underscores and hyphens (1-128 characters).');
+        }
+        if (existingTools.some(tool => tool.id !== selfId && tool.name.trim() === trimmed)) {
+            return nls.localize('theia/ai-tool-sketchpad/nameDuplicate', 'A tool with this name already exists.');
+        }
+        return undefined;
     }
 }
 

--- a/packages/ai-tool-sketchpad/src/package.spec.ts
+++ b/packages/ai-tool-sketchpad/src/package.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-tool-sketchpad/src/package.spec.ts
+++ b/packages/ai-tool-sketchpad/src/package.spec.ts
@@ -14,4 +14,12 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-export * from './sketched-tool';
+/*
+ * This is a placeholder for tests that the extension package should implement
+ * but as yet does not.
+ * Please delete this file when a real test is implemented.
+ */
+
+describe('ai-tool-sketchpad package', () => {
+    it('placeholder to enable mocha', () => true);
+});

--- a/packages/ai-tool-sketchpad/tsconfig.json
+++ b/packages/ai-tool-sketchpad/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../ai-core"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../filesystem"
+    }
+  ]
+}


### PR DESCRIPTION
#### What it does

When designing custom AI agents, users need to iterate on every aspect of agent behavior: system prompts, LLMs, skills, and MCPs can all be adjusted at runtime without rebuilding. Custom tool design was the one remaining gap. Users had to write and register code and rebuild to try different tool shapes (name, description, parameter structure, return value).

This change closes that gap by introducing a new @theia/ai-tool-sketchpad package that lets users define "sketched tools" in a lightweight, declarative tool stubs focused purely on the aspects that matter for high-level design exploration: name, description, input parameters, and return behavior. The implementation is intentionally left out; instead, tools can return a static value or interactively prompt the user for a return value at runtime via a quick input dialog. This makes it possible to simulate any tool response scenario while an agent is running, without writing a single line of implementation code.

How it works:

- A new SketchedToolService reads and writes tool definitions from sketchedTools.yml in the Theia config directory. File-watch support means changes made externally (e.g. editing the YAML directly) are picked up live.
- On startup and on every change, all sketched tools are unregistered and re-registered in the ToolInvocationRegistry, making them immediately available to any AI agent or chat session.
- The returnMode on each tool controls behavior at invocation time: 'static' always returns a fixed string; 'askAtRuntime' opens a quick input prompt showing the tool name and call arguments, letting the user supply the return value on the fly.
- A new Tool Sketchpad widget (master-detail layout, styled to match the Preferences editor) provides a UI for creating, editing, and deleting tools, including nested object and array parameter definitions up to two levels deep.
- All tool definitions and parameter schemas are serialized as YAML and validated on load with backwards-compatible normalization.

<img width="2561" height="1355" alt="image" src="https://github.com/user-attachments/assets/cbe4d764-70c2-4f61-8bae-56b798b83f35" />

#### To be discussed

It helps me exploring different agent designs. Not sure if it should be part of the Theia code base, and if yes, whether it just is useful in the Theia example apps, or in Theia IDE.
Looking forward to your opinions!

#### How to test

* Open the `AI Tool Sketchpad` view
* Create a few sketched tools
* Use them in prompts or agent system messages
* Make sure saved edits of sketched tools are effective immediately
* Make sure a restart keeps the sketched tools alive (they are persisted)
* Test dynamic and static return values of tools

#### Follow-ups

N/A

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
