### PR TITLE
fix: accessibility issues in the AI Chat View

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -335,7 +335,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             command: AI_SHOW_SETTINGS_COMMAND.id,
             group: 'ai-settings',
             priority: 3,
-            tooltip: nls.localize('theia/ai-chat-ui/open-settings-tooltip', 'Open AI settings...'),
+            tooltip: nls.localize('theia/ai-chat-ui/open-settings-tooltip', 'Open AI Settings'),
             isVisible: widget => this.activationService.isActive && this.withWidget(widget),
             when: ENABLE_AI_CONTEXT_KEY
         });

--- a/packages/ai-chat-ui/src/browser/chat-input-mode-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-mode-contribution.ts
@@ -41,7 +41,7 @@ export class ChatInputModeContribution implements CommandContribution, Keybindin
     registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
             command: CHAT_INPUT_CYCLE_MODE_COMMAND.id,
-            keybinding: 'shift+tab',
+            keybinding: 'ctrl+m',
             when: 'chatInputFocus && chatInputHasModes && !suggestWidgetVisible'
         });
     }

--- a/packages/ai-chat-ui/src/browser/chat-view-widget-toolbar-contribution.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget-toolbar-contribution.tsx
@@ -82,8 +82,9 @@ export class ChatViewWidgetToolbarContribution implements TabBarToolbarContribut
         registry.registerItem({
             id: ChatCommands.EDIT_SESSION_SETTINGS.id,
             command: ChatCommands.EDIT_SESSION_SETTINGS.id,
-            tooltip: nls.localize('theia/ai/session-settings-dialog/tooltip', 'Set Session Settings'),
+            tooltip: nls.localize('theia/ai/session-settings-dialog/tooltip', 'Set Session Settings...'),
             priority: 3,
+            group: 'chat-settings',
             when: ENABLE_AI_CONTEXT_KEY
         });
     }

--- a/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
+++ b/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
@@ -18,6 +18,7 @@ import { ChatSessionSettings, CommonChatSessionSettings } from '@theia/ai-chat';
 import { InMemoryResources, URI, nls } from '@theia/core';
 import { AbstractDialog, Message } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
+import { flushSync } from '@theia/core/shared/react-dom';
 import { createRoot, Root } from '@theia/core/shared/react-dom/client';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
 import { MonacoEditorProvider } from '@theia/monaco/lib/browser/monaco-editor-provider';
@@ -253,7 +254,14 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
 
     protected override onAfterAttach(msg: Message): void {
         super.onAfterAttach(msg);
-        this.render();
+        // flushSync ensures React commits the render synchronously so that
+        // attachEditorContainer can query the DOM immediately afterwards.
+        // Without this, React 18 may defer the commit when invoked outside a
+        // browser event handler (e.g. from an Electron IPC callback from an
+        // Electron-rendered native menu), causing attachEditorContainer to
+        // find no .session-settings-advanced element and the Monaco editor
+        // to initialize inside a detached, zero-size node.
+        flushSync(() => this.render());
         this.attachEditorContainer();
         this.createJsonEditor();
     }

