### PR TITLE
fix: Change set diff showing identical sides

### DIFF
--- a/packages/ai-chat/src/browser/change-set-file-element.spec.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.spec.ts
@@ -293,6 +293,132 @@ describe('ChangeSetFileElement', () => {
         });
     });
 
+    describe('post-operation re-read', () => {
+        it('should detect stale state via post-operation re-read after revert', async () => {
+            await element.ensureInitialized();
+
+            // Start from pending state
+            (element as unknown as { _state: string })._state = 'pending';
+
+            // Stub write to simulate an external change during revert
+            mockChangeSetFileService.write.callsFake(async () => {
+                // Some external process modifies the file during our revert
+                mockChangeSetFileService.read.resolves('externally modified during revert');
+            });
+
+            // Stub confirm to return true
+            sandbox.stub(element, 'confirm' as keyof ChangeSetFileElement).resolves(true);
+
+            await element.revert();
+
+            // revert sets state to 'pending' first, but the re-read detects
+            // the file doesn't match original or target, so state becomes 'stale'
+            expect(element.state).to.equal('stale');
+        });
+
+        it('should detect pending state via post-operation re-read after revert', async () => {
+            await element.ensureInitialized();
+
+            (element as unknown as { _state: string })._state = 'applied';
+
+            mockChangeSetFileService.write.resolves();
+            // After the revert, the file on disk matches the original content
+            mockChangeSetFileService.read.resolves(originalContent);
+
+            sandbox.stub(element, 'confirm' as keyof ChangeSetFileElement).resolves(true);
+
+            await element.revert();
+
+            expect(element.state).to.equal('pending');
+        });
+
+        it('should detect applied state via post-operation re-read after apply (delete type)', async () => {
+            element.dispose();
+            container.rebind(ChangeSetElementArgs).toConstantValue({
+                uri: testUri,
+                chatSessionId,
+                requestId: 'test-request',
+                targetState: '',
+                type: 'delete' as const,
+            });
+            element = container.get(ChangeSetFileElement);
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.delete.resolves();
+            mockChangeSetFileService.closeDiff.returns();
+            // After delete, the file is gone so read returns undefined => (undefined ?? '') === ''
+            // which matches targetState (''), so state should be 'applied'
+            mockChangeSetFileService.read.resolves(undefined as unknown as string);
+
+            sandbox.stub(element, 'confirm' as keyof ChangeSetFileElement).resolves(true);
+
+            await element.apply();
+
+            expect(element.state).to.equal('applied');
+        });
+
+        it('should detect stale state via post-operation re-read after apply when file is externally modified', async () => {
+            await element.ensureInitialized();
+
+            // Make createModelReference throw so the catch branch in applyChangesWithMonaco runs,
+            // which falls back to writeFrom.
+            const mockMonacoTextModelService = {
+                createModelReference: sandbox.stub().rejects(new Error('Monaco unavailable')),
+            };
+            container.rebind(MonacoTextModelService).toConstantValue(mockMonacoTextModelService as unknown as MonacoTextModelService);
+            element.dispose();
+            element = container.get(ChangeSetFileElement);
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.writeFrom.resolves();
+            mockChangeSetFileService.closeDiff.returns();
+            // After the apply, the file was changed externally
+            mockChangeSetFileService.read.resolves('externally modified after apply');
+
+            sandbox.stub(element, 'confirm' as keyof ChangeSetFileElement).resolves(true);
+
+            // Access changedUri so _changeResource is created
+            element.changedUri;
+
+            await element.apply();
+
+            // apply's catch block sets state to 'applied', but the post-operation re-read
+            // in the outer finally detects the file differs from both original and target.
+            // Since the state is 'applied', it updates the changeResource content.
+            expect(element.state).to.equal('applied');
+        });
+
+        it('should not re-read when originalState is provided', async () => {
+            element.dispose();
+            container.rebind(ChangeSetElementArgs).toConstantValue({
+                uri: testUri,
+                chatSessionId,
+                requestId: 'test-request',
+                targetState: targetContent,
+                originalState: 'fixed original',
+            });
+            element = container.get(ChangeSetFileElement);
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.write.resolves();
+
+            const readCallCountBeforeRevert = mockChangeSetFileService.read.callCount;
+
+            sandbox.stub(element, 'confirm' as keyof ChangeSetFileElement).resolves(true);
+
+            // Force a state that allows revert to proceed
+            (element as unknown as { _state: string })._state = 'applied';
+
+            await element.revert();
+
+            // No re-read should happen since originalState is provided
+            expect(mockChangeSetFileService.read.callCount).to.equal(readCallCountBeforeRevert);
+
+            // State should be 'pending' (set by revert directly)
+            expect(element.state).to.equal('pending');
+        });
+    });
+
     describe('initialization', () => {
         it('should load original content from file service during init', async () => {
             await element.ensureInitialized();

--- a/packages/ai-chat/src/browser/change-set-file-element.spec.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.spec.ts
@@ -1,0 +1,322 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Container } from '@theia/core/shared/inversify';
+import { Emitter, URI } from '@theia/core';
+import { ConfigurableInMemoryResources } from '@theia/ai-core';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileChangesEvent, FileChangeType } from '@theia/filesystem/lib/common/files';
+import { EditorPreferences } from '@theia/editor/lib/common/editor-preferences';
+import { FileSystemPreferences } from '@theia/filesystem/lib/common';
+import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
+import { MonacoCodeActionService } from '@theia/monaco/lib/browser';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { ChangeSetFileElement, ChangeSetElementArgs } from './change-set-file-element';
+import { ChangeSetFileService } from './change-set-file-service';
+
+disableJSDOM();
+
+describe('ChangeSetFileElement', () => {
+    let sandbox: sinon.SinonSandbox;
+    let container: Container;
+    let element: ChangeSetFileElement;
+    let fileChangeEmitter: Emitter<FileChangesEvent>;
+    let mockChangeSetFileService: sinon.SinonStubbedInstance<ChangeSetFileService>;
+    let inMemoryResources: ConfigurableInMemoryResources;
+
+    const testUri = new URI('file:///test/file.ts');
+    const chatSessionId = 'test-session';
+    const originalContent = 'original content';
+    const targetContent = 'target content';
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        fileChangeEmitter = new Emitter<FileChangesEvent>();
+
+        mockChangeSetFileService = sandbox.createStubInstance(ChangeSetFileService);
+        mockChangeSetFileService.read.resolves(originalContent);
+        mockChangeSetFileService.getName.returns('file.ts');
+        mockChangeSetFileService.getIcon.returns(undefined);
+        mockChangeSetFileService.getAdditionalInfo.returns(undefined);
+
+        inMemoryResources = new ConfigurableInMemoryResources();
+
+        container = new Container();
+
+        container.bind(ChangeSetElementArgs).toConstantValue({
+            uri: testUri,
+            chatSessionId,
+            requestId: 'test-request',
+            targetState: targetContent,
+        });
+
+        container.bind(ChangeSetFileService).toConstantValue(mockChangeSetFileService as unknown as ChangeSetFileService);
+
+        container.bind(FileService).toConstantValue({
+            onDidFilesChange: fileChangeEmitter.event,
+        } as unknown as FileService);
+
+        container.bind(ConfigurableInMemoryResources).toConstantValue(inMemoryResources);
+
+        container.bind(MonacoTextModelService).toConstantValue({} as unknown as MonacoTextModelService);
+        container.bind(EditorPreferences).toConstantValue({} as unknown as EditorPreferences);
+        container.bind(FileSystemPreferences).toConstantValue({} as unknown as FileSystemPreferences);
+        container.bind(MonacoCodeActionService).toConstantValue({} as unknown as MonacoCodeActionService);
+        container.bind(MonacoWorkspace).toConstantValue({} as unknown as MonacoWorkspace);
+
+        container.bind(ChangeSetFileElement).toSelf();
+        element = container.get(ChangeSetFileElement);
+    });
+
+    afterEach(() => {
+        element.dispose();
+        fileChangeEmitter.dispose();
+        sandbox.restore();
+    });
+
+    function fireFileChange(): void {
+        const event = new FileChangesEvent([{
+            resource: testUri,
+            type: FileChangeType.UPDATED,
+        }]);
+        fileChangeEmitter.fire(event);
+    }
+
+    describe('listenForOriginalFileChanges', () => {
+        it('should not update readOnlyResource contents on file change', async () => {
+            await element.ensureInitialized();
+
+            // Access readOnlyUri to ensure the resource is created
+            const readOnlyUri = element.readOnlyUri;
+            const readOnlyResource = inMemoryResources.resolve(readOnlyUri);
+            expect(await readOnlyResource.readContents()).to.equal(originalContent);
+
+            // Simulate the file on disk being changed to the target content (as if apply happened externally)
+            mockChangeSetFileService.read.resolves(targetContent);
+            fireFileChange();
+
+            // Allow the async event handler to run
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // The readOnlyResource should still contain the original content
+            expect(await readOnlyResource.readContents()).to.equal(originalContent);
+        });
+
+        it('should set state to "applied" when file content matches targetState', async () => {
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.read.resolves(targetContent);
+            fireFileChange();
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            expect(element.state).to.equal('applied');
+        });
+
+        it('should set state to "pending" when file content matches original content', async () => {
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.read.resolves(originalContent);
+            fireFileChange();
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            expect(element.state).to.equal('pending');
+        });
+
+        it('should set state to "stale" when file content differs from both original and target', async () => {
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.read.resolves('some other content');
+            fireFileChange();
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            expect(element.state).to.equal('stale');
+        });
+
+        it('should ignore file change events for unrelated URIs', async () => {
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.read.resolves('some other content');
+
+            const unrelatedEvent = new FileChangesEvent([{
+                resource: new URI('file:///other/file.ts'),
+                type: FileChangeType.UPDATED,
+            }]);
+            fileChangeEmitter.fire(unrelatedEvent);
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // State should remain undefined (no change from initial)
+            expect(element.state).to.be.undefined;
+        });
+
+        it('should update changeResource when file changes post-apply', async () => {
+            await element.ensureInitialized();
+
+            // Access changedUri to ensure the _changeResource is created
+            const changedUri = element.changedUri;
+
+            // Move to 'applied' state
+            (element as unknown as { _state: string })._state = 'applied';
+
+            // Simulate file changing to content that differs from both original and target
+            mockChangeSetFileService.read.resolves('externally modified content');
+
+            const changeFired = new Promise<void>(resolve => element.onDidChange(resolve));
+            fireFileChange();
+
+            await changeFired;
+
+            // The _changeResource should have been updated with the new content
+            const changeResource = inMemoryResources.resolve(changedUri);
+            expect(await changeResource.readContents()).to.equal('externally modified content');
+        });
+
+        it('should handle delete type correctly when read returns undefined', async () => {
+            element.dispose();
+            container.rebind(ChangeSetElementArgs).toConstantValue({
+                uri: testUri,
+                chatSessionId,
+                requestId: 'test-request',
+                targetState: '',
+                type: 'delete',
+            });
+            element = container.get(ChangeSetFileElement);
+            await element.ensureInitialized();
+
+            // Simulate read returning undefined (file was deleted)
+            mockChangeSetFileService.read.resolves(undefined as unknown as string);
+            fireFileChange();
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // targetState is '' and (undefined ?? '') === '', so state should be 'applied'
+            expect(element.state).to.equal('applied');
+        });
+
+        it('should skip file change handling when originalState is provided', async () => {
+            // Recreate with originalState set
+            element.dispose();
+            container.rebind(ChangeSetElementArgs).toConstantValue({
+                uri: testUri,
+                chatSessionId,
+                requestId: 'test-request',
+                targetState: targetContent,
+                originalState: 'fixed original',
+            });
+            element = container.get(ChangeSetFileElement);
+            await element.ensureInitialized();
+
+            mockChangeSetFileService.read.resolves('changed content');
+            fireFileChange();
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // State should remain unchanged since the listener was not registered
+            expect(element.state).to.be.undefined;
+        });
+    });
+
+    describe('_isApplying guard', () => {
+        it('should ignore file change events while applying', async () => {
+            await element.ensureInitialized();
+
+            // Access the _isApplying flag via cast to set it for testing
+            (element as unknown as { _isApplying: boolean })._isApplying = true;
+
+            mockChangeSetFileService.read.resolves(targetContent);
+            fireFileChange();
+
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // State should remain unchanged since the listener was skipped
+            expect(element.state).to.be.undefined;
+
+            // Verify read was not called for the file change handler
+            // (only the initial read during initialization should have been called)
+            expect(mockChangeSetFileService.read.callCount).to.equal(1);
+
+            (element as unknown as { _isApplying: boolean })._isApplying = false;
+        });
+
+        it('should resume handling file changes after applying completes', async () => {
+            await element.ensureInitialized();
+
+            // Simulate apply starting
+            (element as unknown as { _isApplying: boolean })._isApplying = true;
+
+            mockChangeSetFileService.read.resolves(targetContent);
+            fireFileChange();
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // Should be ignored
+            expect(element.state).to.be.undefined;
+
+            // Simulate apply completing
+            (element as unknown as { _isApplying: boolean })._isApplying = false;
+
+            // Now fire another file change - this one should be handled
+            fireFileChange();
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            expect(element.state).to.equal('applied');
+        });
+    });
+
+    describe('initialization', () => {
+        it('should load original content from file service during init', async () => {
+            await element.ensureInitialized();
+
+            expect(await element.getOriginalContent()).to.equal(originalContent);
+        });
+
+        it('should use originalState from props when provided', async () => {
+            element.dispose();
+            container.rebind(ChangeSetElementArgs).toConstantValue({
+                uri: testUri,
+                chatSessionId,
+                requestId: 'test-request',
+                targetState: targetContent,
+                originalState: 'explicit original',
+            });
+            element = container.get(ChangeSetFileElement);
+            await element.ensureInitialized();
+
+            expect(await element.getOriginalContent()).to.equal('explicit original');
+            // Reset call count tracking and verify that the new element did not call read
+            // (the initial element from beforeEach may have called read, so we check
+            // that no additional read was called after the stub was reset)
+            expect(mockChangeSetFileService.read.callCount).to.equal(1);
+        });
+    });
+});

