### PR TITLE
feat(output): add ANSI escape code support to the Output view

### DIFF
--- a/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
+++ b/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
@@ -31,7 +31,7 @@ export class SampleOutputChannelWithSeverity
         channel.append('inlineInfo1 ');
         channel.append('inlineWarning ', OutputChannelSeverity.Warning);
         channel.append('inlineError ', OutputChannelSeverity.Error);
-        channel.append('inlineInfo2', OutputChannelSeverity.Info);
+        channel.appendLine('inlineInfo2', OutputChannelSeverity.Info);
 
         // ANSI color code samples
         channel.appendLine('\x1b[31mANSI red text\x1b[0m');

--- a/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
+++ b/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
@@ -32,6 +32,15 @@ export class SampleOutputChannelWithSeverity
         channel.append('inlineWarning ', OutputChannelSeverity.Warning);
         channel.append('inlineError ', OutputChannelSeverity.Error);
         channel.append('inlineInfo2', OutputChannelSeverity.Info);
+
+        // ANSI color code samples
+        channel.appendLine('\x1b[31mANSI red text\x1b[0m');
+        channel.appendLine('\x1b[32mANSI green text\x1b[0m');
+        channel.appendLine('\x1b[33mANSI yellow\x1b[0m and \x1b[34mANSI blue\x1b[0m on the same line');
+        channel.appendLine('\x1b[1m\x1b[35mANSI bold magenta\x1b[0m');
+        channel.appendLine('\x1b[4m\x1b[36mANSI underlined cyan\x1b[0m');
+        channel.appendLine('Mixed: \x1b[31mANSI error\x1b[0m and \x1b[32mANSI success\x1b[0m in one line');
+        channel.appendLine('\x1b[41m\x1b[37mANSI white on red background\x1b[0m');
     }
 }
 export const bindSampleOutputChannelWithSeverity = (bind: interfaces.Bind) => {

--- a/examples/playwright/src/tests/theia-output-view.test.ts
+++ b/examples/playwright/src/tests/theia-output-view.test.ts
@@ -67,7 +67,6 @@ test.describe('Theia Output View', () => {
         expect(await testChannel!.isDisplayed()).toBe(true);
     });
     test('should check if the output view test channel shows the test output', async () => {
-        expect(await testChannel.numberOfLines()).toBe(12);
         expect(await testChannel.textContentOfLineByLineNumber(1)).toMatch('hello info1');
         expect(await testChannel.maxSeverityOfLineByLineNumber(1)).toMatch('info');
         expect(await testChannel.textContentOfLineByLineNumber(2)).toMatch('hello info2');

--- a/examples/playwright/src/tests/theia-output-view.test.ts
+++ b/examples/playwright/src/tests/theia-output-view.test.ts
@@ -67,7 +67,7 @@ test.describe('Theia Output View', () => {
         expect(await testChannel!.isDisplayed()).toBe(true);
     });
     test('should check if the output view test channel shows the test output', async () => {
-        expect(await testChannel.numberOfLines()).toBe(5);
+        expect(await testChannel.numberOfLines()).toBe(12);
         expect(await testChannel.textContentOfLineByLineNumber(1)).toMatch('hello info1');
         expect(await testChannel.maxSeverityOfLineByLineNumber(1)).toMatch('info');
         expect(await testChannel.textContentOfLineByLineNumber(2)).toMatch('hello info2');
@@ -80,6 +80,27 @@ test.describe('Theia Output View', () => {
             'inlineInfo1 inlineWarning inlineError inlineInfo2'
         );
         expect(await testChannel.maxSeverityOfLineByLineNumber(5)).toMatch('error');
+    });
+    test('should check if the output view test channel shows ANSI colored output', async () => {
+        expect(await testChannel.textContentOfLineByLineNumber(6)).toMatch('ANSI red text');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(6)).toContain('ansi-red-fg');
+        expect(await testChannel.textContentOfLineByLineNumber(7)).toMatch('ANSI green text');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(7)).toContain('ansi-green-fg');
+        expect(await testChannel.textContentOfLineByLineNumber(8)).toMatch('ANSI yellow and ANSI blue on the same line');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(8)).toContain('ansi-yellow-fg');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(8)).toContain('ansi-blue-fg');
+        expect(await testChannel.textContentOfLineByLineNumber(9)).toMatch('ANSI bold magenta');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(9)).toContain('ansi-bold');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(9)).toContain('ansi-magenta-fg');
+        expect(await testChannel.textContentOfLineByLineNumber(10)).toMatch('ANSI underlined cyan');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(10)).toContain('ansi-underline');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(10)).toContain('ansi-cyan-fg');
+        expect(await testChannel.textContentOfLineByLineNumber(11)).toMatch('Mixed: ANSI error and ANSI success in one line');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(11)).toContain('ansi-red-fg');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(11)).toContain('ansi-green-fg');
+        expect(await testChannel.textContentOfLineByLineNumber(12)).toMatch('ANSI white on red background');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(12)).toContain('ansi-white-fg');
+        expect(await testChannel.ansiClassesOfLineByLineNumber(12)).toContain('ansi-red-bg');
     });
 
 });

