### PR TITLE
Prompt templates do not get modified only by opening them

### DIFF
--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -18,6 +18,7 @@ import { DisposableCollection, URI, Event, Emitter, nls } from '@theia/core';
 import { OpenerService } from '@theia/core/lib/browser';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { PromptFragmentCustomizationService, CustomAgentDescription, CustomizedPromptFragment, CommandPromptFragmentMetadata } from '../common';
+import { ConfigurableInMemoryResources } from '../common/configurable-in-memory-resources';
 import { BinaryBuffer } from '@theia/core/lib/common/buffer';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
@@ -131,6 +132,9 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
 
     @inject(OpenerService)
     protected readonly openerService: OpenerService;
+
+    @inject(ConfigurableInMemoryResources)
+    protected readonly inMemoryResources: ConfigurableInMemoryResources;
 
     /** Stores URI strings of template files from directories currently being monitored for changes. */
     protected trackedTemplateURIs = new Set<string>();
@@ -852,11 +856,38 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
      */
     protected async editTemplate(id: string, defaultContent?: string): Promise<void> {
         const editorUri = await this.getTemplateURI(id);
-        if (!(await this.fileService.exists(editorUri))) {
-            await this.fileService.createFile(editorUri, BinaryBuffer.fromString(defaultContent ?? ''));
+        if (await this.fileService.exists(editorUri)) {
+            const openHandler = await this.openerService.getOpener(editorUri);
+            openHandler.open(editorUri);
+        } else {
+            await this.openInMemoryTemplate(editorUri, defaultContent ?? '');
         }
-        const openHandler = await this.openerService.getOpener(editorUri);
-        openHandler.open(editorUri);
+    }
+
+    /**
+     * Opens an in-memory resource with the given content, without creating a file on disk.
+     * The file is only created when the user saves in the editor.
+     */
+    protected async openInMemoryTemplate(templateUri: URI, defaultContent: string): Promise<void> {
+        try {
+            this.inMemoryResources.resolve(templateUri);
+        } catch {
+            const resource = this.inMemoryResources.add(templateUri, {
+                contents: defaultContent,
+                initiallyDirty: false,
+                onSave: async (contents: string) => {
+                    const dirUri = templateUri.parent;
+                    if (!(await this.fileService.exists(dirUri))) {
+                        await this.fileService.createFolder(dirUri);
+                    }
+                    await this.fileService.createFile(templateUri, BinaryBuffer.fromString(contents), { overwrite: true });
+                    resource.dispose();
+                }
+            });
+        }
+
+        const openHandler = await this.openerService.getOpener(templateUri);
+        openHandler.open(templateUri);
     }
 
     async removePromptFragmentCustomization(id: string, customizationId: string): Promise<void> {
@@ -978,18 +1009,10 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
             const openHandler = await this.openerService.getOpener(uri);
             openHandler.open(uri);
         } else {
-            // Create a new built-in customization
-            // Get the template URI in the main templates directory (priority 1)
+            // Open the built-in content without creating a file on disk.
+            // The file will only be created when the user saves.
             const templateUri = await this.getTemplateURI(id);
-
-            // If template doesn't exist, create it with default content
-            if (!(await this.fileService.exists(templateUri))) {
-                await this.fileService.createFile(templateUri, BinaryBuffer.fromString(defaultContent));
-            }
-
-            // Open the template in the editor
-            const openHandler = await this.openerService.getOpener(templateUri);
-            openHandler.open(templateUri);
+            await this.openInMemoryTemplate(templateUri, defaultContent);
         }
     }
 


### PR DESCRIPTION
#### What it does

Fixes a bug where opening a prompt template for editing in the agent configuration view immediately marked it as `[edited]`, even if the user made no changes.

The root cause was that `editBuiltIn` (and `editTemplate`) in `DefaultPromptFragmentCustomizationService` unconditionally created the template file on disk before opening it in the editor. This file creation was immediately detected by the file system watcher, which registered it as a customization — causing the `[edited]` indicator to appear the moment the editor opened.

The fix replaces the eager file creation with an in-memory resource (`ConfigurableInMemoryResources`). The template URI is backed by an in-memory resource pre-filled with the built-in content and `initiallyDirty: false`. The actual file on disk is only created when the user explicitly saves their changes, at which point the in-memory resource is disposed and the normal file-based flow takes over.

#### How to test

1. Open the AI Configuration view and select any agent (e.g. *Coder*).
2. In the *Prompt Templates* section, click the ✏️ edit button next to a prompt that has **not** been customized before (no `[edited]` prefix).
3. The editor opens with the built-in content — verify that the template name in the agent configuration view still shows **no** `[edited]` prefix.
4. Make a change in the editor and save (`Ctrl+S` / `Cmd+S`).
5. The template now shows the `[edited]` prefix — confirming the indicator only appears after an actual change is persisted.
6. Click the ↩️ reset button to restore the built-in content and confirm the `[edited]` prefix disappears again.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
