### PR TITLE
core: make SocketWriteBuffer and ReconnectableSocketChannel overridable via DI

### DIFF
--- a/packages/core/src/browser/messaging/messaging-frontend-module.ts
+++ b/packages/core/src/browser/messaging/messaging-frontend-module.ts
@@ -21,10 +21,12 @@ import { LocalConnectionProvider, RemoteConnectionProvider, ServiceConnectionPro
 import { ConnectionSource } from './connection-source';
 import { ConnectionCloseService, connectionCloseServicePath } from '../../common/messaging/connection-management';
 import { WebSocketConnectionProvider } from './ws-connection-provider';
+import { SocketWriteBuffer } from '../../common/messaging/socket-write-buffer';
 
 const backendServiceProvider = Symbol('backendServiceProvider');
 
 export const messagingFrontendModule = new ContainerModule(bind => {
+    bind(SocketWriteBuffer).toSelf();
     bind(ConnectionCloseService).toDynamicValue(ctx => WebSocketConnectionProvider.createProxy(ctx.container, connectionCloseServicePath)).inSingletonScope();
     bind(BrowserFrontendIdProvider).toSelf().inSingletonScope();
     bind(FrontendIdProvider).toService(BrowserFrontendIdProvider);

--- a/packages/core/src/browser/messaging/messaging-frontend-module.ts
+++ b/packages/core/src/browser/messaging/messaging-frontend-module.ts
@@ -26,6 +26,7 @@ import { SocketWriteBuffer } from '../../common/messaging/socket-write-buffer';
 const backendServiceProvider = Symbol('backendServiceProvider');
 
 export const messagingFrontendModule = new ContainerModule(bind => {
+    // Transient: each connection source gets its own private buffer instance.
     bind(SocketWriteBuffer).toSelf();
     bind(ConnectionCloseService).toDynamicValue(ctx => WebSocketConnectionProvider.createProxy(ctx.container, connectionCloseServicePath)).inSingletonScope();
     bind(BrowserFrontendIdProvider).toSelf().inSingletonScope();

--- a/packages/core/src/browser/messaging/ws-connection-source.ts
+++ b/packages/core/src/browser/messaging/ws-connection-source.ts
@@ -33,7 +33,7 @@ export class WebSocketConnectionSource implements ConnectionSource {
     @inject(FrontendIdProvider)
     protected readonly frontendIdProvider: FrontendIdProvider;
 
-    private readonly writeBuffer = new SocketWriteBuffer();
+    protected readonly writeBuffer = new SocketWriteBuffer();
 
     private _socket: Socket;
     get socket(): Socket {

--- a/packages/core/src/browser/messaging/ws-connection-source.ts
+++ b/packages/core/src/browser/messaging/ws-connection-source.ts
@@ -33,7 +33,8 @@ export class WebSocketConnectionSource implements ConnectionSource {
     @inject(FrontendIdProvider)
     protected readonly frontendIdProvider: FrontendIdProvider;
 
-    protected readonly writeBuffer = new SocketWriteBuffer();
+    @inject(SocketWriteBuffer)
+    protected readonly writeBuffer: SocketWriteBuffer;
 
     private _socket: Socket;
     get socket(): Socket {

--- a/packages/core/src/common/message-rpc/channel.ts
+++ b/packages/core/src/common/message-rpc/channel.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { injectable } from 'inversify';
 import { Disposable, DisposableCollection } from '../disposable';
 import { Emitter, Event } from '../event';
 import { ReadBuffer, WriteBuffer } from './message-buffer';
@@ -71,6 +72,7 @@ export type MessageProvider = () => ReadBuffer;
  *  Reusable abstract {@link Channel} implementation that sets up
  *  the basic channel event listeners and offers a generic close method.
  */
+@injectable()
 export abstract class AbstractChannel implements Channel {
 
     onCloseEmitter: Emitter<ChannelCloseEvent> = new Emitter();

--- a/packages/core/src/common/messaging/index.ts
+++ b/packages/core/src/common/messaging/index.ts
@@ -17,3 +17,4 @@
 export * from './handler';
 export * from './proxy-factory';
 export * from './connection-error-handler';
+export * from './socket-write-buffer';

--- a/packages/core/src/common/messaging/socket-write-buffer.ts
+++ b/packages/core/src/common/messaging/socket-write-buffer.ts
@@ -14,13 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { injectable } from 'inversify';
 import { WebSocket } from './web-socket-channel';
 
+@injectable()
 export class SocketWriteBuffer {
-    private static DISCONNECTED_BUFFER_SIZE = 100 * 1024;
+    protected static DISCONNECTED_BUFFER_SIZE = 100 * 1024;
 
-    private disconnectedBuffer: Uint8Array | undefined;
-    private bufferWritePosition = 0;
+    protected disconnectedBuffer: Uint8Array | undefined;
+    protected bufferWritePosition = 0;
 
     buffer(data: Uint8Array): void {
         this.ensureWriteBuffer(data.byteLength);

--- a/packages/core/src/common/messaging/socket-write-buffer.ts
+++ b/packages/core/src/common/messaging/socket-write-buffer.ts
@@ -19,10 +19,14 @@ import { WebSocket } from './web-socket-channel';
 
 @injectable()
 export class SocketWriteBuffer {
-    protected static DISCONNECTED_BUFFER_SIZE = 100 * 1024;
+    private static readonly DEFAULT_DISCONNECTED_BUFFER_SIZE = 100 * 1024;
 
     protected disconnectedBuffer: Uint8Array | undefined;
     protected bufferWritePosition = 0;
+
+    protected get maxBufferSize(): number {
+        return SocketWriteBuffer.DEFAULT_DISCONNECTED_BUFFER_SIZE;
+    }
 
     buffer(data: Uint8Array): void {
         this.ensureWriteBuffer(data.byteLength);
@@ -32,7 +36,7 @@ export class SocketWriteBuffer {
 
     protected ensureWriteBuffer(byteLength: number): void {
         if (!this.disconnectedBuffer) {
-            this.disconnectedBuffer = new Uint8Array(SocketWriteBuffer.DISCONNECTED_BUFFER_SIZE);
+            this.disconnectedBuffer = new Uint8Array(this.maxBufferSize);
             this.bufferWritePosition = 0;
         }
 

--- a/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
+++ b/packages/core/src/electron-browser/messaging/electron-messaging-frontend-module.ts
@@ -26,11 +26,14 @@ import { LocalConnectionProvider, RemoteConnectionProvider, ServiceConnectionPro
 import { WebSocketConnectionProvider } from '../../browser/messaging/ws-connection-provider';
 import { ConnectionCloseService, connectionCloseServicePath } from '../../common/messaging/connection-management';
 import { WebSocketConnectionSource } from '../../browser/messaging/ws-connection-source';
+import { SocketWriteBuffer } from '../../common/messaging/socket-write-buffer';
 
 const backendServiceProvider = Symbol('backendServiceProvider2');
 const localServiceProvider = Symbol('localServiceProvider');
 
 export const messagingFrontendModule = new ContainerModule(bind => {
+    // Transient: each connection source gets its own private buffer instance.
+    bind(SocketWriteBuffer).toSelf();
     bind(ConnectionCloseService).toDynamicValue(ctx => WebSocketConnectionProvider.createProxy(ctx.container, connectionCloseServicePath)).inSingletonScope();
     bind(ElectronWebSocketConnectionSource).toSelf().inSingletonScope();
     bind(WebSocketConnectionSource).toService(ElectronWebSocketConnectionSource);

--- a/packages/core/src/node/messaging/index.ts
+++ b/packages/core/src/node/messaging/index.ts
@@ -17,3 +17,4 @@
 export * from './messaging-service';
 export * from './ipc-connection-provider';
 export * from './ipc-channel';
+export * from './websocket-frontend-connection-service';

--- a/packages/core/src/node/messaging/messaging-backend-module.ts
+++ b/packages/core/src/node/messaging/messaging-backend-module.ts
@@ -24,8 +24,9 @@ import { MessagingListener, MessagingListenerContribution } from './messaging-li
 import { FrontendConnectionService } from './frontend-connection-service';
 import { BackendApplicationContribution } from '../backend-application';
 import { connectionCloseServicePath } from '../../common/messaging/connection-management';
-import { WebsocketFrontendConnectionService } from './websocket-frontend-connection-service';
+import { ReconnectableSocketChannel, WebsocketFrontendConnectionService } from './websocket-frontend-connection-service';
 import { WebsocketEndpoint } from './websocket-endpoint';
+import { SocketWriteBuffer } from '../../common/messaging/socket-write-buffer';
 
 export const messagingBackendModule = new ContainerModule(bind => {
     bindRootContributionProvider(bind, ConnectionContainerModule);
@@ -36,6 +37,8 @@ export const messagingBackendModule = new ContainerModule(bind => {
     bind(MessagingContainer).toDynamicValue(({ container }) => container).inSingletonScope();
     bind(WebsocketEndpoint).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(WebsocketEndpoint);
+    bind(SocketWriteBuffer).toSelf();
+    bind(ReconnectableSocketChannel).toSelf();
     bind(WebsocketFrontendConnectionService).toSelf().inSingletonScope();
     bind(FrontendConnectionService).toService(WebsocketFrontendConnectionService);
     bind(MessagingListener).toSelf().inSingletonScope();

--- a/packages/core/src/node/messaging/messaging-backend-module.ts
+++ b/packages/core/src/node/messaging/messaging-backend-module.ts
@@ -37,6 +37,7 @@ export const messagingBackendModule = new ContainerModule(bind => {
     bind(MessagingContainer).toDynamicValue(({ container }) => container).inSingletonScope();
     bind(WebsocketEndpoint).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(WebsocketEndpoint);
+    // Transient: each connection gets its own private buffer and channel instances.
     bind(SocketWriteBuffer).toSelf();
     bind(ReconnectableSocketChannel).toSelf();
     bind(WebsocketFrontendConnectionService).toSelf().inSingletonScope();

--- a/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
+++ b/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
@@ -15,9 +15,9 @@
 
 import { Channel, WriteBuffer } from '../../common/message-rpc';
 import { MessagingService } from './messaging-service';
-import { inject, injectable } from 'inversify';
+import { inject, injectable, interfaces } from 'inversify';
 import { Socket } from 'socket.io';
-import { ConnectionHandlers } from './default-messaging-service';
+import { ConnectionHandlers, MessagingContainer } from './default-messaging-service';
 import { SocketWriteBuffer } from '../../common/messaging/socket-write-buffer';
 import { FrontendConnectionService } from './frontend-connection-service';
 import { AbstractChannel } from '../../common/message-rpc/channel';
@@ -32,6 +32,9 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
 
     @inject(WebsocketEndpoint)
     protected readonly websocketServer: WebsocketEndpoint;
+
+    @inject(MessagingContainer)
+    protected readonly container: interfaces.Container;
 
     protected readonly wsHandlers = new ConnectionHandlers();
     protected readonly connectionsByFrontend = new Map<string, ReconnectableSocketChannel>();
@@ -94,7 +97,7 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
 
     protected createConnection(socket: Socket, frontEndId: string): ReconnectableSocketChannel {
         console.info(`creating connection for ${frontEndId}`);
-        const channel = new ReconnectableSocketChannel();
+        const channel = this.container.get(ReconnectableSocketChannel);
         channel.connect(socket);
 
         this.connectionsByFrontend.set(frontEndId, channel);
@@ -139,7 +142,10 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
 @injectable()
 export class ReconnectableSocketChannel extends AbstractChannel {
     protected socket: Socket | undefined;
-    protected socketBuffer = new SocketWriteBuffer();
+
+    @inject(SocketWriteBuffer)
+    protected socketBuffer: SocketWriteBuffer;
+
     protected disposables = new DisposableCollection();
 
     connect(socket: Socket): void {

--- a/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
+++ b/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
@@ -149,6 +149,7 @@ export class ReconnectableSocketChannel extends AbstractChannel {
     protected disposables = new DisposableCollection();
 
     connect(socket: Socket): void {
+        this.disposables.dispose();
         this.disposables = new DisposableCollection();
         this.socket = socket;
         const errorHandler = (err: Error) => {

--- a/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
+++ b/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
@@ -136,10 +136,11 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
     }
 }
 
-class ReconnectableSocketChannel extends AbstractChannel {
-    private socket: Socket | undefined;
-    private socketBuffer = new SocketWriteBuffer();
-    private disposables = new DisposableCollection();
+@injectable()
+export class ReconnectableSocketChannel extends AbstractChannel {
+    protected socket: Socket | undefined;
+    protected socketBuffer = new SocketWriteBuffer();
+    protected disposables = new DisposableCollection();
 
     connect(socket: Socket): void {
         this.disposables = new DisposableCollection();


### PR DESCRIPTION
#### What it does

Makes `SocketWriteBuffer` and `ReconnectableSocketChannel` fully extensible by downstream adopters:

- Adds `@injectable()` decorator to `SocketWriteBuffer`, `ReconnectableSocketChannel`, and `AbstractChannel`
- Exports `ReconnectableSocketChannel` (previously file-private)
- Changes all `private` fields to `protected` in both classes
- Binds `SocketWriteBuffer` (transient) in both frontend and backend DI modules
- Binds `ReconnectableSocketChannel` (transient) in the backend DI module
- Injects `SocketWriteBuffer` via `@inject` into `ReconnectableSocketChannel` and `WebSocketConnectionSource` (replacing `new SocketWriteBuffer()`)
- Creates `ReconnectableSocketChannel` instances via `container.get()` in `WebsocketFrontendConnectionService.createConnection()` (replacing `new ReconnectableSocketChannel()`)

Adopters can now swap either class purely via DI rebinding:

```ts
rebind(SocketWriteBuffer).to(MyCustomWriteBuffer);
rebind(ReconnectableSocketChannel).to(MyCustomChannel);
```

#### How to test

1. Verify the application compiles: `npm run compile`
2. Verify the browser app builds and starts: `npm run build:browser && npm run start:browser`
3. Confirm websocket connections still work (open the app, interact normally)
4. Confirm reconnection still works (disconnect network briefly, then reconnect)

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)