### PR TITLE
Limit imports of code in the preload section

### DIFF
--- a/packages/core/src/browser/messaging/connection-source.ts
+++ b/packages/core/src/browser/messaging/connection-source.ts
@@ -14,7 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { Channel, Event } from '../../common';
+import { Channel } from '../../common/message-rpc/channel';
+import { Event } from '../../common/event';
 
 export const ConnectionSource = Symbol('ConnectionSource');
 

--- a/packages/core/src/browser/messaging/service-connection-provider.ts
+++ b/packages/core/src/browser/messaging/service-connection-provider.ts
@@ -15,10 +15,10 @@
 // *****************************************************************************
 
 import { inject, injectable, interfaces, postConstruct } from 'inversify';
-import { Channel, RpcProxy, RpcProxyFactory } from '../../common';
-import { ChannelMultiplexer } from '../../common/message-rpc/channel';
+import { Channel, ChannelMultiplexer } from '../../common/message-rpc/channel';
 import { Deferred } from '../../common/promise-util';
 import { ConnectionSource } from './connection-source';
+import { RpcProxy, RpcProxyFactory } from '../../common/messaging/proxy-factory';
 
 /**
  * Service id for the local connection provider

--- a/packages/core/src/browser/messaging/ws-connection-provider.ts
+++ b/packages/core/src/browser/messaging/ws-connection-provider.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable, interfaces, decorate, unmanaged, inject } from 'inversify';
-import { RpcProxyFactory, RpcProxy } from '../../common';
+import { RpcProxy, RpcProxyFactory } from '../../common/messaging/proxy-factory';
 import { RemoteConnectionProvider, ServiceConnectionProvider } from './service-connection-provider';
 
 decorate(injectable(), RpcProxyFactory);

--- a/packages/core/src/browser/messaging/ws-connection-source.ts
+++ b/packages/core/src/browser/messaging/ws-connection-source.ts
@@ -14,17 +14,19 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { AbstractChannel, Channel, Disposable, DisposableCollection, Emitter, Event, servicesPath } from '../../common';
+import { Emitter, Event } from '../../common/event';
 import { ConnectionSource } from './connection-source';
 import { Socket, io } from 'socket.io-client';
 import { Endpoint } from '../endpoint';
-import { ForwardingChannel } from '../../common/message-rpc/channel';
+import { AbstractChannel, Channel, ForwardingChannel } from '../../common/message-rpc/channel';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from '../../common/message-rpc/uint8-array-message-buffer';
 import { inject, injectable, postConstruct } from 'inversify';
 import { FrontendIdProvider } from './frontend-id-provider';
 import { FrontendApplicationConfigProvider } from '../frontend-application-config-provider';
 import { SocketWriteBuffer } from '../../common/messaging/socket-write-buffer';
 import { ConnectionManagementMessages } from '../../common/messaging/connection-management';
+import { servicesPath } from '../../common/messaging/handler';
+import { Disposable, DisposableCollection } from '../../common/disposable';
 
 @injectable()
 export class WebSocketConnectionSource implements ConnectionSource {

--- a/packages/core/src/browser/preload/i18n-preload-contribution.ts
+++ b/packages/core/src/browser/preload/i18n-preload-contribution.ts
@@ -19,7 +19,7 @@ import { FrontendApplicationConfigProvider } from '../frontend-application-confi
 import { nls } from '../../common/nls';
 import { inject, injectable, named } from 'inversify';
 import { LocalizationServer } from '../../common/i18n/localization-server';
-import { ContributionProvider } from '../../common';
+import { ContributionProvider } from '../../common/contribution-provider';
 import { TextReplacementContribution } from './text-replacement-contribution';
 
 @injectable()

--- a/packages/core/src/browser/preload/os-preload-contribution.ts
+++ b/packages/core/src/browser/preload/os-preload-contribution.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable } from 'inversify';
-import { OS, OSBackendProvider } from '../../common';
+import { OS, OSBackendProvider } from '../../common/os';
 import { PreloadContribution } from './preloader';
 
 @injectable()


### PR DESCRIPTION
#### What it does

Closes https://github.com/eclipse-theia/theia/issues/17280

The were importing from `@theia/browser/lib/common` in our preload code, which led to a bunch of strings not being properly translated after startup. This change adjusts our imports to ensure that we don't import from common, but import the specific symbols directly.

#### How to test

See https://github.com/eclipse-theia/theia/issues/17280.

1. Change the language of Theia.
2. Place a breakpoint in the `localizeByDefault` function of `nls.ts`.
3. The first time this breakpoint is triggered should have its `localization` value already set.

#### Follow-ups

We could maybe extend our linting rules to ensure that we don't accidentally import code that has `nls.localize` calls in the preload section?

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
