### PR TITLE
fix: prevent inverted expand/collapse in capabilities tree during search

### DIFF
--- a/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
@@ -273,9 +273,8 @@ export const GenericCapabilitiesTree: React.FunctionComponent<GenericCapabilitie
             // Only collapse when search was cleared, not on every re-render
             setExpandedNodes(new Set());
         }
-    // Only react to search query and filtered tree changes, not focusedNodeId
-    // Including focusedNodeId would cause all nodes to re-expand on every click while filtering
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+    // Only react to search query and filtered tree changes, not focusedNodeId.
+    // Including focusedNodeId would cause all nodes to re-expand on every click while filtering.
     }, [searchQuery, filteredTree]);
 
     // Get all visible node IDs for keyboard navigation


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/17243

When a search filter is active in the Generic Capabilities tree, clicking a parent node to expand it caused all *other* nodes to expand while the clicked node stayed collapsed (inverted behavior).

The root cause was that the `useEffect` responsible for auto-expanding nodes during search had `focusedNodeId` in its dependency array. Every click on a tree node sets focus (`onMouseDown` → `setFocusedNodeId`), which re-triggered the effect. Since the search query was still non-empty, the effect re-expanded all nodes via `setExpandedNodes(allIds)`. Then `onClick` fired `toggleExpand`, collapsing only the clicked node — producing the inverted behavior.

The fix removes `focusedNodeId` from the dependency array so the effect only runs when `searchQuery` or `filteredTree` actually change. The focused node cleanup is handled using the functional form of `setFocusedNodeId` instead.

#### How to test

1. Open the AI Chat panel and activate the Capabilities Configuration toggle
2. Enter a search term (e.g., "file") in the search box
3. The tree automatically filters and expands matching results
4. Click "Collapse all"
5. Click any parent node ("MCP," "Agents," "Prompts") to expand it
6. **Verify:** Only the clicked node expands (not all other nodes)
7. Click the same node again to collapse it
8. **Verify:** Only the clicked node collapses
9. Also verify that auto-expand still works correctly when typing/changing the search query

#### Follow-ups

None identified.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)