### PR TITLE
Disable listener leak for ext host file watchers

### DIFF
--- a/packages/plugin-ext/src/plugin/file-system-event-service-ext-impl.ts
+++ b/packages/plugin-ext/src/plugin/file-system-event-service-ext-impl.ts
@@ -18,7 +18,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 /**
- * **IMPORTANT** this code is running in the plugin host process and should be closed as possible to VS Code counterpart:
+ * **IMPORTANT** this code is running in the plugin host process and should be close as possible to VS Code counterpart:
  * https://github.com/microsoft/vscode/blob/04c36be045a94fee58e5f8992d3e3fd980294a84/src/vs/workbench/api/common/extHostFileSystemEventService.ts
  * One should be able to diff them to see differences.
  */
@@ -28,7 +28,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/tslint/config */
 
-import { Emitter, WaitUntilEvent, AsyncEmitter, WaitUntilData } from '@theia/core/lib/common/event';
+import { Emitter, Event as EventNamespace, WaitUntilEvent, AsyncEmitter, WaitUntilData } from '@theia/core/lib/common/event';
 import { IRelativePattern, parse } from '@theia/core/lib/common/glob';
 import { UriComponents } from '../common/uri-components';
 import { Disposable, URI, WorkspaceEdit } from './types-impl';
@@ -157,7 +157,10 @@ export class ExtHostFileSystemEventService implements ExtHostFileSystemEventServ
         private readonly _extHostDocumentsAndEditors: ExtHostDocumentsAndEditors,
         private readonly _mainThreadTextEditors: MainThreadTextEditorsShape = rpc.getProxy(PLUGIN_RPC_CONTEXT.TEXT_EDITORS_MAIN)
     ) {
-        //
+        // Language services often watch every component of source trees (including dependencies),
+        // which can result in hundreds of watchers in large projects.
+        // Disable the leak warning (maxListeners 0 = unbounded) to avoid false positives.
+        EventNamespace.setMaxListeners(this._onFileSystemEvent.event, 0);
     }
 
     // --- file events


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

When opening files in a large project like Theia, warnings like this are printed in massive numbers:

```
2026-03-27T15:24:37.914Z plugin-host WARN Possible Emitter memory leak detected. 1902 listeners added. Use event.maxListeners to increase the limit (175). MOST frequent listener (1426)
```

This is a false positive: language servers in particular may create many watchers for different components of their source trees. This PR simply silences the warning for the specific emitter that generates these warnings.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Open the Theia repository and open a TypeScript file.
2. Observe that you don't see hundreds of warnings about listener leakage.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
