### PR TITLE
Fix: Prevent multiple debug sessions spawning when F5 is held down

### DIFF
--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -406,12 +406,10 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         });
         registry.registerCommand(DebugCommands.CONTINUE, {
             execute: () => {
-                if (this.manager.state === DebugState.Stopped && this.manager.currentThread) {
-                    this.manager.currentThread.continue();
-                }
-            },
-            // When there is a debug session, F5 should always be captured by this command
-            isEnabled: () => this.manager.state !== DebugState.Inactive
+        if (this.manager.state === DebugState.Stopped && this.manager.currentThread) {
+            this.manager.currentThread.continue();
+        }
+    }
         });
         registry.registerCommand(DebugCommands.PAUSE, {
             execute: () => this.manager.currentThread && this.manager.currentThread.pause(),
@@ -866,12 +864,12 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         keybindings.registerKeybinding({
             command: DebugCommands.START.id,
             keybinding: 'f5',
-            when: '!inDebugMode'
+            when: 'debugState == inactive'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.START_NO_DEBUG.id,
             keybinding: 'ctrl+f5',
-            when: '!inDebugMode'
+            when: 'debugState == inactive'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.STOP.id,
@@ -902,7 +900,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
         keybindings.registerKeybinding({
             command: DebugCommands.CONTINUE.id,
             keybinding: 'f5',
-            when: 'inDebugMode'
+            when: 'debugState == stopped'
         });
         keybindings.registerKeybinding({
             command: DebugCommands.PAUSE.id,

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -70,6 +70,7 @@ export interface DebugSessionCustomEvent {
 @injectable()
 export class DebugSessionManager {
     protected readonly _sessions = new Map<string, DebugSession>();
+    protected _startLock = false;
 
     protected readonly onWillStartDebugSessionEmitter = new Emitter<WillStartDebugSession>();
     readonly onWillStartDebugSession: Event<WillStartDebugSession> = this.onWillStartDebugSessionEmitter.event;
@@ -202,7 +203,20 @@ export class DebugSessionManager {
             const options = this.debugConfigurationManager.find(optionsOrName);
             return !!options && this.start(options);
         }
-        return optionsOrName.configuration ? this.startConfiguration(optionsOrName) : this.startCompound(optionsOrName);
+        if (this._startLock) {
+            return;
+        }
+        this._startLock = true;
+
+        this.inDebugModeKey.set(true);
+        this.debugStateKey.set('running');
+
+        try {
+            return optionsOrName.configuration ? this.startConfiguration(optionsOrName) : this.startCompound(optionsOrName);
+        } finally {
+            this._startLock = false;
+            this.fireDidChange(this.currentSession);
+        }
     }
 
     protected async startConfiguration(options: DebugConfigurationSessionOptions): Promise<DebugSession | undefined> {


### PR DESCRIPTION
#### What it does
Fixes #14639. 

When holding down F5 while paused at a breakpoint, Theia would spawn multiple concurrent debug sessions instead of simply continuing the paused session.

Root causes identified:
* The START keybinding used `when: '!inDebugMode'` which could briefly evaluate to true during async state transitions between sessions.
* The CONTINUE keybinding used `when: 'inDebugMode'` which is true for both running and stopped states, causing ambiguity.
* The `DebugSessionManager.start()` method updated context keys only after async setup completed, leaving a window where repeated F5 presses could bypass the keybinding guards.
* The hacky `isEnabled: () => this.manager.state !== DebugState.Inactive` on the CONTINUE command (introduced in #14641) masked the root cause without fixing it.
 
Changes:
* Replace `when: '!inDebugMode'` with `when: 'debugState == inactive'` for the START keybinding — precisely targets only when no debug session exists.
* Replace `when: 'inDebugMode'` with `when: 'debugState == stopped'` for the CONTINUE keybinding — only fires when actually paused at a breakpoint.
* Remove the now-unnecessary `isEnabled` hack from the CONTINUE command.
* Add a mutex lock `_startLock` to `start()` in `DebugFrontendApplicationContribution` to prevent concurrent invocations during async execution.
* Immediately update `inDebugModeKey` and `debugStateKey` context keys at the synchronous entry point of `DebugSessionManager.start()` so keybinding `when` clauses reflect the correct state before any async work begins.

#### How to test
1. Open any workspace with a Python file (requires `debugpy` extension).
2. Add a breakpoint on any line.
3. Press F5 once — confirm debugger starts and pauses at the breakpoint.
4. Hold F5 down for 2-3 seconds.
5. Verify only one debug session exists in the THREADS panel — no additional sessions should spawn.
6. Press F5 once more to continue — confirm the session continues normally and does not start a new session.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

* The `START_NO_DEBUG` keybinding (`ctrl+f5`) still uses `when: '!inDebugMode'` and could be updated to `when: 'debugState == inactive'` for consistency — left as a separate follow-up.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
