### PR TITLE
feat: implement terminal command AI Variable

### DIFF
--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -1,0 +1,110 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { AIVariable, AIVariableContext, AIVariableContribution, AIVariableResolutionRequest, AIVariableResolver, AIVariableService, ResolvedAIVariable } from '@theia/ai-core';
+import { MaybePromise, QuickInputService, QuickPickItem, QuickPickItemOrSeparator } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
+
+const TERMINAL_COMMAND_BLOCK: AIVariable = {
+    id: 'ai-terminal:terminal-command-block',
+    description: 'Stores an executed terminal command and its corresponding output.',
+    name: 'terminalCommand',
+    args: [{
+        name: 'index',
+        description: 'Index of the command block in the terminal history. Defaults to the last command if not specified.'
+    }]
+};
+
+interface CommandBlockQuickPickItem extends QuickPickItem {
+      blockIndex: number;
+}
+
+namespace CommandBlockQuickPickItem {
+    export function is(item: QuickPickItemOrSeparator): item is CommandBlockQuickPickItem {
+        return 'blockIndex' in item;
+    }
+}
+
+@injectable()
+export class AiTerminalCommandBlockVariableContribution implements AIVariableContribution, AIVariableResolver {
+
+    @inject(TerminalService)
+    protected readonly terminalService: TerminalService;
+
+    @inject(QuickInputService)
+    protected readonly quickInputService: QuickInputService;
+
+    registerVariables(service: AIVariableService): void {
+        service.registerResolver(TERMINAL_COMMAND_BLOCK, this);
+        service.registerArgumentPicker(TERMINAL_COMMAND_BLOCK, () => this.pickCommandBlock());
+    }
+
+    canResolve(request: AIVariableResolutionRequest, context: AIVariableContext): MaybePromise<number> {
+        return request.variable.name === TERMINAL_COMMAND_BLOCK.name ? 50 : 0;
+    }
+
+    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
+        const terminal = this.terminalService.lastUsedTerminal;
+        if (!terminal) {
+            return undefined;
+        }
+        if (!terminal.commandHistoryState) {
+            return {
+                variable: TERMINAL_COMMAND_BLOCK,
+                value: terminal.buffer.getLines(Math.max(terminal.buffer.length - 50, 0), 50).join('\n'),
+            }
+        }
+        const commandHistory = terminal.commandHistoryState.commandHistory;
+        const commandIndex = request.arg !== undefined ? parseInt(request.arg) : commandHistory.length - 1;
+        const block = commandHistory[commandIndex];
+        if (!block) {
+            return undefined;
+        }
+        return {
+            variable: TERMINAL_COMMAND_BLOCK,
+            value: `${block.command}\n${block.output}`
+        }
+    }
+
+    protected async pickCommandBlock(): Promise<string | undefined> {
+        if (!this.terminalService.lastUsedTerminal?.commandHistoryState) {
+            return undefined;
+        }
+        const commandHistory = this.terminalService.lastUsedTerminal.commandHistoryState.commandHistory;
+        const quickPick = this.quickInputService.createQuickPick();
+        quickPick.items = commandHistory.map((block, i) => (
+            {
+                label: block.command,
+                description: block.output.slice(0, 60),
+                blockIndex: i
+            } as CommandBlockQuickPickItem
+        )).toReversed();
+        quickPick.show();
+        return new Promise(resolve => {
+            quickPick.onDidAccept(() => {
+                const selected = quickPick.selectedItems[0];
+                if (CommandBlockQuickPickItem.is(selected)) {
+                    resolve(String(selected.blockIndex));
+                    quickPick.dispose();
+                }
+            });
+            quickPick.onDidHide(() => {
+                resolve(undefined);
+            })
+        });
+    }
+}

--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -15,17 +15,19 @@
 // *****************************************************************************
 
 import { AIVariable, AIVariableContext, AIVariableContribution, AIVariableResolutionRequest, AIVariableResolver, AIVariableService, ResolvedAIVariable } from '@theia/ai-core';