--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -169,18 +169,32 @@ export class ChangeSetFileElement implements ChangeSetElement {
                 // make sure we are initialized
                 await this._initializationPromise;
             }
-            const newContent = (await this.changeSetFileService.read(this.uri).catch(() => undefined)) ?? '';
-            if (newContent === this._originalContent) {
-                this.state = 'pending';
-            } else if (newContent === this.targetState) {
-                this.state = 'applied';
-            } else if (this.state === 'applied') {
-                this._changeResource?.update({ contents: newContent });
-                this.onDidChangeEmitter.fire();
-            } else {
-                this.state = 'stale';
-            }
+            await this.reevaluateFileState();
         }));
+    }
+
+    /**
+     * Re-reads the file from disk and transitions state accordingly.
+     * This is shared between the file-change listener and the post-operation re-read
+     * so that external changes that were suppressed by the `_isApplying` guard are picked up.
+     * When `originalState` is provided via props, this is a no-op because the element
+     * is not tracking the on-disk file.
+     */
+    protected async reevaluateFileState(): Promise<void> {
+        if (this.elementProps.originalState) {
+            return;
+        }
+        const newContent = (await this.changeSetFileService.read(this.uri).catch(() => undefined)) ?? '';
+        if (newContent === this._originalContent) {
+            this.state = 'pending';
+        } else if (newContent === this.targetState) {
+            this.state = 'applied';
+        } else if (this.state === 'applied') {
+            this._changeResource?.update({ contents: newContent });
+            this.onDidChangeEmitter.fire();
+        } else {
+            this.state = 'stale';
+        }
     }
 
     get uri(): URI {
@@ -315,52 +329,41 @@ export class ChangeSetFileElement implements ChangeSetElement {
             this.changeSetFileService.closeDiff(this.readOnlyUri);
         } finally {
             this._isApplying = false;
-        }
-    }
-
-    async writeChanges(contents?: string): Promise<void> {
-        this._isApplying = true;
-        try {
-            await this.changeSetFileService.writeFrom(this.changedUri, this.uri, contents ?? this.targetState);
-            this.state = 'applied';
-        } finally {
-            this._isApplying = false;
+            await this.reevaluateFileState();
         }
     }
 
     /**
      * Applies changes using Monaco utilities, including loading the model for the base file URI,
      * applying edits, and running code actions on save.
+     *
+     * This is a pure helper — callers are responsible for the `_isApplying` guard.
      */
     protected async applyChangesWithMonaco(contents?: string): Promise<void> {
-        this._isApplying = true;
+        let modelReference: IReference<MonacoEditorModel> | undefined;
         try {
-            let modelReference: IReference<MonacoEditorModel> | undefined;
-            try {
-                modelReference = await this.monacoTextModelService.createModelReference(this.uri);
-                const model = modelReference.object;
-                model.suppressOpenEditorWhenDirty = true;
-                const targetContent = contents ?? this.targetState;
-                const currentContent = model.textEditorModel.getValue();
-                if (currentContent !== targetContent) {
-                    const fullRange = model.textEditorModel.getFullModelRange();
-                    await this.monacoWorkspace.applyBackgroundEdit(model,
-                        [{ range: fullRange, text: targetContent, forceMoveMarkers: false }]);
-                }
-                const languageId = model.languageId;
-                const uriStr = this.uri.toString();
-                await this.codeActionService.applyOnSaveCodeActions(model.textEditorModel, languageId, uriStr, CancellationToken.None);
-                await this.applyFormatting(model, languageId, uriStr);
-                await model.save();
-                this.state = 'applied';
-            } catch (error) {
-                console.error('Failed to apply changes with Monaco:', error);
-                await this.writeChanges(contents);
-            } finally {
-                modelReference?.dispose();
+            modelReference = await this.monacoTextModelService.createModelReference(this.uri);
+            const model = modelReference.object;
+            model.suppressOpenEditorWhenDirty = true;
+            const targetContent = contents ?? this.targetState;
+            const currentContent = model.textEditorModel.getValue();
+            if (currentContent !== targetContent) {
+                const fullRange = model.textEditorModel.getFullModelRange();
+                await this.monacoWorkspace.applyBackgroundEdit(model,
+                    [{ range: fullRange, text: targetContent, forceMoveMarkers: false }]);
             }
+            const languageId = model.languageId;
+            const uriStr = this.uri.toString();
+            await this.codeActionService.applyOnSaveCodeActions(model.textEditorModel, languageId, uriStr, CancellationToken.None);
+            await this.applyFormatting(model, languageId, uriStr);
+            await model.save();
+            this.state = 'applied';
+        } catch (error) {
+            console.error('Failed to apply changes with Monaco:', error);
+            await this.changeSetFileService.writeFrom(this.changedUri, this.uri, contents ?? this.targetState);
+            this.state = 'applied';
         } finally {
-            this._isApplying = false;
+            modelReference?.dispose();
         }
     }
 
@@ -455,8 +458,13 @@ export class ChangeSetFileElement implements ChangeSetElement {
         this.changeResource.update({
             contents: this.targetState,
             onSave: async content => {
-                // Use Monaco utilities when saving from the change resource
-                await this.applyChangesWithMonaco(content);
+                this._isApplying = true;
+                try {
+                    await this.applyChangesWithMonaco(content);
+                } finally {
+                    this._isApplying = false;
+                    await this.reevaluateFileState();
+                }
             }
         });
     }
@@ -474,6 +482,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
             }
         } finally {
             this._isApplying = false;
+            await this.reevaluateFileState();
         }
     }
 

