### PR TITLE
fix: replace fixed sleep timeouts with event-driven waits in parcel watcher tests

### DIFF
--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-watcher.spec.ts
@@ -58,10 +58,12 @@ describe('parcel-filesystem-watcher', function (): void {
 
     it('Should receive file changes events from in the workspace by default.', async function (): Promise<void> {
         const actualUris = new Set<string>();
+        const changeListeners: Array<() => void> = [];
 
         const watcherClient = {
             onDidFilesChanged(event: DidFilesChangedParams): void {
                 event.changes.forEach(c => actualUris.add(c.uri.toString()));
+                changeListeners.forEach(l => l());
             },
             onError(): void {
             }
@@ -76,15 +78,15 @@ describe('parcel-filesystem-watcher', function (): void {
 
         fs.mkdirSync(FileUri.fsPath(root.resolve('foo')));
         expect(fs.statSync(FileUri.fsPath(root.resolve('foo'))).isDirectory()).to.be.true;
-        await sleep(2000);
+        await waitForChange(actualUris, changeListeners, expectedUris[0]);
 
         fs.mkdirSync(FileUri.fsPath(root.resolve('foo').resolve('bar')));
         expect(fs.statSync(FileUri.fsPath(root.resolve('foo').resolve('bar'))).isDirectory()).to.be.true;
-        await sleep(2000);
+        await waitForChange(actualUris, changeListeners, expectedUris[1]);
 
         fs.writeFileSync(FileUri.fsPath(root.resolve('foo').resolve('bar').resolve('baz.txt')), 'baz');
         expect(fs.readFileSync(FileUri.fsPath(root.resolve('foo').resolve('bar').resolve('baz.txt')), 'utf8')).to.be.equal('baz');
-        await sleep(2000);
+        await waitForChange(actualUris, changeListeners, expectedUris[2]);
 
         assert.deepStrictEqual([...actualUris], expectedUris);
     });
@@ -166,6 +168,41 @@ describe('parcel-filesystem-watcher', function (): void {
 
     function sleep(time: number): Promise<unknown> {
         return new Promise(resolve => setTimeout(resolve, time));
+    }
+
+    /**
+     * Wait for a specific URI to appear in the change set, driven by watcher events.
+     * Resolves immediately if the URI is already present.
+     */
+    function waitForChange(
+        receivedUris: Set<string>,
+        listeners: Array<() => void>,
+        expectedUri: string,
+        timeoutMs = 10000
+    ): Promise<void> {
+        if (receivedUris.has(expectedUri)) {
+            return Promise.resolve();
+        }
+        return new Promise<void>((resolve, reject) => {
+            const timer = setTimeout(() => {
+                const idx = listeners.indexOf(check);
+                if (idx >= 0) {
+                    listeners.splice(idx, 1);
+                }
+                reject(new Error(`Timed out after ${timeoutMs}ms waiting for change event: ${expectedUri}`));
+            }, timeoutMs);
+            function check(): void {
+                if (receivedUris.has(expectedUri)) {
+                    clearTimeout(timer);
+                    const idx = listeners.indexOf(check);
+                    if (idx >= 0) {
+                        listeners.splice(idx, 1);
+                    }
+                    resolve();
+                }
+            }
+            listeners.push(check);
+        });
     }
 
 });


### PR DESCRIPTION
#### What it does

Replaces fixed `sleep(2000)` calls in `parcel-filesystem-watcher.spec.ts` with an event-driven `waitForChange()` helper that resolves as soon as the expected file change event arrives. This eliminates timing-related flakiness on Mac CI runners while reducing the first test's runtime from ~6.2s to ~200ms.

Keeps `sleep(200)` where appropriate: watcher startup in `beforeEach` and the "no events after unwatch" test (a fixed wait is correct for proving absence of events).

Fixes #17246

#### How to test

1. Run `npx lerna run test --scope @theia/filesystem` — all 130 tests should pass
2. Verify on Mac CI that the parcel watcher tests pass without flakiness

#### Follow-ups

None identified.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)