### PR TITLE
chore: remove stale CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,0 @@
-# plugin
-packages/plugin/** @theia-ide/plugin-system
-packages/plugin-dev/** @theia-ide/plugin-system
-packages/plugin-ext/** @theia-ide/plugin-system
-packages/plugin-ext-vscode/** @theia-ide/plugin-system


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Removes the stale `.github/CODEOWNERS` file. The file referenced the deprecated `@theia-ide/plugin-system` team, which does not have write access to the repository, causing errors in the GitHub UI currently.

Why delete instead of replacing with `@eclipse-theia` teams?

- A CODEOWNERS file automatically triggers review requests from the listed owners on every PR (GitHub platform behavior, not configurable).
- Adding `@eclipse-theia/ecd-theia-committers` or `@eclipse-theia/ecd-theia-project-leads` would cause automatic review request assignments, which we probably don't want.
- Removing the file does not affect who can merge PRs or any other repository settings.
- Most Eclipse projects (e.g. Langium, GLSP, Sprotty, CDT, Vert.x) do not use CODEOWNERS files either.

We can always re-add coder owners later if needed.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- The otterdog config at `eclipse-theia/.eclipsefdn` contains potentially stale entries (e.g. `codeowner_test` and `che-7.0.0` branch protection rules, old webhooks) that should be cleaned up separately.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
