### PR TITLE
onFocusChange: save on changes of both tab and window focus

### DIFF
--- a/packages/core/src/browser/saveable-service.ts
+++ b/packages/core/src/browser/saveable-service.ts
@@ -22,6 +22,7 @@ import { AutoSaveMode, Saveable, SaveableSource, SaveableWidget, SaveOptions, Sa
 import { waitForClosed, Widget } from './widgets';
 import { FrontendApplicationContribution } from './frontend-application-contribution';
 import { FrontendApplication } from './frontend-application';
+import { WindowFocusService } from './window/window-focus-service';
 import throttle = require('lodash.throttle');
 
 export const SaveErrorChecker = Symbol('SaveErrorChecker');
@@ -48,6 +49,9 @@ export class SaveableService implements FrontendApplicationContribution {
 
     @inject(ContributionProvider) @named(SaveErrorChecker)
     protected readonly errorCheckers: ContributionProvider<SaveErrorChecker>;
+
+    @inject(WindowFocusService)
+    protected readonly windowFocusService: WindowFocusService;
 
     protected saveThrottles = new Map<Widget, AutoSaveThrottle>();
     protected saveMode: AutoSaveMode = 'off';
@@ -131,6 +135,35 @@ export class SaveableService implements FrontendApplicationContribution {
             this.saveThrottles.get(e)?.dispose();
             this.saveThrottles.delete(e);
         });
+        // Save all dirty editors when any application window loses focus
+        this.windowFocusService.onDidWindowChangeFocus(({ hasFocus }) => {
+            if (!hasFocus) {
+                this.saveOnWindowBlur();
+            }
+        });
+    }
+
+    /**
+     * Save all dirty saveables when the application window loses focus.
+     * Triggered for both `onFocusChange` and `onWindowChange` auto-save modes,
+     * matching VSCode's behavior where a window focus loss is a superset of
+     * editor focus loss.
+     */
+    protected saveOnWindowBlur(): void {
+        if (this.saveMode !== 'onWindowChange' && this.saveMode !== 'onFocusChange') {
+            return;
+        }
+        if (!this.shell) {
+            return;
+        }
+        for (const widget of this.shell.widgets) {
+            const saveable = Saveable.get(widget);
+            if (saveable && this.shouldAutoSave(widget, saveable)) {
+                saveable.save({
+                    saveReason: SaveReason.FocusChange
+                });
+            }
+        }
     }
 
     protected updateAutoSaveMode(mode: AutoSaveMode): void {
@@ -169,37 +202,11 @@ export class SaveableService implements FrontendApplicationContribution {
                         saveReason: SaveReason.AfterDelay
                     });
                 }
-            },
-            this.addBlurListener(widget, saveable)
+            }
         );
         this.saveThrottles.set(widget, saveThrottle);
         this.applySaveableWidget(widget, saveable);
         return saveThrottle;
