### PR TITLE
fix(notebook): fix Space key scrolling instead of typing in cell editors

### DIFF
--- a/packages/notebook/src/browser/view/notebook-cell-editor.tsx
+++ b/packages/notebook/src/browser/view/notebook-cell-editor.tsx
@@ -200,6 +200,15 @@ export class CellEditor extends React.Component<CellEditorProps, {}> {
                 [[IContextKeyService, this.props.notebookContextManager.scopedStore]],
                 { contributions: EditorExtensionsRegistry.getEditorContributions().filter(c => c.id !== 'editor.contrib.findController') });
             this.toDispose.push(this.editor);
+            // Monaco's EditContext API uses a plain <div> for text input instead of a <textarea>.
+            // PerfectScrollbar's keyboard handler checks isEditable(activeElement) which only recognizes
+            // input/textarea/select/button/[contenteditable] elements. Setting contenteditable on the
+            // EditContext div makes PerfectScrollbar skip keyboard handling when the editor has focus,
+            // preventing Space/PageUp/PageDown/Home/End/arrows from scrolling the notebook container.
+            const editContextElement = editorNode.querySelector('.native-edit-context');
+            if (editContextElement) {
+                editContextElement.setAttribute('contenteditable', 'false');
+            }
             this.editor.setLanguage(cell.language);
             this.toDispose.push(this.editor.getControl().onDidContentSizeChange(() => {
                 editorNode.style.height = this.editor!.getControl().getContentHeight() + 7 + 'px';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17272

After the Monaco core update (1.96 to 1.108), Monaco switched from a hidden `<textarea>` to the https://developer.mozilla.org/en-US/docs/Web/API/EditContext_API for text input. The focused element in the editor is now a `<div class="native-edit-context">` instead of a `<textarea>`.

PerfectScrollbar's keyboard handler checks `isEditable(activeElement)` which only recognizes input, textarea, select, button, and `[contenteditable]` elements.
Since the EditContext div matches none of these, PerfectScrollbar intercepts Space, arrows, PageUp/Down, Home/End and scrolls the notebook container instead of letting Monaco handle the keypress.

The fix sets `contenteditable="false"` on the EditContext div after creating each notebook cell editor. This makes PerfectScrollbar's isEditable() return true (it matches [contenteditable] regardless of value), causing it to skip keyboard handling when the editor has focus, exactly replicating the pre-EditContext behavior where the <textarea> was recognized.

Also related to https://github.com/eclipse-theia/theia/pull/17140, https://github.com/eclipse-theia/theia/pull/17189

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open a notebook (e.g. sample.ipynb or the mentioned test.ipynb in the issue)
2. Click into a code cell editor

  When focus is in a cell editor:
  - Press Space: should insert a space character, NOT scroll the notebook
  - Arrow keys: should move cursor within the editor
  - Page Up/Down: should move cursor by page within the editor
  - Home/End: should go to start/end of line

  When focus is outside a cell editor (press Escape to exit edit mode, or click the cell sidebar):
  - Space: should scroll the notebook down, Shift+Space should scroll the notebook up
  - Page Up/Down: should scroll the notebook
  - Home/End: should scroll to top/bottom
  - Alt+Arrow: should scroll by a full container width/height (larger jump than plain arrow scrolls)
  - Mouse wheel: should scroll normally


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
