### PR TITLE
Implement multi-root support for agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@
 <a name="breaking_changes_1.72.0">[Breaking Changes:](#breaking_changes_1.72.0)</a>
 
 - [ai-chat] the `'*'` magic key inside `ai-features.chat.toolConfirmation` is no longer honored; migrate to the new `ai-features.chat.defaultToolConfirmation` preference [#17452](https://github.com/eclipse-theia/theia/pull/17452)
+- [ai-chat] removed `FileValidationState.INVALID_SECONDARY` enum member from `ContextFileValidationService`; all workspace roots are now treated equally so the "secondary root" concept no longer exists [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-core] `DefaultSkillService.getWorkspaceSkillsDirectoryPath()` has been renamed to `getWorkspaceSkillsDirectoryPaths()` and now returns `string[]` instead of `string | undefined` to scan all workspace roots [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-ide] `WorkspaceFunctionScope.getWorkspaceRoot()` has been removed; use `getRootMapping()`, `getContainingRoot(uri)`, or `resolveRelativePath(path)` instead [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-ide] `WorkspaceFunctionScope.resolveRelativePath()` is now synchronous (returns `URI` instead of `Promise<URI>`) and expects `<rootName>/<relativePath>` format in multi-root workspaces [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-ide] `WorkspaceFunctionScope.isInPrimaryWorkspace()` has been removed; use `isInWorkspace()` instead, which now checks all roots [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-ide] `optimizeSearchResults()` second parameter changed from `URI` to `WorkspacePathResolver` interface [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-ide] `ContextFileValidationServiceImpl.findInSecondaryWorkspaceRoots()` protected method has been removed [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-terminal] `ShellExecutionRequest.workspaceRoot` property has been removed; CWD is now resolved to an absolute path on the frontend before being sent to the backend [#17262](https://github.com/eclipse-theia/theia/pull/17262)
+- [ai-terminal] `ShellExecutionServerImpl.resolveCwd()` protected method has been removed; CWD resolution now happens in `ShellExecutionTool` on the frontend [#17262](https://github.com/eclipse-theia/theia/pull/17262)
 - [native-webpack-plugin] The `@theia/native-webpack-plugin` package has been renamed to `@theia/bundle-plugin` [#14414](https://github.com/eclipse-theia/theia/pull/14414).
 
 ## 1.71.0 - 4/30/2026

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -2742,10 +2742,7 @@ function buildContextUI(
                 // Use the path directly as the key (same as storage)
                 const validationResult = fileValidationState.get(element.arg);
                 if (validationResult) {
-                    if (validationResult.state === FileValidationState.INVALID_SECONDARY) {
-                        className = 'warning-file';
-                        validationMessage = validationResult.message;
-                    } else if (validationResult.state === FileValidationState.INVALID_NOT_FOUND) {
+                    if (validationResult.state === FileValidationState.INVALID_NOT_FOUND) {
                         className = 'invalid-file';
                         validationMessage = validationResult.message;
                     }

--- a/packages/ai-chat/src/browser/change-set-file-service.ts
+++ b/packages/ai-chat/src/browser/change-set-file-service.ts
@@ -77,7 +77,15 @@ export class ChangeSetFileService {
     getAdditionalInfo(uri: URI): string | undefined {
         const wsUri = this.wsService.getWorkspaceRootUri(uri);
         if (wsUri) {
+            const isMultiRoot = this.wsService.tryGetRoots().length > 1;
             const wsRelative = wsUri.relative(uri);
+            if (isMultiRoot) {
+                const rootName = wsUri.path.base;
+                if (wsRelative?.hasDir) {
+                    return `${rootName} · ${wsRelative.dir.toString()}`;
+                }
+                return rootName;
+            }
             if (wsRelative?.hasDir) {
                 return wsRelative.dir.toString();
             }

--- a/packages/ai-chat/src/browser/change-set-variable.ts
+++ b/packages/ai-chat/src/browser/change-set-variable.ts
@@ -48,9 +48,10 @@ export class ChangeSetVariableContribution implements AIVariableContribution, AI
                 value: ''
             };
         }
-        const entries = await Promise.all(
-            context.model.changeSet.getElements().map(async element => `- file: ${await this.workspaceService.getWorkspaceRelativePath(element.uri)}, status: ${element.state}`)
-        );
+        const entries = context.model.changeSet.getElements().map(element => {
+            const rootPrefixedPath = this.workspaceService.getRootPrefixedPath(element.uri);
+            return `- file: ${rootPrefixedPath}, status: ${element.state}`;
+        });
         return {
             variable: CHANGE_SET_SUMMARY_VARIABLE,
             value: `## Previously Proposed Changes

--- a/packages/ai-chat/src/browser/context-file-validation-service.ts
+++ b/packages/ai-chat/src/browser/context-file-validation-service.ts
@@ -18,7 +18,6 @@ import { URI } from '@theia/core';
 
 export enum FileValidationState {
     VALID = 'valid',
-    INVALID_SECONDARY = 'invalid-secondary',
     INVALID_NOT_FOUND = 'invalid-not-found'
 }
 

--- a/packages/ai-chat/src/browser/file-chat-variable-contribution.ts
+++ b/packages/ai-chat/src/browser/file-chat-variable-contribution.ts
@@ -87,7 +87,8 @@ export class FileChatVariableContribution implements FrontendVariableContributio
                 const selectedItem = quickPick.selectedItems[0];
                 if (selectedItem && FileQuickPickItem.is(selectedItem)) {
                     quickPick.dispose();
-                    resolve(await this.wsService.getWorkspaceRelativePath(selectedItem.uri));
+                    const rootPrefixedPath = this.wsService.getRootPrefixedPath(selectedItem.uri);
+                    resolve(rootPrefixedPath);
                 }
             });
         });
@@ -122,7 +123,7 @@ export class FileChatVariableContribution implements FrontendVariableContributio
 
                 if (selectedItem && FileQuickPickItem.is(selectedItem)) {
                     quickPick.dispose();
-                    const filePath = await this.wsService.getWorkspaceRelativePath(selectedItem.uri);
+                    const filePath = this.wsService.getRootPrefixedPath(selectedItem.uri);
                     const fileName = selectedItem.uri.displayName;
                     const base64Data = await fileToBase64(selectedItem.uri, this.fileService, this.logger);
                     const mimeType = getMimeTypeFromExtension(selectedItem.uri.path.toString());
@@ -280,31 +281,30 @@ export class FileChatVariableContribution implements FrontendVariableContributio
 
         const picks = await this.quickFileSelectService.getPicks(userInput, CancellationToken.None);
 
-        return Promise.all(
-            picks
-                .filter(FileQuickPickItem.is)
-                // only show files with highlights, if the user started typing to filter down the results
-                .filter(p => !userInput || p.highlights?.label)
-                .map(async (pick, index) => {
-                    const relativePath = await this.wsService.getWorkspaceRelativePath(pick.uri);
-                    return {
-                        label: pick.label,
-                        kind: monaco.languages.CompletionItemKind.File,
-                        range,
-                        insertText: `${prefix}${relativePath}`,
-                        detail: await this.wsService.getWorkspaceRelativePath(pick.uri.parent),
-                        // don't let monaco filter the items, as we only return picks that are filtered
-                        filterText: userInput,
-                        // keep the order of the items, but move them to the end of the list
-                        sortText: `ZZ${index.toString().padStart(4, '0')}_${pick.label}`,
-                        command: {
-                            title: VARIABLE_ADD_CONTEXT_COMMAND.label!,
-                            id: VARIABLE_ADD_CONTEXT_COMMAND.id,
-                            arguments: [FILE_VARIABLE.name, relativePath]
-                        }
-                    };
-                })
-        );
+        return picks
+            .filter(FileQuickPickItem.is)
+            // only show files with highlights, if the user started typing to filter down the results
+            .filter(p => !userInput || p.highlights?.label)
+            .map((pick, index) => {
+                const relativePath = this.wsService.getRootPrefixedPath(pick.uri);
+                const parentPath = this.wsService.getRootPrefixedPath(pick.uri.parent);
+                return {
+                    label: pick.label,
+                    kind: monaco.languages.CompletionItemKind.File,
+                    range,
+                    insertText: `${prefix}${relativePath}`,
+                    detail: parentPath,
+                    // don't let monaco filter the items, as we only return picks that are filtered
+                    filterText: userInput,
+                    // keep the order of the items, but move them to the end of the list
+                    sortText: `ZZ${index.toString().padStart(4, '0')}_${pick.label}`,
+                    command: {
+                        title: VARIABLE_ADD_CONTEXT_COMMAND.label!,
+                        id: VARIABLE_ADD_CONTEXT_COMMAND.id,
+                        arguments: [FILE_VARIABLE.name, relativePath]
+                    }
+                };
+            });
     }
 
     /**
@@ -342,7 +342,7 @@ export class FileChatVariableContribution implements FrontendVariableContributio
             const texts: string[] = [];
             for (const uri of uris) {
                 if (await this.fileService.exists(uri)) {
-                    const wsRelativePath = await this.wsService.getWorkspaceRelativePath(uri);
+                    const wsRelativePath = this.wsService.getRootPrefixedPath(uri);
                     const fileName = uri.displayName;
 
                     if (wsRelativePath && this.isImageFile(wsRelativePath)) {

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -86,7 +86,7 @@ export class ChatRequestParserImpl implements ChatRequestParser {
                     // Resolve tool requests in resolved variables
                     this.parseFunctionsFromVariableText(resolvedVariable.value, toolRequests);
                 } else {
-                    this.logger.warn(`Failed to resolve variable ${part.variableName} for ${location}`);
+                    this.logger.warn(`Failed to resolve variable ${part.variableName}${part.variableArg ? ':' + part.variableArg : ''} for ${location}`);
                 }
             }
         }

--- a/packages/ai-claude-code/src/browser/claude-code-command-contribution.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-command-contribution.ts
@@ -65,6 +65,8 @@ export class ClaudeCodeCommandContribution implements CommandContribution {
         });
     }
 
+    // TODO: multi-root workspace support - currently only uses the first (primary) workspace root.
+    // In a multi-root workspace, the user should be prompted to select which workspace root to create/open the file in.
     protected async openFileInWorkspace(file: string, initialContent: string): Promise<void> {
         const roots = this.workspaceService.tryGetRoots();
         if (roots.length < 1) {

--- a/packages/ai-claude-code/src/browser/claude-code-slash-commands-contribution.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-slash-commands-contribution.ts
@@ -209,6 +209,8 @@ export class ClaudeCodeSlashCommandsContribution implements FrontendApplicationC
         }
     }
 
+    // TODO: multi-root workspace support - currently only discovers slash commands from the first workspace root.
+    // Should be updated to scan .claude/commands/ in all workspace roots, potentially merging or namespacing commands by root.
     protected getWorkspaceRoot(): URI | undefined {
         const roots = this.workspaceService.tryGetRoots();
         return roots.length > 0 ? roots[0].resource : undefined;

--- a/packages/ai-codex/src/browser/codex-chat-agent.ts
+++ b/packages/ai-codex/src/browser/codex-chat-agent.ts
@@ -533,6 +533,8 @@ export class CodexChatAgent implements ChatAgent {
         }
     }
 
+    // TODO: multi-root workspace support - currently only uses the first (primary) workspace root.
+    // In a multi-root workspace, the root URI should be resolved based on the context of the current chat request (e.g., the file being discussed).
     protected async getWorkspaceRootUri(): Promise<URI | undefined> {
         const roots = await this.workspaceService.roots;
         if (roots && roots.length > 0) {

--- a/packages/ai-codex/src/browser/codex-frontend-service.ts
+++ b/packages/ai-codex/src/browser/codex-frontend-service.ts
@@ -211,6 +211,8 @@ export class CodexFrontendService {
         return undefined;
     }
 
+    // TODO: multi-root workspace support - currently only uses the first (primary) workspace root.
+    // In a multi-root workspace, the workspace root should be determined based on the active editor or user context.
     protected async getWorkspaceRoot(): Promise<string | undefined> {
         const roots = await this.workspaceService.roots;
         if (roots && roots.length > 0) {

--- a/packages/ai-core/src/browser/file-variable-contribution.ts
+++ b/packages/ai-core/src/browser/file-variable-contribution.ts
@@ -71,9 +71,10 @@ export class FileVariableContribution implements AIVariableContribution, AIVaria
 
         try {
             const content = await this.fileService.readFile(uri);
+            const relativePath = this.wsService.getRootPrefixedPath(uri);
             return {
                 variable: request.variable,
-                value: await this.wsService.getWorkspaceRelativePath(uri),
+                value: relativePath,
                 contextValue: content.value.toString(),
             };
         } catch (error) {
@@ -103,9 +104,26 @@ export class FileVariableContribution implements AIVariableContribution, AIVaria
     }
 
     protected async makeAbsolute(pathStr: string): Promise<URI | undefined> {
-        const path = new Path(Path.normalizePathSeparator(pathStr));
+        const normalizedPath = Path.normalizePathSeparator(pathStr);
+        const path = new Path(normalizedPath);
+
         if (!path.isAbsolute) {
             const workspaceRoots = this.wsService.tryGetRoots();
+
+            const segments = normalizedPath.split('/');
+            if (segments.length > 0) {
+                const potentialRootName = segments[0];
+                for (const root of workspaceRoots) {
+                    if (root.resource.path.base === potentialRootName) {
+                        const restOfPath = segments.slice(1).join('/');
+                        const uri = restOfPath ? root.resource.resolve(restOfPath) : root.resource;
+                        if (await this.fileService.exists(uri)) {
+                            return uri;
+                        }
+                    }
+                }
+            }
+
             const wsUris = workspaceRoots.map(root => root.resource.resolve(path));
             for (const uri of wsUris) {
                 if (await this.fileService.exists(uri)) {
@@ -113,6 +131,7 @@ export class FileVariableContribution implements AIVariableContribution, AIVaria
                 }
             }
         }
+
         const argUri = new URI(pathStr);
         if (await this.fileService.exists(argUri)) {
             return argUri;

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
@@ -14,8 +14,20 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import 'reflect-metadata';
+
 import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
 import { parseTemplateWithMetadata, ParsedTemplate } from './prompttemplate-parser';
+import { CustomizationSource, DefaultPromptFragmentCustomizationService } from './frontend-prompt-customization-service';
+
+disableJSDOM();
 
 describe('Prompt Template Parser', () => {
 
@@ -197,6 +209,193 @@ Template`;
 
             expect(result.metadata?.name).to.be.undefined;
             expect(result.metadata?.description).to.be.undefined;
+        });
+    });
+
+    describe('DefaultPromptFragmentCustomizationService - addTemplate conflict resolution', () => {
+        before(() => disableJSDOM = enableJSDOM());
+        after(() => disableJSDOM());
+
+        interface FragmentEntry {
+            id: string;
+            template: string;
+            sourceUri: string;
+            sourceUris: string[];
+            priority: number;
+            origin: CustomizationSource;
+            customizationId: string;
+        }
+
+        /**
+         * Test subclass that exposes the protected `addTemplate` and `provenanceLabel`
+         * methods so we can unit-test conflict resolution without mocking the filesystem.
+         */
+        class TestableCustomizationService extends DefaultPromptFragmentCustomizationService {
+            // Prevent @postConstruct from running (it touches preferences)
+            protected override init(): void { }
+
+            /** Configure fake workspace roots so provenanceLabel can resolve them. */
+            setRoots(rootUris: string[]): void {
+                const roots = rootUris.map(r => new URI(r));
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (this as any).workspaceService = {
+                    getWorkspaceRootUri(uri: URI): URI | undefined {
+                        return roots.find(root => uri.toString().startsWith(root.toString()));
+                    }
+                };
+            }
+
+            public testAddTemplate(
+                active: Map<string, FragmentEntry>,
+                id: string,
+                template: string,
+                sourceUri: string,
+                all: Map<string, FragmentEntry>,
+                priority: number,
+                origin: CustomizationSource
+            ): void {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (this as any).addTemplate(active, id, template, sourceUri, all, priority, origin);
+            }
+
+            public testProvenanceLabel(sourceUri: string): string {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                return (this as any).provenanceLabel(sourceUri);
+            }
+        }
+
+        let service: TestableCustomizationService;
+        let activeMap: Map<string, FragmentEntry>;
+        let allMap: Map<string, FragmentEntry>;
+
+        beforeEach(() => {
+            service = new TestableCustomizationService();
+            service.setRoots([
+                'file:///rootA',
+                'file:///rootB',
+                'file:///rootC',
+                'file:///home/user/my-project'
+            ]);
+            activeMap = new Map();
+            allMap = new Map();
+        });
+
+        it('adds a fragment when no conflict exists', () => {
+            const uri = 'file:///rootA/.prompts/project-info.prompttemplate';
+            service.testAddTemplate(
+                activeMap, 'project-info', 'Content A', uri, allMap, 2, CustomizationSource.FOLDER
+            );
+
+            expect(activeMap.has('project-info')).to.be.true;
+            expect(activeMap.get('project-info')!.template).to.equal('Content A');
+            expect(activeMap.get('project-info')!.sourceUris).to.deep.equal([uri]);
+        });
+
+        it('higher priority replaces lower priority', () => {
+            service.testAddTemplate(
+                activeMap, 'project-info', 'Low priority',
+                'file:///rootA/.prompts/project-info.prompttemplate', allMap, 1, CustomizationSource.CUSTOMIZED
+            );
+            service.testAddTemplate(
+                activeMap, 'project-info', 'High priority',
+                'file:///rootB/.prompts/project-info.prompttemplate', allMap, 2, CustomizationSource.FOLDER
+            );
+
+            expect(activeMap.get('project-info')!.template).to.equal('High priority');
+        });
+
+        it('same source URI updates in place', () => {
+            const uri = 'file:///rootA/.prompts/project-info.prompttemplate';
+            service.testAddTemplate(activeMap, 'project-info', 'Original', uri, allMap, 2, CustomizationSource.FOLDER);
+            service.testAddTemplate(activeMap, 'project-info', 'Updated', uri, allMap, 2, CustomizationSource.FOLDER);
+
+            expect(activeMap.get('project-info')!.template).to.equal('Updated');
+            expect(activeMap.get('project-info')!.sourceUris).to.deep.equal([uri]);
+        });
+
+        it('equal priority from different sources concatenates with provenance labels', () => {
+            service.testAddTemplate(
+                activeMap, 'project-info', 'Content A',
+                'file:///rootA/.prompts/project-info.prompttemplate', allMap, 2, CustomizationSource.FOLDER
+            );
+            service.testAddTemplate(
+                activeMap, 'project-info', 'Content B',
+                'file:///rootB/.prompts/project-info.prompttemplate', allMap, 2, CustomizationSource.FOLDER
+            );
+
+            const entry = activeMap.get('project-info')!;
+            expect(entry.sourceUris).to.have.lengthOf(2);
+            expect(entry.template).to.contain('Content A');
+            expect(entry.template).to.contain('Content B');
+            expect(entry.template).to.contain('### rootA');
+            expect(entry.template).to.contain('### rootB');
+        });
+
+        it('three-way merge concatenates all sources in order', () => {
+            service.testAddTemplate(
+                activeMap, 'project-info', 'Content A',
+                'file:///rootA/.prompts/project-info.prompttemplate', allMap, 2, CustomizationSource.FOLDER
+            );
+            service.testAddTemplate(
+                activeMap, 'project-info', 'Content B',
+                'file:///rootB/.prompts/project-info.prompttemplate', allMap, 2, CustomizationSource.FOLDER
+            );
+            service.testAddTemplate(
+                activeMap, 'project-info', 'Content C',
+                'file:///rootC/.prompts/project-info.prompttemplate', allMap, 2, CustomizationSource.FOLDER
+            );
+
+            const entry = activeMap.get('project-info')!;
+            expect(entry.sourceUris).to.have.lengthOf(3);
+            expect(entry.template).to.contain('### rootA');
+            expect(entry.template).to.contain('### rootB');
+            expect(entry.template).to.contain('### rootC');
+            // Verify ordering: A before B before C
+            const idxA = entry.template.indexOf('Content A');
+            const idxB = entry.template.indexOf('Content B');
+            const idxC = entry.template.indexOf('Content C');
+            expect(idxA).to.be.lessThan(idxB);
+            expect(idxB).to.be.lessThan(idxC);
+        });
+
+        it('provenanceLabel extracts grandparent directory name from URI', () => {
+            // For "file:///home/user/my-project/.prompts/foo.prompttemplate"
+            // parent is ".prompts", grandparent is "my-project"
+            const label = service.testProvenanceLabel(
+                'file:///home/user/my-project/.prompts/foo.prompttemplate'
+            );
+            expect(label).to.equal('my-project');
+        });
+
+        it('provenanceLabel falls back to parent if grandparent is empty', () => {
+            expect(service.testProvenanceLabel('file:///.prompts/foo.prompttemplate'))
+                .to.equal('.prompts');
+        });
+
+        it('merged entry preserves primary sourceUri for backwards compatibility', () => {
+            const uriA = 'file:///rootA/.prompts/project-info.prompttemplate';
+            const uriB = 'file:///rootB/.prompts/project-info.prompttemplate';
+            service.testAddTemplate(activeMap, 'project-info', 'Content A', uriA, allMap, 2, CustomizationSource.FOLDER);
+            service.testAddTemplate(activeMap, 'project-info', 'Content B', uriB, allMap, 2, CustomizationSource.FOLDER);
+
+            const entry = activeMap.get('project-info')!;
+            // Primary sourceUri should be the first one added
+            expect(entry.sourceUri).to.equal(uriA);
+            // All sources tracked
+            expect(entry.sourceUris).to.deep.equal([uriA, uriB]);
+        });
+
+        it('all map tracks each source independently', () => {
+            const uriA = 'file:///rootA/.prompts/project-info.prompttemplate';
+            const uriB = 'file:///rootB/.prompts/project-info.prompttemplate';
+            service.testAddTemplate(activeMap, 'project-info', 'Content A', uriA, allMap, 2, CustomizationSource.FOLDER);
+            service.testAddTemplate(activeMap, 'project-info', 'Content B', uriB, allMap, 2, CustomizationSource.FOLDER);
+
+            // allCustomizations is keyed by sourceUri, so both should be present
+            expect(allMap.has(uriA)).to.be.true;
+            expect(allMap.has(uriB)).to.be.true;
+            expect(allMap.get(uriA)!.template).to.equal('Content A');
+            expect(allMap.get(uriB)!.template).to.equal('Content B');
         });
     });
 });

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -27,6 +27,7 @@ import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { dump, load } from 'js-yaml';
 import { PROMPT_TEMPLATE_EXTENSION } from './prompttemplate-contribution';
 import { parseTemplateWithMetadata, ParsedTemplate } from './prompttemplate-parser';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 
 /**
  * Default template entry for creating custom agents
@@ -89,8 +90,11 @@ interface PromptFragmentCustomization extends CommandPromptFragmentMetadata {
     /** The template content */
     template: string;
 
-    /** Source URI where this template is stored */
+    /** Source URI where this template is stored (first/primary source when merged) */
     sourceUri: string;
+
+    /** All source URIs when multiple equal-priority sources were merged */
+    sourceUris: string[];
 
     /** Source type of the customization */
     origin: CustomizationSource;
@@ -135,6 +139,9 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
 
     @inject(ConfigurableInMemoryResources)
     protected readonly inMemoryResources: ConfigurableInMemoryResources;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     /** Stores URI strings of template files from directories currently being monitored for changes. */
     protected trackedTemplateURIs = new Set<string>();
@@ -240,6 +247,7 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
             id,
             template,
             sourceUri,
+            sourceUris: [sourceUri],
             priority,
             customizationId,
             origin,
@@ -262,6 +270,16 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
         const existingEntry = activeCustomizationsCopy.get(id);
 
         if (existingEntry) {
+            // If the existing entry was merged from multiple sources and we're
+            // operating on the live maps (incremental watcher update), a single
+            // file change can't reconstruct the merge correctly. Schedule a
+            // full rebuild instead. During update() the maps are fresh locals,
+            // so this check won't fire.
+            if (existingEntry.sourceUris.length > 1 && activeCustomizationsCopy === this.activeCustomizations) {
+                this.update();
+                return;
+            }
+
             // If this is an update to the same file (same source URI)
             if (sourceUri && existingEntry.sourceUri === sourceUri) {
                 // Update the content while keeping the same priority and source
@@ -274,9 +292,17 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
                 activeCustomizationsCopy.set(id, customization);
                 return;
             } else if (priority === existingEntry.priority) {
-                // There is a conflict with the same priority, we ignore the new customization
-                const conflictSourceUri = existingEntry.sourceUri ? ` (Existing source: ${existingEntry.sourceUri}, New source: ${sourceUri})` : '';
-                console.warn(`Fragment conflict detected for ID '${id}' with equal priority.${conflictSourceUri}`);
+                // Same priority from different sources: concatenate with provenance labels.
+                // Build a new object so we don't mutate the entry shared with allCustomizationsCopy.
+                const existingLabel = this.provenanceLabel(existingEntry.sourceUri);
+                const newLabel = this.provenanceLabel(sourceUri);
+                const mergedTemplate = `### ${existingLabel}\n\n${existingEntry.template}\n\n### ${newLabel}\n\n${template}`;
+                const mergedEntry: PromptFragmentCustomization = {
+                    ...existingEntry,
+                    template: mergedTemplate,
+                    sourceUris: [...existingEntry.sourceUris, sourceUri],
+                };
+                activeCustomizationsCopy.set(id, mergedEntry);
             }
             return;
         }
@@ -296,6 +322,24 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
         // This ensures uniqueness across different customization sources
         const sourceHash = this.hashString(sourceUri);
         return `${id}_${sourceHash}`;
+    }
+
+    /**
+     * Extracts a human-readable provenance label from a source URI.
+     * Returns the name of the workspace root that contains the file,
+     * falling back to the file's own base name if it is not inside any root.
+     */
+    protected provenanceLabel(uri: string): string {
+        try {
+            const parsed = new URI(uri);
+            const rootUri = this.workspaceService.getWorkspaceRootUri(parsed);
+            if (rootUri) {
+                return rootUri.path.base;
+            }
+            return parsed.path.dir.base || parsed.path.base || uri;
+        } catch {
+            return uri;
+        }
     }
 
     /**

--- a/packages/ai-core/src/browser/open-editors-variable-contribution.ts
+++ b/packages/ai-core/src/browser/open-editors-variable-contribution.ts
@@ -23,7 +23,8 @@ import { AIVariable, ResolvedAIVariable, AIVariableContribution, AIVariableResol
 
 export const OPEN_EDITORS_VARIABLE: AIVariable = {
     id: 'openEditors',
-    description: nls.localize('theia/ai/core/openEditorsVariable/description', 'A comma-separated list of all currently open files, relative to the workspace root.'),
+    description: nls.localize('theia/ai/core/openEditorsVariable/description',
+        'A comma-separated list of all currently open files as workspace-relative paths (e.g., my-project/src/index.ts).'),
     name: 'openEditors',
 };
 
@@ -80,9 +81,7 @@ export class OpenEditorsVariableContribution implements AIVariableContribution, 
         return openFiles.join(', ');
     }
 
-    protected getWorkspaceRelativePath(uri: URI): string | undefined {
-        const workspaceRootUri = this.workspaceService.getWorkspaceRootUri(uri);
-        const path = workspaceRootUri && workspaceRootUri.path.relative(uri.path);
-        return path && path.toString();
+    protected getWorkspaceRelativePath(uri: URI): string {
+        return this.workspaceService.getRootPrefixedPath(uri);
     }
 }

--- a/packages/ai-core/src/browser/skill-service.ts
+++ b/packages/ai-core/src/browser/skill-service.ts
@@ -171,7 +171,7 @@ export class DefaultSkillService implements SkillService {
         const newDisposables = new DisposableCollection();
         const newSkills = new Map<string, Skill>();
 
-        const workspaceSkillsDir = this.getWorkspaceSkillsDirectoryPath();
+        const workspaceSkillsDirs = this.getWorkspaceSkillsDirectoryPaths();
 
         const homeDirUri = await this.envVariablesServer.getHomeDirUri();
         const homePath = new URI(homeDirUri).path.fsPath();
@@ -183,7 +183,7 @@ export class DefaultSkillService implements SkillService {
         const newWatchedDirectories = new Set<string>();
         const newParentWatchers = new Map<string, string>();
 
-        if (workspaceSkillsDir) {
+        for (const workspaceSkillsDir of workspaceSkillsDirs) {
             await this.processSkillDirectoryWithParentWatching(
                 workspaceSkillsDir,
                 newSkills,
@@ -223,13 +223,9 @@ export class DefaultSkillService implements SkillService {
         this.onSkillsChangedEmitter.fire();
     }
 
-    protected getWorkspaceSkillsDirectoryPath(): string | undefined {
-        const roots = this.workspaceService.tryGetRoots();
-        if (roots.length === 0) {
-            return undefined;
-        }
-        // Use primary workspace root
-        return roots[0].resource.resolve('.prompts/skills').path.fsPath();
+    protected getWorkspaceSkillsDirectoryPaths(): string[] {
+        return this.workspaceService.tryGetRoots()
+            .map(root => root.resource.resolve('.prompts/skills').path.fsPath());
     }
 
     protected async getDefaultSkillsDirectoryPath(): Promise<string> {

--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -52,41 +52,39 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
             {
                 name: 'currentAbsoluteFilePath',
                 description: nls.localize('theia/ai/core/variable-contribution/currentAbsoluteFilePath', 'The absolute path of the \
-                currently opened file. Please note that most agents will expect a relative file path (relative to the current workspace).')
+                currently opened file.')
             }
         ]],
         ['selectedText', [
             {
                 description: nls.localize('theia/ai/core/variable-contribution/currentSelectedText', 'The plain text that is currently selected in the \
-                opened file. This excludes the information where the content is coming from. Please note that most agents will work better with a relative file path \
-                (relative to the current workspace).')
+                opened file. This excludes the information where the content is coming from.')
             }
         ]],
         ['currentText', [
             {
                 name: 'currentFileContent',
                 description: nls.localize('theia/ai/core/variable-contribution/currentFileContent', 'The plain content of the \
-                currently opened file. This excludes the information where the content is coming from. Please note that most agents will work better with a relative file path \
-                (relative to the current workspace).')
+                currently opened file. This excludes the information where the content is coming from.')
             }
         ]],
         ['relativeFile', [
             {
                 name: 'currentRelativeFilePath',
-                description: nls.localize('theia/ai/core/variable-contribution/currentRelativeFilePath', 'The relative path of the \
-                currently opened file.')
+                description: nls.localize('theia/ai/core/variable-contribution/currentRelativeFilePath', 'The workspace-relative path of the \
+                currently opened file (e.g., my-project/src/index.ts).')
             },
             {
                 name: '_f',
-                description: nls.localize('theia/ai/core/variable-contribution/dotRelativePath', 'Short reference to the relative path of the \
+                description: nls.localize('theia/ai/core/variable-contribution/dotRelativePath', 'Short reference to the workspace-relative path of the \
                 currently opened file (\'currentRelativeFilePath\').')
             }
         ]],
         ['relativeFileDirname', [
             {
                 name: 'currentRelativeDirPath',
-                description: nls.localize('theia/ai/core/variable-contribution/currentRelativeDirPath', 'The relative path of the directory \
-                containing the currently opened file.')
+                description: nls.localize('theia/ai/core/variable-contribution/currentRelativeDirPath', 'The workspace-relative path of the directory \
+                containing the currently opened file (e.g., my-project/src).')
             }
         ]],
         ['lineNumber', [{}]],

--- a/packages/ai-editor/src/browser/ai-editor-context-variable.ts
+++ b/packages/ai-editor/src/browser/ai-editor-context-variable.ts
@@ -77,8 +77,7 @@ export class EditorContextVariableContribution implements AIVariableContribution
         const lineNumber = position ? position.lineNumber : 0;
         const column = position ? position.column : 0;
 
-        // Get workspace-relative path
-        const workspaceRelativePath = uri ? await this.workspaceService.getWorkspaceRelativePath(uri) : '';
+        const workspaceRelativePath = uri ? this.workspaceService.getRootPrefixedPath(uri) : '';
 
         // Create base context information
         const baseContext = {

--- a/packages/ai-ide/src/browser/context-file-validation-service-impl.spec.ts
+++ b/packages/ai-ide/src/browser/context-file-validation-service-impl.spec.ts
@@ -78,7 +78,8 @@ describe('ContextFileValidationService', () => {
             roots: Promise.resolve([{
                 resource: workspaceRoot,
                 isDirectory: true
-            } as FileStat])
+            } as FileStat]),
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         // Mock FileService
@@ -300,6 +301,17 @@ describe('ContextFileValidationService', () => {
                     isDirectory: true
                 } as FileStat
             ];
+            // Also override the async roots property for multi-root path resolution
+            (mockWorkspaceService as { roots: Promise<FileStat[]> }).roots = Promise.resolve([
+                {
+                    resource: workspaceRoot,
+                    isDirectory: true
+                } as FileStat,
+                {
+                    resource: workspaceRoot2,
+                    isDirectory: true
+                } as FileStat
+            ]);
 
             // Add files in the second workspace
             existingFiles.set('file:///home/user/other-project/index.js', true);
@@ -313,23 +325,28 @@ describe('ContextFileValidationService', () => {
         });
 
         it('should validate file in first workspace root', async () => {
-            const result = await validationService.validateFile('src/index.tsx');
+            // Use root-prefixed path since resolveRelativePath requires it in multi-root
+            const result = await validationService.validateFile('workspace/src/index.tsx');
             expect(result.state).to.equal(FileValidationState.VALID);
         });
 
         it('should validate file in second workspace root with relative path', async () => {
-            const result = await validationService.validateFile('index.js');
-            expect(result.state).to.equal(FileValidationState.INVALID_SECONDARY);
+            // Use root-prefixed path since resolveRelativePath requires it in multi-root
+            const result = await validationService.validateFile('other-project/index.js');
+            // With multi-root support, files in any root are valid
+            expect(result.state).to.equal(FileValidationState.VALID);
         });
 
         it('should validate file in second workspace root with absolute path', async () => {
             const result = await validationService.validateFile('/home/user/other-project/index.js');
-            expect(result.state).to.equal(FileValidationState.INVALID_SECONDARY);
+            // With multi-root support, files in any root are valid
+            expect(result.state).to.equal(FileValidationState.VALID);
         });
 
         it('should validate file in second workspace root with file:// URI', async () => {
             const result = await validationService.validateFile('file:///home/user/other-project/lib/utils.js');
-            expect(result.state).to.equal(FileValidationState.INVALID_SECONDARY);
+            // With multi-root support, files in any root are valid
+            expect(result.state).to.equal(FileValidationState.VALID);
         });
 
         it('should still reject files outside both workspace roots', async () => {

--- a/packages/ai-ide/src/browser/context-file-validation-service-impl.ts
+++ b/packages/ai-ide/src/browser/context-file-validation-service-impl.ts
@@ -46,29 +46,15 @@ export class ContextFileValidationServiceImpl implements ContextFileValidationSe
 
             const exists = await this.fileService.exists(resolvedUri);
             if (!exists) {
-                const secondaryRootUri = await this.findInSecondaryWorkspaceRoots(pathOrUri);
-                if (secondaryRootUri) {
-                    return {
-                        state: FileValidationState.INVALID_SECONDARY,
-                        message: 'File is in a secondary workspace root. AI agents can only access files in the first workspace root.'
-                    };
-                }
                 return {
                     state: FileValidationState.INVALID_NOT_FOUND,
                     message: 'File does not exist'
                 };
             }
 
-            if (this.workspaceScope.isInPrimaryWorkspace(resolvedUri)) {
-                return {
-                    state: FileValidationState.VALID
-                };
-            }
-
             if (this.workspaceScope.isInWorkspace(resolvedUri)) {
                 return {
-                    state: FileValidationState.INVALID_SECONDARY,
-                    message: 'File is in a secondary workspace root. AI agents can only access files in the first workspace root.'
+                    state: FileValidationState.VALID
                 };
             }
 
@@ -82,39 +68,5 @@ export class ContextFileValidationServiceImpl implements ContextFileValidationSe
                 message: 'File does not exist'
             };
         }
-    }
-
-    protected async findInSecondaryWorkspaceRoots(pathOrUri: string | URI): Promise<URI | undefined> {
-        const roots = this.workspaceService.tryGetRoots();
-        if (roots.length <= 1) {
-            return undefined;
-        }
-
-        for (let i = 1; i < roots.length; i++) {
-            const root = roots[i];
-            let candidateUri: URI;
-
-            if (pathOrUri instanceof URI) {
-                candidateUri = pathOrUri;
-            } else if (pathOrUri.includes('://')) {
-                try {
-                    candidateUri = new URI(pathOrUri);
-                } catch {
-                    continue;
-                }
-            } else {
-                candidateUri = root.resource.resolve(pathOrUri);
-            }
-
-            try {
-                if (await this.fileService.exists(candidateUri)) {
-                    return candidateUri;
-                }
-            } catch {
-                continue;
-            }
-        }
-
-        return undefined;
     }
 }

--- a/packages/ai-ide/src/browser/context-functions.spec.ts
+++ b/packages/ai-ide/src/browser/context-functions.spec.ts
@@ -204,14 +204,11 @@ describe('AddFileToChatContext Validation Tests', () => {
         expect(addedFiles).to.have.lengthOf(1);
     });
 
-    it('should reject files in secondary workspace roots', async () => {
+    it('should accept files in all workspace roots', async () => {
         const mockValidationService: ContextFileValidationService = {
             validateFile: async file => {
                 if (file === '/secondary/root/file.ts') {
-                    return {
-                        state: FileValidationState.INVALID_SECONDARY,
-                        message: 'File is in a secondary workspace root. AI agents can only access files in the first workspace root.'
-                    };
+                    return { state: FileValidationState.VALID };
                 }
                 return { state: FileValidationState.VALID };
             }
@@ -230,11 +227,11 @@ describe('AddFileToChatContext Validation Tests', () => {
         }
 
         const jsonResponse = JSON.parse(result);
-        expect(jsonResponse.added).to.have.lengthOf(0);
-        expect(jsonResponse.rejected).to.have.lengthOf(1);
-        expect(jsonResponse.rejected[0].file).to.equal('/secondary/root/file.ts');
-        expect(jsonResponse.rejected[0].state).to.equal(FileValidationState.INVALID_SECONDARY);
-        expect(addedFiles).to.have.lengthOf(0);
+        expect(jsonResponse.added).to.have.lengthOf(1);
+        expect(jsonResponse.added[0]).to.equal('/secondary/root/file.ts');
+        expect(jsonResponse.rejected).to.have.lengthOf(0);
+        expect(addedFiles).to.have.lengthOf(1);
+        expect(addedFiles[0].arg).to.equal('/secondary/root/file.ts');
     });
 
     it('should add all files when validation service is not available', async () => {

--- a/packages/ai-ide/src/browser/context-functions.ts
+++ b/packages/ai-ide/src/browser/context-functions.ts
@@ -106,7 +106,8 @@ export class AddFileToChatContext implements ToolProvider {
                 properties: {
                     filesToAdd: {
                         type: 'array',
-                        description: 'Array of relative file paths to bookmark (e.g., ["src/index.ts", "package.json"]). Paths are relative to the workspace root.',
+                        description: 'Array of file paths to bookmark ' +
+                            '(e.g., ["my-project/src/index.ts", "backend/package.json"]).',
                         items: { type: 'string' }
                     }
                 },

--- a/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
@@ -86,7 +86,7 @@ describe('File Changeset Functions Cancellation Tests', () => {
 
         // Mock dependencies
         const mockWorkspaceScope = {
-            resolveRelativePath: async () => new URI('file:///workspace/test.txt')
+            resolveRelativePath: () => new URI('file:///workspace/test.txt')
         } as unknown as WorkspaceFunctionScope;
 
         const mockFileService = {

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -82,7 +82,8 @@ export class SuggestFileContent implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'Relative path to the file within the workspace (e.g., "src/index.ts", "config/settings.json").'
+                        description: 'The path to the file within the workspace ' +
+                            '(e.g., "my-project/src/index.ts", "backend/config/settings.json").'
                     },
                     content: {
                         type: 'string',
@@ -157,7 +158,8 @@ export class WriteFileContent implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'Relative path to the file within the workspace (e.g., "src/index.ts", "config/settings.json").'
+                        description: 'The path to the file within the workspace ' +
+                            '(e.g., "my-project/src/index.ts", "backend/config/settings.json").'
                     },
                     content: {
                         type: 'string',
@@ -254,7 +256,9 @@ export class ReplaceContentInFileFunctionHelper {
             properties: {
                 path: {
                     type: 'string',
-                    description: 'Relative path to the file within the workspace (e.g., "src/index.ts"). Must read the file with getFileContent first.'
+                    description: 'The path to the file within the workspace ' +
+                        '(e.g., "my-project/src/index.ts", "backend/src/main.ts"). ' +
+                        'Must read the file with getFileContent first.'
                 },
                 replacements: {
                     type: 'array',
@@ -580,7 +584,8 @@ export class ClearFileChanges implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'Relative path to the file within the workspace (e.g., "src/index.ts").'
+                        description: 'The path to the file within the workspace ' +
+                            '(e.g., "my-project/src/index.ts", "backend/src/main.ts").'
                     }
                 },
                 required: ['path']
@@ -617,7 +622,8 @@ export class GetProposedFileState implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'Relative path to the file within the workspace (e.g., "src/index.ts").'
+                        description: 'The path to the file within the workspace ' +
+                            '(e.g., "my-project/src/index.ts", "backend/src/main.ts").'
                     }
                 },
                 required: ['path']

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -288,6 +288,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
         .inSingletonScope();
 
     bind(AIVariableContribution).to(ContextFilesVariableContribution).inSingletonScope();
+
     bind(PreferenceContribution).toConstantValue({ schema: AiConfigurationPreferences });
 
     bind(FrontendApplicationContribution).to(TemplatePreferenceContribution);

--- a/packages/ai-ide/src/browser/github-repo-variable-contribution.ts
+++ b/packages/ai-ide/src/browser/github-repo-variable-contribution.ts
@@ -33,7 +33,8 @@ import { GitHubRepoService } from '../common/github-repo-protocol';
 export const GITHUB_REPO_NAME_VARIABLE: AIVariable = {
     id: 'github-repo-name-provider',
     name: 'githubRepoName',
-    description: nls.localize('theia/ai/ide/githubRepoName/description', 'The name of the current GitHub repository (e.g., "eclipse-theia/theia")')
+    description: nls.localize('theia/ai/ide/githubRepoName/description',
+        'The GitHub repositories associated with the workspace roots (e.g., "eclipse-theia/theia")')
 };
 
 @injectable()
@@ -71,19 +72,47 @@ export class GitHubRepoVariableContribution implements AIVariableContribution, A
                 return { variable: request.variable, value: 'No GitHub repository is currently selected or detected.' };
             }
 
-            // Get the filesystem path from the workspace root URI
-            const workspaceRoot = workspaceRoots[0].resource;
-            const workspacePath = workspaceRoot.path.fsPath();
+            const repoResults = await Promise.all(
+                workspaceRoots.map(async root => {
+                    const rootPath = root.resource.path.fsPath();
+                    const rootName = root.resource.path.base;
+                    try {
+                        const info = await this.gitHubRepoService.getGitHubRepoInfo(rootPath);
+                        return info ? { rootName, repoName: `${info.owner}/${info.repo}` } : undefined;
+                    } catch {
+                        return undefined;
+                    }
+                })
+            );
 
-            // Use the backend service to get GitHub repository information
-            const repoInfo = await this.gitHubRepoService.getGitHubRepoInfo(workspacePath);
+            const found = repoResults.filter((r): r is { rootName: string; repoName: string } => r !== undefined);
 
-            if (!repoInfo) {
+            if (found.length === 0) {
                 return { variable: request.variable, value: 'No GitHub repository is currently selected or detected.' };
             }
 
-            const repoName = `${repoInfo.owner}/${repoInfo.repo}`;
-            return { variable: request.variable, value: `You are currently working with the GitHub repository: **${repoName}**` };
+            const uniqueRepos = new Map<string, string[]>();
+            for (const { rootName, repoName } of found) {
+                const roots = uniqueRepos.get(repoName);
+                if (roots) {
+                    roots.push(rootName);
+                } else {
+                    uniqueRepos.set(repoName, [rootName]);
+                }
+            }
+
+            if (uniqueRepos.size === 1) {
+                const [repoName] = uniqueRepos.keys();
+                return { variable: request.variable, value: `You are currently working with the GitHub repository: **${repoName}**` };
+            }
+
+            const lines = Array.from(uniqueRepos.entries()).map(
+                ([repoName, roots]) => `- **${repoName}** (${roots.join(', ')})`
+            );
+            return {
+                variable: request.variable,
+                value: `You are currently working with the following GitHub repositories:\n${lines.join('\n')}`
+            };
 
         } catch (error) {
             console.warn('Failed to resolve GitHub repository name:', error);

--- a/packages/ai-ide/src/browser/summarize-session-command-contribution.ts
+++ b/packages/ai-ide/src/browser/summarize-session-command-contribution.ts
@@ -79,7 +79,7 @@ export class SummarizeSessionCommandContribution implements CommandContribution 
 
                 if (existingTaskContext.uri) {
                     if (await this.fileService.exists(existingTaskContext.uri)) {
-                        const wsRelativePath = await this.wsService.getWorkspaceRelativePath(existingTaskContext.uri);
+                        const wsRelativePath = this.wsService.getRootPrefixedPath(existingTaskContext.uri);
                         const fileVariable: AIVariableResolutionRequest = {
                             variable: FILE_VARIABLE,
                             arg: wsRelativePath

--- a/packages/ai-ide/src/browser/template-preference-contribution.ts
+++ b/packages/ai-ide/src/browser/template-preference-contribution.ts
@@ -77,23 +77,24 @@ export class TemplatePreferenceContribution implements FrontendApplicationContri
      * @param changedPreference Optional name of the preference that changed
      */
     protected async updateConfiguration(changedPreference?: string): Promise<void> {
-        const workspaceRoot = this.workspaceService.tryGetRoots()[0];
-        if (!workspaceRoot) {
+        const workspaceRoots = this.workspaceService.tryGetRoots();
+        if (workspaceRoots.length === 0) {
             return;
         }
 
         const trusted = await this.workspaceTrustService.getWorkspaceTrust();
-        const workspaceRootUri = workspaceRoot.resource;
         const configProperties: PromptFragmentCustomizationProperties = {};
 
         if (!changedPreference || changedPreference === PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF) {
             if (trusted) {
                 const relativeDirectories = this.preferenceService.get<string[]>(PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF, []);
-                configProperties.directoryPaths = relativeDirectories.map(dir => {
-                    const path = new Path(dir);
-                    const uri = workspaceRootUri.resolve(path.toString());
-                    return uri.path.toString();
-                });
+                configProperties.directoryPaths = workspaceRoots.flatMap(root =>
+                    relativeDirectories.map(dir => {
+                        const path = new Path(dir);
+                        const uri = root.resource.resolve(path.toString());
+                        return uri.path.toString();
+                    })
+                );
             } else {
                 configProperties.directoryPaths = [];
             }
@@ -110,11 +111,13 @@ export class TemplatePreferenceContribution implements FrontendApplicationContri
         if (!changedPreference || changedPreference === PROMPT_TEMPLATE_WORKSPACE_FILES_PREF) {
             if (trusted) {
                 const relativeFilePaths = this.preferenceService.get<string[]>(PROMPT_TEMPLATE_WORKSPACE_FILES_PREF, []);
-                configProperties.filePaths = relativeFilePaths.map(filePath => {
-                    const path = new Path(filePath);
-                    const uri = workspaceRootUri.resolve(path.toString());
-                    return uri.path.toString();
-                });
+                configProperties.filePaths = workspaceRoots.flatMap(root =>
+                    relativeFilePaths.map(filePath => {
+                        const path = new Path(filePath);
+                        const uri = root.resource.resolve(path.toString());
+                        return uri.path.toString();
+                    })
+                );
             } else {
                 configProperties.filePaths = [];
             }

--- a/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
@@ -53,7 +53,8 @@ describe('UserInteractionTool', () => {
         container = new Container();
 
         mockWorkspaceScope = {
-            getWorkspaceRoot: sinon.stub().resolves(workspaceRoot),
+            resolveRelativePath: sinon.stub().callsFake((path: string) => workspaceRoot.resolve(path)),
+            getContainingRoot: sinon.stub().returns(workspaceRoot),
             ensureWithinWorkspace: sinon.stub()
         };
 

--- a/packages/ai-ide/src/browser/user-interaction-tool.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.ts
@@ -247,11 +247,9 @@ export class UserInteractionTool implements ToolProvider {
     }
 
     async openLink(link: UserInteractionLink): Promise<void> {
-        const workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
-
         if (link.rightRef !== undefined) {
-            const resolvedLeftUri = await this.resolveDiffSideUri(link.ref, workspaceRoot);
-            const resolvedRightUri = await this.resolveDiffSideUri(link.rightRef, workspaceRoot);
+            const resolvedLeftUri = await this.resolveDiffSideUri(link.ref);
+            const resolvedRightUri = await this.resolveDiffSideUri(link.rightRef);
             const left = resolveContentRef(link.ref);
             const right = resolveContentRef(link.rightRef);
             const diffLabel = link.label || buildDiffLabel(left, right);
@@ -269,7 +267,7 @@ export class UserInteractionTool implements ToolProvider {
             }
             const left = resolveContentRef(link.ref) as PathContentRef;
             if (left.gitRef) {
-                const uri = this.resolveUri(left, workspaceRoot);
+                const uri = this.resolveUri(left);
                 let targetUri: URI;
                 if (uri === undefined) {
                     targetUri = this.errorContentUri(left.path, left.gitRef);
@@ -282,8 +280,7 @@ export class UserInteractionTool implements ToolProvider {
                 }
                 await open(this.openerService, targetUri);
             } else {
-                const fileUri = workspaceRoot.resolve(left.path);
-                this.workspaceScope.ensureWithinWorkspace(fileUri, workspaceRoot);
+                const fileUri = this.workspaceScope.resolveRelativePath(left.path);
                 if (!(await this.canResolveUri(fileUri))) {
                     await open(this.openerService, this.fileNotFoundUri(left.path));
                     return;
@@ -297,11 +294,9 @@ export class UserInteractionTool implements ToolProvider {
     }
 
     protected resolveUri(
-        ref: PathContentRef,
-        workspaceRoot: URI
+        ref: PathContentRef
     ): URI | undefined {
-        const fileUri = workspaceRoot.resolve(ref.path);
-        this.workspaceScope.ensureWithinWorkspace(fileUri, workspaceRoot);
+        const fileUri = this.workspaceScope.resolveRelativePath(ref.path);
         if (ref.gitRef) {
             const repo = this.scmService.findRepository(fileUri);
             if (repo) {
@@ -365,12 +360,12 @@ export class UserInteractionTool implements ToolProvider {
         }
     }
 
-    protected async resolveDiffSideUri(ref: ContentRef, workspaceRoot: URI): Promise<URI> {
+    protected async resolveDiffSideUri(ref: ContentRef): Promise<URI> {
         if (isEmptyContentRef(ref)) {
             return this.emptyContentUri(ref.label || '');
         }
         const resolved = resolveContentRef(ref) as PathContentRef;
-        const uri = this.resolveUri(resolved, workspaceRoot);
+        const uri = this.resolveUri(resolved);
         if (uri === undefined) {
             // No SCM provider could resolve the gitRef — surface as an actionable error.
             return this.errorContentUri(resolved.path, resolved.gitRef!);

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -83,7 +83,9 @@ describe('Workspace Functions Cancellation Tests', () => {
 
         // Mock dependencies
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace') }]
+            roots: Promise.resolve([{ resource: new URI('file:///workspace') }]),
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         const mockFileService = {
@@ -193,7 +195,8 @@ describe('Workspace Functions Cancellation Tests', () => {
         };
 
         const handler = getWorkspaceFileList.getTool().handler;
-        const result = await handler(JSON.stringify({ path: '' }), mockCtx);
+        // Use a path that triggers file resolution (root name + subdirectory)
+        const result = await handler(JSON.stringify({ path: 'workspace/dir' }), mockCtx);
 
         expect(result).to.include('Operation cancelled by user');
     });
@@ -226,7 +229,9 @@ describe('FileContentFunction.getArgumentsShortLabel', () => {
         container = new Container();
 
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace') }]
+            roots: Promise.resolve([{ resource: new URI('file:///workspace') }]),
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         const mockFileService = {
@@ -331,7 +336,9 @@ describe('FileContentFunction handler', () => {
         container = new Container();
 
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace') }]
+            roots: Promise.resolve([{ resource: new URI('file:///workspace') }]),
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         mockResolve = async () => ({
@@ -709,7 +716,9 @@ describe('FindFilesByPattern.getArgumentsShortLabel', () => {
         container = new Container();
 
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace') }]
+            roots: Promise.resolve([{ resource: new URI('file:///workspace') }]),
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         const mockFileService = {
@@ -760,6 +769,8 @@ describe('FindFilesByPattern.getArgumentsShortLabel', () => {
     });
 });
 
+// ── HEAD: External allowed paths tests ──────────────────────────────────────
+
 describe('FileContentFunction external paths', () => {
     let container: Container;
     let fileContentFunction: FileContentFunction;
@@ -776,7 +787,9 @@ describe('FileContentFunction external paths', () => {
         trustedScopeOnly = false;
 
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace') }]
+            roots: [{ resource: new URI('file:///workspace') }],
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         const mockFileService = {
@@ -936,7 +949,9 @@ describe('GetWorkspaceFileList / GetWorkspaceDirectoryStructure with external pa
         allowedPaths = [];
 
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace') }]
+            roots: [{ resource: new URI('file:///workspace') }],
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         const mockFileService = {
@@ -992,13 +1007,13 @@ describe('GetWorkspaceFileList / GetWorkspaceDirectoryStructure with external pa
         allowedPaths = ['/external/configs'];
         const tool = container.get(GetWorkspaceFileList).getTool();
         const result = await tool.handler(JSON.stringify({ path: '/external/configs' }), undefined);
-        expect(result).to.deep.equal(['myapp.json', 'sub/']);
+        expect(JSON.parse(result as string)).to.deep.equal({ 'myapp.json': 'file', 'sub': 'directory' });
     });
 
     it('GetWorkspaceFileList still lists workspace-relative paths', async () => {
         const tool = container.get(GetWorkspaceFileList).getTool();
         const result = await tool.handler(JSON.stringify({ path: '' }), undefined);
-        expect(result).to.deep.equal(['a.ts', 'sub/']);
+        expect(JSON.parse(result as string)).to.deep.equal({ workspace: 'directory' });
     });
 
     it('GetWorkspaceDirectoryStructure rejects external root not in the allow-list', async () => {
@@ -1017,7 +1032,7 @@ describe('GetWorkspaceFileList / GetWorkspaceDirectoryStructure with external pa
     it('GetWorkspaceDirectoryStructure preserves prior workspace-only behavior when root omitted', async () => {
         const tool = container.get(GetWorkspaceDirectoryStructure).getTool();
         const result = await tool.handler('', undefined);
-        expect(result).to.deep.equal({ sub: {} });
+        expect(result).to.deep.equal({ workspace: { sub: {} } });
     });
 });
 
@@ -1043,7 +1058,9 @@ describe('FindFilesByPattern with searchRoot', () => {
         allowedPaths = [];
 
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace') }]
+            roots: [{ resource: new URI('file:///workspace') }],
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         const mockFileService = {
@@ -1095,7 +1112,7 @@ describe('FindFilesByPattern with searchRoot', () => {
     it('searches the workspace by default and returns relative paths', async () => {
         const result = await callTool({ pattern: '**/*.ts' });
         const parsed = JSON.parse(result);
-        expect(parsed.files).to.deep.equal(['a.ts']);
+        expect(parsed.files).to.deep.equal(['workspace/a.ts']);
     });
 
     it('rejects searchRoot that is not in the allow-list', async () => {
@@ -1141,7 +1158,9 @@ describe('WorkspaceFunctionScope path-traversal hardening', () => {
         trustAwareGet = <T>(_name: string, _fallback?: T) => allowedPaths as unknown as T;
 
         const mockWorkspaceService = {
-            roots: [{ resource: new URI('file:///workspace/project') }]
+            roots: [{ resource: new URI('file:///workspace/project') }],
+            tryGetRoots: () => [{ resource: new URI('file:///workspace/project') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
         } as unknown as WorkspaceService;
 
         const mockFileService = {
@@ -1317,5 +1336,499 @@ describe('WorkspaceFunctionScope path-traversal hardening', () => {
         const result = await handler(JSON.stringify({ file: '../project-other/file.txt' }), undefined);
         const parsed = JSON.parse(result as string);
         expect(parsed.error).to.include('outside of the workspace');
+    });
+});
+
+// ── Branch: Multi-root workspace tests ──────────────────────────────────────
+
+describe('WorkspaceFunctionScope Multi-Root Tests', () => {
+    let container: Container;
+    let workspaceScope: WorkspaceFunctionScope;
+
+    let disableJSDOMInner: () => void;
+    before(() => {
+        disableJSDOMInner = enableJSDOM();
+    });
+    after(() => {
+        disableJSDOMInner();
+    });
+
+    beforeEach(() => {
+        container = new Container();
+    });
+
+    describe('getRootMapping', () => {
+        it('returns single root with its basename', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [{ resource: new URI('file:///home/user/my-project') }],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const mapping = workspaceScope.getRootMapping();
+            expect(mapping.size).to.equal(1);
+            expect(mapping.get('my-project')?.toString()).to.equal('file:///home/user/my-project');
+        });
+
+        it('returns multiple roots with their basenames', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///home/user/frontend') },
+                    { resource: new URI('file:///home/user/backend') },
+                    { resource: new URI('file:///home/user/shared') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const mapping = workspaceScope.getRootMapping();
+            expect(mapping.size).to.equal(3);
+            expect(mapping.get('frontend')?.toString()).to.equal('file:///home/user/frontend');
+            expect(mapping.get('backend')?.toString()).to.equal('file:///home/user/backend');
+            expect(mapping.get('shared')?.toString()).to.equal('file:///home/user/shared');
+        });
+
+        it('uses first-wins for duplicate basenames (sorted by URI)', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///alice/app') },
+                    { resource: new URI('file:///bob/app') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const mapping = workspaceScope.getRootMapping();
+            // Only one entry for 'app' — the first by URI sort order wins.
+            // The other root is still reachable via resolveRelativePath fallback.
+            expect(mapping.size).to.equal(1);
+            expect(mapping.get('app')?.toString()).to.equal('file:///alice/app');
+        });
+    });
+
+    describe('toWorkspaceRelativePath', () => {
+        it('returns root-prefixed path for file in single root', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [{ resource: new URI('file:///home/user/project') }],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const uri = new URI('file:///home/user/project/src/index.ts');
+            const result = workspaceScope.toWorkspaceRelativePath(uri);
+            expect(result).to.equal('project/src/index.ts');
+        });
+
+        it('returns root-prefixed path for file in multi-root workspace', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///home/user/frontend') },
+                    { resource: new URI('file:///home/user/backend') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const frontendFile = new URI('file:///home/user/frontend/src/App.tsx');
+            expect(workspaceScope.toWorkspaceRelativePath(frontendFile)).to.equal('frontend/src/App.tsx');
+
+            const backendFile = new URI('file:///home/user/backend/src/server.ts');
+            expect(workspaceScope.toWorkspaceRelativePath(backendFile)).to.equal('backend/src/server.ts');
+        });
+
+        it('returns undefined for file outside workspace', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [{ resource: new URI('file:///home/user/project') }],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const uri = new URI('file:///etc/passwd');
+            const result = workspaceScope.toWorkspaceRelativePath(uri);
+            expect(result).to.be.undefined;
+        });
+
+        it('returns just root name for the root directory itself', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [{ resource: new URI('file:///home/user/project') }],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const uri = new URI('file:///home/user/project');
+            const result = workspaceScope.toWorkspaceRelativePath(uri);
+            // When the URI is the root itself, it returns just the root name
+            expect(result).to.equal('project');
+        });
+    });
+
+    describe('resolveRelativePath', () => {
+        function createScope(roots: string[]): WorkspaceFunctionScope {
+            const rootObjects = roots.map(r => ({ resource: new URI(r) }));
+            const mockWorkspaceService = {
+                tryGetRoots: () => rootObjects,
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            return container.get(WorkspaceFunctionScope);
+        }
+
+        describe('Phase 1 — root+relative', () => {
+            it('resolves path with matching root prefix', () => {
+                workspaceScope = createScope(['file:///home/user/frontend', 'file:///home/user/backend']);
+                const result = workspaceScope.resolveRelativePath('backend/src/server.ts');
+                expect(result.toString()).to.equal('file:///home/user/backend/src/server.ts');
+            });
+
+            it('returns the root URI when path is just a root name', () => {
+                workspaceScope = createScope(['file:///home/user/frontend', 'file:///home/user/backend']);
+                const result = workspaceScope.resolveRelativePath('frontend');
+                expect(result.toString()).to.equal('file:///home/user/frontend');
+            });
+
+            it('root name takes priority over subdirectory with same name', () => {
+                // Root named 'src' exists, AND another root has a 'src/' subdirectory
+                workspaceScope = createScope(['file:///home/user/src', 'file:///home/user/app']);
+                const result = workspaceScope.resolveRelativePath('src/index.ts');
+                expect(result.toString()).to.equal('file:///home/user/src/index.ts');
+            });
+        });
+
+        describe('Phase 2 — supra-relative', () => {
+            it('resolves when root basename appears with matching preceding components', () => {
+                workspaceScope = createScope(['file:///home/user/backend']);
+                // 'user/backend/src/file.ts' — 'backend' matches root basename, 'user' matches preceding component
+                const result = workspaceScope.resolveRelativePath('user/backend/src/file.ts');
+                expect(result.toString()).to.equal('file:///home/user/backend/src/file.ts');
+            });
+
+            it('resolves with full preceding path match', () => {
+                workspaceScope = createScope(['file:///home/user/backend']);
+                const result = workspaceScope.resolveRelativePath('home/user/backend/src/file.ts');
+                expect(result.toString()).to.equal('file:///home/user/backend/src/file.ts');
+            });
+
+            it('does not match when preceding components differ', () => {
+                // Must use multi-root so Phase 3 (single-root fallback) doesn't short-circuit
+                workspaceScope = createScope(['file:///home/user/frontend', 'file:///home/user/backend']);
+                // 'other/backend/src/file.ts' — 'other' does NOT match any suffix of 'home/user'
+                expect(() => workspaceScope.resolveRelativePath('other/backend/src/file.ts')).to.throw(/Could not resolve path/);
+            });
+
+            it('resolves with no preceding components (just root basename at start)', () => {
+                // This should be caught by Phase 1 (root+relative) since the first segment IS the root name
+                workspaceScope = createScope(['file:///home/user/backend']);
+                const result = workspaceScope.resolveRelativePath('backend/src/file.ts');
+                expect(result.toString()).to.equal('file:///home/user/backend/src/file.ts');
+            });
+
+            it('resolves supra-relative path in multi-root workspace', () => {
+                workspaceScope = createScope(['file:///home/user/frontend', 'file:///home/user/backend']);
+                const result = workspaceScope.resolveRelativePath('user/backend/src/file.ts');
+                expect(result.toString()).to.equal('file:///home/user/backend/src/file.ts');
+            });
+        });
+
+        describe('Phase 3 — single-root fallback', () => {
+            it('resolves unprefixed path relative to the single root', () => {
+                workspaceScope = createScope(['file:///home/user/project']);
+                const result = workspaceScope.resolveRelativePath('src/index.ts');
+                expect(result.toString()).to.equal('file:///home/user/project/src/index.ts');
+            });
+
+            it('resolves new file path relative to single root', () => {
+                workspaceScope = createScope(['file:///home/user/project']);
+                const result = workspaceScope.resolveRelativePath('new-file.ts');
+                expect(result.toString()).to.equal('file:///home/user/project/new-file.ts');
+            });
+        });
+
+        describe('Phase 4 — error for unresolvable multi-root paths', () => {
+            it('throws when unprefixed path cannot be resolved in multi-root', () => {
+                workspaceScope = createScope(['file:///home/user/frontend', 'file:///home/user/backend']);
+                expect(() => workspaceScope.resolveRelativePath('src/index.ts')).to.throw(/Could not resolve path/);
+            });
+
+            it('error message lists available roots', () => {
+                workspaceScope = createScope(['file:///home/user/frontend', 'file:///home/user/backend']);
+                try {
+                    workspaceScope.resolveRelativePath('src/index.ts');
+                    expect.fail('Expected an error');
+                } catch (e: unknown) {
+                    const error = e as Error;
+                    expect(error.message).to.include('frontend');
+                    expect(error.message).to.include('backend');
+                }
+            });
+
+            it('does not throw when root prefix is provided in multi-root', () => {
+                workspaceScope = createScope(['file:///home/user/frontend', 'file:///home/user/backend']);
+                const result = workspaceScope.resolveRelativePath('frontend/src/index.ts');
+                expect(result.toString()).to.equal('file:///home/user/frontend/src/index.ts');
+            });
+        });
+
+        describe('normalization', () => {
+            it('normalizes backslash paths', () => {
+                workspaceScope = createScope(['file:///home/user/project']);
+                const result = workspaceScope.resolveRelativePath('project\\src\\index.ts');
+                expect(result.toString()).to.equal('file:///home/user/project/src/index.ts');
+            });
+
+            it('resolves .. segments', () => {
+                workspaceScope = createScope(['file:///home/user/project']);
+                const result = workspaceScope.resolveRelativePath('project/src/../src/index.ts');
+                expect(result.toString()).to.equal('file:///home/user/project/src/index.ts');
+            });
+
+            it('normalizes redundant separators', () => {
+                workspaceScope = createScope(['file:///home/user/project']);
+                const result = workspaceScope.resolveRelativePath('project/src//index.ts');
+                expect(result.path.toString()).to.include('project/src/index.ts');
+            });
+
+            it('handles trailing slashes', () => {
+                workspaceScope = createScope(['file:///home/user/project']);
+                const result = workspaceScope.resolveRelativePath('project/src/');
+                expect(result.path.toString()).to.include('project/src');
+            });
+        });
+
+        describe('duplicate root basenames', () => {
+            it('round-trips the mapped root correctly', () => {
+                workspaceScope = createScope(['file:///workspace/a/app', 'file:///workspace/b/app']);
+                const mapping = workspaceScope.getRootMapping();
+                expect(mapping.size).to.equal(1);
+                expect(mapping.get('app')?.toString()).to.equal('file:///workspace/a/app');
+
+                // Round-trip for the mapped root
+                const uri = mapping.get('app')!.resolve('src/index.ts');
+                const relPath = workspaceScope.toWorkspaceRelativePath(uri)!;
+                expect(relPath).to.equal('app/src/index.ts');
+                const resolved = workspaceScope.resolveRelativePath(relPath);
+                expect(resolved.toString()).to.equal(uri.toString());
+            });
+
+            it('unmapped root returns undefined from toWorkspaceRelativePath', () => {
+                workspaceScope = createScope(['file:///workspace/a/app', 'file:///workspace/b/app']);
+                const uri = new URI('file:///workspace/b/app/src/index.ts');
+                const relPath = workspaceScope.toWorkspaceRelativePath(uri);
+                expect(relPath).to.be.undefined;
+            });
+
+            it('resolves app/path to the mapped root (Phase 1)', () => {
+                workspaceScope = createScope(['file:///workspace/a/app', 'file:///workspace/b/app']);
+                // 'app' maps to file:///workspace/a/app (first by URI sort)
+                const result = workspaceScope.resolveRelativePath('app/src/index.ts');
+                expect(result.toString()).to.equal('file:///workspace/a/app/src/index.ts');
+            });
+        });
+    });
+
+    describe('getRootMapping duplicate basename stability', () => {
+        it('assigns the same root to a name regardless of tryGetRoots order', () => {
+            // First ordering
+            const mockWorkspaceServiceA = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///workspace/b/app') },
+                    { resource: new URI('file:///workspace/a/app') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceServiceA);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            const scopeA = container.get(WorkspaceFunctionScope);
+            const mappingA = scopeA.getRootMapping();
+
+            // Reverse ordering in a fresh container
+            const container2 = new Container();
+            const mockWorkspaceServiceB = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///workspace/a/app') },
+                    { resource: new URI('file:///workspace/b/app') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container2.bind(WorkspaceService).toConstantValue(mockWorkspaceServiceB);
+            container2.bind(FileService).toConstantValue({} as FileService);
+            container2.bind(PreferenceService).toConstantValue({ get: () => false });
+            container2.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container2.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container2.bind(WorkspaceFunctionScope).toSelf();
+            const scopeB = container2.get(WorkspaceFunctionScope);
+            const mappingB = scopeB.getRootMapping();
+
+            // Both orderings should produce the same winner for 'app'
+            // (first by URI sort order: file:///workspace/a/app)
+            expect(mappingA.size).to.equal(1);
+            expect(mappingB.size).to.equal(1);
+            expect(mappingA.get('app')?.toString()).to.equal(mappingB.get('app')?.toString());
+            expect(mappingA.get('app')?.toString()).to.equal('file:///workspace/a/app');
+        });
+    });
+
+    describe('getContainingRoot', () => {
+        it('returns the most specific root for nested roots', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///projects/monorepo') },
+                    { resource: new URI('file:///projects/monorepo/packages/shared') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            // File in nested root should resolve to the more specific root
+            const fileInNested = new URI('file:///projects/monorepo/packages/shared/src/utils.ts');
+            const result = workspaceScope.getContainingRoot(fileInNested);
+            expect(result?.toString()).to.equal('file:///projects/monorepo/packages/shared');
+
+            // File in parent root (outside nested) should resolve to parent
+            const fileInParent = new URI('file:///projects/monorepo/src/main.ts');
+            const resultParent = workspaceScope.getContainingRoot(fileInParent);
+            expect(resultParent?.toString()).to.equal('file:///projects/monorepo');
+        });
+
+        it('returns undefined for file outside all workspace roots', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///home/user/project') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const externalFile = new URI('file:///tmp/outside.ts');
+            const result = workspaceScope.getContainingRoot(externalFile);
+            expect(result).to.be.undefined;
+        });
+    });
+
+    describe('round-trip consistency', () => {
+        it('toWorkspaceRelativePath and resolveRelativePath are inverses', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///home/user/frontend') },
+                    { resource: new URI('file:///home/user/backend') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            const originalUri = new URI('file:///home/user/backend/src/index.ts');
+            const relativePath = workspaceScope.toWorkspaceRelativePath(originalUri)!;
+            const resolvedUri = workspaceScope.resolveRelativePath(relativePath);
+
+            expect(resolvedUri.toString()).to.equal(originalUri.toString());
+        });
+
+        it('paths from toWorkspaceRelativePath always have a root prefix that resolves directly', () => {
+            const mockWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///home/user/frontend') },
+                    { resource: new URI('file:///home/user/backend') }
+                ],
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+            container.bind(FileService).toConstantValue({} as FileService);
+            container.bind(PreferenceService).toConstantValue({ get: () => false });
+            container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+            container.bind(WorkspaceFunctionScope).toSelf();
+            workspaceScope = container.get(WorkspaceFunctionScope);
+
+            // Test for each root
+            const roots = workspaceScope.getRootMapping();
+            for (const [rootName, rootUri] of roots) {
+                const fileUri = rootUri.resolve('src/app.ts');
+                const relPath = workspaceScope.toWorkspaceRelativePath(fileUri)!;
+                expect(relPath.startsWith(rootName + '/')).to.be.true;
+                const resolved = workspaceScope.resolveRelativePath(relPath);
+                expect(resolved.toString()).to.equal(fileUri.toString());
+            }
+        });
     });
 });

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -17,7 +17,7 @@ import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core
 import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
 import { CancellationToken, Disposable, OS, PreferenceService, URI, Path } from '@theia/core';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat, FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
@@ -59,17 +59,244 @@ export class WorkspaceFunctionScope {
     @inject(EnvVariablesServer)
     protected readonly envVariablesServer: EnvVariablesServer;
 
-    private gitignoreMatcher: ReturnType<typeof ignore> | undefined;
-    private gitignoreWatcherInitialized = false;
+    private gitignoreMatchers = new Map<string, ReturnType<typeof ignore>>();
+    private gitignoreWatchersInitialized = new Set<string>();
+
+    private _rootMapping: Map<string, URI> | undefined;
+    private _allRootUris: URI[] | undefined;
+
     private homeDirUri: Promise<URI | undefined> | undefined;
 
-    async getWorkspaceRoot(): Promise<URI> {
-        const wsRoots = await this.workspaceService.roots;
-        if (wsRoots.length === 0) {
-            throw new Error('No workspace has been opened yet');
-        }
-        return wsRoots[0].resource;
+    // ── Initialization ──────────────────────────────────────────────────
+
+    @postConstruct()
+    protected init(): void {
+        this.workspaceService.onWorkspaceChanged(() => {
+            this._rootMapping = undefined;
+            this._allRootUris = undefined;
+        });
     }
+
+    // ── Multi-root workspace structure ──────────────────────────────────
+
+    /**
+     * Returns all workspace root URIs (synchronous, cached).
+     */
+    private getAllRootUris(): URI[] {
+        if (!this._allRootUris) {
+            this._allRootUris = this.workspaceService.tryGetRoots().map(root => root.resource);
+        }
+        return this._allRootUris;
+    }
+
+    /**
+     * Returns a mapping of root names to root URIs.
+     *
+     * Root names are always the directory basename. When multiple roots share the
+     * same basename, only the first (by URI sort order) is addressable by name —
+     * the others are still reachable via the `resolveRelativePath` supra-relative
+     * check (which examines path segments against all roots).
+     *
+     * **Known limitation:** duplicate basenames are not disambiguated with synthetic
+     * suffixes because agents observe real filesystem paths in terminal output,
+     * compiler errors, stack traces, etc. Synthetic names like `app-1` would
+     * conflict with those observations and cause more confusion than they solve.
+     * A future improvement could let users assign display names to roots.
+     */
+    getRootMapping(): Map<string, URI> {
+        if (this._rootMapping) {
+            return this._rootMapping;
+        }
+
+        const wsRoots = this.workspaceService.tryGetRoots();
+        const sortedRoots = [...wsRoots].sort((a, b) => a.resource.toString().localeCompare(b.resource.toString()));
+        const mapping = new Map<string, URI>();
+
+        for (const root of sortedRoots) {
+            const basename = root.resource.path.base;
+            if (mapping.has(basename)) {
+                console.debug(
+                    `Multiple workspace roots share the basename '${basename}'. ` +
+                    `Only '${mapping.get(basename)!.toString()}' is addressable as '${basename}'. ` +
+                    `'${root.resource.toString()}' can still be accessed but may require full paths.`
+                );
+                continue;
+            }
+            mapping.set(basename, root.resource);
+        }
+
+        this._rootMapping = mapping;
+        return mapping;
+    }
+
+    /**
+     * Returns the root name for a given root URI based on the cached mapping.
+     */
+    getRootName(rootUri: URI): string | undefined {
+        const mapping = this.getRootMapping();
+        for (const [name, uri] of mapping) {
+            if (uri.toString() === rootUri.toString()) {
+                return name;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * Returns the workspace root that contains the given URI.
+     * If nested roots exist, returns the most specific (deepest) one.
+     */
+    getContainingRoot(uri: URI): URI | undefined {
+        const roots = this.getAllRootUris();
+        const matchingRoots: URI[] = [];
+
+        for (const rootUri of roots) {
+            if (rootUri.scheme === uri.scheme && rootUri.isEqualOrParent(uri)) {
+                matchingRoots.push(rootUri);
+            }
+        }
+
+        matchingRoots.sort((a, b) => b.toString().length - a.toString().length);
+        return matchingRoots[0];
+    }
+
+    /**
+     * Converts a URI to a workspace-relative path with root name prefix.
+     * Format: <rootName>/<relativePath>
+     */
+    toWorkspaceRelativePath(uri: URI): string | undefined {
+        const containingRoot = this.getContainingRoot(uri);
+        if (!containingRoot) {
+            return undefined;
+        }
+
+        const rootName = this.getRootName(containingRoot);
+        if (!rootName) {
+            return undefined;
+        }
+
+        const relativePath = containingRoot.relative(uri);
+        if (!relativePath || relativePath.toString() === '') {
+            return rootName; // URI is the root itself
+        }
+
+        return `${rootName}/${relativePath.toString()}`;
+    }
+
+    // ── Path resolution ─────────────────────────────────────────────────
+
+    /**
+     * Resolves a relative path to a URI using a deterministic, synchronous algorithm.
+     * No filesystem I/O is performed — the agent is expected to use `<rootName>/<relativePath>`
+     * format. If the path cannot be resolved deterministically, an error is thrown.
+     *
+     * Resolution order:
+     * 1. Root+relative: first segment matches a root name → resolve rest relative to that root.
+     * 2. Supra-relative: a root's basename appears as a segment, and any preceding material
+     *    matches the preceding path components of the root → resolve the trailing portion.
+     * 3. Single-root fallback: if exactly one workspace root, resolve relative to it.
+     * 4. Error: tell the agent how to format the path.
+     */
+    resolveRelativePath(relativePath: string): URI {
+        const normalizedPath = new Path(Path.normalizePathSeparator(relativePath)).normalize().toString();
+        const mapping = this.getRootMapping();
+        const roots = this.getAllRootUris();
+        const segments = normalizedPath.split('/');
+
+        // Phase 1 — Root+relative check:
+        if (segments.length > 0) {
+            const potentialRootName = segments[0];
+            const rootUri = mapping.get(potentialRootName);
+            if (rootUri) {
+                const restOfPath = segments.slice(1).join('/');
+                return restOfPath ? rootUri.resolve(restOfPath) : rootUri;
+            }
+        }
+
+        // Phase 2 — Supra-relative check:
+        for (const rootUri of roots) {
+            const rootBasename = rootUri.path.base;
+            for (let i = 0; i < segments.length; i++) {
+                if (segments[i] !== rootBasename) {
+                    continue;
+                }
+                const rootPathSegments = rootUri.path.toString().split('/').filter(s => s.length > 0);
+                const rootPrecedingSegments = rootPathSegments.slice(0, rootPathSegments.length - 1);
+                const pathPrecedingSegments = segments.slice(0, i);
+
+                let matches = true;
+                if (pathPrecedingSegments.length > rootPrecedingSegments.length) {
+                    matches = false;
+                } else {
+                    const rootTail = rootPrecedingSegments.slice(rootPrecedingSegments.length - pathPrecedingSegments.length);
+                    for (let j = 0; j < pathPrecedingSegments.length; j++) {
+                        if (pathPrecedingSegments[j] !== rootTail[j]) {
+                            matches = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (matches) {
+                    const restOfPath = segments.slice(i + 1).join('/');
+                    return restOfPath ? rootUri.resolve(restOfPath) : rootUri;
+                }
+            }
+        }
+
+        // Phase 3 — Single-root fallback:
+        if (roots.length === 1) {
+            return roots[0].resolve(normalizedPath);
+        }
+
+        // Phase 4 — Error:
+        const rootNames = Array.from(mapping.keys());
+        throw new Error(
+            `Could not resolve path '${relativePath}'. In a multi-root workspace, prefix paths with the workspace root name ` +
+            `(e.g., 'rootName/path/to/file'). Available roots: ${rootNames.join(', ')}`
+        );
+    }
+
+    async resolveToUri(pathOrUri: string | URI): Promise<URI | undefined> {
+        if (pathOrUri instanceof URI) {
+            return pathOrUri;
+        }
+
+        if (!pathOrUri) {
+            return undefined;
+        }
+
+        if (pathOrUri.includes('://')) {
+            try {
+                const uri = new URI(pathOrUri);
+                return uri;
+            } catch (error) {
+            }
+        }
+
+        const normalizedPath = Path.normalizePathSeparator(pathOrUri);
+
+        // Reject `..` only when it appears as a path SEGMENT. A filename like
+        // `my..file.json` is a legitimate name. `ensureAccessible` normalizes
+        // URI-form inputs separately as defense-in-depth (e.g. against
+        // percent-encoded `%2e%2e` that bypasses the string-form check).
+        if (WorkspaceFunctionScope.hasParentSegment(normalizedPath)) {
+            return undefined;
+        }
+
+        const tilde = await this.resolveTildePath(normalizedPath);
+        if (tilde) {
+            return tilde;
+        }
+
+        if (WorkspaceFunctionScope.isAbsolutePath(normalizedPath)) {
+            return URI.fromFilePath(normalizedPath);
+        }
+
+        return this.resolveRelativePath(normalizedPath);
+    }
+
+    // ── Access control ──────────────────────────────────────────────────
 
     ensureWithinWorkspace(targetUri: URI, workspaceRootUri: URI): void {
         const normalized = targetUri.normalizePath();
@@ -96,9 +323,9 @@ export class WorkspaceFunctionScope {
     async ensureAccessible(targetUri: URI): Promise<void> {
         const normalized = targetUri.normalizePath();
         const caseSensitive = WorkspaceFunctionScope.pathCaseSensitive;
-        const roots = (await this.workspaceService.roots) ?? [];
-        for (const root of roots) {
-            if (root.resource.scheme === normalized.scheme && root.resource.isEqualOrParent(normalized, caseSensitive)) {
+        const roots = this.getAllRootUris();
+        for (const rootUri of roots) {
+            if (rootUri.scheme === normalized.scheme && rootUri.isEqualOrParent(normalized, caseSensitive)) {
                 return;
             }
         }
@@ -111,6 +338,43 @@ export class WorkspaceFunctionScope {
             `Path is outside the workspace and not covered by the '${ALLOWED_EXTERNAL_PATHS_PREF}' preference.`
         );
     }
+
+    isInWorkspace(uri: URI): boolean {
+        try {
+            const roots = this.getAllRootUris();
+
+            if (roots.length === 0) {
+                return false;
+            }
+
+            for (const rootUri of roots) {
+                if (rootUri.scheme === uri.scheme && rootUri.isEqualOrParent(uri)) {
+                    return true;
+                }
+            }
+
+            return false;
+        } catch {
+            return false;
+        }
+    }
+
+    isInPrimaryWorkspace(uri: URI): boolean {
+        try {
+            const wsRoots = this.workspaceService.tryGetRoots();
+
+            if (wsRoots.length === 0) {
+                return false;
+            }
+
+            const primaryRoot = wsRoots[0].resource;
+            return primaryRoot.scheme === uri.scheme && primaryRoot.isEqualOrParent(uri);
+        } catch {
+            return false;
+        }
+    }
+
+    // ── External path support ───────────────────────────────────────────
 
     /**
      * Resolves the configured external allow-list to URIs. Reads via the
@@ -218,86 +482,6 @@ export class WorkspaceFunctionScope {
         return this.homeDirUri;
     }
 
-    async resolveRelativePath(relativePath: string): Promise<URI> {
-        const workspaceRoot = await this.getWorkspaceRoot();
-        return workspaceRoot.resolve(relativePath);
-    }
-
-    isInWorkspace(uri: URI): boolean {
-        try {
-            const wsRoots = this.workspaceService.tryGetRoots();
-
-            if (wsRoots.length === 0) {
-                return false;
-            }
-
-            for (const root of wsRoots) {
-                const rootUri = root.resource;
-                if (rootUri.scheme === uri.scheme && rootUri.isEqualOrParent(uri)) {
-                    return true;
-                }
-            }
-
-            return false;
-        } catch {
-            return false;
-        }
-    }
-
-    isInPrimaryWorkspace(uri: URI): boolean {
-        try {
-            const wsRoots = this.workspaceService.tryGetRoots();
-
-            if (wsRoots.length === 0) {
-                return false;
-            }
-
-            const primaryRoot = wsRoots[0].resource;
-            return primaryRoot.scheme === uri.scheme && primaryRoot.isEqualOrParent(uri);
-        } catch {
-            return false;
-        }
-    }
-
-    async resolveToUri(pathOrUri: string | URI): Promise<URI | undefined> {
-        if (pathOrUri instanceof URI) {
-            return pathOrUri;
-        }
-
-        if (!pathOrUri) {
-            return undefined;
-        }
-
-        if (pathOrUri.includes('://')) {
-            try {
-                const uri = new URI(pathOrUri);
-                return uri;
-            } catch (error) {
-            }
-        }
-
-        const normalizedPath = Path.normalizePathSeparator(pathOrUri);
-
-        // Reject `..` only when it appears as a path SEGMENT. A filename like
-        // `my..file.json` is a legitimate name. `ensureAccessible` normalizes
-        // URI-form inputs separately as defense-in-depth (e.g. against
-        // percent-encoded `%2e%2e` that bypasses the string-form check).
-        if (WorkspaceFunctionScope.hasParentSegment(normalizedPath)) {
-            return undefined;
-        }
-
-        const tilde = await this.resolveTildePath(normalizedPath);
-        if (tilde) {
-            return tilde;
-        }
-
-        if (WorkspaceFunctionScope.isAbsolutePath(normalizedPath)) {
-            return URI.fromFilePath(normalizedPath);
-        }
-
-        return this.resolveRelativePath(normalizedPath);
-    }
-
     /**
      * Whether the already-separator-normalized path contains `..` as a path
      * segment (not merely as a substring of a filename like `my..file.json`).
@@ -306,8 +490,11 @@ export class WorkspaceFunctionScope {
         return normalizedPath.split('/').some(segment => segment === '..');
     }
 
+    // ── Gitignore / exclusion ───────────────────────────────────────────
+
     private async initializeGitignoreWatcher(workspaceRoot: URI): Promise<void> {
-        if (this.gitignoreWatcherInitialized) {
+        const rootKey = workspaceRoot.toString();
+        if (this.gitignoreWatchersInitialized.has(rootKey)) {
             return;
         }
 
@@ -316,11 +503,11 @@ export class WorkspaceFunctionScope {
 
         this.fileService.onDidFilesChange(async event => {
             if (event.contains(gitignoreUri)) {
-                this.gitignoreMatcher = undefined;
+                this.gitignoreMatchers.delete(rootKey);
             }
         });
 
-        this.gitignoreWatcherInitialized = true;
+        this.gitignoreWatchersInitialized.add(rootKey);
     }
 
     async shouldExclude(stat: FileStat): Promise<boolean> {
@@ -330,8 +517,11 @@ export class WorkspaceFunctionScope {
         if (this.isUserExcluded(stat.resource.path.base, userExcludePatterns)) {
             return true;
         }
-        const workspaceRoot = await this.getWorkspaceRoot();
-        if (shouldConsiderGitIgnore && (await this.isGitIgnored(stat, workspaceRoot))) {
+
+        const containingRoot = this.getContainingRoot(stat.resource);
+        // If the file is outside all workspace roots, we skip gitignore checks
+        // since gitignore rules are relative to their root directory.
+        if (shouldConsiderGitIgnore && containingRoot && (await this.isGitIgnored(stat, containingRoot))) {
             return true;
         }
 
@@ -345,19 +535,22 @@ export class WorkspaceFunctionScope {
     protected async isGitIgnored(stat: FileStat, workspaceRoot: URI): Promise<boolean> {
         await this.initializeGitignoreWatcher(workspaceRoot);
 
+        const rootKey = workspaceRoot.toString();
         const gitignoreUri = workspaceRoot.resolve(this.GITIGNORE_FILE_NAME);
 
         try {
             const fileStat = await this.fileService.resolve(gitignoreUri);
             if (fileStat) {
-                if (!this.gitignoreMatcher) {
+                let matcher = this.gitignoreMatchers.get(rootKey);
+                if (!matcher) {
                     const gitignoreContent = await this.fileService.read(gitignoreUri);
-                    this.gitignoreMatcher = ignore().add(gitignoreContent.value);
+                    matcher = ignore().add(gitignoreContent.value);
+                    this.gitignoreMatchers.set(rootKey, matcher);
                 }
                 const relativePath = workspaceRoot.relative(stat.resource);
                 if (relativePath) {
                     const relativePathStr = relativePath.toString() + (stat.isDirectory ? '/' : '');
-                    if (this.gitignoreMatcher.ignores(relativePathStr)) {
+                    if (matcher.ignores(relativePathStr)) {
                         return true;
                     }
                 }
@@ -379,7 +572,8 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
             id: GetWorkspaceDirectoryStructure.ID,
             name: GetWorkspaceDirectoryStructure.ID,
             description: 'Retrieves the directory tree structure as a nested JSON object. ' +
-                'By default operates on the workspace; pass `root` to inspect a directory listed in the ' +
+                'By default returns all workspace roots with root names as keys. ' +
+                'Pass `root` to inspect a specific directory listed in the ' +
                 '`ai-features.workspaceFunctions.allowedExternalPaths` preference instead. ' +
                 'Lists only directories (no files), excluding common non-essential directories (node_modules, hidden files, etc.). ' +
                 'Useful for getting a high-level overview of project organization. ' +
@@ -392,7 +586,7 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
                         type: 'string',
                         description: 'Optional absolute path or `file://` URI to inspect instead of the workspace. ' +
                             'Must be inside, or equal to, an entry of the `allowedExternalPaths` preference. ' +
-                            'When omitted, the workspace root is used.'
+                            'When omitted, all workspace roots are returned.'
                     }
                 },
             },
@@ -421,23 +615,33 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
             return { error: 'Operation cancelled by user' };
         }
 
-        let rootUri: URI;
         try {
             if (root) {
                 const resolved = await this.workspaceScope.resolveToUri(root);
                 if (!resolved) {
                     return { error: `Invalid root: '${root}'` };
                 }
-                rootUri = resolved;
-                await this.workspaceScope.ensureAccessible(rootUri);
+                await this.workspaceScope.ensureAccessible(resolved);
+                return this.buildDirectoryStructure(resolved, cancellationToken);
             } else {
-                rootUri = await this.workspaceScope.getWorkspaceRoot();
+                const rootMapping = this.workspaceScope.getRootMapping();
+                if (rootMapping.size === 0) {
+                    return { error: 'No workspace has been opened yet' };
+                }
+
+                const result: Record<string, unknown> = {};
+                for (const [rootName, rootUri] of rootMapping) {
+                    if (cancellationToken?.isCancellationRequested) {
+                        return { error: 'Operation cancelled by user' };
+                    }
+                    result[rootName] = await this.buildDirectoryStructure(rootUri, cancellationToken);
+                }
+
+                return result;
             }
         } catch (error) {
             return { error: error.message };
         }
-
-        return this.buildDirectoryStructure(rootUri, cancellationToken);
     }
 
     private async buildDirectoryStructure(uri: URI, cancellationToken?: CancellationToken): Promise<Record<string, unknown>> {
@@ -475,9 +679,10 @@ export class FileContentFunction implements ToolProvider {
             id: FileContentFunction.ID,
             name: FileContentFunction.ID,
             description: 'Returns the content of a specified file as a raw string. ' +
-                'Relative paths resolve against the workspace root. ' +
-                'Absolute paths and `file://` URIs are accepted only when the target is inside the workspace ' +
-                'or covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference; otherwise an error is returned. ' +
+                'File paths use the same format returned by other workspace tools ' +
+                '(e.g., "my-project/src/index.ts"). ' +
+                'Absolute paths and `file://` URIs are accepted when the target is inside the workspace ' +
+                'or covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference. ' +
                 'If the file is currently open in an editor with unsaved changes, returns the editor\'s current content (not the saved file on disk). ' +
                 'Binary files may not be readable and will return an error. ' +
                 'Use this tool to read file contents before making any edits with replacement functions. ' +
@@ -492,8 +697,9 @@ export class FileContentFunction implements ToolProvider {
                 properties: {
                     file: {
                         type: 'string',
-                        description: 'Path to the target file. May be relative to the workspace root (e.g., "src/index.ts"), ' +
-                            'an absolute path, or a `file://` URI. Absolute / URI forms must point inside the workspace ' +
+                        description: 'Path to the target file. May be workspace-relative ' +
+                            '(e.g., "my-project/src/index.ts"), an absolute path, or a `file://` URI. ' +
+                            'Absolute / URI forms must point inside the workspace ' +
                             'or inside a directory listed in the `allowedExternalPaths` preference.',
                     },
                     offset: {
@@ -756,18 +962,17 @@ export class GetWorkspaceFileList implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'Path to a directory. Relative paths resolve against the workspace root ' +
-                            '(e.g., "src", "src/components"); use "" or "." for the workspace root. ' +
-                            'Absolute paths and `file://` URIs are accepted only when the target is inside the workspace ' +
-                            'or covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference.'
+                        description: 'Path to a directory. Workspace-relative paths use the format \'rootName/path\' ' +
+                            '(e.g., \'my-project/src\', \'backend/src/components\'). ' +
+                            'Use \'\' or \'.\' to list the workspace top-level directories. ' +
+                            'Absolute paths and `file://` URIs are accepted when covered by the `allowedExternalPaths` preference.'
                     }
                 },
                 required: ['path']
             },
             description: 'Lists files and directories within a specified directory. ' +
-                'By default operates within the workspace; absolute paths or `file://` URIs may be passed ' +
-                'when they target a location covered by the `allowedExternalPaths` preference. ' +
-                'Returns an array of names where directories are suffixed with "/" (e.g., ["src/", "package.json", "README.md"]). ' +
+                'Returns a JSON object mapping each immediate child name to its type ("directory" or "file"). ' +
+                'Use "" or "." to list the workspace top-level directories. ' +
                 'Use this to explore directory structure step by step. ' +
                 'For finding specific files by pattern, use findFilesByPattern instead. ' +
                 'For searching file contents, use searchInWorkspace instead.',
@@ -784,35 +989,37 @@ export class GetWorkspaceFileList implements ToolProvider {
     @inject(WorkspaceFunctionScope)
     protected workspaceScope: WorkspaceFunctionScope;
 
-    async getProjectFileList(path?: string, cancellationToken?: CancellationToken): Promise<string | string[]> {
+    async getProjectFileList(path?: string, cancellationToken?: CancellationToken): Promise<string> {
         if (cancellationToken?.isCancellationRequested) {
             return JSON.stringify({ error: 'Operation cancelled by user' });
         }
 
-        let targetUri: URI;
-        let workspaceRoot: URI;
         try {
-            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
-        } catch (error) {
-            return JSON.stringify({ error: error.message });
-        }
+            const rootMapping = this.workspaceScope.getRootMapping();
+            if (rootMapping.size === 0) {
+                return JSON.stringify({ error: 'No workspace has been opened yet' });
+            }
 
-        try {
-            if (!path || path === '.') {
-                targetUri = workspaceRoot;
-            } else {
+            if (!path || path === '.' || path === '') {
+                const roots: Record<string, 'directory'> = {};
+                for (const name of rootMapping.keys()) {
+                    roots[name] = 'directory';
+                }
+                return JSON.stringify(roots);
+            }
+
+            let targetUri: URI;
+            try {
                 const resolved = await this.workspaceScope.resolveToUri(path);
                 if (!resolved) {
                     return JSON.stringify({ error: `Invalid path: '${path}'` });
                 }
                 targetUri = resolved;
                 await this.workspaceScope.ensureAccessible(targetUri);
+            } catch (error) {
+                return JSON.stringify({ error: error.message });
             }
-        } catch (error) {
-            return JSON.stringify({ error: error.message });
-        }
 
-        try {
             if (cancellationToken?.isCancellationRequested) {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
             }
@@ -821,23 +1028,23 @@ export class GetWorkspaceFileList implements ToolProvider {
             if (!stat || !stat.isDirectory) {
                 return JSON.stringify({ error: 'Directory not found' });
             }
-            return await this.listFilesDirectly(targetUri, workspaceRoot, cancellationToken);
+            return await this.listFilesDirectly(targetUri, cancellationToken);
         } catch (error) {
             return JSON.stringify({ error: 'Directory not found' });
         }
     }
 
-    private async listFilesDirectly(uri: URI, workspaceRootUri: URI, cancellationToken?: CancellationToken): Promise<string | string[]> {
+    private async listFilesDirectly(uri: URI, cancellationToken?: CancellationToken): Promise<string> {
         if (cancellationToken?.isCancellationRequested) {
             return JSON.stringify({ error: 'Operation cancelled by user' });
         }
 
         const stat = await this.fileService.resolve(uri);
-        const result: string[] = [];
+        const result: Record<string, 'directory' | 'file'> = {};
 
         if (stat && stat.isDirectory) {
             if (await this.workspaceScope.shouldExclude(stat)) {
-                return result;
+                return JSON.stringify(result);
             }
             const children = await this.fileService.resolve(uri);
             if (children.children) {
@@ -849,13 +1056,12 @@ export class GetWorkspaceFileList implements ToolProvider {
                     if (await this.workspaceScope.shouldExclude(child)) {
                         continue;
                     }
-                    const itemName = child.resource.path.base;
-                    result.push(child.isDirectory ? `${itemName}/` : itemName);
+                    result[child.resource.path.base] = child.isDirectory ? 'directory' : 'file';
                 }
             }
         }
 
-        return result;
+        return JSON.stringify(result);
     }
 }
 
@@ -888,8 +1094,8 @@ export class FileDiagnosticProvider implements ToolProvider {
                 properties: {
                     file: {
                         type: 'string',
-                        description: 'The relative path to the target file within the workspace (e.g., "src/index.ts"). ' +
-                            'Must be relative to the workspace root.'
+                        description: 'The path to the target file within the workspace ' +
+                            '(e.g., "my-project/src/index.ts", "backend/src/main.ts").'
                     }
                 },
                 required: ['file']
@@ -897,9 +1103,12 @@ export class FileDiagnosticProvider implements ToolProvider {
             handler: async (arg: string, ctx?: ToolInvocationContext) => {
                 try {
                     const { file } = JSON.parse(arg);
-                    const workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
-                    const targetUri = workspaceRoot.resolve(file);
-                    this.workspaceScope.ensureWithinWorkspace(targetUri, workspaceRoot);
+                    const targetUri = await this.workspaceScope.resolveRelativePath(file);
+                    const containingRoot = this.workspaceScope.getContainingRoot(targetUri);
+                    if (!containingRoot) {
+                        return JSON.stringify({ error: 'Access outside of the workspace is not allowed' });
+                    }
+                    this.workspaceScope.ensureWithinWorkspace(targetUri, containingRoot);
 
                     return this.getDiagnosticsForFile(targetUri, ctx?.cancellationToken);
                 } catch (error) {
@@ -1023,11 +1232,13 @@ export class FindFilesByPattern implements ToolProvider {
             id: FindFilesByPattern.ID,
             name: FindFilesByPattern.ID,
             description: 'Find files matching a given glob pattern. ' +
-                'By default searches the workspace; pass `searchRoot` to search a directory listed in the ' +
+                'By default searches across all workspace roots. ' +
+                'Pass `searchRoot` to search a directory listed in the ' +
                 '`ai-features.workspaceFunctions.allowedExternalPaths` preference instead. ' +
                 'This function allows efficient discovery of files using patterns like \'**/*.ts\' for all TypeScript files or ' +
                 '\'src/**/*.js\' for JavaScript files in the src directory. The function respects gitignore patterns and user exclusions, ' +
-                'returns paths relative to the search root, and limits results to 200 files maximum. ' +
+                'returns workspace-relative paths (e.g., "my-project/src/index.ts") or absolute paths for external roots, ' +
+                'and limits results to 200 files maximum. ' +
                 'Performance note: This traverses directories recursively which may be slow in large workspaces. ' +
                 'For better performance, use specific subdirectory patterns (e.g., \'src/**/*.ts\' instead of \'**/*.ts\'). ' +
                 'Use this to find files by name/extension. Do NOT use this for searching file contents - use searchInWorkspace instead.',
@@ -1053,7 +1264,7 @@ export class FindFilesByPattern implements ToolProvider {
                         description: 'Optional absolute path or `file://` URI to search instead of the workspace. ' +
                             'Must be inside, or equal to, an entry of the `allowedExternalPaths` preference. ' +
                             'When set, results are returned as absolute paths so they can be passed back to getFileContent. ' +
-                            'When omitted (default), the workspace root is searched and results are workspace-relative.'
+                            'When omitted (default), all workspace roots are searched and results are workspace-relative.'
                     }
                 },
                 required: ['pattern']
@@ -1091,45 +1302,79 @@ export class FindFilesByPattern implements ToolProvider {
             return JSON.stringify({ error: 'Operation cancelled by user' });
         }
 
-        let rootUri: URI;
-        let isExternalRoot = false;
         try {
+            const patternMatcher = new Minimatch(pattern, { dot: false });
+            const files: string[] = [];
+            const maxResults = 200;
+
             if (searchRoot) {
                 const resolved = await this.workspaceScope.resolveToUri(searchRoot);
                 if (!resolved) {
                     return JSON.stringify({ error: `Invalid searchRoot: '${searchRoot}'` });
                 }
-                rootUri = resolved;
-                isExternalRoot = !this.workspaceScope.isInWorkspace(rootUri);
+                const rootUri = resolved;
+                const isExternalRoot = !this.workspaceScope.isInWorkspace(rootUri);
                 await this.workspaceScope.ensureAccessible(rootUri);
+
+                const ignorePatterns = isExternalRoot
+                    ? this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, [])
+                    : await this.buildIgnorePatterns(rootUri);
+                const allExcludes = [...ignorePatterns];
+                if (excludePatterns && excludePatterns.length > 0) {
+                    allExcludes.push(...excludePatterns);
+                }
+
+                if (cancellationToken?.isCancellationRequested) {
+                    return JSON.stringify({ error: 'Operation cancelled by user' });
+                }
+
+                const excludeMatchers = allExcludes.map(excludePattern => new Minimatch(excludePattern, { dot: true }));
+
+                await this.traverseDirectory(
+                    rootUri,
+                    rootUri,
+                    undefined,
+                    patternMatcher,
+                    excludeMatchers,
+                    files,
+                    maxResults,
+                    cancellationToken,
+                    isExternalRoot
+                );
             } else {
-                rootUri = await this.workspaceScope.getWorkspaceRoot();
+                const rootMapping = this.workspaceScope.getRootMapping();
+                if (rootMapping.size === 0) {
+                    return JSON.stringify({ error: 'No workspace has been opened yet' });
+                }
+
+                for (const [rootName, rootUri] of rootMapping) {
+                    if (cancellationToken?.isCancellationRequested) {
+                        return JSON.stringify({ error: 'Operation cancelled by user' });
+                    }
+
+                    if (files.length >= maxResults) {
+                        break;
+                    }
+
+                    const ignorePatterns = await this.buildIgnorePatterns(rootUri);
+                    const allExcludes = [...ignorePatterns];
+                    if (excludePatterns && excludePatterns.length > 0) {
+                        allExcludes.push(...excludePatterns);
+                    }
+                    const excludeMatchers = allExcludes.map(excludePattern => new Minimatch(excludePattern, { dot: true }));
+
+                    await this.traverseDirectory(
+                        rootUri,
+                        rootUri,
+                        rootName,
+                        patternMatcher,
+                        excludeMatchers,
+                        files,
+                        maxResults,
+                        cancellationToken
+                    );
+                }
             }
-        } catch (error) {
-            return JSON.stringify({ error: error.message });
-        }
-
-        try {
-            // Build ignore patterns from gitignore (workspace only) and user preferences
-            const ignorePatterns = isExternalRoot
-                ? this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, [])
-                : await this.buildIgnorePatterns(rootUri);
-
-            const allExcludes = [...ignorePatterns];
-            if (excludePatterns && excludePatterns.length > 0) {
-                allExcludes.push(...excludePatterns);
-            }
-
-            if (cancellationToken?.isCancellationRequested) {
-                return JSON.stringify({ error: 'Operation cancelled by user' });
-            }
-
-            const patternMatcher = new Minimatch(pattern, { dot: false });
-            const excludeMatchers = allExcludes.map(excludePattern => new Minimatch(excludePattern, { dot: true }));
-            const files: string[] = [];
-            const maxResults = 200;
-
-            await this.traverseDirectory(rootUri, rootUri, patternMatcher, excludeMatchers, files, maxResults, cancellationToken, isExternalRoot);
 
             if (cancellationToken?.isCancellationRequested) {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
@@ -1180,6 +1425,7 @@ export class FindFilesByPattern implements ToolProvider {
     private async traverseDirectory(
         currentUri: URI,
         searchRoot: URI,
+        rootName: string | undefined,
         patternMatcher: Minimatch,
         excludeMatchers: Minimatch[],
         results: string[],
@@ -1215,10 +1461,25 @@ export class FindFilesByPattern implements ToolProvider {
                 }
 
                 if (child.isDirectory) {
-                    await this.traverseDirectory(child.resource, searchRoot, patternMatcher, excludeMatchers,
-                        results, maxResults, cancellationToken, emitAbsolutePaths);
+                    await this.traverseDirectory(
+                        child.resource,
+                        searchRoot,
+                        rootName,
+                        patternMatcher,
+                        excludeMatchers,
+                        results,
+                        maxResults,
+                        cancellationToken,
+                        emitAbsolutePaths
+                    );
                 } else if (patternMatcher.match(relativePath)) {
-                    results.push(emitAbsolutePaths ? child.resource.path.toString() : relativePath);
+                    if (emitAbsolutePaths) {
+                        results.push(child.resource.path.toString());
+                    } else if (rootName) {
+                        results.push(`${rootName}/${relativePath}`);
+                    } else {
+                        results.push(relativePath);
+                    }
                 }
             }
         } catch {

--- a/packages/ai-ide/src/browser/workspace-launch-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-launch-provider.spec.ts
@@ -20,6 +20,8 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
+import { PreferenceService } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
 import { Container } from '@theia/core/shared/inversify';
 import {
     LaunchListProvider,
@@ -32,6 +34,9 @@ import { DebugSessionOptions } from '@theia/debug/lib/browser/debug-session-opti
 import { DebugConfiguration } from '@theia/debug/lib/common/debug-common';
 import { DebugCompound } from '@theia/debug/lib/common/debug-compound';
 import { DebugSession } from '@theia/debug/lib/browser/debug-session';
+import { WorkspaceFunctionScope } from './workspace-functions';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
 
 disableJSDOM();
 
@@ -53,6 +58,21 @@ describe('Launch Management Tool Providers', () => {
 
     beforeEach(() => {
         container = new Container();
+
+        const mockWorkspaceService = {
+            tryGetRoots: () => [
+                { resource: new URI('file:///workspace') }
+            ],
+            roots: Promise.resolve([
+                { resource: new URI('file:///workspace') }
+            ]),
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue({} as FileService);
+        container.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        container.bind(WorkspaceFunctionScope).toSelf();
 
         const mockConfigs = createMockConfigurations();
 
@@ -96,9 +116,12 @@ describe('Launch Management Tool Providers', () => {
             .bind(DebugSessionManager)
             .toConstantValue(mockDebugSessionManager as DebugSessionManager);
 
-        launchListProvider = container.resolve(LaunchListProvider);
-        launchRunnerProvider = container.resolve(LaunchRunnerProvider);
-        launchStopProvider = container.resolve(LaunchStopProvider);
+        container.bind(LaunchListProvider).toSelf();
+        container.bind(LaunchRunnerProvider).toSelf();
+        container.bind(LaunchStopProvider).toSelf();
+        launchListProvider = container.get(LaunchListProvider);
+        launchRunnerProvider = container.get(LaunchRunnerProvider);
+        launchStopProvider = container.get(LaunchStopProvider);
     });
 
     function createMockConfigurations(): DebugSessionOptions[] {
@@ -125,14 +148,14 @@ describe('Launch Management Tool Providers', () => {
             {
                 name: 'Node.js Debug',
                 configuration: config1,
-                workspaceFolderUri: '/workspace',
+                workspaceFolderUri: 'file:///workspace',
             },
             {
                 name: 'Python Debug',
                 configuration: config2,
-                workspaceFolderUri: '/workspace',
+                workspaceFolderUri: 'file:///workspace',
             },
-            { name: 'Launch All', compound, workspaceFolderUri: '/workspace' },
+            { name: 'Launch All', compound, workspaceFolderUri: 'file:///workspace' },
         ];
     }
 
@@ -159,7 +182,7 @@ describe('Launch Management Tool Providers', () => {
             expect(configurations.map((c: { name: string }) => c.name)).to.include('Python Debug');
             expect(configurations.map((c: { name: string }) => c.name)).to.include('Launch All');
             // All configurations should show running: false since no sessions are active
-            configurations.forEach((config: { name: string; running: boolean }) => {
+            configurations.forEach((config: { name: string; running: boolean; workspaceRoot?: string }) => {
                 expect(config.running).to.equal(false);
             });
         });
@@ -186,6 +209,18 @@ describe('Launch Management Tool Providers', () => {
             expect(configurations).to.have.lengthOf(1);
             expect(configurations[0].name).to.equal('Python Debug');
             expect(configurations[0].running).to.equal(false);
+        });
+
+        it('should include workspace root info in listed configurations', async () => {
+            const tool = launchListProvider.getTool();
+            const result = await tool.handler('{"filter":""}');
+            expect(result).to.be.a('string');
+            const configurations = JSON.parse(result as string);
+
+            // All configs in our mock are scoped to 'file:///workspace' whose basename is 'workspace'
+            configurations.forEach((config: { name: string; running: boolean; workspaceRoot?: string }) => {
+                expect(config.workspaceRoot).to.equal('workspace');
+            });
         });
     });
 
@@ -321,6 +356,82 @@ describe('Launch Management Tool Providers', () => {
             expect(result).to.be.a('string');
             expect(result).to.contain('No active session found');
             expect(result).to.contain('Unknown Config');
+        });
+    });
+
+    describe('Multi-root disambiguation', () => {
+        it('should report ambiguity when same config name exists in multiple roots', async () => {
+            const multiRootContainer = new Container();
+
+            const multiRootWorkspaceService = {
+                tryGetRoots: () => [
+                    { resource: new URI('file:///home/user/frontend') },
+                    { resource: new URI('file:///home/user/backend') }
+                ],
+                roots: Promise.resolve([
+                    { resource: new URI('file:///home/user/frontend') },
+                    { resource: new URI('file:///home/user/backend') }
+                ]),
+                onWorkspaceChanged: () => ({ dispose: () => { } })
+            } as unknown as WorkspaceService;
+
+            multiRootContainer.bind(WorkspaceService).toConstantValue(multiRootWorkspaceService);
+            multiRootContainer.bind(FileService).toConstantValue({} as FileService);
+            multiRootContainer.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+            multiRootContainer.bind(WorkspaceFunctionScope).toSelf();
+
+            const debugConfig: DebugConfiguration = {
+                name: 'Start App',
+                type: 'node',
+                request: 'launch',
+                program: 'app.js',
+            };
+
+            const duplicateConfigs: DebugSessionOptions[] = [
+                { name: 'Start App', configuration: debugConfig, workspaceFolderUri: 'file:///home/user/frontend' },
+                { name: 'Start App', configuration: debugConfig, workspaceFolderUri: 'file:///home/user/backend' },
+            ];
+
+            const mockConfigManager = {
+                load: () => Promise.resolve(),
+                get all(): IterableIterator<DebugSessionOptions> {
+                    return duplicateConfigs[Symbol.iterator]();
+                },
+            };
+
+            const mockSessionManager = {
+                start: async () => ({ id: 'test-session', configuration: { name: 'Start App' } }),
+                terminateSession: () => Promise.resolve(),
+                currentSession: undefined,
+                sessions: [],
+            };
+
+            multiRootContainer.bind(DebugConfigurationManager).toConstantValue(mockConfigManager as unknown as DebugConfigurationManager);
+            multiRootContainer.bind(DebugSessionManager).toConstantValue(mockSessionManager as unknown as DebugSessionManager);
+            multiRootContainer.bind(LaunchRunnerProvider).toSelf();
+            multiRootContainer.bind(LaunchListProvider).toSelf();
+
+            // Listing should show both configs with their respective roots
+            const listTool = multiRootContainer.get(LaunchListProvider).getTool();
+            const listResult = await listTool.handler('{"filter":""}');
+            const configs = JSON.parse(listResult as string);
+            expect(configs).to.have.lengthOf(2);
+            expect(configs[0].workspaceRoot).to.equal('frontend');
+            expect(configs[1].workspaceRoot).to.equal('backend');
+
+            // Running without workspaceRoot should report ambiguity
+            const runTool = multiRootContainer.get(LaunchRunnerProvider).getTool();
+            const ambiguousResult = await runTool.handler('{"configurationName":"Start App"}');
+            expect(ambiguousResult).to.be.a('string');
+            expect(ambiguousResult as string).to.include('Ambiguous');
+            expect(ambiguousResult as string).to.include('frontend');
+            expect(ambiguousResult as string).to.include('backend');
+
+            // Running with workspaceRoot should succeed
+            const disambiguatedResult = await runTool.handler('{"configurationName":"Start App","workspaceRoot":"frontend"}');
+            expect(disambiguatedResult).to.be.a('string');
+            expect(disambiguatedResult as string).to.not.include('Ambiguous');
+            expect(disambiguatedResult as string).to.include('started');
         });
     });
 });

--- a/packages/ai-ide/src/browser/workspace-launch-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-launch-provider.spec.ts
@@ -35,8 +35,24 @@ import { DebugConfiguration } from '@theia/debug/lib/common/debug-common';
 import { DebugCompound } from '@theia/debug/lib/common/debug-compound';
 import { DebugSession } from '@theia/debug/lib/browser/debug-session';
 import { WorkspaceFunctionScope } from './workspace-functions';
+import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+
+const makeTrustAwareReader = (): TrustAwarePreferenceReader => ({
+    get: <T>(_name: string, fallback?: T) => fallback,
+    ready: Promise.resolve(),
+    onDidChangeTrust: () => ({ dispose: () => { } })
+} as unknown as TrustAwarePreferenceReader);
+
+const makeEnvVariablesServer = (): EnvVariablesServer => ({
+    getHomeDirUri: async () => 'file:///home/test',
+    getExecPath: async () => '',
+    getVariables: async () => [],
+    getValue: async () => undefined,
+    getConfigDirUri: async () => 'file:///home/test/.config'
+} as unknown as EnvVariablesServer);
 
 disableJSDOM();
 
@@ -72,6 +88,8 @@ describe('Launch Management Tool Providers', () => {
         container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
         container.bind(FileService).toConstantValue({} as FileService);
         container.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         container.bind(WorkspaceFunctionScope).toSelf();
 
         const mockConfigs = createMockConfigurations();
@@ -378,6 +396,8 @@ describe('Launch Management Tool Providers', () => {
             multiRootContainer.bind(WorkspaceService).toConstantValue(multiRootWorkspaceService);
             multiRootContainer.bind(FileService).toConstantValue({} as FileService);
             multiRootContainer.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+            multiRootContainer.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+            multiRootContainer.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
             multiRootContainer.bind(WorkspaceFunctionScope).toSelf();
 
             const debugConfig: DebugConfiguration = {

--- a/packages/ai-ide/src/browser/workspace-launch-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-launch-provider.ts
@@ -16,6 +16,7 @@
 
 import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { DebugConfigurationManager } from '@theia/debug/lib/browser/debug-configuration-manager';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
@@ -26,10 +27,28 @@ import {
     RUN_LAUNCH_CONFIGURATION_FUNCTION_ID,
     STOP_LAUNCH_CONFIGURATION_FUNCTION_ID
 } from '../common/workspace-functions';
+import { WorkspaceFunctionScope } from './workspace-functions';
+
+/**
+ * Sentinel value returned (and accepted) as `workspaceRoot` for launch
+ * configurations defined in the `.code-workspace` file rather than in a
+ * specific folder's `.vscode/launch.json`.
+ */
+const WORKSPACE_SCOPE_TOKEN = '(workspace)';
 
 export interface LaunchConfigurationInfo {
     name: string;
     running: boolean;
+    /**
+     * Identifies where the configuration is defined:
+     * - A root folder name (e.g. `"frontend"`) for folder-scoped configs.
+     * - `"(workspace)"` for configs defined in the `.code-workspace` file.
+     *
+     * Pass this value back to `runLaunchConfiguration`'s or
+     * `stopLaunchConfiguration`'s `workspaceRoot` parameter to disambiguate
+     * when multiple configurations share the same name.
+     */
+    workspaceRoot?: string;
 }
 
 @injectable()
@@ -41,11 +60,15 @@ export class LaunchListProvider implements ToolProvider {
     @inject(DebugSessionManager)
     protected readonly debugSessionManager: DebugSessionManager;
 
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
     getTool(): ToolRequest {
         return {
             id: LIST_LAUNCH_CONFIGURATIONS_FUNCTION_ID,
             name: LIST_LAUNCH_CONFIGURATIONS_FUNCTION_ID,
-            description: 'Lists available launch configurations in the workspace. Each result includes the configuration name and whether it is currently running. ' +
+            description: 'Lists available launch configurations in the workspace. Each result includes the configuration name, whether it is currently running, ' +
+                'and a "workspaceRoot" (identifying where the configuration is defined). ' +
                 'Optionally provide a filter substring to narrow results by name. If omitted, all configurations are returned. ' +
                 'Always call this before runLaunchConfiguration to discover exact configuration names.',
             parameters: {
@@ -69,20 +92,41 @@ export class LaunchListProvider implements ToolProvider {
     private async getAvailableLaunchConfigurations(filter: string = ''): Promise<LaunchConfigurationInfo[]> {
         await this.debugConfigurationManager.load();
         const configurations: LaunchConfigurationInfo[] = [];
-        const runningSessions = new Set(
-            this.debugSessionManager.sessions.map(session => session.configuration.name)
-        );
         for (const options of this.debugConfigurationManager.all) {
             const name = this.getDisplayName(options);
             if (name.toLowerCase().includes(filter.toLowerCase())) {
-                configurations.push({
+                const folderToken = this.resolveFolderToken(options.workspaceFolderUri);
+                const entry: LaunchConfigurationInfo = {
                     name,
-                    running: runningSessions.has(name)
-                });
+                    running: this.debugSessionManager.sessions.some(
+                        session => session.configuration.name === name
+                            && this.resolveFolderToken(session.options.workspaceFolderUri) === folderToken
+                    ),
+                    workspaceRoot: folderToken
+                };
+                configurations.push(entry);
             }
         }
 
         return configurations;
+    }
+
+    /**
+     * Maps a `workspaceFolderUri` to the addressing token an agent should use.
+     *
+     * - Folder URI → the workspace root name (e.g. `"frontend"`).
+     * - `undefined` (workspace-level config) → `"(workspace)"`.
+     */
+    private resolveFolderToken(workspaceFolderUri: string | undefined): string {
+        if (!workspaceFolderUri) {
+            return WORKSPACE_SCOPE_TOKEN;
+        }
+        try {
+            const uri = new URI(workspaceFolderUri);
+            return this.workspaceScope.getRootName(uri) ?? WORKSPACE_SCOPE_TOKEN;
+        } catch {
+            return WORKSPACE_SCOPE_TOKEN;
+        }
     }
 
     private getDisplayName(options: DebugSessionOptions): string {
@@ -104,19 +148,28 @@ export class LaunchRunnerProvider implements ToolProvider {
     @inject(DebugSessionManager)
     protected readonly debugSessionManager: DebugSessionManager;
 
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
     getTool(): ToolRequest {
         return {
             id: RUN_LAUNCH_CONFIGURATION_FUNCTION_ID,
             name: RUN_LAUNCH_CONFIGURATION_FUNCTION_ID,
             description: 'Starts a launch configuration and returns immediately — the application continues running in the background. ' +
                 'Use listLaunchConfigurations first to discover available configuration names and check whether one is already running. ' +
+                'If multiple configurations share the same name, specify the workspaceRoot parameter to disambiguate. ' +
                 'The response includes the debug session ID on success. If the configuration name doesn\'t match any available configuration, returns an error.',
             parameters: {
                 type: 'object',
                 properties: {
                     configurationName: {
                         type: 'string',
-                        description: 'The name of the launch configuration to execute.'
+                        description: 'The exact name of the launch configuration to start, as returned by listLaunchConfigurations.'
+                    },
+                    workspaceRoot: {
+                        type: 'string',
+                        description: 'The workspaceRoot value as returned by listLaunchConfigurations. ' +
+                            'Required when multiple configurations share the same name.'
                     }
                 },
                 required: ['configurationName']
@@ -127,13 +180,34 @@ export class LaunchRunnerProvider implements ToolProvider {
 
     private async handleRunLaunchConfiguration(argString: string, cancellationToken?: CancellationToken): Promise<string> {
         try {
-            const args: { configurationName: string } = JSON.parse(argString);
+            const args: { configurationName: string; workspaceRoot?: string } = JSON.parse(argString);
 
             await this.debugConfigurationManager.load();
 
-            const options = this.findConfigurationByName(args.configurationName);
-            if (!options) {
+            const allMatches = this.findAllConfigurationsByName(args.configurationName);
+
+            if (allMatches.length === 0) {
                 return `Did not find a launch configuration for the name: '${args.configurationName}'`;
+            }
+
+            let options: DebugSessionOptions;
+
+            if (allMatches.length === 1) {
+                options = allMatches[0];
+            } else if (args.workspaceRoot) {
+                const filtered = this.filterByWorkspaceRoot(allMatches, args.workspaceRoot);
+                if (typeof filtered === 'string') {
+                    return filtered; // error message
+                }
+                if (filtered.length === 0) {
+                    return `No launch configuration '${args.configurationName}' found in workspace root '${args.workspaceRoot}'. `
+                        + 'The configuration may be defined in a different root. Use listLaunchConfigurations to check.';
+                }
+                options = filtered[0];
+            } else {
+                const scopeTokens = allMatches.map(opt => this.resolveFolderToken(opt.workspaceFolderUri));
+                return `Ambiguous launch configuration name '${args.configurationName}' — found in multiple scopes: ${scopeTokens.join(', ')}. `
+                    + 'Please specify the workspaceRoot parameter to disambiguate.';
             }
 
             const session = await this.debugSessionManager.start(options);
@@ -162,14 +236,54 @@ export class LaunchRunnerProvider implements ToolProvider {
         }
     }
 
-    private findConfigurationByName(name: string): DebugSessionOptions | undefined {
+    private findAllConfigurationsByName(name: string): DebugSessionOptions[] {
+        const results: DebugSessionOptions[] = [];
         for (const options of this.debugConfigurationManager.all) {
             const displayName = this.getDisplayName(options);
             if (displayName === name) {
-                return options;
+                results.push(options);
             }
         }
-        return undefined;
+        return results;
+    }
+
+    /**
+     * Filters debug session options by the `workspaceRoot` addressing token the
+     * agent provided.
+     *
+     * Handles the sentinel value `(workspace)` for configs without a folder URI,
+     * as well as normal folder-root names.
+     *
+     * @returns the filtered options array, or an error string if the root is unknown.
+     */
+    private filterByWorkspaceRoot(options: DebugSessionOptions[], workspaceRoot: string): DebugSessionOptions[] | string {
+        if (workspaceRoot === WORKSPACE_SCOPE_TOKEN) {
+            return options.filter(opt => !opt.workspaceFolderUri);
+        }
+        const rootMapping = this.workspaceScope.getRootMapping();
+        const rootUri = rootMapping.get(workspaceRoot);
+        if (!rootUri) {
+            const availableRoots = Array.from(rootMapping.keys()).join(', ');
+            return `Unknown workspace root '${workspaceRoot}'. Available roots: ${availableRoots}`;
+        }
+        const rootUriStr = rootUri.toString();
+        return options.filter(opt => opt.workspaceFolderUri === rootUriStr);
+    }
+
+    /**
+     * Maps a `workspaceFolderUri` to the addressing token an agent should use.
+     * Shared between run and list operations in this class.
+     */
+    private resolveFolderToken(workspaceFolderUri: string | undefined): string {
+        if (!workspaceFolderUri) {
+            return WORKSPACE_SCOPE_TOKEN;
+        }
+        try {
+            const uri = new URI(workspaceFolderUri);
+            return this.workspaceScope.getRootName(uri) ?? WORKSPACE_SCOPE_TOKEN;
+        } catch {
+            return WORKSPACE_SCOPE_TOKEN;
+        }
     }
 
     private getDisplayName(options: DebugSessionOptions): string {
@@ -188,18 +302,28 @@ export class LaunchStopProvider implements ToolProvider {
     @inject(DebugSessionManager)
     protected readonly debugSessionManager: DebugSessionManager;
 
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
     getTool(): ToolRequest {
         return {
             id: STOP_LAUNCH_CONFIGURATION_FUNCTION_ID,
             name: STOP_LAUNCH_CONFIGURATION_FUNCTION_ID,
             description: 'Stops an active launch configuration or debug session. If a configuration name is provided, stops the session matching that name. ' +
-                'If no name is provided, stops the currently active session. Returns an error if no matching active session is found.',
+                'If no name is provided, stops the currently active session. ' +
+                'If multiple sessions share the same configuration name, specify the workspaceRoot parameter to disambiguate. ' +
+                'Returns an error if no matching active session is found.',
             parameters: {
                 type: 'object',
                 properties: {
                     configurationName: {
                         type: 'string',
-                        description: 'The name of the launch configuration to stop. If not provided, stops the current active session.'
+                        description: 'The name of the launch configuration to stop. If omitted, stops the current active debug session.'
+                    },
+                    workspaceRoot: {
+                        type: 'string',
+                        description: 'The workspaceRoot value as returned by listLaunchConfigurations. ' +
+                            'Required when multiple sessions share the same configuration name.'
                     }
                 },
                 required: []
@@ -210,13 +334,32 @@ export class LaunchStopProvider implements ToolProvider {
 
     private async handleStopLaunchConfiguration(argString: string): Promise<string> {
         try {
-            const args: { configurationName?: string } = JSON.parse(argString);
+            const args: { configurationName?: string; workspaceRoot?: string } = JSON.parse(argString);
 
             if (args.configurationName) {
-                // Find and stop specific session by configuration name
-                const session = this.findSessionByConfigurationName(args.configurationName);
-                if (!session) {
+                const matchingSessions = this.findSessionsByConfigurationName(args.configurationName);
+
+                if (matchingSessions.length === 0) {
                     return `No active session found for launch configuration: '${args.configurationName}'`;
+                }
+
+                let session: DebugSession;
+
+                if (matchingSessions.length === 1) {
+                    session = matchingSessions[0];
+                } else if (args.workspaceRoot) {
+                    const filtered = this.filterSessionsByWorkspaceRoot(matchingSessions, args.workspaceRoot);
+                    if (typeof filtered === 'string') {
+                        return filtered; // error message
+                    }
+                    if (filtered.length === 0) {
+                        return `No active session for '${args.configurationName}' in workspace root '${args.workspaceRoot}'.`;
+                    }
+                    session = filtered[0];
+                } else {
+                    const scopeTokens = matchingSessions.map(s => this.resolveSessionFolderToken(s));
+                    return `Ambiguous: multiple active sessions for '${args.configurationName}' in scopes: ${scopeTokens.join(', ')}. `
+                        + 'Please specify the workspaceRoot parameter to disambiguate.';
                 }
 
                 await this.debugSessionManager.terminateSession(session);
@@ -240,9 +383,41 @@ export class LaunchStopProvider implements ToolProvider {
         }
     }
 
-    private findSessionByConfigurationName(configurationName: string): DebugSession | undefined {
-        return this.debugSessionManager.sessions.find(
+    private findSessionsByConfigurationName(configurationName: string): DebugSession[] {
+        return this.debugSessionManager.sessions.filter(
             session => session.configuration.name === configurationName
         );
+    }
+
+    /**
+     * Filters debug sessions by the `workspaceRoot` addressing token the agent provided.
+     */
+    private filterSessionsByWorkspaceRoot(sessions: DebugSession[], workspaceRoot: string): DebugSession[] | string {
+        if (workspaceRoot === WORKSPACE_SCOPE_TOKEN) {
+            return sessions.filter(s => !s.options.workspaceFolderUri);
+        }
+        const rootMapping = this.workspaceScope.getRootMapping();
+        const rootUri = rootMapping.get(workspaceRoot);
+        if (!rootUri) {
+            const availableRoots = Array.from(rootMapping.keys()).join(', ');
+            return `Unknown workspace root '${workspaceRoot}'. Available roots: ${availableRoots}`;
+        }
+        const rootUriStr = rootUri.toString();
+        return sessions.filter(s => s.options.workspaceFolderUri === rootUriStr);
+    }
+
+    /**
+     * Resolves the addressing token for a debug session based on its folder URI.
+     */
+    private resolveSessionFolderToken(session: DebugSession): string {
+        if (!session.options.workspaceFolderUri) {
+            return WORKSPACE_SCOPE_TOKEN;
+        }
+        try {
+            const uri = new URI(session.options.workspaceFolderUri);
+            return this.workspaceScope.getRootName(uri) ?? WORKSPACE_SCOPE_TOKEN;
+        } catch {
+            return WORKSPACE_SCOPE_TOKEN;
+        }
     }
 }

--- a/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
@@ -59,9 +59,10 @@ describe('Workspace Search Provider Cancellation Tests', () => {
         } as unknown as SearchInWorkspaceService;
 
         const mockWorkspaceScope = {
-            getWorkspaceRoot: async () => new URI('file:///workspace'),
+            getRootMapping: () => new Map([['workspace', new URI('file:///workspace')]]),
+            getContainingRoot: () => new URI('file:///workspace'),
             ensureWithinWorkspace: () => { },
-            resolveRelativePath: async (path: string) => new URI(`file:///workspace/${path}`)
+            resolveRelativePath: (path: string) => new URI(`file:///workspace/${path}`)
         } as unknown as WorkspaceFunctionScope;
 
         const mockPreferenceService = {

--- a/packages/ai-ide/src/browser/workspace-search-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.ts
@@ -75,8 +75,9 @@ export class WorkspaceSearchProvider implements ToolProvider {
                     },
                     subDirectoryPath: {
                         type: 'string',
-                        description: 'Optional subdirectory path to limit search scope. Use relative paths from workspace root ' +
-                            '(e.g., "packages/ai-ide/src", "packages/core/src/browser"). If not specified, searches entire workspace.'
+                        description: 'Optional subdirectory path to limit search scope ' +
+                            '(e.g., "frontend/src", "backend/packages/core/src/browser"). ' +
+                            'If not specified, searches the entire workspace.'
                     }
                 },
                 required: ['query', 'useRegExp']
@@ -86,14 +87,21 @@ export class WorkspaceSearchProvider implements ToolProvider {
     }
 
     private async determineSearchRoots(subDirectoryPath?: string): Promise<string[]> {
-        const workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
-
-        if (!subDirectoryPath) {
-            return [workspaceRoot.toString()];
+        const rootMapping = this.workspaceScope.getRootMapping();
+        if (rootMapping.size === 0) {
+            throw new Error('No workspace has been opened yet');
         }
 
-        const subDirUri = workspaceRoot.resolve(subDirectoryPath);
-        this.workspaceScope.ensureWithinWorkspace(subDirUri, workspaceRoot);
+        if (!subDirectoryPath) {
+            return Array.from(rootMapping.values()).map(uri => uri.toString());
+        }
+
+        const subDirUri = await this.workspaceScope.resolveRelativePath(subDirectoryPath);
+        const containingRoot = this.workspaceScope.getContainingRoot(subDirUri);
+        if (!containingRoot) {
+            throw new Error(`Subdirectory '${subDirectoryPath}' is not within any workspace root`);
+        }
+        this.workspaceScope.ensureWithinWorkspace(subDirUri, containingRoot);
 
         try {
             const stat = await this.fileService.resolve(subDirUri);
@@ -195,8 +203,7 @@ export class WorkspaceSearchProvider implements ToolProvider {
             const finalResults = await Promise.race([searchPromise, timeoutPromise]);
             const maxResults = this.preferenceService.get<number>(SEARCH_IN_WORKSPACE_MAX_RESULTS_PREF, 30);
 
-            const workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
-            const formattedResults = optimizeSearchResults(finalResults, workspaceRoot);
+            const formattedResults = optimizeSearchResults(finalResults, this.workspaceScope);
 
             let numberOfMatchesInFinalResults = 0;
             for (const result of finalResults) {
@@ -218,4 +225,3 @@ export class WorkspaceSearchProvider implements ToolProvider {
         }
     }
 }
-

--- a/packages/ai-ide/src/browser/workspace-task-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-task-provider.spec.ts
@@ -15,14 +15,18 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { CancellationTokenSource } from '@theia/core';
-import { TaskListProvider, TaskRunnerProvider } from './workspace-task-provider';
+import { CancellationTokenSource, PreferenceService } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
+import { GLOBAL_SCOPE_TOKEN, TaskListProvider, TaskRunnerProvider, WORKSPACE_SCOPE_TOKEN } from './workspace-task-provider';
 import { ToolInvocationContext } from '@theia/ai-core';
 import { Container } from '@theia/core/shared/inversify';
 import { TaskService } from '@theia/task/lib/browser/task-service';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { TaskConfiguration, TaskInfo } from '@theia/task/lib/common';
+import { TaskConfiguration, TaskInfo, TaskScope } from '@theia/task/lib/common';
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
+import { WorkspaceFunctionScope } from './workspace-functions';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
 
 describe('Workspace Task Provider Cancellation Tests', () => {
     let cancellationTokenSource: CancellationTokenSource;
@@ -48,15 +52,20 @@ describe('Workspace Task Provider Cancellation Tests', () => {
             getTasks: async (token: number) => [
                 {
                     label: 'build',
-                    _scope: 'workspace',
+                    _scope: 'file:///home/user/frontend',
                     type: 'shell'
                 } as TaskConfiguration,
                 {
                     label: 'test',
-                    _scope: 'workspace',
+                    _scope: 'file:///home/user/frontend',
                     type: 'shell'
                 } as TaskConfiguration
             ],
+            runTask: async (task: TaskConfiguration) => ({
+                taskId: 0,
+                terminalId: 0,
+                config: task
+            } as TaskInfo),
             runTaskByLabel: async (token: number, taskLabel: string) => {
                 if (taskLabel === 'build' || taskLabel === 'test') {
                     return {
@@ -64,7 +73,7 @@ describe('Workspace Task Provider Cancellation Tests', () => {
                         terminalId: 0,
                         config: {
                             label: taskLabel,
-                            _scope: 'workspace',
+                            _scope: 'file:///home/user/frontend',
                             type: 'shell'
                         }
                     } as TaskInfo;
@@ -88,9 +97,23 @@ describe('Workspace Task Provider Cancellation Tests', () => {
             } as unknown as TerminalWidget)
         } as unknown as TerminalService;
 
+        const mockWorkspaceService = {
+            tryGetRoots: () => [
+                { resource: new URI('file:///home/user/frontend') }
+            ],
+            roots: Promise.resolve([
+                { resource: new URI('file:///home/user/frontend') }
+            ]),
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
         // Register mocks in the container
         container.bind(TaskService).toConstantValue(mockTaskService);
         container.bind(TerminalService).toConstantValue(mockTerminalService);
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue({} as FileService);
+        container.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(TaskListProvider).toSelf();
         container.bind(TaskRunnerProvider).toSelf();
     });
@@ -173,16 +196,19 @@ describe('Workspace Task Provider Cancellation Tests', () => {
             // Mock getTerminateSignal to never resolve (simulates in-flight handlers)
             mockTaskService.getTerminateSignal = () => new Promise(() => { });
 
-            // Mock runTaskByLabel to return different task IDs
+            // Override getTasks to return three tasks matching the handler calls
+            mockTaskService.getTasks = async () => [
+                { label: 'build', _scope: 'file:///home/user/frontend', type: 'shell' } as TaskConfiguration,
+                { label: 'test', _scope: 'file:///home/user/frontend', type: 'shell' } as TaskConfiguration,
+                { label: 'lint', _scope: 'file:///home/user/frontend', type: 'shell' } as TaskConfiguration
+            ];
+
+            // Mock runTask to return different task IDs for each invocation
             let taskIdCounter = 0;
-            mockTaskService.runTaskByLabel = async (token: number, taskLabel: string) => ({
+            mockTaskService.runTask = async (task: TaskConfiguration) => ({
                 taskId: taskIdCounter++,
                 terminalId: taskIdCounter - 1,
-                config: {
-                    label: taskLabel,
-                    _scope: 'workspace',
-                    type: 'shell'
-                }
+                config: task
             } as TaskInfo);
 
             const taskRunnerProvider = container.get(TaskRunnerProvider);
@@ -225,6 +251,154 @@ describe('Workspace Task Provider Cancellation Tests', () => {
 
         const jsonResponse = JSON.parse(result as string);
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
+    });
+
+    it('TaskListProvider should return tasks with workspace root info', async () => {
+        const taskListProvider = container.get(TaskListProvider);
+        const handler = taskListProvider.getTool().handler;
+        const result = await handler(JSON.stringify({ filter: '' }), mockCtx);
+
+        const tasks = JSON.parse(result as string);
+        expect(tasks).to.have.lengthOf(2);
+        expect(tasks[0]).to.deep.equal({ label: 'build', workspaceRoot: 'frontend' });
+        expect(tasks[1]).to.deep.equal({ label: 'test', workspaceRoot: 'frontend' });
+    });
+
+    it('TaskListProvider should use scope tokens for workspace-scoped and global tasks', async () => {
+        mockTaskService.getTasks = async () => [
+            { label: 'folder-task', _scope: 'file:///home/user/frontend', type: 'shell' } as TaskConfiguration,
+            { label: 'ws-task', _scope: TaskScope.Workspace, type: 'shell' } as unknown as TaskConfiguration,
+            { label: 'global-task', _scope: TaskScope.Global, type: 'shell' } as unknown as TaskConfiguration
+        ];
+
+        const taskListProvider = container.get(TaskListProvider);
+        const handler = taskListProvider.getTool().handler;
+        const result = await handler(JSON.stringify({ filter: '' }), mockCtx);
+
+        const tasks = JSON.parse(result as string);
+        expect(tasks).to.have.lengthOf(3);
+        expect(tasks[0]).to.deep.equal({ label: 'folder-task', workspaceRoot: 'frontend' });
+        expect(tasks[1]).to.deep.equal({ label: 'ws-task', workspaceRoot: WORKSPACE_SCOPE_TOKEN });
+        expect(tasks[2]).to.deep.equal({ label: 'global-task', workspaceRoot: GLOBAL_SCOPE_TOKEN });
+    });
+
+    it('TaskRunnerProvider should disambiguate workspace-scoped task via scope token', async () => {
+        mockTaskService.getTasks = async () => [
+            { label: 'build', _scope: 'file:///home/user/frontend', type: 'shell' } as TaskConfiguration,
+            { label: 'build', _scope: TaskScope.Workspace, type: 'shell' } as unknown as TaskConfiguration
+        ];
+        mockTaskService.runTask = async (task: TaskConfiguration) => ({
+            taskId: 0,
+            terminalId: 0,
+            config: task
+        } as TaskInfo);
+
+        const taskRunnerProvider = container.get(TaskRunnerProvider);
+        const handler = taskRunnerProvider.getTool().handler;
+
+        // Without workspaceRoot → ambiguous
+        const ambiguousResult = await handler(JSON.stringify({ taskName: 'build' }), mockCtx);
+        expect(ambiguousResult as string).to.include('Ambiguous');
+
+        // With (workspace) → picks the workspace-scoped task
+        const wsResult = await handler(JSON.stringify({ taskName: 'build', workspaceRoot: WORKSPACE_SCOPE_TOKEN }), mockCtx);
+        expect(wsResult as string).to.not.include('Ambiguous');
+        expect(wsResult as string).to.not.include('Did not find');
+    });
+
+    it('TaskRunnerProvider should run a uniquely-named task without workspaceRoot', async () => {
+        const taskRunnerProvider = container.get(TaskRunnerProvider);
+        const handler = taskRunnerProvider.getTool().handler;
+        const result = await handler(JSON.stringify({ taskName: 'build' }), mockCtx);
+
+        // Should succeed — single match, no ambiguity
+        expect(result).to.be.a('string');
+        expect(result).to.not.include('Ambiguous');
+    });
+
+    it('TaskRunnerProvider should report ambiguity for duplicate task labels across roots', async () => {
+        // Override mock to return tasks in two different roots with the same label
+        const multiRootTaskService = {
+            ...mockTaskService,
+            getTasks: async () => [
+                { label: 'build', _scope: 'file:///home/user/frontend', type: 'shell' } as TaskConfiguration,
+                { label: 'build', _scope: 'file:///home/user/backend', type: 'shell' } as TaskConfiguration
+            ]
+        } as unknown as TaskService;
+
+        const multiRootContainer = new Container();
+        const multiRootWorkspaceService = {
+            tryGetRoots: () => [
+                { resource: new URI('file:///home/user/frontend') },
+                { resource: new URI('file:///home/user/backend') }
+            ],
+            roots: Promise.resolve([
+                { resource: new URI('file:///home/user/frontend') },
+                { resource: new URI('file:///home/user/backend') }
+            ]),
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        multiRootContainer.bind(TaskService).toConstantValue(multiRootTaskService);
+        multiRootContainer.bind(TerminalService).toConstantValue(mockTerminalService);
+        multiRootContainer.bind(WorkspaceService).toConstantValue(multiRootWorkspaceService);
+        multiRootContainer.bind(FileService).toConstantValue({} as FileService);
+        multiRootContainer.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        multiRootContainer.bind(WorkspaceFunctionScope).toSelf();
+        multiRootContainer.bind(TaskRunnerProvider).toSelf();
+
+        const taskRunnerProvider = multiRootContainer.get(TaskRunnerProvider);
+        const handler = taskRunnerProvider.getTool().handler;
+        const result = await handler(JSON.stringify({ taskName: 'build' }), mockCtx);
+
+        expect(result).to.be.a('string');
+        expect(result as string).to.include('Ambiguous');
+        expect(result as string).to.include('frontend');
+        expect(result as string).to.include('backend');
+    });
+
+    it('TaskRunnerProvider should disambiguate with workspaceRoot parameter', async () => {
+        const multiRootTaskService = {
+            ...mockTaskService,
+            getTasks: async () => [
+                { label: 'build', _scope: 'file:///home/user/frontend', type: 'shell' } as TaskConfiguration,
+                { label: 'build', _scope: 'file:///home/user/backend', type: 'shell' } as TaskConfiguration
+            ],
+            runTask: async (task: TaskConfiguration) => ({
+                taskId: 0,
+                terminalId: 0,
+                config: task
+            } as TaskInfo)
+        } as unknown as TaskService;
+
+        const multiRootContainer = new Container();
+        const multiRootWorkspaceService = {
+            tryGetRoots: () => [
+                { resource: new URI('file:///home/user/frontend') },
+                { resource: new URI('file:///home/user/backend') }
+            ],
+            roots: Promise.resolve([
+                { resource: new URI('file:///home/user/frontend') },
+                { resource: new URI('file:///home/user/backend') }
+            ]),
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        multiRootContainer.bind(TaskService).toConstantValue(multiRootTaskService);
+        multiRootContainer.bind(TerminalService).toConstantValue(mockTerminalService);
+        multiRootContainer.bind(WorkspaceService).toConstantValue(multiRootWorkspaceService);
+        multiRootContainer.bind(FileService).toConstantValue({} as FileService);
+        multiRootContainer.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        multiRootContainer.bind(WorkspaceFunctionScope).toSelf();
+        multiRootContainer.bind(TaskRunnerProvider).toSelf();
+
+        const taskRunnerProvider = multiRootContainer.get(TaskRunnerProvider);
+        const handler = taskRunnerProvider.getTool().handler;
+        const result = await handler(JSON.stringify({ taskName: 'build', workspaceRoot: 'backend' }), mockCtx);
+
+        // Should succeed — disambiguated by workspace root
+        expect(result).to.be.a('string');
+        expect(result).to.not.include('Ambiguous');
     });
 
     it('TaskRunnerProvider should respect cancellation token at the beginning', async () => {

--- a/packages/ai-ide/src/browser/workspace-task-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-task-provider.spec.ts
@@ -25,8 +25,24 @@ import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-servi
 import { TaskConfiguration, TaskInfo, TaskScope } from '@theia/task/lib/common';
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { WorkspaceFunctionScope } from './workspace-functions';
+import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
+
+const makeTrustAwareReader = (): TrustAwarePreferenceReader => ({
+    get: <T>(_name: string, fallback?: T) => fallback,
+    ready: Promise.resolve(),
+    onDidChangeTrust: () => ({ dispose: () => { } })
+} as unknown as TrustAwarePreferenceReader);
+
+const makeEnvVariablesServer = (): EnvVariablesServer => ({
+    getHomeDirUri: async () => 'file:///home/test',
+    getExecPath: async () => '',
+    getVariables: async () => [],
+    getValue: async () => undefined,
+    getConfigDirUri: async () => 'file:///home/test/.config'
+} as unknown as EnvVariablesServer);
 
 describe('Workspace Task Provider Cancellation Tests', () => {
     let cancellationTokenSource: CancellationTokenSource;
@@ -113,6 +129,8 @@ describe('Workspace Task Provider Cancellation Tests', () => {
         container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
         container.bind(FileService).toConstantValue({} as FileService);
         container.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(TaskListProvider).toSelf();
         container.bind(TaskRunnerProvider).toSelf();
@@ -344,6 +362,8 @@ describe('Workspace Task Provider Cancellation Tests', () => {
         multiRootContainer.bind(WorkspaceService).toConstantValue(multiRootWorkspaceService);
         multiRootContainer.bind(FileService).toConstantValue({} as FileService);
         multiRootContainer.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        multiRootContainer.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        multiRootContainer.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         multiRootContainer.bind(WorkspaceFunctionScope).toSelf();
         multiRootContainer.bind(TaskRunnerProvider).toSelf();
 
@@ -389,6 +409,8 @@ describe('Workspace Task Provider Cancellation Tests', () => {
         multiRootContainer.bind(WorkspaceService).toConstantValue(multiRootWorkspaceService);
         multiRootContainer.bind(FileService).toConstantValue({} as FileService);
         multiRootContainer.bind(PreferenceService).toConstantValue({ get: () => false } as unknown as PreferenceService);
+        multiRootContainer.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        multiRootContainer.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         multiRootContainer.bind(WorkspaceFunctionScope).toSelf();
         multiRootContainer.bind(TaskRunnerProvider).toSelf();
 

--- a/packages/ai-ide/src/browser/workspace-task-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-task-provider.ts
@@ -18,8 +18,64 @@ import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core
 import { CancellationToken } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { TaskService } from '@theia/task/lib/browser/task-service';
+import { TaskConfiguration, TaskScope } from '@theia/task/lib/common/task-protocol';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { LIST_TASKS_FUNCTION_ID, RUN_TASK_FUNCTION_ID } from '../common/workspace-functions';
+import { WorkspaceFunctionScope } from './workspace-functions';
+
+import URI from '@theia/core/lib/common/uri';
+
+/**
+ * Sentinel value returned (and accepted) as `workspaceRoot` for tasks defined
+ * in the `.code-workspace` file rather than in a specific folder's `tasks.json`.
+ */
+export const WORKSPACE_SCOPE_TOKEN = '(workspace)';
+
+/**
+ * Sentinel value returned (and accepted) as `workspaceRoot` for user-level
+ * global tasks that are not associated with any workspace or folder.
+ */
+export const GLOBAL_SCOPE_TOKEN = '(global)';
+
+export interface TaskListEntry {
+    /** The task label as defined in tasks.json or by a task provider */
+    label: string;
+    /**
+     * Identifies where the task is defined:
+     * - A root folder name (e.g. `"frontend"`) for folder-scoped tasks.
+     * - `"(workspace)"` for tasks defined in the `.code-workspace` file.
+     * - `"(global)"` for user-level global tasks.
+     *
+     * Pass this value back to `runTask`'s `workspaceRoot` parameter to
+     * disambiguate when multiple tasks share the same label.
+     */
+    workspaceRoot?: string;
+}
+
+/**
+ * Maps a task scope to the addressing token an agent should use.
+ *
+ * - Folder URI string → the workspace root name (e.g. `"frontend"`).
+ * - `TaskScope.Workspace` → `"(workspace)"`.
+ * - `TaskScope.Global` → `"(global)"`.
+ *
+ * If a folder URI cannot be resolved to a known root name, falls back to
+ * `"(workspace)"` so the task remains addressable.
+ */
+export function resolveScopeToken(scope: string | TaskScope.Workspace | TaskScope.Global, workspaceScope: WorkspaceFunctionScope): string {
+    if (scope === TaskScope.Workspace) {
+        return WORKSPACE_SCOPE_TOKEN;
+    }
+    if (scope === TaskScope.Global) {
+        return GLOBAL_SCOPE_TOKEN;
+    }
+    try {
+        const uri = new URI(scope);
+        return workspaceScope.getRootName(uri) ?? WORKSPACE_SCOPE_TOKEN;
+    } catch {
+        return WORKSPACE_SCOPE_TOKEN;
+    }
+}
 
 @injectable()
 export class TaskListProvider implements ToolProvider {
@@ -27,16 +83,18 @@ export class TaskListProvider implements ToolProvider {
     @inject(TaskService)
     protected readonly taskService: TaskService;
 
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
     getTool(): ToolRequest {
         return {
             id: LIST_TASKS_FUNCTION_ID,
             name: LIST_TASKS_FUNCTION_ID,
             description: 'Lists available tasks in the workspace that can be executed with runTask. Returns an array ' +
-                'of task labels (strings). Common task types include npm scripts, shell tasks, and build tasks. ' +
+                'of objects, each with a "label" (the task name) and a "workspaceRoot" (identifying where the task is defined). ' +
                 'Use the filter parameter with an empty string "" to retrieve all tasks, or provide a substring ' +
                 'to filter (e.g., "test" returns tasks containing "test" in the name). ' +
-                'Example return: ["npm: build", "npm: test", "npm: lint"]. ' +
-                'Always call this before runTask to discover exact task names.',
+                'Always call this before runTask to discover exact task names and their workspace roots.',
             parameters: {
                 type: 'object',
                 properties: {
@@ -54,16 +112,22 @@ export class TaskListProvider implements ToolProvider {
                 }
                 const filterArgs: { filter: string } = JSON.parse(argString);
                 const tasks = await this.getAvailableTasks(filterArgs.filter);
-                const taskString = JSON.stringify(tasks);
-                return taskString;
+                return JSON.stringify(tasks);
             }
         };
     }
-    private async getAvailableTasks(filter: string = ''): Promise<string[]> {
+
+    private async getAvailableTasks(filter: string = ''): Promise<TaskListEntry[]> {
         const userActionToken = this.taskService.startUserAction();
         const tasks = await this.taskService.getTasks(userActionToken);
         const filteredTasks = tasks.filter(task => task.label.toLowerCase().includes(filter.toLowerCase()));
-        return filteredTasks.map(task => task.label);
+        return filteredTasks.map(task => this.toTaskListEntry(task));
+    }
+
+    private toTaskListEntry(task: TaskConfiguration): TaskListEntry {
+        const entry: TaskListEntry = { label: task.label };
+        entry.workspaceRoot = resolveScopeToken(task._scope, this.workspaceScope);
+        return entry;
     }
 }
 
@@ -76,6 +140,9 @@ export class TaskRunnerProvider implements ToolProvider {
     @inject(TerminalService)
     protected readonly terminalService: TerminalService;
 
+    @inject(WorkspaceFunctionScope)
+    protected readonly workspaceScope: WorkspaceFunctionScope;
+
     getTool(): ToolRequest {
         return {
             id: RUN_TASK_FUNCTION_ID,
@@ -86,6 +153,7 @@ export class TaskRunnerProvider implements ToolProvider {
                 '(e.g., "npm: build"), test tasks (e.g., "npm: test"), and lint tasks (e.g., "npm: lint"). ' +
                 'If the task fails, the error output is included in the response. Tasks may take significant ' +
                 'time to complete (builds can take minutes). The operation can be cancelled by the user. ' +
+                'If multiple tasks share the same label, specify the workspaceRoot parameter to disambiguate. ' +
                 'Do NOT use this for tasks you haven\'t discovered via listTasks first.',
             parameters: {
                 type: 'object',
@@ -93,6 +161,11 @@ export class TaskRunnerProvider implements ToolProvider {
                     taskName: {
                         type: 'string',
                         description: 'The exact name/label of the task to execute, as returned by listTasks.'
+                    },
+                    workspaceRoot: {
+                        type: 'string',
+                        description: 'The workspaceRoot value as returned by listTasks. ' +
+                            'Required when multiple tasks share the same label.'
                     }
                 },
                 required: ['taskName']
@@ -104,11 +177,38 @@ export class TaskRunnerProvider implements ToolProvider {
 
     private async handleRunTask(argString: string, cancellationToken?: CancellationToken): Promise<string> {
         try {
-            const args: { taskName: string } = JSON.parse(argString);
+            const args: { taskName: string; workspaceRoot?: string } = JSON.parse(argString);
 
             const token = this.taskService.startUserAction();
+            const allTasks = await this.taskService.getTasks(token);
 
-            const taskInfo = await this.taskService.runTaskByLabel(token, args.taskName);
+            const matchingTasks = allTasks.filter(task => task.label === args.taskName);
+
+            if (matchingTasks.length === 0) {
+                return `Did not find a task for the label: '${args.taskName}'`;
+            }
+
+            let taskToRun: TaskConfiguration;
+
+            if (matchingTasks.length === 1) {
+                taskToRun = matchingTasks[0];
+            } else if (args.workspaceRoot) {
+                const filtered = this.filterByWorkspaceRoot(matchingTasks, args.workspaceRoot);
+                if (typeof filtered === 'string') {
+                    return filtered; // error message
+                }
+                if (filtered.length === 0) {
+                    return `No task '${args.taskName}' found in workspace root '${args.workspaceRoot}'. `
+                        + 'The task may be defined in a different root. Use listTasks to check.';
+                }
+                taskToRun = filtered[0];
+            } else {
+                const scopeTokens = matchingTasks.map(task => resolveScopeToken(task._scope, this.workspaceScope));
+                return `Ambiguous task name '${args.taskName}' — found in multiple scopes: ${scopeTokens.join(', ')}. `
+                    + 'Please specify the workspaceRoot parameter to disambiguate.';
+            }
+
+            const taskInfo = await this.taskService.runTask(taskToRun);
             if (!taskInfo) {
                 return `Did not find a task for the label: '${args.taskName}'`;
             }
@@ -147,5 +247,31 @@ export class TaskRunnerProvider implements ToolProvider {
             return JSON.stringify({ success: false, message: error.message || 'Failed to run task' });
         }
     }
-}
 
+    /**
+     * Filters tasks by the `workspaceRoot` addressing token the agent provided.
+     *
+     * Handles the sentinel values `(workspace)` and `(global)` as well as
+     * normal folder-root names.
+     *
+     * @returns the filtered task array, or an error string if the root is unknown.
+     */
+    private filterByWorkspaceRoot(tasks: TaskConfiguration[], workspaceRoot: string): TaskConfiguration[] | string {
+        if (workspaceRoot === WORKSPACE_SCOPE_TOKEN) {
+            return tasks.filter(task => task._scope === TaskScope.Workspace);
+        }
+        if (workspaceRoot === GLOBAL_SCOPE_TOKEN) {
+            return tasks.filter(task => task._scope === TaskScope.Global);
+        }
+        const rootMapping = this.workspaceScope.getRootMapping();
+        const rootUri = rootMapping.get(workspaceRoot);
+        if (!rootUri) {
+            const availableRoots = Array.from(rootMapping.keys()).join(', ');
+            return `Unknown workspace root '${workspaceRoot}'. Available roots: ${availableRoots}`;
+        }
+        const rootUriStr = rootUri.toString();
+        return tasks.filter(
+            task => typeof task._scope === 'string' && task._scope === rootUriStr
+        );
+    }
+}

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -732,4 +732,3 @@ export function getCoderPromptTemplateEditNext(): BasePromptFragment {
         ...({ variantOf: CODER_EDIT_TEMPLATE_ID })
     };
 }
-

--- a/packages/ai-ide/src/common/create-skill-prompt-template.ts
+++ b/packages/ai-ide/src/common/create-skill-prompt-template.ts
@@ -141,6 +141,7 @@ This skill provides instructions for performing comprehensive code reviews.
 \`\`\`
 
 ## Additional Context
+
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
 ## Non-Negotiable Requirements

--- a/packages/ai-ide/src/common/project-info-prompt-template.ts
+++ b/packages/ai-ide/src/common/project-info-prompt-template.ts
@@ -40,7 +40,7 @@ export const projectInfoTemplateVariants = <PromptVariantSet>{
 ### Essential Development Patterns
 Examples for key patterns (refer via relative file paths)
 
-### File Structure  
+### File Structure
 [Important directories/packages and their contents]
 
 ### Build & Development
@@ -68,7 +68,7 @@ Made improvements or adaptations to this prompt template? We'd love for you to s
 https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-contribution --}}
 # Instructions
 
-You are the ProjectInfo agent, an AI assistant specialized in managing project information files. Your role is to help users create, update, 
+You are the ProjectInfo agent, an AI assistant specialized in managing project information files. Your role is to help users create, update,
 and maintain the \`.prompts/project-info.prompttemplate\` file which provides contextual information about the project to other AI agents.
 
 ## Project Info Guidelines
@@ -104,14 +104,14 @@ After completing all sections or if you feel the user is done, offer the user to
 ### Complete Project Info
 - If a project info is incomplete, offer the user to complete it
 
-### Update Project Info  
+### Update Project Info
 - Modify existing project info based on user requirements
 - Do not use a specific workflow for this
 
 ## Workspace Analysis Guidelines
 
 **Auto-Discovery File Patterns**
-When auto-discovering project information or exploring the workspace structure, ALWAYS prioritize examining these file patterns that commonly contain agent instructions 
+When auto-discovering project information or exploring the workspace structure, ALWAYS prioritize examining these file patterns that commonly contain agent instructions
 and project documentation:
 - .github/copilot-instructions.md
 - AGENT.md
@@ -149,6 +149,7 @@ Use these functions liberally to suggest file changes. All changes require user 
 {{prompt:${PROJECT_INFO_TEMPLATE_PROMPT_ID}}}
 
 ## Additional Context
+
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
 ## Workflow Guidelines

--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -35,7 +35,7 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
             type: 'boolean',
             title: nls.localize('theia/ai/workspace/considerGitignore/title', 'Consider .gitignore'),
             description: nls.localize('theia/ai/workspace/considerGitignore/description',
-                'If enabled, excludes files/folders specified in a global .gitignore file (expected location is the workspace root).'),
+                'If enabled, excludes files/folders matched by .gitignore rules found in each workspace root directory.'),
             default: true
         },
         [USER_EXCLUDE_PATTERN_PREF]: {

--- a/packages/ai-ide/src/common/workspace-search-provider-util.ts
+++ b/packages/ai-ide/src/common/workspace-search-provider-util.ts
@@ -18,19 +18,30 @@ import { LinePreview, SearchInWorkspaceResult } from '@theia/search-in-workspace
 import { URI } from '@theia/core';
 
 /**
+ * Interface for workspace scope path resolution.
+ * This allows the utility to work with multi-root workspaces.
+ */
+export interface WorkspacePathResolver {
+    toWorkspaceRelativePath(uri: URI): string | undefined;
+}
+
+/**
  * Optimizes search results for token efficiency while preserving all information.
  * - Groups matches by file to reduce repetition
  * - Trims leading/trailing whitespace from line text
- * - Uses relative file paths
+ * - Uses root-prefixed relative file paths (e.g., "rootName/src/file.ts")
  * - Preserves all line numbers and content
  */
-export function optimizeSearchResults(results: SearchInWorkspaceResult[], workspaceRoot: URI): Array<{ file: string; matches: Array<{ line: number; text: string }> }> {
+export function optimizeSearchResults(
+    results: SearchInWorkspaceResult[],
+    workspacePathResolver: WorkspacePathResolver
+): Array<{ file: string; matches: Array<{ line: number; text: string }> }> {
     return results.map(result => {
         const fileUri = new URI(result.fileUri);
-        const relativePath = workspaceRoot.relative(fileUri);
+        const relativePath = workspacePathResolver.toWorkspaceRelativePath(fileUri);
 
         return {
-            file: relativePath ? relativePath.toString() : result.fileUri,
+            file: relativePath ?? result.fileUri,
             matches: result.matches.map(match => {
                 let lineText: string;
                 if (typeof match.lineText === 'string') {

--- a/packages/ai-terminal/src/browser/shell-execution-tool.ts
+++ b/packages/ai-terminal/src/browser/shell-execution-tool.ts
@@ -25,7 +25,7 @@ import {
     ShellExecutionCanceledResult,
     combineAndTruncate
 } from '../common/shell-execution-server';
-import { CancellationToken, generateUuid } from '@theia/core';
+import { CancellationToken, generateUuid, Path } from '@theia/core';
 
 @injectable()
 export class ShellExecutionTool implements ToolProvider {
@@ -129,7 +129,10 @@ TIMEOUT: Default 2 minutes, max 10 minutes. Specify higher timeout for longer co
                     },
                     cwd: {
                         type: 'string',
-                        description: 'Working directory for command execution. Can be absolute or relative to workspace root. Defaults to the workspace root.'
+                        description: 'Working directory for command execution. ' +
+                            'Use a workspace-relative path (e.g., "backend", "frontend/src") ' +
+                            'or an absolute filesystem path. ' +
+                            'If omitted, defaults to the workspace root (single-root workspaces only).'
                     },
                     timeout: {
                         type: 'number',
@@ -168,9 +171,7 @@ TIMEOUT: Default 2 minutes, max 10 minutes. Specify higher timeout for longer co
             timeout?: number;
         } = JSON.parse(argString);
 
-        // Get workspace root to pass to backend for path resolution
-        const rootUri = this.workspaceService.getWorkspaceRootUri(undefined);
-        const workspaceRoot = rootUri?.path.fsPath();
+        const resolvedCwd = this.resolveCwd(args.cwd);
 
         // Generate execution ID and get tool call ID from context
         const executionId = generateUuid();
@@ -187,11 +188,9 @@ TIMEOUT: Default 2 minutes, max 10 minutes. Specify higher timeout for longer co
         });
 
         try {
-            // Call the backend service (path resolution happens on the backend)
             const result = await this.shellServer.execute({
                 command: args.command,
-                cwd: args.cwd,
-                workspaceRoot,
+                cwd: resolvedCwd,
                 timeout: args.timeout,
                 executionId,
             });
@@ -224,7 +223,53 @@ TIMEOUT: Default 2 minutes, max 10 minutes. Specify higher timeout for longer co
         }
     }
 
-    protected extractToolCallId(ctx: unknown): string | undefined {
+    /**
+     * Resolves a cwd value to an absolute filesystem path.
+     * Handles: undefined (falls back to workspace root), absolute paths (pass-through),
+     * root-relative paths (<rootName>/...), and bare root names.
+     */
+    private resolveCwd(cwd: string | undefined): string {
+        const roots = this.workspaceService.tryGetRoots();
+
+        const rootNames = roots.map(r => r.resource.path.base);
+        if (!cwd) {
+            if (roots.length === 1) {
+                return roots[0].resource.path.fsPath();
+            }
+            throw new Error(
+                'A working directory (cwd) is required in a multi-root workspace. ' +
+                `Available workspace roots: ${rootNames.join(', ')}. ` +
+                'Provide one as cwd (e.g., "backend") or use a sub-path (e.g., "backend/src").'
+            );
+        }
+
+        const normalized = Path.normalizePathSeparator(cwd);
+
+        if (new Path(normalized).isAbsolute) {
+            return normalized;
+        }
+
+        const segments = normalized.split('/');
+        for (const root of roots) {
+            if (root.resource.path.base === segments[0]) {
+                const rest = segments.slice(1).join('/');
+                const resolved = rest ? root.resource.resolve(rest) : root.resource;
+                return resolved.path.fsPath();
+            }
+        }
+
+        if (roots.length === 1) {
+            return roots[0].resource.resolve(normalized).path.fsPath();
+        }
+
+        throw new Error(
+            `Could not resolve working directory '${cwd}' to a workspace root. ` +
+            'In a multi-root workspace, prefix paths with the workspace root name ' +
+            `(e.g., '${rootNames[0]}/path'). Available roots: ${rootNames.join(', ')}.`
+        );
+    }
+
+    protected extractToolCallId(ctx?: unknown): string | undefined {
         if (ctx && typeof ctx === 'object' && 'toolCallId' in ctx) {
             return (ctx as { toolCallId?: string }).toolCallId;
         }

--- a/packages/ai-terminal/src/common/shell-execution-server.ts
+++ b/packages/ai-terminal/src/common/shell-execution-server.ts
@@ -21,10 +21,8 @@ export const shellExecutionPath = '/services/shell-execution';
 
 export interface ShellExecutionRequest {
     command: string;
-    /** Working directory. Can be absolute or relative to workspaceRoot. */
+    /** Working directory. Resolved to an absolute path on the frontend before sending to the backend. */
     cwd?: string;
-    /** Workspace root path for resolving relative cwd paths */
-    workspaceRoot?: string;
     timeout?: number; // milliseconds
     /** Unique ID for this execution, used for cancellation */
     executionId?: string;

--- a/packages/ai-terminal/src/node/shell-execution-server-impl.ts
+++ b/packages/ai-terminal/src/node/shell-execution-server-impl.ts
@@ -14,9 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import * as path from 'path';
 import { injectable } from '@theia/core/shared/inversify';
 import { spawn, ChildProcess, execSync } from 'child_process';
-import * as path from 'path';
 import { ShellExecutionServer, ShellExecutionRequest, ShellExecutionResult } from '../common/shell-execution-server';
 
 const DEFAULT_TIMEOUT = 120000; // 2 minutes
@@ -30,11 +30,15 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
     protected readonly canceledExecutions = new Set<string>();
 
     async execute(request: ShellExecutionRequest): Promise<ShellExecutionResult> {
-        const { command, cwd, workspaceRoot, timeout, executionId } = request;
+        const { command, cwd, timeout, executionId } = request;
+        if (cwd && !path.isAbsolute(cwd)) {
+            throw new Error(
+                `Shell execution backend received a non-absolute cwd: '${cwd}'. ` +
+                'The frontend must resolve cwd to an absolute path before sending it to the backend.'
+            );
+        }
         const effectiveTimeout = Math.min(timeout ?? DEFAULT_TIMEOUT, MAX_TIMEOUT);
         const startTime = Date.now();
-
-        const resolvedCwd = this.resolveCwd(cwd, workspaceRoot);
 
         return new Promise<ShellExecutionResult>(resolve => {
             let stdout = '';
@@ -42,7 +46,7 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
             let killed = false;
 
             const childProcess = spawn(command, [], {
-                cwd: resolvedCwd,
+                cwd,
                 shell: true,
                 detached: process.platform !== 'win32',
                 windowsHide: true,
@@ -93,7 +97,7 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
                             error: 'Command canceled by user',
                             duration,
                             canceled: true,
-                            resolvedCwd,
+                            resolvedCwd: cwd,
                         });
                     } else {
                         resolve({
@@ -103,7 +107,7 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
                             stderr,
                             error: `Command timed out after ${effectiveTimeout}ms`,
                             duration,
-                            resolvedCwd,
+                            resolvedCwd: cwd,
                         });
                     }
                 } else if (code === 0) {
@@ -113,7 +117,7 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
                         stdout,
                         stderr,
                         duration,
-                        resolvedCwd,
+                        resolvedCwd: cwd,
                     });
                 } else {
                     resolve({
@@ -122,7 +126,7 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
                         stdout,
                         stderr,
                         duration,
-                        resolvedCwd,
+                        resolvedCwd: cwd,
                     });
                 }
             });
@@ -142,7 +146,7 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
                     stderr,
                     error: error.message,
                     duration: Date.now() - startTime,
-                    resolvedCwd,
+                    resolvedCwd: cwd,
                 });
             });
         });
@@ -177,18 +181,5 @@ export class ShellExecutionServerImpl implements ShellExecutionServer {
                 // Process may already be dead
             }
         }
-    }
-
-    protected resolveCwd(requestedCwd: string | undefined, workspaceRoot: string | undefined): string | undefined {
-        if (!requestedCwd) {
-            return workspaceRoot;
-        }
-        if (path.isAbsolute(requestedCwd)) {
-            return requestedCwd;
-        }
-        if (workspaceRoot) {
-            return path.resolve(workspaceRoot, requestedCwd);
-        }
-        return requestedCwd;
     }
 }

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -816,6 +816,31 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
         return uri.path.fsPath();
     }
 
+    /**
+     * Returns a workspace-relative path prefixed with the containing root's
+     * directory name, e.g. `backend/src/index.ts`.
+     *
+     * In a single-root workspace the root name is still included so that the
+     * format is consistent regardless of how many roots are open.
+     *
+     * Falls back to the absolute filesystem path if the URI is not contained
+     * in any workspace root.
+     *
+     * @param uri URI of the file
+     */
+    getRootPrefixedPath(uri: URI): string {
+        const rootUri = this.getWorkspaceRootUri(uri);
+        if (!rootUri) {
+            return uri.path.fsPath();
+        }
+        const rootName = rootUri.path.base;
+        const relative = rootUri.relative(uri);
+        if (!relative || relative.toString() === '') {
+            return rootName;
+        }
+        return `${rootName}/${relative.toString()}`;
+    }
+
     areWorkspaceRoots(uris: URI[]): boolean {
         if (!uris.length) {
             return false;


### PR DESCRIPTION
#### What it does

Closes #15278

Adds multi-root workspace support for AI agents. Agents can now access files, run tasks, launch configurations, and execute commands across all workspace roots — not just the first one.

Core changes:
- `WorkspaceFunctionScope` rewritten with cached root mapping, synchronous `resolveRelativePath` (no filesystem I/O), and `toWorkspaceRelativePath` for the canonical `<rootName>/<relativePath>` path convention.
- New `WorkspaceService.getRootPrefixedPath(uri)` method centralizes the repeated `rootName + "/" + relativePath` pattern (replaces 9 duplication sites).
- New `WorkspaceRootsVariableContribution` injects workspace root information into all agent system prompts.
- All tool descriptions updated to document the `<rootName>/<relativePath>` convention.
- Tasks, launch configs, and debug sessions disambiguate by `workspaceRoot` parameter when names collide across roots.
- Shell execution tool now requires `cwd` and resolves it on the frontend.
- Per-root gitignore handling.
- `FileValidationState.INVALID_SECONDARY` removed — all roots treated equally.
- GitHub repo variable, skill service, template preferences, search provider all iterate all roots.
- Editor context variable and change-set file service produce root-prefixed paths.

Known limitations with TODOs: Codex agent, Claude Code command/slash-command contributions still use first root only.

#### How to test

1. Open a multi-root workspace (File → Add Folder to Workspace).
2. In agent mode, ask the agent to read/edit files in different roots — paths should use `rootName/path` format.
3. Run `getWorkspaceDirectoryStructure` — should return all roots keyed by name.
4. List and run tasks/launch configs that exist in multiple roots — agent should be prompted to disambiguate.
5. Shell commands should require `cwd`; verify `cwd: "rootName"` resolves correctly.
6. Verify single-root workspaces still work identically (root name prefix is required but the single-root fallback accepts bare relative paths).

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

- `FileValidationState.INVALID_SECONDARY` removed from `@theia/ai-chat`.
- `WorkspaceFunctionScope.getWorkspaceRoot()` and `WorkspaceFunctionScope.isInPrimaryWorkspace()` removed from `@theia/ai-ide`.
- `WorkspaceFunctionScope.resolveRelativePath()` is now synchronous (returns `URI`, not `Promise<URI>`).
- `ShellExecutionRequest.workspaceRoot` removed from `@theia/ai-terminal`; `cwd` is now resolved on the frontend.
- Shell execution tool now requires `cwd` parameter.
#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
