### PR TITLE
Fix pinned octokit request-action commit in translation workflow

### DIFF
--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -44,7 +44,7 @@ jobs:
           DEEPL_API_TOKEN: ${{ secrets.DEEPL_API_TOKEN }}
 
       - name: Get Actor User Data
-        uses: octokit/request-action@dad4362715ba15d7e1e68ece930a41598f522992 # v2.4.0
+        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
         id: actor_user_data
         with:
           route: GET /users/{user}


### PR DESCRIPTION
#### What it does

See https://github.com/octokit/request-action/releases and https://github.com/octokit/request-action/commits/main/

The current sha used in our workflow is not existing. 

Maybe an error during the last update? On the repository itself it does not feel like something was force pushed, but not sure. 

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
