### PR TITLE
chore: show Linux env variable hint in API key preferences

### DIFF
--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
-import { nls, PreferenceSchema } from '@theia/core';
+import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.anthropic.AnthropicApiKey';
 export const MODELS_PREF = 'ai-features.anthropic.AnthropicModels';
@@ -27,7 +27,7 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             type: 'string',
             markdownDescription: nls.localize('theia/ai/anthropic/apiKey/description',
                 'Enter an API Key of your official Anthropic Account. **Please note:** By using this preference the Anthropic API key will be stored in clear text\
-            on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.'),
+            on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [MODELS_PREF]: {

--- a/packages/ai-claude-code/src/common/claude-code-preferences.ts
+++ b/packages/ai-claude-code/src/common/claude-code-preferences.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
-import { nls, PreferenceSchema } from '@theia/core';
+import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const CLAUDE_CODE_EXECUTABLE_PATH_PREF = 'ai-features.claudeCode.executablePath';
 export const CLAUDE_CODE_API_KEY_PREF = 'ai-features.claudeCode.apiKey';
@@ -34,7 +34,7 @@ export const ClaudeCodePreferencesSchema: PreferenceSchema = {
             type: 'string',
             markdownDescription: nls.localize('theia/ai/claude-code/apiKey/description',
                 'Enter an API Key for Claude Code. **Please note:** By using this preference the API key will be stored in clear text ' +
-                'on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.'),
+                'on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
         },
     }

--- a/packages/ai-google/src/common/google-preferences.ts
+++ b/packages/ai-google/src/common/google-preferences.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
-import { nls, PreferenceSchema } from '@theia/core';
+import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.google.apiKey';
 export const MODELS_PREF = 'ai-features.google.models';
@@ -29,7 +29,7 @@ export const GooglePreferencesSchema: PreferenceSchema = {
             type: 'string',
             markdownDescription: nls.localize('theia/ai/google/apiKey/description',
                 'Enter an API Key of your official Google AI (Gemini) Account. **Please note:** By using this preference the GOOGLE AI API key will be stored in clear text\
-            on the machine running Theia. Use the environment variable `GOOGLE_API_KEY` to set the key securely.'),
+            on the machine running Theia. Use the environment variable `GOOGLE_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [MODELS_PREF]: {

--- a/packages/ai-hugging-face/src/common/huggingface-preferences.ts
+++ b/packages/ai-hugging-face/src/common/huggingface-preferences.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
-import { nls, PreferenceSchema } from '@theia/core';
+import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.huggingFace.apiKey';
 export const MODELS_PREF = 'ai-features.huggingFace.models';
@@ -26,7 +26,7 @@ export const HuggingFacePreferencesSchema: PreferenceSchema = {
             type: 'string',
             markdownDescription: nls.localize('theia/ai/huggingFace/apiKey/mdDescription',
                 'Enter an API Key for your Hugging Face Account. **Please note:** By using this preference the Hugging Face API key will be stored in clear text\
-            on the machine running Theia. Use the environment variable `HUGGINGFACE_API_KEY` to set the key securely.'),
+            on the machine running Theia. Use the environment variable `HUGGINGFACE_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
             tags: ['experimental']
         },

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
-import { nls, PreferenceSchema } from '@theia/core';
+import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.openAiOfficial.openAiApiKey';
 export const MODELS_PREF = 'ai-features.openAiOfficial.officialOpenAiModels';
