### PR TITLE
fix(core): guarantee promise rejection on failure to send RPC call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,13 @@
 
 ## 1.71.0 - TBD
 
+- [core] added `errorHandling` option to `Emitter` to control how listener exceptions are handled: `'log'` (default), `'propagate'` (collect and re-throw), or a custom callback [#17332](https://github.com/eclipse-theia/theia/pull/17332)
 - [editor] replaced the per-URI editor counter system in `EditorManager` with random counters [#17275](https://github.com/eclipse-theia/theia/pull/17275)
 
 <a name="breaking_changes_1.71.0">[Breaking Changes:](#breaking_changes_1.71.0)</a>
 
+- [core] changed the visibility of `ChannelMultiplexer.pendingOpen` from `protected` to `private` [#17332](https://github.com/eclipse-theia/theia/pull/17332)
+- [core] `Uint8ArrayWriteBuffer`'s `onCommit` emitter now propagates exceptions from listeners instead of silently catching them. Code that relied on exceptions being swallowed should add its own error handling [#17332](https://github.com/eclipse-theia/theia/pull/17332)
 - [editor] replaced the per-URI editor counter system in `EditorManager` with random counters [#17275](https://github.com/eclipse-theia/theia/pull/17275):
   - Removed protected field `editorCounters: Map<string, number>`
   - Removed protected method `checkCounterForWidget(widget)`

--- a/packages/core/src/browser/messaging/ws-connection-source.ts
+++ b/packages/core/src/browser/messaging/ws-connection-source.ts
@@ -135,8 +135,8 @@ export class WebSocketConnectionSource implements ConnectionSource {
 
     connectNewChannel(): void {
         if (this.currentChannel) {
-            this.currentChannel.close();
             this.currentChannel.onCloseEmitter.fire({ reason: 'reconnecting channel' });
+            this.currentChannel.close();
         }
         this.writeBuffer.drain();
         this.currentChannel = this.createChannel();

--- a/packages/core/src/common/event.spec.ts
+++ b/packages/core/src/common/event.spec.ts
@@ -29,4 +29,84 @@ describe('Event Objects', () => {
         expect(counter).eq(1);
     });
 
+    describe('Emitter errorHandling option', () => {
+
+        it('should log errors by default', () => {
+            const emitter = new Emitter<void>();
+            const errors: unknown[] = [];
+            const originalError = console.error;
+            console.error = (e: unknown) => errors.push(e);
+
+            try {
+                emitter.event(() => { throw new Error('test error'); });
+                emitter.fire(undefined);
+
+                expect(errors).to.have.lengthOf(1);
+                expect((errors[0] as Error).message).to.equal('test error');
+            } finally {
+                console.error = originalError;
+            }
+        });
+
+        it('should propagate a single error when errorHandling is propagate', () => {
+            const emitter = new Emitter<void>({ errorHandling: 'propagate' });
+
+            emitter.event(() => { throw new Error('boom'); });
+
+            expect(() => emitter.fire(undefined)).to.throw('boom');
+        });
+
+        it('should call all listeners before propagating the error', () => {
+            const emitter = new Emitter<void>({ errorHandling: 'propagate' });
+            let secondCalled = false;
+
+            emitter.event(() => { throw new Error('first fails'); });
+            emitter.event(() => { secondCalled = true; });
+
+            expect(() => emitter.fire(undefined)).to.throw('first fails');
+            expect(secondCalled).to.be.true;
+        });
+
+        it('should throw AggregateError when multiple listeners fail with propagate', () => {
+            const emitter = new Emitter<void>({ errorHandling: 'propagate' });
+
+            emitter.event(() => { throw new Error('error 1'); });
+            emitter.event(() => { throw new Error('error 2'); });
+
+            try {
+                emitter.fire(undefined);
+                expect.fail('Expected an error to be thrown');
+            } catch (err) {
+                expect(err).to.be.instanceOf(AggregateError);
+                const aggregate = err as AggregateError;
+                expect(aggregate.errors).to.have.lengthOf(2);
+                expect(aggregate.errors[0].message).to.equal('error 1');
+                expect(aggregate.errors[1].message).to.equal('error 2');
+            }
+        });
+
+        it('should invoke custom error handler for each error', () => {
+            const errors: unknown[] = [];
+            const emitter = new Emitter<void>({ errorHandling: e => errors.push(e) });
+
+            emitter.event(() => { throw new Error('handled 1'); });
+            emitter.event(() => { throw new Error('handled 2'); });
+            emitter.fire(undefined);
+
+            expect(errors).to.have.lengthOf(2);
+            expect((errors[0] as Error).message).to.equal('handled 1');
+            expect((errors[1] as Error).message).to.equal('handled 2');
+        });
+
+        it('should not throw when no listeners fail with propagate', () => {
+            const emitter = new Emitter<void>({ errorHandling: 'propagate' });
+            let called = false;
+
+            emitter.event(() => { called = true; });
+            emitter.fire(undefined);
+
+            expect(called).to.be.true;
+        });
+    });
+
 });

--- a/packages/core/src/common/event.ts
+++ b/packages/core/src/common/event.ts
@@ -123,6 +123,8 @@ class CallbackList implements Iterable<Callback> {
     private _callbacks: Function[] | undefined;
     private _contexts: any[] | undefined;
 
+    constructor(private readonly errorHandling: ErrorHandlingStrategy = 'log') {}
+
     get length(): number {
         return this._callbacks && this._callbacks.length || 0;
     }
@@ -179,12 +181,24 @@ class CallbackList implements Iterable<Callback> {
 
     public invoke(...args: any[]): any[] {
         const ret: any[] = [];
+        const errors: unknown[] = [];
         for (const callback of this) {
             try {
                 ret.push(callback(...args));
             } catch (e) {
-                console.error(e);
+                if (this.errorHandling === 'propagate') {
+                    errors.push(e);
+                } else if (typeof this.errorHandling === 'function') {
+                    this.errorHandling(e);
+                } else {
+                    console.error(e);
+                }
             }
+        }
+        if (errors.length === 1) {
+            throw errors[0];
+        } else if (errors.length > 1) {
+            throw new AggregateError(errors, 'Multiple event listeners failed');
         }
         return ret;
     }
@@ -199,9 +213,24 @@ class CallbackList implements Iterable<Callback> {
     }
 }
 
+/**
+ * A strategy for handling errors in firing an emitter's event, one of
+ *
+ * - `'log'` (default): errors are caught and logged via `console.error`
+ * - `'propagate'`: all listeners are called; if any throw, the errors are collected
+ *   and re-thrown after all listeners complete (single error re-thrown directly,
+ *   multiple errors wrapped in an `AggregateError`)
+ * - `(error: unknown) => void`: a custom callback invoked for each error
+ */
+export type ErrorHandlingStrategy = 'log' | 'propagate' | ((error: unknown) => void);
+
 export interface EmitterOptions {
     onFirstListenerAdd?: Function;
     onLastListenerRemove?: Function;
+    /**
+     * How errors thrown by event listeners are handled during {@link Emitter.fire}.
+     */
+    errorHandling?: ErrorHandlingStrategy;
 }
 
 export class Emitter<T = any> {
@@ -229,7 +258,7 @@ export class Emitter<T = any> {
         if (!this._event) {
             this._event = Object.assign((listener: (e: T) => any, thisArgs?: any, disposables?: DisposableGroup) => {
                 if (!this._callbacks) {
-                    this._callbacks = new CallbackList();
+                    this._callbacks = new CallbackList(this._options?.errorHandling);
                 }
                 if (this._options && this._options.onFirstListenerAdd && this._callbacks.isEmpty()) {
                     this._options.onFirstListenerAdd(this);

--- a/packages/core/src/common/message-rpc/channel.spec.ts
+++ b/packages/core/src/common/message-rpc/channel.spec.ts
@@ -18,6 +18,7 @@ import { assert, expect, spy, use } from 'chai';
 import * as spies from 'chai-spies';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from './uint8-array-message-buffer';
 import { ChannelMultiplexer, ForwardingChannel, MessageProvider } from './channel';
+import { RpcProtocol } from './rpc-protocol';
 
 use(spies);
 
@@ -83,6 +84,121 @@ describe('Message Channel', () => {
             expect(rightFirstSpy).to.be.called();
 
             expect(openChannelSpy).to.be.called.exactly(4);
+        });
+
+        it('should reject pending open() promises when underlying channel closes', async () => {
+            const pipe = new ChannelPipe();
+            const leftMultiplexer = new ChannelMultiplexer(pipe.left);
+            // Don't create a right multiplexer, so no AckOpen will arrive
+
+            const openPromise = leftMultiplexer.open('test');
+
+            // Close the underlying channel
+            pipe.left.onCloseEmitter.fire({ reason: 'test close' });
+
+            // The open promise should reject, not hang forever
+            try {
+                await openPromise;
+                assert.fail('Expected open() promise to be rejected');
+            } catch (err) {
+                expect(err).to.be.instanceOf(Error);
+                expect((err as Error).message).to.contain('test close');
+            }
+        });
+
+        it('should fire onClose on sub-channels when underlying channel closes', async () => {
+            const pipe = new ChannelPipe();
+            const leftMultiplexer = new ChannelMultiplexer(pipe.left);
+            const rightMultiplexer = new ChannelMultiplexer(pipe.right);
+
+            const leftChannel = await leftMultiplexer.open('test');
+            const rightChannel = rightMultiplexer.getOpenChannel('test');
+            assert.isDefined(rightChannel);
+
+            const leftCloseSpy = spy(() => { });
+            leftChannel.onClose(leftCloseSpy);
+
+            // Close the underlying channel from the remote side
+            pipe.left.onCloseEmitter.fire({ reason: 'underlying closed' });
+
+            expect(leftCloseSpy).to.have.been.called();
+        });
+    });
+
+    describe('Channel close event ordering', () => {
+        it('should not deliver onClose after close() has been called', () => {
+            const channel = new ForwardingChannel('test', () => { }, () => new Uint8ArrayWriteBuffer());
+
+            const closeSpy = spy(() => { });
+            channel.onClose(closeSpy);
+
+            // Bug pattern: close() first (disposes emitters), then fire (no-op)
+            channel.close();
+            channel.onCloseEmitter.fire({ reason: 'too late' });
+
+            // The listener should not be called because close() already disposed the emitter
+            expect(closeSpy).to.not.have.been.called();
+        });
+
+        it('should deliver onClose when fired before close()', () => {
+            const channel = new ForwardingChannel('test', () => { }, () => new Uint8ArrayWriteBuffer());
+
+            const closeSpy = spy(() => { });
+            channel.onClose(closeSpy);
+
+            // Correct pattern: fire first, then close
+            channel.onCloseEmitter.fire({ reason: 'proper close' });
+            channel.close();
+
+            expect(closeSpy).to.have.been.called();
+        });
+    });
+
+    describe('RPC protocol with write buffer overflow', () => {
+        it('should reject the promise when commit fails due to buffer overflow', async () => {
+            // Simulate a channel whose write buffer throws on commit (e.g. SocketWriteBuffer overflow)
+            const channel = new ForwardingChannel('test', () => { }, () => {
+                const buffer = new Uint8ArrayWriteBuffer();
+                buffer.onCommit(() => {
+                    throw new Error('Max disconnected buffer size exceeded');
+                });
+                return buffer;
+            });
+
+            const protocol = new RpcProtocol(channel, undefined, { mode: 'clientOnly' });
+
+            // sendRequest should return a rejected promise, not throw synchronously
+            const promise = protocol.sendRequest('testMethod', []);
+
+            try {
+                await promise;
+                assert.fail('Expected promise to be rejected');
+            } catch (err) {
+                expect(err).to.be.instanceOf(Error);
+                expect((err as Error).message).to.contain('buffer size exceeded');
+            }
+        });
+
+        it('should not leak pending requests when commit fails', async () => {
+            const channel = new ForwardingChannel('test', () => { }, () => {
+                const buffer = new Uint8ArrayWriteBuffer();
+                buffer.onCommit(() => {
+                    throw new Error('Max disconnected buffer size exceeded');
+                });
+                return buffer;
+            });
+
+            const protocol = new RpcProtocol(channel, undefined, { mode: 'clientOnly' });
+
+            // sendRequest should return a rejected promise and clean up pendingRequests
+            try {
+                await protocol.sendRequest('testMethod', []);
+            } catch {
+                // expected: the promise is rejected due to buffer overflow
+            }
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect((protocol as any).pendingRequests.size).to.equal(0);
         });
     });
 });

--- a/packages/core/src/common/message-rpc/channel.ts
+++ b/packages/core/src/common/message-rpc/channel.ts
@@ -152,7 +152,7 @@ export enum MessageTypes {
  * messages and always in one go.
  */
 export class ChannelMultiplexer implements Disposable {
-    protected pendingOpen: Map<string, (channel: ForwardingChannel) => void> = new Map();
+    private pendingOpen: Map<string, { resolve: (channel: ForwardingChannel) => void, reject: (err: Error) => void }> = new Map();
     protected openChannels: Map<string, ForwardingChannel> = new Map();
 
     protected readonly onOpenChannelEmitter = new Emitter<{ id: string, channel: Channel }>();
@@ -180,9 +180,11 @@ export class ChannelMultiplexer implements Disposable {
     onUnderlyingChannelClose(event?: ChannelCloseEvent): void {
         if (!this.toDispose.disposed) {
             this.toDispose.push(Disposable.create(() => {
+                const reason = event?.reason ?? 'Multiplexer main channel has been closed from the remote side!';
+                this.pendingOpen.forEach(pending => pending.reject(new Error(reason)));
                 this.pendingOpen.clear();
                 this.openChannels.forEach(channel => {
-                    channel.onCloseEmitter.fire(event ?? { reason: 'Multiplexer main channel has been closed from the remote side!' });
+                    channel.onCloseEmitter.fire(event ?? { reason });
                 });
 
                 this.openChannels.clear();
@@ -212,13 +214,13 @@ export class ChannelMultiplexer implements Disposable {
     }
 
     protected handleAckOpen(id: string): void {
-        // edge case: both side try to open a channel at the same time.
-        const resolve = this.pendingOpen.get(id);
-        if (resolve) {
+        // edge case: both sides try to open a channel at the same time.
+        const pending = this.pendingOpen.get(id);
+        if (pending) {
             const channel = this.createChannel(id);
             this.pendingOpen.delete(id);
             this.openChannels.set(id, channel);
-            resolve(channel);
+            pending.resolve(channel);
             this.onOpenChannelEmitter.fire({ id, channel });
         } else {
             console.error(`not expecting ack-open on for ${id}`);
@@ -229,10 +231,10 @@ export class ChannelMultiplexer implements Disposable {
         if (!this.openChannels.has(id)) {
             const channel = this.createChannel(id);
             this.openChannels.set(id, channel);
-            const resolve = this.pendingOpen.get(id);
-            if (resolve) {
-                // edge case: both side try to open a channel at the same time.
-                resolve(channel);
+            const pending = this.pendingOpen.get(id);
+            if (pending) {
+                // edge case: both sides try to open a channel at the same time.
+                pending.resolve(channel);
             }
             this.underlyingChannel.getWriteBuffer().writeUint8(MessageTypes.AckOpen).writeString(id).commit();
             this.onOpenChannelEmitter.fire({ id, channel });
@@ -283,7 +285,7 @@ export class ChannelMultiplexer implements Disposable {
             throw new Error(`Another channel with the id '${id}' is already open.`);
         }
         const result = new Promise<Channel>((resolve, reject) => {
-            this.pendingOpen.set(id, resolve);
+            this.pendingOpen.set(id, { resolve, reject });
         });
         this.underlyingChannel.getWriteBuffer().writeUint8(MessageTypes.Open).writeString(id).commit();
         return result;

--- a/packages/core/src/common/message-rpc/rpc-protocol.ts
+++ b/packages/core/src/common/message-rpc/rpc-protocol.ts
@@ -178,9 +178,18 @@ export class RpcProtocol {
         const disposableWrapper = new DisposableWrapper();
         this.pendingRequestCancellationEventListeners.set(id, disposableWrapper);
 
-        const output = this.channel.getWriteBuffer();
-        this.encoder.request(output, id, method, args);
-        output.commit();
+        try {
+            const output = this.channel.getWriteBuffer();
+            this.encoder.request(output, id, method, args);
+            output.commit();
+        } catch (err) {
+            // The message could not be sent (e.g. write buffer overflow).
+            // Clean up the pending request and reject the promise.
+            this.pendingRequests.delete(id);
+            this.disposeCancellationEventListener(id);
+            reply.reject(err);
+            return reply.promise;
+        }
 
         if (cancellationToken?.isCancellationRequested) {
             this.sendCancel(id);

--- a/packages/core/src/common/message-rpc/uint8-array-message-buffer.ts
+++ b/packages/core/src/common/message-rpc/uint8-array-message-buffer.ts
@@ -113,7 +113,7 @@ export class Uint8ArrayWriteBuffer implements WriteBuffer, Disposable {
         return this;
     }
 
-    private onCommitEmitter = new Emitter<Uint8Array>();
+    private onCommitEmitter = new Emitter<Uint8Array>({ errorHandling: 'propagate' });
     get onCommit(): Event<Uint8Array> {
         return this.onCommitEmitter.event;
     }

--- a/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
+++ b/packages/core/src/node/messaging/websocket-frontend-connection-service.ts
@@ -89,6 +89,7 @@ export class WebsocketFrontendConnectionService implements FrontendConnectionSer
         this.closeTimeouts.delete(frontEndId);
 
         connection.onCloseEmitter.fire({ reason });
+        connection.drainBuffer();
         connection.close();
     }
 
@@ -169,6 +170,10 @@ class ReconnectableSocketChannel extends AbstractChannel {
     disconnect(): void {
         this.disposables.dispose();
         this.socket = undefined;
+    }
+
+    drainBuffer(): void {
+        this.socketBuffer.drain();
     }
 
     override getWriteBuffer(): WriteBuffer {


### PR DESCRIPTION
#### What it does

Guarantees RPC promise rejection when channel messages are lost.

Fixes #17332

This PR fixes two different categories of gaps in the rejection of client promises in the RPC framework that otherwise dangle forever. One category is covered by three fixes to prevent RPC promises from dangling when the websocket connection drops and messages cannot be delivered:

1. `ChannelMultiplexer::open()` now stores both `resolve` and `reject` callbacks. When the underlying channel closes, all pending open promises are rejected instead of being silently abandoned.

2. `WebSocketConnectionSource::connectNewChannel()` now fires `onClose` before calling `close()`, ensuring that listeners receive the event before the emitter is disposed.

3. `WebsocketFrontendConnectionService::closeConnection()` now explicitly drains the `ReconnectableSocketChannel`'s write buffer before closing, preventing orphaned buffered data.

----

The other category of problem is the failure to reject client promises for RPC calls that could not be enqueued because the write buffer was full. These are fixed by propagating write buffer errors to reject RPC promises

The `Uint8ArrayWriteBuffer`'s `onCommit` `Emitter` swallowed exceptions from listeners (`Emitter.fire` catches and logs via `CallbackList.invoke`). This meant that when `SocketWriteBuffer::buffer()` threw on overflow, the error was silently discarded and the RPC promise was left dangling forever.

So this PR adds a new `errorHandling` option to `Emitter` with three modes:

- `'log'` (default): catch and console.error, preserving current behavior
- `'propagate'`: call all listeners, collect errors, then throw (single error directly, multiple errors as `AggregateError`)
- custom callback: invoke the callback for each error

The fix then is simply to use `errorHandling: 'propagate'` for the write buffer's `onCommit` `emitter`. This lets exceptions propagate through `commit()` to `sendRequest()`. Also wrap the commit call in `sendRequest()` with try-catch to clean up the orphaned `Deferred` from `pendingRequests` and return a rejected promise.

#### How to test

The PR includes a number of new automated tests that fail without the fixes (TDD). Other than that, I cannot really provide a reproducible scenario in the Theia example applications as these are largely nondeterministic failures under high stress scenarios where one side of the RPC bridge becomes unresponsive to the other. Definitely do regression-test scenarios known to exercise the RPC bridge in Theia.

#### Follow-ups

We may want to consider whether it would be valuable to have a reconciliation protocol on reconnection of frontend and backend for the two sides to exchange identifiers of messages that are awaiting replies so that they can reject any of their RPC calls that won't be getting replies. I think this is not an issue that is actually live in my application; I have more analysis to do there.

#### Breaking changes

There is, technically, a breaking change in the protected API of the `ChannelMultiplexer` class but I think it can be argued that it wouldn't make sense for subclasses to poke around in this handshaking state and so there should be no impact. And there are currently no subclasses. So I've elected to reduce the visibility of the `pendingOpen` property to `private` because really subclasses should not be messing with it.

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