-import { MaybePromise, QuickInputService, QuickPickItem, QuickPickItemOrSeparator } from '@theia/core';
+import { MaybePromise, nls, QuickInputService, QuickPickItem, QuickPickItemOrSeparator } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 
 const TERMINAL_COMMAND_BLOCK: AIVariable = {
     id: 'ai-terminal:terminal-command-block',
-    description: 'Stores an executed terminal command and its corresponding output.',
+    description: nls.localize('theia/ai/terminal/terminalCommandBlockAIVariable/description', 'Stores an executed terminal command and its corresponding output.'),
     name: 'terminalCommand',
     args: [{
         name: 'index',
-        description: 'Index of the command block in the terminal history. Defaults to the last command if not specified.'
+        description: nls.localize('theia/ai/terminal/terminalCommandBlockAIVariable/index/description',
+            'Index of the command block in the terminal history. Defaults to the last command if not specified.'
+        )
     }]
 };
 

--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -53,6 +53,9 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
     @inject(ILogger)
     protected readonly logger: ILogger;
 
+    /** Fallback line count when command history is unavailable. 50 is a heuristic. */
+    protected static readonly FALLBACK_TERMINAL_LINE_COUNT = 50;
+
     registerVariables(service: AIVariableService): void {
         service.registerResolver(TERMINAL_COMMAND_BLOCK, this);
         service.registerArgumentPicker(TERMINAL_COMMAND_BLOCK, () => this.pickCommandBlock());
@@ -68,7 +71,11 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
             return undefined;
         }
         if (!terminal.commandHistoryState) {
-            const bufferContent = terminal.buffer.getLines(Math.max(terminal.buffer.length - 50, 0), 50).join('\n');
+            const bufferContent = terminal.buffer.getLines(
+                Math.max(terminal.buffer.length
+                    - AiTerminalCommandBlockVariableContribution.FALLBACK_TERMINAL_LINE_COUNT, 0),
+                AiTerminalCommandBlockVariableContribution.FALLBACK_TERMINAL_LINE_COUNT
+            ).join('\n');
             if (!bufferContent) {
                 return undefined;
             }
@@ -110,6 +117,11 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
         }
         const commandHistory = this.terminalService.lastUsedTerminal.commandHistoryState.commandHistory;
         const quickPick = this.quickInputService.createQuickPick();
