### PR TITLE
feat: add taskContextId parameter to delegateToAgent tool

### DIFF
--- a/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
@@ -1,0 +1,194 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { AgentDelegationTool } from './agent-delegation-tool';
+import { TASK_CONTEXT_VARIABLE } from './task-context-variable';
+import { AIVariableResolutionRequest } from '@theia/ai-core';
+import {
+    ActiveSessionChangedEvent,
+    ChatAgentService,
+    ChatService,
+    SessionCreatedEvent,
+    SessionDeletedEvent,
+    SessionRenamedEvent,
+} from '../common';
+import { ChatAgentServiceImpl } from '../common/chat-agent-service';
+import { Event } from '@theia/core';
+
+disableJSDOM();
+
+// --- Factory ---
+
+function makeAgentDelegationTool(chatAgentService: ChatAgentService, chatService: ChatService): AgentDelegationTool {
+    const tool = new AgentDelegationTool();
+    Object.defineProperty(tool, 'getChatAgentService', { value: () => chatAgentService });
+    Object.defineProperty(tool, 'getChatService', { value: () => chatService });
+    return tool;
+}
+
+// --- Helper factories ---
+
+function makeContextManager(): { addVariables: sinon.SinonStub; getVariables: sinon.SinonStub } {
+    return {
+        addVariables: sinon.stub(),
+        getVariables: sinon.stub().returns([])
+    };
+}
+
+function makeChangeSet(): { onDidChange: sinon.SinonStub } {
+    return { onDidChange: sinon.stub() };
+}
+
+function makeNewSession(contextManager = makeContextManager()): {
+    id: string;
+    model: {
+        context: ReturnType<typeof makeContextManager>;
+        changeSet: ReturnType<typeof makeChangeSet>;
+    };
+} {
+    return {
+        id: 'new-session-id',
+        model: {
+            context: contextManager,
+            changeSet: makeChangeSet()
+        }
+    };
+}
+
+function makeParentSession(): {
+    id: string;
+    model: {
+        changeSet: { onDidChange: sinon.SinonStub; getElements: sinon.SinonStub };
+    };
+} {
+    return {
+        id: 'parent-session-id',
+        model: {
+            changeSet: {
+                onDidChange: sinon.stub(),
+                getElements: sinon.stub().returns([])
+            }
+        }
+    };
+}
+
+function makeChatAgentService(agentExists = true): ChatAgentService {
+    const stub = sinon.createStubInstance(ChatAgentServiceImpl);
+    stub.getAgent.returns(agentExists ? { id: 'test-agent', name: 'Test Agent' } as never : undefined);
+    stub.getAgents.returns([]);
+    return stub as ChatAgentService;
+}
+
+function makeChatContext(): {
+    cancellationToken: undefined;
+    toolCallId: undefined;
+    request: { session: ReturnType<typeof makeParentSession> };
+    response: object;
+} {
+    return {
+        cancellationToken: undefined,
+        toolCallId: undefined,
+        request: { session: makeParentSession() },
+        response: {}
+    };
+}
+
+type SessionEvent = ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent;
+
+function makeChatService(newSession: ReturnType<typeof makeNewSession>): ChatService {
+    const responseCompleted = Promise.resolve({
+        response: { asString: () => 'agent response' }
+    });
+    return {
+        onSessionEvent: sinon.stub() as Event<SessionEvent>,
+        getSession: sinon.stub(),
+        getSessions: sinon.stub().returns([]),
+        getActiveSession: sinon.stub().returns({ id: 'active-session-id' }),
+        setActiveSession: sinon.stub(),
+        createSession: sinon.stub().returns(newSession),
+        sendRequest: sinon.stub().resolves({ responseCompleted }),
+        deleteSession: sinon.stub().resolves(),
+        renameSession: sinon.stub().resolves(),
+        getAgent: sinon.stub(),
+        deleteChangeSet: sinon.stub(),
+        deleteChangeSetElement: sinon.stub(),
+        cancelRequest: sinon.stub().resolves(),
+        getOrRestoreSession: sinon.stub().resolves(undefined),
+        getPersistedSessions: sinon.stub().resolves({}),
+        hasPersistedSessions: sinon.stub().resolves(false),
+    };
+}
+
+// --- Tests ---
+
+describe('AgentDelegationTool', () => {
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    describe('delegateToAgent() — taskContextId parameter', () => {
+        let contextManager: ReturnType<typeof makeContextManager>;
+        let tool: AgentDelegationTool;
+        let ctx: ReturnType<typeof makeChatContext>;
+
+        beforeEach(() => {
+            contextManager = makeContextManager();
+            const newSession = makeNewSession(contextManager);
+            const agentService = makeChatAgentService();
+            const chatService = makeChatService(newSession);
+            tool = makeAgentDelegationTool(agentService, chatService);
+            ctx = makeChatContext();
+        });
+
+        it('injects TASK_CONTEXT_VARIABLE when taskContextId is provided', async () => {
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something', taskContextId: 'my-task-ctx-id' });
+
+            await tool.getTool().handler(argString, ctx);
+
+            expect(contextManager.addVariables.calledOnce).to.be.true;
+            const callArg: AIVariableResolutionRequest = contextManager.addVariables.firstCall.args[0];
+            expect(callArg.variable).to.equal(TASK_CONTEXT_VARIABLE);
+            expect(callArg.arg).to.equal('my-task-ctx-id');
+        });
+
+        it('does not inject any task context variable when taskContextId is not provided', async () => {
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
+
+            await tool.getTool().handler(argString, ctx);
+
+            expect(contextManager.addVariables.called).to.be.false;
+        });
+
+        it('does not inject any task context variable when taskContextId is an empty string', async () => {
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something', taskContextId: '' });
+
+            await tool.getTool().handler(argString, ctx);
+
+            expect(contextManager.addVariables.called).to.be.false;
+        });
+    });
+});

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -29,6 +29,7 @@ import {
     ChatSession,
     ChatRequestInvocation,
 } from '../common';
