### PR TITLE
Use withServices to detect early Monaco initialization

### DIFF
--- a/packages/monaco/src/browser/monaco-init.spec.ts
+++ b/packages/monaco/src/browser/monaco-init.spec.ts
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
+import { IInstantiationService } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiation';
+import { InstantiationService } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiationService';
+import { ServiceCollection } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/serviceCollection';
+
+disableJSDOM();
+
+/**
+ * @monaco-uplift
+ *
+ * These tests guard internal assumptions that the `patchServices` function in
+ * `monaco-init.ts` makes about the object returned by
+ * `StandaloneServices.get(IInstantiationService)`.  Specifically, it expects:
+ *
+ * 1. The returned object is an instance of the concrete {@link InstantiationService} class.
+ * 2. That class exposes a private `_services` field of type {@link ServiceCollection}.
+ *
+ * Because `_services` is a private implementation detail of Monaco, it may be
+ * renamed or removed in a future release.  If any of these tests fail after a
+ * Monaco version bump, `patchServices` must be updated to match the new internals.
+ */
+describe('Monaco InstantiationService internals', () => {
+
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    it('StandaloneServices.get(IInstantiationService) should be an instance of InstantiationService', () => {
+        const instantiationService = StandaloneServices.get(IInstantiationService);
+        expect(instantiationService).to.be.an.instanceOf(InstantiationService);
+    });
+
+    it('StandaloneServices.get(IInstantiationService) should have a _services property that is a ServiceCollection', () => {
+        const instantiationService = StandaloneServices.get(IInstantiationService);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const services = (instantiationService as any)['_services'];
+        expect(services).to.not.be.undefined;
+        expect(services).to.be.an.instanceOf(ServiceCollection);
+    });
+});

--- a/packages/monaco/src/browser/monaco-init.spec.ts
+++ b/packages/monaco/src/browser/monaco-init.spec.ts
@@ -18,6 +18,7 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';
+import { Disposable } from '@theia/core';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { IInstantiationService } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiation';
 import { InstantiationService } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiationService';
@@ -28,16 +29,18 @@ disableJSDOM();
 /**
  * @monaco-uplift
  *
- * These tests guard internal assumptions that the `patchServices` function in
- * `monaco-init.ts` makes about the object returned by
- * `StandaloneServices.get(IInstantiationService)`.  Specifically, it expects:
+ * These tests guard internal assumptions that `monaco-init.ts` makes about
+ * Monaco's `StandaloneServices`.  Specifically:
  *
- * 1. The returned object is an instance of the concrete {@link InstantiationService} class.
+ * 1. `StandaloneServices.get(IInstantiationService)` returns an instance of the
+ *    concrete {@link InstantiationService} class.
  * 2. That class exposes a private `_services` field of type {@link ServiceCollection}.
+ * 3. `StandaloneServices.withServices` calls its callback **synchronously** when
+ *    services are already initialized (used to detect premature initialization).
  *
- * Because `_services` is a private implementation detail of Monaco, it may be
- * renamed or removed in a future release.  If any of these tests fail after a
- * Monaco version bump, `patchServices` must be updated to match the new internals.
+ * Because these rely on private implementation details of Monaco, they may break
+ * in a future release.  If any of these tests fail after a Monaco version bump,
+ * the corresponding code in `monaco-init.ts` must be updated to match.
  */
 describe('Monaco InstantiationService internals', () => {
 
@@ -55,5 +58,21 @@ describe('Monaco InstantiationService internals', () => {
         const services = (instantiationService as any)['_services'];
         expect(services).to.not.be.undefined;
         expect(services).to.be.an.instanceOf(ServiceCollection);
+    });
+
+    // MonacoInit.init() uses withServices to detect whether StandaloneServices
+    // was already initialized: it passes a callback that sets a flag, then reads
+    // the flag immediately afterwards.  This only works if withServices calls
+    // the callback synchronously when services are already initialized.
+    it('StandaloneServices.withServices should call the callback synchronously when already initialized', () => {
+        // Ensure services are initialized (get triggers initialization if needed).
+        StandaloneServices.get(IInstantiationService);
+
+        let called = false;
+        StandaloneServices.withServices(() => {
+            called = true;
+            return Disposable.NULL;
+        });
+        expect(called).to.be.true;
     });
 });

