### PR TITLE
fix: use partial JSON extraction to prevent tool call label flicker

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -25,6 +25,7 @@ import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
 import { ResponseNode } from '../chat-tree-view';
 import { SubChatWidgetFactory } from '../chat-tree-view/sub-chat-widget';
 import { withToolCallConfirmation } from './tool-confirmation';
+import { extractJsonStringField } from './toolcall-utils';
 import { CompositeTreeNode, ContextMenuRenderer } from '@theia/core/lib/browser';
 import { ContributionProvider, DisposableCollection, nls } from '@theia/core';
 import * as React from '@theia/core/shared/react';
@@ -75,7 +76,14 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
                     prompt = args.prompt;
                 }
             } catch {
-                // ignore parse errors
+                const partialAgentId = extractJsonStringField(response.arguments, 'agentId');
+                if (partialAgentId) {
+                    agentName = this.chatAgentService.getAgent(partialAgentId)?.name ?? partialAgentId;
+                }
+                const partialPrompt = extractJsonStringField(response.arguments, 'prompt');
+                if (partialPrompt) {
+                    prompt = partialPrompt;
+                }
             }
         }
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-utils.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-utils.ts
@@ -16,6 +16,8 @@
 
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
 
+export { extractJsonStringField } from '../../common/toolcall-utils';
+
 const SHORT_STRING_THRESHOLD = 50;
 const MAX_CONDENSED_LENGTH = 80;
 const MAX_CONDENSED_VALUE_LENGTH = 30;

--- a/packages/ai-chat-ui/src/common/toolcall-utils.spec.ts
+++ b/packages/ai-chat-ui/src/common/toolcall-utils.spec.ts
@@ -1,0 +1,118 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { extractJsonStringField } from './toolcall-utils';
+
+describe('extractJsonStringField', () => {
+    describe('complete JSON', () => {
+        it('should extract a string field from valid JSON', () => {
+            const result = extractJsonStringField('{"path": "src/index.ts", "content": "hello"}', 'path');
+            expect(result).to.equal('src/index.ts');
+        });
+
+        it('should extract a different field from valid JSON', () => {
+            const result = extractJsonStringField('{"agentId": "coder", "prompt": "fix the bug"}', 'prompt');
+            expect(result).to.equal('fix the bug');
+        });
+
+        it('should return undefined when field is not present in valid JSON', () => {
+            const result = extractJsonStringField('{"name": "test"}', 'path');
+            expect(result).to.be.undefined;
+        });
+
+        it('should return undefined when field value is not a string', () => {
+            const result = extractJsonStringField('{"count": 42}', 'count');
+            expect(result).to.be.undefined;
+        });
+    });
+
+    describe('incomplete JSON (streaming)', () => {
+        it('should extract field from JSON missing closing brace', () => {
+            const result = extractJsonStringField('{"path": "src/index.ts"', 'path');
+            expect(result).to.equal('src/index.ts');
+        });
+
+        it('should extract field from JSON with missing closing quote on value', () => {
+            const result = extractJsonStringField('{"path": "src/index.ts', 'path');
+            expect(result).to.equal('src/index.ts');
+        });
+
+        it('should extract partial value mid-stream', () => {
+            const result = extractJsonStringField('{"command": "git st', 'command');
+            expect(result).to.equal('git st');
+        });
+
+        it('should return empty string when only the key and opening quote are present', () => {
+            const result = extractJsonStringField('{"path": "', 'path');
+            expect(result).to.equal('');
+        });
+
+        it('should handle JSON without spaces around colon', () => {
+            const result = extractJsonStringField('{"path":"src/utils.ts', 'path');
+            expect(result).to.equal('src/utils.ts');
+        });
+
+        it('should extract first field when additional fields follow incomplete', () => {
+            const result = extractJsonStringField('{"path": "src/index.ts", "content": "hel', 'path');
+            expect(result).to.equal('src/index.ts');
+        });
+
+        it('should extract the second field from partial JSON', () => {
+            const result = extractJsonStringField('{"agentId": "coder", "prompt": "fix the b', 'prompt');
+            expect(result).to.equal('fix the b');
+        });
+    });
+
+    describe('edge cases', () => {
+        it('should return undefined for undefined input', () => {
+            const result = extractJsonStringField(undefined, 'path');
+            expect(result).to.be.undefined;
+        });
+
+        it('should return undefined for empty string input', () => {
+            const result = extractJsonStringField('', 'path');
+            expect(result).to.be.undefined;
+        });
+
+        it('should return undefined when field is not present in partial JSON', () => {
+            const result = extractJsonStringField('{"other": "value', 'path');
+            expect(result).to.be.undefined;
+        });
+
+        it('should return undefined for completely malformed input', () => {
+            const result = extractJsonStringField('{path: value}', 'path');
+            expect(result).to.be.undefined;
+        });
+
+        it('should return undefined for partial key only', () => {
+            const result = extractJsonStringField('{"pat', 'path');
+            expect(result).to.be.undefined;
+        });
+
+        it('should handle escaped quotes - regex stops at first unescaped quote', () => {
+            // With complete JSON, JSON.parse handles escapes correctly
+            const result = extractJsonStringField('{"cmd": "echo \\"hello\\""}', 'cmd');
+            expect(result).to.equal('echo "hello"');
+        });
+
+        it('should handle escaped quotes in partial JSON - regex captures up to first quote', () => {
+            // With incomplete JSON, regex stops at the first unescaped quote character
+            const result = extractJsonStringField('{"cmd": "echo \\"hello', 'cmd');
+            expect(result).to.equal('echo \\');
+        });
+    });
+});

