### PR TITLE
remote: support macOS arm64 and rolling `next` native dependencies

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -58,7 +58,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, ubuntu-22.04, macos-14]
+        os: [windows-2022, ubuntu-22.04, macos-15]
         node: [22.x, 24.x]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/native-dependencies.yml
+++ b/.github/workflows/native-dependencies.yml
@@ -1,5 +1,8 @@
 name: Package Native Dependencies
 
+permissions:
+  contents: read
+
 on: workflow_dispatch
 
 jobs:
@@ -7,7 +10,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["ubuntu-22.04", "windows-latest", "macos-latest"]
+        # macos-15 = arm64, macos-15-intel = x64 (aligned with eclipse-theia/theia-ide).
+        os: [ubuntu-22.04, windows-2022, macos-15, macos-15-intel]
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -24,7 +28,7 @@ jobs:
         with:
           python-version: "3.13"
 
-      - name: Install and Build
+      - name: Install
         shell: bash
         run: |
           npm ci
@@ -48,3 +52,4 @@ jobs:
         with:
           name: native-dependencies-${{ matrix.os }}
           path: ./scripts/native-dependencies-*.zip
+          retention-days: 7

--- a/.github/workflows/native-dependencies.yml
+++ b/.github/workflows/native-dependencies.yml
@@ -3,18 +3,29 @@ name: Package Native Dependencies
 permissions:
   contents: read
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  # Fires after publish-ci.yml completes. publish-next filters for scheduled
+  # next publishes; stable releases use workflow_dispatch instead.
+  # NOTE: Matched by name; renaming publish-ci.yml breaks this trigger.
+  workflow_run:
+    workflows: ["Publish packages to NPM"]
+    types: [completed]
 
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        # Full matrix on dispatch (stable releases), linux-only on workflow_run (next).
         # macos-15 = arm64, macos-15-intel = x64 (aligned with eclipse-theia/theia-ide).
