### PR TITLE
fix: improve buffer overflow handling in SocketWriteBuffer

### DIFF
--- a/packages/core/src/common/messaging/socket-write-buffer.ts
+++ b/packages/core/src/common/messaging/socket-write-buffer.ts
@@ -23,20 +23,24 @@ export class SocketWriteBuffer {
     private bufferWritePosition = 0;
 
     buffer(data: Uint8Array): void {
-        this.ensureWriteBuffer(data.byteLength);
+        if (!this.ensureWriteBuffer(data.byteLength)) {
+            return;
+        }
         this.disconnectedBuffer?.set(data, this.bufferWritePosition);
         this.bufferWritePosition += data.byteLength;
     }
 
-    protected ensureWriteBuffer(byteLength: number): void {
+    protected ensureWriteBuffer(byteLength: number): boolean {
         if (!this.disconnectedBuffer) {
             this.disconnectedBuffer = new Uint8Array(SocketWriteBuffer.DISCONNECTED_BUFFER_SIZE);
             this.bufferWritePosition = 0;
         }
 
         if (this.bufferWritePosition + byteLength > this.disconnectedBuffer.byteLength) {
-            throw new Error(`Max disconnected buffer size exceeded by adding ${byteLength} bytes`);
+            console.warn(`Max disconnected buffer size exceeded by adding ${byteLength} bytes`);
+            return false;
         }
+        return true;
     }
 
     flush(socket: WebSocket): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Fixes: https://github.com/eclipse-theia/theia/issues/17226

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
As mentioned in the past on the same issue: https://github.com/eclipse-theia/theia/issues/13662, it’s challenging to reproduce the problem, but we’re encountering it frequently in cloud environments. Please refer to the steps outlined in the original issue https://github.com/eclipse-theia/theia/issues/13662.

The change in this PR is quite minor. It simply removes the throw error and replaces it with a WARN message, while also making necessary adjustments to the code.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