+        quickPick.title = nls.localize('theia/ai/terminal/terminalCommandBlockAIVariable/quickPick/title', 'Select a command and its output from the terminal history');
+        quickPick.placeholder = nls.localize(
+            'theia/ai/terminal/terminalCommandBlockAIVariable/quickPick/placeholder',
+            'Type to filter commands'
+        );
         quickPick.items = commandHistory.map((block, i) => (
             {
                 label: block.command,

--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { AIVariable, AIVariableContext, AIVariableContribution, AIVariableResolutionRequest, AIVariableResolver, AIVariableService, ResolvedAIVariable } from '@theia/ai-core';
-import { MaybePromise, nls, QuickInputService, QuickPickItem, QuickPickItemOrSeparator } from '@theia/core';
+import { ILogger, MaybePromise, nls, QuickInputService, QuickPickItem, QuickPickItemOrSeparator } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 
@@ -50,6 +50,9 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
     @inject(QuickInputService)
     protected readonly quickInputService: QuickInputService;
 
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
     registerVariables(service: AIVariableService): void {
         service.registerResolver(TERMINAL_COMMAND_BLOCK, this);
         service.registerArgumentPicker(TERMINAL_COMMAND_BLOCK, () => this.pickCommandBlock());
@@ -75,8 +78,12 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
             };
         }
         const commandHistory = terminal.commandHistoryState.commandHistory;
+        if (commandHistory.length === 0) {
+            return undefined;
+        }
         const commandIndex = request.arg !== undefined ? Number(request.arg.trim()) : commandHistory.length - 1;
-        if (isNaN(commandIndex) || !Number.isInteger(commandIndex) || commandIndex < 0 || commandIndex >= commandHistory.length) {
+        if (Number.isNaN(commandIndex) || !Number.isInteger(commandIndex) || commandIndex < 0 || commandIndex >= commandHistory.length) {
+            this.logger.warn(`Invalid terminal command index (must be an integer and between 0 and ${commandHistory.length - 1}): ${request.arg}`);
             return undefined;
         }
         const block = commandHistory[commandIndex];

--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -32,7 +32,7 @@ const TERMINAL_COMMAND_BLOCK: AIVariable = {
 };
 
 interface CommandBlockQuickPickItem extends QuickPickItem {
-      blockIndex: number;
+    blockIndex: number;
 }
 
 namespace CommandBlockQuickPickItem {
@@ -68,7 +68,7 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
             return {
                 variable: TERMINAL_COMMAND_BLOCK,
                 value: terminal.buffer.getLines(Math.max(terminal.buffer.length - 50, 0), 50).join('\n'),
-            }
+            };
         }
         const commandHistory = terminal.commandHistoryState.commandHistory;
         const commandIndex = request.arg !== undefined ? parseInt(request.arg) : commandHistory.length - 1;
@@ -79,7 +79,7 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
         return {
             variable: TERMINAL_COMMAND_BLOCK,
             value: `${block.command}\n${block.output}`
-        }
+        };
     }
 
     protected async pickCommandBlock(): Promise<string | undefined> {
@@ -106,7 +106,7 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
             });
             quickPick.onDidHide(() => {
                 resolve(undefined);
-            })
+            });
         });
     }
 }

--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -65,20 +65,27 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
             return undefined;
         }
         if (!terminal.commandHistoryState) {
+            const bufferContent = terminal.buffer.getLines(Math.max(terminal.buffer.length - 50, 0), 50).join('\n');
+            if (!bufferContent) {
+                return undefined;
+            }
             return {
                 variable: TERMINAL_COMMAND_BLOCK,
-                value: terminal.buffer.getLines(Math.max(terminal.buffer.length - 50, 0), 50).join('\n'),
+                value: bufferContent
             };
         }
         const commandHistory = terminal.commandHistoryState.commandHistory;
-        const commandIndex = request.arg !== undefined ? parseInt(request.arg) : commandHistory.length - 1;
+        const commandIndex = request.arg !== undefined ? Number(request.arg.trim()) : commandHistory.length - 1;
+        if (isNaN(commandIndex) || !Number.isInteger(commandIndex) || commandIndex < 0 || commandIndex >= commandHistory.length) {
+            return undefined;
+        }
         const block = commandHistory[commandIndex];
         if (!block) {
             return undefined;
         }
         return {
             variable: TERMINAL_COMMAND_BLOCK,
-            value: `${block.command}\n${block.output}`
+            value: `### Terminal Command:\n${block.command}\n\n### Terminal Output:\n${block.output}`
         };
     }
 
@@ -91,7 +98,8 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
         quickPick.items = commandHistory.map((block, i) => (
             {
                 label: block.command,
-                description: block.output.slice(0, 60),
+                // replace all whitespace with a single space for better readability
+                description: block.output.replace(/\s+/g, ' ').trim().slice(0, 60),
                 blockIndex: i
             } as CommandBlockQuickPickItem
         )).toReversed();
@@ -101,11 +109,12 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
                 const selected = quickPick.selectedItems[0];
                 if (CommandBlockQuickPickItem.is(selected)) {
                     resolve(String(selected.blockIndex));
-                    quickPick.dispose();
                 }
+                quickPick.dispose();
             });
             quickPick.onDidHide(() => {
                 resolve(undefined);
+                quickPick.dispose();
             });
         });
     }

--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -81,8 +81,16 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
         if (commandHistory.length === 0) {
             return undefined;
         }
