### PR TITLE
Replace thinking mode with reasoning selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,14 @@
 
 ## 1.71.0 - TBD
 
+- [ai] replaced the per-model thinking-mode toggle with a provider-agnostic reasoning selector and `ReasoningSettings` abstraction; the chosen level can be persisted per agent via the chat capabilities save action [#17363](https://github.com/eclipse-theia/theia/pull/17363)
 - [core] added `errorHandling` option to `Emitter` to control how listener exceptions are handled: `'log'` (default), `'propagate'` (collect and re-throw), or a custom callback [#17332](https://github.com/eclipse-theia/theia/pull/17332)
 - [editor] replaced the per-URI editor counter system in `EditorManager` with random counters [#17275](https://github.com/eclipse-theia/theia/pull/17275)
 - [core] the Inversify containers created in the backend for each frontend connection (connection-scoped child containers) now unbind all services via `Container::unbindAllAsync()` upon closure of the RPC channel. This allows clean-up methods annotated with `@preDestroy()` to run, releasing resources. Downstream applications should be aware that service instances deliberately shared between connection-scoped containers, and service instances obtained from the root container that are explicitly bound again in the connection-scoped module, will cause such shared services to be destroyed while still in use in other containers. Both of these scenarios are already Inversify anti-patterns, so are not expected to arise in practice. [#17384](https://github.com/eclipse-theia/theia/pull/17384)
 
 <a name="breaking_changes_1.71.0">[Breaking Changes:](#breaking_changes_1.71.0)</a>
 
+- [ai] removed `ThinkingModeSettings` and the `thinkingMode` field from `UserRequest` / `CommonChatSessionSettings` in favor of `ReasoningSettings { level }` and the `reasoning` field. Provider model descriptions now expose `reasoningSupport` / `reasoningApi`. Adopters consuming `@theia/ai-core` or `@theia/ai-chat` should migrate to the new request shape [#17363](https://github.com/eclipse-theia/theia/pull/17363)
 - [core] changed the visibility of `ChannelMultiplexer.pendingOpen` from `protected` to `private` [#17332](https://github.com/eclipse-theia/theia/pull/17332)
 - [core] `Uint8ArrayWriteBuffer`'s `onCommit` emitter now propagates exceptions from listeners instead of silently catching them. Code that relied on exceptions being swallowed should add its own error handling [#17332](https://github.com/eclipse-theia/theia/pull/17332)
 - [editor] replaced the per-URI editor counter system in `EditorManager` with random counters [#17275](https://github.com/eclipse-theia/theia/pull/17275):

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -16,6 +16,7 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
+import { ReasoningApi, ReasoningSupport } from '@theia/ai-core';
 import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../common';
 import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF } from '../common/anthropic-preferences';
 import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES } from '@theia/ai-core/lib/common/ai-core-preferences';
@@ -38,6 +39,28 @@ const DEFAULT_MODEL_MAX_TOKENS: Record<string, number> = {
     'claude-opus-4-6': 128000,
     'claude-opus-4-1': 32000
 };
+
+/** Claude 4.6+ (Opus/Sonnet/Haiku) use the adaptive thinking API. */
+const EFFORT_REASONING = /^claude-(?:opus|sonnet|haiku)-4-[6-9]/i;
+/** Claude 4.0–4.5 (including dated snapshots) use legacy extended thinking. */
+const BUDGET_REASONING = /^claude-(?:opus|sonnet|haiku)-4-(?:[0-5](?:-|$)|\d{4})/i;
+/** Models that accept the `xhigh` effort value. */
+const XHIGH_EFFORT = /^claude-opus-4-7(?:-|$)/i;
+
+const ANTHROPIC_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'off'
+};
+
+function reasoningApiFor(modelId: string): ReasoningApi | undefined {
+    if (EFFORT_REASONING.test(modelId)) {
+        return 'effort';
+    }
+    if (BUDGET_REASONING.test(modelId)) {
+        return 'budget';
+    }
+    return undefined;
+}
 
 @injectable()
 export class AnthropicFrontendApplicationContribution implements FrontendApplicationContribution {
@@ -136,6 +159,7 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
         const id = `${ANTHROPIC_PROVIDER_ID}/${modelId}`;
         const maxTokens = DEFAULT_MODEL_MAX_TOKENS[modelId];
         const maxRetries = this.aiCorePreferences.get(PREFERENCE_NAME_MAX_RETRIES) ?? 3;
+        const reasoningApi = reasoningApiFor(modelId);
 
         const description: AnthropicModelDescription = {
             id: id,
@@ -143,7 +167,10 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             apiKey: true,
             enableStreaming: true,
             useCaching: true,
-            maxRetries: maxRetries
+            maxRetries: maxRetries,
+            reasoningSupport: reasoningApi ? ANTHROPIC_REASONING_SUPPORT : undefined,
+            reasoningApi,
+            supportsXHighEffort: XHIGH_EFFORT.test(modelId)
         };
 
         if (maxTokens !== undefined) {

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -49,7 +49,7 @@ const XHIGH_EFFORT = /^claude-opus-4-7(?:-|$)/i;
 
 const ANTHROPIC_REASONING_SUPPORT: ReasoningSupport = {
     supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'off'
+    defaultLevel: 'auto'
 };
 
 function reasoningApiFor(modelId: string): ReasoningApi | undefined {
@@ -140,7 +140,9 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                 model.apiKey === newModel.apiKey &&
                 model.maxRetries === newModel.maxRetries &&
                 model.useCaching === newModel.useCaching &&
-                model.enableStreaming === newModel.enableStreaming));
+                model.enableStreaming === newModel.enableStreaming &&
+                model.reasoningApi === newModel.reasoningApi &&
+                model.supportsXHighEffort === newModel.supportsXHighEffort));
 
         this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
         this.manager.createOrUpdateLanguageModels(...modelsToAddOrUpdate);
@@ -188,6 +190,13 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             if (!pref.model || !pref.url || typeof pref.model !== 'string' || typeof pref.url !== 'string') {
                 return acc;
             }
+            // Default to the model-name heuristic so reasoning-capable Claude models exposed via a
+            // custom endpoint still get the selector. Users can override via the `reasoningApi` field
+            // (set to `null` to disable, or to `'effort'` / `'budget'` to force a specific shape).
+            const reasoningApi: typeof pref.reasoningApi = 'reasoningApi' in pref
+                ? (pref.reasoningApi === 'effort' || pref.reasoningApi === 'budget' ? pref.reasoningApi : undefined)
+                : reasoningApiFor(pref.model);
+            const supportsXHighEffort = typeof pref.supportsXHighEffort === 'boolean' ? pref.supportsXHighEffort : XHIGH_EFFORT.test(pref.model);
             return [
                 ...acc,
                 {
@@ -197,7 +206,10 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                     apiKey: typeof pref.apiKey === 'string' || pref.apiKey === true ? pref.apiKey : undefined,
                     enableStreaming: pref.enableStreaming ?? true,
                     useCaching: pref.useCaching ?? true,
-                    maxRetries: pref.maxRetries ?? maxRetries
+                    maxRetries: pref.maxRetries ?? maxRetries,
+                    reasoningSupport: reasoningApi ? ANTHROPIC_REASONING_SUPPORT : undefined,
+                    reasoningApi,
+                    supportsXHighEffort
                 }
             ];
         }, []);

--- a/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
+++ b/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
@@ -13,8 +13,11 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
+import { ReasoningApi, ReasoningSupport } from '@theia/ai-core';
+
 export const ANTHROPIC_LANGUAGE_MODELS_MANAGER_PATH = '/services/anthropic/language-model-manager';
 export const AnthropicLanguageModelsManager = Symbol('AnthropicLanguageModelsManager');
+
 export interface AnthropicModelDescription {
     /**
      * The identifier of the model which will be shown in the UI.
@@ -48,7 +51,16 @@ export interface AnthropicModelDescription {
      * Maximum number of retry attempts when a request fails. Default is 3.
      */
     maxRetries: number;
-
+    /** When set, the UI exposes a reasoning selector and requests are translated to {@link reasoningApi}. */
+    reasoningSupport?: ReasoningSupport;
+    /**
+     * Which Anthropic reasoning API shape to use. Required when `reasoningSupport` is set.
+     * - `'effort'`: adaptive thinking (`thinking: { type: 'adaptive' }` + `output_config: { effort }`)
+     * - `'budget'`: extended thinking (`thinking: { type: 'enabled', budget_tokens: N }`)
+     */
+    reasoningApi?: ReasoningApi;
+    /** True on models that accept the Anthropic `xhigh` effort value. */
+    supportsXHighEffort?: boolean;
 }
 export interface AnthropicLanguageModelsManager {
     apiKey: string | undefined;

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -55,7 +55,12 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             \n\
             - specify `useCaching: false` to indicate that prompt caching shall not be used.\
             \n\
-            - specify `maxRetries: <number>` to indicate the maximum number of retries when a request fails. 3 by default.'),
+            - specify `maxRetries: <number>` to indicate the maximum number of retries when a request fails. 3 by default.\
+            \n\
+            - specify `reasoningApi: "effort" | "budget"` to opt in to the reasoning selector. By default this is inferred\
+            from the `model` name (Claude 4.6+: `effort`; Claude 4.0–4.5: `budget`). Set to `null` to disable.\
+            \n\
+            - specify `supportsXHighEffort: true` for models that accept the Anthropic `xhigh` effort value.'),
             default: [],
             items: {
                 type: 'object',
@@ -91,6 +96,19 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
                         type: 'number',
                         title: nls.localize('theia/ai/anthropic/customEndpoints/maxRetries/title',
                             'Maximum number of retries when a request fails. 3 by default'),
+                    },
+                    reasoningApi: {
+                        type: ['string', 'null'],
+                        enum: ['effort', 'budget', null], // eslint-disable-line no-null/no-null
+                        title: nls.localize('theia/ai/anthropic/customEndpoints/reasoningApi/title',
+                            'Which Anthropic reasoning API shape to use: `effort` for adaptive thinking (Claude 4.6+),'
+                            + ' `budget` for legacy extended thinking (Claude 4.0–4.5), or `null` to disable.'
+                            + ' Inferred from the model name by default.'),
+                    },
+                    supportsXHighEffort: {
+                        type: 'boolean',
+                        title: nls.localize('theia/ai/anthropic/customEndpoints/supportsXHighEffort/title',
+                            'Indicates whether the model accepts the Anthropic `xhigh` effort value. Inferred from the model name by default.'),
                     }
                 }
             }

--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -16,8 +16,37 @@
 
 import { expect } from 'chai';
 import { AnthropicModel, DEFAULT_MAX_TOKENS, addCacheControlToLastMessage } from './anthropic-language-model';
-import { isUsageResponsePart, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core';
+import { isUsageResponsePart, LanguageModelRequest, LanguageModelStreamResponsePart, ReasoningApi, ReasoningSupport, UserRequest } from '@theia/ai-core';
 import type { Anthropic } from '@anthropic-ai/sdk';
+
+const REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+/** Test helper that exposes the otherwise protected getSettings() method. */
+class TestableAnthropicModel extends AnthropicModel {
+    public callGetSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {
+        return this.getSettings(request);
+    }
+}
+
+function createReasoningModel(
+    modelId: string, reasoningApi: ReasoningApi, supportsXHighEffort: boolean = false
+): TestableAnthropicModel {
+    return new TestableAnthropicModel(
+        'test-id', modelId, { status: 'ready' }, true, false,
+        () => 'test-key', undefined, DEFAULT_MAX_TOKENS,
+        3, undefined, REASONING_SUPPORT, reasoningApi, supportsXHighEffort
+    );
+}
+
+function createNonReasoningModel(modelId: string): TestableAnthropicModel {
+    return new TestableAnthropicModel(
+        'test-id', modelId, { status: 'ready' }, true, false,
+        () => 'test-key', undefined, DEFAULT_MAX_TOKENS
+    );
+}
 
 describe('AnthropicModel', () => {
 
@@ -421,6 +450,79 @@ describe('AnthropicModel', () => {
             expect(usageParts).to.have.lengthOf(1);
             expect(usageParts[0].input_tokens).to.equal(800);
             expect(usageParts[0].output_tokens).to.equal(55);
+        });
+    });
+
+    describe('getSettings effort API (adaptive thinking)', () => {
+        it('maps level=minimal to effort=low', () => {
+            const model = createReasoningModel('claude-opus-4-6', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'minimal' } });
+            expect(result.thinking).to.deep.equal({ type: 'adaptive' });
+            expect(result.output_config).to.deep.equal({ effort: 'low' });
+        });
+        it('maps level=low to effort=medium', () => {
+            const model = createReasoningModel('claude-opus-4-6', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'low' } });
+            expect(result.output_config).to.deep.equal({ effort: 'medium' });
+        });
+        it('maps level=medium to effort=high on models without xhigh', () => {
+            const model = createReasoningModel('claude-opus-4-6', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'medium' } });
+            expect(result.output_config).to.deep.equal({ effort: 'high' });
+        });
+        it('maps level=medium to effort=xhigh on models that support xhigh (Opus 4.7)', () => {
+            const model = createReasoningModel('claude-opus-4-7', 'effort', true);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'medium' } });
+            expect(result.output_config).to.deep.equal({ effort: 'xhigh' });
+        });
+        it('maps level=high to effort=max', () => {
+            const model = createReasoningModel('claude-opus-4-6', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'high' } });
+            expect(result.output_config).to.deep.equal({ effort: 'max' });
+        });
+        it('omits output_config on level=auto so the provider default applies', () => {
+            const model = createReasoningModel('claude-opus-4-6', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'auto' } });
+            expect(result.thinking).to.deep.equal({ type: 'adaptive' });
+            expect(result.output_config).to.equal(undefined);
+        });
+        it('omits thinking entirely when level=off', () => {
+            const model = createReasoningModel('claude-opus-4-7', 'effort', true);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'off' } });
+            expect(result.thinking).to.equal(undefined);
+        });
+    });
+
+    describe('getSettings budget API (legacy extended thinking)', () => {
+        it('emits thinking.type="enabled" with budget_tokens for level=medium', () => {
+            const model = createReasoningModel('claude-sonnet-4-20250514', 'budget');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'medium' } });
+            expect(result.thinking).to.deep.equal({ type: 'enabled', budget_tokens: 16000 });
+        });
+        it('enforces Anthropic 1024 minimum budget for level=minimal', () => {
+            const model = createReasoningModel('claude-sonnet-4-20250514', 'budget');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'minimal' } });
+            expect(result.thinking).to.deep.equal({ type: 'enabled', budget_tokens: 1024 });
+        });
+        it('uses a positive budget for level=high', () => {
+            const model = createReasoningModel('claude-sonnet-4-20250514', 'budget');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'high' } });
+            const thinking = result.thinking as { type: string, budget_tokens: number };
+            expect(thinking.type).to.equal('enabled');
+            expect(thinking.budget_tokens).to.be.greaterThan(16000);
+        });
+        it('omits thinking entirely when level=off', () => {
+            const model = createReasoningModel('claude-sonnet-4-20250514', 'budget');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'off' } });
+            expect(result.thinking).to.equal(undefined);
+        });
+    });
+
+    describe('non-reasoning models', () => {
+        it('ignores reasoning settings when the model has no reasoningSupport', () => {
+            const model = createNonReasoningModel('claude-3-5-sonnet-20241022');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'high' } });
+            expect(result.thinking).to.equal(undefined);
         });
     });
 });

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -26,6 +26,8 @@ import {
     LanguageModelStreamResponse,
     LanguageModelStreamResponsePart,
     LanguageModelTextResponse,
+    ReasoningApi,
+    ReasoningSupport,
     ToolCallResult,
     ToolInvocationContext,
     UserRequest
@@ -34,6 +36,7 @@ import { CancellationToken, isArray } from '@theia/core';
 import { Anthropic } from '@anthropic-ai/sdk';
 import type { Base64ImageSource, ImageBlockParam, Message, MessageParam, TextBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources';
 import { createProxyFetch } from '@theia/ai-core/lib/node';
+import { anthropicReasoningFor } from './anthropic-reasoning';
 
 export const DEFAULT_MAX_TOKENS = 4096;
 
@@ -190,7 +193,8 @@ function formatToolCallResult(result: ToolCallResult): ToolResultBlockParam['con
 }
 
 /**
- * Implements the Anthropic language model integration for Theia
+ * Implements the Anthropic language model integration for Theia. Reasoning-level
+ * translation lives in {@link anthropicReasoningFor}.
  */
 export class AnthropicModel implements LanguageModel {
 
@@ -204,27 +208,17 @@ export class AnthropicModel implements LanguageModel {
         public url: string | undefined,
         public maxTokens: number = DEFAULT_MAX_TOKENS,
         public maxRetries: number = 3,
-        public proxy?: string
+        public proxy?: string,
+        public reasoningSupport?: ReasoningSupport,
+        public reasoningApi?: ReasoningApi,
+        public supportsXHighEffort?: boolean
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {
-        const baseSettings = request.settings ?? {};
-
-        if (request.thinkingMode?.enabled) {
-            return {
-                ...baseSettings,
-                thinking: {
-                    type: 'enabled',
-                    budget_tokens: request.thinkingMode.budgetTokens ?? this.defaultThinkingBudget
-                }
-            };
-        }
-
-        return baseSettings;
-    }
-
-    protected get defaultThinkingBudget(): number {
-        return 10000;
+        return {
+            ...request.settings,
+            ...anthropicReasoningFor(request.reasoning?.level, this.reasoningApi, this.supportsXHighEffort)
+        };
     }
 
     async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -64,7 +64,10 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                     status,
                     maxTokens: modelDescription.maxTokens !== undefined ? modelDescription.maxTokens : DEFAULT_MAX_TOKENS,
                     maxRetries: modelDescription.maxRetries,
-                    proxy: proxyUrl
+                    proxy: proxyUrl,
+                    reasoningSupport: modelDescription.reasoningSupport,
+                    reasoningApi: modelDescription.reasoningApi,
+                    supportsXHighEffort: modelDescription.supportsXHighEffort
                 });
             } else {
                 this.languageModelRegistry.addLanguageModels([
@@ -78,7 +81,10 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                         modelDescription.url,
                         modelDescription.maxTokens,
                         modelDescription.maxRetries,
-                        proxyUrl
+                        proxyUrl,
+                        modelDescription.reasoningSupport,
+                        modelDescription.reasoningApi,
+                        modelDescription.supportsXHighEffort
                     )
                 ]);
             }

