### PR TITLE
fix(ai-chat): Fix agent label casing in delegation renderer

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -48,13 +48,13 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
     render(response: ToolCallChatResponseContent, parentNode: ResponseNode): React.ReactNode {
         const delegation = response.id ? this.agentDelegationTool.getDelegation(response.id) : undefined;
 
-        let agentId = response.name ?? AGENT_DELEGATION_FUNCTION_ID;
+        let agentName = response.name ?? AGENT_DELEGATION_FUNCTION_ID;
         let prompt = '';
         if (response.arguments) {
             try {
                 const args = JSON.parse(response.arguments);
                 if (typeof args.agentId === 'string') {
-                    agentId = this.chatAgentService.getAgent(args.agentId)?.name ?? args.agentId;
+                    agentName = this.chatAgentService.getAgent(args.agentId)?.name ?? args.agentId;
                 }
                 if (typeof args.prompt === 'string') {
                     prompt = args.prompt;
@@ -66,7 +66,7 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
 
         return <DelegatedChat
             invocation={delegation?.invocation}
-            agentId={agentId}
+            agentName={agentName}
             prompt={delegation?.prompt ?? prompt}
             finished={response.finished}
             parentNode={parentNode}
@@ -77,7 +77,7 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
 
 interface DelegatedChatProps {
     invocation?: ChatRequestInvocation;
-    agentId: string;
+    agentName: string;
     prompt: string;
     finished?: boolean;
     parentNode: ResponseNode;
@@ -140,7 +140,7 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
     }
 
     override render(): React.ReactNode {
-        const { agentId, prompt } = this.props;
+        const { agentName, prompt } = this.props;
         const hasNode = !!this.state.node;
         const isComplete = this.state.node?.response.isComplete ?? false;
         const isCanceled = this.state.node?.response.isCanceled ?? false;
@@ -176,7 +176,7 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
                     <summary className='delegation-summary'>
                         <div className='delegation-header'>
                             <span className='delegation-agent'>
-                                <span className='codicon codicon-copilot-large' /> {agentId}
+                                <span className='codicon codicon-copilot-large' /> {agentName}
                             </span>
                             <span className='delegation-status'>
                                 <span className={`codicon ${statusIcon} delegation-status-icon`}></span>

--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -24,6 +24,7 @@ import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
 import { GettingStartedWidget } from './getting-started-widget';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { PreviewContribution } from '@theia/preview/lib/browser/preview-contribution';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
@@ -49,6 +50,9 @@ export class GettingStartedContribution extends AbstractViewContribution<Getting
 
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
+
+    @inject(PreviewContribution)
+    protected readonly previewContribution: PreviewContribution;
 
     @inject(FrontendApplicationStateService)
     protected readonly stateService: FrontendApplicationStateService;
@@ -116,6 +120,9 @@ export class GettingStartedContribution extends AbstractViewContribution<Getting
         }));
         const validReadmes = ArrayUtils.coalesce(readmes);
         if (validReadmes.length) {
+            for (const readme of validReadmes) {
+                await this.previewContribution.open(readme);
+            }
         } else {
             // If no readme is found, show the welcome page.
             this.openView({ reveal: true, activate: true });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The delegation renderer sourced the agent label from two different places depending on state: during an active session it used `delegation.agentName` (e.g. "Explore"), but after a page refresh it fell back to the raw LLM argument `args.agentId` (e.g. "explore"), because the in-memory `pendingDelegations` map is lost on reload.

Inject `ChatAgentService` into `DelegationToolRenderer` and resolve the display name via `getAgent(id)?.name` in the fallback path, with graceful degradation to the raw ID if the agent is not registered.

Remove the now-redundant `agentName` field from the delegation object
- the renderer no longer needs the name stored at invocation time.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Ask to delegate. You see that ui switches the label between the progress and complete state. But you need to use an agent where agentId and agentName differ.
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