--- a/packages/monaco/src/browser/monaco-init.ts
+++ b/packages/monaco/src/browser/monaco-init.ts
@@ -63,6 +63,7 @@ import { ILayoutService } from '@theia/monaco-editor-core/esm/vs/platform/layout
 import { Event } from '@theia/monaco-editor-core/esm/vs/base/common/event';
 import * as dom from '@theia/monaco-editor-core/esm/vs/base/browser/dom';
 import { mainWindow } from '@theia/monaco-editor-core/esm/vs/base/browser/window';
+import { Disposable } from '@theia/core';
 
 export const contentHoverWidgetPatcher = createContentHoverWidgetPatcher();
 
@@ -199,6 +200,20 @@ export namespace MonacoInit {
             [ILayoutService.toString()]: new SyncDescriptor(MonacoLayoutServiceConstructor, [])
         };
 
+        // Detect whether StandaloneServices was already initialized before we get a chance to
+        // apply our overrides.  `withServices` calls the callback synchronously when `initialized`
+        // is already `true`, so the flag will be set before we proceed.  If it remains `false`,
+        // our `initialize(overrides)` call below will be the first and our descriptors will be
+        // applied normally.
+        // @monaco-uplift: verify that `withServices` still calls the callback synchronously when
+        // already initialized — if this changes, the premature-initialization detection will break.
+        let isInitialized = false;
+        StandaloneServices.withServices(() => {
+            isInitialized = true;
+            return Disposable.NULL;
+        });
+        const servicesInitializedBeforeOverrides = isInitialized;
+
         // Try the standard initialization path first.
         StandaloneServices.initialize(overrides);
 
@@ -206,46 +221,58 @@ export namespace MonacoInit {
         // triggered as a side-effect during module loading), the call above is a no-op and our overrides are
         // silently dropped.  Detect this situation, warn about it, and inject our service descriptors directly
         // into the internal service collection so that they are used when the services are next resolved.
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const instantiationService = StandaloneServices.get(IInstantiationService) as any;
-        const serviceCollection: ServiceCollection | undefined = instantiationService?._services;
-        if (serviceCollection) {
-            const patchedServices: string[] = [];
-            const alreadyInstantiatedServices: string[] = [];
-            for (const serviceId of Object.keys(overrides)) {
-                const serviceIdentifier = createDecorator(serviceId);
-                const existing = serviceCollection.get(serviceIdentifier);
-                if (existing instanceof SyncDescriptor && existing !== overrides[serviceId]) {
-                    // The override was not applied by initialize() – patch it in manually.
-                    serviceCollection.set(serviceIdentifier, overrides[serviceId]);
-                    patchedServices.push(serviceId);
-                } else if (existing !== undefined && !(existing instanceof SyncDescriptor) && existing !== overrides[serviceId]) {
-                    // The service was already instantiated – we cannot override it anymore.
-                    alreadyInstantiatedServices.push(serviceId);
-                }
-            }
-            if (patchedServices.length > 0) {
-                console.warn(
-                    'StandaloneServices was already initialized before MonacoInit.init() was called. '
-                    + 'This typically happens when a StandaloneServices.get() call is triggered as a side-effect during module loading. '
-                    + 'The following Theia service overrides had to be patched in after the fact: '
-                    + patchedServices.join(', ')
-                    + '. Investigate the module loading order to prevent premature initialization.'
-                );
-            }
-            if (alreadyInstantiatedServices.length > 0) {
-                console.error(
-                    'StandaloneServices was already initialized and the following services were already instantiated '
-                    + 'before MonacoInit.init() could apply Theia overrides: '
-                    + alreadyInstantiatedServices.join(', ')
-                    + '. These services are using the default Monaco implementations instead of Theia\'s. '
-                    + 'This may cause unexpected behavior. Investigate which code triggers premature service resolution.'
-                );
-            }
+        //
+        // We only need this fallback when initialize() was a no-op.  On the normal startup path,
+        // initialize() succeeds and any services that get instantiated during that call (e.g. as
+        // dependencies of editor features) are created from *our* Theia descriptors — not the
+        // Monaco defaults — so they are perfectly fine and must not be flagged.
+        if (servicesInitializedBeforeOverrides) {
+            patchServices(overrides);
         }
 
         // Make sure the global base hover delegate is initialized as otherwise the quick input will throw an error and not update correctly
         // in case no Monaco editor was constructed before and items with keybindings are shown. See #15042.
         setBaseLayerHoverDelegate(StandaloneServices.get(IHoverService));
+    }
+}
+
+function patchServices(overrides: Record<string, SyncDescriptor<unknown>>): void {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const instantiationService = StandaloneServices.get(IInstantiationService) as any;
+    const serviceCollection: ServiceCollection | undefined = instantiationService?._services;
+    if (serviceCollection) {
+        const patchedServices: string[] = [];
+        const alreadyInstantiatedServices: string[] = [];
+        for (const serviceId of Object.keys(overrides)) {
+            const serviceIdentifier = createDecorator(serviceId);
+            const existing = serviceCollection.get(serviceIdentifier);
+            if (existing instanceof SyncDescriptor && existing !== overrides[serviceId]) {
+                // The override was not applied by initialize() – patch it in manually.
+                serviceCollection.set(serviceIdentifier, overrides[serviceId]);
+                patchedServices.push(serviceId);
+            } else if (existing !== undefined && !(existing instanceof SyncDescriptor)) {
+                // The service was already instantiated from the default Monaco
+                // implementation – we cannot override it anymore.
+                alreadyInstantiatedServices.push(serviceId);
+            }
+        }
+        if (patchedServices.length > 0) {
+            console.warn(
+                'StandaloneServices was already initialized before MonacoInit.init() was called. '
+                + 'This typically happens when a StandaloneServices.get() call is triggered as a side-effect during module loading. '
+                + 'The following Theia service overrides had to be patched in after the fact: '
+                + patchedServices.join(', ')
+                + '. Investigate the module loading order to prevent premature initialization.'
+            );
+        }
+        if (alreadyInstantiatedServices.length > 0) {
+            console.error(
+                'StandaloneServices was already initialized and the following services were already instantiated '
+                + 'before MonacoInit.init() could apply Theia overrides: '
+                + alreadyInstantiatedServices.join(', ')
+                + '. These services are using the default Monaco implementations instead of Theia\'s. '
+                + 'This may cause unexpected behavior. Investigate which code triggers premature service resolution.'
+            );
+        }
     }
 }

