### PR TITLE
Provide proper icons for agents and fix icons in ai config

### DIFF
--- a/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/ask-and-continue-chat-agent-contribution.ts
@@ -121,6 +121,7 @@ export class AskAndContinueChatAgent extends AbstractStreamParsingChatAgent {
     ];
     override prompts = [{ id: systemPrompt.id, defaultVariant: systemPrompt }];
     protected override systemPromptId: string | undefined = systemPrompt.id;
+    override iconClass: string = 'codicon codicon-comment-discussion';
 
     @postConstruct()
     addContentMatchers(): void {

--- a/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-chat-agent.ts
@@ -152,7 +152,7 @@ export class ClaudeCodeChatAgent implements ChatAgent {
     id = CLAUDE_CHAT_AGENT_ID;
     name = CLAUDE_CHAT_AGENT_ID;
     description = nls.localize('theia/ai/claude-code/agentDescription', 'Anthropic\'s coding agent');
-    iconClass: string = 'codicon codicon-copilot';
+    iconClass: string = 'codicon codicon-claude';
     locations: ChatAgentLocation[] = ChatAgentLocation.ALL;
     tags = [nls.localizeByDefault('Chat')];
 

--- a/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/prompt-fragments-configuration-widget.tsx
@@ -29,6 +29,7 @@ import * as React from '@theia/core/shared/react';
 import { AgentService } from '@theia/ai-core/lib/common/agent-service';
 import { Agent } from '@theia/ai-core/lib/common/agent';
 import { CustomizationSource } from '@theia/ai-core/lib/browser/frontend-prompt-customization-service';
+import { isChatAgent } from '@theia/ai-chat/';
 
 /**
  * Widget for configuring AI prompt fragments and prompt variant sets.
@@ -464,7 +465,7 @@ export class AIPromptFragmentsConfigurationWidget extends ReactWidget {
                                 <span key={agent.id} className="agent-chip"
                                     title={nls.localize('theia/ai/core/promptFragmentsConfiguration/usedByAgentTitle', 'Used by agent: {0}', agent.name)}
                                     onClick={e => e.stopPropagation()}>
-                                    <span className={codicon('copilot')}></span>
+                                    <span className={(isChatAgent(agent) && agent.iconClass) ? agent.iconClass : codicon('copilot')}></span>
                                     {agent.name}
                                 </span>
                             ))}

--- a/packages/ai-ide/src/browser/ai-configuration/skills-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/skills-configuration-widget.tsx
@@ -22,6 +22,7 @@ import { Skill } from '@theia/ai-core/lib/common/skill';
 import { SkillService } from '@theia/ai-core/lib/browser/skill-service';
 import { PromptFragment, PromptService } from '@theia/ai-core/lib/common/prompt-service';
 import { Agent, AgentService } from '@theia/ai-core';
+import { isChatAgent } from '@theia/ai-chat';
 
 @injectable()
 export class AISkillsConfigurationWidget extends ReactWidget {
@@ -215,7 +216,7 @@ export class AISkillsConfigurationWidget extends ReactWidget {
                         <div className="slash-command-agent-chips">
                             {agents.map(agent => (
                                 <span key={agent.id} className="agent-chip" title={agent.description}>
-                                    <span className={codicon('copilot')}></span>
+                                    <span className={(isChatAgent(agent) && agent.iconClass) ? agent.iconClass : codicon('copilot')}></span>
                                     {agent.name}
                                 </span>
                             ))}

--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -40,6 +40,7 @@ export class ArchitectAgent extends AbstractModeAwareChatAgent {
         identifier: 'default/code',
     }];
     protected defaultLanguageModelPurpose: string = 'chat';
+    override iconClass: string = 'codicon codicon-map';
 
     override description = nls.localize('theia/ai/workspace/workspaceAgent/description',
         'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \

--- a/packages/ai-ide/src/browser/code-reviewer-agent.ts
+++ b/packages/ai-ide/src/browser/code-reviewer-agent.ts
@@ -37,4 +37,5 @@ export class CodeReviewerAgent extends AbstractStreamParsingChatAgent {
 
     override prompts = [{ id: CODE_REVIEWER_SYSTEM_PROMPT_ID, defaultVariant: codeReviewerSystemPrompt, variants: [] }];
     protected override systemPromptId: string = CODE_REVIEWER_SYSTEM_PROMPT_ID;
+    override iconClass: string = 'codicon codicon-code-review';
 }

--- a/packages/ai-ide/src/browser/coder-agent.ts
+++ b/packages/ai-ide/src/browser/coder-agent.ts
@@ -48,6 +48,7 @@ export class CoderAgent extends AbstractModeAwareChatAgent {
         identifier: 'default/code',
     }];
     protected defaultLanguageModelPurpose: string = 'chat';
+    override iconClass: string = 'codicon codicon-code';
 
     override description = nls.localize('theia/ai/workspace/coderAgent/description',
         'An AI assistant integrated into Theia IDE, designed to assist software developers. This agent can access the users workspace, it can get a list of all available files \

--- a/packages/ai-ide/src/browser/create-skill-agent.ts
+++ b/packages/ai-ide/src/browser/create-skill-agent.ts
@@ -35,6 +35,7 @@ export class CreateSkillAgent extends AbstractModeAwareChatAgent {
         identifier: 'default/universal',
     }];
     protected defaultLanguageModelPurpose: string = 'chat';
+    override iconClass: string = 'codicon codicon-wand';
 
     override description = nls.localize('theia/ai/workspace/createSkillAgent/description',
         'An AI assistant for creating new skills. Skills provide reusable instructions and domain knowledge for AI agents. ' +

--- a/packages/ai-ide/src/browser/explore-agent.ts
+++ b/packages/ai-ide/src/browser/explore-agent.ts
@@ -37,4 +37,5 @@ export class ExploreAgent extends AbstractStreamParsingChatAgent {
 
     override prompts = [{ id: EXPLORE_SYSTEM_PROMPT_ID, defaultVariant: exploreSystemPrompt, variants: [] }];
     protected override systemPromptId: string = EXPLORE_SYSTEM_PROMPT_ID;
+    override iconClass: string = 'codicon codicon-compass';
 }

--- a/packages/ai-ide/src/browser/junior-agent.ts
+++ b/packages/ai-ide/src/browser/junior-agent.ts
@@ -37,4 +37,5 @@ export class JuniorAgent extends AbstractStreamParsingChatAgent {
 
     override prompts = [{ id: JUNIOR_SYSTEM_PROMPT_ID, defaultVariant: juniorSystemPrompt, variants: [] }];
     protected override systemPromptId: string = JUNIOR_SYSTEM_PROMPT_ID;
+    override iconClass: string = 'codicon codicon-organization';
 }

--- a/packages/ai-ide/src/browser/project-info-agent.ts
+++ b/packages/ai-ide/src/browser/project-info-agent.ts
@@ -36,5 +36,5 @@ export class ProjectInfoAgent extends AbstractStreamParsingChatAgent {
 
     override prompts = [projectInfoSystemVariants, projectInfoTemplateVariants];
     protected override systemPromptId: string | undefined = projectInfoSystemVariants.id;
-
+    override iconClass: string = 'codicon codicon-repo';
 }

--- a/packages/ai-ide/src/common/command-chat-agents.ts
+++ b/packages/ai-ide/src/common/command-chat-agents.ts
@@ -54,6 +54,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
         purpose: 'command',
         identifier: 'default/universal',
     }];
+    override iconClass: string = 'codicon codicon-server-process';
     protected defaultLanguageModelPurpose: string = 'command';
 
     override description = nls.localize('theia/ai/ide/commandAgent/description',

--- a/packages/ai-ide/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-ide/src/common/orchestrator-chat-agent.ts
@@ -41,7 +41,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent {
     override description = nls.localize('theia/ai/chat/orchestrator/description',
         'This agent analyzes the user request against the description of all available chat agents and selects the best fitting agent to answer the request \
     (by using AI).The user\'s request will be directly delegated to the selected agent without further confirmation.');
-    override iconClass: string = 'codicon codicon-symbol-boolean';
+    override iconClass: string = 'codicon codicon-milestone';
     override agentSpecificVariables = [{
         name: 'availableChatAgents',
         description: nls.localize('theia/ai/chat/orchestrator/vars/availableChatAgents/description',

--- a/packages/ai-ide/src/common/universal-chat-agent.ts
+++ b/packages/ai-ide/src/common/universal-chat-agent.ts
@@ -37,4 +37,5 @@ export class UniversalChatAgent extends AbstractStreamParsingChatAgent {
 
    override prompts = [{ id: 'universal-system', defaultVariant: universalTemplate, variants: [universalTemplateVariant] }];
    protected override systemPromptId: string = 'universal-system';
+   override iconClass: string = 'codicon codicon-comment';
 }


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Sets a proper icon (of course to be discussed) for all agents.
Also fixes the correct icon being shown in the AI Config view.
Before the icons in the ai config (prompts and skills) just showed the default icon always.

Screenshot of icons:
<img width="187" height="1184" alt="Screenshot from 2026-04-10 09-35-02" src="https://github.com/user-attachments/assets/dbe631bb-4a60-48d5-9537-b95a7e65932a" />

Note that the orchestrator icon is inverted because it uses a outline codicon instead of a filled codicon. Should we look for an alternative?

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
Talk to agents look in the ai config and assess the quality of icons.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
