### PR TITLE
fix(workspace): avoid spurious restart dialog from preference change handler

### DIFF
--- a/packages/workspace/src/browser/workspace-trust-service.spec.ts
+++ b/packages/workspace/src/browser/workspace-trust-service.spec.ts
@@ -55,6 +55,10 @@ class TestableWorkspaceTrustService extends WorkspaceTrustService {
     public testShouldReloadForTrustChange(newTrust: boolean): boolean {
         return this.shouldReloadForTrustChange(newTrust);
     }
+
+    public setLastKnownTrustEnabled(value: boolean | undefined): void {
+        this.lastKnownTrustEnabled = value;
+    }
 }
 
 describe('WorkspaceTrustService', () => {
@@ -316,8 +320,9 @@ describe('WorkspaceTrustService', () => {
             areAllWorkspaceUrisTrustedStub = sinon.stub(service as unknown as { areAllWorkspaceUrisTrusted: () => Promise<boolean> }, 'areAllWorkspaceUrisTrusted');
             setWorkspaceTrustStub = sinon.stub(service, 'setWorkspaceTrust').resolves();
             isEmptyWorkspaceStub = sinon.stub(service as unknown as { isEmptyWorkspace: () => Promise<boolean> }, 'isEmptyWorkspace');
-            // Mock workspaceTrustPref - default emptyWindow to false so trusted folders logic runs
-            workspaceTrustPrefStub = { [WORKSPACE_TRUST_EMPTY_WINDOW]: false };
+            // Mock workspaceTrustPref - default emptyWindow to false so trusted folders logic runs;
+            // trust is enabled by default so the trustedFolders branch is exercised
+            workspaceTrustPrefStub = { [WORKSPACE_TRUST_EMPTY_WINDOW]: false, [WORKSPACE_TRUST_ENABLED]: true };
             (service as unknown as { workspaceTrustPref: { [key: string]: unknown } }).workspaceTrustPref = workspaceTrustPrefStub;
             // Default to non-empty workspace
             isEmptyWorkspaceStub.resolves(false);
@@ -459,6 +464,9 @@ describe('WorkspaceTrustService', () => {
                 // Stub isWorkspaceTrustResolved to return true (simulates resolved state)
                 sinon.stub(service, 'isWorkspaceTrustResolved').returns(true);
                 service.setCurrentTrust(true);
+                // Simulate a real user change: effective value just flipped from true to false.
+                service.setLastKnownTrustEnabled(true);
+                workspaceTrustPrefStub[WORKSPACE_TRUST_ENABLED] = false;
             });
 
             it('should reload without setSafeToShutDown when user confirms restart', async () => {
@@ -491,6 +499,45 @@ describe('WorkspaceTrustService', () => {
 
                 expect(windowServiceStub.reload.called).to.be.false;
                 expect(windowServiceStub.setSafeToShutDown.called).to.be.false;
+            });
+
+            it('should not show restart dialog when effective value is unchanged (initial-load event)', async () => {
+                // Simulate the User provider's initial-load event: value already matches what was
+                // observed at trust resolution time.
+                service.setLastKnownTrustEnabled(false);
+                workspaceTrustPrefStub[WORKSPACE_TRUST_ENABLED] = false;
+
+                const change: PreferenceChange = {
+                    preferenceName: WORKSPACE_TRUST_ENABLED,
+                    scope: PreferenceScope.User,
+                    domain: [],
+                    affects: () => true
+                };
+
+                await service.testHandlePreferenceChange(change);
+
+                expect(confirmRestartStub.called).to.be.false;
+                expect(windowServiceStub.reload.called).to.be.false;
+            });
+        });
+
+        describe('trustedFolders change while trust is disabled', () => {
+            it('should not flip currentTrust when `enabled` is false', async () => {
+                workspaceTrustPrefStub[WORKSPACE_TRUST_ENABLED] = false;
+                service.setCurrentTrust(true);
+                areAllWorkspaceUrisTrustedStub.resolves(false);
+
+                const change: PreferenceChange = {
+                    preferenceName: WORKSPACE_TRUST_TRUSTED_FOLDERS,
+                    scope: PreferenceScope.User,
+                    domain: [],
+                    affects: () => true
+                };
+
+                await service.testHandlePreferenceChange(change);
+
+                expect(setWorkspaceTrustStub.called).to.be.false;
+                expect(areAllWorkspaceUrisTrustedStub.called).to.be.false;
             });
         });
 

--- a/packages/workspace/src/browser/workspace-trust-service.ts
+++ b/packages/workspace/src/browser/workspace-trust-service.ts
@@ -110,6 +110,12 @@ export class WorkspaceTrustService {
     protected currentTrust: boolean | undefined;
     protected pendingTrustDialog: Deferred<boolean> | undefined;
     protected pendingTrustRequest: Deferred<boolean | undefined> | undefined;
+    /**
+     * Effective value of `security.workspace.trust.enabled` at the time trust was last resolved.
+     * Used to distinguish a real user change from the initial-load preference change event
+     * that the User provider emits asynchronously after start-up.
+     */
+    protected lastKnownTrustEnabled: boolean | undefined;
 
     protected readonly onDidChangeWorkspaceTrustEmitter = new Emitter<boolean>();
     readonly onDidChangeWorkspaceTrust: Event<boolean> = this.onDidChangeWorkspaceTrustEmitter.event;
@@ -160,6 +166,7 @@ export class WorkspaceTrustService {
 
     protected async resolveWorkspaceTrust(givenTrust?: boolean): Promise<void> {
         if (!this.isWorkspaceTrustResolved()) {
+            this.lastKnownTrustEnabled = !!this.workspaceTrustPref[WORKSPACE_TRUST_ENABLED];
             const trust = givenTrust ?? await this.calculateWorkspaceTrust();
             if (trust !== undefined) {
                 await this.storeWorkspaceTrust(trust);
@@ -399,6 +406,12 @@ export class WorkspaceTrustService {
     protected async handlePreferenceChange(change: PreferenceChange): Promise<void> {
         // Handle trustedFolders changes regardless of scope
         if (change.preferenceName === WORKSPACE_TRUST_TRUSTED_FOLDERS) {
+            // When trust is disabled, trust is unconditionally granted: trustedFolders
+            // changes must not flip `currentTrust` (which would trigger a restart dialog
+            // via `setWorkspaceTrust` → `shouldReloadForTrustChange`).
+            if (!this.workspaceTrustPref[WORKSPACE_TRUST_ENABLED]) {
+                return;
+            }
             // For empty windows with emptyWindow setting enabled, trust should remain true
             if (await this.isEmptyWorkspace() && this.workspaceTrustPref[WORKSPACE_TRUST_EMPTY_WINDOW]) {
                 return;
@@ -416,8 +429,16 @@ export class WorkspaceTrustService {
             }
 
             if (change.preferenceName === WORKSPACE_TRUST_ENABLED) {
-                if (!await this.isEmptyWorkspace() && this.isWorkspaceTrustResolved() && await this.confirmRestart()) {
-                    this.windowService.reload();
+                const currentEnabled = !!this.workspaceTrustPref[WORKSPACE_TRUST_ENABLED];
+                // The preference framework emits a User-scope change event when the user
+                // settings file is first loaded (oldValue undefined → current value). Only
+                // prompt for restart when the effective value has actually changed since
+                // trust was last resolved.
+                if (currentEnabled !== this.lastKnownTrustEnabled) {
+                    this.lastKnownTrustEnabled = currentEnabled;
+                    if (!await this.isEmptyWorkspace() && this.isWorkspaceTrustResolved() && await this.confirmRestart()) {
+                        this.windowService.reload();
+                    }
                 }
                 this.resolveWorkspaceTrust();
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #17353.

`WorkspaceTrustService.handlePreferenceChange` was surfacing the "A setting has changed that requires a restart to take effect" dialog in two cases that should be no-ops. Both are fixed here:

- `trustedFolders` branch: when `security.workspace.trust.enabled` is `false`, trust is unconditionally granted, so the branch is short-circuited before it can flip `currentTrust` (which, since #17098, pops the restart dialog via `shouldReloadForTrustChange`).
- `enabled` branch: the effective value of the preference is tracked at trust-resolution time via `lastKnownTrustEnabled`, and the restart dialog is only shown when it has actually changed. This suppresses the debounced initial-load event emitted by the User preference provider at startup.

Covered by unit tests in `workspace-trust-service.spec.ts`.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the Browser example. It sets `security.workspace.trust.enabled: false` as a default override
2. Open an untrusted folder. Expect: no restart dialog
3. In any app, set `security.workspace.trust.enabled: false` at User scope, reload. Expect: no restart dialog, on neither trusted nor untrusted workspaces
4. With the setting at its default (`true`), toggle it to `false` via the settings UI. Expect: the restart dialog to appear exactly once (this is the legitimate code path)
5. Unit tests pass

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