-    }
-
-    protected addBlurListener(widget: Widget, saveable: Saveable): Disposable {
-        const document = widget.node.ownerDocument;
-        const listener = (() => {
-            if ((this.saveMode === 'onWindowChange' || this.saveMode === 'onFocusChange') && !this.windowHasFocus(document) && this.shouldAutoSave(widget, saveable)) {
-                saveable.save({
-                    saveReason: SaveReason.FocusChange
-                });
-            }
-        }).bind(this);
-        document.addEventListener('blur', listener);
-        return Disposable.create(() => {
-            document.removeEventListener('blur', listener);
-        });
-    }
-
-    protected windowHasFocus(document: Document): boolean {
-        if (document.visibilityState === 'hidden') {
-            return false;
-        } else if (document.hasFocus()) {
-            return true;
-        }
-        // TODO: Add support for iframes
-        return false;
     }
 
     protected shouldAutoSave(widget: Widget, saveable: Saveable): boolean {

--- a/packages/core/src/browser/saveable-service.ts
+++ b/packages/core/src/browser/saveable-service.ts
@@ -180,7 +180,7 @@ export class SaveableService implements FrontendApplicationContribution {
     protected addBlurListener(widget: Widget, saveable: Saveable): Disposable {
         const document = widget.node.ownerDocument;
         const listener = (() => {
-            if (this.saveMode === 'onWindowChange' && !this.windowHasFocus(document) && this.shouldAutoSave(widget, saveable)) {
+            if ((this.saveMode === 'onWindowChange' || this.saveMode === 'onFocusChange') && !this.windowHasFocus(document) && this.shouldAutoSave(widget, saveable)) {
                 saveable.save({
                     saveReason: SaveReason.FocusChange
                 });

--- a/packages/core/src/browser/window/browser-window-module.ts
+++ b/packages/core/src/browser/window/browser-window-module.ts
@@ -24,6 +24,7 @@ import { SecondaryWindowService } from './secondary-window-service';
 import { DefaultSecondaryWindowService } from './default-secondary-window-service';
 import { bindRootContributionProvider } from '../../common';
 import { WindowTitleContribution } from './window-title-service';
+import { WindowFocusService } from './window-focus-service';
 
 export default new ContainerModule(bind => {
     bind(DefaultWindowService).toSelf().inSingletonScope();
@@ -31,5 +32,6 @@ export default new ContainerModule(bind => {
     bind(FrontendApplicationContribution).toService(DefaultWindowService);
     bind(ClipboardService).to(BrowserClipboardService).inSingletonScope();
     bind(SecondaryWindowService).to(DefaultSecondaryWindowService).inSingletonScope();
+    bind(WindowFocusService).toSelf().inSingletonScope();
     bindRootContributionProvider(bind, WindowTitleContribution);
 });

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -22,6 +22,7 @@ import { Saveable } from '../saveable';
 import { Emitter, environment, Event, PreferenceService } from '../../common';
 import { SaveableService } from '../saveable-service';
 import { getAllWidgetsFromSecondaryWindow, getDefaultRestoreArea } from '../secondary-window-handler';
+import { WindowFocusService } from './window-focus-service';
 
 @injectable()
 export class DefaultSecondaryWindowService implements SecondaryWindowService {
@@ -52,6 +53,9 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
 
     @inject(SaveableService)
     protected readonly saveResourceService: SaveableService;
+
+    @inject(WindowFocusService)
+    protected readonly windowFocusService: WindowFocusService;
 
     @postConstruct()
     init(): void {
@@ -106,6 +110,7 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
             this.secondaryWindows.push(newWindow);
             this.onWindowOpenedEmitter.fire(newWindow);
             newWindow.addEventListener('DOMContentLoaded', () => {
+                const focusRegistration = this.windowFocusService.registerWindow(newWindow);
                 newWindow.addEventListener('beforeunload', evt => {
                     const widgets = getAllWidgetsFromSecondaryWindow(newWindow) ?? [widget];
                     for (const w of widgets) {
@@ -120,6 +125,7 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
                 }, { capture: true });
 
                 newWindow.addEventListener('unload', () => {
+                    focusRegistration.dispose();
                     const extIndex = this.secondaryWindows.indexOf(newWindow);
                     if (extIndex > -1) {
                         this.onWindowClosedEmitter.fire(newWindow);

--- a/packages/core/src/browser/window/window-focus-service.ts
+++ b/packages/core/src/browser/window/window-focus-service.ts
@@ -1,0 +1,187 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// based on https://github.com/microsoft/vscode/blob/ea6aac971b851ff8675f9ea04f8c0dfc36034a89/src/vs/workbench/services/host/browser/browserHostService.ts
+// and https://github.com/microsoft/vscode/blob/ea6aac971b851ff8675f9ea04f8c0dfc36034a89/src/vs/base/browser/dom.ts#L1319 (FocusTracker)
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { injectable, postConstruct } from 'inversify';
+import { Disposable, DisposableCollection, Emitter, Event } from '../../common';
+
+export interface WindowFocusEvent {
+    win: Window;
+    hasFocus: boolean;
+}
+
+/**
+ * Tracks focus state for each registered application window independently.
+ *
+ * The main window is registered automatically. Secondary windows should be
+ * registered via {@link registerWindow} — typically by the service responsible
+ * for creating them.
+ *
+ * Uses two complementary signals per window for robust detection:
+ * - `window` `focus`/`blur` events (OS-level window focus changes)
+ * - `document` `visibilitychange` events (browser tab switches)
+ *
+ * Blur events are debounced per window with `setTimeout(0)` so that focus
+ * moving between elements within the same window does not produce a false
+ * blur: the subsequent `focus` event cancels the pending blur before it fires.
+ *
+ * Each per-window event is latched — it only fires when that window's focus
+ * state actually changes.
+ */
+@injectable()
+export class WindowFocusService implements Disposable {
+
+    protected readonly onDidWindowChangeFocusEmitter = new Emitter<WindowFocusEvent>();
+
+    /**
+     * Fires when an individual window's focus state changes.
+     * The event payload identifies which window changed and whether it gained or lost focus.
+     *
+     * A window losing focus to another application window will fire separately
+     * for each window involved: one event with `hasFocus: false` for the window
+     * that lost focus, and one with `hasFocus: true` for the window that gained it.
+     */
+    readonly onDidWindowChangeFocus: Event<WindowFocusEvent> = this.onDidWindowChangeFocusEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection(this.onDidWindowChangeFocusEmitter);
+
+    /** Per-window tracking state. */
+    protected readonly windowStates = new Map<Window, WindowTrackingState>();
+
+    @postConstruct()
+    protected init(): void {
+        this.registerWindow(window);
+    }
+
+    /**
+     * Register a window for focus tracking. The returned {@link Disposable}
+     * removes the window from tracking when disposed.
+     *
+     * The main window is registered automatically. Call this for secondary
+     * windows when they are created.
+     */
+    registerWindow(win: Window): Disposable {
+        if (this.windowStates.has(win)) {
+            return Disposable.NULL;
+        }
+
+        const state: WindowTrackingState = {
+            lastFocusState: this.windowHasFocus(win),
+            pendingBlurTimeout: undefined,
+        };
+        this.windowStates.set(win, state);
+
+        const onFocus = () => this.handleFocus(win, state);
+        const onBlur = () => this.scheduleBlur(win, state);
+        const onVisibilityChange = () => this.updateWindowFocusState(win, state);
+
+        win.addEventListener('focus', onFocus);
+        win.addEventListener('blur', onBlur);
+        win.document.addEventListener('visibilitychange', onVisibilityChange);
+
+        const cleanup = Disposable.create(() => {
+            this.cancelPendingBlur(state);
+            this.windowStates.delete(win);
+            win.removeEventListener('focus', onFocus);
+            win.removeEventListener('blur', onBlur);
+            try {
+                win.document.removeEventListener('visibilitychange', onVisibilityChange);
+            } catch {
+                // The window may already be closed
+            }
+        });
+
+        this.toDispose.push(cleanup);
+        return cleanup;
+    }
+
+    /**
+     * Whether any registered window currently has focus.
+     */
+    get hasFocus(): boolean {
+        for (const win of this.windowStates.keys()) {
+            if (this.windowHasFocus(win)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected windowHasFocus(win: Window): boolean {
+        try {
+            return win.document.hasFocus();
+        } catch {
+            // The window may have been closed
+            return false;
+        }
+    }
+
+    protected handleFocus(win: Window, state: WindowTrackingState): void {
+        // Cancel this window's pending blur — focus arrived before the timeout,
+        // meaning focus just moved between elements within this window.
+        this.cancelPendingBlur(state);
+        this.updateWindowFocusState(win, state);
+    }
+
+    /**
+     * Schedule a deferred blur check for this specific window.
+     * If no `focus` event arrives on this same window before the timeout fires,
+     * we treat it as a real focus loss for that window.
+     */
+    protected scheduleBlur(win: Window, state: WindowTrackingState): void {
+        this.cancelPendingBlur(state);
+        state.pendingBlurTimeout = setTimeout(() => {
+            state.pendingBlurTimeout = undefined;
+            this.updateWindowFocusState(win, state);
+        }, 0);
+    }
+
+    protected cancelPendingBlur(state: WindowTrackingState): void {
+        if (state.pendingBlurTimeout !== undefined) {
+            clearTimeout(state.pendingBlurTimeout);
+            state.pendingBlurTimeout = undefined;
+        }
+    }
+
+    /**
+     * Re-evaluate a single window's focus and fire if it changed (latching).
+     */
+    protected updateWindowFocusState(win: Window, state: WindowTrackingState): void {
+        const focused = this.windowHasFocus(win);
+        if (focused !== state.lastFocusState) {
+            state.lastFocusState = focused;
+            this.onDidWindowChangeFocusEmitter.fire({ win, hasFocus: focused });
+        }
+    }
+
+    dispose(): void {
+        for (const state of this.windowStates.values()) {
+            this.cancelPendingBlur(state);
+        }
+        this.toDispose.dispose();
+    }
+}
+
+interface WindowTrackingState {
+    lastFocusState: boolean;
+    pendingBlurTimeout: ReturnType<typeof setTimeout> | undefined;
+}

--- a/packages/core/src/electron-browser/window/electron-window-module.ts
+++ b/packages/core/src/electron-browser/window/electron-window-module.ts
@@ -32,6 +32,7 @@ import { ExternalAppOpenHandler } from './external-app-open-handler';
 import { ElectronUriHandlerContribution } from '../electron-uri-handler';
 import { bindRootContributionProvider } from '../../common';
 import { WindowTitleContribution } from '../../browser/window/window-title-service';
+import { WindowFocusService } from '../../browser/window/window-focus-service';
 import { WindowZoomStatusBarItem } from './window-zoom-status-bar-item';
 import '../../../src/electron-browser/style/window-zoom-action-bar.css';
 
@@ -50,6 +51,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(ExternalAppOpenHandler).toSelf().inSingletonScope();
     bind(OpenHandler).toService(ExternalAppOpenHandler);
     bindRootContributionProvider(bind, WindowTitleContribution);
+    bind(WindowFocusService).toSelf().inSingletonScope();
     bind(WindowZoomStatusBarItem).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(WindowZoomStatusBarItem);
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

In VSCode, when the autosave mode is `onFocusChange`, a file is saved both when the tab loses focus and when the window loses focus. In Theia, it is only saved when the tab loses focus. This PR adds autosaving on window focus loss to match VSCode's behavior.

Fixes #17146 

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Set autosave mode to `onFocusChange`.
2. Dirty the focused editor.
3. Switch to another application or minimize Theia.
4. Observe that the focused editor is automatically saved.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
