### PR TITLE
Listen to all breakpoint changes

### DIFF
--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.spec.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.spec.ts
@@ -1104,3 +1104,76 @@ describe('BreakpointManager — updateBreakpoint', () => {
         expect(events).to.have.length(0);
     });
 });
+
+describe('BreakpointManager — onDidChangeMarkers catch-all', () => {
+
+    let manager: BreakpointManager;
+
+    beforeEach(() => {
+        ({ manager } = createManager());
+    });
+
+    it('fires when a source breakpoint is added', () => {
+        const uris: URI[] = [];
+        manager.onDidChangeMarkers(uri => uris.push(uri));
+
+        manager.setBreakpoints(FILE_A, [makeSourceBreakpoint(FILE_A, 1)]);
+        expect(uris).to.have.length(1);
+        expect(uris[0].toString()).to.equal(FILE_A.toString());
+    });
+
+    it('fires when a function breakpoint is added', () => {
+        const uris: URI[] = [];
+        manager.onDidChangeMarkers(uri => uris.push(uri));
+
+        manager.addFunctionBreakpoint(makeFunctionBreakpoint('myFunc'));
+        expect(uris).to.have.length(1);
+        expect(uris[0].toString()).to.equal(BreakpointManager.FUNCTION_URI.toString());
+    });
+
+    it('fires when an instruction breakpoint is added', () => {
+        const uris: URI[] = [];
+        manager.onDidChangeMarkers(uri => uris.push(uri));
+
+        manager.addInstructionBreakpoint('0xDEAD', 0);
+        expect(uris).to.have.length(1);
+        expect(uris[0].toString()).to.equal(BreakpointManager.INSTRUCTION_URI.toString());
+    });
+
+    it('fires when a data breakpoint is added', () => {
+        const uris: URI[] = [];
+        manager.onDidChangeMarkers(uri => uris.push(uri));
+
+        manager.addDataBreakpoint(makeDataBreakpoint('d1'));
+        expect(uris).to.have.length(1);
+        expect(uris[0].toString()).to.equal(BreakpointManager.DATA_URI.toString());
+    });
+
+    it('fires when a function breakpoint is removed', () => {
+        manager.addFunctionBreakpoint(makeFunctionBreakpoint('fn'));
+        const wrapper = manager.getFunctionBreakpoints()[0];
+
+        const uris: URI[] = [];
+        manager.onDidChangeMarkers(uri => uris.push(uri));
+
+        manager.removeFunctionBreakpoint(wrapper);
+        expect(uris).to.have.length(1);
+    });
+
+    it('fires for each type during enableAllBreakpoints', () => {
+        manager.setBreakpoints(FILE_A, [makeSourceBreakpoint(FILE_A, 1, { enabled: false })]);
+        manager.addFunctionBreakpoint(makeFunctionBreakpoint('fn'));
+        manager.addInstructionBreakpoint('0xABC', 0);
+        manager.addDataBreakpoint(makeDataBreakpoint('d1'));
+
+        // Disable all first so enableAllBreakpoints has work to do
+        manager.enableAllBreakpoints(false);
+
+        const uris: URI[] = [];
+        manager.onDidChangeMarkers(uri => uris.push(uri));
+
+        manager.enableAllBreakpoints(true);
+        // Should fire once per breakpoint type that changed
+        expect(uris).to.have.length.greaterThanOrEqual(4);
+    });
+});

--- a/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
+++ b/packages/debug/src/browser/breakpoint/breakpoint-manager.ts
@@ -72,6 +72,11 @@ export class BreakpointManager {
     // ── Events ──
 
     protected readonly onDidChangeMarkersEmitter = new Emitter<URI>();
+    /**
+     * Fires when any breakpoint type changes (source, function, instruction, data, or exception).
+     * The URI identifies the affected resource or the synthetic URI for non-source breakpoint types
+     * (e.g. {@link BreakpointManager.FUNCTION_URI}).
+     */
     get onDidChangeMarkers(): Event<URI> {
         return this.onDidChangeMarkersEmitter.event;
     }

--- a/packages/debug/src/browser/view/debug-view-model.ts
+++ b/packages/debug/src/browser/view/debug-view-model.ts
@@ -105,8 +105,8 @@ export class DebugViewModel implements Disposable {
             // This ensures threads view updates for all sessions
             this.fireDidChange();
         }));
-        this.toDispose.push(this.breakpointManager.onDidChangeBreakpoints(e => {
-            this.fireDidChangeBreakpoints(e.uri);
+        this.toDispose.push(this.breakpointManager.onDidChangeMarkers(uri => {
+            this.fireDidChangeBreakpoints(uri);
         }));
         this.toDispose.push(this.manager.onDidResolveLazyVariable(({ session, variable }) => {
             if (session === this.currentSession) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #17276 by switching the event used for breakpoint changes to the `onDidChangeMarkers` event, which catches all breakpoint changes.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Add a function breakpoint.
2. It should immediately appear in the breakpoints view without any other breakpoint change required.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
