### PR TITLE
fix: ensure terminal API object identity and respect grouping mode for plugin-created terminals

### DIFF
--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -257,7 +257,7 @@ import { DocumentsExtImpl } from './documents';
 import { TextEditorCursorStyle } from '../common/editor-options';
 import { PreferenceRegistryExtImpl } from './preference-registry';
 import { OutputChannelRegistryExtImpl } from './output-channel-registry';
-import { TerminalServiceExtImpl, TerminalExtImpl } from './terminal-ext';
+import { TerminalServiceExtImpl } from './terminal-ext';
 import { LanguagesExtImpl } from './languages';
 import { fromDocumentSelector, pluginToPluginInfo, fromGlobPattern } from './type-converters';
 import { DialogsExtImpl } from './dialogs';
@@ -462,7 +462,7 @@ export function createAPIFactory(
         const showErrorMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Error);
         const window: typeof theia.window = {
 
-            get activeTerminal(): TerminalExtImpl | undefined {
+            get activeTerminal(): theia.Terminal | undefined {
                 return terminalExt.activeTerminal;
             },
             get activeTextEditor(): TextEditorExt | undefined {
@@ -471,7 +471,7 @@ export function createAPIFactory(
             get visibleTextEditors(): theia.TextEditor[] {
                 return editors.getVisibleTextEditors();
             },
-            get terminals(): TerminalExtImpl[] {
+            get terminals(): theia.Terminal[] {
                 return terminalExt.terminals;
             },
             onDidChangeActiveTerminal,
@@ -633,7 +633,7 @@ export function createAPIFactory(
             createTerminal(nameOrOptions: theia.TerminalOptions | theia.ExtensionTerminalOptions | theia.ExtensionTerminalOptions | (string | undefined),
                 shellPath?: string,
                 shellArgs?: string[] | string): theia.Terminal {
-                return createAPIObject(terminalExt.createTerminal(plugin, nameOrOptions, shellPath, shellArgs));
+                return terminalExt.createTerminal(plugin, nameOrOptions, shellPath, shellArgs, createAPIObject);
             },
             onDidChangeTerminalState,
             onDidCloseTerminal,

--- a/packages/plugin-ext/src/plugin/terminal-ext.spec.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.spec.ts
@@ -1,0 +1,350 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as chai from 'chai';
+import * as theia from '@theia/plugin';
+import { TerminalServiceMain, Plugin, TerminalOptions } from '../common/plugin-api-rpc';
+import { RPCProtocol, ProxyIdentifier } from '../common/rpc-protocol';
+import { TerminalServiceExtImpl, TerminalExtImpl } from './terminal-ext';
+import { TerminalExitReason } from './types-impl';
+
+const expect = chai.expect;
+
+/**
+ * Creates a mock RPCProtocol that returns the given proxy for TERMINAL_MAIN.
+ */
+function createMockRpc(proxy: Partial<TerminalServiceMain>): RPCProtocol {
+    return {
+        getProxy<T>(_proxyId: ProxyIdentifier<T>): T {
+            return proxy as unknown as T;
+        },
+        set<T, R extends T>(_identifier: ProxyIdentifier<T>, instance: R): R {
+            return instance;
+        },
+        dispose(): void { }
+    } as RPCProtocol;
+}
+
+/**
+ * Creates a minimal mock Plugin object.
+ */
+function createMockPlugin(): Plugin {
+    return {
+        pluginPath: '/test',
+        pluginFolder: '/test',
+        pluginUri: 'file:///test',
+        model: { id: 'test.plugin' } as Plugin['model'],
+        rawModel: {} as Plugin['rawModel'],
+        lifecycle: {} as Plugin['lifecycle'],
+        isUnderDevelopment: false
+    };
+}
+
+/**
+ * Creates a stub TerminalServiceMain that records calls.
+ */
+function createMockProxy(): TerminalServiceMain & { createdTerminals: { id: string; options: TerminalOptions }[] } {
+    const createdTerminals: { id: string; options: TerminalOptions }[] = [];
+    return {
+        createdTerminals,
+        $createTerminal(id: string, options: TerminalOptions): Promise<string> {
+            createdTerminals.push({ id, options });
+            return Promise.resolve(id);
+        },
+        $sendText(): void { },
+        $write(): void { },
+        $resize(): void { },
+        $show(): void { },
+        $hide(): void { },
+        $dispose(): void { },
+        $setName(): void { },
+        $writeByTerminalId(): void { },
+        $resizeByTerminalId(): void { },
+        $disposeByTerminalId(): void { },
+        $setNameByTerminalId(): void { },
+        $setEnvironmentVariableCollection(): void { },
+        $registerTerminalLinkProvider(): void { },
+        $unregisterTerminalLinkProvider(): void { },
+        $registerTerminalObserver(): void { },
+        $unregisterTerminalObserver(): void { },
+    } as unknown as TerminalServiceMain & { createdTerminals: { id: string; options: TerminalOptions }[] };
+}
+
+describe('TerminalServiceExtImpl', () => {
+    let proxy: ReturnType<typeof createMockProxy>;
+    let service: TerminalServiceExtImpl;
+    let plugin: Plugin;
+
+    beforeEach(() => {
+        proxy = createMockProxy();
+        const rpc = createMockRpc(proxy);
+        service = new TerminalServiceExtImpl(rpc);
+        plugin = createMockPlugin();
+    });
+
+    describe('terminals list', () => {
+        it('returns empty array initially', () => {
+            expect(service.terminals).to.deep.equal([]);
+        });
+
+        it('includes terminals after creation via $terminalCreated', () => {
+            service.$terminalCreated('t1', 'Terminal 1');
+            expect(service.terminals).to.have.length(1);
+        });
+
+        it('removes terminals after $terminalClosed', () => {
+            service.$terminalCreated('t1', 'Terminal 1');
+            service.$terminalClosed('t1', { code: 0, reason: TerminalExitReason.Process });
+            expect(service.terminals).to.have.length(0);
+        });
+    });
+
+    describe('API object identity', () => {
+        it('returns the raw TerminalExtImpl when no wrapper is provided', () => {
+            const terminal = service.createTerminal(plugin, 'Test Terminal');
+            expect(terminal).to.be.instanceOf(TerminalExtImpl);
+        });
+
+        it('returns the wrapped API object when a wrapper is provided', () => {
+            const wrapper = (t: TerminalExtImpl): theia.Terminal => ({ ...t, name: 'wrapped' } as unknown as theia.Terminal);
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+            const terminal = service.terminals[0];
+            expect(terminal.name).to.equal('wrapped');
+            expect(terminal).to.not.be.instanceOf(TerminalExtImpl);
+        });
+
+        it('fires onDidOpenTerminal with the API object, not the raw terminal', () => {
+            const apiObject = { marker: 'api-object' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+
+            const opened: theia.Terminal[] = [];
+            service.onDidOpenTerminal(t => opened.push(t));
+
+            // Get the ID from the proxy call
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+
+            expect(opened).to.have.length(1);
+            expect(opened[0]).to.equal(apiObject);
+        });
+
+        it('fires onDidCloseTerminal with the API object', () => {
+            const apiObject = { marker: 'api-object' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+
+            const closed: theia.Terminal[] = [];
+            service.onDidCloseTerminal(t => closed.push(t));
+
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+            service.$terminalClosed(id, { code: 0, reason: TerminalExitReason.Process });
+
+            expect(closed).to.have.length(1);
+            expect(closed[0]).to.equal(apiObject);
+        });
+
+        it('fires onDidChangeTerminalState with the API object on interaction', () => {
+            const apiObject = { marker: 'api-object' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+
+            const stateChanged: theia.Terminal[] = [];
+            service.onDidChangeTerminalState(t => stateChanged.push(t));
+
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+            service.$terminalOnInteraction(id);
+
+            expect(stateChanged).to.have.length(1);
+            expect(stateChanged[0]).to.equal(apiObject);
+        });
+
+        it('fires onDidChangeTerminalState with the API object on shell type change', () => {
+            const apiObject = { marker: 'api-object' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+
+            const stateChanged: theia.Terminal[] = [];
+            service.onDidChangeTerminalState(t => stateChanged.push(t));
+
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+            service.$terminalShellTypeChanged(id, '/bin/zsh');
+
+            expect(stateChanged).to.have.length(1);
+            expect(stateChanged[0]).to.equal(apiObject);
+        });
+
+        it('returns the API object from the terminals list', () => {
+            const apiObject = { marker: 'api-object' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+
+            const terminals = service.terminals;
+            expect(terminals).to.have.length(1);
+            expect(terminals[0]).to.equal(apiObject);
+        });
+
+        it('returns the API object as activeTerminal', () => {
+            const apiObject = { marker: 'api-object' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+            service.$currentTerminalChanged(id);
+
+            expect(service.activeTerminal).to.equal(apiObject);
+        });
+
+        it('cleans up API object on terminal close', () => {
+            const apiObject = { marker: 'api-object' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Test Terminal', undefined, undefined, wrapper);
+
+            const id = proxy.createdTerminals[0].id;
+            service.$terminalCreated(id, 'Test Terminal');
+            service.$terminalClosed(id, { code: 0, reason: TerminalExitReason.Process });
+
+            expect(service.terminals).to.have.length(0);
+        });
+    });
+
+    describe('parentTerminal resolution', () => {
+        it('resolves parentTerminal from API proxy objects', () => {
+            const apiObject = { marker: 'parent-api' } as unknown as theia.Terminal;
+            const wrapper = (_t: TerminalExtImpl): theia.Terminal => apiObject;
+            service.createTerminal(plugin, 'Parent', undefined, undefined, wrapper);
+
+            const parentId = proxy.createdTerminals[0].id;
+            service.$terminalCreated(parentId, 'Parent');
+
+            // Create a child with parentTerminal set to the API object
+            service.createTerminal(plugin, {
+                name: 'Child',
+                location: { parentTerminal: apiObject }
+            } as theia.TerminalOptions);
+
+            expect(proxy.createdTerminals).to.have.length(2);
+            // The second createTerminal call should have passed the parent ID
+            // We verify it was called on the proxy (the parentId arg is the 3rd parameter)
+        });
+
+        it('resolves parentTerminal from raw terminal objects', () => {
+            const rawTerminal = service.createTerminal(plugin, 'Parent');
+
+            const parentId = proxy.createdTerminals[0].id;
+            service.$terminalCreated(parentId, 'Parent');
+
+            // Create a child with parentTerminal set to the raw terminal
+            service.createTerminal(plugin, {
+                name: 'Child',
+                location: { parentTerminal: rawTerminal }
+            } as theia.TerminalOptions);
+
+            expect(proxy.createdTerminals).to.have.length(2);
+        });
+    });
+
+    describe('events for terminals without wrapper', () => {
+        it('fires onDidOpenTerminal with the raw terminal when no wrapper is used', () => {
+            const opened: theia.Terminal[] = [];
+            service.onDidOpenTerminal(t => opened.push(t));
+
+            service.$terminalCreated('ext-t1', 'External Terminal');
+
+            expect(opened).to.have.length(1);
+            expect(opened[0]).to.be.instanceOf(TerminalExtImpl);
+            expect(opened[0].name).to.equal('External Terminal');
+        });
+
+        it('fires onDidCloseTerminal with the raw terminal when no wrapper is used', () => {
+            const closed: theia.Terminal[] = [];
+            service.onDidCloseTerminal(t => closed.push(t));
+
+            service.$terminalCreated('ext-t1', 'External Terminal');
+            service.$terminalClosed('ext-t1', { code: 0, reason: TerminalExitReason.Process });
+
+            expect(closed).to.have.length(1);
+            expect(closed[0]).to.be.instanceOf(TerminalExtImpl);
+        });
+    });
+
+    describe('shell change', () => {
+        it('fires onDidChangeShell when shell changes', async () => {
+            const shells: string[] = [];
+            service.onDidChangeShell(s => shells.push(s));
+
+            await service.$setShell('/bin/zsh');
+
+            expect(shells).to.deep.equal(['/bin/zsh']);
+            expect(service.defaultShell).to.equal('/bin/zsh');
+        });
+
+        it('does not fire onDidChangeShell when shell is the same', async () => {
+            const shells: string[] = [];
+            await service.$setShell('/bin/zsh');
+
+            service.onDidChangeShell(s => shells.push(s));
+            await service.$setShell('/bin/zsh');
+
+            expect(shells).to.deep.equal([]);
+        });
+    });
+
+    describe('$terminalNameChanged', () => {
+        it('updates the terminal name', () => {
+            service.$terminalCreated('t1', 'Old Name');
+            service.$terminalNameChanged('t1', 'New Name');
+
+            expect(service.terminals[0].name).to.equal('New Name');
+        });
+    });
+
+    describe('activeTerminal', () => {
+        it('is undefined initially', () => {
+            expect(service.activeTerminal).to.equal(undefined);
+        });
+
+        it('reflects the current active terminal', () => {
+            service.$terminalCreated('t1', 'Terminal 1');
+            service.$currentTerminalChanged('t1');
+
+            expect(service.activeTerminal).to.not.equal(undefined);
+            expect(service.activeTerminal!.name).to.equal('Terminal 1');
+        });
+
+        it('fires onDidChangeActiveTerminal', () => {
+            const changes: (theia.Terminal | undefined)[] = [];
+            service.onDidChangeActiveTerminal(t => changes.push(t));
+
+            service.$terminalCreated('t1', 'Terminal 1');
+            service.$currentTerminalChanged('t1');
+            service.$currentTerminalChanged(undefined);
+
+            expect(changes).to.have.length(2);
+            expect(changes[0]!.name).to.equal('Terminal 1');
+            expect(changes[1]).to.equal(undefined);
+        });
+    });
+});

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -74,7 +74,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
     }
 
     get terminals(): theia.Terminal[] {
-        return [...this._terminals.keys()].map(id => this.getApiObject(id)!).filter(t => t !== undefined);
+        return [...this._terminals.keys()].map(id => this.getApiObject(id)).filter((t): t is theia.Terminal => t !== undefined);
     }
 
     get defaultShell(): string {
@@ -119,7 +119,15 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         let parentId;
         if (options.location && typeof options.location === 'object' && 'parentTerminal' in options.location) {
             const parentTerminal = options.location.parentTerminal;
-            if (parentTerminal instanceof TerminalExtImpl) {
+            // Check both the API proxy objects and the raw terminals, since
+            // plugins receive the proxy but _terminals stores the raw object.
+            for (const [k, v] of this._terminalApiObjects) {
+                if (v === parentTerminal) {
+                    parentId = k;
+                    break;
+                }
+            }
+            if (!parentId) {
                 for (const [k, v] of this._terminals) {
                     if (v === parentTerminal) {
                         parentId = k;

--- a/packages/plugin-ext/src/plugin/terminal-ext.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext.ts
@@ -38,6 +38,13 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
 
     private readonly _terminals = new Map<string, TerminalExtImpl>();
 
+    /**
+     * Stores the API objects (Proxies) returned to plugins for each terminal.
+     * This ensures that events fire with the same object instance that plugins received,
+     * allowing strict equality checks (===) to work correctly.
+     */
+    private readonly _terminalApiObjects = new Map<string, theia.Terminal>();
+
     private readonly _pseudoTerminals = new Map<string, PseudoTerminal>();
 
     private static nextProviderId = 0;
@@ -66,8 +73,8 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.TERMINAL_MAIN);
     }
 
-    get terminals(): TerminalExtImpl[] {
-        return [...this._terminals.values()];
+    get terminals(): theia.Terminal[] {
+        return [...this._terminals.keys()].map(id => this.getApiObject(id)!).filter(t => t !== undefined);
     }
 
     get defaultShell(): string {
@@ -84,7 +91,9 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
     createTerminal(
         plugin: Plugin,
         nameOrOptions: theia.TerminalOptions | theia.PseudoTerminalOptions | theia.ExtensionTerminalOptions | string | undefined,
-        shellPath?: string, shellArgs?: string[] | string
+        shellPath?: string,
+        shellArgs?: string[] | string,
+        apiObjectWrapper?: (terminal: TerminalExtImpl) => theia.Terminal
     ): theia.Terminal {
         const id = `plugin-terminal-${UUID.uuid4()}`;
         let options: TerminalOptions;
@@ -136,7 +145,16 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         if (typeof nameOrOptions === 'object' && 'pty' in nameOrOptions) {
             creationOptions = nameOrOptions;
         }
-        return this.obtainTerminal(id, options.name || 'Terminal', creationOptions);
+        const terminal = this.obtainTerminal(id, options.name || 'Terminal', creationOptions);
+
+        // If a wrapper function is provided, wrap the terminal and register the API object
+        // This ensures events fire with the same object instance that plugins received
+        if (apiObjectWrapper) {
+            const apiObject = apiObjectWrapper(terminal);
+            this._terminalApiObjects.set(id, apiObject);
+            return apiObject;
+        }
+        return terminal;
     }
 
     attachPtyToTerminal(terminalId: number, pty: theia.Pseudoterminal): void {
@@ -151,6 +169,13 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         }
         terminal.name = name;
         return terminal;
+    }
+
+    /**
+     * Gets the API object for a terminal by ID, falling back to the raw terminal if not set.
+     */
+    protected getApiObject(id: string): theia.Terminal | undefined {
+        return this._terminalApiObjects.get(id) ?? this._terminals.get(id);
     }
 
     $terminalOnInput(id: string, data: string): void {
@@ -168,7 +193,10 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         }
         if (!terminal.state.isInteractedWith) {
             terminal.state = { ...terminal.state, isInteractedWith: true };
-            this.onDidChangeTerminalStateEmitter.fire(terminal);
+            const apiObject = this.getApiObject(id);
+            if (apiObject) {
+                this.onDidChangeTerminalStateEmitter.fire(apiObject);
+            }
         }
     }
 
@@ -179,7 +207,10 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         }
         if (terminal.state.shell !== shellType) {
             terminal.state = { ...terminal.state, shell: shellType };
-            this.onDidChangeTerminalStateEmitter.fire(terminal);
+            const apiObject = this.getApiObject(id);
+            if (apiObject) {
+                this.onDidChangeTerminalStateEmitter.fire(apiObject);
+            }
         }
     }
 
@@ -194,7 +225,10 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
     $terminalCreated(id: string, name: string): void {
         const terminal = this.obtainTerminal(id, name);
         terminal.id.resolve(id);
-        this.onDidOpenTerminalEmitter.fire(terminal);
+        const apiObject = this.getApiObject(id);
+        if (apiObject) {
+            this.onDidOpenTerminalEmitter.fire(apiObject);
+        }
     }
 
     $terminalNameChanged(id: string, name: string): void {
@@ -234,8 +268,12 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
         const terminal = this._terminals.get(id);
         if (terminal) {
             terminal.exitStatus = exitStatus ?? { code: undefined, reason: TerminalExitReason.Unknown };
-            this.onDidCloseTerminalEmitter.fire(terminal);
+            const apiObject = this.getApiObject(id);
+            if (apiObject) {
+                this.onDidCloseTerminalEmitter.fire(apiObject);
+            }
             this._terminals.delete(id);
+            this._terminalApiObjects.delete(id);
         }
         const pseudoTerminal = this._pseudoTerminals.get(id);
         if (pseudoTerminal) {
@@ -245,8 +283,8 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
     }
 
     private activeTerminalId: string | undefined;
-    get activeTerminal(): TerminalExtImpl | undefined {
-        return this.activeTerminalId && this._terminals.get(this.activeTerminalId) || undefined;
+    get activeTerminal(): theia.Terminal | undefined {
+        return this.activeTerminalId && this.getApiObject(this.activeTerminalId) || undefined;
     }
     $currentTerminalChanged(id: string | undefined): void {
         this.activeTerminalId = id;
@@ -319,7 +357,7 @@ export class TerminalServiceExtImpl implements TerminalServiceExt {
 
     async $provideTerminalLinks(line: string, terminalId: string, token: theia.CancellationToken): Promise<ProvidedTerminalLink[]> {
         const links: ProvidedTerminalLink[] = [];
-        const terminal = this._terminals.get(terminalId);
+        const terminal = this.getApiObject(terminalId);
         if (terminal) {
             for (const [providerId, provider] of this.terminalLinkProviders) {
                 const providedLinks = await provider.provideTerminalLinks({ line, terminal }, token);

--- a/packages/terminal-manager/src/browser/terminal-manager-frontend-contribution.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-frontend-contribution.ts
@@ -54,14 +54,6 @@ export class TerminalManagerFrontendContribution implements FrontendApplicationC
     }
 
     /**
-     * Check if a terminal is a debug terminal.
-     * Debug terminals have a 'kind' property set to 'debug'.
-     */
-    protected isDebugTerminal(terminal: TerminalWidget): boolean {
-        return terminal.kind === 'debug';
-    }
-
-    /**
      * Register a listener to route externally created terminals (e.g. from plugins)
      * into the terminal manager when tree mode is active.
      * Terminals created internally via {@link TerminalManagerWidget.createTerminalWidget}

--- a/packages/terminal-manager/src/browser/terminal-manager-frontend-contribution.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-frontend-contribution.ts
@@ -62,16 +62,30 @@ export class TerminalManagerFrontendContribution implements FrontendApplicationC
     }
 
     /**
-     * Register a listener to route debug terminals to numbered pages in the terminal manager.
+     * Register a listener to route externally created terminals (e.g. from plugins)
+     * into the terminal manager when tree mode is active.
+     * Terminals created internally via {@link TerminalManagerWidget.createTerminalWidget}
+     * are skipped because the command handlers handle their placement.
      */
     protected registerTerminalListener(): void {
         this.commandHandlerDisposables.push(
             this.terminalFrontendContribution.onDidCreateTerminal(async terminal => {
-                if (this.isDebugTerminal(terminal)) {
-                    const managerWidget = await this.widgetManager.getOrCreateWidget<TerminalManagerWidget>(TerminalManagerWidget.ID);
-                    if (managerWidget instanceof TerminalManagerWidget) {
-                        managerWidget.addTerminalPage(terminal);
-                    }
+                if (this.isTaskTerminal(terminal) || terminal.hiddenFromUser) {
+                    return;
+                }
+                // Check the flag synchronously (before any await) to correctly
+                // identify terminals created by the manager's command handlers.
+                const managerWidget = this.terminalManagerViewContribution.tryGetWidget();
+                if (managerWidget instanceof TerminalManagerWidget && managerWidget.creatingTerminalInternally) {
+                    return;
+                }
+                const resolvedWidget = managerWidget ?? await this.widgetManager.getOrCreateWidget<TerminalManagerWidget>(TerminalManagerWidget.ID);
+                if (!(resolvedWidget instanceof TerminalManagerWidget)) {
+                    return;
+                }
+                if (!resolvedWidget.terminalWidgetIdsToNodeIds.has(terminal.id)) {
+                    resolvedWidget.addTerminalPage(terminal);
+                    await this.terminalManagerViewContribution.openView({ reveal: true });
                 }
             })
         );
@@ -90,7 +104,6 @@ export class TerminalManagerFrontendContribution implements FrontendApplicationC
             }
             console.debug('Terminal tab style is tree. Override command handlers accordingly.');
             this.registerHandlers();
-            this.registerTerminalListener();
         });
     }
 
@@ -171,6 +184,7 @@ export class TerminalManagerFrontendContribution implements FrontendApplicationC
     protected registerHandlers(): void {
         this.unregisterHandlers();
         this.registerCommands();
+        this.registerTerminalListener();
     }
 
     protected registerCommands(): void {

--- a/packages/terminal-manager/src/browser/terminal-manager-widget.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-widget.ts
@@ -161,17 +161,28 @@ export class TerminalManagerWidget extends BaseWidget implements StatefulWidget,
         }
     }
 
+    /**
+     * Set to `true` while {@link createTerminalWidget} is executing, so that external
+     * listeners can distinguish internally created terminals from external ones (e.g. from plugins).
+     */
+    creatingTerminalInternally = false;
+
     async createTerminalWidget(options: TerminalWidgetOptions = {}): Promise<TerminalWidget> {
-        const terminalWidget = await this.terminalFrontendContribution.newTerminal({
-            // passing 'created' here as a millisecond value rather than the default `new Date().toString()` that Theia uses in
-            // its factory (resolves to something like 'Tue Aug 09 2022 13:21:26 GMT-0500 (Central Daylight Time)').
-            // The state restoration system relies on identifying terminals by their unique options, using an ms value ensures we don't
-            // get a duplication since the original date method is only accurate to within 1s.
-            created: new Date().getTime().toString(),
-            ...options,
-        } as TerminalWidgetOptions);
-        terminalWidget.start();
-        return terminalWidget;
+        this.creatingTerminalInternally = true;
+        try {
+            const terminalWidget = await this.terminalFrontendContribution.newTerminal({
+                // passing 'created' here as a millisecond value rather than the default `new Date().toString()` that Theia uses in
+                // its factory (resolves to something like 'Tue Aug 09 2022 13:21:26 GMT-0500 (Central Daylight Time)').
+                // The state restoration system relies on identifying terminals by their unique options, using an ms value ensures we don't
+                // get a duplication since the original date method is only accurate to within 1s.
+                created: new Date().getTime().toString(),
+                ...options,
+            } as TerminalWidgetOptions);
+            terminalWidget.start();
+            return terminalWidget;
+        } finally {
+            this.creatingTerminalInternally = false;
+        }
     }
 
     protected registerListeners(): void {

--- a/packages/terminal-manager/src/browser/terminal-manager-widget.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-widget.ts
@@ -162,13 +162,18 @@ export class TerminalManagerWidget extends BaseWidget implements StatefulWidget,
     }
 
     /**
-     * Set to `true` while {@link createTerminalWidget} is executing, so that external
+     * Incremented while {@link createTerminalWidget} is executing, so that external
      * listeners can distinguish internally created terminals from external ones (e.g. from plugins).
+     * Uses a counter instead of a boolean to handle concurrent calls correctly.
      */
-    creatingTerminalInternally = false;
+    private _creatingTerminalInternallyCount = 0;
+
+    get creatingTerminalInternally(): boolean {
+        return this._creatingTerminalInternallyCount > 0;
+    }
 
     async createTerminalWidget(options: TerminalWidgetOptions = {}): Promise<TerminalWidget> {
-        this.creatingTerminalInternally = true;
+        this._creatingTerminalInternallyCount++;
         try {
             const terminalWidget = await this.terminalFrontendContribution.newTerminal({
                 // passing 'created' here as a millisecond value rather than the default `new Date().toString()` that Theia uses in
@@ -181,7 +186,7 @@ export class TerminalManagerWidget extends BaseWidget implements StatefulWidget,
             terminalWidget.start();
             return terminalWidget;
         } finally {
-            this.creatingTerminalInternally = false;
+            this._creatingTerminalInternallyCount--;
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #16570                                                                                                                                                
                                                                                                                                                              
  The ms-python extension uses strict instance equality (`===`) in its `terminalCloseHandler` to check whether a terminal has been closed. However, Theia wraps terminal objects in a `Proxy` via `createAPIObject`, so the object returned to extensions differs from the one fired in terminal events. This causes the equality check to fail, making the "Run Python File" button unresponsive after closing and reopening a terminal.                                      
                                                                                                                                                              
  - Terminal events (`onDidOpenTerminal`, `onDidCloseTerminal`, `onDidChangeTerminalState`) now fire with the same Proxy-wrapped API object that was returned to extensions
  - The `terminals` getter and `activeTerminal` also return the API objects
  - A `_terminalApiObjects` map in `TerminalServiceExtImpl` tracks the Proxy wrappers alongside the raw terminal instances
  - Plugin-created terminals are now routed through the terminal manager when `terminal.grouping.mode` is set to `tree`, instead of always appearing as separate tabs in the bottom panel 

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Terminal identity fix (ms-python):
  1. Open a Python file in the example application
  2. Click "Run Python File" in the editor toolbar
  3. Close the terminal that was opened
  4. Click "Run Python File" again                                                                                                                            
  5. Verify the terminal opens and runs again (previously it became unresponsive)

Terminal manager tree mode with plugin-created terminals:
  1. Set `terminal.grouping.mode` to `tree` in preferences
  2. Click "Run Python File" (or any extension that creates a terminal)
  3. Verify the terminal appears inside the terminal manager tree, not as a separate tab in the bottom panel                                                  
  4. Close and re-run to verify it continues working

Task terminals in tree mode:
  1. With `terminal.grouping.mode` set to `tree`, run a task (e.g. via Terminal > Run Task)
  2. Verify the task terminal appears on the Tasks page in the terminal manager (not as a regular page)                                                       
  3. Verify the task completes normally

Integrated terminal in tree mode:
  1. With `terminal.grouping.mode` set to `tree`, create a new terminal via the command palette or Ctrl+`
  2. Verify it appears in the terminal manager tree                                                                                                           
  3. Split the terminal and verify the split also appears correctly in the tree
  4. Verify typing and command execution works normally

Tabbed mode (regression check):
  1. Switch `terminal.grouping.mode` to `tabbed`                                                                                                              
  2. Create a new terminal, run a task, and run a Python file     
  3. Verify all terminals appear as separate tabs in the bottom panel as before
                                                                                                                                                              
  **Switching modes at runtime:**
  1. Start with `tabbed` mode and create some terminals                                                                                                       
  2. Switch to `tree` mode and verify existing terminals migrate to the manager
  3. Switch back to `tabbed` and verify terminals migrate back to tabs

Example python file to test:
```py
from datetime import datetime

def main():
    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
    print(f"The current time is: {now}")
    date = datetime.now().strftime("%Y-%m-%d")
    print(f"The current date is: {date}")
    weekday = datetime.now().strftime("%A")
    print(f"The current weekday is: {weekday}")

if __name__ == "__main__":
    main()
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

  - The `editor/title/run` toolbar button uses a hardcoded `debug-alt` icon instead of dynamically picking up the primary command's icon from the contributing
   extension                                                                                                                                                  
  - Localization keys from bundled sub-extensions (e.g. `%debugpy.command.debuginterminal.title%`) may appear unresolved in the toolbar dropdown

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
