### PR TITLE
Enforce some options for child editors of the merge editor

### DIFF
--- a/packages/scm/src/browser/merge-editor/merge-editor-module.ts
+++ b/packages/scm/src/browser/merge-editor/merge-editor-module.ts
@@ -106,7 +106,9 @@ export class MergeEditorFactory {
         if (!editor) {
             throw new Error('The merge editor only supports Monaco editors as its parts');
         }
-        editor.getControl().updateOptions({ folding: false, codeLens: false, stickyScroll: { enabled: false }, minimap: { enabled: false } });
+        const options: MonacoEditor.IOptions = { glyphMargin: false, folding: false, codeLens: false, stickyScroll: { enabled: false }, minimap: { enabled: false } };
+        editor.getControl().updateOptions(options);
+        editor.getControl().onDidChangeConfiguration(() => editor.getControl().updateOptions(options));
         editor.setShouldDisplayDirtyDiff(false);
         return editorWidget;
     }


### PR DESCRIPTION
#### What it does

There are some options for child editors of the merge editor that need to be always set (not just initially).
This PR enforces that.

#### How to test

1. Open a workspace that has a merge conflict.

2. Click on a file in the Merge Changes section of the Source Control view.

3. Make sure that `View > Toggle Minimap` is off.

3. Click on the `Resolve in Merge Editor` button in the bottom right corner of the editor.

4. `Toggle Minimap`, so that it is now on.

Verify that child editors of the merge editor don't show the minimap, although regular editors do show it.
(Before this change, child editors of the merge editor would show the minimap in this case.)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
