### PR TITLE
Dev Container improvements

### DIFF
--- a/packages/dev-container/README.md
+++ b/packages/dev-container/README.md
@@ -26,6 +26,7 @@ Currently not all of the configuration file properties are implemented. The foll
 - forwardPorts
 - mounts
 - containerEnv
+- remoteEnv
 - remoteUser
 - shutdownAction
 - postCreateCommand

--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { AbstractRemoteRegistryContribution, RemoteRegistry } from '@theia/remote/lib/electron-browser/remote-registry-contribution';
 import { DevContainerFile, LastContainerInfo, RemoteContainerConnectionProvider } from '../electron-common/remote-container-connection-provider';
 import { WorkspaceStorageService } from '@theia/workspace/lib/browser/workspace-storage-service';
@@ -38,9 +38,23 @@ export namespace RemoteContainerCommands {
         label: 'Attach to Running Container',
         category: 'Dev Container'
     }, 'theia/remote/dev-container/attach');
+
+    export const REBUILD_CONTAINER = Command.toLocalizedCommand({
+        id: 'dev-container:rebuild-container',
+        label: 'Rebuild Container',
+        category: 'Dev Container'
+    }, 'theia/remote/dev-container/rebuild');
 }
 
 const LAST_USED_CONTAINER = 'lastUsedContainer';
+const ACTIVE_DEV_CONTAINER_CONTEXT = 'activeDevContainerContext';
+
+interface DevContainerContext {
+    devcontainerFilePath: string;
+    devcontainerFileName: string;
+    hostWorkspacePath: string;
+    containerId: string;
+}
 @injectable()
 export class ContainerConnectionContribution extends AbstractRemoteRegistryContribution implements WorkspaceOpenHandlerContribution {
 
@@ -71,31 +85,85 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
     @inject(ContainerOutputProvider)
     protected readonly containerOutputProvider: ContainerOutputProvider;
 
+    protected hasDevContainerFiles = false;
+
+    @postConstruct()
+    protected init(): void {
+        // Mark that we're in a remote session. sessionStorage survives page
+        // reloads (disconnect) but is cleared on window close (restart).
+        // This lets canHandle() distinguish disconnect from restart.
+        if (this.isRemoteSession()) {
+            sessionStorage.setItem('devcontainer:wasRemote', 'true');
+        }
+        this.workspaceService.ready.then(() => this.checkForDevContainerFiles());
+        this.workspaceService.onWorkspaceChanged(() => this.checkForDevContainerFiles());
+    }
+
+    protected async checkForDevContainerFiles(): Promise<void> {
+        if (this.isRemoteSession()) {
+            this.hasDevContainerFiles = true;
+            return;
+        }
+        const workspace = this.workspaceService.workspace;
+        if (!workspace) {
+            this.hasDevContainerFiles = false;
+            return;
+        }
+        try {
+            const files = await this.connectionProvider.getDevContainerFiles(workspace.resource.path.toString());
+            this.hasDevContainerFiles = files.length > 0;
+        } catch (error) {
+            // Failed to check for devcontainer files, assume none exist
+            this.hasDevContainerFiles = false;
+        }
+    }
+
     registerRemoteCommands(registry: RemoteRegistry): void {
         registry.registerCommand(RemoteContainerCommands.REOPEN_IN_CONTAINER, {
-            execute: () => this.openInContainer()
+            execute: () => this.openInContainer(),
+            isVisible: () => !this.isRemoteSession() && this.hasDevContainerFiles
         });
         registry.registerCommand(RemoteContainerCommands.ATTACH_TO_CONTAINER, {
             execute: () => this.attachToContainer()
         });
+        registry.registerCommand(RemoteContainerCommands.REBUILD_CONTAINER, {
+            execute: () => this.rebuildContainer(),
+            isVisible: () => this.isRemoteSession()
+        });
+    }
+
+    protected isRemoteSession(): boolean {
+        return new URLSearchParams(window.location.search).has('localPort');
     }
 
     canHandle(uri: URI): MaybePromise<boolean> {
-        return uri.scheme === DEV_CONTAINER_WORKSPACE_SCHEME;
+        if (uri.scheme !== DEV_CONTAINER_WORKSPACE_SCHEME) {
+            return false;
+        }
+        // After disconnect (reload), sessionStorage still has the flag from
+        // the remote session's init. Skip auto-reopen so the user gets their
+        // local workspace. After restart (close+open), sessionStorage is
+        // cleared, so auto-reopen works.
+        const wasRemote = sessionStorage.getItem('devcontainer:wasRemote');
+        if (wasRemote) {
+            sessionStorage.removeItem('devcontainer:wasRemote');
+            return false;
+        }
+        return true;
     }
 
     async openWorkspace(uri: URI, options?: WorkspaceInput | undefined): Promise<void> {
         const filePath = new URLSearchParams(uri.query).get(DEV_CONTAINER_PATH_QUERY);
 
         if (!filePath) {
-            throw new Error('No devcontainer file specified for workspace');
+            throw new Error(nls.localize('theia/dev-container/noDevcontainerFileSpecified', 'No devcontainer file specified for workspace'));
         }
 
         const devcontainerFiles = await this.connectionProvider.getDevContainerFiles(uri.path.toString());
         const devcontainerFile = devcontainerFiles.find(file => file.path === filePath);
 
         if (!devcontainerFile) {
-            throw new Error(`Devcontainer file at ${filePath} not found in workspace`);
+            throw new Error(nls.localize('theia/dev-container/devcontainerFileNotFound', 'Devcontainer file at {0} not found in workspace', filePath));
         }
 
         return this.doOpenInContainer(devcontainerFile, uri.path.toString());
@@ -146,17 +214,71 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
         this.openRemote(connectionResult.port, false, connectionResult.workspacePath);
     }
 
+    async rebuildContainer(): Promise<void> {
+        this.containerOutputProvider.openChannel();
+        const progress = await this.messageService.showProgress({
+            text: nls.localize('theia/remote/dev-container/rebuilding', 'Rebuilding dev container')
+        });
+
+        try {
+            // When inside a remote container, read the stored context instead of
+            // scanning the filesystem (the RPC goes to the local backend which
+            // doesn't have the container's workspace path).
+            const ctx = await this.storageService.getData<DevContainerContext | undefined>(ACTIVE_DEV_CONTAINER_CONTEXT);
+            if (ctx) {
+                progress.report({ message: nls.localize('theia/dev-container/removingOldContainer', 'Removing old container...') });
+                try {
+                    await this.connectionProvider.removeContainer(ctx.containerId);
+                } catch (error) {
+                    // Container may already be gone, ignore error
+                }
+                const lastContainerKey = `${LAST_USED_CONTAINER}:${ctx.devcontainerFilePath}`;
+                await this.storageService.setData(lastContainerKey, undefined);
+                progress.cancel();
+                this.doOpenInContainer(
+                    { path: ctx.devcontainerFilePath, name: ctx.devcontainerFileName },
+                    ctx.hostWorkspacePath
+                );
+                return;
+            }
+
+            // Fallback: local workspace — scan for devcontainer files
+            const devcontainerFile = await this.getOrSelectDevcontainerFile();
+            if (!devcontainerFile) {
+                return;
+            }
+            const lastContainerInfoKey = `${LAST_USED_CONTAINER}:${devcontainerFile.path}`;
+            const lastContainerInfo = await this.storageService.getData<LastContainerInfo | undefined>(lastContainerInfoKey);
+            if (lastContainerInfo) {
+                progress.report({ message: nls.localize('theia/dev-container/removingOldContainer', 'Removing old container...') });
+                try {
+                    await this.connectionProvider.removeContainer(lastContainerInfo.id);
+                } catch (error) {
+                    // Container may already be gone, ignore error
+                }
+                await this.storageService.setData(lastContainerInfoKey, undefined);
+            }
+            progress.cancel();
+            this.doOpenInContainer(devcontainerFile);
+        } catch (e) {
+            progress.cancel();
+            this.messageService.error(nls.localize('theia/dev-container/failedToRebuild', 'Failed to rebuild container: {0}', (e as Error).message));
+        }
+    }
+
     async doOpenInContainer(devcontainerFile: DevContainerFile, workspacePath?: string): Promise<void> {
         const lastContainerInfoKey = `${LAST_USED_CONTAINER}:${devcontainerFile.path}`;
         const lastContainerInfo = await this.storageService.getData<LastContainerInfo | undefined>(lastContainerInfoKey);
 
         this.containerOutputProvider.openChannel();
 
+        const hostWorkspacePath = workspacePath ?? this.workspaceService.workspace?.resource.path.toString();
+
         const connectionResult = await this.connectionProvider.connectToContainer({
             nodeDownloadTemplate: this.remotePreferences['remote.nodeDownloadTemplate'],
             lastContainerInfo,
             devcontainerFile: devcontainerFile.path,
-            workspacePath: workspacePath
+            workspacePath: hostWorkspacePath
         });
 
         this.storageService.setData<LastContainerInfo>(lastContainerInfoKey, {
@@ -164,8 +286,16 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
             lastUsed: Date.now()
         });
 
+        // Store full context so rebuild works from inside the container
+        this.storageService.setData<DevContainerContext>(ACTIVE_DEV_CONTAINER_CONTEXT, {
+            devcontainerFilePath: devcontainerFile.path,
+            devcontainerFileName: devcontainerFile.name,
+            hostWorkspacePath: hostWorkspacePath ?? '',
+            containerId: connectionResult.containerId,
+        });
+
         this.workspaceServer.setMostRecentlyUsedWorkspace(
-            `${DEV_CONTAINER_WORKSPACE_SCHEME}:${workspacePath ?? this.workspaceService.workspace?.resource.path}?${DEV_CONTAINER_PATH_QUERY}=${devcontainerFile.path}`);
+            `${DEV_CONTAINER_WORKSPACE_SCHEME}:${hostWorkspacePath}?${DEV_CONTAINER_PATH_QUERY}=${devcontainerFile.path}`);
 
         this.openRemote(connectionResult.port, false, connectionResult.workspacePath);
     }