-        const commandIndex = request.arg !== undefined ? Number(request.arg.trim()) : commandHistory.length - 1;
-        if (Number.isNaN(commandIndex) || !Number.isInteger(commandIndex) || commandIndex < 0 || commandIndex >= commandHistory.length) {
+
+        let commandIndex;
+        if (request.arg === undefined) {
+            commandIndex = commandHistory.length - 1;
+        } else {
+            const trimmedArg = request.arg.trim();
+            commandIndex = trimmedArg.length > 0 ? Number(trimmedArg) : NaN;
+        }
+
+        if (!Number.isInteger(commandIndex) || commandIndex < 0 || commandIndex >= commandHistory.length) {
             this.logger.warn(`Invalid terminal command index (must be an integer and between 0 and ${commandHistory.length - 1}): ${request.arg}`);
             return undefined;
         }

--- a/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-command-block-variable.ts
@@ -89,13 +89,8 @@ export class AiTerminalCommandBlockVariableContribution implements AIVariableCon
             return undefined;
         }
 
-        let commandIndex;
-        if (request.arg === undefined) {
-            commandIndex = commandHistory.length - 1;
-        } else {
-            const trimmedArg = request.arg.trim();
-            commandIndex = trimmedArg.length > 0 ? Number(trimmedArg) : NaN;
-        }
+        const trimmedArg = request.arg?.trim();
+        const commandIndex = trimmedArg ? Number(trimmedArg) : commandHistory.length - 1;
 
         if (!Number.isInteger(commandIndex) || commandIndex < 0 || commandIndex >= commandHistory.length) {
             this.logger.warn(`Invalid terminal command index (must be an integer and between 0 and ${commandHistory.length - 1}): ${request.arg}`);

--- a/packages/ai-terminal/src/browser/ai-terminal-contribution.spec.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-contribution.spec.ts
@@ -1,0 +1,137 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ILogger, QuickInputService } from '@theia/core';
+import { AIVariableContext, AIVariableResolutionRequest } from '@theia/ai-core';
+import { Container } from '@theia/core/shared/inversify';
+import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
+import { TerminalBlock, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
+import { AiTerminalCommandBlockVariableContribution } from './ai-terminal-command-block-variable';
+
+function createMockTerminal(overrides: Partial<{
+    bufferLines: string[];
+    commandHistory: TerminalBlock[];
+}>): TerminalWidget {
+    const { bufferLines = [], commandHistory } = overrides;
+    return {
+        buffer: {
+            length: bufferLines.length,
+            getLines: (start: number, length: number) => bufferLines.slice(start, start + length),
+        },
+        commandHistoryState: commandHistory !== undefined
+            ? { commandHistory }
+            : undefined,
+    } as unknown as TerminalWidget;
+}
+
+function createRequest(arg?: string): AIVariableResolutionRequest {
+    return {
+        variable: { id: 'ai-terminal:terminal-command-block', name: 'terminalCommand', description: '' },
+        arg,
+    };
+}
+
+const mockContext: AIVariableContext = {};
+
+describe('AiTerminalCommandBlockVariableContribution.resolve()', () => {
+    let mockTerminalService: { lastUsedTerminal: TerminalWidget | undefined };
+    let contribution: AiTerminalCommandBlockVariableContribution;
+
+    beforeEach(() => {
+        const container = new Container();
+
+        mockTerminalService = {
+            lastUsedTerminal: createMockTerminal({
+                commandHistory: [
+                    { command: 'ls', output: 'file1\nfile2' },
+                    { command: 'pwd', output: '/home/user' },
+                    { command: 'echo hello world', output: 'hello world' },
+                ]
+            }),
+        };
+
+        container.bind(TerminalService).toConstantValue(mockTerminalService as unknown as TerminalService);
+        container.bind(QuickInputService).toConstantValue({} as unknown as QuickInputService);
+        container.bind(ILogger).toConstantValue({ warn: () => { } } as unknown as ILogger);
+        container.bind(AiTerminalCommandBlockVariableContribution).toSelf();
+        contribution = container.get(AiTerminalCommandBlockVariableContribution);
+    });
+
+    it('returns undefined when there is no last used terminal', async () => {
+        mockTerminalService.lastUsedTerminal = undefined;
+        const result = await contribution.resolve(createRequest(), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+    it('returns the last command when no parameter is passed', async () => {
+        const result = await contribution.resolve(createRequest(), mockContext);
+        expect(result?.value).to.equal('### Terminal Command:\necho hello world\n\n### Terminal Output:\nhello world');
+    });
+
+    it('returns the correct command according to the argument', async () => {
+        const result = await contribution.resolve(createRequest('1'), mockContext);
+        expect(result?.value).to.equal('### Terminal Command:\npwd\n\n### Terminal Output:\n/home/user');
+    });
+
+    it('returns the last 50 lines of the terminal when terminal history is not enabled', async () => {
+        mockTerminalService.lastUsedTerminal = createMockTerminal({
+            bufferLines: ['ls', 'file1\nfile2', 'pwd', '/home/user']
+        });
+        const result = await contribution.resolve(createRequest(), mockContext);
+        expect(result?.value).to.equal('ls\nfile1\nfile2\npwd\n/home/user');
+    });
+
+    it('returns undefined when the terminal history is empty', async () => {
+        mockTerminalService.lastUsedTerminal = createMockTerminal({
+            commandHistory: []
+        });
+        const result = await contribution.resolve(createRequest(), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+    it('returns undefined when the input is not a number', async () => {
+        const result = await contribution.resolve(createRequest('one'), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+    it('returns undefined when the input is not an integer', async () => {
+        const result = await contribution.resolve(createRequest('1.5'), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+    it('returns undefined when the input is an empty string', async () => {
+        const result = await contribution.resolve(createRequest(' '), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+    it('returns undefined when terminal history is not enabled and the buffer is empty', async () => {
+        mockTerminalService.lastUsedTerminal = createMockTerminal({});
+        const result = await contribution.resolve(createRequest(), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+    it('returns undefined when the input is a negative integer', async () => {
+        const result = await contribution.resolve(createRequest('-1'), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+    it('returns undefined when the input index is out of bounds', async () => {
+        const result = await contribution.resolve(createRequest('10'), mockContext);
+        expect(result).to.be.undefined;
+    });
+
+});

--- a/packages/ai-terminal/src/browser/ai-terminal-contribution.spec.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-contribution.spec.ts
@@ -82,6 +82,13 @@ describe('AiTerminalCommandBlockVariableContribution.resolve()', () => {
         expect(result?.value).to.equal('### Terminal Command:\necho hello world\n\n### Terminal Output:\nhello world');
     });
 
+    it('returns the last command when the input is an empty or white space only string', async () => {
+        const emptyStringResult = await contribution.resolve(createRequest(''), mockContext);
+        const whiteSpaceResult = await contribution.resolve(createRequest(''), mockContext);
+        expect(emptyStringResult?.value).to.equal('### Terminal Command:\necho hello world\n\n### Terminal Output:\nhello world');
+        expect(whiteSpaceResult?.value).to.equal('### Terminal Command:\necho hello world\n\n### Terminal Output:\nhello world');
+    });
+
     it('returns the correct command according to the argument', async () => {
         const result = await contribution.resolve(createRequest('1'), mockContext);
         expect(result?.value).to.equal('### Terminal Command:\npwd\n\n### Terminal Output:\n/home/user');
@@ -110,11 +117,6 @@ describe('AiTerminalCommandBlockVariableContribution.resolve()', () => {
 
     it('returns undefined when the input is not an integer', async () => {
         const result = await contribution.resolve(createRequest('1.5'), mockContext);
-        expect(result).to.be.undefined;
-    });
-
-    it('returns undefined when the input is an empty string', async () => {
-        const result = await contribution.resolve(createRequest(' '), mockContext);
         expect(result).to.be.undefined;
     });
 

--- a/packages/ai-terminal/src/browser/ai-terminal-contribution.spec.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-contribution.spec.ts
@@ -84,7 +84,7 @@ describe('AiTerminalCommandBlockVariableContribution.resolve()', () => {
 
     it('returns the last command when the input is an empty or white space only string', async () => {
         const emptyStringResult = await contribution.resolve(createRequest(''), mockContext);
-        const whiteSpaceResult = await contribution.resolve(createRequest(''), mockContext);
+        const whiteSpaceResult = await contribution.resolve(createRequest('   '), mockContext);
         expect(emptyStringResult?.value).to.equal('### Terminal Command:\necho hello world\n\n### Terminal Output:\nhello world');
         expect(whiteSpaceResult?.value).to.equal('### Terminal Command:\necho hello world\n\n### Terminal Output:\nhello world');
     });

--- a/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ChatResponsePartRenderer } from '@theia/ai-chat-ui/lib/browser/chat-response-part-renderer';
-import { Agent } from '@theia/ai-core/lib/common';
+import { Agent, AIVariableContribution } from '@theia/ai-core/lib/common';
 import { bindToolProvider } from '@theia/ai-core/lib/common/tool-invocation-registry';
 import { CommandContribution, MenuContribution, PreferenceContribution } from '@theia/core';
 import { KeybindingContribution, WebSocketConnectionProvider } from '@theia/core/lib/browser';
@@ -31,6 +31,7 @@ import { DefaultShellCommandAnalyzer, ShellCommandAnalyzer } from '../common/she
 
 import '../../src/browser/style/ai-terminal.css';
 import '../../src/browser/style/shell-execution-tool.css';
+import { AiTerminalCommandBlockVariableContribution } from './ai-terminal-command-block-variable';
 
 export default new ContainerModule(bind => {
     bind(AiTerminalCommandContribution).toSelf().inSingletonScope();
@@ -55,4 +56,7 @@ export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: shellCommandPreferences });
 
     bind(ShellCommandAnalyzer).to(DefaultShellCommandAnalyzer).inSingletonScope();
+
+    bind(AiTerminalCommandBlockVariableContribution).toSelf().inSingletonScope();
+    bind(AIVariableContribution).toService(AiTerminalCommandBlockVariableContribution);
 });

--- a/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
+++ b/packages/ai-terminal/src/browser/ai-terminal-frontend-module.ts
@@ -28,10 +28,10 @@ import { ShellExecutionServer, shellExecutionPath } from '../common/shell-execut
 import { ShellCommandPermissionService } from './shell-command-permission-service';
 import { shellCommandPreferences } from '../common/shell-command-preferences';
 import { DefaultShellCommandAnalyzer, ShellCommandAnalyzer } from '../common/shell-command-analyzer';
+import { AiTerminalCommandBlockVariableContribution } from './ai-terminal-command-block-variable';
 
 import '../../src/browser/style/ai-terminal.css';
 import '../../src/browser/style/shell-execution-tool.css';
-import { AiTerminalCommandBlockVariableContribution } from './ai-terminal-command-block-variable';
 
 export default new ContainerModule(bind => {
     bind(AiTerminalCommandContribution).toSelf().inSingletonScope();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR builds on top of #16732.
This PR introduces a new AI Variable that allows the user to target a specific command in their last used terminal.

- the user can specify the command using an index directly or via the arguments picker
- If no index is provided, the variable defaults to the last executed command

If the experimental command history preference is disabled, this ai variable will return the last 50 lines of the terminal buffer.

https://github.com/user-attachments/assets/857d1361-7b75-46c4-9196-5e83f3818aa0

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open the Theia Settings
2. Enable `Terminal › Integrated: Enable Command History`
3. Execute some commands in the terminal
4. Open the AI Chat
5. Use the `#terminalCommand` AI Variable in the AI Chat and choose a terminal command via the arguments picker
6. Prompt the agent to repeat the content of the prompt to verify that the correct command was passed

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