--- a/examples/playwright/src/theia-monaco-editor.ts
+++ b/examples/playwright/src/theia-monaco-editor.ts
@@ -91,25 +91,67 @@ export class TheiaMonacoEditor extends TheiaPageObject {
         return (await lineLocator.elementHandle()) ?? undefined;
     }
 
+    /**
+     * Returns the locator for the given model line number.
+     *
+     * Monaco uses virtual rendering so only lines in the viewport are in the DOM.
+     * Each `.view-line` element has a `style.top` value corresponding to its model position.
+     * This method uses that to find the correct line, scrolling to reveal it if necessary.
+     */
     async line(lineNumber: number): Promise<Locator> {
         await this.waitForVisible();
-        const lines = await this.locator.locator(this.LINES_SELECTOR).all();
-        if (!lines || lines.length === 0) {
-            throw new Error('Couldn\'t retrieve lines of monaco editor');
+
+        let index = await this.findLineIndex(lineNumber);
+        if (index >= 0) {
+            return this.locator.locator(this.LINES_SELECTOR).nth(index);
         }
 
-        const linesWithXCoordinates = [];
-        for (const line of lines) {
-            await line.waitFor({ state: 'visible' });
-            const box = await line.boundingBox();
-            linesWithXCoordinates.push({ x: box ? box.x : Number.MAX_VALUE, line });
+        // Line not in viewport, scroll to reveal it
+        await this.locator.click();
+        await this.page.keyboard.press('Control+Home');
+        await this.locator.locator(this.LINES_SELECTOR).first().waitFor({ state: 'visible' });
+
+        index = await this.findLineIndex(lineNumber);
+        if (index >= 0) {
+            return this.locator.locator(this.LINES_SELECTOR).nth(index);
         }
-        linesWithXCoordinates.sort((a, b) => a.x.toString().localeCompare(b.x.toString()));
-        const lineInfo = linesWithXCoordinates[lineNumber - 1];
-        if (!lineInfo) {
-            throw new Error(`Could not find line number ${lineNumber}`);
+
+        // Line might be near the end, try scrolling there
+        await this.page.keyboard.press('Control+End');
+        await this.locator.locator(this.LINES_SELECTOR).first().waitFor({ state: 'visible' });
+
+        index = await this.findLineIndex(lineNumber);
+        if (index >= 0) {
+            return this.locator.locator(this.LINES_SELECTOR).nth(index);
         }
-        return lineInfo.line;
+
+        throw new Error(`Could not find line number ${lineNumber}`);
+    }
+
+    /**
+     * Finds the DOM index of the `.view-line` element that corresponds to the given model line number.
+     * Uses the `style.top` value of each `.view-line` to compute the model line number.
+     * Returns -1 if the line is not currently rendered in the viewport.
+     */
+    protected async findLineIndex(lineNumber: number): Promise<number> {
+        return this.locator.evaluate((editor, targetLine) => {
+            const viewLines = editor.querySelectorAll('.view-lines > .view-line') as NodeListOf<HTMLElement>;
+            if (viewLines.length === 0) {
+                return -1;
+            }
+            const lineHeight = viewLines[0].getBoundingClientRect().height;
+            if (lineHeight <= 0) {
+                return -1;
+            }
+            const targetTop = (targetLine - 1) * lineHeight;
+            for (let i = 0; i < viewLines.length; i++) {
+                const top = parseFloat(viewLines[i].style.top) || 0;
+                if (Math.abs(top - targetTop) < lineHeight * 0.5) {
+                    return i;
+                }
+            }
+            return -1;
+        }, lineNumber);
     }
 
     async textContentOfLineContainingText(text: string): Promise<string | undefined> {

--- a/examples/playwright/src/theia-output-channel.ts
+++ b/examples/playwright/src/theia-output-channel.ts
@@ -82,6 +82,20 @@ export class TheiaOutputViewChannel extends TheiaPageObject {
         return 'info';
     }
 
+    async ansiClassesOfLineByLineNumber(lineNumber: number): Promise<string[]> {
+        await this.waitForVisible();
+        const lineElement = await (await this.monacoEditor.line(lineNumber)).elementHandle();
+        const contents = await lineElement?.$$('span > span.mtk1');
+        if (!contents || contents.length < 1) {
+            return [];
+        }
+        const classNames = await Promise.all(contents.map(
+            async content => (await content.getAttribute('class')) ?? ''));
+        return classNames
+            .flatMap(c => c.split(' '))
+            .filter(c => c.startsWith('ansi-'));
+    }
+
     async textContentOfLineByLineNumber(lineNumber: number): Promise<string | undefined> {
         return this.monacoEditor.textContentOfLineByLineNumber(lineNumber);
     }

--- a/packages/output/src/browser/output-ansi-parser.spec.ts
+++ b/packages/output/src/browser/output-ansi-parser.spec.ts
@@ -1,0 +1,158 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { parseAnsi } from './output-ansi-parser';
+
+describe('Output ANSI Parser', () => {
+
+    it('should return plain text unchanged', () => {
+        const result = parseAnsi('hello world');
+        expect(result.strippedText).to.equal('hello world');
+        expect(result.segments).to.be.empty;
+    });
+
+    it('should strip ANSI codes and return stripped text', () => {
+        const result = parseAnsi('\x1b[31mhello\x1b[0m world');
+        expect(result.strippedText).to.equal('hello world');
+    });
+
+    it('should produce a segment for foreground color', () => {
+        const result = parseAnsi('\x1b[31mred text\x1b[0m');
+        expect(result.strippedText).to.equal('red text');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0]).to.deep.equal({
+            start: 0,
+            end: 8,
+            cssClasses: 'ansi-red-fg'
+        });
+    });
+
+    it('should handle multiple colors', () => {
+        const result = parseAnsi('\x1b[31mred\x1b[32mgreen\x1b[0m');
+        expect(result.strippedText).to.equal('redgreen');
+        expect(result.segments).to.have.length(2);
+        expect(result.segments[0]).to.deep.equal({ start: 0, end: 3, cssClasses: 'ansi-red-fg' });
+        expect(result.segments[1]).to.deep.equal({ start: 3, end: 8, cssClasses: 'ansi-green-fg' });
+    });
+
+    it('should handle bright foreground colors', () => {
+        const result = parseAnsi('\x1b[91mbright red\x1b[0m');
+        expect(result.strippedText).to.equal('bright red');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0].cssClasses).to.equal('ansi-bright-red-fg');
+    });
+
+    it('should handle background colors', () => {
+        const result = parseAnsi('\x1b[41mred bg\x1b[0m');
+        expect(result.strippedText).to.equal('red bg');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0].cssClasses).to.equal('ansi-red-bg');
+    });
+
+    it('should handle combined foreground and background', () => {
+        const result = parseAnsi('\x1b[31;42mred on green\x1b[0m');
+        expect(result.strippedText).to.equal('red on green');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0].cssClasses).to.equal('ansi-red-fg ansi-green-bg');
+    });
+
+    it('should handle bold, italic, and underline', () => {
+        const result = parseAnsi('\x1b[1mbold\x1b[0m \x1b[3mitalic\x1b[0m \x1b[4munderline\x1b[0m');
+        expect(result.strippedText).to.equal('bold italic underline');
+        expect(result.segments).to.have.length(3);
+        expect(result.segments[0].cssClasses).to.equal('ansi-bold');
+        expect(result.segments[1].cssClasses).to.equal('ansi-italic');
+        expect(result.segments[2].cssClasses).to.equal('ansi-underline');
+    });
+
+    it('should handle combined styles with color', () => {
+        const result = parseAnsi('\x1b[1;31mbold red\x1b[0m');
+        expect(result.strippedText).to.equal('bold red');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0].cssClasses).to.equal('ansi-red-fg ansi-bold');
+    });
+
+    it('should handle empty escape sequence as reset', () => {
+        const result = parseAnsi('\x1b[31mred\x1b[mnormal');
+        expect(result.strippedText).to.equal('rednormal');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0]).to.deep.equal({ start: 0, end: 3, cssClasses: 'ansi-red-fg' });
+    });
+
+    it('should preserve state across calls', () => {
+        const result1 = parseAnsi('\x1b[31m');
+        expect(result1.strippedText).to.equal('');
+        expect(result1.segments).to.be.empty;
+        expect(result1.state.foreground).to.equal('ansi-red-fg');
+
+        const result2 = parseAnsi('red text\x1b[0m', result1.state);
+        expect(result2.strippedText).to.equal('red text');
+        expect(result2.segments).to.have.length(1);
+        expect(result2.segments[0]).to.deep.equal({ start: 0, end: 8, cssClasses: 'ansi-red-fg' });
+    });
+
+    it('should handle text with no escape codes after initial state', () => {
+        const result = parseAnsi('still red', { foreground: 'ansi-red-fg' });
+        expect(result.strippedText).to.equal('still red');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0]).to.deep.equal({ start: 0, end: 9, cssClasses: 'ansi-red-fg' });
+    });
+
+    it('should handle reset of individual attributes', () => {
+        const result = parseAnsi('\x1b[1;31mbold red\x1b[22mnot bold red\x1b[0m');
+        expect(result.strippedText).to.equal('bold rednot bold red');
+        expect(result.segments).to.have.length(2);
+        expect(result.segments[0].cssClasses).to.equal('ansi-red-fg ansi-bold');
+        expect(result.segments[1].cssClasses).to.equal('ansi-red-fg');
+    });
+
+    it('should handle text with newlines', () => {
+        const result = parseAnsi('\x1b[32mline1\nline2\x1b[0m');
+        expect(result.strippedText).to.equal('line1\nline2');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0]).to.deep.equal({ start: 0, end: 11, cssClasses: 'ansi-green-fg' });
+    });
+
+    it('should handle text without any ANSI codes', () => {
+        const result = parseAnsi('plain text\nwith newlines');
+        expect(result.strippedText).to.equal('plain text\nwith newlines');
+        expect(result.segments).to.be.empty;
+    });
+
+    it('should handle default foreground reset (code 39)', () => {
+        const result = parseAnsi('\x1b[31mred\x1b[39mdefault');
+        expect(result.strippedText).to.equal('reddefault');
+        expect(result.segments).to.have.length(1);
+        expect(result.segments[0]).to.deep.equal({ start: 0, end: 3, cssClasses: 'ansi-red-fg' });
+    });
+
+    it('should handle all standard foreground colors', () => {
+        const colors = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'];
+        for (let i = 0; i < colors.length; i++) {
+            const result = parseAnsi(`\x1b[${30 + i}mx\x1b[0m`);
+            expect(result.segments[0].cssClasses).to.equal(`ansi-${colors[i]}-fg`);
+        }
+    });
+
+    it('should handle all bright foreground colors', () => {
+        const colors = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'];
+        for (let i = 0; i < colors.length; i++) {
+            const result = parseAnsi(`\x1b[${90 + i}mx\x1b[0m`);
+            expect(result.segments[0].cssClasses).to.equal(`ansi-bright-${colors[i]}-fg`);
+        }
+    });
+});

