### PR TITLE
Fix test extensions (e.g., Python unittest) and improve test output UX

### DIFF
--- a/examples/api-samples/src/browser/test/test-controller.ts
+++ b/examples/api-samples/src/browser/test/test-controller.ts
@@ -377,7 +377,9 @@ export class TestControllerImpl implements TestController {
     }
     onItemsChanged: Event<TreeDelta<string, TestItemImpl>[]> = this.deltaBuilder.onDidFlush;
 
-    resolveChildren(item: TestItem): void {
+    canResolveChildren: boolean = false;
+
+    resolveChildren(item?: TestItem): void {
         // nothing to do
     }
 

--- a/packages/plugin-ext/src/main/browser/test-main.ts
+++ b/packages/plugin-ext/src/main/browser/test-main.ts
@@ -411,6 +411,7 @@ class TestControllerImpl implements TestController {
     readonly deltaBuilder = new AccumulatingTreeDeltaEmitter<string, TestItemImpl>(300);
     canRefresh: boolean;
     canResolveChildren: boolean = false;
+    private hasTriggeredInitialResolve: boolean = false;
     readonly items = new TestItemCollection(this, item => item.path, () => this.deltaBuilder);
 
     constructor(private readonly proxy: TestingExt, readonly id: string, public label: string) {
@@ -510,8 +511,8 @@ class TestControllerImpl implements TestController {
         }
         if ('canResolve' in change) {
             this.canResolveChildren = change.canResolve!;
-            if (change.canResolve) {
-                // Trigger root-level test discovery, matching VS Code behavior
+            if (change.canResolve && !this.hasTriggeredInitialResolve) {
+                this.hasTriggeredInitialResolve = true;
                 this.resolveChildren();
             }
         }

--- a/packages/plugin-ext/src/main/browser/test-main.ts
+++ b/packages/plugin-ext/src/main/browser/test-main.ts
@@ -410,7 +410,7 @@ class TestControllerImpl implements TestController {
     private _runs = new SimpleObservableCollection<TestRunImpl>();
     readonly deltaBuilder = new AccumulatingTreeDeltaEmitter<string, TestItemImpl>(300);
     canRefresh: boolean;
-    private canResolveChildren: boolean = false;
+    canResolveChildren: boolean = false;
     readonly items = new TestItemCollection(this, item => item.path, () => this.deltaBuilder);
 
     constructor(private readonly proxy: TestingExt, readonly id: string, public label: string) {
@@ -510,6 +510,10 @@ class TestControllerImpl implements TestController {
         }
         if ('canResolve' in change) {
             this.canResolveChildren = change.canResolve!;
+            if (change.canResolve) {
+                // Trigger root-level test discovery, matching VS Code behavior
+                this.resolveChildren();
+            }
         }
         if ('label' in change) {
             this.label = change.label!;
@@ -543,9 +547,14 @@ class TestControllerImpl implements TestController {
     }
     onItemsChanged: Event<TreeDelta<string, TestItemImpl>[]> = this.deltaBuilder.onDidFlush;
 
-    resolveChildren(item: TestItem): void {
+    resolveChildren(item?: TestItem): void {
         if (this.canResolveChildren) {
-            this.proxy.$onResolveChildren(this.id, itemToPath(item));
+            if (item) {
+                this.proxy.$onResolveChildren(this.id, itemToPath(item));
+            } else {
+                // Root-level resolve: trigger discovery of top-level test items
+                this.proxy.$onResolveChildren(this.id, []);
+            }
         }
     }
 

--- a/packages/plugin-ext/src/plugin/test-item.ts
+++ b/packages/plugin-ext/src/plugin/test-item.ts
@@ -132,9 +132,14 @@ export class TestItemCollection implements theia.TestItemCollection {
         return this.values.size;
     }
     replace(items: readonly theia.TestItem[]): void {
-        const toRemove = this.values.values.map(item => item.id);
-        items.forEach(item => this.add(item));
-        toRemove.forEach(key => this.delete(key));
+        const toDelete = new Set(this.values.values.map(item => item.id));
+        for (const item of items) {
+            toDelete.delete(item.id);
+            this.add(item);
+        }
+        for (const id of toDelete) {
+            this.delete(id);
+        }
     }
 
     forEach(callback: (item: theia.TestItem, collection: theia.TestItemCollection) => unknown, thisArg?: unknown): void {

--- a/packages/plugin-ext/src/plugin/tests.ts
+++ b/packages/plugin-ext/src/plugin/tests.ts
@@ -299,6 +299,9 @@ export class TestRun implements theia.TestRun {
     }
 
     end(): void {
+        if (this.ended) {
+            return;
+        }
         this.changeBatcher.flush();
         this.ended = true;
         this.proxy.$notifyTestRunEnded(this.controller.id, this.id);

--- a/packages/plugin-ext/src/plugin/tests.ts
+++ b/packages/plugin-ext/src/plugin/tests.ts
@@ -434,7 +434,9 @@ export class TestingExtImpl implements TestingExt {
                 controller.resolveHandler(undefined);
             } else {
                 const item = controller.items.find(path);
-                if (item?.canResolveChildren) { // the item and resolve handler might have been been changed, but not sent to the front end
+                // The `main` side should only request resolution for items with `canResolveChildren`, but with event batching,
+                // the flag can be out of sync with the state on the `plugin` side. The state on the `plugin` side is authoritative.
+                if (item?.canResolveChildren) {
                     controller.resolveHandler(item);
                 }
             }

--- a/packages/plugin-ext/src/plugin/tests.ts
+++ b/packages/plugin-ext/src/plugin/tests.ts
@@ -299,6 +299,7 @@ export class TestRun implements theia.TestRun {
     }
 
     end(): void {
+        this.changeBatcher.flush();
         this.ended = true;
         this.proxy.$notifyTestRunEnded(this.controller.id, this.id);
     }
@@ -428,9 +429,14 @@ export class TestingExtImpl implements TestingExt {
     $onResolveChildren(controllerId: string, path: string[]): void {
         const controller = this.withController(controllerId);
         if (controller.resolveHandler) {
-            const item = controller.items.find(path);
-            if (item?.canResolveChildren) { // the item and resolve handler might have been been changed, but not sent to the front end
-                controller.resolveHandler?.(item);
+            if (path.length === 0) {
+                // Root-level resolve: discover top-level test items
+                controller.resolveHandler(undefined);
+            } else {
+                const item = controller.items.find(path);
+                if (item?.canResolveChildren) { // the item and resolve handler might have been been changed, but not sent to the front end
+                    controller.resolveHandler(item);
+                }
             }
         }
     }

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -119,7 +119,22 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
     $onWorkspaceFoldersChanged(event: WorkspaceRootsChangeEvent): void {
         const newRoots = event.roots || [];
-        const newFolders = newRoots.map((root, index) => this.toWorkspaceFolder(root, index));
+        const oldFoldersByUri = new Map<string, theia.WorkspaceFolder>();
+        if (this.folders) {
+            for (const folder of this.folders) {
+                oldFoldersByUri.set(folder.uri.toString(), folder);
+            }
+        }
+        const newFolders = newRoots.map((root, index) => {
+            const existing = oldFoldersByUri.get(root);
+            if (existing) {
+                // Preserve object identity even if the index changed,
+                // since extensions may use folder objects as Map keys.
+                Object.assign(existing, { index });
+                return existing;
+            }
+            return this.toWorkspaceFolder(root, index);
+        });
         const delta = this.deltaFolders(this.folders, newFolders);
 
         this.folders = newFolders;

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -39,7 +39,6 @@ import { Disposable, URI } from './types-impl';
 import { normalize } from '@theia/core/lib/common/paths';
 import { relative } from '../common/paths-util';
 import { Schemes, UriComponents } from '../common/uri-components';
-import { toWorkspaceFolder } from './type-converters';
 import { MessageRegistryExt } from './message-registry';
 import * as Converter from './type-converters';
 import { FileStat } from '@theia/filesystem/lib/common/files';
@@ -347,7 +346,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
             const folderPath = folder.uri.toString();
 
             if (resourcePath === folderPath) {
-                return toWorkspaceFolder(folder);
+                return folder;
             }
 
             if (resourcePath.startsWith(folderPath)

--- a/packages/test/src/browser/test-execution-progress-service.ts
+++ b/packages/test/src/browser/test-execution-progress-service.ts
@@ -17,6 +17,7 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { Widget } from '@theia/core/lib/browser';
 import { TestResultViewContribution } from './view/test-result-view-contribution';
+import { TestOutputViewContribution } from './view/test-output-view-contribution';
 import { TestViewContribution } from './view/test-view-contribution';
 import { TestPreferences } from '../common/test-preferences';
 
@@ -32,6 +33,9 @@ export class DefaultTestExecutionProgressService implements TestExecutionProgres
     @inject(TestResultViewContribution)
     protected readonly testResultView: TestResultViewContribution;
 
+    @inject(TestOutputViewContribution)
+    protected readonly testOutputView: TestOutputViewContribution;
+
     @inject(TestViewContribution)
     protected readonly testView: TestViewContribution;
 
@@ -45,6 +49,7 @@ export class DefaultTestExecutionProgressService implements TestExecutionProgres
                 this.openTestResultView();
             }
         }
+        this.testOutputView.openView({ activate: !preserveFocus });
     }
 
     async openTestResultView(): Promise<Widget> {

--- a/packages/test/src/browser/test-execution-progress-service.ts
+++ b/packages/test/src/browser/test-execution-progress-service.ts
@@ -47,9 +47,9 @@ export class DefaultTestExecutionProgressService implements TestExecutionProgres
             const openTesting = this.testPreferences['testing.openTesting'];
             if (openTesting === 'openOnTestStart') {
                 this.openTestResultView();
+                this.testOutputView.openView({ activate: false });
             }
         }
-        this.testOutputView.openView({ activate: !preserveFocus });
     }
 
     async openTestResultView(): Promise<Widget> {

--- a/packages/test/src/browser/test-service.ts
+++ b/packages/test/src/browser/test-service.ts
@@ -173,12 +173,14 @@ export interface TestController {
     readonly tests: readonly TestItem[];
     readonly testRunProfiles: readonly TestRunProfile[];
     readonly testRuns: readonly TestRun[];
+    readonly canResolveChildren: boolean;
 
     readonly onItemsChanged: Event<TreeDelta<string, TestItem>[]>;
     readonly onRunsChanged: Event<CollectionDelta<TestRun, TestRun>>;
     readonly onProfilesChanged: Event<CollectionDelta<TestRunProfile, TestRunProfile>>;
 
     refreshTests(token: CancellationToken): Promise<void>;
+    resolveChildren(item?: TestItem): void;
     clearRuns(): void;
 }
 

--- a/packages/test/src/browser/view/test-output-ui-model.ts
+++ b/packages/test/src/browser/view/test-output-ui-model.ts
@@ -27,6 +27,7 @@ export interface ActiveRunEvent {
 export interface TestOutputSource {
     readonly output: readonly TestOutputItem[];
     onDidAddTestOutput: Event<TestOutputItem[]>;
+    readonly noOutputMessage?: string;
 }
 
 export interface ActiveTestStateChangedEvent {

--- a/packages/test/src/browser/view/test-output-widget.ts
+++ b/packages/test/src/browser/view/test-output-widget.ts
@@ -78,7 +78,11 @@ export class TestOutputWidget extends BaseWidget {
         this.disposeOnSetInput = new DisposableCollection();
         this.term.clear();
         if (selectedOutputSource) {
-            selectedOutputSource.output.forEach(item => this.term.writeln(item.output));
+            if (selectedOutputSource.output.length === 0 && selectedOutputSource.noOutputMessage) {
+                this.term.writeln(selectedOutputSource.noOutputMessage);
+            } else {
+                selectedOutputSource.output.forEach(item => this.term.writeln(item.output));
+            }
             this.disposeOnSetInput.push(selectedOutputSource.onDidAddTestOutput(items => {
                 items.forEach(item => this.term.writeln(item.output));
             }));

--- a/packages/test/src/browser/view/test-result-widget.ts
+++ b/packages/test/src/browser/view/test-result-widget.ts
@@ -62,6 +62,10 @@ export class TestResultWidget extends BaseWidget {
                 this.setInput(e.messages);
             }
         })]);
+        const currentState = this.uiModel.selectedTestState;
+        if (TestFailure.is(currentState)) {
+            this.setInput(currentState.messages);
+        }
     }
 
     protected override onAfterAttach(msg: Message): void {

--- a/packages/test/src/browser/view/test-run-view-contribution.ts
+++ b/packages/test/src/browser/view/test-run-view-contribution.ts
@@ -14,14 +14,24 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { AbstractViewContribution, Widget } from '@theia/core/lib/browser';
+import { AbstractViewContribution, Widget, codicon } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { TestRun, TestService } from '../test-service';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { TestRunTreeWidget } from './test-run-widget';
+import { TestOutputViewContribution } from './test-output-view-contribution';
 import { TEST_VIEW_CONTAINER_ID, TestViewCommands } from './test-view-contribution';
-import { CommandRegistry, MenuModelRegistry, nls } from '@theia/core';
+import { Command, CommandRegistry, MenuModelRegistry, nls } from '@theia/core';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+
+export namespace TestRunViewCommands {
+    export const SHOW_OUTPUT: Command = Command.toLocalizedCommand({
+        id: 'testing.showTestOutput',
+        label: 'Show Test Output',
+        category: 'Test',
+        iconClass: codicon('symbol-keyword')
+    }, 'theia/test/showTestOutput', nls.getDefaultKey('Test'));
+}
 
 export const TEST_RUNS_CONTEXT_MENU = ['test-runs-context-menu'];
 export const TEST_RUNS_INLINE_MENU = [...TEST_RUNS_CONTEXT_MENU, 'inline'];
@@ -31,6 +41,7 @@ export class TestRunViewContribution extends AbstractViewContribution<TestRunTre
 
     @inject(TestService) protected readonly testService: TestService;
     @inject(ContextKeyService) protected readonly contextKeys: ContextKeyService;
+    @inject(TestOutputViewContribution) protected readonly testOutputView: TestOutputViewContribution;
 
     constructor() {
         super({
@@ -45,6 +56,11 @@ export class TestRunViewContribution extends AbstractViewContribution<TestRunTre
     }
 
     registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        registry.registerItem({
+            id: TestRunViewCommands.SHOW_OUTPUT.id,
+            command: TestRunViewCommands.SHOW_OUTPUT.id,
+            priority: 0
+        });
         registry.registerItem({
             id: TestViewCommands.CLEAR_ALL_RESULTS.id,
             command: TestViewCommands.CLEAR_ALL_RESULTS.id,
@@ -61,6 +77,11 @@ export class TestRunViewContribution extends AbstractViewContribution<TestRunTre
 
     override registerCommands(commands: CommandRegistry): void {
         super.registerCommands(commands);
+        commands.registerCommand(TestRunViewCommands.SHOW_OUTPUT, {
+            isEnabled: w => this.withWidget(w, () => true),
+            isVisible: w => this.withWidget(w, () => true),
+            execute: () => this.testOutputView.openView({ activate: true })
+        });
         commands.registerCommand(TestViewCommands.CANCEL_RUN, {
             isEnabled: t => TestRun.is(t) && t.isRunning,
             isVisible: t => TestRun.is(t),

--- a/packages/test/src/browser/view/test-run-widget.tsx
+++ b/packages/test/src/browser/view/test-run-widget.tsx
@@ -182,6 +182,8 @@ export class TestRunTreeWidget extends TreeWidget {
     @inject(TestExecutionStateManager) protected readonly stateManager: TestExecutionStateManager;
     @inject(TestOutputUIModel) protected readonly uiModel: TestOutputUIModel;
 
+    protected readonly selectedItemStateListener = new DisposableCollection();
+
     constructor(
         @inject(TreeProps) props: TreeProps,
         @inject(TreeModel) model: TreeModel,
@@ -199,7 +201,9 @@ export class TestRunTreeWidget extends TreeWidget {
     protected override init(): void {
         super.init();
         this.addClass('theia-test-run-view');
-        this.model.onSelectionChanged(() => {
+        this.toDispose.push(this.selectedItemStateListener);
+        this.toDispose.push(this.model.onSelectionChanged(() => {
+            this.selectedItemStateListener.dispose();
             const node = this.model.selectedNodes[0];
             if (node instanceof TestRunNode) {
                 this.uiModel.selectedOutputSource = {
@@ -209,28 +213,37 @@ export class TestRunTreeWidget extends TreeWidget {
                     onDidAddTestOutput: Event.map(node.run.onDidChangeTestOutput, evt => evt.map(item => item[1]))
                 };
             } else if (node instanceof TestItemNode) {
-                const testState = node.parent.run.getTestState(node.item);
+                const run = node.parent.run;
+                const item = node.item;
                 this.uiModel.selectedOutputSource = {
                     get output(): readonly TestOutputItem[] {
-                        const itemOutput = node.parent.run.getOutput(node.item);
+                        const itemOutput = run.getOutput(item);
                         if (itemOutput.length > 0) {
                             return itemOutput;
                         }
-                        if (TestFailure.is(testState)) {
-                            return testState.messages.map(msg => ({
+                        const currentState = run.getTestState(item);
+                        if (TestFailure.is(currentState)) {
+                            return currentState.messages.map(msg => ({
                                 output: typeof msg.message === 'string' ? msg.message : msg.message.value
                             }));
                         }
                         return [];
                     },
-                    onDidAddTestOutput: Event.map(node.parent.run.onDidChangeTestOutput, evt =>
-                        evt.filter(item => item[0] === node.item).map(item => item[1])
+                    onDidAddTestOutput: Event.map(run.onDidChangeTestOutput, evt =>
+                        evt.filter(output => output[0] === item).map(output => output[1])
                     ),
                     noOutputMessage: nls.localizeByDefault('The test case did not report any output.')
                 };
-                this.uiModel.selectedTestState = testState;
+                this.uiModel.selectedTestState = run.getTestState(item);
+                // Keep selectedTestState (and its derived context key) in sync while this item stays selected.
+                this.selectedItemStateListener.push(run.onDidChangeTestState(deltas => {
+                    const update = deltas.find(delta => delta.test === item);
+                    if (update) {
+                        this.uiModel.selectedTestState = update.newState;
+                    }
+                }));
             }
-        });
+        }));
     }
 
     protected override renderTree(model: TreeModel): React.ReactNode {

--- a/packages/test/src/browser/view/test-run-widget.tsx
+++ b/packages/test/src/browser/view/test-run-widget.tsx
@@ -25,7 +25,6 @@ import * as React from '@theia/core/shared/react';
 import { Disposable, DisposableCollection, Event, nls } from '@theia/core';
 import { TestExecutionStateManager } from './test-execution-state-manager';
 import { TestOutputUIModel } from './test-output-ui-model';
-import { TestOutputViewContribution } from './test-output-view-contribution';
 
 class TestRunNode implements TreeNode, SelectableTreeNode {
     constructor(readonly counter: number, readonly id: string, readonly run: TestRun, readonly parent: CompositeTreeNode) { }
@@ -182,7 +181,6 @@ export class TestRunTreeWidget extends TreeWidget {
     @inject(ThemeService) protected readonly themeService: ThemeService;
     @inject(TestExecutionStateManager) protected readonly stateManager: TestExecutionStateManager;
     @inject(TestOutputUIModel) protected readonly uiModel: TestOutputUIModel;
-    @inject(TestOutputViewContribution) protected readonly testOutputView: TestOutputViewContribution;
 
     constructor(
         @inject(TreeProps) props: TreeProps,
@@ -211,22 +209,26 @@ export class TestRunTreeWidget extends TreeWidget {
                     onDidAddTestOutput: Event.map(node.run.onDidChangeTestOutput, evt => evt.map(item => item[1]))
                 };
             } else if (node instanceof TestItemNode) {
+                const testState = node.parent.run.getTestState(node.item);
                 this.uiModel.selectedOutputSource = {
                     get output(): readonly TestOutputItem[] {
                         const itemOutput = node.parent.run.getOutput(node.item);
-                        return itemOutput.length > 0 ? itemOutput : node.parent.run.getOutput();
+                        if (itemOutput.length > 0) {
+                            return itemOutput;
+                        }
+                        if (TestFailure.is(testState)) {
+                            return testState.messages.map(msg => ({
+                                output: typeof msg.message === 'string' ? msg.message : msg.message.value
+                            }));
+                        }
+                        return [];
                     },
-                    onDidAddTestOutput: Event.map(node.parent.run.onDidChangeTestOutput, evt => {
-                        const itemEvents = evt.filter(item => item[0] === node.item).map(item => item[1]);
-                        return itemEvents.length > 0 ? itemEvents : evt.map(item => item[1]);
-                    })
+                    onDidAddTestOutput: Event.map(node.parent.run.onDidChangeTestOutput, evt =>
+                        evt.filter(item => item[0] === node.item).map(item => item[1])
+                    ),
+                    noOutputMessage: nls.localizeByDefault('The test case did not report any output.')
                 };
-                this.uiModel.selectedTestState = node.parent.run.getTestState(node.item);
-            }
-        });
-        this.model.onOpenNode(node => {
-            if (node instanceof TestRunNode || node instanceof TestItemNode) {
-                this.testOutputView.openView({ activate: true });
+                this.uiModel.selectedTestState = testState;
             }
         });
     }

--- a/packages/test/src/browser/view/test-run-widget.tsx
+++ b/packages/test/src/browser/view/test-run-widget.tsx
@@ -25,6 +25,7 @@ import * as React from '@theia/core/shared/react';
 import { Disposable, DisposableCollection, Event, nls } from '@theia/core';
 import { TestExecutionStateManager } from './test-execution-state-manager';
 import { TestOutputUIModel } from './test-output-ui-model';
+import { TestOutputViewContribution } from './test-output-view-contribution';
 
 class TestRunNode implements TreeNode, SelectableTreeNode {
     constructor(readonly counter: number, readonly id: string, readonly run: TestRun, readonly parent: CompositeTreeNode) { }
@@ -181,6 +182,7 @@ export class TestRunTreeWidget extends TreeWidget {
     @inject(ThemeService) protected readonly themeService: ThemeService;
     @inject(TestExecutionStateManager) protected readonly stateManager: TestExecutionStateManager;
     @inject(TestOutputUIModel) protected readonly uiModel: TestOutputUIModel;
+    @inject(TestOutputViewContribution) protected readonly testOutputView: TestOutputViewContribution;
 
     constructor(
         @inject(TreeProps) props: TreeProps,
@@ -211,11 +213,20 @@ export class TestRunTreeWidget extends TreeWidget {
             } else if (node instanceof TestItemNode) {
                 this.uiModel.selectedOutputSource = {
                     get output(): readonly TestOutputItem[] {
-                        return node.parent.run.getOutput(node.item);
+                        const itemOutput = node.parent.run.getOutput(node.item);
+                        return itemOutput.length > 0 ? itemOutput : node.parent.run.getOutput();
                     },
-                    onDidAddTestOutput: Event.map(node.parent.run.onDidChangeTestOutput, evt => evt.filter(item => item[0] === node.item).map(item => item[1]))
+                    onDidAddTestOutput: Event.map(node.parent.run.onDidChangeTestOutput, evt => {
+                        const itemEvents = evt.filter(item => item[0] === node.item).map(item => item[1]);
+                        return itemEvents.length > 0 ? itemEvents : evt.map(item => item[1]);
+                    })
                 };
                 this.uiModel.selectedTestState = node.parent.run.getTestState(node.item);
+            }
+        });
+        this.model.onOpenNode(node => {
+            if (node instanceof TestRunNode || node instanceof TestItemNode) {
+                this.testOutputView.openView({ activate: true });
             }
         });
     }

--- a/packages/test/src/browser/view/test-tree-widget.tsx
+++ b/packages/test/src/browser/view/test-tree-widget.tsx
@@ -95,6 +95,7 @@ export class TestTree extends TreeImpl {
             parent.testItem.resolveChildren();
             return Promise.resolve(parent.testItem.tests.map(test => this.createTestNode(parent.controller, parent, test)));
         } else if (TestControllerNode.is(parent)) {
+            parent.controller.resolveChildren();
             return Promise.resolve(parent.controller.tests.map(test => this.createTestNode(parent.controller, parent, test)));
         } else if (TestRoot.is(parent)) {
             return Promise.resolve(this.testService.getControllers().map(controller => this.createControllerNode(parent, controller)));

--- a/packages/test/src/browser/view/test-tree-widget.tsx
+++ b/packages/test/src/browser/view/test-tree-widget.tsx
@@ -95,7 +95,6 @@ export class TestTree extends TreeImpl {
             parent.testItem.resolveChildren();
             return Promise.resolve(parent.testItem.tests.map(test => this.createTestNode(parent.controller, parent, test)));
         } else if (TestControllerNode.is(parent)) {
-            parent.controller.resolveChildren();
             return Promise.resolve(parent.controller.tests.map(test => this.createTestNode(parent.controller, parent, test)));
         } else if (TestRoot.is(parent)) {
             return Promise.resolve(this.testService.getControllers().map(controller => this.createControllerNode(parent, controller)));

--- a/packages/test/src/common/collections.ts
+++ b/packages/test/src/common/collections.ts
@@ -128,13 +128,9 @@ abstract class AbstractIndexedCollection<K, T> {
 
     protected doAdd(key: K, value: T): T | undefined {
         const previous = this.keys.get(key);
-        if (previous !== undefined) {
-            return previous;
-        } else {
-            this.keys.set(key, value);
-            this._values = undefined;
-            return undefined;
-        }
+        this.keys.set(key, value);
+        this._values = undefined;
+        return previous !== undefined ? previous : undefined;
     }
 
     remove(key: K): T | undefined {

--- a/packages/test/src/common/collections.ts
+++ b/packages/test/src/common/collections.ts
@@ -130,7 +130,7 @@ abstract class AbstractIndexedCollection<K, T> {
         const previous = this.keys.get(key);
         this.keys.set(key, value);
         this._values = undefined;
-        return previous !== undefined ? previous : undefined;
+        return previous;
     }
 
     remove(key: K): T | undefined {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes multiple bugs that prevented test extensions (e.g. Python unittest, Playwright Test) from working reliably in Theia. Resolves #16389 

Bug fixes:

- `getWorkspaceFolder` now returns the original folder object instead of creating a new one, preserving reference equality for extensions that use `workspace.uri` as a `Map` key
- Root-level test discovery is now triggered by calling `resolveHandler(undefined)` when a controller registers, matching VS Code behavior
- `TestRun.end()` now flushes the change batcher so pending state updates are not silently dropped
- `TestItemCollection.replace()` no longer deletes newly-added items that share IDs with old ones
- `AbstractIndexedCollection.doAdd()` now actually replaces existing entries instead of silently discarding the new value

UX improvements:

- Auto-open Test Output panel when a test run starts
- Add "Show Test Output" toolbar button to the Test Runs view
- Open Test Output panel on double-click of test run/item nodes
- Show the selected test item's own output if present, falling back to the failure messages for failed/errored tests and to a placeholder for everything else

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Python unittest:

1. Start an example application and make sure the builtins are downloaded; python is a builtin
2. Create a workspace folder and add a test file, e.g. as example this `test/mytest.py`:
   ```python
   import unittest

   def add(a, b):
       return a + b

   class TestAddFunction(unittest.TestCase):
       def test_add_positive_numbers(self):
           self.assertEqual(add(2, 3), 5)

       def test_add_negative_numbers(self):
           self.assertEqual(add(-1, -1), -2)

       def test_add_mixed_sign_numbers(self):
           self.assertEqual(add(-1, 1), 0)
       def test_expect_failure(self):
           self.assertEqual(add(-1, 1), 5, "This test fails intentionally")

   if __name__ == '__main__':
       unittest.main()
   ```
3. Open the Command Palette and run "Python: Configure Tests" → select "unittest" → select `./test` as root → `*test.py` as pattern
4. Open the Testing panel - tests should appear automatically (reload can be necessary on the first setup though)
5. Run tests - verify they pass and results appear in the Test Runs section below the Test Explorer
6. Modify the test file (e.g. change an expected value) and run again - verify results update correctly
7. Run multiple times consecutively - verify tests remain stable

Playwright Test:

1. Install the "Playwright Test for VS Code" extension from Open VSX (`ms-playwright.playwright`)
2. Open a the theia repo (has `playwright.config.ts` and `.spec.ts` test files)
3. Tests should appear in the Testing panel and can be run

Test output visibility:

1. After running any test, verify the Test Output panel opens automatically in the bottom area
2. In the Test Runs area, click the icon to open/focus the Test Output panel
3. Select the test run and verify the output summary is shown in the test output view
4. Select individual test items in Test Runs and verify output is shown in the test output view
   - for the expected failing test case you can see the error stack
   - for the successful ones you see the placeholder string `The test case did not report any output.`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- The `ms-python.vscode-python-envs` extension's PET binary is not included when the Python extension is downloaded as a universal (non-platform-specific) VSIX from Open VSX. This causes the Python environment picker to not work properly. A follow-up could ensure Theia downloads platform-specific extension packages when available.
- The `ms-python.vscode-python-envs` extension may register a duplicate "Select Python Interpreter" status bar item alongside the one from `ms-python.python`, likely because both extensions register their own item and the coordination between them relies on VS Code-specific internals.
- Show extension-contributed welcome views (e.g. "Configure Python Tests" button) in the Testing panel when no tests are configured
- Catch and surface errors from `resolveHandler` (e.g. "Test provider types are not aligned") as error items in the test tree, matching VS Code's UX
- Defer the initial root-level resolveHandler(undefined) call until the user reveals the Test Explorer, so we don't populate test trees that never get looked at. The follow-up needs to also cover command-palette workflows (e.g. "Run All Tests", "Refresh Tests") so they still trigger discovery when the view was never opened, see review thread on https://github.com/eclipse-theia/theia/pull/17341#discussion_r3080983872.  

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