--- a/packages/monaco/src/browser/monaco-init.ts
+++ b/packages/monaco/src/browser/monaco-init.ts
@@ -36,6 +36,7 @@ import { ICodeEditorService } from '@theia/monaco-editor-core/esm/vs/editor/brow
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { SyncDescriptor } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/descriptors';
 import { IInstantiationService, createDecorator } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiation';
+import { InstantiationService } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/instantiationService';
 import { ServiceCollection } from '@theia/monaco-editor-core/esm/vs/platform/instantiation/common/serviceCollection';
 import { MonacoEditorServiceFactory, MonacoEditorServiceFactoryType } from './monaco-editor-service';
 import { IConfigurationService } from '@theia/monaco-editor-core/esm/vs/platform/configuration/common/configuration';
@@ -236,43 +237,60 @@ export namespace MonacoInit {
     }
 }
 
+// @monaco-uplift: verify that the concrete InstantiationService class still exposes a
+// private `_services: ServiceCollection` property.  See monaco-init.spec.ts for a CI
+// guard that will flag a mismatch after a Monaco version bump.
 function patchServices(overrides: Record<string, SyncDescriptor<unknown>>): void {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const instantiationService = StandaloneServices.get(IInstantiationService) as any;
-    const serviceCollection: ServiceCollection | undefined = instantiationService?._services;
-    if (serviceCollection) {
-        const patchedServices: string[] = [];
-        const alreadyInstantiatedServices: string[] = [];
-        for (const serviceId of Object.keys(overrides)) {
-            const serviceIdentifier = createDecorator(serviceId);
-            const existing = serviceCollection.get(serviceIdentifier);
-            if (existing instanceof SyncDescriptor && existing !== overrides[serviceId]) {
-                // The override was not applied by initialize() – patch it in manually.
-                serviceCollection.set(serviceIdentifier, overrides[serviceId]);
-                patchedServices.push(serviceId);
-            } else if (existing !== undefined && !(existing instanceof SyncDescriptor)) {
-                // The service was already instantiated from the default Monaco
-                // implementation – we cannot override it anymore.
-                alreadyInstantiatedServices.push(serviceId);
-            }
+    const instantiationService = StandaloneServices.get(IInstantiationService);
+    if (!(instantiationService instanceof InstantiationService)) {
+        console.error(
+            'StandaloneServices returned an IInstantiationService that is not an instance of InstantiationService. '
+            + 'Theia service overrides cannot be patched in after premature initialization. '
+            + 'Investigate whether Monaco\'s internal InstantiationService class has been refactored.'
+        );
+        return;
+    }
+    const serviceCollection = instantiationService['_services'];
+    if (!(serviceCollection instanceof ServiceCollection)) {
+        console.error(
+            'InstantiationService._services is not a ServiceCollection (got '
+            + (serviceCollection === undefined ? 'undefined' : typeof serviceCollection)
+            + '). Theia service overrides cannot be patched in after premature initialization. '
+            + 'Investigate whether Monaco\'s InstantiationService internals have changed.'
+        );
+        return;
+    }
+    const patchedServices: string[] = [];
+    const alreadyInstantiatedServices: string[] = [];
+    for (const serviceId of Object.keys(overrides)) {
+        const serviceIdentifier = createDecorator(serviceId);
+        const existing = serviceCollection.get(serviceIdentifier);
+        if (existing instanceof SyncDescriptor && existing !== overrides[serviceId]) {
+            // The override was not applied by initialize() – patch it in manually.
+            serviceCollection.set(serviceIdentifier, overrides[serviceId]);
+            patchedServices.push(serviceId);
+        } else if (existing !== undefined && !(existing instanceof SyncDescriptor)) {
+            // The service was already instantiated from the default Monaco
+            // implementation – we cannot override it anymore.
+            alreadyInstantiatedServices.push(serviceId);
         }
-        if (patchedServices.length > 0) {
-            console.warn(
-                'StandaloneServices was already initialized before MonacoInit.init() was called. '
-                + 'This typically happens when a StandaloneServices.get() call is triggered as a side-effect during module loading. '
-                + 'The following Theia service overrides had to be patched in after the fact: '
-                + patchedServices.join(', ')
-                + '. Investigate the module loading order to prevent premature initialization.'
-            );
-        }
-        if (alreadyInstantiatedServices.length > 0) {
-            console.error(
-                'StandaloneServices was already initialized and the following services were already instantiated '
-                + 'before MonacoInit.init() could apply Theia overrides: '
-                + alreadyInstantiatedServices.join(', ')
-                + '. These services are using the default Monaco implementations instead of Theia\'s. '
-                + 'This may cause unexpected behavior. Investigate which code triggers premature service resolution.'
-            );
-        }
+    }
+    if (patchedServices.length > 0) {
+        console.warn(
+            'StandaloneServices was already initialized before MonacoInit.init() was called. '
+            + 'This typically happens when a StandaloneServices.get() call is triggered as a side-effect during module loading. '
+            + 'The following Theia service overrides had to be patched in after the fact: '
+            + patchedServices.join(', ')
+            + '. Investigate the module loading order to prevent premature initialization.'
+        );
+    }
+    if (alreadyInstantiatedServices.length > 0) {
+        console.error(
+            'StandaloneServices was already initialized and the following services were already instantiated '
+            + 'before MonacoInit.init() could apply Theia overrides: '
+            + alreadyInstantiatedServices.join(', ')
+            + '. These services are using the default Monaco implementations instead of Theia\'s. '
+            + 'This may cause unexpected behavior. Investigate which code triggers premature service resolution.'
+        );
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes #17245 by using a targeted check to detect whether Monaco services had been initialized before our call to `StandaloneServices.initialize`

#### How to test

1. In the normal case, you should not see the log reported in #17245
2. If you put a breakpoint after our call to `StandaloneServices.initialize`, you should see that `isInitialized` is `true` and `servicesInitializedBeforeOverrides` is `false`, since we have then initialized the services, but they hadn't been initialized before our call.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