+import { TASK_CONTEXT_VARIABLE } from './task-context-variable';
 
 @injectable()
 export class AgentDelegationTool implements ToolProvider {
@@ -50,7 +51,8 @@ export class AgentDelegationTool implements ToolProvider {
                 'Delegate a task or question to a specific AI agent. IMPORTANT: When you delegate a task or question to a specific AI agent using this tool, ' +
                 'remember that each sub-agent operates solely within its specialized capabilities and tools and does not have access to previous conversation context ' +
                 ' or external systems. Therefore, it is crucial to provide all necessary context and detailed information directly within your request to ensure accurate ' +
-                'and effective task completion.',
+                'and effective task completion. ' +
+                'You may optionally pass a taskContextId to make a specific task context (e.g. a plan) available to the delegated agent via its system prompt.',
             parameters: {
                 type: 'object',
                 properties: {
@@ -63,6 +65,10 @@ export class AgentDelegationTool implements ToolProvider {
                         type: 'string',
                         description:
                             'The task, question, or prompt to pass to the specified agent.',
+                    },
+                    taskContextId: {
+                        type: 'string',
+                        description: 'Optional task context ID to make available to the delegated agent. The agent will see the task context in its system prompt.',
                     },
                 },
                 required: ['agentId', 'prompt'],
@@ -88,7 +94,7 @@ export class AgentDelegationTool implements ToolProvider {
 
         try {
             const args = JSON.parse(arg_string);
-            const { agentId, prompt } = args;
+            const { agentId, prompt, taskContextId } = args;
 
             if (!agentId || !prompt) {
                 const errorMsg = 'Both agentId and prompt parameters are required.';
@@ -121,11 +127,19 @@ export class AgentDelegationTool implements ToolProvider {
                     { focus: false },
                     agent
                 );
+
                 // Set root session ID to enable task context sharing across delegation chains
                 // Root is either the current root (for nested delegation) or current session (for first-level delegation)
                 const rootId = ctx.rootSessionId || ctx.request.session.id;
                 newSession.rootSessionId = rootId;
                 newSession.model.rootSessionId = rootId;
+
+                if (taskContextId) {
+                    newSession.model.context.addVariables({
+                        variable: TASK_CONTEXT_VARIABLE,
+                        arg: taskContextId
+                    });
+                }
 
                 // Immediately restore the original active session to avoid confusing the user
                 if (currentActiveSession) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Allow the delegating agent to explicitly specify which task context
a delegated agent should see. When taskContextId is provided,
the corresponding TASK_CONTEXT_VARIABLE is injected into the new
session's context, making it available via {{taskContextSummary}}
in the delegated agent's system prompt.


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Ask Architect to create a plan. Give access to the delegateToAgent function to the prompt and ask to "implement plan with coder". Coder should now resolve the task context correctly.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