--- a/packages/dev-container/src/electron-browser/container-connection-contribution.ts
+++ b/packages/dev-container/src/electron-browser/container-connection-contribution.ts
@@ -32,6 +32,12 @@ export namespace RemoteContainerCommands {
         label: 'Reopen in Container',
         category: 'Dev Container'
     }, 'theia/remote/dev-container/connect');
+
+    export const ATTACH_TO_CONTAINER = Command.toLocalizedCommand({
+        id: 'dev-container:attach-to-container',
+        label: 'Attach to Running Container',
+        category: 'Dev Container'
+    }, 'theia/remote/dev-container/attach');
 }
 
 const LAST_USED_CONTAINER = 'lastUsedContainer';
@@ -68,6 +74,9 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
     registerRemoteCommands(registry: RemoteRegistry): void {
         registry.registerCommand(RemoteContainerCommands.REOPEN_IN_CONTAINER, {
             execute: () => this.openInContainer()
+        });
+        registry.registerCommand(RemoteContainerCommands.ATTACH_TO_CONTAINER, {
+            execute: () => this.attachToContainer()
         });
     }
 
@@ -108,6 +117,33 @@ export class ContainerConnectionContribution extends AbstractRemoteRegistryContr
             return;
         }
         this.doOpenInContainer(devcontainerFile);