@@ -28,7 +28,7 @@ export const OpenAiPreferencesSchema: PreferenceSchema = {
             type: 'string',
             markdownDescription: nls.localize('theia/ai/openai/apiKey/mdDescription',
                 'Enter an API Key of your official OpenAI Account. **Please note:** By using this preference the Open AI API key will be stored in clear text \
-on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to set the key securely.'),
+on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [MODELS_PREF]: {

--- a/packages/ai-vercel-ai/src/common/vercel-ai-preferences.ts
+++ b/packages/ai-vercel-ai/src/common/vercel-ai-preferences.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
-import { nls, PreferenceSchema } from '@theia/core';
+import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const OPENAI_API_KEY_PREF = 'ai-features.vercelAi.openaiApiKey';
 export const ANTHROPIC_API_KEY_PREF = 'ai-features.vercelAi.anthropicApiKey';
@@ -31,7 +31,7 @@ export const VercelAiPreferencesSchema: PreferenceSchema = {
             markdownDescription: nls.localize('theia/ai/vercelai/openaiApiKey/mdDescription',
                 'Enter an API Key for OpenAI models used by the Vercel AI SDK. \
                 **Please note:** By using this preference the API key will be stored in clear text \
-        on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to set the key securely.'),
+        on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
             tags: ['experimental']
         },
@@ -40,7 +40,7 @@ export const VercelAiPreferencesSchema: PreferenceSchema = {
             markdownDescription: nls.localize('theia/ai/vercelai/anthropicApiKey/mdDescription',
                 'Enter an API Key for Anthropic models used by the Vercel AI SDK. \
                 **Please note:** By using this preference the API key will be stored in clear text \
-        on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.'),
+        on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
             tags: ['experimental']
         },

--- a/packages/core/src/common/preferences/preference-utils.ts
+++ b/packages/core/src/common/preferences/preference-utils.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 STMicroelectronics and others.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,15 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-export * from './defaults-preference-provider';
-export * from './preference-language-override-service';
-export * from './preference-provider-impl';
-export * from './preference-provider';
-export * from './preference-schema-service';
-export * from './preference-schema';
-export * from './preference-scope';
-export * from './preference-service';
-export * from './injectable-preference-proxy';
-export * from './preference-proxy';
-export * from './preference-configurations';
-export * from './preference-utils';
+import { nls } from '../nls';
+import { isOSX, isWindows } from '../os';
+
+/**
+ * Hint appended to API key preference descriptions on Linux, where environment variables
+ * set in `~/.bashrc` are not available to desktop-launched applications.
+ */
+export const LINUX_ENV_HINT = !isWindows && !isOSX
+    ? ' ' + nls.localize('theia/ai-core/preferences/linuxEnvHint',
+        'On Linux, make sure the variable is defined in `~/.profile` (not just `~/.bashrc`) if you launch the application from a desktop shortcut.' +
+        ' See the [documentation](https://theia-ide.org/docs/user_ai/#setting-api-keys) for details.')
+    : '';

--- a/packages/scanoss/src/common/scanoss-preferences.ts
+++ b/packages/scanoss/src/common/scanoss-preferences.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
+import { LINUX_ENV_HINT, PreferenceSchema } from '@theia/core';
 
 export const SCAN_OSS_API_KEY_PREF = 'ai-features.SCANOSS.apiKey';
 
@@ -23,7 +23,7 @@ export const ScanOSSPreferencesSchema: PreferenceSchema = {
         [SCAN_OSS_API_KEY_PREF]: {
             type: 'string',
             markdownDescription: 'Enter an API Key of your SCANOSS  Account. **Please note:** By using this preference the key will be stored in clear text\
-            on the machine running Theia. Use the environment variable `SCANOSS_API_KEY` to set the key securely.',
+            on the machine running Theia. Use the environment variable `SCANOSS_API_KEY` to set the key securely.' + LINUX_ENV_HINT,
             title: 'SCANOSS API Key'
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves https://github.com/eclipse-theia/theia-ide/issues/601

- Add OS-conditional `LINUX_ENV_HINT` to `preference-utils` that appends a hint about `~/.profile` vs `~/.bashrc` on Linux only
- Append the hint to all AI provider API key preference descriptions

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Check the api key preferences in the Settings UI if the hint shows.
- The link to the docs page is currently not functional yet, but there is also a PR open for this: https://github.com/eclipse-theia/theia-website/pull/941. The preview for this doc page can be viewed here: https://eclipse-theia.github.io/theia-website-previews/pr-previews/pr-941/docs/user_ai/#setting-api-keys (the path is the same as it will be for the production docs page)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