--- a/packages/ai-anthropic/src/node/anthropic-reasoning.ts
+++ b/packages/ai-anthropic/src/node/anthropic-reasoning.ts
@@ -1,0 +1,69 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ReasoningApi, ReasoningLevel } from '@theia/ai-core';
+
+type AnthropicEffort = 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+
+/**
+ * Translates a reasoning level to the Anthropic request fragment to merge into `settings`.
+ * Returns `{}` when reasoning is not requested, unsupported, or disabled — so the caller
+ * can spread it unconditionally.
+ *
+ * See https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking.
+ *
+ * @param api `'effort'` for adaptive thinking, `'budget'` for legacy extended thinking.
+ * @param supportsXHighEffort set on models that accept the `xhigh` effort value.
+ */
+export function anthropicReasoningFor(
+    level: ReasoningLevel | undefined,
+    api: ReasoningApi | undefined,
+    supportsXHighEffort: boolean = false
+): Record<string, unknown> {
+    if (!level || !api || level === 'off') {
+        return {};
+    }
+    if (api === 'effort') {
+        const effort = anthropicEffortForLevel(level, supportsXHighEffort);
+        // On `auto`, omit `output_config` so Anthropic's own default applies.
+        return {
+            thinking: { type: 'adaptive' },
+            ...(effort ? { output_config: { effort } } : {})
+        };
+    }
+    // Legacy extended thinking requires a minimum budget of 1024 tokens.
+    return { thinking: { type: 'enabled', budget_tokens: anthropicBudgetForLevel(level) } };
+}
+
+function anthropicEffortForLevel(level: ReasoningLevel, supportsXHighEffort: boolean): AnthropicEffort | undefined {
+    switch (level) {
+        case 'minimal': return 'low';
+        case 'low': return 'medium';
+        case 'medium': return supportsXHighEffort ? 'xhigh' : 'high';
+        case 'high': return 'max';
+        default: return undefined; // 'auto' → provider default
+    }
+}
+
+function anthropicBudgetForLevel(level: ReasoningLevel): number {
+    switch (level) {
+        case 'minimal': return 1024;
+        case 'low': return 4096;
+        case 'medium': return 16000;
+        case 'high': return 32000;
+        default: return 8000; // 'auto' has no native equivalent on the legacy API
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -22,7 +22,7 @@ import { ChatAgentService } from '@theia/ai-chat/lib/common/chat-agent-service';
 import { ParsedChatRequest } from '@theia/ai-chat/lib/common/parsed-chat-request';
 import {
     GenericCapabilitySelections, AIVariableResolutionRequest, ParsedCapability,
-    FrontendLanguageModelRegistry, ReasoningLevel, ReasoningSupport,
+    FrontendLanguageModelRegistry, ReasoningLevel, ReasoningSettings, ReasoningSupport,
     PREFERENCE_NAME_REASONING, ReasoningPreferenceEntry
 } from '@theia/ai-core';
 import { mergeReasoningSettings } from '@theia/ai-core/lib/browser/frontend-language-model-service';
@@ -248,6 +248,8 @@ export class AIChatInputWidget extends ReactWidget {
     protected currentReasoningSupport?: ReasoningSupport;
     /** Id (`provider/model`) of the model that backs {@link currentReasoningSupport}; used to resolve preference defaults. */
     protected currentLanguageModelId?: string;
+    /** Saved reasoning selection for the receiving agent (loaded from {@link AISettingsService}); used to detect unsaved changes. */
+    protected savedReasoning?: ReasoningSettings;
 
     protected handleReasoningChange = (level: ReasoningLevel): void => {
         const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
@@ -268,6 +270,7 @@ export class AIChatInputWidget extends ReactWidget {
 
     /**
      * Resolves the reasoning level to display in the selector. Priority: session override →
+     * persisted per-agent selection (from {@link AISettingsService}) →
      * `ai-features.reasoning.defaults` preference entry matching the current model/agent →
      * model's declared default → `'off'`.
      */
@@ -279,6 +282,9 @@ export class AIChatInputWidget extends ReactWidget {
         const sessionLevel = session?.model.settings?.commonSettings?.reasoning?.level;
         if (sessionLevel) {
             return sessionLevel;
+        }
+        if (this.savedReasoning?.level) {
+            return this.savedReasoning.level;
         }
         return this.resolvePreferenceReasoningLevel() ?? this.currentReasoningSupport.defaultLevel ?? 'off';
     }
@@ -357,22 +363,47 @@ export class AIChatInputWidget extends ReactWidget {
             const agentSettings = await this.aiSettingsService.getAgentSettings(agentId);
             const savedOverrides = agentSettings?.capabilityOverrides;
             const savedGenericSelections = agentSettings?.genericCapabilitySelections;
+            const savedReasoning = agentSettings?.reasoning;
 
             // Store saved state for comparison
             this.savedCapabilityOverrides = savedOverrides ? { ...savedOverrides } : undefined;
             this.savedGenericCapabilitySelections = savedGenericSelections ? { ...savedGenericSelections } : undefined;
+            this.savedReasoning = savedReasoning ? { ...savedReasoning } : undefined;
 
             // Initialize from saved settings, or empty if none
             this.userCapabilityOverrides = savedOverrides
                 ? new Map(Object.entries(savedOverrides))
                 : new Map<string, boolean>();
             this.genericCapabilitySelections = savedGenericSelections ?? {};
+            // Mirror the saved per-agent reasoning into the chat session so the selector reflects it
+            // immediately and `hasReasoningChangesFromSaved` can compare like-with-like.
+            this.applyReasoningToSession(savedReasoning);
         }
 
         // Update disabled generic capabilities (already used in agent prompt)
         this.disabledGenericCapabilities = await this.capabilitiesService.getUsedGenericCapabilitiesForAgent(agentId, modeId);
 
         this.update();
+    }
+
+    /** Updates the active chat session's `commonSettings.reasoning`; pass `undefined` to clear. */
+    protected applyReasoningToSession(reasoning: ReasoningSettings | undefined): void {
+        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
+        if (!session) {
+            return;
+        }
+        const currentSettings = session.model.settings ?? {};
+        const currentCommon = currentSettings.commonSettings ?? {};
+        if ((currentCommon.reasoning?.level ?? undefined) === (reasoning?.level ?? undefined)) {
+            return; // no-op when already in sync
+        }
+        const newCommon: typeof currentCommon = { ...currentCommon };
+        if (reasoning) {
+            newCommon.reasoning = { ...reasoning };
+        } else {
+            delete newCommon.reasoning;
+        }
+        (session.model as MutableChatModel).setSettings({ ...currentSettings, commonSettings: newCommon });
     }
 
     protected async updateAvailableGenericCapabilities(): Promise<void> {
@@ -503,14 +534,32 @@ export class AIChatInputWidget extends ReactWidget {
     }
 
     /**
-     * Checks if there are any unsaved changes (capability overrides or generic selections).
+     * Checks if the current session reasoning differs from the saved per-agent value.
      */
-    public hasAnyChangesFromSaved(): boolean {
-        return (this.hasCapabilityChangesFromSaved() || this.hasGenericCapabilityChangesFromSaved()) && this.receivingAgent !== undefined;
+    protected hasReasoningChangesFromSaved(): boolean {
+        if (!this.currentReasoningSupport) {
+            return false;
+        }
+        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
+        const sessionLevel = session?.model.settings?.commonSettings?.reasoning?.level;
+        const savedLevel = this.savedReasoning?.level;
+        return sessionLevel !== savedLevel;
     }
 
     /**
-     * Saves current capability selections to settings.
+     * Checks if there are any unsaved changes (capability overrides, generic selections, or reasoning).
+     */
+    public hasAnyChangesFromSaved(): boolean {
+        if (this.receivingAgent === undefined) {
+            return false;
+        }
+        return this.hasCapabilityChangesFromSaved()
+            || this.hasGenericCapabilityChangesFromSaved()
+            || this.hasReasoningChangesFromSaved();
+    }
+
+    /**
+     * Saves current capability selections and reasoning to settings.
      */
     public async saveCurrentSelectionsToSettings(): Promise<void> {
         if (!this.receivingAgent) {
@@ -525,12 +574,16 @@ export class AIChatInputWidget extends ReactWidget {
             capabilityOverrides[key] = value;
         }
 
+        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
+        const sessionReasoning = session?.model.settings?.commonSettings?.reasoning;
+
         try {
             await this.aiSettingsService.updateAgentSettings(agentId, {
                 capabilityOverrides: Object.keys(capabilityOverrides).length > 0 ? capabilityOverrides : undefined,
                 genericCapabilitySelections: GenericCapabilitySelections.hasSelections(this.genericCapabilitySelections)
                     ? this.genericCapabilitySelections
-                    : undefined
+                    : undefined,
+                reasoning: sessionReasoning ? { ...sessionReasoning } : undefined
             });
 
             // Update saved state to match current
@@ -538,6 +591,7 @@ export class AIChatInputWidget extends ReactWidget {
             this.savedGenericCapabilitySelections = GenericCapabilitySelections.hasSelections(this.genericCapabilitySelections)
                 ? { ...this.genericCapabilitySelections }
                 : undefined;
+            this.savedReasoning = sessionReasoning ? { ...sessionReasoning } : undefined;
 
             this.update();
         } catch (error) {

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -248,10 +248,10 @@ export class AIChatInputWidget extends ReactWidget {
     protected currentReasoningSupport?: ReasoningSupport;
     /** Id (`provider/model`) of the model that backs {@link currentReasoningSupport}; used to resolve preference defaults. */
     protected currentLanguageModelId?: string;
-    /** Saved reasoning selection for the receiving agent (loaded from {@link AISettingsService}); used to detect unsaved changes. */
+    /** Saved reasoning selection for the receiving agent (loaded from {@link AISettingsService}); kept in sync with the persisted value. */
     protected savedReasoning?: ReasoningSettings;
 
-    protected handleReasoningChange = (level: ReasoningLevel): void => {
+    protected handleReasoningChange = async (level: ReasoningLevel): Promise<void> => {
         const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
         if (!session) {
             return;
@@ -265,6 +265,20 @@ export class AIChatInputWidget extends ReactWidget {
             }
         };
         (session.model as MutableChatModel).setSettings(newSettings);
+
+        // Auto-persist the reasoning selection per-agent so it is restored on the next session
+        // and the capabilities indicator does not light up for an unrelated configuration concern.
+        if (this.receivingAgent) {
+            try {
+                await this.aiSettingsService.updateAgentSettings(this.receivingAgent.agentId, {
+                    reasoning: { level }
+                });
+                this.savedReasoning = { level };
+            } catch (error) {
+                console.error('Failed to persist reasoning selection:', error);
+            }
+        }
+
         this.update();
     };
 
@@ -376,7 +390,7 @@ export class AIChatInputWidget extends ReactWidget {
                 : new Map<string, boolean>();
             this.genericCapabilitySelections = savedGenericSelections ?? {};
             // Mirror the saved per-agent reasoning into the chat session so the selector reflects it
-            // immediately and `hasReasoningChangesFromSaved` can compare like-with-like.
+            // immediately on session/agent switch.
             this.applyReasoningToSession(savedReasoning);
         }
 
@@ -534,32 +548,20 @@ export class AIChatInputWidget extends ReactWidget {
     }
 
     /**
-     * Checks if the current session reasoning differs from the saved per-agent value.
-     */
-    protected hasReasoningChangesFromSaved(): boolean {
-        if (!this.currentReasoningSupport) {
-            return false;
-        }
-        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
-        const sessionLevel = session?.model.settings?.commonSettings?.reasoning?.level;
-        const savedLevel = this.savedReasoning?.level;
-        return sessionLevel !== savedLevel;
-    }
-
-    /**
-     * Checks if there are any unsaved changes (capability overrides, generic selections, or reasoning).
+     * Checks if there are any unsaved changes (capability overrides or generic selections).
+     * Reasoning is auto-persisted in {@link handleReasoningChange} and is intentionally excluded.
      */
     public hasAnyChangesFromSaved(): boolean {
         if (this.receivingAgent === undefined) {
             return false;
         }
         return this.hasCapabilityChangesFromSaved()
-            || this.hasGenericCapabilityChangesFromSaved()
-            || this.hasReasoningChangesFromSaved();
+            || this.hasGenericCapabilityChangesFromSaved();
     }
 
     /**
-     * Saves current capability selections and reasoning to settings.
+     * Saves current capability selections to settings.
+     * Reasoning is auto-persisted via {@link handleReasoningChange} and is not part of this flow.
      */
     public async saveCurrentSelectionsToSettings(): Promise<void> {
         if (!this.receivingAgent) {
@@ -574,16 +576,12 @@ export class AIChatInputWidget extends ReactWidget {
             capabilityOverrides[key] = value;
         }
 
-        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
-        const sessionReasoning = session?.model.settings?.commonSettings?.reasoning;
-
         try {
             await this.aiSettingsService.updateAgentSettings(agentId, {
                 capabilityOverrides: Object.keys(capabilityOverrides).length > 0 ? capabilityOverrides : undefined,
                 genericCapabilitySelections: GenericCapabilitySelections.hasSelections(this.genericCapabilitySelections)
                     ? this.genericCapabilitySelections
-                    : undefined,
-                reasoning: sessionReasoning ? { ...sessionReasoning } : undefined
+                    : undefined
             });
 
             // Update saved state to match current
@@ -591,7 +589,6 @@ export class AIChatInputWidget extends ReactWidget {
             this.savedGenericCapabilitySelections = GenericCapabilitySelections.hasSelections(this.genericCapabilitySelections)
                 ? { ...this.genericCapabilitySelections }
                 : undefined;
-            this.savedReasoning = sessionReasoning ? { ...sessionReasoning } : undefined;
 
             this.update();
         } catch (error) {
@@ -2177,15 +2174,6 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({
                         hoverService={hoverService}
                     />
                 )}
-                {reasoningSelectorProps.show && reasoningSelectorProps.reasoningSupport && (
-                    <ReasoningSelector
-                        reasoningSupport={reasoningSelectorProps.reasoningSupport}
-                        currentLevel={reasoningSelectorProps.currentLevel}
-                        onReasoningChange={reasoningSelectorProps.onReasoningChange}
-                        disabled={!isEnabled}
-                        hoverService={hoverService}
-                    />
-                )}
                 {capabilitiesToggle.show && (
                     <span
                         className={`option${capabilitiesToggle.isOpen ? ' toggled' : ''}`}
@@ -2208,6 +2196,15 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({
                             <span className="theia-capabilities-unsaved-indicator" />
                         )}
                     </span>
+                )}
+                {reasoningSelectorProps.show && reasoningSelectorProps.reasoningSupport && (
+                    <ReasoningSelector
+                        reasoningSupport={reasoningSelectorProps.reasoningSupport}
+                        currentLevel={reasoningSelectorProps.currentLevel}
+                        onReasoningChange={reasoningSelectorProps.onReasoningChange}
+                        disabled={!isEnabled}
+                        hoverService={hoverService}
+                    />
                 )}
             </div>
         </div>
@@ -2407,7 +2404,7 @@ const ReasoningSelector: React.FunctionComponent<ReasoningSelectorProps> = React
     return (
         <span onMouseEnter={hoverHandler(hoverService, title)}>
             <SelectComponent
-                className={`theia-ChatInput-ReasoningSelector${disabled ? ' disabled' : ''}`}
+                className={`theia-ChatInput-ReasoningSelector reasoning-level-${effectiveLevel}${disabled ? ' disabled' : ''}`}
                 options={options}
                 defaultValue={effectiveLevel}
                 onChange={handleChange}

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -16,11 +16,16 @@
 import {
     ChangeSet, ChangeSetElement, ChatAgent, ChatChangeEvent, ChatHierarchyBranch,
     ChatModel, ChatRequestModel, ChatService, ChatSuggestion, EditableChatRequestModel,
-    ChatRequestParser, ChatMode, ChatSession
+    ChatRequestParser, ChatMode, ChatSession, MutableChatModel, ChatSessionSettings
 } from '@theia/ai-chat';
 import { ChatAgentService } from '@theia/ai-chat/lib/common/chat-agent-service';
 import { ParsedChatRequest } from '@theia/ai-chat/lib/common/parsed-chat-request';
-import { GenericCapabilitySelections, AIVariableResolutionRequest, ParsedCapability } from '@theia/ai-core';
+import {
+    GenericCapabilitySelections, AIVariableResolutionRequest, ParsedCapability,
+    FrontendLanguageModelRegistry, ReasoningLevel, ReasoningSupport,
+    PREFERENCE_NAME_REASONING, ReasoningPreferenceEntry
+} from '@theia/ai-core';
+import { mergeReasoningSettings } from '@theia/ai-core/lib/browser/frontend-language-model-service';
 import { ChangeSetDecoratorService } from '@theia/ai-chat/lib/browser/change-set-decorator-service';
 import { ImageContextVariable } from '@theia/ai-chat/lib/common/image-context-variable';
 import { AgentCompletionNotificationService, FrontendVariableService, AIActivationService, CompletionNotificationOptions } from '@theia/ai-core/lib/browser';
@@ -165,6 +170,9 @@ export class AIChatInputWidget extends ReactWidget {
     @inject(PromptService)
     protected readonly promptService: PromptService;
 
+    @inject(FrontendLanguageModelRegistry)
+    protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
+
     @inject(PreferenceService) @optional()
     protected readonly preferenceService: PreferenceService | undefined;
 
@@ -235,6 +243,81 @@ export class AIChatInputWidget extends ReactWidget {
             await this.updateCapabilitiesForAgent(this.receivingAgent.agentId, mode);
         }
     };
+
+    /** Reasoning capability of the model the receiving agent would currently use; undefined hides the selector. */
+    protected currentReasoningSupport?: ReasoningSupport;
+    /** Id (`provider/model`) of the model that backs {@link currentReasoningSupport}; used to resolve preference defaults. */
+    protected currentLanguageModelId?: string;
+
+    protected handleReasoningChange = (level: ReasoningLevel): void => {
+        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
+        if (!session) {
+            return;
+        }
+        const currentSettings = session.model.settings ?? {};
+        const newSettings: ChatSessionSettings = {
+            ...currentSettings,
+            commonSettings: {
+                ...currentSettings.commonSettings,
+                reasoning: { level }
+            }
+        };
+        (session.model as MutableChatModel).setSettings(newSettings);
+        this.update();
+    };
+
+    /**
+     * Resolves the reasoning level to display in the selector. Priority: session override →
+     * `ai-features.reasoning.defaults` preference entry matching the current model/agent →
+     * model's declared default → `'off'`.
+     */
+    protected getCurrentReasoningLevel(): ReasoningLevel | undefined {
+        if (!this.currentReasoningSupport) {
+            return undefined;
+        }
+        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
+        const sessionLevel = session?.model.settings?.commonSettings?.reasoning?.level;
+        if (sessionLevel) {
+            return sessionLevel;
+        }
+        return this.resolvePreferenceReasoningLevel() ?? this.currentReasoningSupport.defaultLevel ?? 'off';
+    }
+
+    protected resolvePreferenceReasoningLevel(): ReasoningLevel | undefined {
+        if (!this.preferenceService || !this.currentLanguageModelId) {
+            return undefined;
+        }
+        const entries = this.preferenceService.get<ReasoningPreferenceEntry[]>(PREFERENCE_NAME_REASONING, []);
+        const [providerId, modelId] = this.currentLanguageModelId.split('/');
+        return mergeReasoningSettings(entries, modelId, providerId, this.receivingAgent?.agentId)?.reasoning?.level;
+    }
+
+    protected async updateReasoningSupport(agentId: string | undefined): Promise<void> {
+        let support: ReasoningSupport | undefined;
+        let modelId: string | undefined;
+        if (agentId) {
+            const agent = this.chatAgentService.getAgent(agentId);
+            if (agent) {
+                for (const requirement of agent.languageModelRequirements ?? []) {
+                    try {
+                        const model = await this.languageModelRegistry.selectLanguageModel({ agent: agent.id, ...requirement });
+                        if (model?.reasoningSupport) {
+                            support = model.reasoningSupport;
+                            modelId = model.id;
+                            break;
+                        }
+                    } catch (error) {
+                        console.warn('Failed to resolve language model for reasoning support:', error);
+                    }
+                }
+            }
+        }
+        if (support !== this.currentReasoningSupport || modelId !== this.currentLanguageModelId) {
+            this.currentReasoningSupport = support;
+            this.currentLanguageModelId = modelId;
+            this.update();
+        }
+    }
 
     protected handleCapabilityChange = (fragmentId: string, enabled: boolean): void => {
         const defaultCapability = this.capabilityDefaults.find(c => c.fragmentId === fragmentId);
@@ -659,12 +742,22 @@ export class AIChatInputWidget extends ReactWidget {
                 if (change.preferenceName === CHAT_VIEW_TOKEN_USAGE_ENABLED) {
                     this.tokenUsageEnabled = this.preferenceService?.get<boolean>(CHAT_VIEW_TOKEN_USAGE_ENABLED, false) ?? false;
                     this.update();
+                } else if (change.preferenceName === PREFERENCE_NAME_REASONING) {
+                    // Refresh the reasoning selector display when the default preference changes.
+                    this.update();
                 }
             }));
         }
         // Listen for prompt fragment changes to refresh capabilities
         this.toDispose.push(this.capabilitiesService.onDidChangeCapabilities(() => {
             this.refreshCapabilities();
+        }));
+
+        // Refresh reasoning capability if the language model registry changes (model added/removed/alias re-resolved).
+        this.toDispose.push(this.languageModelRegistry.onChange(() => {
+            if (this.receivingAgent) {
+                this.updateReasoningSupport(this.receivingAgent.agentId);
+            }
         }));
 
         // When the default mode changes externally (e.g. via AI Configuration),
@@ -832,11 +925,13 @@ export class AIChatInputWidget extends ReactWidget {
             // Only preserve overrides on forced refresh if the session has previous requests
             const shouldPreserveOverrides = needsRefresh && hasPreviousRequests;
             await this.updateCapabilitiesForAgent(agentId, initialModeId, shouldPreserveOverrides);
+            this.updateReasoningSupport(agentId);
         } else if (!agent && this.receivingAgent !== undefined) {
             this.receivingAgent = undefined;
             this.capabilityDefaults = [];
             this.userCapabilityOverrides = new Map();
             this.chatInputHasModesKey.set(false);
+            this.currentReasoningSupport = undefined;
             this.update();
         }
     }
@@ -1031,6 +1126,11 @@ export class AIChatInputWidget extends ReactWidget {
                     currentMode: this.receivingAgent?.currentModeId,
                     onModeChange: this.handleModeChange,
                     keybindingHint: this.getModeKeybindingHint(),
+                }}
+                reasoningSelectorProps={{
+                    reasoningSupport: this.currentReasoningSupport,
+                    currentLevel: this.getCurrentReasoningLevel(),
+                    onReasoningChange: this.handleReasoningChange,
                 }}
                 capabilitiesProps={{
                     capabilities: this.capabilityDefaults,
@@ -1363,6 +1463,11 @@ interface ChatInputProperties {
         currentMode?: string;
         onModeChange: (mode: string) => void;
         keybindingHint?: string;
+    };
+    reasoningSelectorProps: {
+        reasoningSupport?: ReasoningSupport;
+        currentLevel?: ReasoningLevel;
+        onReasoningChange: (level: ReasoningLevel) => void;
     };
     capabilitiesProps: {
         capabilities: ParsedCapability[];
@@ -1864,6 +1969,12 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
                         onModeChange: props.modeSelectorProps.onModeChange,
                         keybindingHint: props.modeSelectorProps.keybindingHint,
                     }}
+                    reasoningSelectorProps={{
+                        show: !!props.reasoningSelectorProps.reasoningSupport,
+                        reasoningSupport: props.reasoningSelectorProps.reasoningSupport,
+                        currentLevel: props.reasoningSelectorProps.currentLevel,
+                        onReasoningChange: props.reasoningSelectorProps.onReasoningChange,
+                    }}
                     capabilitiesToggle={{
                         show: props.showCapabilities !== false,
                         isOpen: props.capabilitiesProps.isOpen,
@@ -1909,6 +2020,12 @@ interface ChatInputOptionsProps {
         onModeChange: (mode: string) => void;
         keybindingHint?: string;
     };
+    reasoningSelectorProps: {
+        show: boolean;
+        reasoningSupport?: ReasoningSupport;
+        currentLevel?: ReasoningLevel;
+        onReasoningChange: (level: ReasoningLevel) => void;
+    };
     capabilitiesToggle: {
         show: boolean;
         isOpen: boolean;
@@ -1926,6 +2043,7 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({
     hoverService,
     tokenUsage,
     modeSelectorProps,
+    reasoningSelectorProps,
     capabilitiesToggle
 }) => {
     const capabilitiesLabel = nls.localize('theia/ai/chat-ui/toggleCapabilitiesConfig', 'Toggle Capabilities Configuration');
@@ -2002,6 +2120,15 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({
                         onModeChange={modeSelectorProps.onModeChange}
                         disabled={!isEnabled}
                         keybindingHint={modeSelectorProps.keybindingHint}
+                        hoverService={hoverService}
+                    />
+                )}
+                {reasoningSelectorProps.show && reasoningSelectorProps.reasoningSupport && (
+                    <ReasoningSelector
+                        reasoningSupport={reasoningSelectorProps.reasoningSupport}
+                        currentLevel={reasoningSelectorProps.currentLevel}
+                        onReasoningChange={reasoningSelectorProps.onReasoningChange}
+                        disabled={!isEnabled}
                         hoverService={hoverService}
                     />
                 )}
@@ -2178,6 +2305,57 @@ const ChatModeSelector: React.FunctionComponent<ChatModeSelectorProps> = React.m
                 className={`theia-ChatInput-ModeSelector${disabled ? ' disabled' : ''}`}
                 options={options}
                 defaultValue={currentMode ?? modes[0]?.id ?? ''}
+                onChange={handleChange}
+            />
+        </span>
+    );
+});
+
+interface ReasoningSelectorProps {
+    reasoningSupport: ReasoningSupport;
+    currentLevel?: ReasoningLevel;
+    onReasoningChange: (level: ReasoningLevel) => void;
+    disabled?: boolean;
+    hoverService: HoverService;
+}
+
+const reasoningLevelLabel = (level: ReasoningLevel): string => {
+    switch (level) {
+        case 'off': return nls.localizeByDefault('Off');
+        case 'minimal': return nls.localize('theia/ai/chat-ui/reasoning/minimal', 'Minimal');
+        case 'low': return nls.localize('theia/ai/chat-ui/reasoning/low', 'Low');
+        case 'medium': return nls.localize('theia/ai/chat-ui/reasoning/medium', 'Medium');
+        case 'high': return nls.localize('theia/ai/chat-ui/reasoning/high', 'High');
+        case 'auto': return nls.localizeByDefault('Auto');
+    }
+};
+
+const ReasoningSelector: React.FunctionComponent<ReasoningSelectorProps> = React.memo(({
+    reasoningSupport, currentLevel, onReasoningChange, disabled, hoverService
+}) => {
+    const options: SelectOption[] = React.useMemo(
+        () => reasoningSupport.supportedLevels.map(level => ({ value: level, label: reasoningLevelLabel(level) })),
+        [reasoningSupport]
+    );
+
+    const handleChange = React.useCallback(
+        (option: SelectOption) => {
+            if (option.value) {
+                onReasoningChange(option.value as ReasoningLevel);
+            }
+        },
+        [onReasoningChange]
+    );
+
+    const title = nls.localizeByDefault('Reasoning');
+    const effectiveLevel = currentLevel ?? reasoningSupport.defaultLevel ?? reasoningSupport.supportedLevels[0] ?? 'off';
+
+    return (
+        <span onMouseEnter={hoverHandler(hoverService, title)}>
+            <SelectComponent
+                className={`theia-ChatInput-ReasoningSelector${disabled ? ' disabled' : ''}`}
+                options={options}
+                defaultValue={effectiveLevel}
                 onChange={handleChange}
             />
         </span>

--- a/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
+++ b/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
@@ -27,59 +27,6 @@ export interface SessionSettingsDialogProps {
     initialSettings: ChatSessionSettings | undefined;
 }
 
-interface ThinkingModeSectionProps {
-    enabled: boolean;
-    budgetTokens: number;
-    onEnabledChange: (enabled: boolean) => void;
-    onBudgetChange: (budget: number) => void;
-}
-
-const ThinkingModeSection: React.FC<ThinkingModeSectionProps> = ({
-    enabled,
-    budgetTokens,
-    onEnabledChange,
-    onBudgetChange
-}) => (
-    <div className="session-settings-thinking-mode">
-        <div className="session-settings-section-header">
-            {nls.localize('theia/ai/session-settings-dialog/thinkingMode', 'Thinking Mode')}
-        </div>
-        <div className="session-settings-section-note">
-            {nls.localize('theia/ai/session-settings-dialog/thinkingModeNote', 'Some models may ignore this setting.')}
-        </div>
-        <div className="session-settings-checkbox-container">
-            <input
-                type="checkbox"
-                id="thinking-enabled"
-                checked={enabled}
-                onChange={e => onEnabledChange(e.target.checked)}
-            />
-            <label htmlFor="thinking-enabled">
-                {nls.localize('theia/ai/session-settings-dialog/enableThinking', 'Enable extended thinking')}
-            </label>
-        </div>
-        <div className="session-settings-budget-container">
-            <label
-                htmlFor="thinking-budget"
-                className={!enabled ? 'disabled' : ''}
-            >
-                {nls.localize('theia/ai/session-settings-dialog/budgetTokens', 'Budget tokens:')}
-            </label>
-            <input
-                type="number"
-                id="thinking-budget"
-                min={1000}
-                max={100000}
-                step={1000}
-                value={budgetTokens}
-                placeholder="10000"
-                disabled={!enabled}
-                onChange={e => onBudgetChange(parseInt(e.target.value, 10))}
-            />
-        </div>
-    </div>
-);
-
 interface ConfirmationTimeoutSectionProps {
     enabled: boolean;
     timeoutSeconds: number;
@@ -156,35 +103,21 @@ const ErrorMessage: React.FC<ErrorMessageProps> = ({ message }) => (
 );
 
 interface DialogContentProps {
-    thinkingEnabled: boolean;
-    thinkingBudget: number;
     confirmationTimeoutEnabled: boolean;
     confirmationTimeoutSeconds: number;
     errorMessage: string;
-    onThinkingEnabledChange: (enabled: boolean) => void;
-    onThinkingBudgetChange: (budget: number) => void;
     onConfirmationTimeoutEnabledChange: (enabled: boolean) => void;
     onConfirmationTimeoutSecondsChange: (seconds: number) => void;
 }
 
 const DialogContent: React.FC<DialogContentProps> = ({
-    thinkingEnabled,
-    thinkingBudget,
     confirmationTimeoutEnabled,
     confirmationTimeoutSeconds,
     errorMessage,
-    onThinkingEnabledChange,
-    onThinkingBudgetChange,
     onConfirmationTimeoutEnabledChange,
     onConfirmationTimeoutSecondsChange
 }) => (
     <div className="session-settings-container">
-        <ThinkingModeSection
-            enabled={thinkingEnabled}
-            budgetTokens={thinkingBudget}
-            onEnabledChange={onThinkingEnabledChange}
-            onBudgetChange={onThinkingBudgetChange}
-        />
         <ConfirmationTimeoutSection
             enabled={confirmationTimeoutEnabled}
             timeoutSeconds={confirmationTimeoutSeconds}
@@ -204,11 +137,10 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
     protected initialAdvancedSettingsString: string;
     protected errorMessage: string = '';
 
-    protected thinkingEnabled: boolean;
-    protected thinkingBudget: number;
-
     protected confirmationTimeoutEnabled: boolean;
     protected confirmationTimeoutSeconds: number;
+
+    protected preservedReasoning: CommonChatSessionSettings['reasoning'];
 
     protected contentRoot: Root;
     protected editorContainerNode: HTMLDivElement;
@@ -226,9 +158,8 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
         const initialSettings = options.initialSettings;
         this.settings = initialSettings ? { ...initialSettings } : {};
 
-        // Extract thinking mode settings from commonSettings
-        this.thinkingEnabled = this.settings.commonSettings?.thinkingMode?.enabled ?? false;
-        this.thinkingBudget = this.settings.commonSettings?.thinkingMode?.budgetTokens ?? 10000;
+        // Reasoning is edited in the chat input; preserve it across this dialog.
+        this.preservedReasoning = this.settings.commonSettings?.reasoning;
 
         // Extract confirmation timeout settings from commonSettings
         const savedTimeout = this.settings.commonSettings?.confirmationTimeout;
@@ -281,13 +212,9 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
     protected render(): void {
         this.contentRoot.render(
             <DialogContent
-                thinkingEnabled={this.thinkingEnabled}
-                thinkingBudget={this.thinkingBudget}
                 confirmationTimeoutEnabled={this.confirmationTimeoutEnabled}
                 confirmationTimeoutSeconds={this.confirmationTimeoutSeconds}
                 errorMessage={this.errorMessage}
-                onThinkingEnabledChange={this.handleThinkingEnabledChange}
-                onThinkingBudgetChange={this.handleThinkingBudgetChange}
                 onConfirmationTimeoutEnabledChange={this.handleConfirmationTimeoutEnabledChange}
                 onConfirmationTimeoutSecondsChange={this.handleConfirmationTimeoutSecondsChange}
             />
@@ -387,20 +314,6 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
         }
     }
 
-    protected handleThinkingEnabledChange = (enabled: boolean): void => {
-        this.thinkingEnabled = enabled;
-        this.updateSettingsFromCommonSettings();
-        this.render();
-        this.attachEditorContainer();
-    };
-
-    protected handleThinkingBudgetChange = (budget: number): void => {
-        this.thinkingBudget = budget;
-        this.updateSettingsFromCommonSettings();
-        this.render();
-        this.attachEditorContainer();
-    };
-
     protected handleConfirmationTimeoutEnabledChange = (enabled: boolean): void => {
         this.confirmationTimeoutEnabled = enabled;
         this.updateSettingsFromCommonSettings();
@@ -417,11 +330,8 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
 
     protected updateSettingsFromCommonSettings(): void {
         const commonSettings: CommonChatSessionSettings = {};
-        if (this.thinkingEnabled) {
-            commonSettings.thinkingMode = {
-                enabled: true,
-                budgetTokens: isNaN(this.thinkingBudget) ? undefined : this.thinkingBudget
-            };
+        if (this.preservedReasoning) {
+            commonSettings.reasoning = this.preservedReasoning;
         }
         if (this.confirmationTimeoutEnabled && !isNaN(this.confirmationTimeoutSeconds) && this.confirmationTimeoutSeconds > 0) {
             commonSettings.confirmationTimeout = this.confirmationTimeoutSeconds;

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -730,6 +730,11 @@ div:last-child>.theia-ChatNode {
   outline: none;
 }
 
+/* Anchor for the off-level slash overlay drawn via ::after. */
+.theia-ChatInput-ReasoningSelector.theia-select-component {
+  position: relative;
+}
+
 .theia-ChatInput-ModeSelector .theia-select-component-chevron,
 .theia-ChatInput-ReasoningSelector .theia-select-component-chevron {
   font-size: var(--theia-ui-font-size1);
@@ -752,6 +757,74 @@ div:last-child>.theia-ChatNode {
   opacity: var(--theia-mod-disabled-opacity);
   cursor: default;
   pointer-events: none;
+}
+
+/* Inject a leading lightbulb icon inside the reasoning selector so it shares the dropdown's
+   click area, hover/focus styles, and visual bounds (no DOM gap, single control). Sized to match
+   the toolbar's other codicons (e.g. capabilities wrench) rather than the small chevron.
+   The base glyph is the filled lightbulb (\ea61); per-level overrides below swap glyph, opacity
+   or color to give a visual cue that scales with the chosen reasoning intensity. */
+.theia-ChatInput-ReasoningSelector.theia-select-component::before {
+  font-family: codicon;
+  content: '\ea61';
+  /* codicon-lightbulb (filled) — default for low/medium/high */
+  font-size: var(--theia-icon-size);
+  line-height: 1;
+  margin-right: calc(var(--theia-ui-padding) / 3);
+  display: inline-flex;
+  align-items: center;
+}
+
+/* Off: empty bulb glyph + CSS-drawn diagonal slash overlay (mimics MDI's lightbulb-off). */
+.theia-ChatInput-ReasoningSelector.reasoning-level-off::before {
+  content: '\ec40';
+  /* codicon-lightbulb-empty */
+  opacity: 0.85;
+}
+
+.theia-ChatInput-ReasoningSelector.reasoning-level-off::after {
+  content: '';
+  position: absolute;
+  /* Center over the ::before icon area: padding-left + half icon width. */
+  left: calc(var(--theia-ui-padding) * 2 / 3 + var(--theia-icon-size) / 2);
+  top: 50%;
+  width: calc(var(--theia-icon-size) * 0.95);
+  height: 1.5px;
+  background-color: currentColor;
+  border-radius: 1px;
+  transform: translate(-50%, -50%) rotate(-45deg);
+  pointer-events: none;
+  opacity: 0.85;
+}
+
+/* Minimal: empty (outline only) bulb at low opacity — "on, but barely".
+   Lower opacity than `low` so the brightness order matches the level order:
+   the crisper outline at full opacity would otherwise read brighter than a filled bulb at 0.55. */
+.theia-ChatInput-ReasoningSelector.reasoning-level-minimal::before {
+  content: '\ec40';
+  /* codicon-lightbulb-empty */
+  opacity: 0.5;
+}
+
+/* Low: filled bulb, perceptibly more present than minimal. */
+.theia-ChatInput-ReasoningSelector.reasoning-level-low::before {
+  opacity: 0.7;
+}
+
+/* Medium: filled bulb, moderately bright. */
+.theia-ChatInput-ReasoningSelector.reasoning-level-medium::before {
+  opacity: 0.9;
+}
+
+/* High: filled bulb at full opacity, tinted with the warning foreground (warm/yellow). */
+.theia-ChatInput-ReasoningSelector.reasoning-level-high::before {
+  color: var(--theia-editorWarning-foreground);
+}
+
+/* Auto: lightbulb-sparkle — "the model decides automatically". */
+.theia-ChatInput-ReasoningSelector.reasoning-level-auto::before {
+  content: '\ec1f';
+  /* codicon-lightbulb-sparkle */
 }
 
 .theia-CodePartRenderer-root {

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -713,8 +713,9 @@ div:last-child>.theia-ChatNode {
   flex-direction: row-reverse;
 }
 
-/* Mode selector - compact SelectComponent inside toolbar */
-.theia-ChatInput-ModeSelector.theia-select-component {
+/* Mode and reasoning selectors - compact SelectComponents inside toolbar */
+.theia-ChatInput-ModeSelector.theia-select-component,
+.theia-ChatInput-ReasoningSelector.theia-select-component {
   min-width: unset;
   min-height: unset;
   height: calc(var(--theia-icon-size) + var(--theia-ui-padding) - 1px);
@@ -729,21 +730,25 @@ div:last-child>.theia-ChatNode {
   outline: none;
 }
 
-.theia-ChatInput-ModeSelector .theia-select-component-chevron {
+.theia-ChatInput-ModeSelector .theia-select-component-chevron,
+.theia-ChatInput-ReasoningSelector .theia-select-component-chevron {
   font-size: var(--theia-ui-font-size1);
   margin-left: calc(var(--theia-ui-padding) / 3);
 }
 
-.theia-ChatInput-ModeSelector.theia-select-component:hover {
+.theia-ChatInput-ModeSelector.theia-select-component:hover,
+.theia-ChatInput-ReasoningSelector.theia-select-component:hover {
   background-color: var(--theia-toolbar-hoverBackground);
 }
 
-.theia-ChatInput-ModeSelector.theia-select-component:focus-visible {
+.theia-ChatInput-ModeSelector.theia-select-component:focus-visible,
+.theia-ChatInput-ReasoningSelector.theia-select-component:focus-visible {
   outline: 1px solid var(--theia-focusBorder);
   outline-offset: -1px;
 }
 
-.theia-ChatInput-ModeSelector.disabled {
+.theia-ChatInput-ModeSelector.disabled,
+.theia-ChatInput-ReasoningSelector.disabled {
   opacity: var(--theia-mod-disabled-opacity);
   cursor: default;
   pointer-events: none;
@@ -1208,12 +1213,6 @@ div:last-child>.theia-ChatNode {
   outline-color: var(--theia-editor-background);
 }
 
-.session-settings-thinking-mode {
-  padding: 8px 0;
-  border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
-  margin-bottom: 8px;
-}
-
 .session-settings-section-header {
   font-weight: 600;
   font-size: 13px;
@@ -1241,35 +1240,6 @@ div:last-child>.theia-ChatNode {
 .session-settings-checkbox-container label {
   cursor: pointer;
   user-select: none;
-}
-
-.session-settings-budget-container {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-left: 22px;
-}
-
-.session-settings-budget-container label {
-  white-space: nowrap;
-}
-
-.session-settings-budget-container label.disabled {
-  color: var(--theia-disabledForeground);
-}
-
-.session-settings-budget-container input[type="number"] {
-  width: 100px;
-  padding: 4px 8px;
-  border: 1px solid var(--theia-input-border);
-  border-radius: 4px;
-  background-color: var(--theia-input-background);
-  color: var(--theia-input-foreground);
-}
-
-.session-settings-budget-container input[type="number"]:disabled {
-  opacity: var(--theia-mod-disabled-opacity);
-  cursor: not-allowed;
 }
 
 .session-settings-confirmation-timeout {

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -512,7 +512,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
                 messages,
                 tools,
                 settings,
-                thinkingMode: commonSettings?.thinkingMode,
+                reasoning: commonSettings?.reasoning,
                 agentId: this.id,
                 sessionId: request.session.id,
                 requestId: request.id,

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -23,11 +23,11 @@ import {
     AIVariableResolutionRequest,
     GenericCapabilitySelections,
     LanguageModelMessage,
+    ReasoningSettings,
     ResolvedAIContextVariable,
     ResolvedAIVariable,
     TextMessage,
     ThinkingMessage,
-    ThinkingModeSettings,
     ToolCallResult,
     ToolRequest,
     ToolResultMessage,
@@ -221,11 +221,8 @@ export interface ChatHierarchyBranchItem<TRequest extends ChatRequestModel = Cha
 }
 
 export interface CommonChatSessionSettings {
-    /**
-     * Theia-specific settings for extended thinking mode.
-     * These are processed by Theia and converted to provider-specific formats.
-     */
-    thinkingMode?: ThinkingModeSettings;
+    /** Reasoning configuration for this session; applied to reasoning-capable models. */
+    reasoning?: ReasoningSettings;
     /** Per-session tool confirmation timeout in seconds. Overrides the global preference when set. */
     confirmationTimeout?: number;
 }

--- a/packages/ai-core/src/browser/frontend-language-model-service.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-service.ts
@@ -18,13 +18,13 @@ import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { Prioritizeable } from '@theia/core/lib/common/prioritizeable';
 import { WorkspaceTrustService } from '@theia/workspace/lib/browser/workspace-trust-service';
-import { LanguageModel, LanguageModelResponse, ThinkingModeSettings, UserRequest } from '../common';
+import { LanguageModel, LanguageModelResponse, ReasoningSettings, UserRequest } from '../common';
 import { LanguageModelServiceImpl } from '../common/language-model-service';
 import {
     PREFERENCE_NAME_REQUEST_SETTINGS,
-    PREFERENCE_NAME_THINKING_MODE,
+    PREFERENCE_NAME_REASONING,
     RequestSetting,
-    ThinkingModeSetting,
+    ReasoningPreferenceEntry,
     getRequestSettingSpecificity
 } from '../common/ai-core-preferences';
 import { TrustAwarePreferenceReader } from './trust-aware-preference-reader';
@@ -42,13 +42,12 @@ export class FrontendLanguageModelServiceImpl extends LanguageModelServiceImpl {
         languageModel: LanguageModel,
         languageModelRequest: UserRequest
     ): Promise<LanguageModelResponse> {
+        const requestSettings = this.trustAwareReader.get<RequestSetting[]>(PREFERENCE_NAME_REQUEST_SETTINGS, []) ?? [];
+        const reasoningEntries = this.trustAwareReader.get<ReasoningPreferenceEntry[]>(PREFERENCE_NAME_REASONING, []) ?? [];
         const trusted = await this.workspaceTrustService.getWorkspaceTrust();
         if (!trusted) {
             throw new Error(nls.localize('theia/ai-core/aiDisabledInRestrictedMode', 'AI features are not available in untrusted workspaces.'));
         }
-
-        const requestSettings = this.trustAwareReader.get<RequestSetting[]>(PREFERENCE_NAME_REQUEST_SETTINGS, []) ?? [];
-        const thinkingModeSettings = this.trustAwareReader.get<ThinkingModeSetting[]>(PREFERENCE_NAME_THINKING_MODE, []) ?? [];
 
         const ids = languageModel.id.split('/');
         const matchingSetting = mergeRequestSettings(requestSettings, ids[1], ids[0], languageModelRequest.agentId);
@@ -67,9 +66,16 @@ export class FrontendLanguageModelServiceImpl extends LanguageModelServiceImpl {
             };
         }
 
-        const matchingThinkingMode = mergeThinkingModeSettings(thinkingModeSettings, ids[1], ids[0], languageModelRequest.agentId);
-        if (matchingThinkingMode?.thinkingMode && !languageModelRequest.thinkingMode) {
-            languageModelRequest.thinkingMode = matchingThinkingMode.thinkingMode;
+        // Reasoning resolution order (highest first): already-set session override → preference entry
+        // matching this scope → model's declared `defaultLevel`. The selector displays the same
+        // fallback chain, so what the user sees is what gets sent.
+        if (!languageModelRequest.reasoning) {
+            const matchingReasoning = mergeReasoningSettings(reasoningEntries, ids[1], ids[0], languageModelRequest.agentId);
+            if (matchingReasoning?.reasoning) {
+                languageModelRequest.reasoning = matchingReasoning.reasoning;
+            } else if (languageModel.reasoningSupport?.defaultLevel) {
+                languageModelRequest.reasoning = { level: languageModel.reasoningSupport.defaultLevel };
+            }
         }
 
         return super.sendRequest(languageModel, languageModelRequest);
@@ -88,29 +94,29 @@ export const mergeRequestSettings = (requestSettings: RequestSetting[], modelId:
     return matchingSetting;
 };
 
-export const mergeThinkingModeSettings = (
-    thinkingModeSettings: ThinkingModeSetting[],
+export const mergeReasoningSettings = (
+    reasoningEntries: ReasoningPreferenceEntry[],
     modelId: string,
     providerId: string,
     agentId?: string
-): ThinkingModeSetting | undefined => {
-    const prioritizedSettings = Prioritizeable.prioritizeAllSync(thinkingModeSettings,
+): ReasoningPreferenceEntry | undefined => {
+    const prioritizedSettings = Prioritizeable.prioritizeAllSync(reasoningEntries,
         setting => getRequestSettingSpecificity(setting, {
             modelId,
             providerId,
             agentId
         }));
-    const matchingSetting = prioritizedSettings.reduceRight<ThinkingModeSetting | undefined>(
+    const matchingSetting = prioritizedSettings.reduceRight<ReasoningPreferenceEntry | undefined>(
         (acc, cur) => {
             if (!acc) {
                 return cur.value;
             }
             return {
                 ...acc,
-                thinkingMode: {
-                    ...acc.thinkingMode,
-                    ...cur.value.thinkingMode
-                } as ThinkingModeSettings
+                reasoning: {
+                    ...acc.reasoning,
+                    ...cur.value.reasoning
+                } as ReasoningSettings
             };
         },
         undefined

--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -24,12 +24,13 @@ import {
     NOTIFICATION_TYPE_DESCRIPTIONS,
     NotificationType
 } from './notification-types';
+import { ReasoningSettings } from './language-model';
 import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
 
 export const AI_CORE_PREFERENCES_TITLE = nls.localize('theia/ai-core/preferences/title', 'AI Features');
 export const PREFERENCE_NAME_PROMPT_TEMPLATES = 'ai-features.promptTemplates.promptTemplatesFolder';
 export const PREFERENCE_NAME_REQUEST_SETTINGS = 'ai-features.modelSettings.requestSettings';
-export const PREFERENCE_NAME_THINKING_MODE = 'ai-features.thinkingMode.defaults';
+export const PREFERENCE_NAME_REASONING = 'ai-features.reasoning.defaults';
 export const PREFERENCE_NAME_MAX_RETRIES = 'ai-features.modelSettings.maxRetries';
 export const PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE = 'ai-features.notifications.default';
 export const PREFERENCE_NAME_SKILL_DIRECTORIES = 'ai-features.skills.skillDirectories';
@@ -149,19 +150,21 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
             },
             default: []
         },
-        [PREFERENCE_NAME_THINKING_MODE]: {
-            title: nls.localize('theia/ai/core/thinkingMode/title', 'Thinking Mode Settings'),
-            markdownDescription: nls.localize('theia/ai/core/thinkingMode/mdDescription',
-                'Allows specifying thinking mode settings for models that support extended thinking capabilities.\n\
-            Each setting consists of:\n\
-            - `scope`: Defines when the setting applies:\n\
-              - `modelId` (optional): The model ID to match\n\
-              - `providerId` (optional): The provider ID to match\n\
-              - `agentId` (optional): The agent ID to match\n\
-            - `thinkingMode`: Thinking mode configuration:\n\
-              - `enabled` (boolean): Whether thinking mode is enabled\n\
-              - `budgetTokens` (number, optional): Maximum tokens for thinking (if supported by the model)\n\
-            Settings are matched based on specificity (agent: 100, model: 10, provider: 1 points).'),
+        [PREFERENCE_NAME_REASONING]: {
+            title: nls.localize('theia/ai/core/reasoning/title', 'Reasoning Defaults'),
+            markdownDescription: nls.localize('theia/ai/core/reasoning/mdDescription',
+                'Default value for the chat input\'s reasoning selector, applied to models that support reasoning.\n\
+            This is a UI-level setting: the chosen level is translated to the provider\'s native API parameters at request time\
+            (e.g. Anthropic `thinking` / `output_config.effort`, OpenAI `reasoning.effort`, Gemini `thinkingConfig`) and\
+            takes precedence over any raw values supplied via `#ai-features.modelSettings.requestSettings#` for the same fields.\n\n\
+            Each entry consists of:\n\
+            - `scope`: Defines when the setting applies (`modelId`, `providerId`, `agentId`).\n\
+            - `reasoning.level`: One of `off`, `minimal`, `low`, `medium`, `high`, `auto`.\n\n\
+            Precedence at runtime (highest first): session override via the selector → this preference →\
+            the model\'s declared default. Whichever the selector displays is what gets sent. To override\
+            a provider\'s reasoning field manually via `#ai-features.modelSettings.requestSettings#`, set\
+            `reasoning.level` to `off` here so the level-based translation is disabled.\n\n\
+            Entries are matched based on scope specificity (agent: 100, model: 10, provider: 1 points).'),
             type: 'array',
             items: {
                 type: 'object',
@@ -169,37 +172,22 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
                     scope: {
                         type: 'object',
                         properties: {
-                            modelId: {
-                                type: 'string',
-                                description: nls.localize('theia/ai/core/thinkingMode/scope/modelId/description', 'The (optional) model id')
-                            },
-                            providerId: {
-                                type: 'string',
-                                description: nls.localize('theia/ai/core/thinkingMode/scope/providerId/description', 'The (optional) provider id to apply the settings to.')
-                            },
-                            agentId: {
-                                type: 'string',
-                                description: nls.localize('theia/ai/core/thinkingMode/scope/agentId/description', 'The (optional) agent id to apply the settings to.')
-                            }
+                            modelId: { type: 'string' },
+                            providerId: { type: 'string' },
+                            agentId: { type: 'string' }
                         }
                     },
-                    thinkingMode: {
+                    reasoning: {
                         type: 'object',
                         additionalProperties: false,
-                        description: nls.localize('theia/ai/core/thinkingMode/thinkingMode/description', 'Thinking mode configuration.'),
                         properties: {
-                            enabled: {
-                                type: 'boolean',
-                                default: false,
-                                description: nls.localize('theia/ai/core/thinkingMode/thinkingMode/enabled/description', 'Whether thinking mode is enabled.')
-                            },
-                            budgetTokens: {
-                                type: 'number',
-                                description: nls.localize('theia/ai/core/thinkingMode/thinkingMode/budgetTokens/description',
-                                    'Maximum tokens to use for thinking. Only applicable if the model supports thinking budget.')
+                            level: {
+                                type: 'string',
+                                enum: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+                                default: 'auto'
                             }
                         },
-                        required: ['enabled']
+                        required: ['level']
                     }
                 },
                 additionalProperties: false
@@ -236,7 +224,7 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
 export interface AICoreConfiguration {
     [PREFERENCE_NAME_PROMPT_TEMPLATES]: string | undefined;
     [PREFERENCE_NAME_REQUEST_SETTINGS]: Array<RequestSetting> | undefined;
-    [PREFERENCE_NAME_THINKING_MODE]: Array<ThinkingModeSetting> | undefined;
+    [PREFERENCE_NAME_REASONING]: Array<ReasoningPreferenceEntry> | undefined;
     [PREFERENCE_NAME_MAX_RETRIES]: number | undefined;
     [PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE]: NotificationType | undefined;
     [PREFERENCE_NAME_SKILL_DIRECTORIES]: string[] | undefined;
@@ -254,9 +242,9 @@ export interface Scope {
     agentId?: string;
 }
 
-export interface ThinkingModeSetting {
+export interface ReasoningPreferenceEntry {
     scope?: Scope;
-    thinkingMode?: { enabled: boolean; budgetTokens?: number };
+    reasoning?: ReasoningSettings;
 }
 
 export const AICorePreferences = Symbol('AICorePreferences');

--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -153,18 +153,27 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
         [PREFERENCE_NAME_REASONING]: {
             title: nls.localize('theia/ai/core/reasoning/title', 'Reasoning Defaults'),
             markdownDescription: nls.localize('theia/ai/core/reasoning/mdDescription',
-                'Default value for the chat input\'s reasoning selector, applied to models that support reasoning.\n\
-            This is a UI-level setting: the chosen level is translated to the provider\'s native API parameters at request time\
-            (e.g. Anthropic `thinking` / `output_config.effort`, OpenAI `reasoning.effort`, Gemini `thinkingConfig`) and\
-            takes precedence over any raw values supplied via `#ai-features.modelSettings.requestSettings#` for the same fields.\n\n\
-            Each entry consists of:\n\
-            - `scope`: Defines when the setting applies (`modelId`, `providerId`, `agentId`).\n\
-            - `reasoning.level`: One of `off`, `minimal`, `low`, `medium`, `high`, `auto`.\n\n\
-            Precedence at runtime (highest first): session override via the selector → this preference →\
-            the model\'s declared default. Whichever the selector displays is what gets sent. To override\
-            a provider\'s reasoning field manually via `#ai-features.modelSettings.requestSettings#`, set\
-            `reasoning.level` to `off` here so the level-based translation is disabled.\n\n\
-            Entries are matched based on scope specificity (agent: 100, model: 10, provider: 1 points).'),
+                'Default value for the chat input\'s reasoning selector, applied to models that support reasoning.\n\n'
+                + 'This is a UI-level setting: the chosen level is translated to the provider\'s native API parameters'
+                + ' at request time (e.g. Anthropic `thinking` / `output_config.effort`, OpenAI `reasoning.effort`,'
+                + ' Gemini `thinkingConfig`) and takes precedence over any raw values supplied via'
+                + ' `#ai-features.modelSettings.requestSettings#` for the same fields.\n\n'
+                + 'Each entry consists of:\n'
+                + '- `scope`: Defines when the setting applies (`modelId`, `providerId`, `agentId`).\n'
+                + '- `reasoning.level`: One of `off`, `minimal`, `low`, `medium`, `high`, `auto`.\n\n'
+                + 'Precedence at runtime (highest first): session override via the selector → this preference →'
+                + ' the model\'s declared default. Whichever the selector displays is what gets sent. To override'
+                + ' a provider\'s reasoning field manually via `#ai-features.modelSettings.requestSettings#`, set'
+                + ' `reasoning.level` to `off` here so the level-based translation is disabled.\n\n'
+                + 'Entries are matched based on scope specificity (agent: 100, model: 10, provider: 1 points).\n\n'
+                + 'Example:\n'
+                + '```json\n'
+                + '[\n'
+                + '  { "scope": { "providerId": "anthropic" }, "reasoning": { "level": "medium" } },\n'
+                + '  { "scope": { "modelId": "openai/gpt-5" }, "reasoning": { "level": "high" } },\n'
+                + '  { "scope": { "agentId": "Coder" }, "reasoning": { "level": "off" } }\n'
+                + ']\n'
+                + '```'),
             type: 'array',
             items: {
                 type: 'object',

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -19,9 +19,27 @@ import { inject, injectable, named, postConstruct } from '@theia/core/shared/inv
 
 export type MessageActor = 'user' | 'ai' | 'system';
 
-export interface ThinkingModeSettings {
-    enabled: boolean;
-    budgetTokens?: number;
+/** Provider-agnostic reasoning level; each provider maps this to its native API. */
+export type ReasoningLevel = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'auto';
+
+export interface ReasoningSettings {
+    level: ReasoningLevel;
+}
+
+/**
+ * Shape of a model's reasoning parameter in its native API.
+ * - `'effort'`: discrete effort enum.
+ * - `'budget'`: numeric token budget.
+ */
+export type ReasoningApi = 'effort' | 'budget';
+
+/**
+ * Declares a model's reasoning capabilities. When unset, the chat UI hides the
+ * reasoning selector and providers ignore the `reasoning` field on requests.
+ */
+export interface ReasoningSupport {
+    readonly supportedLevels: ReadonlyArray<ReasoningLevel>;
+    readonly defaultLevel?: ReasoningLevel;
 }
 
 export type LanguageModelMessage = TextMessage | ThinkingMessage | ToolUseMessage | ToolResultMessage | ImageMessage;
@@ -272,7 +290,8 @@ export interface LanguageModelRequest {
     response_format?: { type: 'text' } | { type: 'json_object' } | ResponseFormatJsonSchema;
     settings?: { [key: string]: unknown };
     clientSettings?: { keepToolCalls: boolean; keepThinking: boolean };
-    thinkingMode?: ThinkingModeSettings;
+    /** Provider-agnostic reasoning configuration; providers translate it to their native API. */
+    reasoning?: ReasoningSettings;
 }
 export interface ResponseFormatJsonSchema {
     type: 'json_schema';
@@ -441,6 +460,7 @@ export interface LanguageModelMetaData {
     readonly maxInputTokens?: number;
     readonly maxOutputTokens?: number;
     readonly status: LanguageModelStatus;
+    readonly reasoningSupport?: ReasoningSupport;
 }
 
 export namespace LanguageModelMetaData {

--- a/packages/ai-core/src/common/settings-service.ts
+++ b/packages/ai-core/src/common/settings-service.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { Event } from '@theia/core';
-import { LanguageModelRequirement } from './language-model';
+import { LanguageModelRequirement, ReasoningSettings } from './language-model';
 import { NotificationType } from './notification-types';
 import { GenericCapabilitySelections } from './capability-utils';
 
@@ -58,4 +58,10 @@ export interface AgentSettings {
      * Stores selected IDs for each capability type.
      */
     genericCapabilitySelections?: GenericCapabilitySelections;
+    /**
+     * Persisted reasoning selection for this agent. When set, the chat input's reasoning selector
+     * is initialized to this value at session start instead of falling back to the preference
+     * default or the model's declared default.
+     */
+    reasoning?: ReasoningSettings;
 }

--- a/packages/ai-core/src/node/backend-language-model-registry.ts
+++ b/packages/ai-core/src/node/backend-language-model-registry.ts
@@ -62,6 +62,7 @@ export class BackendLanguageModelRegistryImpl extends DefaultLanguageModelRegist
             family: model.family,
             maxInputTokens: model.maxInputTokens,
             maxOutputTokens: model.maxOutputTokens,
+            reasoningSupport: model.reasoningSupport,
         };
     }
 }

--- a/packages/ai-google/src/browser/google-frontend-application-contribution.ts
+++ b/packages/ai-google/src/browser/google-frontend-application-contribution.ts
@@ -16,11 +16,32 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
+import { ReasoningApi, ReasoningSupport } from '@theia/ai-core';
 import { GoogleLanguageModelsManager, GoogleModelDescription } from '../common';
 import { API_KEY_PREF, MODELS_PREF, MAX_RETRIES, RETRY_DELAY_OTHER_ERRORS, RETRY_DELAY_RATE_LIMIT } from '../common/google-preferences';
 import { PreferenceService } from '@theia/core';
 
 const GOOGLE_PROVIDER_ID = 'google';
+
+/** Gemini 3 uses `thinkingConfig.thinkingLevel`. */
+const EFFORT_REASONING = /^gemini-3(?:\.|-)/i;
+/** Gemini 2.5 uses `thinkingConfig.thinkingBudget` (integer; `-1` dynamic, `0` off). */
+const BUDGET_REASONING = /^gemini-2\.5(?:-|$)/i;
+
+const GEMINI_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'off'
+};
+
+function reasoningApiFor(modelId: string): ReasoningApi | undefined {
+    if (EFFORT_REASONING.test(modelId)) {
+        return 'effort';
+    }
+    if (BUDGET_REASONING.test(modelId)) {
+        return 'budget';
+    }
+    return undefined;
+}
 
 @injectable()
 export class GoogleFrontendApplicationContribution implements FrontendApplicationContribution {
@@ -87,12 +108,15 @@ export class GoogleFrontendApplicationContribution implements FrontendApplicatio
 
     protected createGeminiModelDescription(modelId: string): GoogleModelDescription {
         const id = `${GOOGLE_PROVIDER_ID}/${modelId}`;
+        const reasoningApi = reasoningApiFor(modelId);
 
         const description: GoogleModelDescription = {
             id: id,
             model: modelId,
             apiKey: true,
-            enableStreaming: true
+            enableStreaming: true,
+            reasoningSupport: reasoningApi ? GEMINI_REASONING_SUPPORT : undefined,
+            reasoningApi
         };
 
         return description;

--- a/packages/ai-google/src/browser/google-frontend-application-contribution.ts
+++ b/packages/ai-google/src/browser/google-frontend-application-contribution.ts
@@ -30,7 +30,7 @@ const BUDGET_REASONING = /^gemini-2\.5(?:-|$)/i;
 
 const GEMINI_REASONING_SUPPORT: ReasoningSupport = {
     supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'off'
+    defaultLevel: 'auto'
 };
 
 function reasoningApiFor(modelId: string): ReasoningApi | undefined {

--- a/packages/ai-google/src/common/google-language-models-manager.ts
+++ b/packages/ai-google/src/common/google-language-models-manager.ts
@@ -13,8 +13,11 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
+import { ReasoningApi, ReasoningSupport } from '@theia/ai-core';
+
 export const GOOGLE_LANGUAGE_MODELS_MANAGER_PATH = '/services/google/language-model-manager';
 export const GoogleLanguageModelsManager = Symbol('GoogleLanguageModelsManager');
+
 export interface GoogleModelDescription {
     /**
      * The identifier of the model which will be shown in the UI.
@@ -36,7 +39,14 @@ export interface GoogleModelDescription {
      * Maximum number of tokens to generate. Default is 4096.
      */
     maxTokens?: number;
-
+    /** When set, the UI exposes a reasoning selector and requests are translated to {@link reasoningApi}. */
+    reasoningSupport?: ReasoningSupport;
+    /**
+     * Which Gemini reasoning API shape to use. Required when `reasoningSupport` is set.
+     * - `'effort'`: `thinkingConfig.thinkingLevel` (Gemini 3+)
+     * - `'budget'`: `thinkingConfig.thinkingBudget` (Gemini 2.5)
+     */
+    reasoningApi?: ReasoningApi;
 }
 
 export interface GoogleLanguageModelsManager {

--- a/packages/ai-google/src/node/google-language-model.spec.ts
+++ b/packages/ai-google/src/node/google-language-model.spec.ts
@@ -1,0 +1,88 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { LanguageModelRequest, ReasoningApi, ReasoningSupport } from '@theia/ai-core';
+import { GoogleModel } from './google-language-model';
+
+const GEMINI_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+class TestableGoogleModel extends GoogleModel {
+    public callGetSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {
+        return this.getSettings(request);
+    }
+}
+
+function createModel(modelId: string, reasoningApi?: ReasoningApi): TestableGoogleModel {
+    return new TestableGoogleModel(
+        'test-id', modelId, { status: 'ready' }, true,
+        () => 'test-key',
+        () => ({ maxRetriesOnErrors: 0, retryDelayOnRateLimitError: -1, retryDelayOnOtherErrors: -1 }),
+        reasoningApi ? GEMINI_REASONING_SUPPORT : undefined,
+        reasoningApi
+    );
+}
+
+describe('GoogleModel reasoning translation', () => {
+
+    describe('effort API (Gemini 3 thinkingLevel)', () => {
+        it('maps level=medium to thinkingConfig.thinkingLevel=medium', () => {
+            const model = createModel('gemini-3-pro', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'medium' } });
+            expect(result.thinkingConfig).to.deep.include({ thinkingLevel: 'medium', includeThoughts: true });
+        });
+        it('omits thinkingConfig entirely when level=off', () => {
+            const model = createModel('gemini-3-pro', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'off' } });
+            expect(result.thinkingConfig).to.equal(undefined);
+        });
+        it('omits thinkingConfig for level=auto (provider default applies)', () => {
+            const model = createModel('gemini-3-pro', 'effort');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'auto' } });
+            expect(result.thinkingConfig).to.equal(undefined);
+        });
+    });
+
+    describe('budget API (Gemini 2.5 thinkingBudget)', () => {
+        it('omits thinkingConfig entirely when level=off', () => {
+            const model = createModel('gemini-2.5-pro', 'budget');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'off' } });
+            expect(result.thinkingConfig).to.equal(undefined);
+        });
+        it('maps level=auto to thinkingBudget=-1 (dynamic)', () => {
+            const model = createModel('gemini-2.5-pro', 'budget');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'auto' } });
+            expect(result.thinkingConfig).to.deep.include({ thinkingBudget: -1, includeThoughts: true });
+        });
+        it('maps level=medium to a moderate positive budget', () => {
+            const model = createModel('gemini-2.5-pro', 'budget');
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'medium' } });
+            const config = result.thinkingConfig as { thinkingBudget: number };
+            expect(config.thinkingBudget).to.be.greaterThan(0);
+        });
+    });
+
+    describe('non-reasoning models', () => {
+        it('ignores reasoning settings on gemini-1.5-flash', () => {
+            const model = createModel('gemini-1.5-flash', undefined);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'high' } });
+            expect(result.thinkingConfig).to.equal(undefined);
+        });
+    });
+});

--- a/packages/ai-google/src/node/google-language-model.ts
+++ b/packages/ai-google/src/node/google-language-model.ts
@@ -24,6 +24,8 @@ import {
     LanguageModelStreamResponse,
     LanguageModelStreamResponsePart,
     LanguageModelTextResponse,
+    ReasoningApi,
+    ReasoningSupport,
     ToolCallResult,
     ToolInvocationContext,
     UserRequest
@@ -32,6 +34,7 @@ import { CancellationToken } from '@theia/core';
 import { GoogleGenAI, FunctionCallingConfigMode, FunctionDeclaration, Content, Schema, Part, Modality, FunctionResponse, ToolConfig } from '@google/genai';
 import { wait } from '@theia/core/lib/common/promise-util';
 import { GoogleLanguageModelRetrySettings } from './google-language-models-manager-impl';
+import { googleReasoningFor } from './google-reasoning';
 import { UUID } from '@theia/core/shared/@lumino/coreutils';
 
 interface ToolCallback {
@@ -135,7 +138,8 @@ function toGoogleRole(message: LanguageModelMessage): 'user' | 'model' {
 }
 
 /**
- * Implements the Gemini language model integration for Theia
+ * Implements the Gemini language model integration for Theia. Reasoning-level
+ * translation lives in {@link googleReasoningFor}.
  */
 export class GoogleModel implements LanguageModel {
 
@@ -146,21 +150,15 @@ export class GoogleModel implements LanguageModel {
         public enableStreaming: boolean,
         public apiKey: () => string | undefined,
         public retrySettings: () => GoogleLanguageModelRetrySettings,
+        public reasoningSupport?: ReasoningSupport,
+        public reasoningApi?: ReasoningApi
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {
-        const baseSettings = request.settings ?? {};
-
-        if (request.thinkingMode?.enabled) {
-            return {
-                ...baseSettings,
-                thinkingConfig: {
-                    includeThoughts: true
-                }
-            };
-        }
-
-        return baseSettings;
+        return {
+            ...request.settings,
+            ...googleReasoningFor(request.reasoning?.level, this.reasoningApi)
+        };
     }
 
     async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {

--- a/packages/ai-google/src/node/google-language-models-manager-impl.ts
+++ b/packages/ai-google/src/node/google-language-models-manager-impl.ts
@@ -74,7 +74,9 @@ export class GoogleLanguageModelsManagerImpl implements GoogleLanguageModelsMana
                     enableStreaming: modelDescription.enableStreaming,
                     apiKey: apiKeyProvider,
                     retrySettings: retrySettingsProvider,
-                    status
+                    status,
+                    reasoningSupport: modelDescription.reasoningSupport,
+                    reasoningApi: modelDescription.reasoningApi
                 });
             } else {
                 this.languageModelRegistry.addLanguageModels([
@@ -84,7 +86,9 @@ export class GoogleLanguageModelsManagerImpl implements GoogleLanguageModelsMana
                         status,
                         modelDescription.enableStreaming,
                         apiKeyProvider,
-                        retrySettingsProvider
+                        retrySettingsProvider,
+                        modelDescription.reasoningSupport,
+                        modelDescription.reasoningApi
                     )
                 ]);
             }

--- a/packages/ai-google/src/node/google-reasoning.ts
+++ b/packages/ai-google/src/node/google-reasoning.ts
@@ -1,0 +1,49 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ReasoningApi, ReasoningLevel } from '@theia/ai-core';
+
+/**
+ * Translates a reasoning level to the Gemini request fragment to merge into `settings`.
+ * Returns `{}` when reasoning is not requested, unsupported, or disabled — so the caller
+ * can spread it unconditionally. Per the Gemini docs `thinkingLevel` and `thinkingBudget`
+ * must never appear together.
+ *
+ * @param api `'effort'` for `thinkingConfig.thinkingLevel` (string enum),
+ *            `'budget'` for `thinkingConfig.thinkingBudget` (`-1` dynamic, positive = token cap).
+ */
+export function googleReasoningFor(level: ReasoningLevel | undefined, api: ReasoningApi | undefined): Record<string, unknown> {
+    if (!level || !api || level === 'off') {
+        return {};
+    }
+    if (api === 'effort') {
+        const thinkingLevel =
+            level === 'minimal' ? 'minimal' :
+                level === 'low' ? 'low' :
+                    level === 'medium' ? 'medium' :
+                        level === 'high' ? 'high' :
+                            undefined; // 'auto' → omit so the provider default applies
+        return thinkingLevel ? { thinkingConfig: { thinkingLevel, includeThoughts: true } } : {};
+    }
+    const thinkingBudget =
+        level === 'auto' ? -1 :
+            level === 'minimal' ? 1024 :
+                level === 'low' ? 4096 :
+                    level === 'medium' ? 16000 :
+                        level === 'high' ? 24576 :
+                            -1;
+    return { thinkingConfig: { thinkingBudget, includeThoughts: true } };
+}

--- a/packages/ai-ide/src/common/orchestrator-chat-agent.ts
+++ b/packages/ai-ide/src/common/orchestrator-chat-agent.ts
@@ -122,7 +122,7 @@ export class OrchestratorChatAgent extends AbstractStreamParsingChatAgent {
                 messages,
                 tools,
                 settings,
-                thinkingMode: commonSettings?.thinkingMode,
+                reasoning: commonSettings?.reasoning,
                 agentId: this.id,
                 sessionId: request.session.id,
                 requestId: request.id,

--- a/packages/ai-ollama/src/browser/ollama-frontend-application-contribution.ts
+++ b/packages/ai-ollama/src/browser/ollama-frontend-application-contribution.ts
@@ -16,7 +16,7 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { OllamaLanguageModelsManager, OllamaModelDescription } from '../common';
+import { OLLAMA_REASONING_SUPPORT, OllamaLanguageModelsManager, OllamaModelDescription } from '../common';
 import { HOST_PREF, MODELS_PREF } from '../common/ollama-preferences';
 import { PreferenceService } from '@theia/core';
 
@@ -80,7 +80,11 @@ export class OllamaFrontendApplicationContribution implements FrontendApplicatio
 
         return {
             id: id,
-            model: modelId
+            model: modelId,
+            // Whether the underlying model supports thinking is checked per-request via `ollama.show`;
+            // for non-thinking models the reasoning level is silently ignored, so it's safe to always
+            // advertise reasoning support and let the runtime decide.
+            reasoningSupport: OLLAMA_REASONING_SUPPORT
         };
     }
 }

--- a/packages/ai-ollama/src/common/ollama-language-models-manager.ts
+++ b/packages/ai-ollama/src/common/ollama-language-models-manager.ts
@@ -14,8 +14,20 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { ReasoningSupport } from '@theia/ai-core';
+
 export const OLLAMA_LANGUAGE_MODELS_MANAGER_PATH = '/services/ollama/language-model-manager';
 export const OllamaLanguageModelsManager = Symbol('OllamaLanguageModelsManager');
+
+/**
+ * Coarse Ollama reasoning support advertised at registration time. Whether a given Ollama model
+ * actually supports thinking is discovered per-request via `ollama.show`; for models without it
+ * the selector value is silently ignored.
+ */
+export const OLLAMA_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
 
 export interface OllamaModelDescription {
     /**
@@ -26,6 +38,11 @@ export interface OllamaModelDescription {
      * The name or ID of the model in the Ollama environment.
      */
     model: string;
+    /**
+     * When set, the chat exposes a reasoning selector for this model. Defaults to {@link OLLAMA_REASONING_SUPPORT};
+     * Ollama checks at request time whether the model supports thinking, so this is safe to leave on for any model.
+     */
+    reasoningSupport?: ReasoningSupport;
 }
 
 export interface OllamaLanguageModelsManager {

--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -22,6 +22,7 @@ import {
     LanguageModelStreamResponse,
     LanguageModelStreamResponsePart,
     ReasoningSettings,
+    ReasoningSupport,
     ToolCall,
     ToolRequest,
     ToolRequestParametersProperties,
@@ -59,7 +60,8 @@ export class OllamaModel implements LanguageModel {
         protected readonly model: string,
         public status: LanguageModelStatus,
         protected host: () => string | undefined,
-        public proxy?: string
+        public proxy?: string,
+        public reasoningSupport?: ReasoningSupport
     ) { }
 
     async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {

--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -21,7 +21,7 @@ import {
     LanguageModelResponse,
     LanguageModelStreamResponse,
     LanguageModelStreamResponsePart,
-    ThinkingModeSettings,
+    ReasoningSettings,
     ToolCall,
     ToolRequest,
     ToolRequestParametersProperties,
@@ -34,6 +34,7 @@ import {
 import { CancellationToken } from '@theia/core';
 import { ChatRequest, Message, Ollama, Options, Tool, ToolCall as OllamaToolCall } from 'ollama';
 import { createProxyFetch } from '@theia/ai-core/lib/node';
+import { ollamaThinkParamFor } from './ollama-reasoning';
 
 export const OllamaModelIdentifier = Symbol('OllamaModelIdentifier');
 
@@ -74,7 +75,7 @@ export class OllamaModel implements LanguageModel {
             stream
         };
         const structured = request.response_format?.type === 'json_schema';
-        return this.dispatchRequest(ollama, ollamaRequest, structured, cancellationToken, request.thinkingMode);
+        return this.dispatchRequest(ollama, ollamaRequest, structured, cancellationToken, request.reasoning);
     }
 
     /**
@@ -94,7 +95,7 @@ export class OllamaModel implements LanguageModel {
         ollamaRequest: ExtendedChatRequest,
         structured: boolean,
         cancellation?: CancellationToken,
-        thinkingMode?: ThinkingModeSettings
+        reasoning?: ReasoningSettings
     ): Promise<LanguageModelResponse> {
 
         // Handle structured output request
@@ -104,21 +105,21 @@ export class OllamaModel implements LanguageModel {
 
         if (isNonStreaming(ollamaRequest)) {
             // handle non-streaming request
-            return this.handleNonStreamingRequest(ollama, ollamaRequest, cancellation, thinkingMode);
+            return this.handleNonStreamingRequest(ollama, ollamaRequest, cancellation, reasoning);
         }
 
         // handle streaming request
-        return this.handleStreamingRequest(ollama, ollamaRequest, cancellation, thinkingMode);
+        return this.handleStreamingRequest(ollama, ollamaRequest, cancellation, reasoning);
     }
 
     protected async handleStreamingRequest(
         ollama: Ollama,
         chatRequest: ExtendedChatRequest,
         cancellation?: CancellationToken,
-        thinkingMode?: ThinkingModeSettings
+        reasoning?: ReasoningSettings
     ): Promise<LanguageModelStreamResponse> {
         const supportsThinking = await this.checkThinkingSupport(ollama, chatRequest.model);
-        const thinkParam = supportsThinking ? this.getThinkingParameter(thinkingMode, chatRequest.model) : false;
+        const thinkParam = supportsThinking ? this.getThinkingParameter(reasoning, chatRequest.model) : false;
         const responseStream = await ollama.chat({
             ...chatRequest,
             stream: true,
@@ -193,7 +194,7 @@ export class OllamaModel implements LanguageModel {
                             ollama,
                             chatRequest,
                             cancellation,
-                            thinkingMode
+                            reasoning
                         );
 
                         // Stream the continued response
@@ -225,56 +226,13 @@ export class OllamaModel implements LanguageModel {
         return result?.capabilities?.includes('thinking') || false;
     }
 
-    /**
-     * Determines the value for Ollama's 'think' parameter based on the request's thinking mode settings.
-     *
-     * Note: Most models support boolean values for 'think', but some models (e.g., GPT-OSS) require
-     * effort levels ('low', 'medium', 'high') and ignore boolean values.
-     *
-     * @param thinkingMode The thinking mode settings from the request.
-     * @param model The model name to check for special handling.
-     * @returns The appropriate 'think' parameter value for the model.
-     */
-    protected getThinkingParameter(thinkingMode: ThinkingModeSettings | undefined, model: string): boolean | 'low' | 'medium' | 'high' {
-        if (!thinkingMode?.enabled) {
-            return false;
-        }
-
-        if (this.requiresEffortLevel(model)) {
-            return this.budgetTokensToEffortLevel(thinkingMode.budgetTokens);
-        }
-
-        return true;
+    protected getThinkingParameter(reasoning: ReasoningSettings | undefined, model: string): boolean | 'low' | 'medium' | 'high' {
+        return ollamaThinkParamFor(reasoning?.level, this.requiresEffortLevel(model));
     }
 
-    /**
-     * Checks if the model requires effort levels instead of boolean for the 'think' parameter.
-     *
-     * @param model The model name to check.
-     * @returns true if the model requires effort levels.
-     */
+    /** Checks if the model requires effort levels instead of a boolean for `think`. */
     protected requiresEffortLevel(model: string): boolean {
         return model.toLowerCase().includes('gpt-oss');
-    }
-
-    /**
-     * Maps budget tokens to Ollama effort levels.
-     *
-     * @param budgetTokens Optional budget tokens from thinking mode settings.
-     * @returns The effort level ('low', 'medium', or 'high').
-     */
-    protected budgetTokensToEffortLevel(budgetTokens: number | undefined): 'low' | 'medium' | 'high' {
-        if (budgetTokens === undefined) {
-            return 'medium';
-        }
-
-        if (budgetTokens <= 2000) {
-            return 'low';
-        } else if (budgetTokens <= 20000) {
-            return 'medium';
-        } else {
-            return 'high';
-        }
     }
 
     protected async handleStructuredOutputRequest(ollama: Ollama, chatRequest: ChatRequest): Promise<LanguageModelParsedResponse> {
@@ -310,14 +268,14 @@ export class OllamaModel implements LanguageModel {
         ollama: Ollama,
         chatRequest: ExtendedNonStreamingChatRequest,
         cancellation?: CancellationToken,
-        thinkingMode?: ThinkingModeSettings
+        reasoning?: ReasoningSettings
     ): Promise<LanguageModelResponse> {
         try {
             // even though we have a non-streaming request, we still use the streaming version for two reasons:
             // 1. we can abort the stream if the request is cancelled instead of having to wait for the entire response
             // 2. we can use think: true so the Ollama API separates thinking from content and we can filter out the thoughts in the response
             const supportsThinking = await this.checkThinkingSupport(ollama, chatRequest.model);
-            const thinkParam = supportsThinking ? this.getThinkingParameter(thinkingMode, chatRequest.model) : false;
+            const thinkParam = supportsThinking ? this.getThinkingParameter(reasoning, chatRequest.model) : false;
             const responseStream = await ollama.chat({ ...chatRequest, stream: true, think: thinkParam });
             cancellation?.onCancellationRequested(() => {
                 responseStream.abort();
@@ -368,7 +326,7 @@ export class OllamaModel implements LanguageModel {
                 }
 
                 // recurse to get the final response content (the intermediate content remains hidden, it is only part of the conversation)
-                return this.handleNonStreamingRequest(ollama, chatRequest, cancellation, thinkingMode);
+                return this.handleNonStreamingRequest(ollama, chatRequest, cancellation, reasoning);
             }
 
             // if no tool calls are necessary, return the final response content

--- a/packages/ai-ollama/src/node/ollama-language-models-manager-impl.ts
+++ b/packages/ai-ollama/src/node/ollama-language-models-manager-impl.ts
@@ -56,7 +56,8 @@ export class OllamaLanguageModelsManagerImpl implements OllamaLanguageModelsMana
                 const status = this.calculateStatus(host);
                 await this.languageModelRegistry.patchLanguageModel<OllamaModel>(modelDescription.id, {
                     proxy: proxyUrl,
-                    status
+                    status,
+                    reasoningSupport: modelDescription.reasoningSupport
                 });
             } else {
                 const status = this.calculateStatus(host);
@@ -66,7 +67,8 @@ export class OllamaLanguageModelsManagerImpl implements OllamaLanguageModelsMana
                         modelDescription.model,
                         status,
                         hostProvider,
-                        proxyUrl
+                        proxyUrl,
+                        modelDescription.reasoningSupport
                     )
                 ]);
             }

--- a/packages/ai-ollama/src/node/ollama-reasoning.ts
+++ b/packages/ai-ollama/src/node/ollama-reasoning.ts
@@ -1,0 +1,40 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ReasoningLevel } from '@theia/ai-core';
+
+/**
+ * Translates a reasoning level to Ollama's `think` parameter. Most models accept a boolean,
+ * but some (e.g. GPT-OSS) require an effort string — set {@link requiresEffortLevel} for those.
+ * Returns `false` when reasoning is not requested or disabled.
+ */
+export function ollamaThinkParamFor(
+    level: ReasoningLevel | undefined,
+    requiresEffortLevel: boolean
+): boolean | 'low' | 'medium' | 'high' {
+    if (!level || level === 'off') {
+        return false;
+    }
+    if (!requiresEffortLevel) {
+        return true;
+    }
+    switch (level) {
+        case 'minimal':
+        case 'low': return 'low';
+        case 'high': return 'high';
+        default: return 'medium'; // 'medium' and 'auto'
+    }
+}

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -16,6 +16,7 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
+import { ReasoningSupport } from '@theia/ai-core';
 import { OpenAiLanguageModelsManager, OpenAiModelDescription, OPENAI_PROVIDER_ID } from '../common';
 import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF, USE_RESPONSE_API_PREF } from '../common/openai-preferences';
 import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES } from '@theia/ai-core/lib/common/ai-core-preferences';
@@ -132,7 +133,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             enableStreaming: !openAIModelsWithDisabledStreaming.includes(modelId),
             supportsStructuredOutput: !openAIModelsWithoutStructuredOutput.includes(modelId),
             maxRetries: maxRetries,
-            useResponseApi: useResponseApi
+            useResponseApi: useResponseApi,
+            reasoningSupport: reasoningSupportFor(modelId)
         };
     }
 
@@ -168,3 +170,28 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
 const openAIModelsWithDisabledStreaming: string[] = [];
 const openAIModelsNotSupportingDeveloperMessages = ['o1-preview', 'o1-mini'];
 const openAIModelsWithoutStructuredOutput = ['o1-preview', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo', 'o1-mini', 'gpt-4o-2024-05-13'];
+
+/** GPT-5 family: supports `minimal` in addition to `low | medium | high`. */
+const GPT5_REASONING = /^gpt-5(?:\.|-|$)/i;
+/** o-series reasoning models (o1, o3, o4): `low | medium | high`. */
+const O_SERIES_REASONING = /^o[134](?:-|$)/i;
+
+const GPT5_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'off'
+};
+
+const O_SERIES_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'off'
+};
+
+function reasoningSupportFor(modelId: string): ReasoningSupport | undefined {
+    if (GPT5_REASONING.test(modelId)) {
+        return GPT5_REASONING_SUPPORT;
+    }
+    if (O_SERIES_REASONING.test(modelId)) {
+        return O_SERIES_REASONING_SUPPORT;
+    }
+    return undefined;
+}

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -105,7 +105,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                 model.developerMessageSettings === newModel.developerMessageSettings &&
                 model.supportsStructuredOutput === newModel.supportsStructuredOutput &&
                 model.enableStreaming === newModel.enableStreaming &&
-                model.useResponseApi === newModel.useResponseApi));
+                model.useResponseApi === newModel.useResponseApi &&
+                reasoningSupportEquals(model.reasoningSupport, newModel.reasoningSupport)));
 
         this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
         this.manager.createOrUpdateLanguageModels(...modelsToAddOrUpdate);
@@ -146,6 +147,12 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             if (!pref.model || !pref.url || typeof pref.model !== 'string' || typeof pref.url !== 'string') {
                 return acc;
             }
+            // Default to the model-name heuristic so reasoning-capable GPT-5 / o-series models exposed via
+            // a custom endpoint still get the selector. Users can override via `reasoningSupport`
+            // (set to `null` to disable, or to a full `ReasoningSupport` object to customize).
+            const reasoningSupport: ReasoningSupport | undefined = 'reasoningSupport' in pref
+                ? (isReasoningSupport(pref.reasoningSupport) ? pref.reasoningSupport : undefined)
+                : reasoningSupportFor(pref.model);
 
             return [
                 ...acc,
@@ -160,11 +167,34 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     supportsStructuredOutput: pref.supportsStructuredOutput ?? true,
                     enableStreaming: pref.enableStreaming ?? true,
                     maxRetries: pref.maxRetries ?? maxRetries,
-                    useResponseApi: pref.useResponseApi ?? false
+                    useResponseApi: pref.useResponseApi ?? false,
+                    reasoningSupport
                 }
             ];
         }, []);
     }
+}
+
+function isReasoningSupport(value: unknown): value is ReasoningSupport {
+    return !!value && typeof value === 'object' && Array.isArray((value as ReasoningSupport).supportedLevels);
+}
+
+/**
+ * Structural equality for {@link ReasoningSupport}. Used by {@link handleCustomModelChanges} to avoid
+ * needless model re-creation when the user supplies an explicit `reasoningSupport` object via
+ * preferences — each JSON deserialization yields a fresh object reference, so a `===` check would
+ * always report a change even when the contents are identical.
+ */
+function reasoningSupportEquals(a: ReasoningSupport | undefined, b: ReasoningSupport | undefined): boolean {
+    if (a === b) {
+        return true;
+    }
+    if (!a || !b) {
+        return false;
+    }
+    return a.defaultLevel === b.defaultLevel
+        && a.supportedLevels.length === b.supportedLevels.length
+        && a.supportedLevels.every((level, index) => level === b.supportedLevels[index]);
 }
 
 const openAIModelsWithDisabledStreaming: string[] = [];
@@ -178,12 +208,12 @@ const O_SERIES_REASONING = /^o[134](?:-|$)/i;
 
 const GPT5_REASONING_SUPPORT: ReasoningSupport = {
     supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'off'
+    defaultLevel: 'auto'
 };
 
 const O_SERIES_REASONING_SUPPORT: ReasoningSupport = {
     supportedLevels: ['off', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'off'
+    defaultLevel: 'auto'
 };
 
 function reasoningSupportFor(modelId: string): ReasoningSupport | undefined {

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -13,6 +13,8 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
+import { ReasoningSupport } from '@theia/ai-core';
+
 export const OPENAI_LANGUAGE_MODELS_MANAGER_PATH = '/services/open-ai/language-model-manager';
 export const OpenAiLanguageModelsManager = Symbol('OpenAiLanguageModelsManager');
 
@@ -68,6 +70,8 @@ export interface OpenAiModelDescription {
      * Default is `false` for custom models.
      */
     useResponseApi?: boolean;
+    /** When set, the UI exposes a reasoning selector and the level is translated to the OpenAI reasoning parameter. */
+    reasoningSupport?: ReasoningSupport;
 }
 export interface OpenAiLanguageModelsManager {
     apiKey: string | undefined;

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -85,6 +85,10 @@ Best effort is made to convert non-conformant schemas, but errors are still poss
             \n\
             - specify `useResponseApi: true` to use the newer OpenAI Response API instead of the Chat Completion API (requires compatible endpoint).\
             \n\
+            - specify `reasoningSupport` to opt in to the chat reasoning selector. By default this is inferred from the\
+            `model` name (GPT-5 / o-series). Set to `null` to disable, or to an object with `supportedLevels` (e.g.\
+            `["off", "low", "medium", "high", "auto"]`) and an optional `defaultLevel` to customize.\
+            \n\
             Refer to [our documentation](https://theia-ide.org/docs/user_ai/#openai-compatible-models-eg-via-vllm) for more information.'),
             default: [],
             items: {
@@ -141,6 +145,25 @@ Best effort is made to convert non-conformant schemas, but errors are still poss
                         title: nls.localize('theia/ai/openai/customEndpoints/useResponseApi/title',
                             'Use the newer OpenAI Response API instead of the Chat Completion API. `false` by default for custom providers.'
                             + 'Note: Will automatically fall back to Chat Completions API when tools are used.'),
+                    },
+                    reasoningSupport: {
+                        type: ['object', 'null'],
+                        title: nls.localize('theia/ai/openai/customEndpoints/reasoningSupport/title',
+                            'Declares the model\'s reasoning capabilities. When set the chat shows a reasoning selector'
+                            + ' for this model. Set to `null` to disable. Inferred from the model name by default.'),
+                        properties: {
+                            supportedLevels: {
+                                type: 'array',
+                                items: {
+                                    type: 'string',
+                                    enum: ['off', 'minimal', 'low', 'medium', 'high', 'auto']
+                                }
+                            },
+                            defaultLevel: {
+                                type: 'string',
+                                enum: ['off', 'minimal', 'low', 'medium', 'high', 'auto']
+                            }
+                        }
                     }
                 }
             }

--- a/packages/ai-openai/src/node/openai-language-model.spec.ts
+++ b/packages/ai-openai/src/node/openai-language-model.spec.ts
@@ -1,0 +1,104 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { LanguageModelRequest, ReasoningSupport } from '@theia/ai-core';
+import { OpenAiModel, OpenAiModelUtils } from './openai-language-model';
+import { OpenAiResponseApiUtils } from './openai-response-api-utils';
+
+const GPT5_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+const O_SERIES_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+class TestableOpenAiModel extends OpenAiModel {
+    public callGetSettings(request: LanguageModelRequest, forResponseApi: boolean = false): Record<string, unknown> {
+        return this.getSettings(request, forResponseApi);
+    }
+}
+
+function createModel(modelId: string, reasoningSupport?: ReasoningSupport): TestableOpenAiModel {
+    return new TestableOpenAiModel(
+        'test-id', modelId, { status: 'ready' }, true,
+        () => 'test-key', () => undefined,
+        false, undefined, undefined,
+        new OpenAiModelUtils(), new OpenAiResponseApiUtils(),
+        'developer', 3, false, undefined, reasoningSupport
+    );
+}
+
+describe('OpenAiModel reasoning translation', () => {
+
+    describe('Responses API (GPT-5)', () => {
+        it('maps level=minimal to reasoning.effort=minimal', () => {
+            const model = createModel('gpt-5', GPT5_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'minimal' } }, true);
+            expect(result.reasoning).to.deep.equal({ effort: 'minimal' });
+        });
+        it('maps level=high to reasoning.effort=high', () => {
+            const model = createModel('gpt-5', GPT5_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'high' } }, true);
+            expect(result.reasoning).to.deep.equal({ effort: 'high' });
+        });
+        it('omits reasoning entirely when level=off', () => {
+            const model = createModel('gpt-5', GPT5_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'off' } }, true);
+            expect(result.reasoning).to.equal(undefined);
+        });
+        it('omits reasoning when level=auto (provider default applies)', () => {
+            const model = createModel('gpt-5', GPT5_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'auto' } }, true);
+            expect(result.reasoning).to.equal(undefined);
+        });
+    });
+
+    describe('Chat Completions API (o-series)', () => {
+        it('maps level=medium to reasoning_effort=medium', () => {
+            const model = createModel('o3-mini', O_SERIES_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'medium' } }, false);
+            expect(result.reasoning_effort).to.equal('medium');
+        });
+        it('buckets minimal to low (o-series does not accept minimal)', () => {
+            const model = createModel('o3-mini', O_SERIES_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'minimal' } }, false);
+            expect(result.reasoning_effort).to.equal('low');
+        });
+        it('omits reasoning_effort for level=off', () => {
+            const model = createModel('o3-mini', O_SERIES_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'off' } }, false);
+            expect(result.reasoning_effort).to.equal(undefined);
+        });
+        it('omits reasoning_effort for level=auto', () => {
+            const model = createModel('o3-mini', O_SERIES_REASONING_SUPPORT);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'auto' } }, false);
+            expect(result.reasoning_effort).to.equal(undefined);
+        });
+    });
+
+    describe('non-reasoning models', () => {
+        it('ignores reasoning settings when the model has no reasoningSupport', () => {
+            const model = createModel('gpt-4o', undefined);
+            const result = model.callGetSettings({ messages: [], reasoning: { level: 'high' } }, true);
+            expect(result.reasoning).to.equal(undefined);
+            expect(result.reasoning_effort).to.equal(undefined);
+        });
+    });
+});

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -23,7 +23,8 @@ import {
     LanguageModelTextResponse,
     UserRequest,
     ImageContent,
-    LanguageModelStatus
+    LanguageModelStatus,
+    ReasoningSupport
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { injectable } from '@theia/core/shared/inversify';
@@ -36,6 +37,7 @@ import { OPENAI_PROVIDER_ID } from '../common';
 import type { FinalRequestOptions } from 'openai/internal/request-options';
 import type { RunnerOptions } from 'openai/lib/AbstractChatCompletionRunner';
 import { OpenAiResponseApiUtils, processSystemMessages } from './openai-response-api-utils';
+import { openAiReasoningFor } from './openai-reasoning';
 import { createProxyFetch } from '@theia/ai-core/lib/node';
 
 export class MistralFixedOpenAI extends OpenAI {
@@ -103,72 +105,16 @@ export class OpenAiModel implements LanguageModel {
         public developerMessageSettings: DeveloperMessageSettings = 'developer',
         public maxRetries: number = 3,
         public useResponseApi: boolean = false,
-        public proxy?: string
+        public proxy?: string,
+        public reasoningSupport?: ReasoningSupport
     ) { }
 
-    /**
-     * Checks if the model is an o-series model that supports reasoning.
-     * Models like o1, o1-mini, o1-preview, o3, o3-mini, o4-mini support the reasoning_effort parameter.
-     * These models use: reasoning_effort: 'low' | 'medium' | 'high'
-     */
-    protected supportsReasoning(): boolean {
-        return /^o[134](-|$)/i.test(this.model);
-    }
-
-    /**
-     * Checks if the model is a GPT-5 series model (gpt-5, gpt-5.1, gpt-5.2).
-     * These models use a different reasoning parameter format: reasoning: { effort: 'none' | 'low' | 'medium' | 'high' }
-     */
-    protected supportsGPT5Reasoning(): boolean {
-        return /^gpt-5(\.?[012])?(-|$)/i.test(this.model);
-    }
-
-    /**
-     * Gets the settings for a request, optionally including reasoning parameters.
-     * @param request The language model request
-     * @param forResponseApi Whether the settings are for the Response API (true) or Chat Completions API (false).
-     *                       GPT-5 reasoning parameters are only supported with the Response API.
-     */
+    /** Reasoning-level translation lives in {@link openAiReasoningFor}. */
     protected getSettings(request: LanguageModelRequest, forResponseApi: boolean = false): Record<string, unknown> {
-        const baseSettings = request.settings ?? {};
-
-        if (request.thinkingMode?.enabled && forResponseApi && this.supportsGPT5Reasoning()) {
-            const budgetTokens = request.thinkingMode.budgetTokens ?? 10000;
-            let effort: 'none' | 'low' | 'medium' | 'high';
-            if (budgetTokens <= 0) {
-                effort = 'none';
-            } else if (budgetTokens <= 2000) {
-                effort = 'low';
-            } else if (budgetTokens <= 20000) {
-                effort = 'medium';
-            } else {
-                effort = 'high';
-            }
-
-            return {
-                ...baseSettings,
-                reasoning: { effort }
-            };
-        }
-
-        if (request.thinkingMode?.enabled && this.supportsReasoning()) {
-            const budgetTokens = request.thinkingMode.budgetTokens ?? 10000;
-            let reasoningEffort: 'low' | 'medium' | 'high';
-            if (budgetTokens <= 2000) {
-                reasoningEffort = 'low';
-            } else if (budgetTokens <= 20000) {
-                reasoningEffort = 'medium';
-            } else {
-                reasoningEffort = 'high';
-            }
-
-            return {
-                ...baseSettings,
-                reasoning_effort: reasoningEffort
-            };
-        }
-
-        return baseSettings;
+        return {
+            ...request.settings,
+            ...openAiReasoningFor(request.reasoning?.level, forResponseApi, !!this.reasoningSupport)
+        };
     }
 
     async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -100,7 +100,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                     status,
                     maxRetries: modelDescription.maxRetries,
                     useResponseApi: modelDescription.useResponseApi ?? false,
-                    proxy: proxyUrl
+                    proxy: proxyUrl,
+                    reasoningSupport: modelDescription.reasoningSupport
                 });
             } else {
                 this.languageModelRegistry.addLanguageModels([
@@ -119,7 +120,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         modelDescription.developerMessageSettings,
                         modelDescription.maxRetries,
                         modelDescription.useResponseApi ?? false,
-                        proxyUrl
+                        proxyUrl,
+                        modelDescription.reasoningSupport
                     )
                 ]);
             }

--- a/packages/ai-openai/src/node/openai-reasoning.ts
+++ b/packages/ai-openai/src/node/openai-reasoning.ts
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ReasoningLevel } from '@theia/ai-core';
+
+/**
+ * Translates a reasoning level to the OpenAI request fragment to merge into `settings`.
+ * Returns `{}` when reasoning is not requested, unsupported, or disabled — so the caller
+ * can spread it unconditionally.
+ *
+ * @param forResponseApi `true` for the Responses API (`reasoning: { effort }`, supports `minimal`);
+ *                        `false` for Chat Completions (`reasoning_effort`, `low`|`medium`|`high` only).
+ * @param supportsReasoning `false` for models without reasoning support — returns `{}`.
+ */
+export function openAiReasoningFor(
+    level: ReasoningLevel | undefined,
+    forResponseApi: boolean,
+    supportsReasoning: boolean
+): Record<string, unknown> {
+    if (!level || !supportsReasoning) {
+        return {};
+    }
+    if (forResponseApi) {
+        const responsesEffort =
+            level === 'minimal' ? 'minimal' :
+                level === 'low' ? 'low' :
+                    level === 'medium' ? 'medium' :
+                        level === 'high' ? 'high' :
+                            undefined;
+        return responsesEffort ? { reasoning: { effort: responsesEffort } } : {};
+    }
+    // Chat Completions has no 'minimal' — map it down to 'low'.
+    const chatEffort =
+        level === 'minimal' || level === 'low' ? 'low' :
+            level === 'medium' ? 'medium' :
+                level === 'high' ? 'high' :
+                    undefined;
+    return chatEffort ? { reasoning_effort: chatEffort } : {};
+}

--- a/packages/ai-openai/src/node/openai-reasoning.ts
+++ b/packages/ai-openai/src/node/openai-reasoning.ts
@@ -30,7 +30,7 @@ export function openAiReasoningFor(
     forResponseApi: boolean,
     supportsReasoning: boolean
 ): Record<string, unknown> {
-    if (!level || !supportsReasoning) {
+    if (!level || !supportsReasoning || level === 'off') {
         return {};
     }
     if (forResponseApi) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The previous thinking mode setting (enabled flag + budget tokens) and its editor in the session settings dialog were modeled after Anthropic's original extended-thinking API. Current providers have converged on level-based reasoning APIs that are incompatible with that shape:

- Anthropic Claude 4.6+ uses adaptive thinking with effort levels
- OpenAI GPT-5 / o-series use a discrete `reasoning.effort` enum
- Gemini 3 uses `thinkingConfig.thinkingLevel`

Introduce a provider-agnostic `ReasoningSettings { level }` abstraction with values `off | minimal | low | medium | high | auto`. Each provider declares a `ReasoningSupport` capability as data on its model description, and a small pure helper translates the level into the provider's native request fragment. Both API shapes are covered: effort (Anthropic adaptive, OpenAI, Gemini 3) and budget (Anthropic legacy, Gemini 2.5).

Move the UI from the session settings dialog to a compact selector next to the chat mode selector, shown only for reasoning-capable models. The selector value is the active setting — what the user sees is what gets sent. Precedence at request time is session override (selector click) → the new `ai-features.reasoning.defaults` preference → the model's declared default.

The level-based translation takes precedence over raw values supplied via `ai-features.modelSettings.requestSettings` for the same fields, so the model default is `off` rather than `auto`. This keeps the selector honest (shows "Off" rather than an ambiguous "Auto"), avoids surprise reasoning costs, and lets raw `requestSettings` pass through untouched out of the box.


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Test the two different setting, see what happens. For simple questions you can explicitly ask the model to think.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