+    }
+
+    async attachToContainer(): Promise<void> {
+        const containers = await this.connectionProvider.listRunningContainers();
+        if (containers.length === 0) {
+            this.messageService.info(nls.localize('theia/remote/dev-container/noRunningContainers', 'No running containers found.'));
+            return;
+        }
+
+        const selected = await this.quickInputService.pick(containers.map(container => ({
+            type: 'item' as const,
+            label: container.name || container.id.substring(0, 12),
+            description: container.image,
+            detail: container.status,
+            container
+        })), {
+            title: nls.localize('theia/remote/dev-container/selectContainer', 'Select a running container to attach to')
+        });
+
+        if (!selected) {
+            return;
+        }
+
+        this.containerOutputProvider.openChannel();
+
+        const connectionResult = await this.connectionProvider.attachToContainer(selected.container.id);
+        this.openRemote(connectionResult.port, false, connectionResult.workspacePath);
     }
 
     async doOpenInContainer(devcontainerFile: DevContainerFile, workspacePath?: string): Promise<void> {

--- a/packages/dev-container/src/electron-browser/dev-container-frontend-module.ts
+++ b/packages/dev-container/src/electron-browser/dev-container-frontend-module.ts
@@ -23,6 +23,7 @@ import { ContainerInfoContribution } from './container-info-contribution';
 import { FrontendApplicationContribution, LabelProviderContribution } from '@theia/core/lib/browser';
 import { WorkspaceOpenHandlerContribution } from '@theia/workspace/lib/browser/workspace-service';
 import { WindowTitleContribution } from '@theia/core/lib/browser/window/window-title-service';
+import { DevContainerSuggestionContribution } from './dev-container-suggestion-contribution';
 
 export default new ContainerModule(bind => {
     bind(ContainerConnectionContribution).toSelf().inSingletonScope();
@@ -40,4 +41,7 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(ContainerInfoContribution);
     bind(WindowTitleContribution).toService(ContainerInfoContribution);
     bind(LabelProviderContribution).toService(ContainerInfoContribution);
+
+    bind(DevContainerSuggestionContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(DevContainerSuggestionContribution);
 });

--- a/packages/dev-container/src/electron-browser/dev-container-suggestion-contribution.ts
+++ b/packages/dev-container/src/electron-browser/dev-container-suggestion-contribution.ts
@@ -1,0 +1,93 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { CommandService, MessageService, nls } from '@theia/core';
+import { FrontendApplicationContribution, LocalStorageService } from '@theia/core/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { RemoteContainerConnectionProvider } from '../electron-common/remote-container-connection-provider';
+import { RemoteContainerCommands } from './container-connection-contribution';
+import { RemoteStatusService } from '@theia/remote/lib/electron-common/remote-status-service';
+
+const DONT_SHOW_AGAIN_KEY = 'dev-container.suggestion.dontShowAgain';
+
+@injectable()
+export class DevContainerSuggestionContribution implements FrontendApplicationContribution {
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(RemoteContainerConnectionProvider)
+    protected readonly connectionProvider: RemoteContainerConnectionProvider;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    @inject(RemoteStatusService)
+    protected readonly remoteStatusService: RemoteStatusService;
+
+    @inject(LocalStorageService)
+    protected readonly storageService: LocalStorageService;
+
+    onStart(): void {
+        this.checkForDevContainer();
+    }
+
+    protected async checkForDevContainer(): Promise<void> {
+        const containerPort = parseInt(new URLSearchParams(location.search).get('port') ?? '0');
+        if (containerPort > 0) {
+            const status = await this.remoteStatusService.getStatus(containerPort);
+            if (status?.alive) {
+                return;
+            }
+        }
+
+        const dontShowAgain = await this.storageService.getData<boolean>(DONT_SHOW_AGAIN_KEY);
+        if (dontShowAgain) {
+            return;
+        }
+
+        await this.workspaceService.ready;
+        const workspace = this.workspaceService.workspace;
+        if (!workspace) {
+            return;
+        }
+
+        try {
+            const devcontainerFiles = await this.connectionProvider.getDevContainerFiles(workspace.resource.path.toString());
+            if (devcontainerFiles.length > 0) {
+                const reopenAction = nls.localize('theia/remote/dev-container/reopenInContainer', 'Reopen in Container');
+                const dontShowAgainAction = nls.localizeByDefault("Don't Show Again");
+                const result = await this.messageService.info(
+                    nls.localize('theia/remote/dev-container/suggestion',
+                        'This workspace has a dev container configuration. Would you like to reopen it in a container?'),
+                    reopenAction,
+                    dontShowAgainAction
+                );
+                if (result === reopenAction) {
+                    this.commandService.executeCommand(RemoteContainerCommands.REOPEN_IN_CONTAINER.id);
+                } else if (result === dontShowAgainAction) {
+                    await this.storageService.setData(DONT_SHOW_AGAIN_KEY, true);
+                }
+            }
+        } catch (error) {
+            // Silently ignore if we can't check for devcontainer files
+        }
+    }
+}

--- a/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
@@ -45,8 +45,17 @@ export interface DevContainerFile {
     path: string;
 }
 
+export interface RunningContainerInfo {
+    id: string;
+    name: string;
+    image: string;
+    status: string;
+}
+
 export interface RemoteContainerConnectionProvider extends RpcServer<ContainerOutputProvider> {
     connectToContainer(options: ContainerConnectionOptions): Promise<ContainerConnectionResult>;
     getDevContainerFiles(workspacePath: string): Promise<DevContainerFile[]>;
     getCurrentContainerInfo(port: number): Promise<ContainerInspectInfo | undefined>;
+    listRunningContainers(): Promise<RunningContainerInfo[]>;
+    attachToContainer(containerId: string): Promise<ContainerConnectionResult>;
 }

--- a/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-common/remote-container-connection-provider.ts
@@ -58,4 +58,5 @@ export interface RemoteContainerConnectionProvider extends RpcServer<ContainerOu
     getCurrentContainerInfo(port: number): Promise<ContainerInspectInfo | undefined>;
     listRunningContainers(): Promise<RunningContainerInfo[]>;
     attachToContainer(containerId: string): Promise<ContainerConnectionResult>;
+    removeContainer(containerId: string): Promise<void>;
 }

--- a/packages/dev-container/src/electron-node/dev-container-file-service.ts
+++ b/packages/dev-container/src/electron-node/dev-container-file-service.ts
@@ -23,7 +23,7 @@ import * as fs from '@theia/core/shared/fs-extra';
 import { ContributionProvider, Path, URI } from '@theia/core';
 import { VariableResolverContribution } from './devcontainer-contributions/variable-resolver-contribution';
 
-const VARIABLE_REGEX = /^\$\{(.+?)(?::(.+))?\}$/;
+const VARIABLE_REGEX = /\$\{(.+?)(?::(.+?))?\}/g;
 
 @injectable()
 export class DevContainerFileService {
@@ -35,16 +35,14 @@ export class DevContainerFileService {
     protected readonly variableResolverContributions: ContributionProvider<VariableResolverContribution>;
 
     protected resolveVariable(value: string): string {
-        const match = value.match(VARIABLE_REGEX);
-        if (match) {
-            const [, type, variable] = match;
+        return value.replace(VARIABLE_REGEX, (match, type, variable) => {
             for (const contribution of this.variableResolverContributions.getContributions()) {
                 if (contribution.canResolve(type)) {
                     return contribution.resolve(variable ?? type);
                 }
             }
-        }
-        return value;
+            return match;
+        });
     }
 
     protected resolveVariablesRecursively<T>(obj: T): T {

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/cli-enhancing-creation-contributions.spec.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/cli-enhancing-creation-contributions.spec.ts
@@ -1,0 +1,519 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { SettingsContribution } from './cli-enhancing-creation-contributions';
+import { RemoteCliContext } from '@theia/core/lib/node/remote/remote-cli-contribution';
+import { OS } from '@theia/core/lib/common/os';
+import * as Docker from 'dockerode';
+
+describe('SettingsContribution', () => {
+    let settingsContribution: SettingsContribution;
+
+    beforeEach(() => {
+        settingsContribution = new SettingsContribution();
+    });
+
+    describe('base64 encoding for complex values', () => {
+
+        it('should encode nested objects as base64', async () => {
+            const nestedSettings = {
+                'editor.codeActionsOnSave': {
+                    'source.fixAll': true,
+                    'source.organizeImports': true
+                }
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: nestedSettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--set-preference=editor\.codeActionsOnSave=base64:/);
+
+            const base64Part = args[0].split('base64:')[1];
+            const decoded = JSON.parse(Buffer.from(base64Part, 'base64').toString('utf-8'));
+            expect(decoded).to.deep.equal(nestedSettings['editor.codeActionsOnSave']);
+        });
+
+        it('should encode deeply nested objects as base64', async () => {
+            const deeplyNestedSettings = {
+                'complex.setting': {
+                    level1: {
+                        level2: {
+                            level3: {
+                                value: 'deep'
+                            }
+                        }
+                    }
+                }
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: deeplyNestedSettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--set-preference=complex\.setting=base64:/);
+
+            const base64Part = args[0].split('base64:')[1];
+            const decoded = JSON.parse(Buffer.from(base64Part, 'base64').toString('utf-8'));
+            expect(decoded).to.deep.equal(deeplyNestedSettings['complex.setting']);
+        });
+
+        it('should encode arrays as base64', async () => {
+            const arraySettings = {
+                'files.exclude': ['**/.git', '**/.svn', '**/node_modules']
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: arraySettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--set-preference=files\.exclude=base64:/);
+
+            const base64Part = args[0].split('base64:')[1];
+            const decoded = JSON.parse(Buffer.from(base64Part, 'base64').toString('utf-8'));
+            expect(decoded).to.deep.equal(arraySettings['files.exclude']);
+        });
+
+        it('should encode arrays of objects as base64', async () => {
+            const complexArraySettings = {
+                'launch.configurations': [
+                    { type: 'node', request: 'launch', name: 'Launch Program' },
+                    { type: 'chrome', request: 'attach', name: 'Attach to Chrome' }
+                ]
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: complexArraySettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--set-preference=launch\.configurations=base64:/);
+
+            const base64Part = args[0].split('base64:')[1];
+            const decoded = JSON.parse(Buffer.from(base64Part, 'base64').toString('utf-8'));
+            expect(decoded).to.deep.equal(complexArraySettings['launch.configurations']);
+        });
+
+        it('should encode empty objects as base64', async () => {
+            const emptyObjectSettings = {
+                'empty.object': {}
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: emptyObjectSettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--set-preference=empty\.object=base64:/);
+
+            const base64Part = args[0].split('base64:')[1];
+            const decoded = JSON.parse(Buffer.from(base64Part, 'base64').toString('utf-8'));
+            expect(decoded).to.deep.equal({});
+        });
+
+        it('should encode empty arrays as base64', async () => {
+            const emptyArraySettings = {
+                'empty.array': []
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: emptyArraySettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--set-preference=empty\.array=base64:/);
+
+            const base64Part = args[0].split('base64:')[1];
+            const decoded = JSON.parse(Buffer.from(base64Part, 'base64').toString('utf-8'));
+            expect(decoded).to.deep.equal([]);
+        });
+
+        it('should handle values containing equals signs in objects', async () => {
+            const settingsWithEquals = {
+                'test.config': {
+                    formula: 'a=b+c',
+                    equation: 'x=y=z'
+                }
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: settingsWithEquals
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--set-preference=test\.config=base64:/);
+
+            const base64Part = args[0].split('base64:')[1];
+            const decoded = JSON.parse(Buffer.from(base64Part, 'base64').toString('utf-8'));
+            expect(decoded).to.deep.equal(settingsWithEquals['test.config']);
+            expect(decoded.formula).to.equal('a=b+c');
+            expect(decoded.equation).to.equal('x=y=z');
+        });
+    });
+
+    describe('round-trip encode/decode validation', () => {
+
+        const simulateDecode = (encodedArg: string): unknown => {
+            const prefixRemoved = encodedArg.substring('--set-preference='.length);
+            const firstEqualIndex = prefixRemoved.indexOf('=');
+            let rawValue = prefixRemoved.substring(firstEqualIndex + 1);
+            if (rawValue.startsWith('base64:')) {
+                rawValue = Buffer.from(rawValue.substring('base64:'.length), 'base64').toString('utf-8');
+            }
+            return JSON.parse(rawValue);
+        };
+
+        it('should successfully round-trip nested objects', async () => {
+            const originalValue = {
+                nested: {
+                    deep: {
+                        value: 'test',
+                        number: 42
+                    }
+                }
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: { 'test.setting': originalValue }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            const decodedValue = simulateDecode(args[0]);
+            expect(decodedValue).to.deep.equal(originalValue);
+        });
+
+        it('should successfully round-trip arrays', async () => {
+            const originalValue = ['item1', 'item2', 'item3'];
+
+            const containerConfig = {
+                image: 'test',
+                settings: { 'test.array': originalValue }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            const decodedValue = simulateDecode(args[0]);
+            expect(decodedValue).to.deep.equal(originalValue);
+        });
+
+        it('should successfully round-trip values with equals signs', async () => {
+            const originalValue = {
+                equation: 'a=b=c',
+                formula: 'x=y'
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: { 'test.equals': originalValue }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            const decodedValue = simulateDecode(args[0]);
+            expect(decodedValue).to.deep.equal(originalValue);
+        });
+
+        it('should successfully round-trip empty objects', async () => {
+            const originalValue = {};
+
+            const containerConfig = {
+                image: 'test',
+                settings: { 'test.empty': originalValue }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            const decodedValue = simulateDecode(args[0]);
+            expect(decodedValue).to.deep.equal(originalValue);
+        });
+
+        it('should successfully round-trip mixed complex structures', async () => {
+            const originalValue = {
+                string: 'test',
+                number: 123,
+                boolean: true,
+                array: [1, 'two', { three: 3 }],
+                nested: {
+                    deep: {
+                        value: 'with=equals'
+                    }
+                }
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: { 'test.complex': originalValue }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            const decodedValue = simulateDecode(args[0]);
+            expect(decodedValue).to.deep.equal(originalValue);
+        });
+    });
+
+    describe('primitive values (not base64 encoded)', () => {
+
+        it('should not encode string values as base64', async () => {
+            const stringSettings = {
+                'editor.fontSize': '14'
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: stringSettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.equal('--set-preference=editor.fontSize="14"');
+            expect(args[0]).to.not.include('base64:');
+        });
+
+        it('should not encode number values as base64', async () => {
+            const numberSettings = {
+                'editor.tabSize': 4
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: numberSettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.equal('--set-preference=editor.tabSize=4');
+            expect(args[0]).to.not.include('base64:');
+        });
+
+        it('should not encode boolean values as base64', async () => {
+            const booleanSettings = {
+                'editor.wordWrap': true
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: booleanSettings
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.equal('--set-preference=editor.wordWrap=true');
+            expect(args[0]).to.not.include('base64:');
+        });
+
+        it('should handle strings containing equals signs without base64', async () => {
+            const stringWithEquals = {
+                'test.value': 'a=b'
+            };
+
+            const containerConfig = {
+                image: 'test',
+                settings: stringWithEquals
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.equal('--set-preference=test.value="a=b"');
+            expect(args[0]).to.not.include('base64:');
+        });
+    });
+
+    describe('vscode customizations', () => {
+
+        it('should merge settings from customizations.vscode.settings', async () => {
+            const containerConfig = {
+                image: 'test',
+                settings: {
+                    'editor.fontSize': '14'
+                },
+                customizations: {
+                    vscode: {
+                        settings: {
+                            'editor.tabSize': 4,
+                            'files.exclude': ['**/.git']
+                        }
+                    }
+                }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(3);
+            expect(args.some(arg => arg.includes('editor.fontSize'))).to.be.true;
+            expect(args.some(arg => arg.includes('editor.tabSize'))).to.be.true;
+            expect(args.some(arg => arg.includes('files.exclude'))).to.be.true;
+        });
+
+        it('should override settings with customizations.vscode.settings', async () => {
+            const containerConfig = {
+                image: 'test',
+                settings: {
+                    'editor.fontSize': '14'
+                },
+                customizations: {
+                    vscode: {
+                        settings: {
+                            'editor.fontSize': '16'
+                        }
+                    }
+                }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.equal('--set-preference=editor.fontSize="16"');
+        });
+    });
+
+    describe('edge cases', () => {
+
+        it('should return empty array when no config is set', () => {
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+            expect(args).to.be.empty;
+        });
+
+        it('should handle config with no settings', async () => {
+            const containerConfig = {
+                image: 'test'
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.be.empty;
+        });
+
+        it('should clear config after enhanceArgs is called', async () => {
+            const containerConfig = {
+                image: 'test',
+                settings: { 'test.setting': 'value' }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const firstCall = settingsContribution.enhanceArgs(context);
+            const secondCall = settingsContribution.enhanceArgs(context);
+
+            expect(firstCall).to.have.lengthOf(1);
+            expect(secondCall).to.be.empty;
+        });
+
+        it('should handle undefined values', async () => {
+            const containerConfig = {
+                image: 'test',
+                settings: {
+                    'test.undefined': undefined
+                }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.equal('--set-preference=test.undefined=undefined');
+        });
+
+        it('should handle special characters in setting keys', async () => {
+            const containerConfig = {
+                image: 'test',
+                settings: {
+                    'setting.with-dash': 'value',
+                    'setting.with_underscore': 'value'
+                }
+            };
+
+            await settingsContribution.handleContainerCreation({} as Docker.ContainerCreateOptions, containerConfig);
+            const context: RemoteCliContext = { platform: { os: OS.Type.Linux, arch: 'x64' }, directory: '/workspace' };
+            const args = settingsContribution.enhanceArgs(context);
+
+            expect(args).to.have.lengthOf(2);
+            expect(args.some(arg => arg.includes('setting.with-dash'))).to.be.true;
+            expect(args.some(arg => arg.includes('setting.with_underscore'))).to.be.true;
+        });
+    });
+});

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/cli-enhancing-creation-contributions.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/cli-enhancing-creation-contributions.ts
@@ -59,7 +59,13 @@ export class SettingsContribution implements RemoteCliContribution, ContainerCre
             ...(this.currentConfig.customizations?.vscode?.settings ?? [])
         };
         this.currentConfig = undefined;
-        return Object.entries(settings).map(([key, value]) => `--set-preference=${key}=${JSON.stringify(value)}`) ?? [];
+        return Object.entries(settings).map(([key, value]) => {
+            const jsonValue = JSON.stringify(value);
+            if (value && typeof value === 'object') {
+                return `--set-preference=${key}=base64:${Buffer.from(jsonValue).toString('base64')}`;
+            }
+            return `--set-preference=${key}=${jsonValue}`;
+        });
     }
 
     async handleContainerCreation(createOptions: Docker.ContainerCreateOptions, containerConfig: DevContainerConfiguration): Promise<void> {

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
@@ -20,7 +20,7 @@ import { DevContainerConfiguration, DockerfileContainer, ImageContainer, NonComp
 import { Path } from '@theia/core';
 import { ContainerOutputProvider } from '../../electron-common/container-output-provider';
 import * as fs from '@theia/core/shared/fs-extra';
-import { RemotePortForwardingProvider } from '@theia/remote/lib/electron-common/remote-port-forwarding-provider';
+import { ForwardedPort, RemotePortForwardingProvider } from '@theia/remote/lib/electron-common/remote-port-forwarding-provider';
 import { RemoteDockerContainerConnection } from '../remote-container-connection-provider';
 import { WorkspaceCreationContribution } from './workspace-creation-contribution';
 import { parseWorkspaceMount } from '../dockerode-utils';
@@ -122,9 +122,38 @@ export class ForwardPortsContribution implements ContainerCreationContribution {
                 port = forward;
             }
 
-            this.portForwardingProvider.forwardPort(connection.localPort, { port, address });
+            const forwardedPort: ForwardedPort = { port, address };
+            const attributes = this.getPortAttributes(containerConfig, port);
+            if (attributes) {
+                forwardedPort.label = attributes.label;
+                forwardedPort.protocol = attributes.protocol;
+                forwardedPort.onAutoForward = attributes.onAutoForward;
+            }
+            this.portForwardingProvider.forwardPort(connection.localPort, forwardedPort);
         }
 
+    }
+
+    protected getPortAttributes(containerConfig: DevContainerConfiguration,
+        port: number): { label?: string; protocol?: 'http' | 'https'; onAutoForward?: ForwardedPort['onAutoForward'] } | undefined {
+        if (!containerConfig.portsAttributes) {
+            return undefined;
+        }
+        const portStr = String(port);
+        for (const [pattern, attributes] of Object.entries(containerConfig.portsAttributes)) {
+            if (pattern === portStr) {
+                return attributes;
+            }
+            const rangeMatch = pattern.match(/^(\d+)-(\d+)$/);
+            if (rangeMatch) {
+                const start = parseInt(rangeMatch[1]);
+                const end = parseInt(rangeMatch[2]);
+                if (port >= start && port <= end) {
+                    return attributes;
+                }
+            }
+        }
+        return undefined;
     }
 
 }

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
@@ -17,9 +17,12 @@ import * as Docker from 'dockerode';
 import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { ContainerCreationContribution } from '../docker-container-service';
 import { DevContainerConfiguration, DockerfileContainer, ImageContainer, NonComposeContainerBase } from '../devcontainer-file';
-import { Path } from '@theia/core';
+import { ILogger, Path } from '@theia/core';
 import { ContainerOutputProvider } from '../../electron-common/container-output-provider';
 import * as fs from '@theia/core/shared/fs-extra';
+import * as os from 'os';
+import * as path from 'path';
+import * as cp from 'child_process';
 import { ForwardedPort, RemotePortForwardingProvider } from '@theia/remote/lib/electron-common/remote-port-forwarding-provider';
 import { RemoteDockerContainerConnection } from '../remote-container-connection-provider';
 import { WorkspaceCreationContribution } from './workspace-creation-contribution';
@@ -34,6 +37,8 @@ export function registerContainerCreationContributions(bind: interfaces.Bind): v
     bind(ContainerCreationContribution).to(PostCreateCommandContribution).inSingletonScope();
     bind(ContainerCreationContribution).to(ContainerEnvContribution).inSingletonScope();
     bind(ContainerCreationContribution).to(WorkspaceCreationContribution).inSingletonScope();
+    bind(ContainerCreationContribution).to(HostConfigSharingContribution).inSingletonScope();
+    bind(ContainerCreationContribution).to(DefaultShellContribution).inSingletonScope();
 }
 
 @injectable()
@@ -216,6 +221,289 @@ export class ContainerEnvContribution implements ContainerCreationContribution {
             }
             for (const [key, value] of Object.entries(containerConfig.containerEnv)) {
                 createOptions.Env.push(`${key}=${value}`);
+            }
+        }
+    }
+}
+
+@injectable()
+export class HostConfigSharingContribution implements ContainerCreationContribution {
+
+    protected static readonly ISOLATED_SSH_DIR = path.join(os.homedir(), '.theia', 'dev-container', 'ssh');
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
+    async handleContainerCreation(createOptions: Docker.ContainerCreateOptions, containerConfig: DevContainerConfiguration): Promise<void> {
+        const mounts = createOptions.HostConfig?.Mounts ?? [];
+        const hasExistingMount = (targetSuffix: string): boolean =>
+            mounts.some(m => m.Target?.endsWith(targetSuffix));
+
+        // SSH: bind-mount an isolated SSH directory instead of the real ~/.ssh
+        const sshSigningInfo = await this.detectSshSigningKey();
+        if (!hasExistingMount('/.ssh')) {
+            const isolatedSshDir = await this.ensureIsolatedSshDir(sshSigningInfo);
+            if (isolatedSshDir) {
+                mounts.push({
+                    Source: isolatedSshDir,
+                    Target: this.getContainerHomePath(containerConfig, '.ssh'),
+                    Type: 'bind',
+                    ReadOnly: true
+                });
+            }
+        }
+
+        // Git config: bind-mount to a temp path; will be copied in post-create
+        const gitconfigPath = path.join(os.homedir(), '.gitconfig');
+        if (await fs.pathExists(gitconfigPath) && !hasExistingMount('/.gitconfig')) {
+            mounts.push({
+                Source: gitconfigPath,
+                Target: '/tmp/host_gitconfig',
+                Type: 'bind',
+                ReadOnly: true
+            });
+        }
+    }
+
+    async handlePostCreate(containerConfig: DevContainerConfiguration, container: Docker.Container, _api: Docker, outputprovider: ContainerOutputProvider): Promise<void> {
+        const user = (containerConfig.remoteUser ?? containerConfig.containerUser ?? 'root') as string;
+        const containerHome = this.getContainerHomePath(containerConfig, '');
+        const containerSshDir = `${containerHome}.ssh`;
+
+        try {
+            // Fix SSH permissions (bind-mount may not preserve them)
+            await this.execInContainer(container, 'root',
+                `if [ -d "${containerSshDir}" ]; then ` +
+                `chmod 700 "${containerSshDir}" 2>/dev/null; ` +
+                `find "${containerSshDir}" -name "id_*" ! -name "*.pub" -exec chmod 600 {} \\; 2>/dev/null; ` +
+                `find "${containerSshDir}" -name "*.pub" -exec chmod 644 {} \\; 2>/dev/null; ` +
+                `chmod 644 "${containerSshDir}/known_hosts" "${containerSshDir}/config" 2>/dev/null; ` +
+                // Also fix signing key permissions if present
+                `find "${containerSshDir}" -name "git_signing_key*" ! -name "*.pub" -exec chmod 600 {} \\; 2>/dev/null; ` +
+                'true; fi'
+            );
+
+            // Copy host gitconfig into container user's home so the container user owns it
+            const sshSigningInfo = await this.detectSshSigningKey();
+            let gitConfigCmd =
+                'if [ -f /tmp/host_gitconfig ]; then ' +
+                `cp /tmp/host_gitconfig "${containerHome}.gitconfig" && ` +
+                `chown ${user}:$(id -gn ${user}) "${containerHome}.gitconfig" 2>/dev/null; ` +
+                'fi';
+
+            if (sshSigningInfo?.format === 'ssh' && sshSigningInfo.keyFile) {
+                // SSH signing: rewrite the signing key path to point to the container's SSH dir
+                const containerKeyPath = `${containerSshDir}/git_signing_key`;
+                gitConfigCmd += ` && git config --global user.signingkey "${containerKeyPath}"`;
+            } else {
+                // GPG signing or no format: disable (GPG keys aren't available in containers)
+                gitConfigCmd += ' && git config --global commit.gpgsign false 2>/dev/null' +
+                    ' && git config --global tag.gpgsign false 2>/dev/null';
+            }
+            gitConfigCmd += '; true';
+
+            await this.execInContainer(container, user, gitConfigCmd);
+
+            // Install an SSH agent startup script in /etc/profile.d/ so that
+            // login shells (bash -l, started by THEIA_SHELL_ARGS=-l) reuse a
+            // single agent. The agent socket lives in /tmp so it works even
+            // when ~/.ssh is mounted read-only.
+            // The agent starts empty — keys are added automatically on first use
+            // via AddKeysToAgent=yes in the SSH config. This avoids passphrase
+            // prompts during non-interactive shell initialization.
+            const agentScript = [
+                '#!/bin/sh',
+                'SSH_AGENT_SOCK="/tmp/theia-ssh-agent.sock"',
+                'if [ ! -S "$SSH_AGENT_SOCK" ]; then',
+                '    eval $(ssh-agent -a "$SSH_AGENT_SOCK") > /dev/null 2>&1',
+                'fi',
+                'export SSH_AUTH_SOCK="$SSH_AGENT_SOCK"',
+            ].join('\n');
+
+            await this.execInContainer(container, 'root',
+                `mkdir -p /etc/profile.d && printf '%s\\n' '${agentScript.replace(/'/g, "'\\''")}' > /etc/profile.d/ssh-agent.sh && chmod 644 /etc/profile.d/ssh-agent.sh`
+            );
+        } catch (error) {
+            outputprovider?.onRemoteOutput(`Host config sharing: ${error.message}`);
+        }
+    }
+
+    protected async detectSshSigningKey(): Promise<{ format: string; keyFile?: string } | undefined> {
+        try {
+            const format = await this.gitConfigGet('gpg.format');
+            if (format !== 'ssh') {
+                return format ? { format } : undefined;
+            }
+            const signingKey = await this.gitConfigGet('user.signingkey');
+            return { format: 'ssh', keyFile: signingKey || undefined };
+        } catch (error) {
+            // Git config not available or command failed
+            return undefined;
+        }
+    }
+
+    protected gitConfigGet(key: string): Promise<string> {
+        return new Promise<string>((resolve, reject) => {
+            cp.exec(`git config --global --get ${key}`, (err, stdout) => {
+                if (err) {
+                    resolve('');
+                } else {
+                    resolve(stdout.trim());
+                }
+            });
+        });
+    }
+
+    protected async ensureIsolatedSshDir(sshSigningInfo?: { format: string; keyFile?: string }): Promise<string | undefined> {
+        const isolatedDir = HostConfigSharingContribution.ISOLATED_SSH_DIR;
+        try {
+            await fs.mkdirs(isolatedDir);
+
+            // Copy known_hosts from real ~/.ssh so host verification works
+            const realKnownHosts = path.join(os.homedir(), '.ssh', 'known_hosts');
+            const isolatedKnownHosts = path.join(isolatedDir, 'known_hosts');
+            if (await fs.pathExists(realKnownHosts) && !await fs.pathExists(isolatedKnownHosts)) {
+                await fs.copy(realKnownHosts, isolatedKnownHosts);
+            }
+
+            // Copy SSH config and all keys it references via IdentityFile
+            const realConfig = path.join(os.homedir(), '.ssh', 'config');
+            const isolatedConfig = path.join(isolatedDir, 'config');
+            if (await fs.pathExists(realConfig)) {
+                // Always refresh the config — rewrite IdentityFile paths so they
+                // resolve inside the container (where ~/.ssh is a different user's home)
+                const rawConfig = await fs.readFile(realConfig, 'utf-8');
+                // Parse IdentityFile entries from the ORIGINAL config and copy referenced keys
+                const identityFiles = rawConfig.match(/^\s*IdentityFile\s+(.+)$/gm);
+                // Rewrite absolute and ~/ paths to just the filename under ~/.ssh/
+                let rewrittenConfig = rawConfig.replace(
+                    /^(\s*IdentityFile\s+)(.+)$/gm,
+                    (_match, prefix, filePath) => `${prefix}~/.ssh/${path.basename(filePath.trim())}`
+                );
+                // Prepend AddKeysToAgent so that after the user enters a passphrase
+                // once, the key is automatically cached in the running ssh-agent
+                if (!/^\s*AddKeysToAgent\s/m.test(rewrittenConfig)) {
+                    rewrittenConfig = 'Host *\n    AddKeysToAgent yes\n\n' + rewrittenConfig;
+                }
+                await fs.writeFile(isolatedConfig, rewrittenConfig);
+                if (identityFiles) {
+                    for (const line of identityFiles) {
+                        const keyRef = line.replace(/^\s*IdentityFile\s+/, '').trim()
+                            .replace(/^~\//, os.homedir() + '/');
+                        const keyName = path.basename(keyRef);
+                        const isolatedKey = path.join(isolatedDir, keyName);
+                        if (await fs.pathExists(keyRef) && !await fs.pathExists(isolatedKey)) {
+                            await fs.copy(keyRef, isolatedKey);
+                            if (await fs.pathExists(keyRef + '.pub')) {
+                                await fs.copy(keyRef + '.pub', isolatedKey + '.pub');
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Generate a dedicated ed25519 keypair if none exists
+            const keyPath = path.join(isolatedDir, 'id_ed25519');
+            if (!await fs.pathExists(keyPath)) {
+                await new Promise<void>((resolve, reject) => {
+                    cp.exec(`ssh-keygen -t ed25519 -f "${keyPath}" -N "" -C "theia-dev-container"`, err => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve();
+                        }
+                    });
+                });
+                const pubKey = await fs.readFile(keyPath + '.pub', 'utf-8');
+                this.logger.info('Dev Container SSH: generated new keypair. Register this public key with your Git provider:\n' + pubKey.trim());
+            }
+
+            // Copy the SSH signing key if git is configured for SSH signing
+            if (sshSigningInfo?.format === 'ssh' && sshSigningInfo.keyFile) {
+                const signingKeyPath = sshSigningInfo.keyFile.replace(/^~\//, os.homedir() + '/');
+                const isolatedSigningKey = path.join(isolatedDir, 'git_signing_key');
+                if (await fs.pathExists(signingKeyPath) && !await fs.pathExists(isolatedSigningKey)) {
+                    await fs.copy(signingKeyPath, isolatedSigningKey);
+                    // Also copy the .pub if it exists
+                    if (await fs.pathExists(signingKeyPath + '.pub')) {
+                        await fs.copy(signingKeyPath + '.pub', isolatedSigningKey + '.pub');
+                    }
+                }
+            }
+
+            return isolatedDir;
+        } catch (error) {
+            this.logger.error('Failed to set up isolated SSH directory:', error);
+            return undefined;
+        }
+    }
+
+    protected async execInContainer(container: Docker.Container, user: string, cmd: string): Promise<void> {
+        const exec = await container.exec({
+            Cmd: ['sh', '-c', cmd],
+            User: user,
+            AttachStdout: true,
+            AttachStderr: true
+        });
+        await exec.start({});
+    }
+
+    protected getContainerHomePath(containerConfig: DevContainerConfiguration, relativePath: string): string {
+        const user = containerConfig.remoteUser ?? containerConfig.containerUser;
+        if (user && user !== 'root') {
+            return `/home/${user}/${relativePath}`;
+        }
+        return `/root/${relativePath}`;
+    }
+}
+
+@injectable()
+export class DefaultShellContribution implements ContainerCreationContribution {
+    async handleContainerCreation(createOptions: Docker.ContainerCreateOptions, containerConfig: DevContainerConfiguration, api: Docker): Promise<void> {
+        // Set shell and terminal env vars at container creation time so they are
+        // inherited by ALL processes (including docker exec calls).
+        // The remote Theia server is launched via `sh -c` (non-login shell), so
+        // env vars must be baked into the container environment.
+        if (!createOptions.Env) {
+            createOptions.Env = [];
+        }
+        const setIfMissing = (key: string, value: string): void => {
+            if (!createOptions.Env!.some(e => e.startsWith(key + '='))) {
+                createOptions.Env!.push(`${key}=${value}`);
+            }
+        };
+        // Prefer bash; fall back to /bin/sh for minimal images (e.g. Alpine) that don't ship bash.
+        const shell = createOptions.Image && (await this.isBashAvailable(api, createOptions.Image)) === false
+            ? '/bin/sh'
+            : '/bin/bash';
+        setIfMissing('THEIA_SHELL', shell);
+        // Start as login shell so /etc/profile.d/ and ~/.bashrc are sourced,
+        // giving the user a proper prompt and SSH agent env vars.
+        setIfMissing('THEIA_SHELL_ARGS', '-l');
+        setIfMissing('SHELL', shell);
+        setIfMissing('TERM', 'xterm-256color');
+        setIfMissing('COLORTERM', 'truecolor');
+    }
+
+    protected async isBashAvailable(api: Docker, image: string): Promise<boolean | undefined> {
+        let probe: Docker.Container | undefined;
+        try {
+            probe = await api.createContainer({
+                Image: image,
+                Cmd: ['sh', '-c', 'command -v bash']
+            });
+            await probe.start();
+            const { StatusCode } = await probe.wait();
+            return StatusCode === 0;
+        } catch {
+            return undefined;
+        } finally {
+            if (probe) {
+                try {
+                    await probe.remove();
+                } catch {
+                    // ignore — container may already be gone
+                }
             }
         }
     }

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/main-container-creation-contributions.ts
@@ -93,7 +93,7 @@ export class DockerFileContribution implements ContainerCreationContribution {
                 }, progress => outputprovider.onRemoteOutput(OutputHelper.parseProgress(progress))));
                 createOptions.Image = imageId;
             } catch (error) {
-                outputprovider.onRemoteOutput(`could not build dockerfile "${dockerfile}" reason: ${error.message}`);
+                outputprovider.onRemoteOutput(`Could not build dockerfile "${dockerfile}": ${error.message}`);
                 throw error;
             }
         }
@@ -141,6 +141,7 @@ export class MountsContribution implements ContainerCreationContribution {
                 parseWorkspaceMount(mount) :
                 { Source: mount.source, Target: mount.target, Type: mount.type ?? 'bind' }) ?? []);
     }
+
 }
 
 @injectable()
@@ -170,7 +171,7 @@ export class PostCreateCommandContribution implements ContainerCreationContribut
                     const stream = await exec.start({ Tty: true });
                     stream.on('data', chunk => outputprovider.onRemoteOutput(chunk.toString()));
                 } catch (error) {
-                    outputprovider.onRemoteOutput('could not execute postCreateCommand ' + JSON.stringify(command) + ' reason:' + error.message);
+                    outputprovider.onRemoteOutput(`Could not execute postCreateCommand ${JSON.stringify(command)}: ${error.message}`);
                 }
             }
         }

--- a/packages/dev-container/src/electron-node/devcontainer-contributions/variable-resolver-contribution.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-contributions/variable-resolver-contribution.ts
@@ -31,7 +31,6 @@ export function registerVariableResolverContributions(bind: interfaces.Bind): vo
 @injectable()
 export class LocalEnvVariableResolver implements VariableResolverContribution {
     canResolve(type: string): boolean {
-        console.log(`Resolving localEnv variable: ${type}`);
         return type === 'localEnv';
     }
 

--- a/packages/dev-container/src/electron-node/devcontainer-file.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-file.ts
@@ -413,3 +413,15 @@ export interface MountConfig {
     target: string,
     type: 'volume' | 'bind',
 }
+
+export namespace DevContainerConfiguration {
+    /**
+     * Creates an empty DevContainerConfiguration with minimal valid properties.
+     * Used when attaching to existing containers where no devcontainer.json is available.
+     */
+    export function empty(): DevContainerConfiguration {
+        return {
+            image: 'unknown'
+        } as DevContainerConfiguration;
+    }
+}

--- a/packages/dev-container/src/electron-node/devcontainer-file.ts
+++ b/packages/dev-container/src/electron-node/devcontainer-file.ts
@@ -255,7 +255,7 @@ export interface DevContainerCommon {
      * Remote environment variables to set for processes spawned in the container including lifecycle scripts and any remote editor/IDE server process.
      */
     remoteEnv?: {
-        [k: string]: string | null
+        [k: string]: string | undefined
     }
     /**
      * The username to use for spawning processes in the container including lifecycle scripts and any remote editor/IDE server process.

--- a/packages/dev-container/src/electron-node/remote-container-connection-provider.spec.ts
+++ b/packages/dev-container/src/electron-node/remote-container-connection-provider.spec.ts
@@ -1,0 +1,152 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { RemoteDockerContainerConnection } from './remote-container-connection-provider';
+import { DevContainerConfiguration } from './devcontainer-file';
+import { ILogger } from '@theia/core';
+import * as Docker from 'dockerode';
+
+class TestableDockerContainerConnection extends RemoteDockerContainerConnection {
+    public testGetRemoteEnv(): string[] | undefined {
+        return this.getRemoteEnv();
+    }
+}
+
+function createConnection(config: DevContainerConfiguration): TestableDockerContainerConnection {
+    const mockDocker = {
+        getEvents: () => Promise.resolve({ on: () => { } })
+    } as unknown as Docker;
+    const mockContainer = {} as unknown as Docker.Container;
+    const mockLogger = {} as ILogger;
+    return new TestableDockerContainerConnection({
+        id: 'test-id',
+        name: 'test',
+        type: 'Dev Container',
+        docker: mockDocker,
+        container: mockContainer,
+        config,
+        logger: mockLogger
+    });
+}
+
+describe('RemoteDockerContainerConnection', () => {
+
+    describe('getRemoteEnv', () => {
+
+        it('should return undefined when remoteEnv is not set', () => {
+            const connection = createConnection({
+                image: 'test'
+            } as DevContainerConfiguration);
+
+            expect(connection.testGetRemoteEnv()).to.be.undefined;
+        });
+
+        it('should return undefined when remoteEnv is empty', () => {
+            const connection = createConnection({
+                image: 'test',
+                remoteEnv: {}
+            } as DevContainerConfiguration);
+
+            expect(connection.testGetRemoteEnv()).to.be.undefined;
+        });
+
+        it('should convert remoteEnv entries to KEY=value format', () => {
+            const connection = createConnection({
+                image: 'test',
+                remoteEnv: {
+                    'MY_VAR': 'my_value',
+                    'ANOTHER_VAR': 'another_value'
+                }
+            } as DevContainerConfiguration);
+
+            const env = connection.testGetRemoteEnv();
+            expect(env).to.have.lengthOf(2);
+            expect(env).to.include('MY_VAR=my_value');
+            expect(env).to.include('ANOTHER_VAR=another_value');
+        });
+
+        it('should filter out entries with undefined values', () => {
+            const connection = createConnection({
+                image: 'test',
+                remoteEnv: {
+                    'KEEP_VAR': 'value',
+                    'REMOVE_VAR': undefined
+                }
+            } as DevContainerConfiguration);
+
+            const env = connection.testGetRemoteEnv();
+            expect(env).to.have.lengthOf(1);
+            expect(env).to.include('KEEP_VAR=value');
+        });
+
+        it('should return undefined when all entries have undefined values', () => {
+            const connection = createConnection({
+                image: 'test',
+                remoteEnv: {
+                    'VAR1': undefined,
+                    'VAR2': undefined
+                }
+            } as DevContainerConfiguration);
+
+            const env = connection.testGetRemoteEnv();
+            expect(env).to.have.lengthOf(0);
+        });
+
+        it('should handle values containing equals signs', () => {
+            const connection = createConnection({
+                image: 'test',
+                remoteEnv: {
+                    'CONNECTION_STRING': 'host=localhost;port=5432'
+                }
+            } as DevContainerConfiguration);
+
+            const env = connection.testGetRemoteEnv();
+            expect(env).to.have.lengthOf(1);
+            expect(env).to.include('CONNECTION_STRING=host=localhost;port=5432');
+        });
+
+        it('should handle empty string values', () => {
+            const connection = createConnection({
+                image: 'test',
+                remoteEnv: {
+                    'EMPTY_VAR': ''
+                }
+            } as DevContainerConfiguration);
+
+            const env = connection.testGetRemoteEnv();
+            expect(env).to.have.lengthOf(1);
+            expect(env).to.include('EMPTY_VAR=');
+        });
+
+        it('should handle values with special characters', () => {
+            const connection = createConnection({
+                image: 'test',
+                remoteEnv: {
+                    'PATH_EXTRA': '/usr/local/bin:/custom/path',
+                    'QUOTED': 'hello "world"',
+                    'SPACED': 'hello world'
+                }
+            } as DevContainerConfiguration);
+
+            const env = connection.testGetRemoteEnv();
+            expect(env).to.have.lengthOf(3);
+            expect(env).to.include('PATH_EXTRA=/usr/local/bin:/custom/path');
+            expect(env).to.include('QUOTED=hello "world"');
+            expect(env).to.include('SPACED=hello world');
+        });
+    });
+});

--- a/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
@@ -146,7 +146,7 @@ export class DevContainerConnectionProvider implements RemoteContainerConnection
 
             return {
                 containerId: container.id,
-                workspacePath: devContainerConfig.workspaceFolder ?? (await container.inspect()).Mounts[0].Destination,
+                workspacePath: devContainerConfig.workspaceFolder ?? this.inferWorkspacePath(await container.inspect()),
                 port: localPort.toString(),
             };
         } catch (e) {
@@ -237,9 +237,7 @@ export class DevContainerConnectionProvider implements RemoteContainerConnection
             const localPort = (server.address() as net.AddressInfo).port;
             remote.localPort = localPort;
 
-            const workspacePath = containerInfo.Mounts.length > 0
-                ? containerInfo.Mounts[0].Destination
-                : containerInfo.Config.WorkingDir || '/';
+            const workspacePath = this.inferWorkspacePath(containerInfo);
 
             return {
                 containerId: container.id,
@@ -252,6 +250,32 @@ export class DevContainerConnectionProvider implements RemoteContainerConnection
             throw e;
         } finally {
             progress.cancel();
+        }
+    }
+
+    protected inferWorkspacePath(containerInfo: Docker.ContainerInspectInfo): string {
+        // Skip mounts that are injected by HostConfigSharingContribution
+        // (SSH dir, gitconfig) — these are not workspace mounts.
+        const workspaceMount = containerInfo.Mounts.find(m =>
+            !m.Destination.endsWith('/.ssh') &&
+            !m.Destination.endsWith('/.gitconfig') &&
+            m.Destination !== '/tmp/host_gitconfig'
+        );
+        return (workspaceMount?.Destination ?? containerInfo.Config.WorkingDir) || '/';
+    }
+
+    async removeContainer(containerId: string): Promise<void> {
+        try {
+            const docker = new Docker();
+            const container = docker.getContainer(containerId);
+            const info = await container.inspect();
+            if (info.State.Running) {
+                await container.stop();
+            }
+            await container.remove();
+        } catch (e) {
+            console.error('Failed to remove container:', e);
+            throw e;
         }
     }
 

--- a/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
@@ -17,7 +17,7 @@
 import * as net from 'net';
 import {
     ContainerConnectionOptions, ContainerConnectionResult,
-    DevContainerFile, RemoteContainerConnectionProvider
+    DevContainerFile, RemoteContainerConnectionProvider, RunningContainerInfo
 } from '../electron-common/remote-container-connection-provider';
 import { RemoteConnection, RemoteExecOptions, RemoteExecResult, RemoteExecTester, RemoteStatusReport } from '@theia/remote/lib/electron-node/remote-types';
 import { RemoteSetupResult, RemoteSetupService } from '@theia/remote/lib/electron-node/setup/remote-setup-service';
@@ -180,6 +180,79 @@ export class DevContainerConnectionProvider implements RemoteContainerConnection
             return undefined;
         }
         return connection.container.inspect();
+    }
+
+    async listRunningContainers(): Promise<RunningContainerInfo[]> {
+        try {
+            const docker = new Docker();
+            const containers = await docker.listContainers({ all: false });
+            return containers.map(container => ({
+                id: container.Id,
+                name: (container.Names[0] ?? '').replace(/^\//, ''),
+                image: container.Image,
+                status: container.Status
+            }));
+        } catch (e) {
+            console.error('Failed to list running containers:', e);
+            return [];
+        }
+    }
+
+    async attachToContainer(containerId: string): Promise<ContainerConnectionResult> {
+        const docker = new Docker();
+        const container = docker.getContainer(containerId);
+        const containerInfo = await container.inspect();
+
+        const progress = await this.messageService.showProgress({
+            text: 'Attaching to container',
+        });
+        try {
+            const report: RemoteStatusReport = message => progress.report({ message });
+            report('Connecting to remote system...');
+
+            const remote = new RemoteDockerContainerConnection({
+                id: generateUuid(),
+                name: containerInfo.Name.replace(/^\//, ''),
+                type: 'Dev Container',
+                docker,
+                container,
+                config: DevContainerConfiguration.empty(),
+                logger: this.logger
+            });
+
+            const result = await this.remoteSetup.setup({
+                connection: remote,
+                report,
+            });
+            remote.remoteSetupResult = result;
+
+            const registration = this.remoteConnectionService.register(remote);
+            const server = await this.serverProvider.getProxyServer(socket => {
+                remote.forwardOut(socket);
+            });
+            remote.onDidDisconnect(() => {
+                server.close();
+                registration.dispose();
+            });
+            const localPort = (server.address() as net.AddressInfo).port;
+            remote.localPort = localPort;
+
+            const workspacePath = containerInfo.Mounts.length > 0
+                ? containerInfo.Mounts[0].Destination
+                : containerInfo.Config.WorkingDir || '/';
+
+            return {
+                containerId: container.id,
+                workspacePath,
+                port: localPort.toString(),
+            };
+        } catch (e) {
+            this.messageService.error(e.message);
+            console.error(e);
+            throw e;
+        } finally {
+            progress.cancel();
+        }
     }
 
     dispose(): void {
@@ -386,11 +459,15 @@ export class RemoteDockerContainerConnection implements RemoteConnection {
     protected async shutdownContainer(sync: boolean): Promise<unknown> {
         const remoteHost = this.getDockerHost();
 
-        const shutdownAction = this.config.shutdownAction ?? this.config.dockerComposeFile ? 'stopCompose' : 'stopContainer';
+        const shutdownAction = this.config.shutdownAction ?? (this.config.dockerComposeFile ? 'stopCompose' : 'stopContainer');
 
         if (shutdownAction === 'stopContainer') {
             return sync ? execSync(`docker ${remoteHost}stop ${this.container.id}`) : this.container.stop();
         } else if (shutdownAction === 'stopCompose') {
+            if (!this.config.dockerComposeFile) {
+                console.warn('shutdownAction is stopCompose but dockerComposeFile is not defined, falling back to stopContainer');
+                return sync ? execSync(`docker ${remoteHost}stop ${this.container.id}`) : this.container.stop();
+            }
             const composeFilePath = resolveComposeFilePath(this.config);
             return sync ? execSync(`docker ${remoteHost}compose -f ${composeFilePath} stop`) :
                 new Promise<void>((res, rej) => exec(`docker ${remoteHost}compose -f ${composeFilePath} stop`, err => {

--- a/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
+++ b/packages/dev-container/src/electron-node/remote-container-connection-provider.ts
@@ -348,12 +348,23 @@ export class RemoteDockerContainerConnection implements RemoteConnection {
         this.logger = options.logger;
     }
 
+    protected getRemoteEnv(): string[] | undefined {
+        const remoteEnv = this.config.remoteEnv;
+        if (!remoteEnv || Object.keys(remoteEnv).length === 0) {
+            return undefined;
+        }
+        return Object.entries(remoteEnv)
+            .filter(([, value]) => value !== undefined)
+            .map(([key, value]) => `${key}=${value}`);
+    }
+
     async forwardOut(socket: Socket, port?: number): Promise<void> {
         const node = `${this.remoteSetupResult.nodeDirectory}/bin/node`;
         const devContainerServer = `${this.remoteSetupResult.applicationDirectory}/backend/dev-container-server.js`;
         try {
             const ttySession = await this.container.exec({
                 Cmd: ['sh', '-c', `${node} ${devContainerServer} -target-port=${port ?? this.remotePort}`],
+                Env: this.getRemoteEnv(),
                 AttachStdin: true, AttachStdout: true, AttachStderr: true
             });
 
@@ -371,7 +382,9 @@ export class RemoteDockerContainerConnection implements RemoteConnection {
         const deferred = new Deferred<RemoteExecResult>();
         try {
             // TODO add windows container support
-            const execution = await this.container.exec({ Cmd: ['sh', '-c', `${cmd} ${args?.join(' ') ?? ''}`], AttachStdout: true, AttachStderr: true });
+            const execution = await this.container.exec({
+                Cmd: ['sh', '-c', `${cmd} ${args?.join(' ') ?? ''}`], Env: this.getRemoteEnv(), AttachStdout: true, AttachStderr: true
+            });
             let stdoutBuffer = '';
             let stderrBuffer = '';
             const stream = await execution?.start({});
@@ -395,7 +408,9 @@ export class RemoteDockerContainerConnection implements RemoteConnection {
         const deferred = new Deferred<RemoteExecResult>();
         try {
             // TODO add windows container support
-            const execution = await this.container.exec({ Cmd: ['sh', '-c', `${cmd} ${args?.join(' ') ?? ''}`], AttachStdout: true, AttachStderr: true });
+            const execution = await this.container.exec({
+                Cmd: ['sh', '-c', `${cmd} ${args?.join(' ') ?? ''}`], Env: this.getRemoteEnv(), AttachStdout: true, AttachStderr: true
+            });
             let stdoutBuffer = '';
             let stderrBuffer = '';
             const stream = await execution?.start({});

--- a/packages/preferences/src/node/preference-cli-contribution.ts
+++ b/packages/preferences/src/node/preference-cli-contribution.ts
@@ -36,7 +36,11 @@ export class PreferenceCliContribution implements CliContribution, CliPreference
             const preferences: string[] = args.setPreference instanceof Array ? args.setPreference : [args.setPreference];
             for (const preference of preferences) {
                 const firstEqualIndex = preference.indexOf('=');
-                this.preferences.push([preference.substring(0, firstEqualIndex), JSON.parse(preference.substring(firstEqualIndex + 1))]);
+                let rawValue = preference.substring(firstEqualIndex + 1);
+                if (rawValue.startsWith('base64:')) {
+                    rawValue = Buffer.from(rawValue.substring('base64:'.length), 'base64').toString('utf-8');
+                }
+                this.preferences.push([preference.substring(0, firstEqualIndex), JSON.parse(rawValue)]);
             }
         }
     }

--- a/packages/remote/src/electron-browser/port-forwarding/port-forwading-contribution.ts
+++ b/packages/remote/src/electron-browser/port-forwarding/port-forwading-contribution.ts
@@ -14,10 +14,18 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { nls } from '@theia/core';
+import { Command, nls } from '@theia/core';
 import { AbstractViewContribution } from '@theia/core/lib/browser';
 import { injectable } from '@theia/core/shared/inversify';
 import { PortForwardingWidget, PORT_FORWARDING_WIDGET_ID } from './port-forwarding-widget';
+
+export namespace PortForwardingCommands {
+    export const TOGGLE = Command.toLocalizedCommand({
+        id: 'port-forwarding:toggle',
+        label: 'Ports: Focus on Ports View',
+        category: 'View'
+    }, 'theia/remote/port-forwarding/focusPorts');
+}
 
 @injectable()
 export class PortForwardingContribution extends AbstractViewContribution<PortForwardingWidget> {
@@ -27,7 +35,8 @@ export class PortForwardingContribution extends AbstractViewContribution<PortFor
             widgetName: nls.localizeByDefault('Ports'),
             defaultWidgetOptions: {
                 area: 'bottom'
-            }
+            },
+            toggleCommandId: PortForwardingCommands.TOGGLE.id
         });
     }
 }

--- a/packages/remote/src/electron-browser/port-forwarding/port-forwarding-service.ts
+++ b/packages/remote/src/electron-browser/port-forwarding/port-forwarding-service.ts
@@ -22,6 +22,7 @@ import { getCurrentPort } from '@theia/core/lib/electron-browser/messaging/elect
 export interface ForwardedPort {
     localPort?: number;
     address?: string;
+    label?: string;
     origin?: string;
     editing: boolean;
 }
@@ -40,7 +41,7 @@ export class PortForwardingService {
     @postConstruct()
     init(): void {
         this.provider.getForwardedPorts().then(ports => {
-            this.forwardedPorts.push(...ports.map(p => ({ address: p.address, localPort: p.port, editing: false })));
+            this.forwardedPorts.push(...ports.map(p => ({ address: p.address, localPort: p.port, label: p.label, editing: false })));
             this.onDidChangePortsEmitter.fire();
         });
     }

--- a/packages/remote/src/electron-browser/port-forwarding/port-forwarding-widget.tsx
+++ b/packages/remote/src/electron-browser/port-forwarding/port-forwarding-widget.tsx
@@ -63,8 +63,8 @@ export class PortForwardingWidget extends ReactWidget {
                 <thead>
                     <tr>
                         <th className='port-table-header'>{nls.localizeByDefault('Port')}</th>
+                        <th className='port-table-header'>{nls.localizeByDefault('Label')}</th>
                         <th className='port-table-header'>{nls.localizeByDefault('Address')}</th>
-                        <th className='port-table-header'>{nls.localizeByDefault('Running Process')}</th>
                         <th className='port-table-header'>{nls.localizeByDefault('Origin')}</th>
                     </tr>
                 </thead>
@@ -72,8 +72,8 @@ export class PortForwardingWidget extends ReactWidget {
                     {this.portForwardingService.forwardedPorts.map(port => (
                         <tr key={port.address && port.localPort ? `${port.address}:${port.localPort}` : 'editing'}>
                             {this.renderPortColumn(port)}
+                            <td>{port.label ?? ''}</td>
                             {this.renderAddressColumn(port)}
-                            <td></td>
                             <td>{port.origin ? nls.localizeByDefault(port.origin) : ''}</td>
                         </tr>
                     ))}

--- a/packages/remote/src/electron-common/remote-port-forwarding-provider.ts
+++ b/packages/remote/src/electron-common/remote-port-forwarding-provider.ts
@@ -21,6 +21,9 @@ export const RemotePortForwardingProvider = Symbol('RemoteSSHConnectionProvider'
 export interface ForwardedPort {
     port: number;
     address?: string;
+    label?: string;
+    protocol?: 'http' | 'https';
+    onAutoForward?: 'notify' | 'openBrowser' | 'openBrowserOnce' | 'openPreview' | 'silent' | 'ignore';
 }
 
 export interface RemotePortForwardingProvider {

--- a/packages/workspace/src/browser/workspace-service.ts
+++ b/packages/workspace/src/browser/workspace-service.ts
@@ -121,8 +121,48 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
     }
 
     protected async doInit(): Promise<void> {
-        const wsUriString = await this.getDefaultWorkspaceUri();
-        const wsStat = await this.toFileStat(wsUriString);
+        let wsUriString = await this.getDefaultWorkspaceUri();
+        if (wsUriString) {
+            const wsUri = new URI(wsUriString);
+            if (wsUri.scheme !== 'file') {
+                let handled = false;
+                for (const handler of this.openHandlerContribution.getContributions()) {
+                    if (await handler.canHandle(wsUri)) {
+                        try {
+                            // openWorkspace reloads the window on success, so if we
+                            // reach the timeout the connection attempt is hanging.
+                            await Promise.race([
+                                handler.openWorkspace(wsUri),
+                                new Promise<void>((_, reject) => setTimeout(() => reject(new Error('timeout')), 120000))
+                            ]);
+                            handled = true;
+                        } catch {
+                            // Failed or timed out — fall through to local workspace
+                        }
+                        break;
+                    }
+                }
+                if (handled) {
+                    this._ready.resolve();
+                    return;
+                }
+                // No handler could open this non-file URI, or it failed/timed out.
+                // Fall back to the most recent local workspace.
+                const recents = await this.server.getRecentWorkspaces();
+                wsUriString = recents.find(r => new URI(r).scheme === 'file');
+            }
+        }
+        let wsStat = await this.toFileStat(wsUriString);
+        if (!wsStat && wsUriString) {
+            // The URI (e.g. from the URL hash after a remote disconnect) points
+            // to a path that doesn't exist locally. Fall back to the most recent
+            // local workspace.
+            const recents = await this.server.getRecentWorkspaces();
+            const fallback = recents.find(r => new URI(r).scheme === 'file');
+            if (fallback) {
+                wsStat = await this.toFileStat(fallback);
+            }
+        }
         await this.setWorkspace(wsStat);
 
         this.fileService.onDidFilesChange(event => {
@@ -246,7 +286,9 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
             this.setURLFragment('');
         }
         this.updateTitle();
-        await this.server.setMostRecentlyUsedWorkspace(this._workspace ? this._workspace.resource.toString() : '');
+        if (!this.isRemoteSession()) {
+            await this.server.setMostRecentlyUsedWorkspace(this._workspace ? this._workspace.resource.toString() : '');
+        }
         await this.updateWorkspace();
     }
 
@@ -373,7 +415,22 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
     }
 
     protected setMostRecentlyUsedWorkspace(): void {
-        this.server.setMostRecentlyUsedWorkspace(this._workspace ? this._workspace.resource.toString() : '');
+        if (!this.isRemoteSession()) {
+            this.server.setMostRecentlyUsedWorkspace(this._workspace ? this._workspace.resource.toString() : '');
+        }
+    }
+
+    /**
+     * Returns true if the current window is connected to a remote backend.
+     * In remote sessions, we must not overwrite the local MRU with the remote
+     * workspace's file URI, as the local MRU should retain the remote connection
+     * URI (e.g. `devcontainer://...`) so the session can be restored on restart.
+     *
+     * Detection: the backend port is always in `?port=`. When connected to a
+     * remote, the URL also has `?localPort=` (the original backend port).
+     */
+    protected isRemoteSession(): boolean {
+        return new URLSearchParams(window.location.search).has('localPort');
     }
 
     async recentWorkspaces(): Promise<string[]> {
@@ -540,7 +597,9 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
             this._workspace = undefined;
             this._roots.length = 0;
 
-            await this.server.setMostRecentlyUsedWorkspace('');
+            if (!this.isRemoteSession()) {
+                await this.server.setMostRecentlyUsedWorkspace('');
+            }
             this.reloadWindow('');
         }
     }
@@ -663,7 +722,9 @@ export class WorkspaceService implements FrontendApplicationContribution, Worksp
         let stat = await this.toFileStat(resource);
         Object.assign(workspaceData, await this.getWorkspaceDataFromFile());
         stat = await this.writeWorkspaceFile(stat, WorkspaceData.buildWorkspaceData(this._roots, workspaceData));
-        await this.server.setMostRecentlyUsedWorkspace(resource.toString());
+        if (!this.isRemoteSession()) {
+            await this.server.setMostRecentlyUsedWorkspace(resource.toString());
+        }
         // If saving a workspace based on an untitled workspace, delete the old file.
         const toDelete = this.isUntitledWorkspace(this.workspace?.resource) && this.workspace!.resource;
         await this.setWorkspace(stat);


### PR DESCRIPTION
#### What it does

Contributes to https://github.com/eclipse-theia/theia/issues/14294

This PR adds several new features, bug fixes, and quality improvements to the dev container support in Theia:

**New features:**
- **Variable resolver fixes**: Handle variables embedded in strings in devcontainer.json (e.g. `${localEnv:HOME}/path`)
- **MountsContribution fix**: Pass through all mount options (source, target, type) correctly instead of silently dropping them
- **SettingsContribution fix**: Fix JSON quoting when injecting preferences through the shell by base64-encoding complex objects
- **portsAttributes support**: Implement `portsAttributes` from devcontainer.json, allowing port labels, protocols, and auto-forward behavior to be configured
- **Attach to Running Container**: Add a command to attach to an already-running Docker container without a devcontainer.json
- **SSH credential injection, git identity sharing, and shell detection**: Automatically set up an isolated SSH directory with key forwarding, inject host `.gitconfig` (with SSH signing key rewriting), configure a login shell with SSH agent, and share host credentials into the container
- **Auto-reopen in last active dev container after restart**: On application restart, automatically reconnect to the previously used dev container
- **Suggest to reopen workspace in dev container**: When opening a workspace that contains a devcontainer.json, show a notification suggesting to reopen in a container
- **Rebuild Container command**: Add a command to rebuild the dev container from scratch (removing the old container) while preserving the devcontainer file context
- **Ports view and port labels**: Expose the Ports view in the remote package and display port labels from `portsAttributes`

#### How to test

Prerequisites: Docker must be installed and running.

1. **Reopen in Container**
   - Open a workspace that contains a `.devcontainer/devcontainer.json`
   - Run `Dev Container: Reopen in Container` from the command palette
   - Verify Theia connects to the container and the workspace is available

2. **Suggestion notification**
   - Open a workspace with a devcontainer.json from a local (non-remote) session
   - Verify a notification appears suggesting to reopen in a container
   - Click "Reopen in Container" and verify it works

3. **Rebuild Container**
   - While connected to a dev container, run `Dev Container: Rebuild Container`
   - Verify the old container is removed and a new one is created
   - Verify the workspace reconnects automatically

4. **Attach to Running Container**
   - Start a Docker container manually (e.g. `docker run -it ubuntu bash`)
   - Run `Dev Container: Attach to Running Container`
   - Select the running container and verify Theia connects

5. **SSH credentials and git identity**
   - Ensure you have `~/.ssh/config` and `~/.gitconfig` on the host
   - Reopen in a container and verify:
     - `git config user.name` and `user.email` are inherited
     - `ssh -T git@github.com` works (key forwarding)
     - SSH agent is running (`echo $SSH_AUTH_SOCK`)

6. **Port forwarding with labels**
   - Use a devcontainer.json with `forwardPorts` and `portsAttributes` (e.g. label, protocol)
   - Verify ports are forwarded and labels appear in the Ports view

7. **Variable resolver with embedded variables**
   - Use a devcontainer.json with variables embedded in strings, e.g.:
     ```json
     { "remoteEnv": { "MY_VAR": "${localEnv:HOME}/projects" } }
     ```
   - Reopen in the container and verify `echo $MY_VAR` resolves to the host's `$HOME/projects` (not the literal `${localEnv:HOME}` string)

8. **Mount options pass-through**
   - Add a `mounts` entry in devcontainer.json using the string form with extra options, e.g.:
     ```json
     { "mounts": ["type=bind,source=${localEnv:HOME}/.config,target=/home/vscode/.config,readonly"] }
     ```
   - Reopen in the container and verify the mount exists (`mount | grep .config`), is read-only, and uses the correct source/target paths

9. **Settings with complex JSON values**
   - Add a complex (object/array) setting in devcontainer.json, e.g.:
     ```json
     { "settings": { "editor.tokenColorCustomizations": { "comments": "#FF0000" } } }
     ```
   - Reopen in the container and verify the preference is applied correctly in the running Theia instance (open Settings and search for the key)
   - Previously, object values were broken by shell quoting when passed as `--set-preference` CLI arguments

10. **Auto-reopen after restart**
    - Connect to a dev container, then close and reopen Theia
    - Verify it automatically reconnects to the same container

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)