--- a/packages/ai-history/src/browser/ai-history-contribution.ts
+++ b/packages/ai-history/src/browser/ai-history-contribution.ts
@@ -231,7 +231,7 @@ export class AIHistoryViewContribution extends AIViewContribution<AIHistoryView>
         registry.registerItem({
             id: 'chat-view.' + OPEN_AI_HISTORY_VIEW.id,
             command: OPEN_AI_HISTORY_VIEW.id,
-            tooltip: nls.localize('theia/ai/history/open-history-tooltip', 'Open AI history...'),
+            tooltip: nls.localize('theia/ai/history/open-history-tooltip', 'Open AI Agent History'),
             group: 'ai-settings',
             priority: 1,
             isVisible: widget => this.activationService.isActive && widget instanceof ChatViewWidget

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-view-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-view-contribution.ts
@@ -66,7 +66,7 @@ export class AIAgentConfigurationViewContribution extends AIViewContribution<AIC
         registry.registerItem({
             id: 'chat-view.' + OPEN_AI_CONFIG_VIEW.id,
             command: OPEN_AI_CONFIG_VIEW.id,
-            tooltip: nls.localize('theia/ai-ide/open-agent-settings-tooltip', 'Open Agent settings...'),
+            tooltip: nls.localize('theia/ai-ide/open-ai-configuration-tooltip', 'Open AI Configuration'),
             group: 'ai-settings',
             priority: 2,
             isVisible: widget => this.activationService.isActive && widget instanceof ChatViewWidget

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -22,7 +22,7 @@ import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-v
 import { ChatSessionCardActionContribution } from './chat-session-card-action-contribution';
 import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
 import { CommandRegistry, ContributionProvider, DisposableCollection, Emitter, Event, PreferenceService } from '@theia/core';
-import { Card, CardActionButton, codicon, HoverService } from '@theia/core/lib/browser';
+import { Card, CardActionButton, codicon, HoverService, buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
@@ -535,7 +535,9 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
                         renderCard={this.renderSessionCard}
                     />
                     <div className="theia-WelcomeMessage-BrowseAllLink">
-                        <a onClick={this.handleBrowseAllChats}>
+                        <a {...buttonKeyboardProps(nls.localize('theia/ai/ide/browseAllChats', 'Browse all chats...'))}
+                            onClick={this.handleBrowseAllChats}
+                            onKeyDown={this.handleBrowseAllChatsKeyDown}>
                             {nls.localize('theia/ai/ide/browseAllChats', 'Browse all chats...')}
                         </a>
                     </div>
@@ -580,5 +582,12 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     protected handleBrowseAllChats = (): void => {
         this.commandRegistry.executeCommand(AI_CHAT_SHOW_CHATS_COMMAND.id);
+    };
+
+    protected handleBrowseAllChatsKeyDown = (e: React.KeyboardEvent): void => {
+        if (isActivationKey(e)) {
+            e.preventDefault();
+            this.handleBrowseAllChats();
+        }
     };
 }

--- a/packages/core/src/browser/components/card.tsx
+++ b/packages/core/src/browser/components/card.tsx
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import * as React from 'react';
+import { buttonKeyboardProps, isActivationKey } from '../keyboard/keyboard-utils';
 
 export interface CardActionButton {
     /** Icon class (e.g., codicon) */
@@ -69,13 +70,21 @@ export const Card = React.memo(function Card(props: CardProps): React.ReactEleme
     } = props;
 
     const isInteractive = onClick !== undefined;
+    const [hasFocus, setHasFocus] = React.useState(false);
 
     const handleKeyDown = React.useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
-        if (onClick && (e.key === 'Enter' || e.key === ' ')) {
+        if (onClick && isActivationKey(e)) {
             e.preventDefault();
             onClick();
         }
     }, [onClick]);
+
+    const handleFocus = React.useCallback(() => setHasFocus(true), []);
+    const handleBlur = React.useCallback((e: React.FocusEvent<HTMLDivElement>) => {
+        if (!e.currentTarget.contains(e.relatedTarget as Node)) {
+            setHasFocus(false);
+        }
+    }, []);
 
     const cardClasses = [
         'theia-Card',
@@ -94,6 +103,8 @@ export const Card = React.memo(function Card(props: CardProps): React.ReactEleme
             role={isInteractive ? 'button' : undefined}
             tabIndex={isInteractive ? 0 : undefined}
             onKeyDown={isInteractive ? handleKeyDown : undefined}
+            onFocus={actionButtons ? handleFocus : undefined}
+            onBlur={actionButtons ? handleBlur : undefined}
         >
             {icon && (
                 <div className={`theia-Card-icon ${icon}`}></div>
@@ -115,7 +126,7 @@ export const Card = React.memo(function Card(props: CardProps): React.ReactEleme
                                     key={i}
                                     className={`theia-Card-action-btn ${btn.iconClass}`}
                                     title={btn.title}
-                                    aria-label={btn.title}
+                                    {...buttonKeyboardProps(btn.title, hasFocus ? 0 : -1)}
                                     onClick={btn.onClick}
                                 />
                             ))}

--- a/packages/core/src/browser/keyboard/index.ts
+++ b/packages/core/src/browser/keyboard/index.ts
@@ -18,3 +18,4 @@ export * from './keys';
 export * from './keyboard-layout-service';
 export * from './browser-keyboard-layout-provider';
 export * from './browser-keyboard-frontend-contribution';
+export * from './keyboard-utils';

--- a/packages/core/src/browser/keyboard/keyboard-utils.ts
+++ b/packages/core/src/browser/keyboard/keyboard-utils.ts
@@ -1,0 +1,37 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Query whether the keyboard event represents an element activation.
+ * That is, whether the user pressed `Enter` or `Space` on a focusable
+ * element with `role="button"` or similar interactive role.
+ */
+export function isActivationKey(e: React.KeyboardEvent | KeyboardEvent): boolean {
+    return e.key === 'Enter' || e.key === ' ';
+}
+
+/**
+ * Returns the ARIA/accessibility props that make a non-button HTML element
+ * keyboard-navigable and screen-reader-accessible as a button.
+ *
+ * Spread these onto the element alongside `onClick` and `onKeyDown`:
+ * ```tsx
+ * <div {...buttonKeyboardProps(label)} onClick={handler} onKeyDown={e => isActivationKey(e) && handler()} />
+ * ```
+ */
+export function buttonKeyboardProps(ariaLabel: string, tabIndex = 0): React.HTMLAttributes<HTMLElement> {
+    return { tabIndex, role: 'button', 'aria-label': ariaLabel };
+}

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.tsx
@@ -16,6 +16,7 @@
 
 import { inject, injectable, postConstruct } from 'inversify';
 import * as React from 'react';
+import { buttonKeyboardProps, isActivationKey } from '../../keyboard/keyboard-utils';
 import { ContextKeyService } from '../../context-key-service';
 import { CommandRegistry, Disposable, DisposableCollection, nls } from '../../../common';
 import { Anchor, ContextMenuAccess, ContextMenuRenderer } from '../../context-menu-renderer';
@@ -150,7 +151,10 @@ export class TabBarToolbar extends ReactWidget {
 
     protected renderMore(): React.ReactNode {
         return !!this.more.size && <div key='__more__' className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled'}>
-            <div id='__more__' className={codicon('ellipsis', true)} onClick={this.showMoreContextMenu}
+            <div id='__more__' className={codicon('ellipsis', true)}
+                {...buttonKeyboardProps(nls.localizeByDefault('More Actions...'))}
+                onClick={this.showMoreContextMenu}
+                onKeyDown={this.handleMoreKeyDown}
                 title={nls.localizeByDefault('More Actions...')} />
         </div>;
     }
@@ -160,6 +164,15 @@ export class TabBarToolbar extends ReactWidget {
         event.preventDefault();
         const anchor = toAnchor(event);
         this.renderMoreContextMenu(anchor);
+    };
+
+    protected handleMoreKeyDown = (event: React.KeyboardEvent) => {
+        if (isActivationKey(event)) {
+            event.preventDefault();
+            event.stopPropagation();
+            const { left, bottom } = (event.currentTarget as HTMLElement).getBoundingClientRect();
+            this.renderMoreContextMenu({ x: left, y: bottom });
+        }
     };
 
     renderMoreContextMenu(anchor: Anchor): ContextMenuAccess {

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-toolbar-item.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-toolbar-item.tsx
@@ -23,6 +23,7 @@ import { KeybindingRegistry } from '../../keybinding';
 import { ACTION_ITEM } from '../../widgets';
 import { TabBarToolbar } from './tab-bar-toolbar';
 import * as React from 'react';
+import { buttonKeyboardProps, isActivationKey } from '../../keyboard/keyboard-utils';
 import { ActionMenuNode, GroupImpl, MenuNode } from '../../../common/menu';
 
 export interface TabBarToolbarItem {
@@ -195,15 +196,23 @@ export class RenderedToolbarItemImpl extends AbstractToolbarItemImpl<RenderedToo
     };
 
     protected executeCommand(e: React.MouseEvent<HTMLElement>, widget: Widget): void {
+        this.doExecuteCommand(e, widget);
+    };
+
+    protected doExecuteCommand(e: React.SyntheticEvent<HTMLElement>, widget: Widget): void {
         e.preventDefault();
         e.stopPropagation();
-
         if (!this.isEnabled(widget)) {
             return;
         }
-
         if (this.action.command) {
             this.commandRegistry.executeCommand(this.action.command, widget);
+        }
+    }
+
+    protected onKeyDownEvent = (e: React.KeyboardEvent<HTMLElement>, widget: Widget) => {
+        if (isActivationKey(e)) {
+            this.doExecuteCommand(e, widget);
         }
     };
 
@@ -249,7 +258,9 @@ export class RenderedToolbarItemImpl extends AbstractToolbarItemImpl<RenderedToo
             onMouseUp={this.onMouseUpEvent}
             onMouseOut={this.onMouseUpEvent} >
             <div id={this.action.id} className={classNames.join(' ')}
+                {...buttonKeyboardProps(tooltip)}
                 onClick={e => this.executeCommand(e, widget)}
+                onKeyDown={e => this.onKeyDownEvent(e, widget)}
                 title={tooltip} > {innerText}
             </div>
         </div>;

--- a/packages/core/src/browser/style/card.css
+++ b/packages/core/src/browser/style/card.css
@@ -101,11 +101,13 @@
     transition: opacity 0.15s;
 }
 
-.theia-Card:hover .theia-Card-footer-time {
+.theia-Card:hover .theia-Card-footer-time,
+.theia-Card:focus-within .theia-Card-footer-time {
     opacity: 0;
 }
 
-.theia-Card:hover .theia-Card-footer-actions {
+.theia-Card:hover .theia-Card-footer-actions,
+.theia-Card:focus-within .theia-Card-footer-actions {
     opacity: 1;
     pointer-events: auto;
 }

--- a/packages/core/src/electron-main/electron-api-main.ts
+++ b/packages/core/src/electron-main/electron-api-main.ts
@@ -136,6 +136,8 @@ export class TheiaMainApi implements ElectronMainApplicationContribution {
             }
             popup.popup({
                 window: electronWindow,
+                x,
+                y,
                 callback: () => {
                     this.openPopups.delete(menuId);
                     event.sender.send(CHANNEL_ON_CLOSE_POPUP, menuId);


### PR DESCRIPTION
#### What it does

Addresses #17037, cleaning up the AI Chat view toolbar a bit and fixing several keyboard accessibility issues across the chat UI and the generic tab-bar toolbar.                                                                    
                                                                                                                                                                                                                                                  
Toolbar naming and clutter
  - renamed the "Open Agent settings…" toolbar tooltip to "Open AI Configuration" to match the view's menu label.                                                                                                                                 
  - renamed "Open AI history…" → "Open AI Agent History" and "Open AI settings…" → "Open AI Settings" for consistency.                                                                                                                            
  - moved the "Set Session Settings" toolbar item into the ellipsis ("more") menu and added an ellipsis to indicate that it opens a modal dialog.

Keyboard navigation
  - made sure that toolbar items are included in the tab order. This is implemented in the core toolbar renderer, so it applies across the board. For the AI Chat view this means that by Shift+Tab from inside the chat transcript you'll navigate back into the toolbar, whereas previously you would have just ended up in some editor in the main workbench area
  - in the Recent Chats welcome UI, card action buttons are now shown when a card is focused by keyboard so that they then participate sensibly in the tab order                                                                        
  - the "Browse all chats…" link in the welcome page is now included in the tab order
  - **removed Shift+tab as the keybinding for "Cycle Chat Mode"**. Shift+Tab is a reserved browser focus-navigation key; binding it to any other action traps keyboard users inside the chat input field. The keybinding is replaced with Ctrl+M (Alt+M was considered but it inserts a combining diacritic mark in the chat input on commonly used Mac keyboard layouts.)
                                                                                                                                                                                                                                                  
#### How to test

1. Open the AI Chat view.                                                                                                                                     
2. Open the ellipsis menu and confirm "Set Session Settings..." appears there (not inline in the toolbar) and the menu also includes "Open AI Configuration" and other actions to open related views by their proper names.
3. From the chat session transcript, Shift+Tab until focus enters the toolbar and see how you can navigate between items with (Shift+)Tab. Activate them with Enter or Space.
4. Tab to the "…" ellipsis button and press Enter. The context menu should open anchored to the button.                     
5. On the AI welcome page, Tab through the recent session cards.
6. Tab to the "Browse all chats…" link and press Enter. The chat history panel should open.                                                                                                                                                   
7. Tab along into the chat input, then press Shift+Tab. Focus should move out of the input, not cycle the mode. Press Ctrl+M to cycle the mode.                                                                        

#### Follow-ups

- The `isActivationKey` / `buttonKeyboardProps` utilities could be used at the many other existing call sites in the codebase (e.g. ai-terminal, remote, notebook) that handle keyboard interactions with buttons. But maybe not before we decide whether this is better wrapped up in an injectable service that can be customized/replaced by downstream applications. Or maybe these shouldn't be shared utilities at all and instead brought back into the AI packages addressed in this PR
- "Move View to Secondary Window" scoping for the AI Chat view (the remaining item from #17037) is deferred. Putting it in the ellipsis menu only for ChatViewWidget without affecting other extractable widgets has no clean solution within the current toolbar architecture and warrants a separate issue.                                                                                                                                                                                             
                                                                         
#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

The `doExecuteCommand()` is a new protected method on `RenderedToolbarItemImpl`. This is additive, not breaking. The signature of `executeCommand` is unchanged.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
