### PR TITLE
Ensure unique counters for editor widgets in a merge editor

### DIFF
--- a/packages/scm/src/browser/merge-editor/merge-editor-module.ts
+++ b/packages/scm/src/browser/merge-editor/merge-editor-module.ts
@@ -84,7 +84,12 @@ export class MergeEditorFactory {
     }
 
     protected async createEditorWidget(uri: URI, disposables: DisposableCollection): Promise<EditorWidget> {
-        const editorWidget = await this.editorManager.createByUri(uri);
+        const editorWidget = await this.editorManager.createByUri(uri, {
+            // Note that regular editor widgets have their counters restored between sessions, unlike editor widgets contained in a merge editor.
+            // Therefore, it is important to ensure that counters of editor widgets in a merge editor cannot conflict with counters of regular editor widgets,
+            // including those that have not yet been restored. See https://github.com/eclipse-theia/theia/issues/17256.
+            counter: Date.now()
+        });
         disposables.push(editorWidget);
         const editor = MonacoEditor.get(editorWidget);
         if (!editor) {


### PR DESCRIPTION
#### What it does

Fixes #17256.

#### How to test

Please use the steps for reproducing #17256 to verify that the regular editor is now restored correctly. (Note that the merge editor is not expected to be restored at this time. It's a separate issue tracked in #17251.)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