--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -108,6 +108,7 @@ export class ChangeSetFileElement implements ChangeSetElement {
     protected _state: ChangeSetElementState;
 
     private _originalContent: string | undefined;
+    protected _isApplying = false;
     protected _initialized = false;
     protected _initializationPromise: Promise<void> | undefined;
     protected _targetStateWithCodeActions: string | undefined;
@@ -163,17 +164,19 @@ export class ChangeSetFileElement implements ChangeSetElement {
         }
         this.toDispose.push(this.fileService.onDidFilesChange(async event => {
             if (!event.contains(this.uri)) { return; }
+            if (this._isApplying) { return; }
             if (!this._initialized && this._initializationPromise) {
                 // make sure we are initialized
                 await this._initializationPromise;
             }
-            // If we are applied, the tricky thing becomes the question what to revert to; otherwise, what to apply.
-            const newContent = await this.changeSetFileService.read(this.uri).catch(() => '');
-            this.readOnlyResource.update({ contents: newContent });
+            const newContent = (await this.changeSetFileService.read(this.uri).catch(() => undefined)) ?? '';
             if (newContent === this._originalContent) {
                 this.state = 'pending';
             } else if (newContent === this.targetState) {
                 this.state = 'applied';
+            } else if (this.state === 'applied') {
+                this._changeResource?.update({ contents: newContent });
+                this.onDidChangeEmitter.fire();
             } else {
                 this.state = 'stale';
             }
@@ -298,21 +301,31 @@ export class ChangeSetFileElement implements ChangeSetElement {
         await this.ensureInitialized();
         if (!await this.confirm('Apply')) { return; }
 
-        if (this.type === 'delete') {
-            await this.changeSetFileService.delete(this.uri);
-            this.state = 'applied';
-            this.changeSetFileService.closeDiff(this.readOnlyUri);
-            return;
-        }
+        this._isApplying = true;
+        try {
+            if (this.type === 'delete') {
+                await this.changeSetFileService.delete(this.uri);
+                this.state = 'applied';
+                this.changeSetFileService.closeDiff(this.readOnlyUri);
+                return;
+            }
 
-        // Load Monaco model for the base file URI and apply changes
-        await this.applyChangesWithMonaco(contents);
-        this.changeSetFileService.closeDiff(this.readOnlyUri);
+            // Load Monaco model for the base file URI and apply changes
+            await this.applyChangesWithMonaco(contents);
+            this.changeSetFileService.closeDiff(this.readOnlyUri);
+        } finally {
+            this._isApplying = false;
+        }
     }
 
     async writeChanges(contents?: string): Promise<void> {
-        await this.changeSetFileService.writeFrom(this.changedUri, this.uri, contents ?? this.targetState);
-        this.state = 'applied';
+        this._isApplying = true;
+        try {
+            await this.changeSetFileService.writeFrom(this.changedUri, this.uri, contents ?? this.targetState);
+            this.state = 'applied';
+        } finally {
+            this._isApplying = false;
+        }
     }
 
     /**
@@ -320,29 +333,34 @@ export class ChangeSetFileElement implements ChangeSetElement {
      * applying edits, and running code actions on save.
      */
     protected async applyChangesWithMonaco(contents?: string): Promise<void> {
-        let modelReference: IReference<MonacoEditorModel> | undefined;
+        this._isApplying = true;
         try {
-            modelReference = await this.monacoTextModelService.createModelReference(this.uri);
-            const model = modelReference.object;
-            model.suppressOpenEditorWhenDirty = true;
-            const targetContent = contents ?? this.targetState;
-            const currentContent = model.textEditorModel.getValue();
-            if (currentContent !== targetContent) {
-                const fullRange = model.textEditorModel.getFullModelRange();
-                await this.monacoWorkspace.applyBackgroundEdit(model,
-                    [{ range: fullRange, text: targetContent, forceMoveMarkers: false }]);
+            let modelReference: IReference<MonacoEditorModel> | undefined;
+            try {
+                modelReference = await this.monacoTextModelService.createModelReference(this.uri);
+                const model = modelReference.object;
+                model.suppressOpenEditorWhenDirty = true;
+                const targetContent = contents ?? this.targetState;
+                const currentContent = model.textEditorModel.getValue();
+                if (currentContent !== targetContent) {
+                    const fullRange = model.textEditorModel.getFullModelRange();
+                    await this.monacoWorkspace.applyBackgroundEdit(model,
+                        [{ range: fullRange, text: targetContent, forceMoveMarkers: false }]);
+                }
+                const languageId = model.languageId;
+                const uriStr = this.uri.toString();
+                await this.codeActionService.applyOnSaveCodeActions(model.textEditorModel, languageId, uriStr, CancellationToken.None);
+                await this.applyFormatting(model, languageId, uriStr);
+                await model.save();
+                this.state = 'applied';
+            } catch (error) {
+                console.error('Failed to apply changes with Monaco:', error);
+                await this.writeChanges(contents);
+            } finally {
+                modelReference?.dispose();
             }
-            const languageId = model.languageId;
-            const uriStr = this.uri.toString();
-            await this.codeActionService.applyOnSaveCodeActions(model.textEditorModel, languageId, uriStr, CancellationToken.None);
-            await this.applyFormatting(model, languageId, uriStr);
-            await model.save();
-            this.state = 'applied';
-        } catch (error) {
-            console.error('Failed to apply changes with Monaco:', error);
-            await this.writeChanges(contents);
         } finally {
-            modelReference?.dispose();
+            this._isApplying = false;
         }
     }
 
@@ -446,11 +464,16 @@ export class ChangeSetFileElement implements ChangeSetElement {
     async revert(): Promise<void> {
         await this.ensureInitialized();
         if (!await this.confirm('Revert')) { return; }
-        this.state = 'pending';
-        if (this.type === 'add') {
-            await this.changeSetFileService.delete(this.uri);
-        } else if (this._originalContent) {
-            await this.changeSetFileService.write(this.uri, this._originalContent);
+        this._isApplying = true;
+        try {
+            this.state = 'pending';
+            if (this.type === 'add') {
+                await this.changeSetFileService.delete(this.uri);
+            } else if (this._originalContent) {
+                await this.changeSetFileService.write(this.uri, this._originalContent);
+            }
+        } finally {
+            this._isApplying = false;
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The file change listener in ChangeSetFileElement
unconditionally overwrites the read-only (left) side of the diff with current disk content. After applying changes, both sides display the same content, making the diff useless.

Remove the readOnlyResource update from the file
change handler so the original content is preserved. Add an _isApplying guard flag to prevent race
conditions where self-triggered file change events evaluate state before apply() completes. Handle
post-apply file divergence by updating the right side of the diff when external changes occur. Fix delete element state detection where read() returns undefined instead of empty string, causing false stale states.

Fixes #17107

Big thanks to @Hanksha as the fix is based on his suggestion.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Trigger a change in agent mode and see that you now see a diff.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