--- a/packages/ai-chat-ui/src/common/toolcall-utils.ts
+++ b/packages/ai-chat-ui/src/common/toolcall-utils.ts
@@ -14,26 +14,23 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { extractJsonStringField } from '@theia/ai-chat-ui/lib/common/toolcall-utils';
-
-export interface ShellExecutionInput {
-    command: string;
-    cwd?: string;
-    timeout?: number;
-}
-
 /**
- * Parses shell execution input from potentially incomplete JSON.
- * During streaming, extracts partial command value via regex when JSON.parse fails.
+ * Extracts a string field value from potentially incomplete JSON.
+ * Tries JSON.parse first, then falls back to regex extraction for streaming scenarios.
  */
-export function parseShellExecutionInput(args: string | undefined): ShellExecutionInput {
-    if (!args) {
-        return { command: '' };
+export function extractJsonStringField(json: string | undefined, fieldName: string): string | undefined {
+    if (!json) {
+        return undefined;
     }
-
     try {
-        return JSON.parse(args);
+        const parsed = JSON.parse(json);
+        if (parsed && typeof parsed === 'object' && fieldName in parsed && typeof parsed[fieldName] === 'string') {
+            return parsed[fieldName];
+        }
     } catch {
-        return { command: extractJsonStringField(args, 'command') ?? '' };
+        const regex = new RegExp('"' + fieldName + '"\\s*:\\s*"([^"]*)"?');
+        const match = regex.exec(json);
+        return match?.[1];
     }
+    return undefined;
 }

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -25,6 +25,7 @@ import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceFunctionScope } from './workspace-functions';
 
 import { nls } from '@theia/core';
+import { extractJsonStringField } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/toolcall-utils';
 import {
     CLEAR_FILE_CHANGES_ID,
     GET_PROPOSED_CHANGES_ID,
@@ -43,7 +44,10 @@ function createPathShortLabel(args: string, hasMore: boolean): { label: string; 
             return { label: String(parsed.path), hasMore };
         }
     } catch {
-        // ignore parse errors
+        const path = extractJsonStringField(args, 'path');
+        if (path) {
+            return { label: path, hasMore };
+        }
     }
     return undefined;
 }

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -38,16 +38,9 @@ import {
 } from '../common/file-changeset-function-ids';
 
 function createPathShortLabel(args: string, hasMore: boolean): { label: string; hasMore: boolean } | undefined {
-    try {
-        const parsed = JSON.parse(args);
-        if (parsed && typeof parsed === 'object' && 'path' in parsed) {
-            return { label: String(parsed.path), hasMore };
-        }
-    } catch {
-        const path = extractJsonStringField(args, 'path');
-        if (path) {
-            return { label: path, hasMore };
-        }
+    const path = extractJsonStringField(args, 'path');
+    if (path) {
+        return { label: path, hasMore };
     }
     return undefined;
 }

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -24,6 +24,7 @@ import {
     GET_WORKSPACE_DIRECTORY_STRUCTURE_FUNCTION_ID,
     GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FIND_FILES_BY_PATTERN_FUNCTION_ID
 } from '../common/workspace-functions';
+import { extractJsonStringField } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/toolcall-utils';
 import ignore from 'ignore';
 import { Minimatch } from 'minimatch';
 import { CONSIDER_GITIGNORE_PREF, FILE_CONTENT_MAX_SIZE_KB_PREF, USER_EXCLUDE_PATTERN_PREF } from '../common/workspace-preferences';
@@ -319,7 +320,10 @@ export class FileContentFunction implements ToolProvider {
                         return { label: String(parsed.file), hasMore };
                     }
                 } catch {
-                    // ignore parse errors
+                    const file = extractJsonStringField(args, 'file');
+                    if (file) {
+                        return { label: file, hasMore: false };
+                    }
                 }
                 return undefined;
             },
@@ -451,7 +455,7 @@ export class FileContentFunction implements ToolProvider {
         } catch (e) {
             if (e instanceof FileOperationError &&
                 (e.fileOperationResult === FileOperationResult.FILE_TOO_LARGE ||
-                 e.fileOperationResult === FileOperationResult.FILE_EXCEEDS_MEMORY_LIMIT)) {
+                    e.fileOperationResult === FileOperationResult.FILE_EXCEEDS_MEMORY_LIMIT)) {
                 return JSON.stringify({
                     error: 'File exceeds the configured ' + maxSizeKB + 'KB size limit. ' +
                         'Use the \'offset\' (0-based) and \'limit\' parameters to read specific line ranges, ' +
@@ -837,7 +841,10 @@ export class FindFilesByPattern implements ToolProvider {
                         return { label: String(parsed.pattern), hasMore: keys.length > 1 };
                     }
                 } catch {
-                    // ignore parse errors
+                    const pattern = extractJsonStringField(args, 'pattern');
+                    if (pattern) {
+                        return { label: pattern, hasMore: false };
+                    }
                 }
                 return undefined;
             },


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Introduce extractJsonStringField utility that tries JSON.parse first, then falls back to regex extraction for incomplete/streaming JSON. Refactor parseShellExecutionInput to use the new utility. Update getArgumentsShortLabel implementations
(createPathShortLabel, FileContentFunction, FindFilesByPattern) to fall back to partial extraction when JSON.parse fails.
Update DelegationToolRenderer to show agentId and
prompt from partial JSON during streaming.

Fixes #17216

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
See the original issue.

Ask Coder to update some file.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
