### PR TITLE
feat(scm): add SCM history graph with VS Code-compatible plugin API

### DIFF
--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -962,6 +962,17 @@ export namespace ScmCommandArg {
     }
 }
 
+export interface ScmHistoryItemCommandArg {
+    sourceControlHandle: number;
+    id: string;
+    type: 'historyItem' | 'historyItemRef';
+}
+export namespace ScmHistoryItemCommandArg {
+    export function is(arg: unknown): arg is ScmHistoryItemCommandArg {
+        return isObject(arg) && 'sourceControlHandle' in arg && 'id' in arg && 'type' in arg;
+    }
+}
+
 export interface ScmExt {
     createSourceControl(plugin: Plugin, id: string, label: string, rootUri?: theia.Uri): theia.SourceControl;
     getLastInputBox(plugin: Plugin): theia.SourceControlInputBox | undefined;
@@ -970,6 +981,11 @@ export interface ScmExt {
     $validateInput(sourceControlHandle: number, value: string, cursorPosition: number): Promise<[string, number] | undefined>;
     $setSelectedSourceControl(selectedSourceControlHandle: number | undefined): Promise<void>;
     $provideOriginalResource(sourceControlHandle: number, uri: string, token: theia.CancellationToken): Promise<UriComponents | undefined>;
+    $provideHistoryItemRefs(sourceControlHandle: number, historyItemRefs: string[] | undefined, token: theia.CancellationToken): Promise<ScmHistoryItemRefDto[] | undefined>;
+    $provideHistoryItems(sourceControlHandle: number, options: ScmHistoryOptionsDto, token: theia.CancellationToken): Promise<ScmHistoryItemDto[] | undefined>;
+    $provideHistoryItemChanges(sourceControlHandle: number, historyItemId: string, historyItemParentId: string | undefined, token: theia.CancellationToken): Promise<ScmHistoryItemChangeDto[] | undefined>;
+    $resolveHistoryItem(sourceControlHandle: number, historyItemId: string, token: theia.CancellationToken): Promise<ScmHistoryItemDto | undefined>;
+    $resolveHistoryItemRefsCommonAncestor(sourceControlHandle: number, historyItemRefs: string[], token: theia.CancellationToken): Promise<string | undefined>;
 }
 
 export namespace TimelineCommandArg {
@@ -1054,6 +1070,8 @@ export interface ScmMain {
     $setInputBoxEnabled(sourceControlHandle: number, enabled: boolean): void;
 
     $setActionButton(sourceControlHandle: number, actionButton: ScmActionButton | undefined): void;
+    $onDidChangeCurrentHistoryItemRefs(sourceControlHandle: number): void;
+    $onDidChangeHistoryItemRefs(sourceControlHandle: number, event: ScmHistoryItemRefsChangeEventDto): void;
 }
 
 export interface SourceControlProviderFeatures {
@@ -1063,6 +1081,10 @@ export interface SourceControlProviderFeatures {
     acceptInputCommand?: Command;
     statusBarCommands?: Command[];
     contextValue?: string;
+    hasHistoryProvider?: boolean;
+    currentHistoryItemRef?: ScmHistoryItemRefDto;
+    currentHistoryItemRemoteRef?: ScmHistoryItemRefDto;
+    currentHistoryItemBaseRef?: ScmHistoryItemRefDto;
 }
 
 export interface SourceControlGroupFeatures {
@@ -1097,6 +1119,55 @@ export interface ScmRawResourceSplice {
 export interface ScmRawResourceSplices {
     handle: number,
     splices: ScmRawResourceSplice[]
+}
+
+export interface ScmHistoryItemRefDto {
+    id: string;
+    name: string;
+    description?: string;
+    revision?: string;
+    icon?: UriComponents | { light: UriComponents; dark: UriComponents } | ThemeIcon;
+    category?: string;
+}
+
+export interface ScmHistoryItemRefsChangeEventDto {
+    added: ScmHistoryItemRefDto[];
+    removed: ScmHistoryItemRefDto[];
+    modified: ScmHistoryItemRefDto[];
+}
+
+export interface ScmHistoryItemStatisticsDto {
+    files: number;
+    insertions: number;
+    deletions: number;
+}
+
+export interface ScmHistoryItemDto {
+    id: string;
+    parentIds?: string[];
+    subject: string;
+    message?: string | MarkdownString;
+    author?: string;
+    authorEmail?: string;
+    authorIcon?: UriComponents | { light: UriComponents; dark: UriComponents } | ThemeIcon;
+    displayId?: string;
+    timestamp?: number;
+    tooltip?: string | MarkdownString;
+    statistics?: ScmHistoryItemStatisticsDto;
+    references?: ScmHistoryItemRefDto[];
+}
+
+export interface ScmHistoryItemChangeDto {
+    uri: UriComponents;
+    originalUri?: UriComponents;
+    modifiedUri?: UriComponents;
+    renameUri?: UriComponents;
+}
+
+export interface ScmHistoryOptionsDto {
+    cursor?: string;
+    limit?: number | { id: string };
+    historyItemRefs?: string[];
 }
 
 export interface SourceControlResourceState {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1165,9 +1165,10 @@ export interface ScmHistoryItemChangeDto {
 }
 
 export interface ScmHistoryOptionsDto {
-    cursor?: string;
-    limit?: number | { id: string };
+    skip?: number;
+    limit?: number | { id?: string };
     historyItemRefs?: string[];
+    filterText?: string;
 }
 
 export interface SourceControlResourceState {

--- a/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
+++ b/packages/plugin-ext/src/main/browser/menus/menus-contribution-handler.ts
@@ -23,6 +23,7 @@ import { TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-too
 import { DeployedPlugin, IconUrl, Menu } from '../../../common';
 import { ScmWidget } from '@theia/scm/lib/browser/scm-widget';
 import { ScmRepositoriesWidget, SCM_SOURCE_CONTROL_TITLE_MENU } from '@theia/scm/lib/browser/scm-repositories-widget';
+import { ScmHistoryGraphWidget, SCM_HISTORY_TITLE_MENU } from '@theia/scm/lib/browser/scm-history-graph-widget';
 import { KeybindingRegistry, QuickCommandService, codicon } from '@theia/core/lib/browser';
 import {
     CodeEditorWidgetUtil, codeToTheiaMappings, ContributionPoint,
@@ -63,6 +64,7 @@ export class MenusContributionPointHandler {
         });
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_SCM_TITLE_MENU, widget => widget instanceof ScmWidget);
         this.tabBarToolbar.registerMenuDelegate(SCM_SOURCE_CONTROL_TITLE_MENU, widget => widget instanceof ScmRepositoriesWidget);
+        this.tabBarToolbar.registerMenuDelegate(SCM_HISTORY_TITLE_MENU, widget => widget instanceof ScmHistoryGraphWidget);
         this.tabBarToolbar.registerMenuDelegate(PLUGIN_VIEW_TITLE_MENU, widget => !CodeEditorWidgetUtil.is(widget));
     }
 

--- a/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
+++ b/packages/plugin-ext/src/main/browser/menus/plugin-menu-command-adapter.ts
@@ -25,7 +25,7 @@ import { DirtyDiffWidget } from '@theia/scm/lib/browser/dirty-diff/dirty-diff-wi
 import { Change, LineRange } from '@theia/scm/lib/browser/dirty-diff/diff-computer';
 import { IChange } from '@theia/monaco-editor-core/esm/vs/editor/common/diff/legacyLinesDiffComputer';
 import { TimelineItem } from '@theia/timeline/lib/common/timeline-model';
-import { ScmCommandArg, TimelineCommandArg, TreeViewItemReference } from '../../../common';
+import { ScmCommandArg, ScmHistoryItemCommandArg, TimelineCommandArg, TreeViewItemReference } from '../../../common';
 import { TestItemReference, TestMessageArg } from '../../../common/test-types';
 import { PluginScmProvider, PluginScmResource, PluginScmResourceGroup } from '../scm-main';
 import { TreeViewWidget } from '../view/tree-view-widget';
@@ -70,6 +70,9 @@ export class PluginMenuCommandAdapter {
             ['scm/resourceGroup/context', toScmArgs],
             ['scm/resourceState/context', toScmArgs],
             ['scm/repository', toScmArgs],
+            ['scm/history/title', () => [this.toScmArg(this.scmService.selectedRepository)]],
+            ['scm/historyItem/context', (...args) => this.toScmHistoryArgs(...args)],
+            ['scm/historyItemRef/context', (...args) => this.toScmHistoryArgs(...args)],
             ['scm/title', () => [this.toScmArg(this.scmService.selectedRepository)]],
             ['scm/sourceControl', toScmArgs],
             ['scm/sourceControl/title', () => [this.toScmArg(this.scmService.selectedRepository)]],
@@ -146,6 +149,16 @@ export class PluginMenuCommandAdapter {
             }
         }
         return scmArgs;
+    }
+
+    protected toScmHistoryArgs(...args: any[]): any[] {
+        const result: any[] = [];
+        for (const arg of args) {
+            if (ScmHistoryItemCommandArg.is(arg) || ScmCommandArg.is(arg)) {
+                result.push(arg);
+            }
+        }
+        return result;
     }
 
     protected toScmArg(arg: any): ScmCommandArg | undefined {

--- a/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
+++ b/packages/plugin-ext/src/main/browser/menus/vscode-theia-menu-mappings.ts
@@ -29,6 +29,9 @@ import { PLUGIN_SCM_CHANGE_TITLE_MENU } from '@theia/scm/lib/browser/dirty-diff/
 import {
     SCM_REPOSITORY_MENU, SCM_SOURCE_CONTROL_MENU, SCM_SOURCE_CONTROL_TITLE_MENU, SCM_TITLE_MENU
 } from '@theia/scm/lib/browser/scm-repositories-widget';
+import {
+    SCM_HISTORY_TITLE_MENU, SCM_HISTORY_ITEM_CONTEXT_MENU, SCM_HISTORY_ITEM_REF_CONTEXT_MENU
+} from '@theia/scm/lib/browser/scm-history-graph-widget';
 import { TIMELINE_ITEM_CONTEXT_MENU } from '@theia/timeline/lib/browser/timeline-tree-widget';
 import { COMMENT_CONTEXT, COMMENT_THREAD_CONTEXT, COMMENT_TITLE } from '../comments/comment-thread-widget';
 import { VIEW_ITEM_CONTEXT_MENU } from '../view/tree-view-widget';
@@ -65,6 +68,9 @@ export const implementedVSCodeContributionPoints = [
     'scm/repository',
     'scm/sourceControl',
     'scm/sourceControl/title',
+    'scm/history/title',
+    'scm/historyItem/context',
+    'scm/historyItemRef/context',
     'scm/title',
     'timeline/item/context',
     'testing/item/context',
@@ -103,6 +109,9 @@ export const codeToTheiaMappings = new Map<string, MenuPath[]>([
     ['scm/repository', [SCM_REPOSITORY_MENU]],
     ['scm/sourceControl', [SCM_SOURCE_CONTROL_MENU]],
     ['scm/sourceControl/title', [SCM_SOURCE_CONTROL_TITLE_MENU]],
+    ['scm/history/title', [SCM_HISTORY_TITLE_MENU]],
+    ['scm/historyItem/context', [SCM_HISTORY_ITEM_CONTEXT_MENU]],
+    ['scm/historyItemRef/context', [SCM_HISTORY_ITEM_REF_CONTEXT_MENU]],
     ['scm/title', [SCM_TITLE_MENU]],
     ['testing/item/context', [TEST_VIEW_CONTEXT_MENU]],
     ['testing/message/context', [TEST_RUNS_CONTEXT_MENU]],

--- a/packages/plugin-ext/src/main/browser/scm-main.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.ts
@@ -228,9 +228,10 @@ export class PluginScmHistoryProvider implements ScmHistoryProvider {
 
     async provideHistoryItems(options: ScmHistoryOptions, token: CancellationToken): Promise<ScmHistoryItem[] | undefined> {
         const dto: ScmHistoryOptionsDto = {
-            cursor: options.cursor,
+            skip: options.skip,
             limit: options.limit,
             historyItemRefs: options.historyItemRefs ? [...options.historyItemRefs] : undefined,
+            filterText: options.filterText,
         };
         const cts = new CancellationTokenSource();
         const listener = token.onCancellationRequested(() => cts.cancel());

--- a/packages/plugin-ext/src/main/browser/scm-main.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.ts
@@ -27,14 +27,24 @@ import {
     ScmMain,
     SourceControlProviderFeatures,
     ScmRawResourceSplices, ScmRawResourceGroup,
-    ScmActionButton as RpcScmActionButton
+    ScmActionButton as RpcScmActionButton,
+    ScmHistoryItemRefDto,
+    ScmHistoryItemDto,
+    ScmHistoryItemChangeDto,
+    ScmHistoryOptionsDto,
+    ScmHistoryItemRefsChangeEventDto
 } from '../../common/plugin-api-rpc';
-import { ScmProvider, ScmResource, ScmResourceDecorations, ScmResourceGroup, ScmCommand, ScmActionButton } from '@theia/scm/lib/browser/scm-provider';
+import {
+    ScmProvider, ScmResource, ScmResourceDecorations, ScmResourceGroup, ScmCommand, ScmActionButton,
+    ScmHistoryProvider, ScmHistoryItemRef, ScmHistoryItemRefsChangeEvent,
+    ScmHistoryOptions, ScmHistoryItem, ScmHistoryItemChange
+} from '@theia/scm/lib/browser/scm-provider';
 import { ScmRepository } from '@theia/scm/lib/browser/scm-repository';
 import { ScmService } from '@theia/scm/lib/browser/scm-service';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { interfaces } from '@theia/core/shared/inversify';
 import { Emitter, Event } from '@theia/core/lib/common/event';
+import { CancellationToken, CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import URI from '@theia/core/lib/common/uri';
 import { URI as vscodeURI } from '@theia/core/shared/vscode-uri';
@@ -104,6 +114,197 @@ export class PluginScmResource implements ScmResource {
     }
 }
 
+function historyItemRefFromDto(dto: ScmHistoryItemRefDto): ScmHistoryItemRef {
+    return {
+        id: dto.id,
+        name: dto.name,
+        description: dto.description,
+        revision: dto.revision,
+        icon: dto.icon ? (ThemeIcon.isThemeIcon(dto.icon) ? ThemeIcon.asClassName(dto.icon) :
+            'light' in dto.icon ? vscodeURI.revive(dto.icon.light).toString() : vscodeURI.revive(dto.icon as UriComponents).toString()) : undefined,
+        category: dto.category,
+    };
+}
+
+function historyItemFromDto(dto: ScmHistoryItemDto): ScmHistoryItem {
+    return {
+        id: dto.id,
+        parentIds: dto.parentIds,
+        subject: dto.subject,
+        message: typeof dto.message === 'string' ? dto.message : dto.message?.value,
+        author: dto.author,
+        authorEmail: dto.authorEmail,
+        authorIcon: dto.authorIcon ? (ThemeIcon.isThemeIcon(dto.authorIcon) ? ThemeIcon.asClassName(dto.authorIcon) :
+            'light' in dto.authorIcon ? vscodeURI.revive(dto.authorIcon.light).toString() : vscodeURI.revive(dto.authorIcon as UriComponents).toString()) : undefined,
+        displayId: dto.displayId,
+        timestamp: dto.timestamp,
+        tooltip: typeof dto.tooltip === 'string' ? dto.tooltip : dto.tooltip?.value,
+        statistics: dto.statistics ? {
+            files: dto.statistics.files,
+            insertions: dto.statistics.insertions,
+            deletions: dto.statistics.deletions,
+        } : undefined,
+        references: dto.references ? dto.references.map(historyItemRefFromDto) : undefined,
+    };
+}
+
+function historyItemChangeFromDto(dto: ScmHistoryItemChangeDto): ScmHistoryItemChange {
+    return {
+        uri: vscodeURI.revive(dto.uri).toString(),
+        originalUri: dto.originalUri ? vscodeURI.revive(dto.originalUri).toString() : undefined,
+        modifiedUri: dto.modifiedUri ? vscodeURI.revive(dto.modifiedUri).toString() : undefined,
+        renameUri: dto.renameUri ? vscodeURI.revive(dto.renameUri).toString() : undefined,
+    };
+}
+
+export class PluginScmHistoryProvider implements ScmHistoryProvider {
+
+    private readonly onDidChangeCurrentHistoryItemRefsEmitter = new Emitter<void>();
+    readonly onDidChangeCurrentHistoryItemRefs: Event<void> = this.onDidChangeCurrentHistoryItemRefsEmitter.event;
+
+    private readonly onDidChangeHistoryItemRefsEmitter = new Emitter<ScmHistoryItemRefsChangeEvent>();
+    readonly onDidChangeHistoryItemRefs: Event<ScmHistoryItemRefsChangeEvent> = this.onDidChangeHistoryItemRefsEmitter.event;
+
+    private _currentHistoryItemRef: ScmHistoryItemRef | undefined;
+    get currentHistoryItemRef(): ScmHistoryItemRef | undefined { return this._currentHistoryItemRef; }
+
+    private _currentHistoryItemRemoteRef: ScmHistoryItemRef | undefined;
+    get currentHistoryItemRemoteRef(): ScmHistoryItemRef | undefined { return this._currentHistoryItemRemoteRef; }
+
+    private _currentHistoryItemBaseRef: ScmHistoryItemRef | undefined;
+    get currentHistoryItemBaseRef(): ScmHistoryItemRef | undefined { return this._currentHistoryItemBaseRef; }
+
+    private readonly disposables = new DisposableCollection();
+    private pendingRequests = new Set<CancellationTokenSource>();
+
+    constructor(
+        private readonly proxy: ScmExt,
+        private readonly handle: number
+    ) {
+        this.disposables.push(this.onDidChangeCurrentHistoryItemRefsEmitter);
+        this.disposables.push(this.onDidChangeHistoryItemRefsEmitter);
+    }
+
+    updateFromFeatures(features: SourceControlProviderFeatures): void {
+        if (features.currentHistoryItemRef !== undefined) {
+            this._currentHistoryItemRef = features.currentHistoryItemRef ? historyItemRefFromDto(features.currentHistoryItemRef) : undefined;
+        }
+        if (features.currentHistoryItemRemoteRef !== undefined) {
+            this._currentHistoryItemRemoteRef = features.currentHistoryItemRemoteRef ? historyItemRefFromDto(features.currentHistoryItemRemoteRef) : undefined;
+        }
+        if (features.currentHistoryItemBaseRef !== undefined) {
+            this._currentHistoryItemBaseRef = features.currentHistoryItemBaseRef ? historyItemRefFromDto(features.currentHistoryItemBaseRef) : undefined;
+        }
+    }
+
+    fireDidChangeCurrentHistoryItemRefs(): void {
+        this.onDidChangeCurrentHistoryItemRefsEmitter.fire();
+    }
+
+    fireDidChangeHistoryItemRefs(event: ScmHistoryItemRefsChangeEventDto): void {
+        this.onDidChangeHistoryItemRefsEmitter.fire({
+            added: event.added.map(historyItemRefFromDto),
+            removed: event.removed.map(historyItemRefFromDto),
+            modified: event.modified.map(historyItemRefFromDto),
+        });
+    }
+
+    async provideHistoryItemRefs(historyItemRefs: string[] | undefined, token: CancellationToken): Promise<ScmHistoryItemRef[] | undefined> {
+        const cts = new CancellationTokenSource();
+        const listener = token.onCancellationRequested(() => cts.cancel());
+        this.pendingRequests.add(cts);
+        try {
+            const result = await this.proxy.$provideHistoryItemRefs(this.handle, historyItemRefs, cts.token);
+            if (!result) {
+                return undefined;
+            }
+            return result.map(historyItemRefFromDto);
+        } finally {
+            listener.dispose();
+            this.pendingRequests.delete(cts);
+            cts.dispose();
+        }
+    }
+
+    async provideHistoryItems(options: ScmHistoryOptions, token: CancellationToken): Promise<ScmHistoryItem[] | undefined> {
+        const dto: ScmHistoryOptionsDto = {
+            cursor: options.cursor,
+            limit: options.limit,
+            historyItemRefs: options.historyItemRefs ? [...options.historyItemRefs] : undefined,
+        };
+        const cts = new CancellationTokenSource();
+        const listener = token.onCancellationRequested(() => cts.cancel());
+        this.pendingRequests.add(cts);
+        try {
+            const result = await this.proxy.$provideHistoryItems(this.handle, dto, cts.token);
+            if (!result) {
+                return undefined;
+            }
+            return result.map(historyItemFromDto);
+        } finally {
+            listener.dispose();
+            this.pendingRequests.delete(cts);
+            cts.dispose();
+        }
+    }
+
+    async provideHistoryItemChanges(historyItemId: string, historyItemParentId: string | undefined, token: CancellationToken): Promise<ScmHistoryItemChange[] | undefined> {
+        const cts = new CancellationTokenSource();
+        const listener = token.onCancellationRequested(() => cts.cancel());
+        this.pendingRequests.add(cts);
+        try {
+            const result = await this.proxy.$provideHistoryItemChanges(this.handle, historyItemId, historyItemParentId, cts.token);
+            if (!result) {
+                return undefined;
+            }
+            return result.map(historyItemChangeFromDto);
+        } finally {
+            listener.dispose();
+            this.pendingRequests.delete(cts);
+            cts.dispose();
+        }
+    }
+
+    async resolveHistoryItem(historyItemId: string, token: CancellationToken): Promise<ScmHistoryItem | undefined> {
+        const cts = new CancellationTokenSource();
+        const listener = token.onCancellationRequested(() => cts.cancel());
+        this.pendingRequests.add(cts);
+        try {
+            const result = await this.proxy.$resolveHistoryItem(this.handle, historyItemId, cts.token);
+            if (!result) {
+                return undefined;
+            }
+            return historyItemFromDto(result);
+        } finally {
+            listener.dispose();
+            this.pendingRequests.delete(cts);
+            cts.dispose();
+        }
+    }
+
+    async resolveHistoryItemRefsCommonAncestor(historyItemRefs: string[], token: CancellationToken): Promise<string | undefined> {
+        const cts = new CancellationTokenSource();
+        const listener = token.onCancellationRequested(() => cts.cancel());
+        this.pendingRequests.add(cts);
+        try {
+            return await this.proxy.$resolveHistoryItemRefsCommonAncestor(this.handle, historyItemRefs, cts.token) ?? undefined;
+        } finally {
+            listener.dispose();
+            this.pendingRequests.delete(cts);
+            cts.dispose();
+        }
+    }
+
+    dispose(): void {
+        for (const cts of this.pendingRequests) {
+            cts.cancel();
+            cts.dispose();
+        }
+        this.pendingRequests.clear();
+        this.disposables.dispose();
+    }
+}
+
 export class PluginScmProvider implements ScmProvider {
 
     private _id = this.contextValue;
@@ -117,6 +318,11 @@ export class PluginScmProvider implements ScmProvider {
 
     private _actionButton: ScmActionButton | undefined;
     get actionButton(): ScmActionButton | undefined { return this._actionButton; }
+
+    private _historyProvider: PluginScmHistoryProvider | undefined;
+    get historyProvider(): ScmHistoryProvider | undefined {
+        return this._historyProvider;
+    }
 
     private features: SourceControlProviderFeatures = {};
 
@@ -172,7 +378,21 @@ export class PluginScmProvider implements ScmProvider {
 
     updateSourceControl(features: SourceControlProviderFeatures): void {
         this.features = { ...this.features, ...features };
+
+        if (typeof features.hasHistoryProvider !== 'undefined') {
+            if (features.hasHistoryProvider && !this._historyProvider) {
+                this._historyProvider = new PluginScmHistoryProvider(this.proxy, this.handle);
+            } else if (!features.hasHistoryProvider && this._historyProvider) {
+                this._historyProvider.dispose();
+                this._historyProvider = undefined;
+            }
+        }
+
         this.onDidChangeEmitter.fire();
+
+        if (this._historyProvider) {
+            this._historyProvider.updateFromFeatures(features);
+        }
 
         if (typeof features.commitTemplate !== 'undefined') {
             this.onDidChangeCommitTemplateEmitter.fire(this.commitTemplate!);
@@ -303,7 +523,10 @@ export class PluginScmProvider implements ScmProvider {
         this.onDidChangeActionButtonEmitter.fire(actionButton);
     }
 
-    dispose(): void { }
+    dispose(): void {
+        this._historyProvider?.dispose();
+        this._historyProvider = undefined;
+    }
 }
 
 export class ScmMainImpl implements ScmMain {
@@ -545,5 +768,25 @@ export class ScmMainImpl implements ScmMain {
         } : undefined;
 
         provider.updateActionButton(converted);
+    }
+
+    $onDidChangeCurrentHistoryItemRefs(sourceControlHandle: number): void {
+        const repository = this.repositories.get(sourceControlHandle);
+        if (!repository) {
+            return;
+        }
+        const provider = repository.provider as PluginScmProvider;
+        const historyProvider = provider.historyProvider as PluginScmHistoryProvider | undefined;
+        historyProvider?.fireDidChangeCurrentHistoryItemRefs();
+    }
+
+    $onDidChangeHistoryItemRefs(sourceControlHandle: number, event: ScmHistoryItemRefsChangeEventDto): void {
+        const repository = this.repositories.get(sourceControlHandle);
+        if (!repository) {
+            return;
+        }
+        const provider = repository.provider as PluginScmProvider;
+        const historyProvider = provider.historyProvider as PluginScmHistoryProvider | undefined;
+        historyProvider?.fireDidChangeHistoryItemRefs(event);
     }
 }

--- a/packages/plugin-ext/src/plugin/scm.spec.ts
+++ b/packages/plugin-ext/src/plugin/scm.spec.ts
@@ -1,0 +1,614 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Tests for the SCM history provider bridge.
+ *
+ * These tests validate the plugin-side logic in isolation without requiring
+ * the full Theia runtime — following the pattern from workspace.spec.ts.
+ */
+
+import * as assert from 'assert';
+import { Emitter } from '@theia/core/lib/common/event';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { ScmCommandArg, ScmHistoryItemCommandArg } from '../common/plugin-api-rpc';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface HistoryItemRef {
+    readonly id: string;
+    readonly name: string;
+    readonly description?: string;
+    readonly revision?: string;
+    readonly category?: string;
+}
+
+interface HistoryItemRefsChangeEvent {
+    readonly added: readonly HistoryItemRef[];
+    readonly removed: readonly HistoryItemRef[];
+    readonly modified: readonly HistoryItemRef[];
+}
+
+interface HistoryItem {
+    readonly id: string;
+    readonly parentIds?: readonly string[];
+    readonly subject: string;
+    readonly author?: string;
+    readonly authorEmail?: string;
+    readonly displayId?: string;
+    readonly timestamp?: number;
+}
+
+interface HistoryOptions {
+    readonly cursor?: string;
+    readonly limit?: number | { id: string };
+    readonly historyItemRefs?: readonly string[];
+}
+
+/**
+ * Extracted from SourceControlImpl.historyProvider setter logic.
+ * Tests the event subscription and proxy notification pattern.
+ *
+ * Note: SourceControlImpl cannot be instantiated directly in unit tests because
+ * it depends on ScmMain (RPC proxy) and CommandRegistryImpl, both of which
+ * require a full Theia runtime with inversify bindings and RPC channels.
+ * Instead, the bridge pattern extracts the logic under test into a standalone
+ * class that mirrors the real implementation, following the same pattern used
+ * in workspace.spec.ts for other plugin-side logic.
+ */
+class HistoryProviderBridge {
+    private _historyProvider: any;
+    private _historyProviderDisposables = new DisposableCollection();
+
+    readonly updateSourceControlCalls: Array<{ features: any }> = [];
+    readonly onDidChangeCurrentHistoryItemRefsCalls: number[] = [];
+    readonly onDidChangeHistoryItemRefsCalls: Array<{ event: any }> = [];
+
+    private historyItemRefToDto(ref: HistoryItemRef): any {
+        return { id: ref.id, name: ref.name, description: ref.description, revision: ref.revision, category: ref.category };
+    }
+
+    setHistoryProvider(provider: any): void {
+        this._historyProviderDisposables.dispose();
+        this._historyProviderDisposables = new DisposableCollection();
+        this._historyProvider = provider;
+
+        if (provider) {
+            this._historyProviderDisposables.push(
+                provider.onDidChangeCurrentHistoryItemRefs(() => {
+                    this.updateSourceControlCalls.push({
+                        features: {
+                            hasHistoryProvider: true,
+                            currentHistoryItemRef: provider.currentHistoryItemRef ? this.historyItemRefToDto(provider.currentHistoryItemRef) : undefined,
+                        }
+                    });
+                    this.onDidChangeCurrentHistoryItemRefsCalls.push(1);
+                })
+            );
+            this._historyProviderDisposables.push(
+                provider.onDidChangeHistoryItemRefs((event: HistoryItemRefsChangeEvent) => {
+                    this.onDidChangeHistoryItemRefsCalls.push({
+                        event: {
+                            added: event.added.map((r: HistoryItemRef) => this.historyItemRefToDto(r)),
+                            removed: event.removed.map((r: HistoryItemRef) => this.historyItemRefToDto(r)),
+                            modified: event.modified.map((r: HistoryItemRef) => this.historyItemRefToDto(r)),
+                        }
+                    });
+                })
+            );
+        }
+
+        this.updateSourceControlCalls.push({
+            features: {
+                hasHistoryProvider: !!provider,
+                currentHistoryItemRef: provider?.currentHistoryItemRef ? this.historyItemRefToDto(provider.currentHistoryItemRef) : undefined,
+            }
+        });
+    }
+
+    async provideHistoryItems(options: HistoryOptions): Promise<any[] | undefined> {
+        if (!this._historyProvider) {
+            return undefined;
+        }
+        const result = await this._historyProvider.provideHistoryItems(options);
+        if (!result) {
+            return undefined;
+        }
+        return result.map((item: HistoryItem) => ({
+            id: item.id,
+            parentIds: item.parentIds ? [...item.parentIds] : undefined,
+            subject: item.subject,
+            author: item.author,
+            authorEmail: item.authorEmail,
+            displayId: item.displayId,
+            timestamp: item.timestamp,
+        }));
+    }
+
+    async provideHistoryItemRefs(refs: string[] | undefined): Promise<HistoryItemRef[] | undefined> {
+        if (!this._historyProvider) {
+            return undefined;
+        }
+        const result = await this._historyProvider.provideHistoryItemRefs(refs);
+        return result;
+    }
+
+    dispose(): void {
+        this._historyProviderDisposables.dispose();
+    }
+}
+
+describe('SCM history provider bridge (plugin side)', () => {
+    let bridge: HistoryProviderBridge;
+    let bridgeDisposables: DisposableCollection;
+
+    beforeEach(() => {
+        bridgeDisposables = new DisposableCollection();
+        bridge = new HistoryProviderBridge();
+    });
+
+    afterEach(() => {
+        bridge.dispose();
+        bridgeDisposables.dispose();
+    });
+
+    it('setting historyProvider sends hasHistoryProvider: true', () => {
+        const onCurrentRefs = new Emitter<void>();
+        const onHistoryRefs = new Emitter<HistoryItemRefsChangeEvent>();
+        bridgeDisposables.push(onCurrentRefs);
+        bridgeDisposables.push(onHistoryRefs);
+
+        const provider = {
+            currentHistoryItemRef: { id: 'refs/heads/main', name: 'main' },
+            onDidChangeCurrentHistoryItemRefs: onCurrentRefs.event,
+            onDidChangeHistoryItemRefs: onHistoryRefs.event,
+            provideHistoryItemRefs: async () => [],
+            provideHistoryItems: async () => [],
+        };
+
+        bridge.setHistoryProvider(provider);
+
+        const lastCall = bridge.updateSourceControlCalls[bridge.updateSourceControlCalls.length - 1];
+        assert.ok(lastCall, 'Expected $updateSourceControl to be called');
+        assert.strictEqual(lastCall.features.hasHistoryProvider, true);
+        assert.strictEqual(lastCall.features.currentHistoryItemRef?.id, 'refs/heads/main');
+        assert.strictEqual(lastCall.features.currentHistoryItemRef?.name, 'main');
+    });
+
+    it('setting historyProvider to undefined sends hasHistoryProvider: false', () => {
+        const onCurrentRefs = new Emitter<void>();
+        const onHistoryRefs = new Emitter<HistoryItemRefsChangeEvent>();
+        bridgeDisposables.push(onCurrentRefs);
+        bridgeDisposables.push(onHistoryRefs);
+
+        const provider = {
+            currentHistoryItemRef: undefined,
+            onDidChangeCurrentHistoryItemRefs: onCurrentRefs.event,
+            onDidChangeHistoryItemRefs: onHistoryRefs.event,
+            provideHistoryItemRefs: async () => [],
+            provideHistoryItems: async () => [],
+        };
+
+        bridge.setHistoryProvider(provider);
+        bridge.setHistoryProvider(undefined);
+
+        const lastCall = bridge.updateSourceControlCalls[bridge.updateSourceControlCalls.length - 1];
+        assert.ok(lastCall, 'Expected $updateSourceControl to be called');
+        assert.strictEqual(lastCall.features.hasHistoryProvider, false);
+    });
+
+    it('onDidChangeCurrentHistoryItemRefs fires proxy notification', () => {
+        const onCurrentRefs = new Emitter<void>();
+        const onHistoryRefs = new Emitter<HistoryItemRefsChangeEvent>();
+        bridgeDisposables.push(onCurrentRefs);
+        bridgeDisposables.push(onHistoryRefs);
+
+        const provider = {
+            currentHistoryItemRef: { id: 'refs/heads/main', name: 'main' },
+            onDidChangeCurrentHistoryItemRefs: onCurrentRefs.event,
+            onDidChangeHistoryItemRefs: onHistoryRefs.event,
+            provideHistoryItemRefs: async () => [],
+            provideHistoryItems: async () => [],
+        };
+
+        bridge.setHistoryProvider(provider);
+        const callsBefore = bridge.onDidChangeCurrentHistoryItemRefsCalls.length;
+        onCurrentRefs.fire();
+
+        assert.strictEqual(bridge.onDidChangeCurrentHistoryItemRefsCalls.length, callsBefore + 1);
+    });
+
+    it('onDidChangeHistoryItemRefs fires proxy notification with mapped DTOs', () => {
+        const onCurrentRefs = new Emitter<void>();
+        const onHistoryRefs = new Emitter<HistoryItemRefsChangeEvent>();
+        bridgeDisposables.push(onCurrentRefs);
+        bridgeDisposables.push(onHistoryRefs);
+
+        const provider = {
+            currentHistoryItemRef: undefined,
+            onDidChangeCurrentHistoryItemRefs: onCurrentRefs.event,
+            onDidChangeHistoryItemRefs: onHistoryRefs.event,
+            provideHistoryItemRefs: async () => [],
+            provideHistoryItems: async () => [],
+        };
+
+        bridge.setHistoryProvider(provider);
+
+        const changeEvent: HistoryItemRefsChangeEvent = {
+            added: [{ id: 'refs/heads/feature', name: 'feature' }],
+            removed: [],
+            modified: [],
+        };
+        onHistoryRefs.fire(changeEvent);
+
+        assert.strictEqual(bridge.onDidChangeHistoryItemRefsCalls.length, 1);
+        assert.strictEqual(bridge.onDidChangeHistoryItemRefsCalls[0].event.added[0].id, 'refs/heads/feature');
+        assert.strictEqual(bridge.onDidChangeHistoryItemRefsCalls[0].event.added[0].name, 'feature');
+    });
+
+    it('provideHistoryItems delegates to historyProvider and maps results to DTOs', async () => {
+        const onCurrentRefs = new Emitter<void>();
+        const onHistoryRefs = new Emitter<HistoryItemRefsChangeEvent>();
+        bridgeDisposables.push(onCurrentRefs);
+        bridgeDisposables.push(onHistoryRefs);
+
+        const expectedItems: HistoryItem[] = [
+            {
+                id: 'abc123',
+                subject: 'Initial commit',
+                parentIds: [],
+                author: 'Test User',
+                authorEmail: 'test@example.com',
+                displayId: 'abc1234',
+                timestamp: 1700000000000,
+            }
+        ];
+
+        const provider = {
+            currentHistoryItemRef: undefined,
+            onDidChangeCurrentHistoryItemRefs: onCurrentRefs.event,
+            onDidChangeHistoryItemRefs: onHistoryRefs.event,
+            provideHistoryItemRefs: async () => [],
+            provideHistoryItems: async (_opts: HistoryOptions) => expectedItems,
+        };
+
+        bridge.setHistoryProvider(provider);
+
+        const result = await bridge.provideHistoryItems({ limit: 10 });
+
+        assert.ok(result, 'Expected result to be defined');
+        assert.strictEqual(result.length, 1);
+        assert.strictEqual(result[0].id, 'abc123');
+        assert.strictEqual(result[0].subject, 'Initial commit');
+        assert.strictEqual(result[0].author, 'Test User');
+        assert.strictEqual(result[0].displayId, 'abc1234');
+        assert.strictEqual(result[0].timestamp, 1700000000000);
+    });
+
+    it('provideHistoryItems returns undefined when no history provider set', async () => {
+        const result = await bridge.provideHistoryItems({ limit: 10 });
+        assert.strictEqual(result, undefined);
+    });
+
+    it('provideHistoryItemRefs delegates to historyProvider', async () => {
+        const onCurrentRefs = new Emitter<void>();
+        const onHistoryRefs = new Emitter<HistoryItemRefsChangeEvent>();
+        bridgeDisposables.push(onCurrentRefs);
+        bridgeDisposables.push(onHistoryRefs);
+
+        const expectedRefs: HistoryItemRef[] = [
+            { id: 'refs/heads/main', name: 'main' },
+            { id: 'refs/heads/feature', name: 'feature' },
+        ];
+
+        const provider = {
+            currentHistoryItemRef: undefined,
+            onDidChangeCurrentHistoryItemRefs: onCurrentRefs.event,
+            onDidChangeHistoryItemRefs: onHistoryRefs.event,
+            provideHistoryItemRefs: async () => expectedRefs,
+            provideHistoryItems: async () => [],
+        };
+
+        bridge.setHistoryProvider(provider);
+
+        const result = await bridge.provideHistoryItemRefs(undefined);
+
+        assert.ok(result, 'Expected result to be defined');
+        assert.strictEqual(result.length, 2);
+        assert.strictEqual(result[0].id, 'refs/heads/main');
+        assert.strictEqual(result[1].id, 'refs/heads/feature');
+    });
+});
+
+describe('SCM history command arg type guards and processors', () => {
+
+    describe('ScmHistoryItemCommandArg.is()', () => {
+        it('returns true for historyItem arg with all required fields', () => {
+            const arg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'abc', type: 'historyItem' };
+            assert.strictEqual(ScmHistoryItemCommandArg.is(arg), true);
+        });
+
+        it('returns true for historyItemRef arg with all required fields', () => {
+            const arg: ScmHistoryItemCommandArg = { sourceControlHandle: 1, id: 'refs/heads/main', type: 'historyItemRef' };
+            assert.strictEqual(ScmHistoryItemCommandArg.is(arg), true);
+        });
+
+        it('returns false for plain ScmCommandArg (sourceControlHandle only)', () => {
+            const arg: ScmCommandArg = { sourceControlHandle: 0 };
+            assert.strictEqual(ScmHistoryItemCommandArg.is(arg), false);
+        });
+
+        it('returns false for null and non-objects', () => {
+            assert.strictEqual(ScmHistoryItemCommandArg.is(undefined), false);
+            assert.strictEqual(ScmHistoryItemCommandArg.is('string'), false);
+            assert.strictEqual(ScmHistoryItemCommandArg.is(42), false);
+        });
+
+        it('returns false for object missing id field', () => {
+            assert.strictEqual(ScmHistoryItemCommandArg.is({ sourceControlHandle: 0, type: 'historyItem' }), false);
+        });
+
+        it('returns false for object missing sourceControlHandle', () => {
+            assert.strictEqual(ScmHistoryItemCommandArg.is({ id: 'abc', type: 'historyItem' }), false);
+        });
+
+        it('returns false for object missing type field', () => {
+            assert.strictEqual(ScmHistoryItemCommandArg.is({ sourceControlHandle: 0, id: 'abc' }), false);
+        });
+    });
+
+    describe('Guard specificity: ScmCommandArg.is() vs ScmHistoryItemCommandArg.is()', () => {
+        it('ScmCommandArg.is() matches history item args (broad guard)', () => {
+            // ScmCommandArg only checks for sourceControlHandle — it DOES match history args.
+            // This is why history processors are registered before the generic processor,
+            // so the more-specific guard wins by running first.
+            const historyItemArg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'abc', type: 'historyItem' };
+            assert.strictEqual(ScmCommandArg.is(historyItemArg), true,
+                'ScmCommandArg.is() matches history item args because it only checks sourceControlHandle');
+        });
+
+        it('ScmHistoryItemCommandArg.is() does NOT match plain ScmCommandArg', () => {
+            const plainArg: ScmCommandArg = { sourceControlHandle: 0 };
+            assert.strictEqual(ScmHistoryItemCommandArg.is(plainArg), false,
+                'ScmHistoryItemCommandArg.is() requires id and type to be present');
+        });
+    });
+
+    describe('History item argument processor', () => {
+        interface MockRef {
+            id: string;
+            name: string;
+        }
+
+        interface MockHistoryProvider {
+            id: string;
+            currentHistoryItemRef?: MockRef;
+            currentHistoryItemRemoteRef?: MockRef;
+            currentHistoryItemBaseRef?: MockRef;
+        }
+
+        interface MockSourceControl {
+            historyProvider: MockHistoryProvider | undefined;
+        }
+
+        function makeHistoryItemProcessor(
+            sourceControls: Map<number, MockSourceControl>
+        ): (arg: unknown) => unknown {
+            return (arg: unknown) => {
+                if (!ScmHistoryItemCommandArg.is(arg) || arg.type !== 'historyItem') {
+                    return arg;
+                }
+                const sourceControl = sourceControls.get(arg.sourceControlHandle);
+                if (!sourceControl?.historyProvider) {
+                    return undefined;
+                }
+                return { id: arg.id };
+            };
+        }
+
+        function makeHistoryItemRefProcessor(
+            sourceControls: Map<number, MockSourceControl>
+        ): (arg: unknown) => unknown {
+            return (arg: unknown) => {
+                if (!ScmHistoryItemCommandArg.is(arg) || arg.type !== 'historyItemRef') {
+                    return arg;
+                }
+                const sourceControl = sourceControls.get(arg.sourceControlHandle);
+                if (!sourceControl?.historyProvider) {
+                    return undefined;
+                }
+                const provider = sourceControl.historyProvider as any;
+                const ref = [provider.currentHistoryItemRef, provider.currentHistoryItemRemoteRef, provider.currentHistoryItemBaseRef]
+                    .find((r: any) => r?.id === arg.id);
+                return ref ?? { id: arg.id };
+            };
+        }
+
+        function makeGenericScmProcessor(sourceControls: Map<number, MockSourceControl>): (arg: unknown) => unknown {
+            return (arg: unknown) => {
+                if (!ScmCommandArg.is(arg)) {
+                    return arg;
+                }
+                const sourceControl = sourceControls.get(arg.sourceControlHandle);
+                if (!sourceControl) {
+                    return undefined;
+                }
+                return sourceControl;
+            };
+        }
+
+        it('history item processor returns { id } for a known history item', () => {
+            const sourceControls = new Map<number, MockSourceControl>();
+            sourceControls.set(0, { historyProvider: { id: 'git' } });
+
+            const processor = makeHistoryItemProcessor(sourceControls);
+            const arg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'abc123', type: 'historyItem' };
+            const result = processor(arg);
+
+            assert.deepStrictEqual(result, { id: 'abc123' });
+        });
+
+        it('history item processor returns undefined when source control has no historyProvider', () => {
+            const sourceControls = new Map<number, MockSourceControl>();
+            sourceControls.set(0, { historyProvider: undefined });
+
+            const processor = makeHistoryItemProcessor(sourceControls);
+            const arg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'abc123', type: 'historyItem' };
+            const result = processor(arg);
+
+            assert.strictEqual(result, undefined);
+        });
+
+        it('history item ref processor returns currentHistoryItemRef from provider when id matches', () => {
+            const currentRef = { id: 'refs/heads/main', name: 'main' };
+            const sourceControls = new Map<number, MockSourceControl>();
+            sourceControls.set(0, { historyProvider: { id: 'git', currentHistoryItemRef: currentRef } });
+
+            const processor = makeHistoryItemRefProcessor(sourceControls);
+            const arg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'refs/heads/main', type: 'historyItemRef' };
+            const result = processor(arg);
+
+            assert.strictEqual(result, currentRef, 'should return the exact provider ref object');
+        });
+
+        it('history item ref processor returns { id } when ref id is not among current provider refs', () => {
+            const sourceControls = new Map<number, MockSourceControl>();
+            sourceControls.set(0, { historyProvider: { id: 'git', currentHistoryItemRef: { id: 'refs/heads/main', name: 'main' } } });
+
+            const processor = makeHistoryItemRefProcessor(sourceControls);
+            const arg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'refs/heads/other', type: 'historyItemRef' };
+            const result = processor(arg);
+
+            assert.deepStrictEqual(result, { id: 'refs/heads/other' });
+        });
+
+        it('type discriminator: historyItem arg is NOT processed by ref processor', () => {
+            const sourceControls = new Map<number, MockSourceControl>();
+            const currentRef = { id: 'refs/heads/main', name: 'main' };
+            sourceControls.set(0, { historyProvider: { id: 'git', currentHistoryItemRef: currentRef } });
+
+            const refProcessor = makeHistoryItemRefProcessor(sourceControls);
+            const historyItemArg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'refs/heads/main', type: 'historyItem' };
+
+            // Even though the id matches a known ref, the type discriminator prevents the ref
+            // processor from consuming it — it should be passed through unchanged.
+            const result = refProcessor(historyItemArg);
+            assert.strictEqual(result, historyItemArg,
+                'ref processor must not consume an arg with type historyItem');
+        });
+
+        it('type discriminator: historyItemRef arg is NOT processed by item processor', () => {
+            const sourceControls = new Map<number, MockSourceControl>();
+            sourceControls.set(0, { historyProvider: { id: 'git' } });
+
+            const itemProcessor = makeHistoryItemProcessor(sourceControls);
+            const refArg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'refs/heads/main', type: 'historyItemRef' };
+
+            // The item processor must not consume an arg with type historyItemRef.
+            const result = itemProcessor(refArg);
+            assert.strictEqual(result, refArg,
+                'item processor must not consume an arg with type historyItemRef');
+        });
+
+        it('type discriminator fixes ordering bug: ref arg survives processor 1 intact', () => {
+            // Regression test for the ordering bug described in the task:
+            // Before the fix, Processor 1 (historyItem) would intercept the ref arg because
+            // both processors used the same ScmHistoryItemCommandArg.is() guard without
+            // checking the type discriminator. The ref arg would be "resolved" as a missing
+            // history item and returned as { id: ref.id }, stripping sourceControlHandle.
+            // Processor 2 would then fail to match (no sourceControlHandle) and pass through
+            // the degraded { id } object.
+            //
+            // With the fix, Processor 1 sees type === 'historyItemRef', skips, and passes the
+            // arg through unchanged so Processor 2 can correctly resolve it.
+            const sourceControls = new Map<number, MockSourceControl>();
+            const mainRef = { id: 'refs/heads/main', name: 'main' };
+            sourceControls.set(0, { historyProvider: { id: 'git', currentHistoryItemRef: mainRef } });
+
+            const itemProcessor = makeHistoryItemProcessor(sourceControls);
+            const refProcessor = makeHistoryItemRefProcessor(sourceControls);
+
+            const refArg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'refs/heads/main', type: 'historyItemRef' };
+
+            // Simulate the reduce chain: arg passes through processor 1, then processor 2
+            const afterP1 = itemProcessor(refArg);
+            // Processor 1 must pass it through unchanged (not strip sourceControlHandle)
+            assert.strictEqual(afterP1, refArg,
+                'Processor 1 must not consume the historyItemRef arg');
+
+            const afterP2 = refProcessor(afterP1 as ScmHistoryItemCommandArg);
+            // Processor 2 must resolve it to the full ref object
+            assert.strictEqual(afterP2, mainRef,
+                'Processor 2 must resolve the ref arg to the full SourceControlHistoryItemRef');
+        });
+
+        it('discriminated interface works for both history items and refs: type field routes correctly', () => {
+            const sourceControls = new Map<number, MockSourceControl>();
+            const remoteRef = { id: 'refs/remotes/origin/main', name: 'origin/main' };
+            sourceControls.set(1, { historyProvider: { id: 'git', currentHistoryItemRemoteRef: remoteRef } });
+
+            const historyItemArg: ScmHistoryItemCommandArg = { sourceControlHandle: 1, id: 'deadbeef', type: 'historyItem' };
+            const historyRefArg: ScmHistoryItemCommandArg = { sourceControlHandle: 1, id: 'refs/remotes/origin/main', type: 'historyItemRef' };
+
+            // Both are valid ScmHistoryItemCommandArg
+            assert.strictEqual(ScmHistoryItemCommandArg.is(historyItemArg), true);
+            assert.strictEqual(ScmHistoryItemCommandArg.is(historyRefArg), true);
+
+            // Item processor resolves a commit by id (skips ref arg)
+            const itemProcessor = makeHistoryItemProcessor(sourceControls);
+            assert.deepStrictEqual(itemProcessor(historyItemArg), { id: 'deadbeef' });
+            assert.strictEqual(itemProcessor(historyRefArg), historyRefArg,
+                'item processor must pass through historyItemRef args unchanged');
+
+            // Ref processor resolves a ref by id (skips item arg)
+            const refProcessor = makeHistoryItemRefProcessor(sourceControls);
+            assert.strictEqual(refProcessor(historyRefArg), remoteRef);
+            assert.strictEqual(refProcessor(historyItemArg), historyItemArg,
+                'ref processor must pass through historyItem args unchanged');
+        });
+
+        it('generic ScmCommandArg processor does NOT match history item args (guard specificity)', () => {
+            // Because we rely on registration order (history processors run first),
+            // verify here that if the generic processor receives a history item arg,
+            // it would treat it as a plain ScmCommandArg and NOT pass it through unchanged.
+            const sourceControls = new Map<number, MockSourceControl>();
+            sourceControls.set(0, { historyProvider: { id: 'git' } });
+
+            const genericProcessor = makeGenericScmProcessor(sourceControls);
+            const historyItemArg: ScmHistoryItemCommandArg = { sourceControlHandle: 0, id: 'abc123', type: 'historyItem' };
+
+            // The generic processor DOES match (ScmCommandArg.is() is true for history args),
+            // but it returns the sourceControl object — not the historyItem shape.
+            // This confirms why history processors must be registered first.
+            const result = genericProcessor(historyItemArg);
+            assert.ok(result !== undefined, 'Generic processor matched history item arg');
+            assert.ok(!('id' in (result as object) && Object.keys(result as object).length === 1),
+                'Generic processor should NOT return the history item shape { id }');
+        });
+
+        it('history item processor passes through non-matching args unchanged', () => {
+            const sourceControls = new Map<number, MockSourceControl>();
+            const processor = makeHistoryItemProcessor(sourceControls);
+
+            const plainArg: ScmCommandArg = { sourceControlHandle: 42 };
+            const result = processor(plainArg);
+
+            // Not a ScmHistoryItemCommandArg (missing 'id' and 'type'), so returned unchanged
+            assert.strictEqual(result, plainArg);
+        });
+    });
+});
+

--- a/packages/plugin-ext/src/plugin/scm.spec.ts
+++ b/packages/plugin-ext/src/plugin/scm.spec.ts
@@ -53,9 +53,10 @@ interface HistoryItem {
 }
 
 interface HistoryOptions {
-    readonly cursor?: string;
-    readonly limit?: number | { id: string };
+    readonly skip?: number;
+    readonly limit?: number | { id?: string };
     readonly historyItemRefs?: readonly string[];
+    readonly filterText?: string;
 }
 
 /**

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -28,16 +28,22 @@ import {
     ScmMain, ScmRawResource, ScmRawResourceGroup,
     ScmRawResourceSplice, ScmRawResourceSplices,
     SourceControlGroupFeatures,
-    ScmActionButton
+    ScmActionButton,
+    ScmHistoryItemRefDto,
+    ScmHistoryItemDto,
+    ScmHistoryItemChangeDto,
+    ScmHistoryOptionsDto,
+    ScmHistoryItemRefsChangeEventDto
 } from '../common';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
 import { CommandRegistryImpl } from '../plugin/command-registry';
 import { Splice } from '../common/arrays';
 import { UriComponents } from '../common/uri-components';
 import { Command } from '../common/plugin-api-rpc-model';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { URI, ThemeIcon } from './types-impl';
-import { ScmCommandArg } from '../common/plugin-api-rpc';
+import { ScmCommandArg, ScmHistoryItemCommandArg } from '../common/plugin-api-rpc';
 import { sep } from '@theia/core/lib/common/paths';
 import { PluginIconPath } from './plugin-icon-path';
 import { createAPIObject } from './plugin-context';
@@ -538,6 +544,47 @@ class ScmResourceGroupImpl implements theia.SourceControlResourceGroup {
     }
 }
 
+function historyItemRefToDto(ref: theia.SourceControlHistoryItemRef): ScmHistoryItemRefDto {
+    return {
+        id: ref.id,
+        name: ref.name,
+        description: ref.description,
+        revision: ref.revision,
+        icon: ref.icon,
+        category: ref.category,
+    };
+}
+
+function historyItemToDto(item: theia.SourceControlHistoryItem): ScmHistoryItemDto {
+    return {
+        id: item.id,
+        parentIds: item.parentIds ? [...item.parentIds] : undefined,
+        subject: item.subject,
+        message: item.message,
+        author: item.author,
+        authorEmail: item.authorEmail,
+        authorIcon: item.authorIcon,
+        displayId: item.displayId,
+        timestamp: item.timestamp,
+        tooltip: item.tooltip,
+        statistics: item.statistics ? {
+            files: item.statistics.files,
+            insertions: item.statistics.insertions,
+            deletions: item.statistics.deletions,
+        } : undefined,
+        references: item.references ? item.references.map(historyItemRefToDto) : undefined,
+    };
+}
+
+function historyItemChangeToDto(change: theia.SourceControlHistoryItemChange): ScmHistoryItemChangeDto {
+    return {
+        uri: change.uri,
+        originalUri: change.originalUri,
+        modifiedUri: change.modifiedUri,
+        renameUri: change.renameUri,
+    };
+}
+
 class SourceControlImpl implements theia.SourceControl {
 
     private static handlePool: number = 0;
@@ -689,6 +736,53 @@ class SourceControlImpl implements theia.SourceControl {
         this.proxy.$updateSourceControl(this.handle, { contextValue });
     }
 
+    private _historyProvider: theia.SourceControlHistoryProvider | undefined = undefined;
+    private _historyProviderDisposables = new DisposableCollection();
+
+    readonly historyItems = new Map<string, theia.SourceControlHistoryItem>();
+    readonly historyItemRefs = new Map<string, theia.SourceControlHistoryItemRef>();
+
+    get historyProvider(): theia.SourceControlHistoryProvider | undefined {
+        return this._historyProvider;
+    }
+
+    set historyProvider(provider: theia.SourceControlHistoryProvider | undefined) {
+        this._historyProviderDisposables.dispose();
+        this._historyProviderDisposables = new DisposableCollection();
+        this._historyProvider = provider;
+
+        if (provider) {
+            this._historyProviderDisposables.push(
+                provider.onDidChangeCurrentHistoryItemRefs(() => {
+                    this.proxy.$updateSourceControl(this.handle, {
+                        hasHistoryProvider: true,
+                        currentHistoryItemRef: provider.currentHistoryItemRef ? historyItemRefToDto(provider.currentHistoryItemRef) : undefined,
+                        currentHistoryItemRemoteRef: provider.currentHistoryItemRemoteRef ? historyItemRefToDto(provider.currentHistoryItemRemoteRef) : undefined,
+                        currentHistoryItemBaseRef: provider.currentHistoryItemBaseRef ? historyItemRefToDto(provider.currentHistoryItemBaseRef) : undefined,
+                    });
+                    this.proxy.$onDidChangeCurrentHistoryItemRefs(this.handle);
+                })
+            );
+            this._historyProviderDisposables.push(
+                provider.onDidChangeHistoryItemRefs(event => {
+                    const dto: ScmHistoryItemRefsChangeEventDto = {
+                        added: event.added.map(historyItemRefToDto),
+                        removed: event.removed.map(historyItemRefToDto),
+                        modified: event.modified.map(historyItemRefToDto),
+                    };
+                    this.proxy.$onDidChangeHistoryItemRefs(this.handle, dto);
+                })
+            );
+        }
+
+        this.proxy.$updateSourceControl(this.handle, {
+            hasHistoryProvider: !!provider,
+            currentHistoryItemRef: provider?.currentHistoryItemRef ? historyItemRefToDto(provider.currentHistoryItemRef) : undefined,
+            currentHistoryItemRemoteRef: provider?.currentHistoryItemRemoteRef ? historyItemRefToDto(provider.currentHistoryItemRemoteRef) : undefined,
+            currentHistoryItemBaseRef: provider?.currentHistoryItemBaseRef ? historyItemRefToDto(provider.currentHistoryItemBaseRef) : undefined,
+        });
+    }
+
     private readonly onDidDisposeEmitter = new Emitter<void>();
     readonly onDidDispose = this.onDidDisposeEmitter.event;
 
@@ -783,6 +877,14 @@ class SourceControlImpl implements theia.SourceControl {
         return this.groups.get(handle);
     }
 
+    getHistoryItem(id: string): theia.SourceControlHistoryItem | undefined {
+        return this.historyItems.get(id);
+    }
+
+    getHistoryItemRef(id: string): theia.SourceControlHistoryItemRef | undefined {
+        return this.historyItemRefs.get(id);
+    }
+
     setSelectionState(selected: boolean): void {
         this._selected = selected;
         this.onDidChangeSelectionEmitter.fire(selected);
@@ -792,6 +894,7 @@ class SourceControlImpl implements theia.SourceControl {
         this.acceptInputDisposables.dispose();
         this._statusBarDisposables.dispose();
         this._actionButtonDisposables.dispose();
+        this._historyProviderDisposables.dispose();
 
         this.groups.forEach(group => group.dispose());
         this.proxy.$unregisterSourceControl(this.handle);
@@ -816,6 +919,32 @@ export class ScmExtImpl implements ScmExt {
 
     constructor(rpc: RPCProtocol, private commands: CommandRegistryImpl) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.SCM_MAIN);
+
+        // Register history item arg processor before the generic ScmCommandArg processor
+        // so the more-specific guard matches first.
+        commands.registerArgumentProcessor({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            processArgument: (arg: any) => {
+                if (!ScmHistoryItemCommandArg.is(arg) || arg.type !== 'historyItem') {
+                    return arg;
+                }
+                const sourceControl = this.sourceControls.get(arg.sourceControlHandle);
+                const item = sourceControl?.getHistoryItem(arg.id);
+                return item ?? { id: arg.id };
+            }
+        });
+
+        commands.registerArgumentProcessor({
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            processArgument: (arg: any) => {
+                if (!ScmHistoryItemCommandArg.is(arg) || arg.type !== 'historyItemRef') {
+                    return arg;
+                }
+                const sourceControl = this.sourceControls.get(arg.sourceControlHandle);
+                const ref = sourceControl?.getHistoryItemRef(arg.id);
+                return ref ?? { id: arg.id };
+            }
+        });
 
         commands.registerArgumentProcessor({
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -940,6 +1069,73 @@ export class ScmExtImpl implements ScmExt {
             return Promise.resolve(undefined);
         }
         return [result.message, result.type];
+    }
+
+    async $provideHistoryItemRefs(sourceControlHandle: number, historyItemRefs: string[] | undefined, token: CancellationToken): Promise<ScmHistoryItemRefDto[] | undefined> {
+        const sourceControl = this.sourceControls.get(sourceControlHandle);
+        if (!sourceControl || !sourceControl.historyProvider) {
+            return undefined;
+        }
+        const result = await sourceControl.historyProvider.provideHistoryItemRefs(historyItemRefs, token);
+        if (!result) {
+            return undefined;
+        }
+        sourceControl.historyItemRefs.clear();
+        for (const ref of result) {
+            sourceControl.historyItemRefs.set(ref.id, ref);
+        }
+        return result.map(historyItemRefToDto);
+    }
+
+    async $provideHistoryItems(sourceControlHandle: number, options: ScmHistoryOptionsDto, token: CancellationToken): Promise<ScmHistoryItemDto[] | undefined> {
+        const sourceControl = this.sourceControls.get(sourceControlHandle);
+        if (!sourceControl || !sourceControl.historyProvider) {
+            return undefined;
+        }
+        const result = await sourceControl.historyProvider.provideHistoryItems(options, token);
+        if (!result) {
+            return undefined;
+        }
+        for (const item of result) {
+            sourceControl.historyItems.set(item.id, item);
+        }
+        return result.map(historyItemToDto);
+    }
+
+    async $provideHistoryItemChanges(
+        sourceControlHandle: number, historyItemId: string,
+        historyItemParentId: string | undefined, token: CancellationToken
+    ): Promise<ScmHistoryItemChangeDto[] | undefined> {
+        const sourceControl = this.sourceControls.get(sourceControlHandle);
+        if (!sourceControl || !sourceControl.historyProvider) {
+            return undefined;
+        }
+        const result = await sourceControl.historyProvider.provideHistoryItemChanges(historyItemId, historyItemParentId, token);
+        if (!result) {
+            return undefined;
+        }
+        return result.map(historyItemChangeToDto);
+    }
+
+    async $resolveHistoryItem(sourceControlHandle: number, historyItemId: string, token: CancellationToken): Promise<ScmHistoryItemDto | undefined> {
+        const sourceControl = this.sourceControls.get(sourceControlHandle);
+        if (!sourceControl || !sourceControl.historyProvider) {
+            return undefined;
+        }
+        const result = await sourceControl.historyProvider.resolveHistoryItem(historyItemId, token);
+        if (!result) {
+            return undefined;
+        }
+        return historyItemToDto(result);
+    }
+
+    async $resolveHistoryItemRefsCommonAncestor(sourceControlHandle: number, historyItemRefs: string[], token: CancellationToken): Promise<string | undefined> {
+        const sourceControl = this.sourceControls.get(sourceControlHandle);
+        if (!sourceControl || !sourceControl.historyProvider) {
+            return undefined;
+        }
+        const result = await sourceControl.historyProvider.resolveHistoryItemRefsCommonAncestor(historyItemRefs, token);
+        return result ?? undefined;
     }
 
     $setSelectedSourceControl(selectedSourceControlHandle: number | undefined): Promise<void> {

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12711,6 +12711,69 @@ export module '@theia/plugin' {
         readonly description?: string;
     }
 
+    export interface SourceControlHistoryItemRef {
+        readonly id: string;
+        readonly name: string;
+        readonly description?: string;
+        readonly revision?: string;
+        readonly icon?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+        readonly category?: string;
+    }
+
+    export interface SourceControlHistoryItemRefsChangeEvent {
+        readonly added: readonly SourceControlHistoryItemRef[];
+        readonly removed: readonly SourceControlHistoryItemRef[];
+        readonly modified: readonly SourceControlHistoryItemRef[];
+    }
+
+    export interface SourceControlHistoryOptions {
+        readonly cursor?: string;
+        readonly limit?: number | { id: string };
+        readonly historyItemRefs?: readonly string[];
+    }
+
+    export interface SourceControlHistoryItemStatistics {
+        readonly files: number;
+        readonly insertions: number;
+        readonly deletions: number;
+    }
+
+    export interface SourceControlHistoryItem {
+        readonly id: string;
+        readonly parentIds?: readonly string[];
+        readonly subject: string;
+        readonly message?: string | MarkdownString;
+        readonly author?: string;
+        readonly authorEmail?: string;
+        readonly authorIcon?: Uri | { light: Uri; dark: Uri } | ThemeIcon;
+        readonly displayId?: string;
+        readonly timestamp?: number;
+        readonly statistics?: SourceControlHistoryItemStatistics;
+        readonly references?: readonly SourceControlHistoryItemRef[];
+        readonly tooltip?: string | MarkdownString;
+    }
+
+    export interface SourceControlHistoryItemChange {
+        readonly uri: Uri;
+        readonly originalUri?: Uri;
+        readonly modifiedUri?: Uri;
+        readonly renameUri?: Uri;
+    }
+
+    export interface SourceControlHistoryProvider {
+        readonly currentHistoryItemRef?: SourceControlHistoryItemRef;
+        readonly currentHistoryItemRemoteRef?: SourceControlHistoryItemRef;
+        readonly currentHistoryItemBaseRef?: SourceControlHistoryItemRef;
+        readonly onDidChangeCurrentHistoryItemRefs: Event<void>;
+        readonly onDidChangeHistoryItemRefs: Event<SourceControlHistoryItemRefsChangeEvent>;
+
+        provideHistoryItemRefs(historyItemRefs: string[] | undefined, token: CancellationToken): ProviderResult<SourceControlHistoryItemRef[]>;
+        provideHistoryItems(options: SourceControlHistoryOptions, token: CancellationToken): ProviderResult<SourceControlHistoryItem[]>;
+        provideHistoryItemChanges(historyItemId: string, historyItemParentId: string | undefined, token: CancellationToken): ProviderResult<SourceControlHistoryItemChange[]>;
+        resolveHistoryItem(historyItemId: string, token: CancellationToken): ProviderResult<SourceControlHistoryItem>;
+        resolveHistoryItemRefsCommonAncestor(historyItemRefs: string[], token: CancellationToken): ProviderResult<string>;
+    }
+
     /**
      * An source control is able to provide {@link SourceControlResourceState resource states}
      * to the editor and interact with the editor in several source control related ways.
@@ -12783,6 +12846,11 @@ export module '@theia/plugin' {
          * Optional action button displayed under the source control's input box.
          */
         actionButton?: ScmActionButton;
+
+        /**
+         * Optional history provider.
+         */
+        historyProvider?: SourceControlHistoryProvider;
 
         /**
          * Dispose this source control.

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12727,9 +12727,10 @@ export module '@theia/plugin' {
     }
 
     export interface SourceControlHistoryOptions {
-        readonly cursor?: string;
-        readonly limit?: number | { id: string };
+        readonly skip?: number;
+        readonly limit?: number | { id?: string };
         readonly historyItemRefs?: readonly string[];
+        readonly filterText?: string;
     }
 
     export interface SourceControlHistoryItemStatistics {

--- a/packages/scm/src/browser/scm-context-key-service.ts
+++ b/packages/scm/src/browser/scm-context-key-service.ts
@@ -48,6 +48,21 @@ export class ScmContextKeyService {
         return this._scmProviderCount;
     }
 
+    protected _scmHistoryItemRef: ContextKey<string | undefined>;
+    get scmHistoryItemRef(): ContextKey<string | undefined> {
+        return this._scmHistoryItemRef;
+    }
+
+    protected _scmCurrentHistoryItemRefHasRemote: ContextKey<boolean>;
+    get scmCurrentHistoryItemRefHasRemote(): ContextKey<boolean> {
+        return this._scmCurrentHistoryItemRefHasRemote;
+    }
+
+    protected _scmCurrentHistoryItemRefHasBase: ContextKey<boolean>;
+    get scmCurrentHistoryItemRefHasBase(): ContextKey<boolean> {
+        return this._scmCurrentHistoryItemRefHasBase;
+    }
+
     @postConstruct()
     protected init(): void {
         this._scmProvider = this.contextKeyService.createKey<string | undefined>('scmProvider', undefined);
@@ -55,6 +70,9 @@ export class ScmContextKeyService {
         this._scmResourceGroup = this.contextKeyService.createKey<string | undefined>('scmResourceGroup', undefined);
         this._scmResourceGroupState = this.contextKeyService.createKey<string | undefined>('scmResourceGroupState', undefined);
         this._scmProviderCount = this.contextKeyService.createKey<number>('scm.providerCount', 0);
+        this._scmHistoryItemRef = this.contextKeyService.createKey<string | undefined>('scmHistoryItemRef', undefined);
+        this._scmCurrentHistoryItemRefHasRemote = this.contextKeyService.createKey<boolean>('scmCurrentHistoryItemRefHasRemote', false);
+        this._scmCurrentHistoryItemRefHasBase = this.contextKeyService.createKey<boolean>('scmCurrentHistoryItemRefHasBase', false);
     }
 
     match(expression: string | undefined): boolean {

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -455,10 +455,10 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
             {
                 id: 'scmGraph.historyItemRefForeground',
                 defaults: {
-                    dark: 'badge.foreground',
-                    light: 'badge.foreground',
-                    hcDark: 'badge.foreground',
-                    hcLight: 'badge.foreground'
+                    dark: '#ffffff',
+                    light: '#ffffff',
+                    hcDark: '#ffffff',
+                    hcLight: '#ffffff'
                 },
                 description: 'Foreground color for ref badge labels in the SCM history graph.'
             },

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -411,6 +411,147 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
      */
     registerColors(colors: ColorRegistry): void {
         colors.register(
+            // SCM Graph lane colors (matching VS Code's scm.graph.* color IDs)
+            {
+                id: 'scmGraph.historyItemHoverDefaultLabelForeground',
+                defaults: {
+                    dark: '#0078d4',
+                    light: '#0078d4',
+                    hcDark: '#0078d4',
+                    hcLight: '#0078d4'
+                },
+                description: 'Default foreground color for history item labels in the SCM history graph on hover.'
+            },
+            {
+                id: 'scmGraph.historyItemHoverAdditionsForeground',
+                defaults: {
+                    dark: '#81b88b',
+                    light: '#388a34',
+                    hcDark: '#81b88b',
+                    hcLight: '#388a34'
+                },
+                description: 'Foreground color for additions in the SCM history graph on hover.'
+            },
+            {
+                id: 'scmGraph.historyItemHoverDeletionsForeground',
+                defaults: {
+                    dark: '#c74e39',
+                    light: '#a1260d',
+                    hcDark: '#c74e39',
+                    hcLight: '#a1260d'
+                },
+                description: 'Foreground color for deletions in the SCM history graph on hover.'
+            },
+            {
+                id: 'scmGraph.historyItemHoverLabelForeground',
+                defaults: {
+                    dark: '#e2e2e2',
+                    light: '#3b3b3b',
+                    hcDark: '#ffffff',
+                    hcLight: '#000000'
+                },
+                description: 'Foreground color for labels in the SCM history graph on hover.'
+            },
+            {
+                id: 'scmGraph.historyItemRefForeground',
+                defaults: {
+                    dark: 'badge.foreground',
+                    light: 'badge.foreground',
+                    hcDark: 'badge.foreground',
+                    hcLight: 'badge.foreground'
+                },
+                description: 'Foreground color for ref badge labels in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.historyItemRefColor',
+                defaults: {
+                    dark: '#0078d4',
+                    light: '#0078d4',
+                    hcDark: '#0078d4',
+                    hcLight: '#0078d4'
+                },
+                description: 'Color for ref labels in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.historyItemRemoteRefColor',
+                defaults: {
+                    dark: '#b267e6',
+                    light: '#8b009b',
+                    hcDark: '#b267e6',
+                    hcLight: '#8b009b'
+                },
+                description: 'Color for remote ref labels in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.historyItemTagRefColor',
+                defaults: {
+                    dark: '#d7ba7d',
+                    light: '#8d6914',
+                    hcDark: '#d7ba7d',
+                    hcLight: '#8d6914'
+                },
+                description: 'Color for tag ref labels in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.historyItemBaseRefColor',
+                defaults: {
+                    dark: '#a1260d',
+                    light: '#a1260d',
+                    hcDark: '#a1260d',
+                    hcLight: '#a1260d'
+                },
+                description: 'Color for base ref labels in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.foreground1',
+                defaults: {
+                    dark: '#ffb000',
+                    light: '#ffb000',
+                    hcDark: '#ffb000',
+                    hcLight: '#ffb000'
+                },
+                description: 'Foreground color 1 for additional lanes in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.foreground2',
+                defaults: {
+                    dark: '#dc267f',
+                    light: '#dc267f',
+                    hcDark: '#dc267f',
+                    hcLight: '#dc267f'
+                },
+                description: 'Foreground color 2 for additional lanes in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.foreground3',
+                defaults: {
+                    dark: '#994f00',
+                    light: '#994f00',
+                    hcDark: '#994f00',
+                    hcLight: '#994f00'
+                },
+                description: 'Foreground color 3 for additional lanes in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.foreground4',
+                defaults: {
+                    dark: '#40b0a6',
+                    light: '#40b0a6',
+                    hcDark: '#40b0a6',
+                    hcLight: '#40b0a6'
+                },
+                description: 'Foreground color 4 for additional lanes in the SCM history graph.'
+            },
+            {
+                id: 'scmGraph.foreground5',
+                defaults: {
+                    dark: '#b66dff',
+                    light: '#b66dff',
+                    hcDark: '#b66dff',
+                    hcLight: '#b66dff'
+                },
+                description: 'Foreground color 5 for additional lanes in the SCM history graph.'
+            },
             {
                 id: ScmColors.editorGutterModifiedBackground, defaults: {
                     dark: '#1B81A8',

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -45,6 +45,8 @@ import { LabelProviderContribution } from '@theia/core/lib/browser/label-provide
 import { bindScmPreferences } from '../common/scm-preferences';
 import { bindMergeEditor } from './merge-editor/merge-editor-module';
 import { ScmRepositoriesWidget } from './scm-repositories-widget';
+import { ScmHistoryGraphWidget } from './scm-history-graph-widget';
+import { ScmHistoryGraphModel } from './scm-history-graph-model';
 
 export default new ContainerModule(bind => {
     bind(ScmContextKeyService).toSelf().inSingletonScope();
@@ -88,6 +90,13 @@ export default new ContainerModule(bind => {
         createWidget: () => container.get(ScmRepositoriesWidget)
     })).inSingletonScope();
 
+    bind(ScmHistoryGraphModel).toSelf().inSingletonScope();
+    bind(ScmHistoryGraphWidget).toSelf();
+    bind(WidgetFactory).toDynamicValue(({ container }) => ({
+        id: ScmHistoryGraphWidget.ID,
+        createWidget: () => container.get(ScmHistoryGraphWidget)
+    })).inSingletonScope();
+
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
         id: SCM_VIEW_CONTAINER_ID,
         createWidget: async () => {
@@ -109,6 +118,12 @@ export default new ContainerModule(bind => {
                 order: 1,
                 canHide: false,
                 initiallyCollapsed: false
+            });
+            const graphWidget = await widgetManager.getOrCreateWidget(ScmHistoryGraphWidget.ID);
+            viewContainer.addWidget(graphWidget, {
+                order: 2,
+                canHide: true,
+                initiallyCollapsed: true
             });
             return viewContainer;
         }

--- a/packages/scm/src/browser/scm-history-graph-helpers.ts
+++ b/packages/scm/src/browser/scm-history-graph-helpers.ts
@@ -1,0 +1,175 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ScmHistoryItemRef, ScmHistoryItemChange } from './scm-provider';
+
+/**
+ * Returns the CSS color variable for the given lane index.
+ * Uses Theia's `--theia-scmGraph-*` variables, mirroring the VS Code
+ * scm graph color scheme:
+ *   lane 0 (current ref)  → historyItemRefColor
+ *   lane 1 (remote ref)   → historyItemRemoteRefColor
+ *   lane 2 (base ref)     → historyItemBaseRefColor
+ *   lane 3–7              → foreground1–5
+ */
+export function laneColor(index: number): string {
+    switch (index % 8) {
+        case 0: return 'var(--theia-scmGraph-historyItemRefColor)';
+        case 1: return 'var(--theia-scmGraph-historyItemRemoteRefColor)';
+        case 2: return 'var(--theia-scmGraph-historyItemBaseRefColor)';
+        case 3: return 'var(--theia-scmGraph-foreground1)';
+        case 4: return 'var(--theia-scmGraph-foreground2)';
+        case 5: return 'var(--theia-scmGraph-foreground3)';
+        case 6: return 'var(--theia-scmGraph-foreground4)';
+        default: return 'var(--theia-scmGraph-foreground5)';
+    }
+}
+
+export function getChangeStatus(change: ScmHistoryItemChange): string {
+    if (!change.originalUri) {
+        return 'A';
+    }
+    if (!change.modifiedUri) {
+        return 'D';
+    }
+    if (change.renameUri) {
+        return 'R';
+    }
+    return 'M';
+}
+
+export function getFileName(uri: string): string {
+    const parts = uri.split('/');
+    return parts[parts.length - 1] || uri;
+}
+
+export function getFilePath(uri: string): string {
+    try {
+        const u = new URL(uri);
+        return u.pathname;
+    } catch {
+        return uri;
+    }
+}
+
+/**
+ * Returns the repo-relative path of the given URI, stripping the rootUri prefix.
+ * Falls back to the full path if rootUri is unavailable or doesn't match.
+ */
+export function getRepoRelativePath(uri: string, rootUri: string | undefined): string {
+    const fullPath = getFilePath(uri);
+    if (!rootUri) {
+        return fullPath;
+    }
+    const rootPath = getFilePath(rootUri);
+    // Normalize: ensure rootPath ends with '/'
+    const rootPrefix = rootPath.endsWith('/') ? rootPath : rootPath + '/';
+    if (fullPath.startsWith(rootPrefix)) {
+        return fullPath.slice(rootPrefix.length);
+    }
+    return fullPath;
+}
+
+export function getRefBadgeClass(ref: ScmHistoryItemRef): string {
+    const cat = (ref.category ?? '').toLowerCase();
+    if (cat === 'heads' || cat === 'head' || ref.id.startsWith('refs/heads/')) {
+        return 'head';
+    }
+    if (cat === 'remotes' || cat === 'remote' || ref.id.startsWith('refs/remotes/')) {
+        return 'remote';
+    }
+    if (cat === 'tags' || cat === 'tag' || ref.id.startsWith('refs/tags/')) {
+        return 'tag';
+    }
+    if (cat === 'base') {
+        return 'base';
+    }
+    return 'head';
+}
+
+export function isTagRef(ref: ScmHistoryItemRef): boolean {
+    const cat = (ref.category ?? '').toLowerCase();
+    if (cat === 'tags' || cat === 'tag') {
+        return true;
+    }
+    // Fall back to checking the ref id prefix (e.g. 'refs/tags/v1.0')
+    return ref.id.startsWith('refs/tags/');
+}
+
+export function isRemoteRef(ref: ScmHistoryItemRef): boolean {
+    const cat = (ref.category ?? '').toLowerCase();
+    if (cat === 'remotes' || cat === 'remote') {
+        return true;
+    }
+    // Fall back to checking the ref id prefix (e.g. 'refs/remotes/origin/main')
+    return ref.id.startsWith('refs/remotes/');
+}
+
+/**
+ * Extracts the local branch name from a remote ref name like "origin/master" → "master".
+ * Falls back to the full name if no slash is found.
+ */
+export function getLocalNameFromRemote(remoteName: string): string {
+    const slashIdx = remoteName.indexOf('/');
+    return slashIdx >= 0 ? remoteName.slice(slashIdx + 1) : remoteName;
+}
+
+export interface DeduplicatedRef {
+    ref: ScmHistoryItemRef;
+    /** True when both a local and a remote ref for this branch exist on this commit. */
+    hasBoth: boolean;
+}
+
+/**
+ * Deduplicates refs: when a local branch (e.g. "master") and a remote branch
+ * (e.g. "origin/master") both appear, collapse them into one entry with `hasBoth=true`.
+ * Tags and other ref types are passed through unchanged.
+ */
+export function deduplicateRefs(refs: readonly ScmHistoryItemRef[]): DeduplicatedRef[] {
+    const localNames = new Set<string>();
+    for (const ref of refs) {
+        if (!isRemoteRef(ref) && !isTagRef(ref)) {
+            localNames.add(ref.name.toLowerCase());
+        }
+    }
+
+    const result: DeduplicatedRef[] = [];
+    const suppressedRemotes = new Set<string>();
+
+    // First pass: identify remote refs that have a matching local branch
+    for (const ref of refs) {
+        if (isRemoteRef(ref)) {
+            const localName = getLocalNameFromRemote(ref.name).toLowerCase();
+            if (localNames.has(localName)) {
+                suppressedRemotes.add(ref.id);
+            }
+        }
+    }
+
+    // Second pass: emit all refs except suppressed remote ones;
+    // mark local branches that have a matching remote with hasBoth=true
+    for (const ref of refs) {
+        if (suppressedRemotes.has(ref.id)) {
+            continue;
+        }
+        const hasBoth = !isRemoteRef(ref) && !isTagRef(ref)
+            ? refs.some(r => isRemoteRef(r) && getLocalNameFromRemote(r.name).toLowerCase() === ref.name.toLowerCase())
+            : false;
+        result.push({ ref, hasBoth });
+    }
+
+    return result;
+}

--- a/packages/scm/src/browser/scm-history-graph-lanes.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-lanes.spec.ts
@@ -1,0 +1,635 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { computeGraphRows } from './scm-history-graph-lanes';
+
+describe('computeGraphRows', () => {
+
+    function lanes(commits: { id: string; parentIds?: string[] }[]): number[] {
+        return computeGraphRows(commits).map(r => r.lane);
+    }
+
+    // -------------------------------------------------------------------------
+    // Linear history
+    // -------------------------------------------------------------------------
+    describe('linear history', () => {
+        const commits = [
+            { id: 'C', parentIds: ['B'] },
+            { id: 'B', parentIds: ['A'] },
+            { id: 'A', parentIds: [] },
+        ];
+
+        it('all commits stay in lane 0', () => {
+            expect(lanes(commits)).to.deep.equal([0, 0, 0]);
+        });
+
+        it('colors are all 0', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows.map(r => r.color)).to.deep.equal([0, 0, 0]);
+        });
+
+        it('first parent same-lane continuation emits no separate edge (handled by commit line)', () => {
+            const rows = computeGraphRows(commits);
+            // Row 0 (C): first parent B is in the same lane — no edge emitted
+            // Only pass-through edges from other lanes (none here) are emitted
+            const edgesC = rows[0].edges.filter(e => e.fromLane === 0 && e.toLane === 0);
+            expect(edgesC.length).to.equal(0);
+        });
+
+        it('root commit (A) emits no edges', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[2].edges).to.be.empty;
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Single branch + merge
+    // -------------------------------------------------------------------------
+    describe('branch and merge', () => {
+        //   M  ← merge commit (parents: D, E)
+        //   |\
+        //   D  E  ← two parallel commits
+        //   |  |
+        //   B  B  (same B — E's parent is B too)
+        //    \ |
+        //     B
+        //     |
+        //     A
+        //
+        // Topological order (newest first): M, D, E, B, A
+        const commits = [
+            { id: 'M', parentIds: ['D', 'E'] },
+            { id: 'D', parentIds: ['B'] },
+            { id: 'E', parentIds: ['B'] },
+            { id: 'B', parentIds: ['A'] },
+            { id: 'A', parentIds: [] },
+        ];
+
+        it('merge commit M is in lane 0', () => {
+            expect(lanes(commits)[0]).to.equal(0);
+        });
+
+        it('D (first parent) stays in lane 0', () => {
+            expect(lanes(commits)[1]).to.equal(0);
+        });
+
+        it('E (second parent) is in a different lane', () => {
+            expect(lanes(commits)[2]).to.not.equal(0);
+        });
+
+        it('B and A eventually converge back to lane 0', () => {
+            const ls = lanes(commits);
+            // B must be in lane 0 (first parent chain)
+            expect(ls[3]).to.equal(0);
+            // A also stays in lane 0
+            expect(ls[4]).to.equal(0);
+        });
+
+        it('M emits a branch-out edge for second parent E', () => {
+            const rows = computeGraphRows(commits);
+            const mEdges = rows[0].edges;
+            // Branch-out: from commit lane 0 to E's new lane
+            const branchOut = mEdges.filter(e => e.type === 'branch-out' && e.fromLane === 0);
+            expect(branchOut.length).to.be.greaterThan(0);
+        });
+
+        it('M does not emit a merge-in edge (no existing lane converges into M)', () => {
+            const rows = computeGraphRows(commits);
+            const mEdges = rows[0].edges;
+            const mergeIn = mEdges.filter(e => e.type === 'merge-in');
+            expect(mergeIn.length).to.equal(0);
+        });
+
+        it('E emits a merge-in edge (E parent B is already in lane 0)', () => {
+            const rows = computeGraphRows(commits);
+            // E is at index 2, in lane 1; its parent B is already in lane 0.
+            // merge-in edge: fromLane=0 (B's lane), toLane=1 (E's commit lane)
+            const eRow = rows[2];
+            const eEdges = eRow.edges;
+            const mergeIn = eEdges.filter(e => e.type === 'merge-in' && e.fromLane === 0 && e.toLane === eRow.lane);
+            expect(mergeIn.length).to.be.greaterThan(0);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Parallel independent branches
+    // -------------------------------------------------------------------------
+    describe('parallel independent branches', () => {
+        // Two completely independent branches interleaved in the list.
+        // Newest first: A2, B2, A1, B1
+        // A2 and A1 are on one branch, B2 and B1 on another.
+        const commits = [
+            { id: 'A2', parentIds: ['A1'] },
+            { id: 'B2', parentIds: ['B1'] },
+            { id: 'A1', parentIds: [] },
+            { id: 'B1', parentIds: [] },
+        ];
+
+        it('A2 is in lane 0', () => {
+            expect(lanes(commits)[0]).to.equal(0);
+        });
+
+        it('B2 is in a different lane from A2', () => {
+            const ls = lanes(commits);
+            expect(ls[1]).to.not.equal(ls[0]);
+        });
+
+        it('A1 is in lane 0 (continues A2 branch)', () => {
+            expect(lanes(commits)[2]).to.equal(0);
+        });
+
+        it('B1 continues in the same lane as B2', () => {
+            const ls = lanes(commits);
+            expect(ls[3]).to.equal(ls[1]);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Octopus merge (3 parents)
+    // -------------------------------------------------------------------------
+    describe('octopus merge', () => {
+        // O merges P1, P2, P3
+        // O, P1, P2, P3
+        const commits = [
+            { id: 'O', parentIds: ['P1', 'P2', 'P3'] },
+            { id: 'P1', parentIds: [] },
+            { id: 'P2', parentIds: [] },
+            { id: 'P3', parentIds: [] },
+        ];
+
+        it('O is in lane 0', () => {
+            expect(lanes(commits)[0]).to.equal(0);
+        });
+
+        it('P1 is in lane 0 (first parent)', () => {
+            expect(lanes(commits)[1]).to.equal(0);
+        });
+
+        it('P2 is in a distinct lane', () => {
+            const ls = lanes(commits);
+            expect(ls[2]).to.not.equal(0);
+        });
+
+        it('P3 is in a distinct lane different from P2', () => {
+            const ls = lanes(commits);
+            expect(ls[3]).to.not.equal(ls[2]);
+        });
+
+        it('O emits 2 branch-out edges (for P2 and P3; P1 same-lane has no edge)', () => {
+            const rows = computeGraphRows(commits);
+            const oEdges = rows[0].edges.filter(e => e.type === 'branch-out');
+            expect(oEdges.length).to.equal(2);
+        });
+
+        it('O emits no merge-in edges (no existing lanes converge into O)', () => {
+            const rows = computeGraphRows(commits);
+            const mergeIn = rows[0].edges.filter(e => e.type === 'merge-in');
+            expect(mergeIn.length).to.equal(0);
+        });
+
+        it('lane colors are correct modulo 8', () => {
+            const rows = computeGraphRows(commits);
+            rows.forEach(r => expect(r.color).to.equal(r.lane % 8));
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Root commit with no parents
+    // -------------------------------------------------------------------------
+    describe('single root commit', () => {
+        const commits = [{ id: 'R', parentIds: [] }];
+
+        it('is placed in lane 0', () => {
+            expect(lanes(commits)).to.deep.equal([0]);
+        });
+
+        it('emits no edges', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[0].edges).to.be.empty;
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Empty input
+    // -------------------------------------------------------------------------
+    describe('empty input', () => {
+        it('returns an empty array', () => {
+            expect(computeGraphRows([])).to.deep.equal([]);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // hasContinuation and hasTopLine
+    // -------------------------------------------------------------------------
+    describe('hasContinuation and hasTopLine', () => {
+
+        describe('linear history', () => {
+            const commits = [
+                { id: 'C', parentIds: ['B'] },
+                { id: 'B', parentIds: ['A'] },
+                { id: 'A', parentIds: [] },
+            ];
+
+            it('first (newest/HEAD) commit has hasContinuation:true, hasTopLine:false', () => {
+                const rows = computeGraphRows(commits);
+                expect(rows[0].hasContinuation).to.equal(true);
+                expect(rows[0].hasTopLine).to.equal(false);
+            });
+
+            it('middle commit has hasContinuation:true, hasTopLine:true', () => {
+                const rows = computeGraphRows(commits);
+                expect(rows[1].hasContinuation).to.equal(true);
+                expect(rows[1].hasTopLine).to.equal(true);
+            });
+
+            it('root (oldest) commit has hasContinuation:false, hasTopLine:true', () => {
+                const rows = computeGraphRows(commits);
+                expect(rows[2].hasContinuation).to.equal(false);
+                expect(rows[2].hasTopLine).to.equal(true);
+            });
+        });
+
+        describe('branch-and-merge', () => {
+            // Topology: E (lane 1, parent B already in lane 0) — the merge
+            // convergence commit whose lane is freed after it is rendered.
+            //
+            //   M  (lane 0, parents: D, E)
+            //   |\
+            //   D  E  (D lane 0, E lane 1)
+            //   | /
+            //   B  (lane 0)
+            //   |
+            //   A  (lane 0)
+            const commits = [
+                { id: 'M', parentIds: ['D', 'E'] },
+                { id: 'D', parentIds: ['B'] },
+                { id: 'E', parentIds: ['B'] },
+                { id: 'B', parentIds: ['A'] },
+                { id: 'A', parentIds: [] },
+            ];
+
+            it('merge commit E (whose parent B is already in lane 0) has hasContinuation:false, hasTopLine:true', () => {
+                const rows = computeGraphRows(commits);
+                // E is at index 2; its first parent B is already in lane 0,
+                // so its own lane is freed — hasContinuation must be false.
+                // E was reserved as a parent by M, so hasTopLine must be true.
+                expect(rows[2].hasContinuation).to.equal(false);
+                expect(rows[2].hasTopLine).to.equal(true);
+            });
+        });
+
+        describe('single root commit (no parents)', () => {
+            it('has hasContinuation:false, hasTopLine:false', () => {
+                const rows = computeGraphRows([{ id: 'R', parentIds: [] }]);
+                expect(rows[0].hasContinuation).to.equal(false);
+                expect(rows[0].hasTopLine).to.equal(false);
+            });
+        });
+
+    });
+
+    // -------------------------------------------------------------------------
+    // Lane freeing on merge convergence
+    // -------------------------------------------------------------------------
+    describe('lane freeing on merge convergence', () => {
+        // Topology: M→D,E → B → A
+        //
+        //   M  (lane 0, parents: D, E)
+        //   |\
+        //   D  E  (D in lane 0, E in lane 1)
+        //   | /
+        //   B  (lane 0 — E's parent B is already tracked in lane 0)
+        //   |
+        //   A  (lane 0)
+        //
+        // After rendering E (lane 1, parent B already in lane 0), lane 1 must
+        // be freed so that subsequent commits can reuse it.
+        const commits = [
+            { id: 'M', parentIds: ['D', 'E'] },
+            { id: 'D', parentIds: ['B'] },
+            { id: 'E', parentIds: ['B'] },
+            { id: 'B', parentIds: ['A'] },
+            { id: 'A', parentIds: [] },
+        ];
+
+        it('E is placed in lane 1', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[2].lane).to.equal(1); // E
+        });
+
+        it('B is in lane 0 (converges back after E)', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[3].lane).to.equal(0); // B
+        });
+
+        it('A is in lane 0', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[4].lane).to.equal(0); // A
+        });
+
+        it('lane 1 is freed after E — B row has no pass-through edge for lane 1', () => {
+            const rows = computeGraphRows(commits);
+            // Row for B (index 3): there should be no pass-through edge that
+            // goes from lane 1 to lane 1, because E has already been rendered
+            // and its lane should have been freed.
+            const bRow = rows[3];
+            const spuriousEdge = bRow.edges.find(
+                e => e.fromLane === 1 && e.toLane === 1
+            );
+            expect(spuriousEdge).to.be.undefined;
+        });
+
+        it('lane 1 is reusable after E — new branch between B and A uses lane 1', () => {
+            // Insert an independent branch X→Y between B and A so that at the
+            // point X is processed, lane 0 is still occupied by 'A' (B's
+            // parent).  Lane 1 must have been freed after E, so X should
+            // occupy lane 1 rather than opening a new lane 2.
+            const commitsWithExtra = [
+                { id: 'M', parentIds: ['D', 'E'] },
+                { id: 'D', parentIds: ['B'] },
+                { id: 'E', parentIds: ['B'] },
+                { id: 'B', parentIds: ['A'] },
+                // X is an independent commit whose parent Y hasn't appeared
+                // yet.  At this point lane 0 holds 'A', lane 1 was freed after
+                // E — so X should claim lane 1.
+                { id: 'X', parentIds: ['Y'] },
+                { id: 'A', parentIds: [] },
+                { id: 'Y', parentIds: [] },
+            ];
+            const rows = computeGraphRows(commitsWithExtra);
+            // X (index 4) should reuse the freed lane 1 rather than lane 2.
+            expect(rows[4].lane).to.equal(1);
+        });
+
+        it('E emits a merge-in edge from lane 0 into E\'s commit lane (B already in lane 0)', () => {
+            const rows = computeGraphRows(commits);
+            // E is at index 2, in lane 1; B is in lane 0.
+            // merge-in edge: fromLane=0 (B's existing lane), toLane=1 (E's commit lane)
+            const eRow = rows[2];
+            const eEdges = eRow.edges;
+            const mergeIn = eEdges.filter(e => e.type === 'merge-in' && e.fromLane === 0 && e.toLane === eRow.lane);
+            expect(mergeIn.length).to.equal(1);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Lane color wraps at 8
+    // -------------------------------------------------------------------------
+    describe('color wrapping', () => {
+        it('lane color is always lane % 8', () => {
+            // 4 parallel chains so we have lanes 0, 1, 2, 3 occupied at once.
+            // Chain structure: X0→X1→X2, Y0→Y1→Y2, etc., interleaved.
+            const commits = [
+                { id: 'X0', parentIds: ['X1'] },
+                { id: 'Y0', parentIds: ['Y1'] },
+                { id: 'Z0', parentIds: ['Z1'] },
+                { id: 'W0', parentIds: ['W1'] },
+                { id: 'X1', parentIds: [] },
+                { id: 'Y1', parentIds: [] },
+                { id: 'Z1', parentIds: [] },
+                { id: 'W1', parentIds: [] },
+            ];
+            const rows = computeGraphRows(commits);
+            // Every row's color must equal lane % 8
+            rows.forEach(r => expect(r.color).to.equal(r.lane % 8));
+        });
+
+        it('assigns distinct lanes to 8 simultaneous branches', () => {
+            // 8 independent commits whose parents haven't been seen yet
+            const commits = [
+                { id: 'A', parentIds: ['a'] },
+                { id: 'B', parentIds: ['b'] },
+                { id: 'C', parentIds: ['c'] },
+                { id: 'D', parentIds: ['d'] },
+                { id: 'E', parentIds: ['e'] },
+                { id: 'F', parentIds: ['f'] },
+                { id: 'G', parentIds: ['g'] },
+                { id: 'H', parentIds: ['h'] },
+            ];
+            const rows = computeGraphRows(commits);
+            const laneSet = new Set(rows.map(r => r.lane));
+            expect(laneSet.size).to.equal(8); // all distinct lanes
+            // Color of lane 7 is 7, lane 0 is 0
+            const lane7 = rows.find(r => r.lane === 7);
+            expect(lane7).to.not.be.undefined;
+            expect(lane7!.color).to.equal(7);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Edge type correctness
+    // -------------------------------------------------------------------------
+    describe('edge types', () => {
+        it('pass-through edges have fromLane === toLane', () => {
+            const commits = [
+                { id: 'A', parentIds: ['a'] },
+                { id: 'B', parentIds: ['b'] },
+                { id: 'C', parentIds: ['c'] },
+            ];
+            const rows = computeGraphRows(commits);
+            // Row for B (index 1): A's lane (0) passes through as pass-through
+            const bPassThrough = rows[1].edges.filter(e => e.type === 'pass-through');
+            bPassThrough.forEach(e => expect(e.fromLane).to.equal(e.toLane));
+        });
+
+        it('branch-out edges have fromLane equal to commit lane', () => {
+            const commits = [
+                { id: 'M', parentIds: ['D', 'E'] },
+                { id: 'D', parentIds: [] },
+                { id: 'E', parentIds: [] },
+            ];
+            const rows = computeGraphRows(commits);
+            const mRow = rows[0];
+            const branchOut = mRow.edges.filter(e => e.type === 'branch-out');
+            branchOut.forEach(e => expect(e.fromLane).to.equal(mRow.lane));
+        });
+
+        it('merge-in edges have toLane equal to commit lane', () => {
+            // M (lane 0) parents: D (lane 0, new), E (lane 1, new)
+            // E (lane 1) parent: B (already in lane 0 from D)
+            const commits2 = [
+                { id: 'M', parentIds: ['D', 'E'] },
+                { id: 'D', parentIds: ['B'] },
+                { id: 'E', parentIds: ['B'] },  // B already in lane 0
+                { id: 'B', parentIds: [] },
+            ];
+            const rows = computeGraphRows(commits2);
+            const eRow = rows[2]; // E
+            const mergeIn = eRow.edges.filter(e => e.type === 'merge-in');
+            // toLane of merge-in must equal the commit's own lane
+            mergeIn.forEach(e => expect(e.toLane).to.equal(eRow.lane));
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Sibling branches (branch tips sharing the same parent)
+    // -------------------------------------------------------------------------
+    describe('sibling branches sharing the same parent', () => {
+        // Two branch tips that were NOT pre-reserved, both pointing at the same
+        // parent P.  This mirrors the real-world case where two refs (e.g. HEAD
+        // and origin/HEAD) diverge from a common ancestor:
+        //
+        //   A  (lane 0, parent P)   ← branch tip, not pre-reserved
+        //   B  (lane 1, parent P)   ← sibling branch tip, not pre-reserved
+        //   P  (lane 0, parent Q)   ← common parent
+        //   Q  (lane 0)             ← root
+        const commits = [
+            { id: 'A', parentIds: ['P'] },
+            { id: 'B', parentIds: ['P'] },
+            { id: 'P', parentIds: ['Q'] },
+            { id: 'Q', parentIds: [] },
+        ];
+
+        it('A is placed in lane 0', () => {
+            expect(computeGraphRows(commits)[0].lane).to.equal(0);
+        });
+
+        it('B is placed in lane 1 (sibling gets new lane)', () => {
+            expect(computeGraphRows(commits)[1].lane).to.equal(1);
+        });
+
+        it('P converges back to lane 0', () => {
+            expect(computeGraphRows(commits)[2].lane).to.equal(0);
+        });
+
+        it('A row (row 0) emits NO branch-out edges (siblings are not connected to each other)', () => {
+            const rows = computeGraphRows(commits);
+            const aEdges = rows[0].edges;
+            const branchOut = aEdges.filter(e => e.type === 'branch-out');
+            expect(branchOut.length).to.equal(0);
+        });
+
+        it('B row (row 1) has hasTopLine:false (lane starts fresh, no connection from above)', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[1].hasTopLine).to.equal(false);
+        });
+
+        it('B row (row 1) has hasContinuation:true (lane continues as pass-through to parent P at row 2)', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[1].hasContinuation).to.equal(true);
+        });
+
+        it('B row (row 1) does NOT emit a merge-in edge', () => {
+            // A merge-in on B\'s row would mean "a top-of-row line curves into B\'s
+            // circle", which is wrong since B was not pre-reserved.
+            const rows = computeGraphRows(commits);
+            const mergeIn = rows[1].edges.filter(e => e.type === 'merge-in');
+            expect(mergeIn.length).to.equal(0);
+        });
+
+        it('A row (row 0) has hasTopLine:false (A was not pre-reserved)', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[0].hasTopLine).to.equal(false);
+        });
+
+        it('P row (row 2) has hasTopLine:true (continuing from A\'s lane)', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[2].hasTopLine).to.equal(true);
+        });
+
+        it('B row (row 1) has a pass-through edge for lane 0', () => {
+            // Lane 0 (pointing at P) continues as a pass-through through B\'s row.
+            const rows = computeGraphRows(commits);
+            const passThrough = rows[1].edges.find(e => e.type === 'pass-through' && e.fromLane === 0 && e.toLane === 0);
+            expect(passThrough).to.not.be.undefined;
+        });
+
+        it('P row (row 2) has a merge-in edge from lane 1', () => {
+            // Lane 1 (kept alive through B) converges into P\'s lane 0 with a merge-in.
+            const rows = computeGraphRows(commits);
+            const mergeIn = rows[2].edges.find(e => e.type === 'merge-in' && e.fromLane === 1 && e.toLane === 0);
+            expect(mergeIn).to.not.be.undefined;
+        });
+
+        it('P row (row 2) has no pass-through for lane 1 (lane 1 is freed at P)', () => {
+            const rows = computeGraphRows(commits);
+            const spurious = rows[2].edges.find(e => e.fromLane === 1 && e.toLane === 1 && e.type === 'pass-through');
+            expect(spurious).to.be.undefined;
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Three sibling branches sharing the same parent
+    // -------------------------------------------------------------------------
+    describe('three sibling branches sharing the same parent', () => {
+        // A, B, C all have parent P and none were pre-reserved.
+        // Rows: A(lane0), B(lane1), C(lane2), P(lane0), ...
+        const commits = [
+            { id: 'A', parentIds: ['P'] },
+            { id: 'B', parentIds: ['P'] },
+            { id: 'C', parentIds: ['P'] },
+            { id: 'P', parentIds: [] },
+        ];
+
+        it('A is lane 0', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[0].lane).to.equal(0);
+        });
+
+        it('B is lane 1', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[1].lane).to.equal(1);
+        });
+
+        it('C is in a lane other than lane 0', () => {
+            // C is a sibling tip; its lane is re-assigned from freed lanes
+            const rows = computeGraphRows(commits);
+            expect(rows[2].lane).to.not.equal(0);
+        });
+
+        it('A row emits NO branch-out edges (siblings are not connected to each other)', () => {
+            const rows = computeGraphRows(commits);
+            const branchOuts = rows[0].edges.filter(e => e.type === 'branch-out');
+            expect(branchOuts.length).to.equal(0);
+        });
+
+        it('B row emits NO branch-out edges', () => {
+            const rows = computeGraphRows(commits);
+            const branchOuts = rows[1].edges.filter(e => e.type === 'branch-out');
+            expect(branchOuts.length).to.equal(0);
+        });
+
+        it('B and C rows both have hasTopLine:false (lanes start fresh, no connection from above)', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[1].hasTopLine).to.equal(false);
+            expect(rows[2].hasTopLine).to.equal(false);
+        });
+
+        it('B and C rows have no merge-in edges', () => {
+            const rows = computeGraphRows(commits);
+            expect(rows[1].edges.filter(e => e.type === 'merge-in').length).to.equal(0);
+            expect(rows[2].edges.filter(e => e.type === 'merge-in').length).to.equal(0);
+        });
+
+        it('P row has merge-in edges from both B\'s lane and C\'s lane', () => {
+            const rows = computeGraphRows(commits);
+            // P is at index 3, in lane 0.  Both lane 1 (B) and lane 2 (C) must
+            // converge into P with merge-in edges.
+            const pRow = rows[3];
+            const mergeInFromLane1 = pRow.edges.find(
+                e => e.type === 'merge-in' && e.fromLane === rows[1].lane && e.toLane === pRow.lane
+            );
+            const mergeInFromLane2 = pRow.edges.find(
+                e => e.type === 'merge-in' && e.fromLane === rows[2].lane && e.toLane === pRow.lane
+            );
+            expect(mergeInFromLane1).to.not.be.undefined;
+            expect(mergeInFromLane2).to.not.be.undefined;
+        });
+    });
+
+});
+

--- a/packages/scm/src/browser/scm-history-graph-lanes.ts
+++ b/packages/scm/src/browser/scm-history-graph-lanes.ts
@@ -1,0 +1,258 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * DAG graph lane computation for SCM commit history visualization.
+ *
+ * Each row in the graph has:
+ * - `lane`: the column index where the commit circle is drawn
+ * - `color`: a lane index (0-7) used to pick a CSS color variable
+ * - `edges`: segments to draw on this row — each segment connects two lane
+ *   positions and carries a color and type
+ *
+ * Edge types determine how each segment is rendered in the SVG:
+ * - `'pass-through'`: straight vertical line through the full row height
+ * - `'branch-out'`:  bezier curve starting at the commit's Y (mid-row),
+ *                    sweeping down to the new lane at the bottom of the row
+ * - `'merge-in'`:    bezier curve starting at the source lane at the top of
+ *                    the row, sweeping into the commit's Y (mid-row)
+ */
+
+export type GraphEdgeType = 'pass-through' | 'branch-out' | 'merge-in';
+
+export interface GraphEdge {
+    /** Source lane position (top of the row for pass-through/merge-in; commit lane for branch-out). */
+    readonly fromLane: number;
+    /** Target lane position (bottom of the row for pass-through/branch-out; commit lane for merge-in). */
+    readonly toLane: number;
+    /** Color index (0–7) for this edge. */
+    readonly color: number;
+    /** How this edge should be rendered in the SVG. */
+    readonly type: GraphEdgeType;
+}
+
+export interface GraphRow {
+    /** Lane index where the commit node is rendered. */
+    readonly lane: number;
+    /** Color index for the commit node dot. */
+    readonly color: number;
+    /** Edges crossing or originating on this row. */
+    readonly edges: readonly GraphEdge[];
+    /**
+     * Whether the commit's lane continues downward (i.e. first parent stays in
+     * the same lane). When false, no bottom line segment is drawn below the
+     * commit circle (root commit or merge convergence where the lane is freed).
+     */
+    readonly hasContinuation: boolean;
+    /**
+     * Whether there is an incoming line from above on the commit's lane (i.e.
+     * the commit was referenced as a parent by an earlier row). When false,
+     * no top line segment is drawn above the commit circle.
+     */
+    readonly hasTopLine: boolean;
+}
+
+/**
+ * Mutable version of GraphRow used internally during computation.
+ */
+interface MutableGraphRow {
+    lane: number;
+    color: number;
+    edges: GraphEdge[];
+    hasContinuation: boolean;
+    hasTopLine: boolean;
+}
+
+/**
+ * Compute graph rows for an ordered list of commits (topological order,
+ * newest first). Each commit must supply its own `id` and `parentIds`.
+ *
+ * @param commits Topologically sorted commits (newest → oldest).
+ * @returns One `GraphRow` per commit in the same order.
+ */
+export function computeGraphRows(
+    commits: ReadonlyArray<{ id: string; parentIds?: readonly string[] }>
+): GraphRow[] {
+    // lanes[i] = id of commit that "owns" lane i (i.e. we are waiting for this
+    // commit to appear in the list so we can close the lane).
+    const lanes: (string | undefined)[] = [];
+    // laneColors[i] = the color index permanently assigned to lane i
+    const laneColors: (number | undefined)[] = [];
+
+    const rows: MutableGraphRow[] = [];
+
+    for (const commit of commits) {
+        const parentIds = commit.parentIds ?? [];
+
+        // --- 1. Find or assign a lane for this commit -----------------------
+        let myLane = lanes.indexOf(commit.id);
+        // hasTopLine: true when this commit was already reserved as a parent by
+        // an earlier row — meaning there IS a connection coming from above.
+        const hasTopLine = myLane !== -1;
+        if (myLane === -1) {
+            // Not yet tracked → open a new lane
+            myLane = firstFreeLane(lanes);
+            lanes[myLane] = commit.id;
+            laneColors[myLane] = myLane % 8;
+        }
+
+        const myColor = laneColors[myLane] ?? myLane % 8;
+
+        // Collect any duplicate lane occupants: other lanes that were kept
+        // alive pointing at this same commit (sibling branch tips whose lane
+        // was preserved until the parent row).  These emit merge-in edges and
+        // are freed before the pass-through snapshot so they don't appear as
+        // spurious pass-through lines on this row.
+        const duplicateLanes: { lane: number; color: number }[] = [];
+        if (hasTopLine) {
+            for (let li = 0; li < lanes.length; li++) {
+                if (lanes[li] === commit.id && li !== myLane) {
+                    duplicateLanes.push({ lane: li, color: laneColors[li] ?? li % 8 });
+                    lanes[li] = undefined;
+                    laneColors[li] = undefined;
+                }
+            }
+        }
+
+        // --- 2. Snapshot current lane state before mutations ----------------
+        const lanesCopy = lanes.slice();
+
+        // --- 3. Determine parent lane assignments ---------------------------
+        const parentLanes: number[] = [];
+        // Track which parents were ALREADY in existing lanes (merge-in) vs new
+        const parentIsExisting: boolean[] = [];
+
+        for (let pi = 0; pi < parentIds.length; pi++) {
+            const pid = parentIds[pi];
+
+            const parentLane = lanesCopy.indexOf(pid);
+
+            if (parentLane !== -1 && parentLane !== myLane) {
+                if (hasTopLine) {
+                    // Pre-reserved commit: parent already has a lane → merge-in edge on this row.
+                    parentLanes.push(parentLane);
+                    parentIsExisting.push(true);
+                } else {
+                    // Non-pre-reserved sibling branch tip: keep this lane alive so it
+                    // passes through as a pass-through line until the parent row, where
+                    // a merge-in is emitted via the duplicateLanes mechanism.
+                    // No edge is emitted here; record myLane so hasContinuation is true.
+                    lanes[myLane] = pid;
+                    parentLanes.push(myLane);
+                    parentIsExisting.push(false);
+                }
+            } else if (parentLane === myLane) {
+                // First parent inherits this lane (fast-forward) — straight down
+                parentLanes.push(myLane);
+                parentIsExisting.push(false); // treated as inline continuation
+            } else {
+                // New parent → assign a lane
+                if (pi === 0) {
+                    // First parent continues in the same lane
+                    lanes[myLane] = pid;
+                    // Keep the same color as myLane for the first parent
+                    parentLanes.push(myLane);
+                    parentIsExisting.push(false);
+                } else {
+                    // Additional parents get new lanes — branch-out
+                    const newLane = firstFreeLane(lanes);
+                    lanes[newLane] = pid;
+                    laneColors[newLane] = newLane % 8;
+                    parentLanes.push(newLane);
+                    parentIsExisting.push(false);
+                }
+            }
+        }
+
+        // If the commit has no parents (root commit), free the lane
+        if (parentIds.length === 0) {
+            lanes[myLane] = undefined;
+            laneColors[myLane] = undefined;
+        } else if (!parentLanes.includes(myLane)) {
+            // No parent inherited myLane — decide whether to free or keep the lane.
+            if (hasTopLine) {
+                // Pre-reserved commit (merge convergence): free the lane immediately.
+                lanes[myLane] = undefined;
+                laneColors[myLane] = undefined;
+            } else {
+                // Non-pre-reserved sibling branch tip: keep the lane alive pointing
+                // at the first parent so it persists as a pass-through until the
+                // parent row.  At the parent row, the duplicate lane occupant is
+                // detected and a merge-in edge is emitted there instead.
+                lanes[myLane] = parentIds[0];
+            }
+        }
+
+        // --- 4. Emit edges --------------------------------------------------
+        const edges: GraphEdge[] = [];
+
+        // Pass-through lines: lanes that were occupied before this row and
+        // are NOT the commit's own lane continue straight through.
+        for (let li = 0; li < lanesCopy.length; li++) {
+            const occupant = lanesCopy[li];
+            if (!occupant || occupant === commit.id) {
+                continue;
+            }
+            const color = laneColors[li] ?? li % 8;
+            edges.push({ fromLane: li, toLane: li, color, type: 'pass-through' });
+        }
+
+        for (let pi = 0; pi < parentIds.length; pi++) {
+            const toLane = parentLanes[pi];
+            const isExisting = parentIsExisting[pi];
+
+            if (toLane === myLane) {
+                // First parent continues in the same lane — no edge is emitted.
+                // The vertical connection is represented by hasContinuation:true on
+                // this row and hasTopLine:true on the parent's row; the SVG renderer
+                // draws the top/bottom line segments around the commit circle instead.
+                continue;
+            }
+
+            if (isExisting) {
+                // Merge-in: an existing lane at the top of the row curves into
+                // the commit position at mid-row.
+                const color = laneColors[toLane] ?? toLane % 8;
+                edges.push({ fromLane: toLane, toLane: myLane, color, type: 'merge-in' });
+            } else {
+                // Branch-out: the commit spawns a new lane below mid-row.
+                const color = laneColors[toLane] ?? toLane % 8;
+                edges.push({ fromLane: myLane, toLane, color, type: 'branch-out' });
+            }
+        }
+
+        // Merge-in edges for duplicate lane occupants (sibling branch tips
+        // converging into this commit's lane).
+        for (const dl of duplicateLanes) {
+            edges.push({ fromLane: dl.lane, toLane: myLane, color: dl.color, type: 'merge-in' });
+        }
+
+        // hasContinuation: true if the first parent continues in the same lane,
+        // OR if this is a sibling branch tip whose lane was kept alive (pointing
+        // at the parent) so it persists as a pass-through to the parent row.
+        const hasContinuation = parentIds.length > 0 && (parentLanes[0] === myLane || lanes[myLane] === parentIds[0]);
+
+        rows.push({ lane: myLane, color: myColor, edges, hasContinuation, hasTopLine });
+    }
+
+    return rows;
+}
+
+/** Returns the index of the first undefined slot, or lanes.length if full. */
+function firstFreeLane(lanes: (string | undefined)[]): number {
+    const idx = lanes.indexOf(undefined);
+    return idx === -1 ? lanes.length : idx;
+}

--- a/packages/scm/src/browser/scm-history-graph-model.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.spec.ts
@@ -34,15 +34,15 @@ class StubHistoryProvider implements ScmHistoryProvider {
 
     /** Pages this provider will return on consecutive calls (FIFO). */
     pages: ScmHistoryItem[][] = [];
-    /** Captured cursors for each call. */
-    receivedCursors: (string | undefined)[] = [];
+    /** Captured options for each call (so tests can assert what was sent). */
+    receivedOptions: ScmHistoryOptions[] = [];
 
     async provideHistoryItemRefs(): Promise<ScmHistoryItemRef[] | undefined> {
         return [];
     }
 
     async provideHistoryItems(options: ScmHistoryOptions): Promise<ScmHistoryItem[] | undefined> {
-        this.receivedCursors.push(options.cursor);
+        this.receivedOptions.push(options);
         return this.pages.shift() ?? [];
     }
 
@@ -73,12 +73,8 @@ function makeItems(start: number, count: number): ScmHistoryItem[] {
 }
 
 /**
- * Creates a model instance with a stub history provider, bypassing inversify
- * and the SCM service so we can directly drive pagination and observe state.
- *
- * The model's @postConstruct refresh() runs against an empty SCM service
- * (no selected repository), which leaves the model idle. We then wire the
- * provider in and exercise pagination via loadPage() directly.
+ * Instantiates the model with a stub provider, bypassing inversify and the
+ * SCM service so tests can drive pagination directly via loadPage().
  */
 function createModel(provider: ScmHistoryProvider): { model: ScmHistoryGraphModel; loadPage(): Promise<void> } {
     const model = new ScmHistoryGraphModel();
@@ -95,9 +91,7 @@ function createModel(provider: ScmHistoryProvider): { model: ScmHistoryGraphMode
         onDidChangeSelectedRepository: new Emitter<ScmRepository | undefined>().event,
         selectedRepository: undefined,
     };
-    // Drive postConstruct manually now that the dependency is in place.
     internals.init();
-    // Inject the provider directly, bypassing the SCM service lookup.
     internals._provider = provider;
     return {
         model,
@@ -107,7 +101,7 @@ function createModel(provider: ScmHistoryProvider): { model: ScmHistoryGraphMode
 
 describe('ScmHistoryGraphModel - pagination', () => {
 
-    it('hasMore is true when a full page returns and contains new items', async () => {
+    it('hasMore is true when a full page returns', async () => {
         const provider = new StubHistoryProvider();
         provider.pages = [makeItems(1, PAGE_SIZE)];
         const { model, loadPage } = createModel(provider);
@@ -116,7 +110,6 @@ describe('ScmHistoryGraphModel - pagination', () => {
 
         expect(model.entries).to.have.length(PAGE_SIZE);
         expect(model.hasMore).to.be.true;
-        expect(provider.receivedCursors).to.deep.equal([undefined]);
     });
 
     it('hasMore is false when fewer than a full page is returned', async () => {
@@ -130,65 +123,49 @@ describe('ScmHistoryGraphModel - pagination', () => {
         expect(model.hasMore).to.be.false;
     });
 
-    it('deduplicates items returned across pages without growing entries beyond the unique set', async () => {
-        const provider = new StubHistoryProvider();
-        // Page 1: items c1..c50. Page 2 echoes the cursor commit (item c50)
-        // plus 49 new items c51..c99 -> 50 fetched, 49 new.
-        provider.pages = [
-            makeItems(1, PAGE_SIZE),
-            makeItems(50, PAGE_SIZE), // includes item id 'c50' as the first
-        ];
-        const { model, loadPage } = createModel(provider);
-
-        await loadPage();
-        expect(model.entries).to.have.length(PAGE_SIZE);
-        await loadPage();
-
-        const ids = model.entries.map(e => e.item.id);
-        const uniqueIds = new Set(ids);
-        expect(ids.length).to.equal(uniqueIds.size, 'no duplicates expected after dedup');
-        // 50 from page 1 + 49 unique from page 2.
-        expect(model.entries).to.have.length(PAGE_SIZE + (PAGE_SIZE - 1));
-        expect(model.hasMore).to.be.true;
-    });
-
-    // Regression test for https://github.com/eclipse-theia/theia/pull/17263 -
-    // when a full page comes back but every item is a duplicate (e.g. the
-    // provider re-returns already-loaded items because the cursor cannot be
-    // honored), `hasMore` must become false instead of leaving "Load more"
-    // visible but unable to make progress.
-    it('hasMore becomes false when a full page returns only duplicates', async () => {
-        const provider = new StubHistoryProvider();
-        const firstPage = makeItems(1, PAGE_SIZE);
-        provider.pages = [
-            firstPage,
-            // Provider echoes the SAME 50 items - all duplicates.
-            firstPage.slice(),
-        ];
-        const { model, loadPage } = createModel(provider);
-
-        await loadPage();
-        expect(model.entries).to.have.length(PAGE_SIZE);
-        expect(model.hasMore).to.be.true;
-
-        await loadPage();
-        expect(model.entries).to.have.length(PAGE_SIZE, 'should not grow when all items are duplicates');
-        expect(model.hasMore).to.be.false;
-    });
-
-    it('advances the cursor to the last fetched item across pages', async () => {
+    it('paginates using skip = current entry count', async () => {
         const provider = new StubHistoryProvider();
         provider.pages = [
             makeItems(1, PAGE_SIZE),
             makeItems(51, PAGE_SIZE),
+            makeItems(101, 10),
         ];
+        const { model, loadPage } = createModel(provider);
+
+        await loadPage();
+        expect(model.entries).to.have.length(PAGE_SIZE);
+        expect(provider.receivedOptions[0].skip).to.equal(0);
+
+        await loadPage();
+        expect(model.entries).to.have.length(2 * PAGE_SIZE);
+        expect(provider.receivedOptions[1].skip).to.equal(PAGE_SIZE);
+
+        await loadPage();
+        expect(model.entries).to.have.length(2 * PAGE_SIZE + 10);
+        expect(provider.receivedOptions[2].skip).to.equal(2 * PAGE_SIZE);
+    });
+
+    it('passes skip and not cursor (cursor is not part of the VS Code SCM history options API)', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, PAGE_SIZE)];
         const { loadPage } = createModel(provider);
 
         await loadPage();
-        await loadPage();
 
-        // First call has no cursor; second call uses the id of the last item
-        // from page 1 (c50).
-        expect(provider.receivedCursors).to.deep.equal([undefined, 'c50']);
+        expect((provider.receivedOptions[0] as { cursor?: string }).cursor).to.be.undefined;
+        expect(provider.receivedOptions[0]).to.have.property('skip');
+    });
+
+    it('does not grow entries when a provider re-returns duplicates', async () => {
+        const provider = new StubHistoryProvider();
+        const firstPage = makeItems(1, PAGE_SIZE);
+        provider.pages = [firstPage, firstPage.slice()];
+        const { model, loadPage } = createModel(provider);
+
+        await loadPage();
+        expect(model.entries).to.have.length(PAGE_SIZE);
+
+        await loadPage();
+        expect(model.entries).to.have.length(PAGE_SIZE, 'should not grow when all items are duplicates');
     });
 });

--- a/packages/scm/src/browser/scm-history-graph-model.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.spec.ts
@@ -1,0 +1,194 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Emitter } from '@theia/core/lib/common/event';
+import { ScmHistoryGraphModel, PAGE_SIZE } from './scm-history-graph-model';
+import { ScmHistoryItem, ScmHistoryItemRef, ScmHistoryItemChange, ScmHistoryOptions, ScmHistoryProvider } from './scm-provider';
+import { ScmRepository } from './scm-repository';
+
+class StubHistoryProvider implements ScmHistoryProvider {
+    readonly currentHistoryItemRef: ScmHistoryItemRef | undefined;
+    readonly currentHistoryItemRemoteRef: ScmHistoryItemRef | undefined;
+    readonly currentHistoryItemBaseRef: ScmHistoryItemRef | undefined;
+
+    readonly onDidChangeCurrentHistoryItemRefs = new Emitter<void>().event;
+    readonly onDidChangeHistoryItemRefs = new Emitter<{
+        readonly added: readonly ScmHistoryItemRef[];
+        readonly removed: readonly ScmHistoryItemRef[];
+        readonly modified: readonly ScmHistoryItemRef[];
+    }>().event;
+
+    /** Pages this provider will return on consecutive calls (FIFO). */
+    pages: ScmHistoryItem[][] = [];
+    /** Captured cursors for each call. */
+    receivedCursors: (string | undefined)[] = [];
+
+    async provideHistoryItemRefs(): Promise<ScmHistoryItemRef[] | undefined> {
+        return [];
+    }
+
+    async provideHistoryItems(options: ScmHistoryOptions): Promise<ScmHistoryItem[] | undefined> {
+        this.receivedCursors.push(options.cursor);
+        return this.pages.shift() ?? [];
+    }
+
+    async provideHistoryItemChanges(): Promise<ScmHistoryItemChange[] | undefined> {
+        return [];
+    }
+
+    async resolveHistoryItem(): Promise<ScmHistoryItem | undefined> {
+        return undefined;
+    }
+
+    async resolveHistoryItemRefsCommonAncestor(): Promise<string | undefined> {
+        return undefined;
+    }
+}
+
+function makeItems(start: number, count: number): ScmHistoryItem[] {
+    const items: ScmHistoryItem[] = [];
+    for (let i = 0; i < count; i++) {
+        const id = `c${start + i}`;
+        items.push({
+            id,
+            subject: `commit ${id}`,
+            parentIds: [`c${start + i + 1}`],
+        });
+    }
+    return items;
+}
+
+/**
+ * Creates a model instance with a stub history provider, bypassing inversify
+ * and the SCM service so we can directly drive pagination and observe state.
+ *
+ * The model's @postConstruct refresh() runs against an empty SCM service
+ * (no selected repository), which leaves the model idle. We then wire the
+ * provider in and exercise pagination via loadPage() directly.
+ */
+function createModel(provider: ScmHistoryProvider): { model: ScmHistoryGraphModel; loadPage(): Promise<void> } {
+    const model = new ScmHistoryGraphModel();
+    const internals = model as unknown as {
+        scmService: {
+            onDidChangeSelectedRepository: Emitter<ScmRepository | undefined>['event'];
+            selectedRepository: ScmRepository | undefined;
+        };
+        _provider: ScmHistoryProvider | undefined;
+        init(): void;
+        loadPage(): Promise<void>;
+    };
+    internals.scmService = {
+        onDidChangeSelectedRepository: new Emitter<ScmRepository | undefined>().event,
+        selectedRepository: undefined,
+    };
+    // Drive postConstruct manually now that the dependency is in place.
+    internals.init();
+    // Inject the provider directly, bypassing the SCM service lookup.
+    internals._provider = provider;
+    return {
+        model,
+        loadPage: () => internals.loadPage(),
+    };
+}
+
+describe('ScmHistoryGraphModel - pagination', () => {
+
+    it('hasMore is true when a full page returns and contains new items', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, PAGE_SIZE)];
+        const { model, loadPage } = createModel(provider);
+
+        await loadPage();
+
+        expect(model.entries).to.have.length(PAGE_SIZE);
+        expect(model.hasMore).to.be.true;
+        expect(provider.receivedCursors).to.deep.equal([undefined]);
+    });
+
+    it('hasMore is false when fewer than a full page is returned', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, 10)];
+        const { model, loadPage } = createModel(provider);
+
+        await loadPage();
+
+        expect(model.entries).to.have.length(10);
+        expect(model.hasMore).to.be.false;
+    });
+
+    it('deduplicates items returned across pages without growing entries beyond the unique set', async () => {
+        const provider = new StubHistoryProvider();
+        // Page 1: items c1..c50. Page 2 echoes the cursor commit (item c50)
+        // plus 49 new items c51..c99 -> 50 fetched, 49 new.
+        provider.pages = [
+            makeItems(1, PAGE_SIZE),
+            makeItems(50, PAGE_SIZE), // includes item id 'c50' as the first
+        ];
+        const { model, loadPage } = createModel(provider);
+
+        await loadPage();
+        expect(model.entries).to.have.length(PAGE_SIZE);
+        await loadPage();
+
+        const ids = model.entries.map(e => e.item.id);
+        const uniqueIds = new Set(ids);
+        expect(ids.length).to.equal(uniqueIds.size, 'no duplicates expected after dedup');
+        // 50 from page 1 + 49 unique from page 2.
+        expect(model.entries).to.have.length(PAGE_SIZE + (PAGE_SIZE - 1));
+        expect(model.hasMore).to.be.true;
+    });
+
+    // Regression test for https://github.com/eclipse-theia/theia/pull/17263 -
+    // when a full page comes back but every item is a duplicate (e.g. the
+    // provider re-returns already-loaded items because the cursor cannot be
+    // honored), `hasMore` must become false instead of leaving "Load more"
+    // visible but unable to make progress.
+    it('hasMore becomes false when a full page returns only duplicates', async () => {
+        const provider = new StubHistoryProvider();
+        const firstPage = makeItems(1, PAGE_SIZE);
+        provider.pages = [
+            firstPage,
+            // Provider echoes the SAME 50 items - all duplicates.
+            firstPage.slice(),
+        ];
+        const { model, loadPage } = createModel(provider);
+
+        await loadPage();
+        expect(model.entries).to.have.length(PAGE_SIZE);
+        expect(model.hasMore).to.be.true;
+
+        await loadPage();
+        expect(model.entries).to.have.length(PAGE_SIZE, 'should not grow when all items are duplicates');
+        expect(model.hasMore).to.be.false;
+    });
+
+    it('advances the cursor to the last fetched item across pages', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [
+            makeItems(1, PAGE_SIZE),
+            makeItems(51, PAGE_SIZE),
+        ];
+        const { loadPage } = createModel(provider);
+
+        await loadPage();
+        await loadPage();
+
+        // First call has no cursor; second call uses the id of the last item
+        // from page 1 (c50).
+        expect(provider.receivedCursors).to.deep.equal([undefined, 'c50']);
+    });
+});

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -155,11 +155,17 @@ export class ScmHistoryGraphModel {
                 return;
             }
 
-            const newItems: ScmHistoryItem[] = items ?? [];
-            this._hasMore = newItems.length >= PAGE_SIZE;
-            if (newItems.length > 0) {
-                this._cursor = newItems[newItems.length - 1].id;
+            const fetchedItems: ScmHistoryItem[] = items ?? [];
+            this._hasMore = fetchedItems.length >= PAGE_SIZE;
+            if (fetchedItems.length > 0) {
+                this._cursor = fetchedItems[fetchedItems.length - 1].id;
             }
+
+            // Deduplicate: the cursor-based pagination may re-return the
+            // last item of the previous page. Filter out any items that
+            // were already loaded to prevent graph duplication on scroll.
+            const existingIds = new Set(this._entries.map(e => e.item.id));
+            const newItems = fetchedItems.filter(i => !existingIds.has(i.id));
 
             const allItems = [...this._entries.map(e => e.item), ...newItems];
             const graphRows = computeGraphRows(allItems.map(i => ({

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -1,0 +1,208 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Emitter } from '@theia/core/lib/common/event';
+import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
+import { ScmService } from './scm-service';
+import { ScmHistoryItem, ScmHistoryProvider, ScmHistoryOptions } from './scm-provider';
+import { computeGraphRows, GraphRow } from './scm-history-graph-lanes';
+
+export const PAGE_SIZE = 50;
+
+export interface HistoryGraphEntry {
+    readonly item: ScmHistoryItem;
+    readonly graphRow: GraphRow;
+}
+
+@injectable()
+export class ScmHistoryGraphModel {
+
+    @inject(ScmService) protected readonly scmService: ScmService;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected readonly toDisposeOnProviderChange = new DisposableCollection();
+
+    protected _entries: HistoryGraphEntry[] = [];
+    protected _hasMore = false;
+    protected _loading = false;
+    protected _hasAttemptedLoad = false;
+    protected _cursor: string | undefined;
+    protected _provider: ScmHistoryProvider | undefined;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+
+    protected cancelSource = new CancellationTokenSource();
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.pushAll([
+            Disposable.create(() => this.toDisposeOnProviderChange.dispose()),
+            this.onDidChangeEmitter,
+            this.scmService.onDidChangeSelectedRepository(() => this.refresh()),
+        ]);
+        this.refresh();
+    }
+
+    dispose(): void {
+        this.cancelSource.cancel();
+        this.toDispose.dispose();
+    }
+
+    get provider(): ScmHistoryProvider | undefined {
+        return this._provider;
+    }
+
+    get entries(): readonly HistoryGraphEntry[] {
+        return this._entries;
+    }
+
+    get hasMore(): boolean {
+        return this._hasMore;
+    }
+
+    get loading(): boolean {
+        return this._loading;
+    }
+
+    /**
+     * Returns true once the model has completed at least one load attempt
+     * (regardless of whether history items were found). This is used by
+     * the widget to distinguish "still initializing" from "no history".
+     */
+    get hasAttemptedLoad(): boolean {
+        return this._hasAttemptedLoad;
+    }
+
+    refresh(): void {
+        this.cancelSource.cancel();
+        this.cancelSource = new CancellationTokenSource();
+
+        this.toDisposeOnProviderChange.dispose();
+
+        const repo = this.scmService.selectedRepository;
+        const hp = repo?.provider.historyProvider;
+        this._provider = hp;
+
+        if (this._provider) {
+            this.toDisposeOnProviderChange.push(
+                this._provider.onDidChangeCurrentHistoryItemRefs(() => this.refresh())
+            );
+            this.toDisposeOnProviderChange.push(
+                this._provider.onDidChangeHistoryItemRefs(() => this.refresh())
+            );
+        } else if (repo) {
+            // historyProvider is not yet available; listen for provider changes
+            // so that refresh() is retried when historyProvider becomes available.
+            this.toDisposeOnProviderChange.push(
+                repo.provider.onDidChange(() => this.refresh())
+            );
+        }
+
+        this._entries = [];
+        this._cursor = undefined;
+        this._hasMore = false;
+
+        this.loadPage();
+    }
+
+    async loadMore(): Promise<void> {
+        if (this._loading || !this._hasMore) {
+            return;
+        }
+        await this.loadPage();
+    }
+
+    protected async loadPage(): Promise<void> {
+        if (!this._provider) {
+            this._entries = [];
+            this._hasMore = false;
+            this._loading = false;
+            this._hasAttemptedLoad = true;
+            this.onDidChangeEmitter.fire();
+            return;
+        }
+
+        this._loading = true;
+        this.onDidChangeEmitter.fire();
+
+        const token = this.cancelSource.token;
+        try {
+            const historyItemRefs = this.getCurrentHistoryItemRefs();
+            const options: ScmHistoryOptions = {
+                cursor: this._cursor,
+                limit: PAGE_SIZE,
+                historyItemRefs: historyItemRefs.length > 0 ? historyItemRefs : undefined,
+            };
+            const items = await this._provider.provideHistoryItems(options, token);
+
+            if (token.isCancellationRequested) {
+                return;
+            }
+
+            const newItems: ScmHistoryItem[] = items ?? [];
+            this._hasMore = newItems.length >= PAGE_SIZE;
+            if (newItems.length > 0) {
+                this._cursor = newItems[newItems.length - 1].id;
+            }
+
+            const allItems = [...this._entries.map(e => e.item), ...newItems];
+            const graphRows = computeGraphRows(allItems.map(i => ({
+                id: i.id,
+                parentIds: i.parentIds,
+            })));
+
+            this._entries = allItems.map((item, idx) => ({
+                item,
+                graphRow: graphRows[idx],
+            }));
+        } catch (err) {
+            if (!token.isCancellationRequested) {
+                console.error('ScmHistoryGraphModel: failed to load history', err);
+            }
+        } finally {
+            if (!token.isCancellationRequested) {
+                this._loading = false;
+                this._hasAttemptedLoad = true;
+                this.onDidChangeEmitter.fire();
+            }
+        }
+    }
+
+    /**
+     * Returns the set of ref IDs to pass to `provideHistoryItems`.
+     * Mirrors what VS Code's SCM Graph view does: only pass the current
+     * branch ref, its remote tracking ref, and the merge-base ref.
+     */
+    protected getCurrentHistoryItemRefs(): string[] {
+        if (!this._provider) {
+            return [];
+        }
+        const refs: string[] = [];
+        if (this._provider.currentHistoryItemRef) {
+            refs.push(this._provider.currentHistoryItemRef.id);
+        }
+        if (this._provider.currentHistoryItemRemoteRef) {
+            refs.push(this._provider.currentHistoryItemRemoteRef.id);
+        }
+        if (this._provider.currentHistoryItemBaseRef) {
+            refs.push(this._provider.currentHistoryItemBaseRef.id);
+        }
+        return refs;
+    }
+}

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -156,7 +156,6 @@ export class ScmHistoryGraphModel {
             }
 
             const fetchedItems: ScmHistoryItem[] = items ?? [];
-            this._hasMore = fetchedItems.length >= PAGE_SIZE;
             if (fetchedItems.length > 0) {
                 this._cursor = fetchedItems[fetchedItems.length - 1].id;
             }
@@ -166,6 +165,12 @@ export class ScmHistoryGraphModel {
             // were already loaded to prevent graph duplication on scroll.
             const existingIds = new Set(this._entries.map(e => e.item.id));
             const newItems = fetchedItems.filter(i => !existingIds.has(i.id));
+
+            // Only advertise more pages when the provider actually produced
+            // progress: a full page AND at least one new item. If the provider
+            // re-returns only items we already have, further requests would
+            // be stuck in a loop without ever advancing the cursor.
+            this._hasMore = fetchedItems.length >= PAGE_SIZE && newItems.length > 0;
 
             const allItems = [...this._entries.map(e => e.item), ...newItems];
             const graphRows = computeGraphRows(allItems.map(i => ({

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -41,7 +41,6 @@ export class ScmHistoryGraphModel {
     protected _hasMore = false;
     protected _loading = false;
     protected _hasAttemptedLoad = false;
-    protected _cursor: string | undefined;
     protected _provider: ScmHistoryProvider | undefined;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
@@ -115,7 +114,6 @@ export class ScmHistoryGraphModel {
         }
 
         this._entries = [];
-        this._cursor = undefined;
         this._hasMore = false;
 
         this.loadPage();
@@ -145,7 +143,7 @@ export class ScmHistoryGraphModel {
         try {
             const historyItemRefs = this.getCurrentHistoryItemRefs();
             const options: ScmHistoryOptions = {
-                cursor: this._cursor,
+                skip: this._entries.length,
                 limit: PAGE_SIZE,
                 historyItemRefs: historyItemRefs.length > 0 ? historyItemRefs : undefined,
             };
@@ -156,21 +154,11 @@ export class ScmHistoryGraphModel {
             }
 
             const fetchedItems: ScmHistoryItem[] = items ?? [];
-            if (fetchedItems.length > 0) {
-                this._cursor = fetchedItems[fetchedItems.length - 1].id;
-            }
+            this._hasMore = fetchedItems.length >= PAGE_SIZE;
 
-            // Deduplicate: the cursor-based pagination may re-return the
-            // last item of the previous page. Filter out any items that
-            // were already loaded to prevent graph duplication on scroll.
+            // Filter out any items already loaded so the graph does not show duplicates.
             const existingIds = new Set(this._entries.map(e => e.item.id));
             const newItems = fetchedItems.filter(i => !existingIds.has(i.id));
-
-            // Only advertise more pages when the provider actually produced
-            // progress: a full page AND at least one new item. If the provider
-            // re-returns only items we already have, further requests would
-            // be stuck in a loop without ever advancing the cursor.
-            this._hasMore = fetchedItems.length >= PAGE_SIZE && newItems.length > 0;
 
             const allItems = [...this._entries.map(e => e.item), ...newItems];
             const graphRows = computeGraphRows(allItems.map(i => ({
@@ -196,9 +184,9 @@ export class ScmHistoryGraphModel {
     }
 
     /**
-     * Returns the set of ref IDs to pass to `provideHistoryItems`.
-     * Mirrors what VS Code's SCM Graph view does: only pass the current
-     * branch ref, its remote tracking ref, and the merge-base ref.
+     * Returns the revisions of the current branch ref, its remote tracking ref,
+     * and the merge-base ref to pass to `provideHistoryItems`. Providers walk
+     * history starting from these revisions.
      */
     protected getCurrentHistoryItemRefs(): string[] {
         if (!this._provider) {
@@ -206,13 +194,13 @@ export class ScmHistoryGraphModel {
         }
         const refs: string[] = [];
         if (this._provider.currentHistoryItemRef) {
-            refs.push(this._provider.currentHistoryItemRef.id);
+            refs.push(this._provider.currentHistoryItemRef.revision ?? this._provider.currentHistoryItemRef.id);
         }
         if (this._provider.currentHistoryItemRemoteRef) {
-            refs.push(this._provider.currentHistoryItemRemoteRef.id);
+            refs.push(this._provider.currentHistoryItemRemoteRef.revision ?? this._provider.currentHistoryItemRemoteRef.id);
         }
         if (this._provider.currentHistoryItemBaseRef) {
-            refs.push(this._provider.currentHistoryItemBaseRef.id);
+            refs.push(this._provider.currentHistoryItemBaseRef.revision ?? this._provider.currentHistoryItemBaseRef.id);
         }
         return refs;
     }

--- a/packages/scm/src/browser/scm-history-graph-tooltip.ts
+++ b/packages/scm/src/browser/scm-history-graph-tooltip.ts
@@ -35,7 +35,7 @@ export function formatRelativeTime(ms: number): string {
     }
     if (diffDay >= 1) {
         return diffDay === 1
-            ? nls.localize('theia/scm/1DayAgo', '1 day ago')
+            ? nls.localizeByDefault('{0} day ago', diffDay)
             : nls.localizeByDefault('{0} days ago', diffDay);
     }
     if (diffHour >= 1) {

--- a/packages/scm/src/browser/scm-history-graph-tooltip.ts
+++ b/packages/scm/src/browser/scm-history-graph-tooltip.ts
@@ -1,0 +1,213 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import { codicon } from '@theia/core/lib/browser/widgets/widget';
+import { nls } from '@theia/core/lib/common/nls';
+import { ScmHistoryItemRef } from './scm-provider';
+import { HistoryGraphEntry } from './scm-history-graph-model';
+import { laneColor, getRefBadgeClass, deduplicateRefs, isTagRef, isRemoteRef } from './scm-history-graph-helpers';
+
+export function formatRelativeTime(ms: number): string {
+    const now = Date.now();
+    const diffMs = now - ms;
+    const diffSec = Math.floor(diffMs / 1000);
+    const diffMin = Math.floor(diffSec / 60);
+    const diffHour = Math.floor(diffMin / 60);
+    const diffDay = Math.floor(diffHour / 24);
+
+    if (diffDay > 30) {
+        return new Date(ms).toLocaleDateString();
+    }
+    if (diffDay >= 1) {
+        return diffDay === 1
+            ? nls.localize('theia/scm/1DayAgo', '1 day ago')
+            : nls.localizeByDefault('{0} days ago', diffDay);
+    }
+    if (diffHour >= 1) {
+        return diffHour === 1
+            ? nls.localize('theia/scm/1HourAgo', '1 hour ago')
+            : nls.localizeByDefault('{0} hours ago', diffHour);
+    }
+    if (diffMin >= 1) {
+        return diffMin === 1
+            ? nls.localize('theia/scm/1MinuteAgo', '1 minute ago')
+            : nls.localizeByDefault('{0} minutes ago', diffMin);
+    }
+    return nls.localize('theia/scm/justNow', 'just now');
+}
+
+export function formatAbsoluteDate(ms: number): string {
+    return new Date(ms).toLocaleString(undefined, {
+        year: 'numeric',
+        month: 'long',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+    });
+}
+
+/**
+ * Appends a theme icon `<i>` element followed by a text node into a container.
+ */
+export function appendIconText(container: HTMLElement, iconName: string, text: string): void {
+    const icon = document.createElement('i');
+    icon.className = codicon(iconName) + ' icon-inline';
+    container.appendChild(icon);
+    container.appendChild(document.createTextNode(` ${text}`));
+}
+
+export function createHoverHr(): HTMLElement {
+    return document.createElement('hr');
+}
+
+/** Creates a ref badge element for the HTML tooltip. */
+export function buildTooltipRefBadge(
+    ref: ScmHistoryItemRef,
+    iconClass: string,
+    showText: boolean,
+    bgColor: string,
+    extraClass?: string
+): HTMLElement {
+    const badge = document.createElement('span');
+    badge.className = `scm-history-ref-badge ${getRefBadgeClass(ref)} tooltip-badge${extraClass ? ' ' + extraClass : ''}`;
+    badge.title = ref.description ?? ref.name;
+    badge.style.backgroundColor = bgColor;
+    badge.style.color = 'var(--theia-scmGraph-historyItemRefForeground, var(--theia-badge-foreground))';
+    const icon = document.createElement('i');
+    icon.className = `codicon ${iconClass} scm-history-ref-icon`;
+    badge.appendChild(icon);
+    if (showText) {
+        const text = document.createElement('span');
+        text.className = 'scm-history-ref-text';
+        text.textContent = ref.name;
+        badge.appendChild(text);
+    }
+    return badge;
+}
+
+export function buildHtmlTooltip(entry: HistoryGraphEntry, markdownRenderer: MarkdownRenderer): HTMLElement {
+    const { item } = entry;
+    const badgeColor = laneColor(entry.graphRow.color);
+    const container = document.createElement('div');
+    container.className = 'scm-history-tooltip';
+
+    // Header
+    if (item.author || item.timestamp !== undefined) {
+        const header = document.createElement('div');
+        header.className = 'scm-history-tooltip-header';
+        header.style.fontWeight = 'bold';
+        header.style.marginBottom = '4px';
+
+        if (item.author) {
+            appendIconText(header, 'account', item.author);
+        }
+        if (item.timestamp !== undefined) {
+            if (item.author) {
+                header.appendChild(document.createTextNode('\u00a0\u00a0'));
+            }
+            const timeSpan = document.createElement('span');
+            appendIconText(timeSpan, 'clock', `${formatRelativeTime(item.timestamp)} (${formatAbsoluteDate(item.timestamp)})`);
+            header.appendChild(timeSpan);
+        }
+
+        container.appendChild(header);
+        container.appendChild(createHoverHr());
+    }
+
+    // Body
+    const bodyText = (item.message && item.message.trim() !== item.subject.trim())
+        ? item.message.trim()
+        : item.subject;
+    const bodyMd = new MarkdownStringImpl(bodyText);
+    const rendered = markdownRenderer.render(bodyMd);
+    container.appendChild(rendered.element);
+
+    // Stats
+    if (item.statistics) {
+        const s = item.statistics;
+        container.appendChild(createHoverHr());
+
+        const stats = document.createElement('div');
+        stats.className = 'scm-history-tooltip-stats';
+
+        const fileCount = s.files === 1 ? '1 file changed' : `${s.files} files changed`;
+        const filesStrong = document.createElement('strong');
+        filesStrong.textContent = fileCount;
+        stats.appendChild(filesStrong);
+
+        if (s.insertions > 0) {
+            stats.appendChild(document.createTextNode(', '));
+            const ins = document.createElement('span');
+            ins.className = 'scm-history-stat-added';
+            ins.textContent = `${s.insertions} insertion${s.insertions === 1 ? '' : 's'}(+)`;
+            stats.appendChild(ins);
+        }
+
+        if (s.deletions > 0) {
+            stats.appendChild(document.createTextNode(', '));
+            const del = document.createElement('span');
+            del.className = 'scm-history-stat-deleted';
+            del.textContent = `${s.deletions} deletion${s.deletions === 1 ? '' : 's'}(-)`;
+            stats.appendChild(del);
+        }
+
+        container.appendChild(stats);
+    }
+
+    // Refs + hash
+    const hasRefs = item.references && item.references.length > 0;
+    if (hasRefs || item.displayId) {
+        container.appendChild(createHoverHr());
+
+        const refsRow = document.createElement('div');
+        refsRow.className = 'scm-history-tooltip-refs';
+        refsRow.style.display = 'flex';
+        refsRow.style.flexWrap = 'wrap';
+        refsRow.style.gap = '4px';
+        refsRow.style.alignItems = 'center';
+
+        if (hasRefs) {
+            const deduplicated = deduplicateRefs(item.references!);
+            for (const { ref, hasBoth } of deduplicated) {
+                const isTag = isTagRef(ref);
+                const isRemote = isRemoteRef(ref);
+
+                if (isTag) {
+                    refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-tag', true, badgeColor));
+                } else if (isRemote) {
+                    refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-cloud', true, badgeColor));
+                } else {
+                    refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-git-branch', true, badgeColor));
+                    if (hasBoth) {
+                        refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-cloud', false, badgeColor, 'scm-history-ref-badge-cloud'));
+                    }
+                }
+            }
+        }
+
+        if (item.displayId) {
+            const hash = document.createElement('code');
+            hash.textContent = item.displayId;
+            refsRow.appendChild(hash);
+        }
+
+        container.appendChild(refsRow);
+    }
+
+    return container;
+}

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -1,0 +1,712 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { Virtuoso } from '@theia/core/shared/react-virtuoso';
+import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
+import { LabelProvider } from '@theia/core/lib/browser/label-provider';
+import { HoverService } from '@theia/core/lib/browser/hover-service';
+import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { ScmHistoryGraphModel, HistoryGraphEntry } from './scm-history-graph-model';
+import { ScmHistoryItemRef, ScmHistoryItemChange } from './scm-provider';
+import { ScmService } from './scm-service';
+import { GraphRow } from './scm-history-graph-lanes';
+import URI from '@theia/core/lib/common/uri';
+import { nls } from '@theia/core/lib/common/nls';
+import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
+import { MenuPath } from '@theia/core/lib/common/menu/menu-types';
+import { ContextMenuRenderer } from '@theia/core/lib/browser/context-menu-renderer';
+import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
+import { DiffUris } from '@theia/core/lib/browser/diff-uris';
+import { ScmContextKeyService } from './scm-context-key-service';
+import {
+    laneColor, getChangeStatus, getFileName, getFilePath, getRepoRelativePath,
+    getRefBadgeClass, isTagRef, isRemoteRef, deduplicateRefs, DeduplicatedRef
+} from './scm-history-graph-helpers';
+import { buildHtmlTooltip } from './scm-history-graph-tooltip';
+
+/** Menu path matching the VS Code 'scm/history/title' contribution point (graph section toolbar). */
+export const SCM_HISTORY_TITLE_MENU: MenuPath = ['plugin_scm/history/title'];
+/** Menu path matching the VS Code 'scm/historyItem/context' contribution point (commit row context menu). */
+export const SCM_HISTORY_ITEM_CONTEXT_MENU: MenuPath = ['plugin_scm/historyItem/context'];
+/** Menu path matching the VS Code 'scm/historyItemRef/context' contribution point (ref badge context menu). */
+export const SCM_HISTORY_ITEM_REF_CONTEXT_MENU: MenuPath = ['plugin_scm/historyItemRef/context'];
+
+// ── Layout constants ────────────────────────────────────────────────────────
+
+const ROW_HEIGHT = 22;
+/** Horizontal width of each lane column in the SVG — matches VS Code exactly. */
+const LANE_WIDTH = 22;
+/** Y position of the commit dot — vertically centered in the row. */
+const DOT_CY = 11;
+
+/** Renders a ref badge as a JSX element for the commit row. */
+function renderJsxRefBadge(
+    ref: ScmHistoryItemRef,
+    iconClass: string,
+    showText: boolean,
+    style: React.CSSProperties,
+    key: string,
+    onContextMenu?: (e: React.MouseEvent) => void
+): React.ReactElement {
+    return (
+        <span
+            key={key}
+            className={`scm-history-ref-badge ${getRefBadgeClass(ref)}`}
+            title={ref.description ?? ref.name}
+            style={style}
+            onContextMenu={onContextMenu}
+        >
+            <i className={`codicon ${iconClass} scm-history-ref-icon`} />
+            {showText && <span className='scm-history-ref-text'>{ref.name}</span>}
+        </span>
+    );
+}
+
+// ── Widget ──────────────────────────────────────────────────────────────────
+
+@injectable()
+export class ScmHistoryGraphWidget extends ReactWidget {
+
+    static readonly ID = 'scm-history-graph-widget';
+    static readonly LABEL = nls.localizeByDefault('Graph');
+
+    @inject(ScmHistoryGraphModel) protected readonly model: ScmHistoryGraphModel;
+    @inject(HoverService) protected readonly hoverService: HoverService;
+    @inject(MarkdownRendererFactory) protected readonly markdownRendererFactory: MarkdownRendererFactory;
+    @inject(ScmService) protected readonly scmService: ScmService;
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+    @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer;
+    @inject(OpenerService) protected readonly openerService: OpenerService;
+    @inject(ScmContextKeyService) protected readonly scmContextKeys: ScmContextKeyService;
+
+    protected selectedIndex = -1;
+    /** Currently selected change row key (`${itemId}-${ci}`), or undefined. */
+    protected selectedChangeKey: string | undefined;
+    /** Map from commit id → loaded changes (undefined = not loaded yet). */
+    protected expandedChanges = new Map<string, ScmHistoryItemChange[] | 'loading'>();
+    /** Set of commit ids that are currently expanded. */
+    protected expandedIds = new Set<string>();
+    /** Map from commit id → in-flight CancellationTokenSource for loadChanges. */
+    protected loadChangesCts = new Map<string, CancellationTokenSource>();
+
+    constructor() {
+        super();
+        this.id = ScmHistoryGraphWidget.ID;
+        this.title.label = ScmHistoryGraphWidget.LABEL;
+        this.title.caption = ScmHistoryGraphWidget.LABEL;
+        this.title.closable = false;
+        this.addClass('scm-history-graph-container');
+        this.node.tabIndex = 0;
+    }
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(
+            this.model.onDidChange(() => {
+                this.updateContextKeys();
+                this.update();
+            })
+        );
+        this.toDispose.push({
+            dispose: () => {
+                for (const cts of this.loadChangesCts.values()) {
+                    cts.cancel();
+                    cts.dispose();
+                }
+                this.loadChangesCts.clear();
+            }
+        });
+        this.update();
+    }
+
+    protected updateContextKeys(): void {
+        const provider = this.model.provider;
+        this.scmContextKeys.scmCurrentHistoryItemRefHasRemote.set(!!provider?.currentHistoryItemRemoteRef);
+        this.scmContextKeys.scmCurrentHistoryItemRefHasBase.set(!!provider?.currentHistoryItemBaseRef);
+    }
+
+    protected render(): React.ReactNode {
+        const { entries, hasMore, loading } = this.model;
+
+        // Only show the empty state once the model has completed at least one load attempt.
+        // While the model is still initializing (provider not yet set, no load attempted),
+        // render a loading indicator to avoid a flash of "no history" on startup.
+        if (!loading && entries.length === 0) {
+            if (!this.model.hasAttemptedLoad) {
+                return (
+                    <div className='scm-history-loading'>
+                        {nls.localizeByDefault('Loading')}
+                    </div>
+                );
+            }
+            return (
+                <div className='scm-history-empty'>
+                    {nls.localize('theia/scm/noHistory', 'No source control history available.')}
+                </div>
+            );
+        }
+
+        // Determine how many lanes are active for SVG width
+        const maxLane = entries.reduce((max, e) => {
+            const rowMax = Math.max(e.graphRow.lane, ...e.graphRow.edges.map(ed => Math.max(ed.fromLane, ed.toLane)));
+            return Math.max(max, rowMax);
+        }, 0);
+        const svgWidth = (maxLane + 1) * LANE_WIDTH;
+
+        const footer = loading
+            ? () => <div className='scm-history-loading'>{nls.localizeByDefault('Loading')}</div>
+            : hasMore
+                ? () => (
+                    <div
+                        className='scm-history-load-more'
+                        onClick={this.handleLoadMore}
+                        role='button'
+                        tabIndex={0}
+                        onKeyDown={this.handleLoadMoreKey}
+                    >
+                        {nls.localizeByDefault('Load more')}
+                    </div>
+                )
+                : undefined;
+
+        return (
+            <Virtuoso
+                className='scm-history-graph-list'
+                data={entries as HistoryGraphEntry[]}
+                itemContent={(idx, entry) => this.renderRow(entry, idx, svgWidth)}
+                endReached={hasMore && !loading ? this.handleEndReached : undefined}
+                overscan={500}
+                components={footer ? { Footer: footer } : {}}
+                style={{ overflowX: 'hidden' }}
+            />
+        );
+    }
+
+    protected handleEndReached = (): void => {
+        if (this.model.hasMore && !this.model.loading) {
+            this.model.loadMore();
+        }
+    };
+
+    protected renderRow(entry: HistoryGraphEntry, idx: number, svgWidth: number): React.ReactElement {
+        const { item, graphRow } = entry;
+        const isSelected = idx === this.selectedIndex;
+        const isExpanded = this.expandedIds.has(item.id);
+        const changes = this.expandedChanges.get(item.id);
+        // The first commit (idx === 0) on lane 0 is treated as HEAD/current
+        const isHead = idx === 0 && graphRow.lane === 0;
+
+        return (
+            <React.Fragment key={item.id}>
+                <div
+                    className={`scm-history-graph-row${isSelected ? ' selected' : ''}`}
+                    onClick={() => this.handleRowClick(idx, entry)}
+                    onContextMenu={e => this.handleRowContextMenu(e, entry)}
+                    onMouseEnter={e => this.handleRowMouseEnter(e, entry)}
+                    onMouseLeave={() => this.hoverService.cancelHover()}
+                >
+                    {this.renderGraphSvg(graphRow, svgWidth, isHead)}
+                    <div className='scm-history-graph-info'>
+                        <span className='scm-history-subject'>{item.subject}</span>
+                        {item.author && (
+                            <span className='scm-history-author'>{item.author}</span>
+                        )}
+                        {item.references && item.references.length > 0 && (
+                            <span className='scm-history-badges scm-history-badges-right'>
+                                {this.renderRefBadges(item.references, entry)}
+                            </span>
+                        )}
+                    </div>
+                </div>
+                {isExpanded && this.renderChangesRows(item.id, svgWidth, graphRow, changes)}
+            </React.Fragment>
+        );
+    }
+
+    protected _markdownRenderer: MarkdownRenderer | undefined;
+    protected get markdownRenderer(): MarkdownRenderer {
+        this._markdownRenderer ||= this.markdownRendererFactory();
+        return this._markdownRenderer;
+    }
+
+    protected handleRowMouseEnter = (e: React.MouseEvent<HTMLDivElement>, entry: HistoryGraphEntry): void => {
+        this.hoverService.requestHover({
+            content: buildHtmlTooltip(entry, this.markdownRenderer),
+            target: e.currentTarget,
+            position: 'right',
+        });
+    };
+
+    protected renderChangesRows(
+        itemId: string,
+        svgWidth: number,
+        graphRow: GraphRow,
+        changes: ScmHistoryItemChange[] | 'loading' | undefined
+    ): React.ReactElement {
+        if (changes === 'loading' || changes === undefined) {
+            return (
+                <div key={`${itemId}-loading`} className='scm-history-changes-loading'>
+                    {nls.localizeByDefault('Loading')}
+                </div>
+            );
+        }
+
+        if (changes.length === 0) {
+            return (
+                <div key={`${itemId}-empty`} className='scm-history-changes-empty'>
+                    {nls.localize('theia/scm/noChanges', 'No changed files.')}
+                </div>
+            );
+        }
+
+        return (
+            <React.Fragment key={`${itemId}-changes`}>
+                {changes.map((change, ci) =>
+                    this.renderChangeRow(change, ci, itemId, svgWidth, graphRow)
+                )}
+            </React.Fragment>
+        );
+    }
+
+    protected renderChangeRow(
+        change: ScmHistoryItemChange,
+        ci: number,
+        itemId: string,
+        svgWidth: number,
+        graphRow: GraphRow
+    ): React.ReactElement {
+        const rootUri = this.scmService.selectedRepository?.provider.rootUri;
+        const uri = change.modifiedUri ?? change.originalUri ?? change.uri;
+        const relativePath = getRepoRelativePath(uri, rootUri);
+        const fileName = getFileName(relativePath);
+        const dirPath = relativePath.includes('/')
+            ? relativePath.slice(0, relativePath.lastIndexOf('/'))
+            : '';
+        const status = getChangeStatus(change);
+        const statusClass = status === 'A' ? 'added' : status === 'D' ? 'deleted' : status === 'R' ? 'renamed' : 'modified';
+        const resourceUri = new URI(uri);
+        const fileIcon = this.labelProvider.getIcon(resourceUri);
+        const changeKey = `${itemId}-change-${ci}`;
+        const isSelected = this.selectedChangeKey === changeKey;
+
+        return (
+            <div
+                key={changeKey}
+                className={`scm-history-change-row${isSelected ? ' selected' : ''}`}
+                onClick={e => this.handleChangeClick(e, change, changeKey)}
+                role='treeitem'
+                tabIndex={-1}
+            >
+                {this.renderChangeRowSvg(graphRow, svgWidth)}
+                <div className='scm-history-change-info'>
+                    <span className={`${fileIcon} file-icon scm-history-change-file-icon`} />
+                    <div className='scm-history-change-name-container'>
+                        <span className='name scm-history-change-name' title={relativePath}>{fileName}</span>
+                        {dirPath && <span className='path scm-history-change-dir'>{dirPath}</span>}
+                    </div>
+                    <span className={`scm-history-change-status ${statusClass}`}>{status}</span>
+                </div>
+            </div>
+        );
+    }
+
+    protected handleChangeClick = (e: React.MouseEvent, change: ScmHistoryItemChange, changeKey: string): void => {
+        e.stopPropagation();
+        this.selectedChangeKey = changeKey;
+        this.update();
+        this.openChange(change);
+    };
+
+    protected openChange(change: ScmHistoryItemChange): void {
+        try {
+            if (change.originalUri && change.modifiedUri) {
+                const originalUri = new URI(change.originalUri);
+                const modifiedUri = new URI(change.modifiedUri);
+                const label = getFileName(getFilePath(change.modifiedUri));
+                open(this.openerService, DiffUris.encode(originalUri, modifiedUri, label));
+            } else if (change.modifiedUri) {
+                open(this.openerService, new URI(change.modifiedUri));
+            } else if (change.originalUri) {
+                open(this.openerService, new URI(change.originalUri));
+            } else {
+                open(this.openerService, new URI(change.uri));
+            }
+        } catch (err) {
+            console.error('ScmHistoryGraphWidget: failed to open change', err);
+        }
+    }
+
+    protected renderChangeRowSvg(graphRow: GraphRow, svgWidth: number): React.ReactElement {
+        const commitX = graphRow.lane * LANE_WIDTH + 11;
+        const commitColor = laneColor(graphRow.color);
+        const elements: React.ReactElement[] = [];
+        let keyIdx = 0;
+
+        for (const edge of graphRow.edges) {
+            if (edge.type !== 'pass-through') {
+                continue;
+            }
+            const x = edge.fromLane * LANE_WIDTH + 11;
+            const color = laneColor(edge.color);
+            elements.push(
+                <path
+                    key={`pass-${keyIdx++}`}
+                    fill='none'
+                    strokeWidth='1px'
+                    strokeLinecap='round'
+                    d={`M ${x} 0 V 22`}
+                    style={{ stroke: color }}
+                />
+            );
+        }
+
+        if (graphRow.hasContinuation) {
+            elements.push(
+                <path
+                    key={`commit-${keyIdx++}`}
+                    fill='none'
+                    strokeWidth='1px'
+                    strokeLinecap='round'
+                    d={`M ${commitX} 0 V 22`}
+                    style={{ stroke: commitColor }}
+                />
+            );
+        }
+
+        return (
+            <svg
+                className='scm-history-graph-svg'
+                style={{ height: `${ROW_HEIGHT}px`, width: `${svgWidth}px` }}
+            >
+                {elements}
+            </svg>
+        );
+    }
+
+    /**
+     * Renders the SVG graph column for a commit row, matching VS Code's SVG structure:
+     *
+     * - Each lane is 22px wide; circle cx = lane * 22 + 11, cy = 11
+     * - Pass-through lanes: full vertical line M x 0 V 22
+     * - Commit lane: top segment (M commitX 0 V 11) + bottom segment (M commitX 11 V 22)
+     * - HEAD/current commit (first entry): r=7 with inner dot, NO top segment
+     * - Normal commit: r=5
+     * - Branch-out edge: diagonal S-curve bezier from commit position (commitX, cy)
+     *   sweeping down to the new lane at the bottom: M commitX cy C commitX 22 newX cy newX 22
+     * - Merge-in edge: bezier from the source lane at the top curving into
+     *   the commit position: M srcX 0 C srcX cy commitX cy commitX cy
+     */
+    protected renderGraphSvg(row: GraphRow, svgWidth: number, isHead: boolean): React.ReactElement {
+        const commitX = row.lane * LANE_WIDTH + 11;
+        const cy = DOT_CY;
+        const commitColor = laneColor(row.color);
+
+        const elements: React.ReactElement[] = [];
+        let keyIdx = 0;
+
+        // Pass-through lines: straight vertical line through the full row height
+        for (const edge of row.edges) {
+            if (edge.type !== 'pass-through') {
+                continue;
+            }
+            const x = edge.fromLane * LANE_WIDTH + 11;
+            const color = laneColor(edge.color);
+            elements.push(
+                <path
+                    key={`pass-${keyIdx++}`}
+                    fill='none'
+                    strokeWidth='1px'
+                    strokeLinecap='round'
+                    d={`M ${x} 0 V 22`}
+                    style={{ stroke: color }}
+                />
+            );
+        }
+
+        // Merge-in edges: source lane at top curves into the commit position (mid-row)
+        for (const edge of row.edges) {
+            if (edge.type !== 'merge-in') {
+                continue;
+            }
+            const srcX = edge.fromLane * LANE_WIDTH + 11;
+            const color = laneColor(edge.color);
+            // Cubic bezier: start at (srcX, 0), control points pull both ends to mid-row,
+            // end at commit position (commitX, cy)
+            const d = `M ${srcX} 0 C ${srcX} ${cy}, ${commitX} ${cy}, ${commitX} ${cy}`;
+            elements.push(
+                <path
+                    key={`merge-${keyIdx++}`}
+                    fill='none'
+                    strokeWidth='1px'
+                    strokeLinecap='round'
+                    d={d}
+                    style={{ stroke: color }}
+                />
+            );
+        }
+
+        // Commit lane lines — split at cy=11
+        // Top segment: only drawn if there is an incoming line from above
+        // (i.e. this commit was referenced as a parent by an earlier row)
+        if (row.hasTopLine) {
+            elements.push(
+                <path
+                    key={`top-${keyIdx++}`}
+                    fill='none'
+                    strokeWidth='1px'
+                    strokeLinecap='round'
+                    d={`M ${commitX} 0 V ${cy}`}
+                    style={{ stroke: commitColor }}
+                />
+            );
+        }
+        // Bottom segment: only drawn if the lane continues to a parent below
+        if (row.hasContinuation) {
+            elements.push(
+                <path
+                    key={`bottom-${keyIdx++}`}
+                    fill='none'
+                    strokeWidth='1px'
+                    strokeLinecap='round'
+                    d={`M ${commitX} ${cy} V 22`}
+                    style={{ stroke: commitColor }}
+                />
+            );
+        }
+
+        // Branch-out edges: commit position (mid-row) curves down to a new lane at bottom
+        for (const edge of row.edges) {
+            if (edge.type !== 'branch-out') {
+                continue;
+            }
+            const dstX = edge.toLane * LANE_WIDTH + 11;
+            const color = laneColor(edge.color);
+            // Diagonal S-curve bezier: CP1 keeps x at srcX while y goes to bottom;
+            // CP2 keeps y at cy while x reaches dstX — produces a smooth sweep
+            // down-and-right (or left) from the commit circle to the target lane.
+            const srcX = edge.fromLane * LANE_WIDTH + 11;
+            const d = `M ${srcX} ${cy} C ${srcX} 22, ${dstX} ${cy}, ${dstX} 22`;
+            elements.push(
+                <path
+                    key={`branch-${keyIdx++}`}
+                    fill='none'
+                    strokeWidth='1px'
+                    strokeLinecap='round'
+                    d={d}
+                    style={{ stroke: color }}
+                />
+            );
+        }
+
+        // Commit circle — drawn last so it renders on top of all lines
+        if (isHead) {
+            elements.push(
+                <circle
+                    key={`circle-${keyIdx++}`}
+                    cx={commitX}
+                    cy={cy}
+                    r={7}
+                    style={{ strokeWidth: '2px', fill: commitColor }}
+                />
+            );
+            elements.push(
+                <circle
+                    key={`inner-${keyIdx++}`}
+                    cx={commitX}
+                    cy={cy}
+                    r={2}
+                    style={{ strokeWidth: '4px', fill: 'var(--theia-editor-background)', stroke: 'var(--theia-editor-background)' }}
+                />
+            );
+        } else {
+            elements.push(
+                <circle
+                    key={`circle-${keyIdx++}`}
+                    cx={commitX}
+                    cy={cy}
+                    r={5}
+                    style={{ strokeWidth: '2px', fill: commitColor }}
+                />
+            );
+        }
+
+        return (
+            <svg
+                className='scm-history-graph-svg'
+                style={{ height: `${ROW_HEIGHT}px`, width: `${svgWidth}px` }}
+            >
+                {elements}
+            </svg>
+        );
+    }
+
+    protected renderRefBadges(refs?: readonly ScmHistoryItemRef[], entry?: HistoryGraphEntry): React.ReactNode {
+        if (!refs || refs.length === 0) {
+            return undefined;
+        }
+
+        const laneColorValue = entry ? laneColor(entry.graphRow.color) : undefined;
+        const deduplicated = deduplicateRefs(refs);
+        const style: React.CSSProperties = laneColorValue
+            ? { backgroundColor: laneColorValue, color: 'var(--theia-scmGraph-historyItemRefForeground, var(--theia-badge-foreground))' }
+            : {};
+
+        const badges: React.ReactElement[] = [];
+        for (const info of deduplicated) {
+            if (badges.length >= 3) {
+                break;
+            }
+            const { ref, hasBoth } = info as DeduplicatedRef;
+            const isTag = isTagRef(ref);
+            const isRemote = isRemoteRef(ref);
+            const onContextMenu = entry ? (e: React.MouseEvent) => this.handleRefBadgeContextMenu(e, entry, ref) : undefined;
+
+            if (isTag) {
+                badges.push(renderJsxRefBadge(ref, 'codicon-tag', false, style, ref.id, onContextMenu));
+            } else if (isRemote) {
+                badges.push(renderJsxRefBadge(ref, 'codicon-cloud', true, style, ref.id, onContextMenu));
+            } else {
+                badges.push(renderJsxRefBadge(ref, 'codicon-git-branch', true, style, ref.id, onContextMenu));
+                if (hasBoth && badges.length < 3) {
+                    badges.push(
+                        <span
+                            key={`${ref.id}-cloud`}
+                            className='scm-history-ref-badge scm-history-ref-badge-cloud'
+                            title={ref.description ?? ref.name}
+                            style={style}
+                        >
+                            <i className='codicon codicon-cloud scm-history-ref-icon' />
+                        </span>
+                    );
+                }
+            }
+        }
+        return badges;
+    }
+
+    protected handleRowContextMenu = (e: React.MouseEvent, entry: HistoryGraphEntry): void => {
+        e.preventDefault();
+        e.stopPropagation();
+        const repo = this.scmService.selectedRepository;
+        if (!repo) {
+            return;
+        }
+        const { item } = entry;
+        if (item.references && item.references.length > 0) {
+            this.scmContextKeys.scmHistoryItemRef.set(item.references[0].id);
+        } else {
+            this.scmContextKeys.scmHistoryItemRef.set(undefined);
+        }
+        const sourceControlHandle = repo.provider.handle;
+        const args = sourceControlHandle !== undefined
+            ? [{ sourceControlHandle }, { sourceControlHandle, id: item.id, type: 'historyItem' as const }]
+            : [];
+        this.contextMenuRenderer.render({
+            menuPath: SCM_HISTORY_ITEM_CONTEXT_MENU,
+            anchor: e.nativeEvent,
+            args,
+            context: this.node
+        });
+    };
+
+    protected handleRefBadgeContextMenu = (e: React.MouseEvent, entry: HistoryGraphEntry, ref: ScmHistoryItemRef): void => {
+        e.preventDefault();
+        e.stopPropagation();
+        const repo = this.scmService.selectedRepository;
+        if (!repo) {
+            return;
+        }
+        this.scmContextKeys.scmHistoryItemRef.set(ref.id);
+        const sourceControlHandle = repo.provider.handle;
+        const args = sourceControlHandle !== undefined
+            ? [{ sourceControlHandle }, { sourceControlHandle, id: ref.id, type: 'historyItemRef' as const }]
+            : [];
+        this.contextMenuRenderer.render({
+            menuPath: SCM_HISTORY_ITEM_REF_CONTEXT_MENU,
+            anchor: e.nativeEvent,
+            args,
+            context: this.node
+        });
+    };
+
+    protected handleRowClick = (idx: number, entry: HistoryGraphEntry): void => {
+        this.selectedIndex = idx;
+        const { item } = entry;
+
+        if (this.expandedIds.has(item.id)) {
+            this.expandedIds.delete(item.id);
+            const cts = this.loadChangesCts.get(item.id);
+            if (cts) {
+                cts.cancel();
+                cts.dispose();
+                this.loadChangesCts.delete(item.id);
+            }
+        } else {
+            this.expandedIds.add(item.id);
+            if (!this.expandedChanges.has(item.id)) {
+                this.loadChanges(entry);
+            }
+        }
+
+        this.update();
+    };
+
+    protected async loadChanges(entry: HistoryGraphEntry): Promise<void> {
+        const { item } = entry;
+        const provider = this.model.provider;
+        if (!provider) {
+            this.expandedChanges.set(item.id, []);
+            this.update();
+            return;
+        }
+
+        this.expandedChanges.set(item.id, 'loading');
+        this.update();
+
+        const cts = new CancellationTokenSource();
+        this.loadChangesCts.set(item.id, cts);
+        this.toDispose.push(cts);
+        try {
+            const parentId = item.parentIds?.[0];
+            const changes = await provider.provideHistoryItemChanges(item.id, parentId, cts.token);
+            if (!cts.token.isCancellationRequested) {
+                this.expandedChanges.set(item.id, changes ?? []);
+                this.update();
+            }
+        } catch (err) {
+            if (!cts.token.isCancellationRequested) {
+                console.error('ScmHistoryGraphWidget: failed to load changes', err);
+                this.expandedChanges.set(item.id, []);
+                this.update();
+            }
+        } finally {
+            this.loadChangesCts.delete(item.id);
+        }
+    }
+
+    protected handleLoadMore = (): void => {
+        this.model.loadMore();
+    };
+
+    protected handleLoadMoreKey = (e: React.KeyboardEvent): void => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            this.model.loadMore();
+        }
+    };
+
+}

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -218,7 +218,6 @@ export class ScmHistoryGraphWidget extends ReactWidget {
                     onClick={() => this.handleRowClick(idx, entry)}
                     onContextMenu={e => this.handleRowContextMenu(e, entry)}
                     onMouseEnter={e => this.handleRowMouseEnter(e, entry)}
-                    onMouseLeave={() => this.hoverService.cancelHover()}
                 >
                     {this.renderGraphSvg(graphRow, svgWidth, isHead)}
                     <div className='scm-history-graph-info'>

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -249,6 +249,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
             content: buildHtmlTooltip(entry, this.markdownRenderer),
             target: e.currentTarget,
             position: 'right',
+            interactive: true,
         });
     };
 

--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -123,9 +123,10 @@ export interface ScmHistoryItemRefsChangeEvent {
 }
 
 export interface ScmHistoryOptions {
-    readonly cursor?: string;
-    readonly limit?: number | { id: string };
+    readonly skip?: number;
+    readonly limit?: number | { id?: string };
     readonly historyItemRefs?: readonly string[];
+    readonly filterText?: string;
 }
 
 export interface ScmHistoryItemStatistics {

--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -18,11 +18,13 @@
 
 import { Disposable, Event } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
+import { CancellationToken } from '@theia/core/lib/common/cancellation';
 
 export interface ScmProvider extends Disposable {
     readonly id: string;
     readonly label: string;
     readonly rootUri: string;
+    readonly handle?: number;
 
     readonly acceptInputCommand?: ScmCommand;
 
@@ -41,6 +43,8 @@ export interface ScmProvider extends Disposable {
     readonly onDidChangeActionButton?: Event<ScmActionButton | undefined>;
 
     readonly providerContextValue?: string;
+
+    readonly historyProvider?: ScmHistoryProvider;
 }
 
 export const ScmResourceGroup = Symbol('ScmResourceGroup');
@@ -101,4 +105,67 @@ export interface ScmActionButton {
     secondaryCommands?: ScmCommand[][];
     enabled?: boolean;
     description?: string;
+}
+
+export interface ScmHistoryItemRef {
+    readonly id: string;
+    readonly name: string;
+    readonly description?: string;
+    readonly revision?: string;
+    readonly icon?: string;
+    readonly category?: string;
+}
+
+export interface ScmHistoryItemRefsChangeEvent {
+    readonly added: readonly ScmHistoryItemRef[];
+    readonly removed: readonly ScmHistoryItemRef[];
+    readonly modified: readonly ScmHistoryItemRef[];
+}
+
+export interface ScmHistoryOptions {
+    readonly cursor?: string;
+    readonly limit?: number | { id: string };
+    readonly historyItemRefs?: readonly string[];
+}
+
+export interface ScmHistoryItemStatistics {
+    readonly files: number;
+    readonly insertions: number;
+    readonly deletions: number;
+}
+
+export interface ScmHistoryItem {
+    readonly id: string;
+    readonly parentIds?: readonly string[];
+    readonly subject: string;
+    readonly message?: string;
+    readonly author?: string;
+    readonly authorEmail?: string;
+    readonly authorIcon?: string;
+    readonly displayId?: string;
+    readonly timestamp?: number;
+    readonly tooltip?: string;
+    readonly statistics?: ScmHistoryItemStatistics;
+    readonly references?: readonly ScmHistoryItemRef[];
+}
+
+export interface ScmHistoryItemChange {
+    readonly uri: string;
+    readonly originalUri?: string;
+    readonly modifiedUri?: string;
+    readonly renameUri?: string;
+}
+
+export interface ScmHistoryProvider {
+    readonly currentHistoryItemRef?: ScmHistoryItemRef;
+    readonly currentHistoryItemRemoteRef?: ScmHistoryItemRef;
+    readonly currentHistoryItemBaseRef?: ScmHistoryItemRef;
+    readonly onDidChangeCurrentHistoryItemRefs: Event<void>;
+    readonly onDidChangeHistoryItemRefs: Event<ScmHistoryItemRefsChangeEvent>;
+
+    provideHistoryItemRefs(historyItemRefs: string[] | undefined, token: CancellationToken): Promise<ScmHistoryItemRef[] | undefined>;
+    provideHistoryItems(options: ScmHistoryOptions, token: CancellationToken): Promise<ScmHistoryItem[] | undefined>;
+    provideHistoryItemChanges(historyItemId: string, historyItemParentId: string | undefined, token: CancellationToken): Promise<ScmHistoryItemChange[] | undefined>;
+    resolveHistoryItem(historyItemId: string, token: CancellationToken): Promise<ScmHistoryItem | undefined>;
+    resolveHistoryItemRefsCommonAncestor(historyItemRefs: string[], token: CancellationToken): Promise<string | undefined>;
 }

--- a/packages/scm/src/browser/style/index.css
+++ b/packages/scm/src/browser/style/index.css
@@ -14,15 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
  ********************************************************************************/
 
+@import './scm-history-graph.css';
+
 .theia-scm-commit {
   overflow: hidden;
   font-size: var(--theia-ui-font-size1);
   max-height: calc(100% - var(--theia-border-width));
   position: relative;
-  padding: var(--theia-ui-padding)
-           max(var(--theia-ui-padding), var(--theia-scrollbar-width))
-           var(--theia-ui-padding)
-           calc(var(--theia-ui-padding) * 3);
+  padding: var(--theia-ui-padding) max(var(--theia-ui-padding), var(--theia-scrollbar-width)) var(--theia-ui-padding) calc(var(--theia-ui-padding) * 3);
 }
 
 .theia-scm {
@@ -141,9 +140,9 @@
 .theia-scm-validation-message-info {
   background-color: var(--theia-inputValidation-infoBackground) !important;
   color: var(--theia-inputValidation-infoForeground);
-  border: var(--theia-border-width) solid
-    var(--theia-inputValidation-infoBorder);
-  border-top: none; /* remove top border since the input declares it already */
+  border: var(--theia-border-width) solid var(--theia-inputValidation-infoBorder);
+  border-top: none;
+  /* remove top border since the input declares it already */
 }
 
 .theia-scm-validation-message-success {
@@ -155,17 +154,17 @@
 .theia-scm-validation-message-warning {
   background-color: var(--theia-inputValidation-warningBackground) !important;
   color: var(--theia-inputValidation-warningForeground);
-  border: var(--theia-border-width) solid
-    var(--theia-inputValidation-warningBorder);
-  border-top: none; /* remove top border since the input declares it already */
+  border: var(--theia-border-width) solid var(--theia-inputValidation-warningBorder);
+  border-top: none;
+  /* remove top border since the input declares it already */
 }
 
 .theia-scm-validation-message-error {
   background-color: var(--theia-inputValidation-errorBackground) !important;
   color: var(--theia-inputValidation-errorForeground);
-  border: var(--theia-border-width) solid
-    var(--theia-inputValidation-errorBorder);
-  border-top: none; /* remove top border since the input declares it already */
+  border: var(--theia-border-width) solid var(--theia-inputValidation-errorBorder);
+  border-top: none;
+  /* remove top border since the input declares it already */
 }
 
 .theia-scm-action-button-container {

--- a/packages/scm/src/browser/style/scm-history-graph.css
+++ b/packages/scm/src/browser/style/scm-history-graph.css
@@ -1,0 +1,313 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource GmbH and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* ── Widget container ────────────────────────────────────────────────────── */
+.scm-history-graph-container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+    font-size: var(--theia-ui-font-size1);
+}
+
+/* ── Scrollable list area ────────────────────────────────────────────────── */
+.scm-history-graph-list {
+    flex: 1;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/* ── Individual commit row ───────────────────────────────────────────────── */
+.scm-history-graph-row {
+    display: flex;
+    align-items: flex-start;
+    height: 22px;
+    cursor: pointer;
+    padding-right: var(--theia-ui-padding);
+    box-sizing: border-box;
+    overflow: hidden;
+}
+
+.scm-history-graph-row:hover {
+    background-color: var(--theia-list-hoverBackground);
+    color: var(--theia-list-hoverForeground);
+}
+
+.scm-history-graph-row.selected {
+    background-color: var(--theia-list-activeSelectionBackground);
+    color: var(--theia-list-activeSelectionForeground);
+}
+
+/* ── SVG lane column ─────────────────────────────────────────────────────── */
+.scm-history-graph-svg {
+    flex-shrink: 0;
+    overflow: visible;
+    display: block;
+}
+
+/* ── Commit info column ──────────────────────────────────────────────────── */
+.scm-history-graph-info {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    gap: 4px;
+    padding-left: 4px;
+    overflow: hidden;
+    height: 22px;
+}
+
+/* ── Subject line (primary content) ─────────────────────────────────────── */
+.scm-history-subject {
+    flex-shrink: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-weight: normal;
+}
+
+/* ── Author name (dimmed, next to subject) ───────────────────────────────── */
+.scm-history-author {
+    flex-shrink: 1;
+    min-width: 0;
+    font-size: var(--theia-ui-font-size0);
+    opacity: 0.7;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    padding-left: 4px;
+}
+
+/* ── Badges container (pushed to the right) ─────────────────────────────── */
+.scm-history-badges {
+    display: flex;
+    align-items: center;
+    gap: 2px;
+    flex-shrink: 0;
+    padding-left: 4px;
+}
+
+.scm-history-badges-right {
+    margin-left: auto;
+}
+
+/* ── Ref badges (branch / tag labels) ───────────────────────────────────── */
+.scm-history-ref-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 0 6px;
+    border-radius: 10px;
+    font-size: var(--theia-ui-font-size0);
+    line-height: 1;
+    min-height: 15px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    max-width: 140px;
+    overflow: hidden;
+    box-sizing: border-box;
+}
+
+.scm-history-ref-badge .scm-history-ref-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+.scm-history-ref-badge .scm-history-ref-icon {
+    flex-shrink: 0;
+    font-size: 11px;
+    line-height: 1;
+}
+
+/* Tooltip badges always show text, override max-width */
+.scm-history-ref-badge.tooltip-badge {
+    max-width: none;
+}
+
+/* Fallback colors when no inline lane color is set */
+.scm-history-ref-badge.head {
+    background-color: var(--theia-scmGraph-historyItemRefColor, var(--theia-badge-background));
+    color: var(--theia-badge-foreground);
+}
+
+.scm-history-ref-badge.remote {
+    background-color: var(--theia-scmGraph-historyItemRemoteRefColor, var(--theia-statusBar-background));
+    color: var(--theia-statusBar-foreground);
+}
+
+.scm-history-ref-badge.tag {
+    background-color: var(--theia-scmGraph-historyItemBaseRefColor, var(--theia-inputValidation-warningBackground));
+    color: var(--theia-inputValidation-warningForeground);
+}
+
+.scm-history-ref-badge.base {
+    background-color: var(--theia-list-inactiveSelectionBackground);
+    color: var(--theia-list-inactiveSelectionForeground);
+}
+
+/* Icon-only cloud badge (remote tracking indicator) */
+.scm-history-ref-badge-cloud {
+    padding: 0 4px;
+    max-width: none;
+}
+
+/* ── Changed files rows (expanded below a commit) ───────────────────────── */
+.scm-history-change-row {
+    display: flex;
+    align-items: center;
+    height: 22px;
+    box-sizing: border-box;
+    padding-right: var(--theia-ui-padding);
+    cursor: pointer;
+}
+
+.scm-history-change-row:hover {
+    background-color: var(--theia-list-hoverBackground);
+    color: var(--theia-list-hoverForeground);
+}
+
+.scm-history-change-row.selected {
+    background-color: var(--theia-list-activeSelectionBackground);
+    color: var(--theia-list-activeSelectionForeground);
+}
+
+.scm-history-change-info {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    gap: 4px;
+    padding-left: 4px;
+    overflow: hidden;
+}
+
+.scm-history-change-file-icon {
+    flex-shrink: 0;
+}
+
+.scm-history-change-name-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.scm-history-change-name {
+    flex-shrink: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.scm-history-change-dir {
+    flex: 1;
+    font-size: var(--theia-ui-font-size0);
+    opacity: 0.6;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    padding-left: 4px;
+}
+
+.scm-history-change-status {
+    flex-shrink: 0;
+    font-size: var(--theia-ui-font-size0);
+    font-weight: bold;
+    width: 14px;
+    text-align: center;
+    margin-left: auto;
+}
+
+.scm-history-change-status.added {
+    color: var(--theia-gitDecoration-addedResourceForeground, #388a34);
+}
+
+.scm-history-change-status.deleted {
+    color: var(--theia-gitDecoration-deletedResourceForeground, #a1260d);
+}
+
+.scm-history-change-status.modified {
+    color: var(--theia-gitDecoration-modifiedResourceForeground, #0078d4);
+}
+
+.scm-history-change-status.renamed {
+    color: var(--theia-gitDecoration-renamedResourceForeground, #b180d7);
+}
+
+.scm-history-changes-loading,
+.scm-history-changes-empty {
+    display: flex;
+    align-items: center;
+    height: 22px;
+    padding-left: 24px;
+    font-size: var(--theia-ui-font-size0);
+    opacity: 0.6;
+}
+
+/* ── Load-more button ────────────────────────────────────────────────────── */
+.scm-history-load-more {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 28px;
+    cursor: pointer;
+    font-size: var(--theia-ui-font-size1);
+    color: var(--theia-textLink-foreground);
+    flex-shrink: 0;
+}
+
+.scm-history-load-more:hover {
+    text-decoration: underline;
+}
+
+/* ── Loading spinner placeholder ────────────────────────────────────────── */
+.scm-history-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 28px;
+    font-size: var(--theia-ui-font-size1);
+    opacity: 0.6;
+}
+
+/* ── Tooltip header icon alignment ──────────────────────────────────────── */
+.scm-history-tooltip-header .icon-inline {
+    vertical-align: middle;
+}
+
+/* ── Tooltip stat colors (used inside .theia-hover) ─────────────────────── */
+.scm-history-stat-added {
+    color: var(--theia-gitDecoration-addedResourceForeground, #388a34);
+}
+
+.scm-history-stat-deleted {
+    color: var(--theia-gitDecoration-deletedResourceForeground, #a1260d);
+}
+
+/* ── Empty state ─────────────────────────────────────────────────────────── */
+.scm-history-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    opacity: 0.6;
+    font-size: var(--theia-ui-font-size1);
+    padding: var(--theia-ui-padding);
+    text-align: center;
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Implement the Source Control Graph view, enabling extensions like
vscode.git to render a commit DAG with branch lane lines, ref badges,
author info, tooltips, and context menus inside the SCM ViewContainer.

Plugin API & RPC bridge:
- Add SourceControlHistoryProvider and related types to theia.d.ts
- Add ScmExt/ScmMain RPC methods and DTOs for history items, refs,
  and changes
- Bridge plugin-side SourceControlImpl.historyProvider to main-side
  PluginScmHistoryProvider with cancellation chaining

Graph UI:
- ScmHistoryGraphWidget (ReactWidget + Virtuoso) with SVG lane
  rendering, commit expansion, click-to-open-diff, and hover tooltips
- ScmHistoryGraphModel with paginated loading and provider lifecycle
- computeGraphRows pure function for DAG lane computation supporting
  linear, merge, branch-out, octopus, and sibling topologies
- Ref badge deduplication (local+remote collapse) with lane colors

Menus & context keys:
- Register scm/history/title, scm/historyItem/context, and
  scm/historyItemRef/context menu contribution points
- Add ScmHistoryItemCommandArg with type-discriminated argument
  processors (registered before generic ScmCommandArg processor)
- Add scmHistoryItemRef, scmCurrentHistoryItemRefHasRemote, and
  scmCurrentHistoryItemRefHasBase context keys
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open a workspace which has a git repo and see that there is a git graph now available.
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
