### PR TITLE
Prevent illegal array size when constructing menu bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   - Removed protected method `createCounterForUri(uri)` (replaced by `nextCounter()`)
   - Removed protected method `getOrCreateCounterForUri(uri)`
 - [plugin-ext] changed the timing of plugin contribution loading: `beforeLoadContributions` now waits for `attached_shell` instead of `initialized_layout`. Overrides of `beforeLoadContributions` or `loadContributions` that assume the full layout is already initialized may need to adjust their logic [#17278](https://github.com/eclipse-theia/theia/pull/17278)
+- [core] disabled Lumino's overflow menu feature in the main menu bar by passing `overflowMenuOptions: { isVisible: false }` to the `MenuBarWidget` constructor. The feature was never functional in Theia and could cause a `RangeError` when toggling menu bar visibility. Adopters who need overflow menu support can override `BrowserMainMenuFactory.createMenuBar` to construct the `DynamicMenuBarWidget` with different options [#17362](https://github.com/eclipse-theia/theia/pull/17362)
 
 ## 1.70.0 - 3/26/2026
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -718,8 +718,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             execute: title => title?.owner && this.shell.toggleMaximized(title?.owner),
         }));
         commandRegistry.registerCommand(CommonCommands.SHOW_MENU_BAR, {
-            isEnabled: () => !isOSX,
-            isVisible: () => !isOSX,
+            isEnabled: () => !this.isElectron() || !isOSX,
+            isVisible: () => !this.isElectron() || !isOSX,
             execute: () => {
                 const menuBarVisibility = 'window.menuBarVisibility';
                 const visibility = this.preferences[menuBarVisibility];

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -143,7 +143,14 @@ export class DynamicMenuBarWidget extends MenuBarWidget {
     protected previousFocusedElement: HTMLElement | undefined;
 
     constructor() {
-        super();
+        // Disable Lumino's overflow menu feature. The feature has a bug where
+        // `onUpdateRequest` consumes a stale `_overflowIndex` (only recomputed at the
+        // end of the method), which causes a RangeError when the menu bar is rendered
+        // at zero width. Additionally, Theia's CSS does not constrain the menu bar's
+        // offsetWidth to the available space, so the overflow detection never triggers.
+        // See https://github.com/eclipse-theia/theia/issues/17352
+        // See https://github.com/jupyterlab/lumino/issues/811
+        super({ overflowMenuOptions: { isVisible: false } });
         // HACK we need to hook in on private method _openChildMenu. Don't do this at home!
         DynamicMenuBarWidget.prototype['_openChildMenu'] = () => {
             if (this.activeMenu instanceof DynamicMenuWidget) {
@@ -161,22 +168,6 @@ export class DynamicMenuBarWidget extends MenuBarWidget {
             }
             super['_openChildMenu']();
         };
-    }
-
-    /**
-     * Workaround for a Lumino bug: {@link MenuBar.clearMenus clearMenus} does not reset the
-     * private `_overflowMenu` and `_overflowIndex` fields. On the next `onUpdateRequest`, the
-     * stale `_overflowMenu !== null` causes the visible-menu count to go negative, which in
-     * turn triggers `new Array(-1)` → `RangeError: Invalid array length`.
-     *
-     * See https://github.com/eclipse-theia/theia/issues/17352
-     */
-    override clearMenus(): void {
-        super.clearMenus();
-        // eslint-disable-next-line no-null/no-null
-        this['_overflowMenu'] = null;
-        this['_overflowIndex'] = -1;
-        this['_menuItemSizes'] = [];
     }
 
     async activateMenu(label: string, ...labels: string[]): Promise<MenuWidget> {

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -163,6 +163,21 @@ export class DynamicMenuBarWidget extends MenuBarWidget {
         };
     }
 
+    /**
+     * Workaround for a Lumino bug: {@link MenuBar.clearMenus clearMenus} does not reset the
+     * private `_overflowMenu` and `_overflowIndex` fields. On the next `onUpdateRequest`, the
+     * stale `_overflowMenu !== null` causes the visible-menu count to go negative, which in
+     * turn triggers `new Array(-1)` → `RangeError: Invalid array length`.
+     *
+     * See https://github.com/eclipse-theia/theia/issues/17352
+     */
+    override clearMenus(): void {
+        super.clearMenus();
+        this['_overflowMenu'] = null;
+        this['_overflowIndex'] = -1;
+        this['_menuItemSizes'] = [];
+    }
+
     async activateMenu(label: string, ...labels: string[]): Promise<MenuWidget> {
         const menu = this.menus.find(m => m.title.label === label);
         if (!menu) {

--- a/packages/core/src/browser/menu/browser-menu-plugin.ts
+++ b/packages/core/src/browser/menu/browser-menu-plugin.ts
@@ -173,6 +173,7 @@ export class DynamicMenuBarWidget extends MenuBarWidget {
      */
     override clearMenus(): void {
         super.clearMenus();
+        // eslint-disable-next-line no-null/no-null
         this['_overflowMenu'] = null;
         this['_overflowIndex'] = -1;
         this['_menuItemSizes'] = [];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes #17352 by disabling Lumino's overflow menu feature for the main menu bar. The overflow feature has a bug where `onUpdateRequest` consumes a stale `_overflowIndex` (only recomputed at the end of the method), which causes a `RangeError` when the menu bar is rendered at zero width — exactly what happens when toggling the menu bar visibility. Additionally, Theia's CSS does not constrain the menu bar's `offsetWidth` to the available space, so the overflow detection never triggers in practice.

The fix passes `{ overflowMenuOptions: { isVisible: false } }` to the `MenuBarWidget` constructor to disable the feature entirely.

Also restricts the "Toggle Menu Bar" command to non-macOS or non-Electron contexts (it was previously hidden on all macOS, but it should be available in the browser on macOS).

See also: https://github.com/jupyterlab/lumino/issues/811

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. In the browser... (or, probably, in Electron on Windows or Linux)
2. Use the View > Appearance > Toggle Menu Bar command two or more times
3. The menu bar should not be broken at any point.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)