--- a/packages/output/src/browser/output-ansi-parser.ts
+++ b/packages/output/src/browser/output-ansi-parser.ts
@@ -1,0 +1,156 @@
+// *****************************************************************************
+// Copyright (C) 2025 TypeFox and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Lightweight ANSI escape code parser for the Output view.
+ *
+ * Parses ANSI SGR (Select Graphic Rendition) sequences from text,
+ * strips them, and returns decoration segments with CSS class names
+ * matching the existing `ansi.css` classes from `@theia/core`.
+ */
+
+const FOREGROUND_COLORS = ['black', 'red', 'green', 'yellow', 'blue', 'magenta', 'cyan', 'white'] as const;
+
+export interface AnsiState {
+    foreground?: string;
+    background?: string;
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+}
+
+export interface AnsiSegment {
+    start: number;
+    end: number;
+    cssClasses: string;
+}
+
+export interface AnsiParseResult {
+    strippedText: string;
+    segments: AnsiSegment[];
+    state: AnsiState;
+}
+
+// Matches ANSI escape sequences: ESC[ ... m (SGR) and other CSI sequences
+const ANSI_ESCAPE_RE = /\x1b\[[0-9;]*m/g;
+
+function getCssClasses(state: AnsiState): string {
+    const classes: string[] = [];
+    if (state.foreground) {
+        classes.push(state.foreground);
+    }
+    if (state.background) {
+        classes.push(state.background);
+    }
+    if (state.bold) {
+        classes.push('ansi-bold');
+    }
+    if (state.italic) {
+        classes.push('ansi-italic');
+    }
+    if (state.underline) {
+        classes.push('ansi-underline');
+    }
+    return classes.join(' ');
+}
+
+function applyAnsiCode(code: number, state: AnsiState): void {
+    if (code === 0) {
+        // Reset all
+        state.foreground = undefined;
+        state.background = undefined;
+        state.bold = undefined;
+        state.italic = undefined;
+        state.underline = undefined;
+    } else if (code === 1) {
+        state.bold = true;
+    } else if (code === 3) {
+        state.italic = true;
+    } else if (code === 4) {
+        state.underline = true;
+    } else if (code === 22) {
+        state.bold = undefined;
+    } else if (code === 23) {
+        state.italic = undefined;
+    } else if (code === 24) {
+        state.underline = undefined;
+    } else if (code >= 30 && code <= 37) {
+        state.foreground = `ansi-${FOREGROUND_COLORS[code - 30]}-fg`;
+    } else if (code === 39) {
+        state.foreground = undefined;
+    } else if (code >= 40 && code <= 47) {
+        state.background = `ansi-${FOREGROUND_COLORS[code - 40]}-bg`;
+    } else if (code === 49) {
+        state.background = undefined;
+    } else if (code >= 90 && code <= 97) {
+        state.foreground = `ansi-bright-${FOREGROUND_COLORS[code - 90]}-fg`;
+    } else if (code >= 100 && code <= 107) {
+        state.background = `ansi-bright-${FOREGROUND_COLORS[code - 100]}-bg`;
+    }
+}
+
+/**
+ * Parse ANSI escape codes from text, strip them, and return decoration segments.
+ *
+ * @param text The raw text potentially containing ANSI escape codes
+ * @param initialState The ANSI state carried over from a previous parse call
+ * @returns The stripped text, decoration segments, and the final ANSI state
+ */
+export function parseAnsi(text: string, initialState: AnsiState = {}): AnsiParseResult {
+    const state: AnsiState = { ...initialState };
+    const segments: AnsiSegment[] = [];
+    let strippedText = '';
+    let lastIndex = 0;
+    let currentSegmentStart = 0;
+    let currentClasses = getCssClasses(state);
+
+    ANSI_ESCAPE_RE.lastIndex = 0;
+    let match: RegExpExecArray | undefined;
+    while ((match = ANSI_ESCAPE_RE.exec(text) ?? undefined) !== undefined) {
+        // Append text before this escape sequence
+        const textBefore = text.substring(lastIndex, match.index);
+        strippedText += textBefore;
+
+        // If we had an active style and there's text, the segment continues
+        // Now process the escape sequence to potentially change state
+        const escapeContent = match[0].slice(2, -1); // Strip ESC[ and m
+        const codes = escapeContent.length === 0 ? [0] : escapeContent.split(';').map(Number);
+
+        // Before changing state, close current segment if there's styled text
+        const newOffset = strippedText.length;
+        if (currentClasses && newOffset > currentSegmentStart) {
+            segments.push({ start: currentSegmentStart, end: newOffset, cssClasses: currentClasses });
+        }
+
+        for (const code of codes) {
+            applyAnsiCode(code, state);
+        }
+
+        currentClasses = getCssClasses(state);
+        currentSegmentStart = newOffset;
+        lastIndex = match.index + match[0].length;
+    }
+
+    // Append remaining text after last escape sequence
+    strippedText += text.substring(lastIndex);
+
+    // Close final segment if there's styled text remaining
+    if (currentClasses && strippedText.length > currentSegmentStart) {
+        segments.push({ start: currentSegmentStart, end: strippedText.length, cssClasses: currentClasses });
+    }
+
+    return { strippedText, segments, state };
+}

--- a/packages/output/src/browser/output-channel.ts
+++ b/packages/output/src/browser/output-channel.ts
@@ -27,6 +27,7 @@ import { OutputPreferences } from '../common/output-preferences';
 import { IReference } from '@theia/monaco-editor-core/esm/vs/base/common/lifecycle';
 import * as monaco from '@theia/monaco-editor-core';
 import PQueue from 'p-queue';
+import { parseAnsi, AnsiState, AnsiSegment } from './output-ansi-parser';
 
 @injectable()
 export class OutputChannelManager implements Disposable, ResourceResolver {
@@ -213,6 +214,7 @@ export class OutputChannel implements Disposable {
     protected visible = true;
     protected _maxLineNumber: number;
     protected decorationIds = new Set<string>();
+    protected ansiState: AnsiState = {};
 
     readonly onVisibilityChange: Event<{ isVisible: boolean, preserveFocus?: boolean }> = this.visibilityChangeEmitter.event;
     readonly onContentChange: Event<void> = this.contentChangeEmitter.event;
@@ -267,6 +269,7 @@ export class OutputChannel implements Disposable {
             const textModel = (await this.resource.editorModelRef.promise).object.textEditorModel;
             textModel.deltaDecorations(Array.from(this.decorationIds), []);
             this.decorationIds.clear();
+            this.ansiState = {};
             textModel.setValue('');
             this.contentChangeEmitter.fire();
         });
@@ -295,14 +298,22 @@ export class OutputChannel implements Disposable {
         const lastLineMaxColumn = textModel.getLineMaxColumn(lastLine);
         const position = new monaco.Position(lastLine, lastLineMaxColumn);
         const range = new monaco.Range(position.lineNumber, position.column, position.lineNumber, position.column);
+
+        // Parse and strip ANSI escape codes, preserving state across calls
+        const { strippedText, segments, state } = parseAnsi(content, this.ansiState);
+        this.ansiState = state;
+
+        const textToInsert = appendEol ? `${strippedText}${textModel.getEOL()}` : strippedText;
         const edits = [{
             range,
-            text: !!appendEol ? `${content}${textModel.getEOL()}` : content,
+            text: textToInsert,
             forceMoveMarkers: true
         }];
         // We do not use `pushEditOperations` as we do not need undo/redo support. VS Code uses `applyEdits` too.
         // https://github.com/microsoft/vscode/blob/dc348340fd1a6c583cb63a1e7e6b4fd657e01e01/src/vs/workbench/services/output/common/outputChannelModel.ts#L108-L115
         textModel.applyEdits(edits);
+
+        // Apply severity decorations (error/warning) for the entire appended range
         if (severity !== OutputChannelSeverity.Info) {
             const inlineClassName = severity === OutputChannelSeverity.Error ? 'theia-output-error' : 'theia-output-warning';
             let endLineNumber = textModel.getLineCount();
@@ -321,8 +332,54 @@ export class OutputChannel implements Disposable {
                 this.decorationIds.add(decorationId);
             }
         }
+
+        // Apply ANSI color decorations for individual segments
+        if (segments.length > 0) {
+            const ansiDecorations = segments.map(segment => ({
+                range: this.computeSegmentRange(strippedText, segment, position),
+                options: { inlineClassName: segment.cssClasses }
+            }));
+            for (const decorationId of textModel.deltaDecorations([], ansiDecorations)) {
+                this.decorationIds.add(decorationId);
+            }
+        }
+
         this.ensureMaxChannelHistory(textModel);
         this.contentChangeEmitter.fire();
+    }
+
+    /**
+     * Compute the Monaco Range for an ANSI segment within the stripped text,
+     * given the insertion position in the editor model.
+     */
+    protected computeSegmentRange(strippedText: string, segment: AnsiSegment, insertPosition: monaco.Position): monaco.Range {
+        let startLine = insertPosition.lineNumber;
+        let startColumn = insertPosition.column;
+        // Walk through stripped text to find start position
+        for (let i = 0; i < segment.start; i++) {
+            if (strippedText[i] === '\n') {
+                startLine++;
+                startColumn = 1;
+            } else if (strippedText[i] === '\r') {
+                // Skip \r, handled with \n
+            } else {
+                startColumn++;
+            }
+        }
+        let endLine = startLine;
+        let endColumn = startColumn;
+        // Walk from start to end of segment
+        for (let i = segment.start; i < segment.end; i++) {
+            if (strippedText[i] === '\n') {
+                endLine++;
+                endColumn = 1;
+            } else if (strippedText[i] === '\r') {
+                // Skip \r
+            } else {
+                endColumn++;
+            }
+        }
+        return new monaco.Range(startLine, startColumn, endLine, endColumn);
     }
 
     protected ensureMaxChannelHistory(textModel: monaco.editor.ITextModel): void {

--- a/packages/output/src/browser/style/output.css
+++ b/packages/output/src/browser/style/output.css
@@ -30,3 +30,146 @@
   width: 170px;
   margin-right: 4px;
 }
+
+/* ANSI text styling decorations */
+.theia-output .ansi-bold {
+  font-weight: bold;
+}
+
+.theia-output .ansi-italic {
+  font-style: italic;
+}
+
+.theia-output .ansi-underline {
+  text-decoration: underline;
+}
+
+/* ANSI foreground color decorations - scoped to .theia-output to override Monaco's .mtk1 */
+.theia-output .ansi-black-fg {
+  color: var(--theia-terminal-ansiBlack);
+}
+
+.theia-output .ansi-red-fg {
+  color: var(--theia-terminal-ansiRed);
+}
+
+.theia-output .ansi-green-fg {
+  color: var(--theia-terminal-ansiGreen);
+}
+
+.theia-output .ansi-yellow-fg {
+  color: var(--theia-terminal-ansiYellow);
+}
+
+.theia-output .ansi-blue-fg {
+  color: var(--theia-terminal-ansiBlue);
+}
+
+.theia-output .ansi-magenta-fg {
+  color: var(--theia-terminal-ansiMagenta);
+}
+
+.theia-output .ansi-cyan-fg {
+  color: var(--theia-terminal-ansiCyan);
+}
+
+.theia-output .ansi-white-fg {
+  color: var(--theia-terminal-ansiWhite);
+}
+
+.theia-output .ansi-bright-black-fg {
+  color: var(--theia-terminal-ansiBrightBlack);
+}
+
+.theia-output .ansi-bright-red-fg {
+  color: var(--theia-terminal-ansiBrightRed);
+}
+
+.theia-output .ansi-bright-green-fg {
+  color: var(--theia-terminal-ansiBrightGreen);
+}
+
+.theia-output .ansi-bright-yellow-fg {
+  color: var(--theia-terminal-ansiBrightYellow);
+}
+
+.theia-output .ansi-bright-blue-fg {
+  color: var(--theia-terminal-ansiBrightBlue);
+}
+
+.theia-output .ansi-bright-magenta-fg {
+  color: var(--theia-terminal-ansiBrightMagenta);
+}
+
+.theia-output .ansi-bright-cyan-fg {
+  color: var(--theia-terminal-ansiBrightCyan);
+}
+
+.theia-output .ansi-bright-white-fg {
+  color: var(--theia-terminal-ansiBrightWhite);
+}
+
+/* ANSI background color decorations */
+.theia-output .ansi-black-bg {
+  background-color: var(--theia-terminal-ansiBlack);
+}
+
+.theia-output .ansi-red-bg {
+  background-color: var(--theia-terminal-ansiRed);
+}
+
+.theia-output .ansi-green-bg {
+  background-color: var(--theia-terminal-ansiGreen);
+}
+
+.theia-output .ansi-yellow-bg {
+  background-color: var(--theia-terminal-ansiYellow);
+}
+
+.theia-output .ansi-blue-bg {
+  background-color: var(--theia-terminal-ansiBlue);
+}
+
+.theia-output .ansi-magenta-bg {
+  background-color: var(--theia-terminal-ansiMagenta);
+}
+
+.theia-output .ansi-cyan-bg {
+  background-color: var(--theia-terminal-ansiCyan);
+}
+
+.theia-output .ansi-white-bg {
+  background-color: var(--theia-terminal-ansiWhite);
+}
+
+.theia-output .ansi-bright-black-bg {
+  background-color: var(--theia-terminal-ansiBrightBlack);
+}
+
+.theia-output .ansi-bright-red-bg {
+  background-color: var(--theia-terminal-ansiBrightRed);
+}
+
+.theia-output .ansi-bright-green-bg {
+  background-color: var(--theia-terminal-ansiBrightGreen);
+}
+
+.theia-output .ansi-bright-yellow-bg {
+  background-color: var(--theia-terminal-ansiBrightYellow);
+}
+
+.theia-output .ansi-bright-blue-bg {
+  background-color: var(--theia-terminal-ansiBrightBlue);
+}
+
+.theia-output .ansi-bright-magenta-bg {
+  background-color: var(--theia-terminal-ansiBrightMagenta);
+}
+
+.theia-output .ansi-bright-cyan-bg {
+  background-color: var(--theia-terminal-ansiBrightCyan);
+}
+
+.theia-output .ansi-bright-white-bg {
+  background-color: var(--theia-terminal-ansiBrightWhite);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Adds ANSI SGR escape sequence parsing and rendering to the Output view (colors, bold, italic, underline)
- Replaces raw escape code display with styled inline decorations via Monaco editor
- Uses CSS classes scoped under .theia-output, referencing existing terminal ANSI color variables
- Includes unit tests for the ANSI parser

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open the Output view and select the sample channel `API Sample: my test channel` that emits ANSI escape codes (e.g. colored build output, test runners)
- Verify that colors, bold, italic, and underline styles render correctly instead of raw escape sequences
- Verify this also works with different light/dark themes

e.g.  in light theme:
<img height="175" alt="image" src="https://github.com/user-attachments/assets/66f2bc15-7813-4d92-86fe-d28c2fca946b" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