-        os: [ubuntu-22.04, windows-2022, macos-15, macos-15-intel]
+        os: ${{ fromJSON(github.event_name == 'workflow_dispatch' && '["ubuntu-22.04","windows-2022","macos-15","macos-15-intel"]' || '["ubuntu-22.04"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # On workflow_run, check out the exact published commit.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       # Update the node version here after every Electron upgrade
       - name: Use Node.js v22.20.0
@@ -53,3 +64,40 @@ jobs:
           name: native-dependencies-${{ matrix.os }}
           path: ./scripts/native-dependencies-*.zip
           retention-days: 7
+
+  # Publishes a rolling `next` pre-release after a successful scheduled npm
+  # next publish on master. Stable releases skip this; the maintainer attaches
+  # artifacts to the vX.Y.Z release manually.
+  publish-next:
+    name: Publish to rolling `next` pre-release
+    needs: build
+    if: >-
+      ${{ github.event_name == 'workflow_run' &&
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'schedule' &&
+          github.event.workflow_run.head_branch == 'master' }}
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
+    steps:
+      - name: Download native-dependencies artifacts
+        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        with:
+          pattern: native-dependencies-*
+          merge-multiple: true
+          path: ./native-deps
+
+      - name: Publish rolling `next` release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PUBLISHED_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: |
+          gh release delete next --yes --cleanup-tag 2>/dev/null || true
+          gh release create next \
+            --title "Native Dependencies - Next ($(date -u '+%Y-%m-%d'))" \
+            --notes "Automated next build of native dependencies from \`master\` (commit \`${PUBLISHED_SHA}\`, $(date -u '+%Y-%m-%d %H:%M UTC'))." \
+            --prerelease \
+            --target "${PUBLISHED_SHA}" \
+            ./native-deps/native-dependencies-*.zip

--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -99,6 +99,27 @@ jobs:
         env:
           NPM_CONFIG_PROVENANCE: "true"
 
+      - name: Create and push git tag (Next)
+        # Tag the published commit so the canary version published to npm has a
+        # 1:1 mapping to a git commit. Consumed by native-dependencies.yml via
+        # workflow_run to build native dependencies at exactly this commit.
+        if: ${{ env.RELEASE_TYPE == 'next' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config --local user.email "eclipse-theia-bot@eclipse.org"
+          git config --local user.name "eclipse-theia-bot"
+          VERSION=$(npm view @theia/core@next version)
+          if [ -z "$VERSION" ]; then
+            echo "Failed to resolve the just-published next version from npm." >&2
+            exit 1
+          fi
+          TAG="v${VERSION}"
+          echo "Tagging $TAG at $(git rev-parse HEAD)"
+          git tag "$TAG"
+          git push origin "$TAG"
+
       - name: Submit PR for package updates
         if: ${{ env.RELEASE_TYPE != 'next' }}
         shell: bash

--- a/doc/Publishing.md
+++ b/doc/Publishing.md
@@ -403,6 +403,7 @@ _NOTE:_ Performing the release locally will publish unsigned packages to NPM.
   - Reference the `changelog` and breaking changes.
   - Attach _Native Dependencies_ artifacts (the extracted zips).
     - native-dependencies-darwin-arm64.zip
+    - native-dependencies-darwin-x64.zip
     - native-dependencies-linux-x64.zip
     - native-dependencies-win32-x64.zip
   - Mark the release as `latest`
@@ -425,6 +426,7 @@ Eclipse Theia v{{version}}
   - Use `Generate release notes` for the changelog link.
   - Attach _Native Dependencies_ artifacts (the extracted zips).
     - native-dependencies-darwin-arm64.zip
+    - native-dependencies-darwin-x64.zip
     - native-dependencies-linux-x64.zip
     - native-dependencies-win32-x64.zip
   - Optional: Mark the release as `latest` (_Uncheck for a patch on an OLDER version!!_).

--- a/packages/remote/src/electron-node/setup/app-native-dependency-contribution.spec.ts
+++ b/packages/remote/src/electron-node/setup/app-native-dependency-contribution.spec.ts
@@ -41,6 +41,11 @@ describe('AppNativeDependencyContribution', () => {
         expect(x64).to.equal(`${base}/v1.70.2/native-dependencies-darwin-x64.zip`);
     });
 
+    it('routes -next. versions to the rolling `next` tag', () => {
+        const url = contribution.publicGetDefaultURLForFile({ os: OS.Type.Linux, arch: 'x64' }, '1.71.0-next.28+df29ab0fb');
+        expect(url).to.equal(`${base}/next/native-dependencies-linux-x64.zip`);
+    });
+
     it('throws a clear error for unsupported (os, arch) combinations', () => {
         expect(() => contribution.publicGetDefaultURLForFile({ os: OS.Type.Linux, arch: 'arm64' }, '1.70.2'))
             .to.throw(/No prebuilt native dependencies are published/);

--- a/packages/remote/src/electron-node/setup/app-native-dependency-contribution.spec.ts
+++ b/packages/remote/src/electron-node/setup/app-native-dependency-contribution.spec.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { OS } from '@theia/core';
+import { RemotePlatform } from '@theia/core/lib/node/remote/remote-cli-contribution';
+import { AppNativeDependencyContribution } from './app-native-dependency-contribution';
+
+class TestableAppNativeDependencyContribution extends AppNativeDependencyContribution {
+    publicGetDefaultURLForFile(remotePlatform: RemotePlatform, theiaVersion: string): string {
+        return this.getDefaultURLForFile(remotePlatform, theiaVersion);
+    }
+}
+
+describe('AppNativeDependencyContribution', () => {
+    const contribution = new TestableAppNativeDependencyContribution();
+    const base = 'https://github.com/eclipse-theia/theia/releases/download';
+
+    it('builds stable URLs for linux-x64', () => {
+        const url = contribution.publicGetDefaultURLForFile({ os: OS.Type.Linux, arch: 'x64' }, '1.70.2');
+        expect(url).to.equal(`${base}/v1.70.2/native-dependencies-linux-x64.zip`);
+    });
+
+    it('builds stable URLs for both Mac variants', () => {
+        const arm = contribution.publicGetDefaultURLForFile({ os: OS.Type.OSX, arch: 'arm64' }, '1.70.2');
+        expect(arm).to.equal(`${base}/v1.70.2/native-dependencies-darwin-arm64.zip`);
+        const x64 = contribution.publicGetDefaultURLForFile({ os: OS.Type.OSX, arch: 'x64' }, '1.70.2');
+        expect(x64).to.equal(`${base}/v1.70.2/native-dependencies-darwin-x64.zip`);
+    });
+
+    it('throws a clear error for unsupported (os, arch) combinations', () => {
+        expect(() => contribution.publicGetDefaultURLForFile({ os: OS.Type.Linux, arch: 'arm64' }, '1.70.2'))
+            .to.throw(/No prebuilt native dependencies are published/);
+        expect(() => contribution.publicGetDefaultURLForFile({ os: OS.Type.Windows, arch: 'arm64' }, '1.70.2'))
+            .to.throw(/No prebuilt native dependencies are published/);
+    });
+});

--- a/packages/remote/src/electron-node/setup/app-native-dependency-contribution.ts
+++ b/packages/remote/src/electron-node/setup/app-native-dependency-contribution.ts
@@ -25,9 +25,15 @@ export class AppNativeDependencyContribution implements RemoteNativeDependencyCo
     appDownloadUrlBase = 'https://github.com/eclipse-theia/theia/releases/download';
 
     protected getDefaultURLForFile(remotePlatform: RemotePlatform, theiaVersion: string): string {
-        if (remotePlatform.arch !== 'x64') {
-            throw new Error(`Unsupported remote architecture '${remotePlatform.arch}'. Remote support is only available for x64 architectures.`);
-        }
+        this.validatePlatform(remotePlatform);
+        return `${this.appDownloadUrlBase}/${this.getReleaseTag(theiaVersion)}/${this.getAssetName(remotePlatform)}`;
+    }
+
+    protected getReleaseTag(theiaVersion: string): string {
+        return `v${theiaVersion}`;
+    }
+
+    protected getAssetName(remotePlatform: RemotePlatform): string {
         let platform: string;
         if (remotePlatform.os === OS.Type.Windows) {
             platform = 'win32';
@@ -36,7 +42,24 @@ export class AppNativeDependencyContribution implements RemoteNativeDependencyCo
         } else {
             platform = 'linux';
         }
-        return `${this.appDownloadUrlBase}/v${theiaVersion}/native-dependencies-${platform}-${remotePlatform.arch}.zip`;
+        return `native-dependencies-${platform}-${remotePlatform.arch}.zip`;
+    }
+
+    /**
+     * Validates that native dependencies are actually published for the given
+     * remote platform. The set of supported (os, arch) pairs mirrors the set
+     * accepted by `RemoteNodeSetupService.validatePlatform`, minus combinations
+     * for which we don't yet build native-dependency zips in CI.
+     */
+    protected validatePlatform(remotePlatform: RemotePlatform): void {
+        const { os, arch } = remotePlatform;
+        const supported =
+            (os === OS.Type.Windows && arch === 'x64') ||
+            (os === OS.Type.Linux && arch === 'x64') ||
+            (os === OS.Type.OSX && (arch === 'x64' || arch === 'arm64'));
+        if (!supported) {
+            throw new Error(`No prebuilt native dependencies are published for '${os}-${arch}'.`);
+        }
     }
 
     async download(options: DownloadOptions): Promise<DependencyDownload> {

--- a/packages/remote/src/electron-node/setup/app-native-dependency-contribution.ts
+++ b/packages/remote/src/electron-node/setup/app-native-dependency-contribution.ts
@@ -19,6 +19,13 @@ import { RemoteNativeDependencyContribution, DownloadOptions, DependencyDownload
 import { RemotePlatform } from '@theia/core/lib/node/remote/remote-cli-contribution';
 import { OS } from '@theia/core';
 
+/**
+ * GitHub release tag used for rolling pre-release publications of native
+ * dependencies for next-channel Theia versions (e.g. `1.71.0-next.28+sha`).
+ * Stable versions resolve to a `v<version>` tag instead.
+ */
+export const NEXT_RELEASE_TAG = 'next';
+
 @injectable()
 export class AppNativeDependencyContribution implements RemoteNativeDependencyContribution {
 
@@ -29,8 +36,13 @@ export class AppNativeDependencyContribution implements RemoteNativeDependencyCo
         return `${this.appDownloadUrlBase}/${this.getReleaseTag(theiaVersion)}/${this.getAssetName(remotePlatform)}`;
     }
 
+    /**
+     * Returns the GitHub release tag from which to download the native dependencies.
+     * Next-channel versions (containing `-next.`) resolve to the rolling `next`
+     * pre-release; stable versions resolve to `v<theiaVersion>`.
+     */
     protected getReleaseTag(theiaVersion: string): string {
-        return `v${theiaVersion}`;
+        return /-next\./.test(theiaVersion) ? NEXT_RELEASE_TAG : `v${theiaVersion}`;
     }
 
     protected getAssetName(remotePlatform: RemotePlatform): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Resolves GH-17266
- Resolves eclipse-theia/theia-ide/issues/701

macOS arm64 support for remote/dev-container:
- Removes the hard x64-only restriction in `AppNativeDependencyContribution` that blocked all non-x64 remote connections
- Validates against actually-published (os, arch) pairs instead: `win32-x64`, `linux-x64`, `darwin-x64`, `darwin-arm64`
- Splits URL construction into overridable `getReleaseTag` / `getAssetName` methods for downstream customization via DI
- Expands the `native-dependencies` workflow matrix to build both `macos-15` (arm64) and `macos-15-intel` (x64), aligned with `eclipse-theia/theia-ide`
- Updates `doc/Publishing.md` to list the new `darwin-x64` zip

Rolling `next` pre-release for native dependencies:
- Adds a `workflow_run` trigger to `native-dependencies.yml`, chained to `publish-ci.yml`. After each successful scheduled npm next publish on master, the workflow rebuilds linux-x64 native deps from the exact published commit and publishes them to a rolling `next` GitHub pre-release (matching the pattern from `theia-ide/build-next-release.yml`)
- Maps `-next.` Theia versions to the `next` release tag in `AppNativeDependencyContribution.getReleaseTag`, so next-channel consumers automatically resolve to the rolling pre-release
- Adds a git-tagging step to `publish-ci.yml` for next publishes, providing 1:1 traceability between npm next versions and git commits

CI runner update:
- Updates `ci-cd.yml` macOS runner from `macos-14` to `macos-15`, aligned with `theia-ide` and the `native-dependencies` workflow

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Run unit tests
- Stable path: trigger "Package Native Dependencies" via `workflow_dispatch` on the PR branch. Verify 4 artifacts appear (`ubuntu-22.04`, `windows-2022`, `macos-15`, `macos-15-intel`), each containing a correctly named zip
  - Test run: https://github.com/eclipse-theia/theia/actions/runs/24390563954
- Next path: after merge, wait for the next scheduled npm next publish. Verify the `next` GitHub pre-release is created with `native-dependencies-linux-x64.zip` and that the updated URL resolves
- Git tagging: after merge, verify a `v<next-version>` tag is pushed after the next scheduled npm next publish

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
