### PR TITLE
perf(core): improvements to start-up performance logging

### DIFF
--- a/dev-packages/application-manager/src/generator/abstract-generator.ts
+++ b/dev-packages/application-manager/src/generator/abstract-generator.ts
@@ -66,4 +66,13 @@ export abstract class AbstractGenerator {
         return JSON.stringify(object, undefined, 4);
     }
 
+    protected emitStartupLogger(component: string, epochLabel: string, options?: { requirePerformance?: boolean }): string {
+        const perfImport = options?.requirePerformance ? 'const { performance } = require(\'perf_hooks\');\n' : '';
+        return `${perfImport}const startupLog = (milestone) => console.debug(\`${component}: \${milestone} [\${(performance.now() / 1000).toFixed(3)} s since ${epochLabel}]\`);`;
+    }
+
+    protected emitStartupLog(milestone: string): string {
+        return `startupLog('${milestone}');`;
+    }
+
 }

--- a/dev-packages/application-manager/src/generator/backend-generator.ts
+++ b/dev-packages/application-manager/src/generator/backend-generator.ts
@@ -36,6 +36,8 @@ export class BackendGenerator extends AbstractGenerator {
         return `// @ts-check
 
 require('@theia/core/shared/reflect-metadata');
+${this.emitStartupLogger('Electron main', 'electron main start', { requirePerformance: true })}
+${this.emitStartupLog('loading modules...')}
 
 // Workaround for https://github.com/electron/electron/issues/9225. Chrome has an issue where
 // in certain locales (e.g. PL), image metrics are wrongly computed. We explicitly set the
@@ -69,7 +71,7 @@ process.env.LC_NUMERIC = 'C';
         app.quit();
         return;
     }
-    
+
     const container = new Container();
     container.load(electronMainApplicationModule);
     container.bind(ElectronMainApplicationGlobals).toConstantValue({
@@ -78,21 +80,25 @@ process.env.LC_NUMERIC = 'C';
         THEIA_FRONTEND_HTML_PATH: resolve(__dirname, '..', '..', 'lib', 'frontend', 'index.html'),
         THEIA_SECONDARY_WINDOW_HTML_PATH: resolve(__dirname, '..', '..', 'lib', 'frontend', 'secondary-window.html')
     });
-    
+    ${this.emitStartupLog('container created')}
+
     function load(raw) {
         return Promise.resolve(raw.default).then(module =>
             container.load(module)
         );
     }
-    
+
     async function start() {
+        ${this.emitStartupLog('resolving application')}
         const application = container.get(ElectronMainApplication);
+        ${this.emitStartupLog('application resolved')}
         await application.start(config);
     }
 
     try {
 ${Array.from(electronMainModules?.values() ?? [], jsModulePath => `\
         await load(require('${jsModulePath}'));`).join(EOL)}
+        ${this.emitStartupLog('modules loaded')}
         await start();
     } catch (reason) {
         if (typeof reason !== 'number') {
@@ -109,7 +115,9 @@ ${Array.from(electronMainModules?.values() ?? [], jsModulePath => `\
 
     protected compileServer(backendModules: Map<string, string>): string {
         return `// @ts-check
-require('reflect-metadata');${this.ifElectron(`
+require('reflect-metadata');
+${this.emitStartupLogger('Backend server', 'backend process start', { requirePerformance: true })}
+${this.emitStartupLog('loading modules...')}${this.ifElectron(`
 
 // Patch electron version if missing, see https://github.com/eclipse-theia/theia/pull/7361#pullrequestreview-377065146
 if (typeof process.versions.electron === 'undefined' && typeof process.env.THEIA_ELECTRON_VERSION === 'string') {
@@ -134,6 +142,7 @@ const container = new Container();
 container.load(backendApplicationModule);
 container.load(messagingBackendModule);
 container.load(loggerBackendModule);
+${this.emitStartupLog('container created')}
 
 function defaultServeStatic(app) {
     app.use(express.static(path.resolve(__dirname, '../../lib/frontend')))
@@ -150,8 +159,13 @@ async function start(port, host, argv = process.argv) {
         container.bind(BackendApplicationServer).toConstantValue({ configure: defaultServeStatic });
     }
     let result = undefined;
-    await container.get(CliManager).initializeCli(argv.slice(2), 
-        () => container.get(BackendApplication).configured,
+    await container.get(CliManager).initializeCli(argv.slice(2),
+        () => {
+            ${this.emitStartupLog('resolving application')}
+            const application = container.get(BackendApplication);
+            ${this.emitStartupLog('application resolved')}
+            return application.configured;
+        },
         async () => {
             result = container.get(BackendApplication).start(port, host);
         });
@@ -166,11 +180,12 @@ module.exports = async (port, host, argv) => {
     try {
 ${Array.from(backendModules.values(), jsModulePath => `\
         await load(require('${jsModulePath}'));`).join(EOL)}
+        ${this.emitStartupLog('modules loaded')}
         return await start(port, host, argv);
     } catch (error) {
         if (typeof error !== 'number') {
             console.error('Failed to start the backend application:');
-            console.error(error); 
+            console.error(error);
             process.exitCode = 1;
         }
         throw error;
@@ -181,6 +196,8 @@ ${Array.from(backendModules.values(), jsModulePath => `\
 
     protected compileMain(backendModules: Map<string, string>): string {
         return `// @ts-check
+${this.emitStartupLogger('Backend main', 'backend process start', { requirePerformance: true })}
+${this.emitStartupLog('entry point loaded')}
 const { BackendApplicationConfigProvider } = require('@theia/core/lib/node/backend-application-config-provider');
 const main = require('@theia/core/lib/node/main');
 

--- a/dev-packages/application-manager/src/generator/frontend-generator.ts
+++ b/dev-packages/application-manager/src/generator/frontend-generator.ts
@@ -73,6 +73,8 @@ export class FrontendGenerator extends AbstractGenerator {
         return `\
 // @ts-check
 require('reflect-metadata');
+${this.emitStartupLogger('Frontend', 'frontend page start')}
+${this.emitStartupLog('loading modules...')}
 const { Container } = require('@theia/core/shared/inversify');
 const { FrontendApplicationConfigProvider } = require('@theia/core/lib/browser/frontend-application-config-provider');
 
@@ -114,23 +116,28 @@ module.exports = (async () => {
     ${this.ifBrowserOnly(`const { messagingFrontendOnlyModule } = require('@theia/core/lib/browser-only/messaging/messaging-frontend-only-module');
     container.load(messagingFrontendOnlyModule);`)}
 
+    ${this.emitStartupLog('container created')}
+
     await preload(container);
+    ${this.emitStartupLog('preloaded')}
 
     ${this.ifMonaco(() => `
     const { MonacoInit } = require('@theia/monaco/lib/browser/monaco-init');
     `)};
 
     const { FrontendApplication } = require('@theia/core/lib/browser');
-    const { frontendApplicationModule } = require('@theia/core/lib/browser/frontend-application-module');    
+    const { frontendApplicationModule } = require('@theia/core/lib/browser/frontend-application-module');
     const { loggerFrontendModule } = require('@theia/core/lib/browser/logger-frontend-module');
 
     container.load(frontendApplicationModule);
     ${this.pck.ifBrowserOnly(`const { frontendOnlyApplicationModule } = require('@theia/core/lib/browser-only/frontend-only-application-module');
     container.load(frontendOnlyApplicationModule);`)}
-    
+
     container.load(loggerFrontendModule);
     ${this.ifBrowserOnly(`const { loggerFrontendOnlyModule } = require('@theia/core/lib/browser-only/logger-frontend-only-module');
     container.load(loggerFrontendOnlyModule);`)}
+
+    ${this.emitStartupLog('core modules loaded')}
 
     try {
 ${Array.from(frontendModules.values(), jsModulePath => `\
@@ -138,6 +145,7 @@ ${Array.from(frontendModules.values(), jsModulePath => `\
         ${this.ifMonaco(() => `
         MonacoInit.init(container);
         `)};
+        ${this.emitStartupLog('modules loaded')}
         await start();
     } catch (reason) {
         console.error('Failed to start the frontend application.');
@@ -148,7 +156,10 @@ ${Array.from(frontendModules.values(), jsModulePath => `\
 
     function start() {
         (window['theia'] = window['theia'] || {}).container = container;
-        return container.get(FrontendApplication).start();
+        ${this.emitStartupLog('resolving application')}
+        const application = container.get(FrontendApplication);
+        ${this.emitStartupLog('application resolved')}
+        return application.start();
     }
 })();
 `;

--- a/package.json
+++ b/package.json
@@ -101,8 +101,8 @@
     "watch:electron": "cd examples/electron && npm run -s watch",
     "watch": "concurrently --kill-others \"npm run -s watch:browser\" \"npm run -s watch:electron\"",
     "performance:startup": "npm run -s performance:startup:browser && npm run -s performance:startup:electron",
-    "performance:startup:browser": "concurrently --success first -k -r \"cd scripts/performance && node browser-performance.js --name 'Browser Frontend Startup' --folder browser --runs 10\" \"npm run -s --cwd examples/browser start\"",
-    "performance:startup:electron": "npm run -s electron rebuild && cd scripts/performance && node electron-performance.js --name 'Electron Frontend Startup' --folder electron --runs 10",
+    "performance:startup:browser": "concurrently --success first -k -r \"cd scripts/performance && node browser-performance.js --name 'Browser Frontend Startup' --folder browser --runs 10\" \"npm --prefix examples/browser run -s start\"",
+    "performance:startup:electron": "npm run -s rebuild:electron && cd scripts/performance && node electron-performance.js --name 'Electron Frontend Startup' --folder electron --runs 10",
     "zip:native:dependencies": "node ./scripts/zip-native-dependencies.js"
   },
   "workspaces": [

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "watch:electron": "cd examples/electron && npm run -s watch",
     "watch": "concurrently --kill-others \"npm run -s watch:browser\" \"npm run -s watch:electron\"",
     "performance:startup": "npm run -s performance:startup:browser && npm run -s performance:startup:electron",
-    "performance:startup:browser": "concurrently --success first -k -r \"cd scripts/performance && node browser-performance.js --name 'Browser Frontend Startup' --folder browser --runs 10\" \"npm --prefix examples/browser run -s start\"",
+    "performance:startup:browser": "concurrently --success first -k -r \"cd scripts/performance && node browser-performance.js --name 'Browser Frontend Startup' --folder browser --runs 10\" \"npm --prefix examples/browser run -s start -- --log-level=debug\"",
     "performance:startup:electron": "npm run -s rebuild:electron && cd scripts/performance && node electron-performance.js --name 'Electron Frontend Startup' --folder electron --runs 10",
     "zip:native:dependencies": "node ./scripts/zip-native-dependencies.js"
   },

--- a/packages/core/src/browser/frontend-application-contribution.ts
+++ b/packages/core/src/browser/frontend-application-contribution.ts
@@ -28,7 +28,7 @@ export interface FrontendApplicationContribution {
     /**
      * Called on application startup before configure is called.
      */
-    initialize?(): void;
+    initialize?(): MaybePromise<void>;
 
     /**
      * Called before commands, key bindings and menus are initialized.
@@ -103,7 +103,7 @@ export namespace OnWillStopAction {
 @injectable()
 export abstract class DefaultFrontendApplicationContribution implements FrontendApplicationContribution {
 
-    initialize(): void {
+    initialize(): MaybePromise<void> {
         // NOOP
     }
 

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { inject, injectable, named } from 'inversify';
-import { ContributionProvider, CommandRegistry, MenuModelRegistry, isOSX, BackendStopwatch, LogLevel, Stopwatch } from '../common';
+import { ContributionProvider, CommandRegistry, MenuModelRegistry, isOSX, BackendStopwatch, LogLevel, MeasurementContext, Stopwatch } from '../common';
 import { MaybePromise } from '../common/types';
 import { KeybindingRegistry } from './keybinding';
 import { Widget } from './widgets';
@@ -48,6 +48,8 @@ export class FrontendApplication {
     @inject(BackendStopwatch)
     protected readonly backendStopwatch: BackendStopwatch;
 
+    private settlementContext?: MeasurementContext<FrontendApplicationContribution>;
+
     constructor(
         @inject(CommandRegistry) protected readonly commands: CommandRegistry,
         @inject(MenuModelRegistry) protected readonly menus: MenuModelRegistry,
@@ -74,6 +76,7 @@ export class FrontendApplication {
      */
     async start(): Promise<void> {
         const startup = this.backendStopwatch.start('frontend');
+        this.settlementContext = new MeasurementContext(this.stopwatch, 'Frontend', TIMER_WARNING_THRESHOLD);
 
         await this.measure('startContributions', () => this.startContributions(), 'Start frontend contributions', false);
         this.stateService.state = 'started_contributions';
@@ -91,8 +94,9 @@ export class FrontendApplication {
         await this.measure('revealShell', () => this.revealShell(host), 'Replace loading indicator with ready workbench UI (animation)', false);
         this.registerEventListeners();
         this.stateService.state = 'ready';
+        this.settlementContext?.armAllSettled();
 
-        startup.then(idToken => this.backendStopwatch.stop(idToken, 'Frontend application start', []));
+        startup.then(idToken => this.backendStopwatch.stop(idToken, 'Frontend application startup sequence completed (async work may still be pending)', []));
     }
 
     /**
@@ -229,9 +233,8 @@ export class FrontendApplication {
     protected async createDefaultLayout(): Promise<void> {
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.initializeLayout) {
-                await this.measure(contribution.constructor.name + '.initializeLayout',
-                    () => contribution.initializeLayout!(this)
-                );
+                await this.measureContribution(contribution, 'initializeLayout',
+                    () => contribution.initializeLayout!(this));
             }
         }
     }
@@ -239,9 +242,8 @@ export class FrontendApplication {
     protected async fireOnDidInitializeLayout(): Promise<void> {
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.onDidInitializeLayout) {
-                await this.measure(contribution.constructor.name + '.onDidInitializeLayout',
-                    () => contribution.onDidInitializeLayout!(this)
-                );
+                await this.measureContribution(contribution, 'onDidInitializeLayout',
+                    () => contribution.onDidInitializeLayout!(this));
             }
         }
     }
@@ -253,9 +255,8 @@ export class FrontendApplication {
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.initialize) {
                 try {
-                    await this.measure(contribution.constructor.name + '.initialize',
-                        () => contribution.initialize!()
-                    );
+                    await this.measureContribution(contribution, 'initialize',
+                        () => contribution.initialize!());
                 } catch (error) {
                     console.error('Could not initialize contribution', error);
                 }
@@ -265,9 +266,8 @@ export class FrontendApplication {
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.configure) {
                 try {
-                    await this.measure(contribution.constructor.name + '.configure',
-                        () => contribution.configure!(this)
-                    );
+                    await this.measureContribution(contribution, 'configure',
+                        () => contribution.configure!(this));
                 } catch (error) {
                     console.error('Could not configure contribution', error);
                 }
@@ -291,9 +291,8 @@ export class FrontendApplication {
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.onStart) {
                 try {
-                    await this.measure(contribution.constructor.name + '.onStart',
-                        () => contribution.onStart!(this)
-                    );
+                    await this.measureContribution(contribution, 'onStart',
+                        () => contribution.onStart!(this));
                 } catch (error) {
                     console.error('Could not start contribution', error);
                 }
@@ -316,6 +315,16 @@ export class FrontendApplication {
             }
         }
         console.info('<<< All frontend contributions have been stopped.');
+    }
+
+    protected async measureContribution<T>(contribution: FrontendApplicationContribution, hook: string, fn: () => MaybePromise<T>): Promise<T> {
+        let innerResult: MaybePromise<T>;
+        this.settlementContext?.ensureEntry(contribution);
+        const result = await this.measure(contribution.constructor.name + '.' + hook,
+            () => (innerResult = fn())
+        );
+        this.settlementContext?.trackSettlement(contribution, innerResult!);
+        return result;
     }
 
     protected async measure<T>(name: string, fn: () => MaybePromise<T>, message = `Frontend ${name}`, threshold = true): Promise<T> {

--- a/packages/core/src/browser/performance/frontend-stopwatch.ts
+++ b/packages/core/src/browser/performance/frontend-stopwatch.ts
@@ -22,7 +22,7 @@ export class FrontendStopwatch extends Stopwatch {
 
     constructor() {
         super({
-            owner: 'frontend',
+            owner: 'frontend page',
             now: () => performance.now(),
         });
     }

--- a/packages/core/src/common/performance/index.ts
+++ b/packages/core/src/common/performance/index.ts
@@ -16,4 +16,5 @@
 
 export * from './measurement';
 export * from './stopwatch';
+export * from './simple-stopwatch';
 export * from './measurement-protocol';

--- a/packages/core/src/common/performance/simple-stopwatch.ts
+++ b/packages/core/src/common/performance/simple-stopwatch.ts
@@ -1,0 +1,91 @@
+// *****************************************************************************
+// Copyright (C) 2026 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { LogLevel } from '../logger';
+import { Measurement, MeasurementOptions } from './measurement';
+import { Stopwatch } from './stopwatch';
+
+/**
+ * A simple {@link Stopwatch} that uses a caller-supplied time function and logs
+ * via `console`. Usable without Inversify DI: this class does not assign nor
+ * use the inherited `logger` field.
+ */
+export class SimpleStopwatch extends Stopwatch {
+
+    constructor(owner: string, now: () => number) {
+        super({ owner, now });
+    }
+
+    start(name: string, options?: MeasurementOptions): Measurement {
+        const now = this.defaultLogOptions.now;
+        const startTime = now();
+
+        return this.createMeasurement(name, () => ({
+            startTime,
+            duration: now() - startTime
+        }), options);
+    }
+
+    protected override log(measurement: Measurement, activity: string, options: {
+        now: () => number;
+        owner?: string;
+        context?: string;
+        arguments?: any[];
+    } & MeasurementOptions): void {
+        const elapsed = measurement.stop();
+        const level = this.logLevel(elapsed, options);
+
+        if (Number.isNaN(elapsed)) {
+            switch (level) {
+                case LogLevel.ERROR:
+                case LogLevel.FATAL:
+                    break;
+                default:
+                    return;
+            }
+        }
+
+        const origin = options.owner ?? 'application';
+        const timeFromStart = `${(options.now() / 1000).toFixed(3)} s since ${origin} start`;
+        const whatWasMeasured = options.context ? `[${options.context}] ${activity}` : activity;
+        const message = `${whatWasMeasured}: ${elapsed.toFixed(1)} ms [${timeFromStart}]`;
+        const args = options.arguments ?? [];
+
+        switch (level) {
+            case LogLevel.FATAL:
+            case LogLevel.ERROR:
+                console.error(message, ...args);
+                break;
+            case LogLevel.WARN:
+                console.warn(message, ...args);
+                break;
+            case LogLevel.INFO:
+                console.info(message, ...args);
+                break;
+            case LogLevel.DEBUG:
+                console.debug(message, ...args);
+                break;
+            case LogLevel.TRACE:
+                console.trace(message, ...args);
+                break;
+            default:
+                console.log(message, ...args);
+                break;
+        }
+    }
+}

--- a/packages/core/src/common/performance/stopwatch.spec.ts
+++ b/packages/core/src/common/performance/stopwatch.spec.ts
@@ -1,0 +1,321 @@
+// *****************************************************************************
+// Copyright (C) 2026 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Deferred } from '../promise-util';
+import { Measurement, MeasurementOptions } from './measurement';
+import { MeasurementContext } from './stopwatch';
+import { SimpleStopwatch } from './simple-stopwatch';
+
+/**
+ * A fake {@link Measurement} whose log methods are sinon spies, with a
+ * configurable duration returned by {@link stop}.
+ */
+class FakeMeasurement implements Measurement {
+    name: string;
+    elapsed?: number;
+    duration: number;
+
+    readonly log = sinon.spy();
+    readonly info = sinon.spy();
+    readonly debug = sinon.spy();
+    readonly warn = sinon.spy();
+    readonly error = sinon.spy();
+
+    readonly stop = sinon.spy((): number => {
+        if (this.elapsed === undefined) {
+            this.elapsed = this.duration;
+        }
+        return this.elapsed;
+    });
+
+    constructor(name: string, duration: number = 0) {
+        this.name = name;
+        this.duration = duration;
+    }
+}
+
+/**
+ * A fake {@link Stopwatch} that creates {@link FakeMeasurement}s with
+ * configurable durations and records all invocations of {@link start}.
+ */
+class FakeStopwatch extends SimpleStopwatch {
+    defaultDuration = 0;
+    readonly durationByName = new Map<string, number>();
+    readonly created: FakeMeasurement[] = [];
+
+    override readonly start = sinon.spy((name: string, _options?: MeasurementOptions): Measurement => {
+        const duration = this.durationByName.get(name) ?? this.defaultDuration;
+        const measurement = new FakeMeasurement(name, duration);
+        this.created.push(measurement);
+        return measurement;
+    });
+
+    constructor() {
+        super('test', () => 0);
+    }
+
+    /** Return the first measurement created with the given name, or `undefined`. */
+    measurementFor(name: string): FakeMeasurement | undefined {
+        return this.created.find(m => m.name === name);
+    }
+}
+
+class TestContribution { }
+class OtherTestContribution { }
+
+/**
+ * Allow any already-queued microtasks (such as `.then` callbacks attached to
+ * already-settled promises) to run before assertions.
+ */
+async function flushPromises(): Promise<void> {
+    for (let i = 0; i < 5; i++) {
+        await Promise.resolve();
+    }
+}
+
+describe('MeasurementContext', () => {
+
+    let stopwatch: FakeStopwatch;
+
+    beforeEach(() => {
+        stopwatch = new FakeStopwatch();
+    });
+
+    describe('ensureEntry', () => {
+
+        it('starts a per-contribution measurement', () => {
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 250);
+
+            context.ensureEntry(new TestContribution());
+
+            sinon.assert.calledWith(stopwatch.start, 'TestContribution.settled', sinon.match({ thresholdMillis: 250 }));
+        });
+
+        it('starts a per-contribution measurement only once per item', () => {
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+
+            context.ensureEntry(item);
+            context.ensureEntry(item);
+            context.ensureEntry(item);
+
+            const started = stopwatch.start.getCalls().filter(c => c.args[0] === 'TestContribution.settled');
+            expect(started).to.have.length(1);
+        });
+
+        it('starts independent measurements for distinct items', () => {
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+
+            context.ensureEntry(new TestContribution());
+            context.ensureEntry(new TestContribution());
+
+            const started = stopwatch.start.getCalls().filter(c => c.args[0] === 'TestContribution.settled');
+            expect(started).to.have.length(2);
+        });
+    });
+
+    describe('trackSettlement', () => {
+
+        it('is a no-op for a synchronous result', async () => {
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            context.trackSettlement(item, undefined);
+            context.armAllSettled();
+            await flushPromises();
+
+            const perContribution = stopwatch.measurementFor('TestContribution.settled')!;
+            sinon.assert.notCalled(perContribution.debug);
+            sinon.assert.notCalled(perContribution.warn);
+            sinon.assert.notCalled(perContribution.info);
+
+            // Synchronous results do not increment allSettledPending, so arming fires the
+            // aggregate message immediately.
+            const allSettled = stopwatch.measurementFor('frontend-all-settled')!;
+            sinon.assert.calledOnce(allSettled.info);
+        });
+
+        it('does not log a per-contribution settlement when only one promise was tracked', async () => {
+            // The single lifecycle measurement already describes the duration of a solo tracked
+            // promise, so the per-contribution aggregate must stay silent.
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            context.trackSettlement(item, Promise.resolve());
+            context.armAllSettled();
+            await flushPromises();
+
+            const perContribution = stopwatch.measurementFor('TestContribution.settled')!;
+            sinon.assert.notCalled(perContribution.debug);
+            sinon.assert.notCalled(perContribution.warn);
+            sinon.assert.notCalled(perContribution.info);
+        });
+
+        it('logs a debug settlement message once multiple tracked promises all resolve under the threshold', async () => {
+            stopwatch.durationByName.set('TestContribution.settled', 50);
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            const first = new Deferred<void>();
+            const second = new Deferred<void>();
+            context.trackSettlement(item, first.promise);
+            context.trackSettlement(item, second.promise);
+
+            // Before any promise resolves, nothing has been logged.
+            const perContribution = stopwatch.measurementFor('TestContribution.settled')!;
+            sinon.assert.notCalled(perContribution.debug);
+
+            first.resolve();
+            await flushPromises();
+            sinon.assert.notCalled(perContribution.debug);
+
+            second.resolve();
+            await flushPromises();
+            sinon.assert.calledOnceWithExactly(perContribution.debug, 'Frontend TestContribution settled');
+            sinon.assert.notCalled(perContribution.warn);
+        });
+
+        it('logs a warn settlement message when multiple tracked promises exceed the threshold', async () => {
+            stopwatch.durationByName.set('TestContribution.settled', 500);
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            context.trackSettlement(item, Promise.resolve());
+            context.trackSettlement(item, Promise.resolve());
+            await flushPromises();
+
+            const perContribution = stopwatch.measurementFor('TestContribution.settled')!;
+            sinon.assert.calledOnceWithExactly(perContribution.warn, 'Frontend TestContribution took longer than expected to settle');
+            sinon.assert.notCalled(perContribution.debug);
+        });
+
+        it('treats a rejected promise as settled', async () => {
+            stopwatch.durationByName.set('TestContribution.settled', 10);
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            const rejecting = new Deferred<void>();
+            context.trackSettlement(item, Promise.resolve());
+            context.trackSettlement(item, rejecting.promise);
+            rejecting.reject(new Error('expected failure'));
+            await flushPromises();
+
+            const perContribution = stopwatch.measurementFor('TestContribution.settled')!;
+            sinon.assert.calledOnce(perContribution.debug);
+        });
+
+        it('tracks promises independently for each contribution', async () => {
+            stopwatch.durationByName.set('TestContribution.settled', 50);
+            stopwatch.durationByName.set('OtherTestContribution.settled', 50);
+            const context = new MeasurementContext<object>(stopwatch, 'Frontend', 100);
+
+            const a = new TestContribution();
+            const b = new OtherTestContribution();
+            context.ensureEntry(a);
+            context.ensureEntry(b);
+
+            context.trackSettlement(a, Promise.resolve());
+            context.trackSettlement(a, Promise.resolve());
+            context.trackSettlement(b, Promise.resolve());
+            await flushPromises();
+
+            // a had two tracked promises: logs once.
+            sinon.assert.calledOnce(stopwatch.measurementFor('TestContribution.settled')!.debug);
+            // b had a single tracked promise: logs nothing.
+            sinon.assert.notCalled(stopwatch.measurementFor('OtherTestContribution.settled')!.debug);
+        });
+    });
+
+    describe('armAllSettled', () => {
+
+        it('logs the aggregate message immediately when armed with zero pending promises', () => {
+            const context = new MeasurementContext(stopwatch, 'Frontend', 100);
+
+            context.armAllSettled();
+
+            const allSettled = stopwatch.measurementFor('frontend-all-settled')!;
+            sinon.assert.calledOnceWithExactly(allSettled.info, 'All frontend contributions settled');
+        });
+
+        it('defers the aggregate log until the last tracked promise settles', async () => {
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            const pending = new Deferred<void>();
+            context.trackSettlement(item, pending.promise);
+            context.armAllSettled();
+
+            const allSettled = stopwatch.measurementFor('frontend-all-settled')!;
+            sinon.assert.notCalled(allSettled.info);
+
+            pending.resolve();
+            await flushPromises();
+
+            sinon.assert.calledOnce(allSettled.info);
+        });
+
+        it('does not log the aggregate message when all promises settle before arming', async () => {
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            context.trackSettlement(item, Promise.resolve());
+            await flushPromises();
+
+            const allSettled = stopwatch.measurementFor('frontend-all-settled')!;
+            sinon.assert.notCalled(allSettled.info);
+        });
+
+        it('logs the aggregate message when arming after all tracked promises have already settled', async () => {
+            const context = new MeasurementContext<TestContribution>(stopwatch, 'Frontend', 100);
+            const item = new TestContribution();
+            context.ensureEntry(item);
+
+            context.trackSettlement(item, Promise.resolve());
+            await flushPromises();
+
+            const allSettled = stopwatch.measurementFor('frontend-all-settled')!;
+            sinon.assert.notCalled(allSettled.info);
+
+            context.armAllSettled();
+            sinon.assert.calledOnce(allSettled.info);
+        });
+
+        it('logs the aggregate message exactly once when multiple contributions finish', async () => {
+            const context = new MeasurementContext<object>(stopwatch, 'Frontend', 100);
+            const a = new TestContribution();
+            const b = new OtherTestContribution();
+            context.ensureEntry(a);
+            context.ensureEntry(b);
+
+            context.trackSettlement(a, Promise.resolve());
+            context.trackSettlement(b, Promise.resolve());
+            context.armAllSettled();
+            await flushPromises();
+
+            const allSettled = stopwatch.measurementFor('frontend-all-settled')!;
+            sinon.assert.calledOnce(allSettled.info);
+        });
+    });
+});

--- a/packages/core/src/common/performance/stopwatch.ts
+++ b/packages/core/src/common/performance/stopwatch.ts
@@ -170,14 +170,115 @@ export abstract class Stopwatch {
             }
         }
 
-        const start = options.owner ? `${options.owner} start` : 'start';
-        const timeFromStart = `Finished ${(options.now() / 1000).toFixed(3)} s after ${start}`;
+        const origin = options.owner ?? 'application';
+        const timeFromStart = `${(options.now() / 1000).toFixed(3)} s since ${origin} start`;
         const whatWasMeasured = options.context ? `[${options.context}] ${activity}` : activity;
         this.logger.log(level, `${whatWasMeasured}: ${elapsed.toFixed(1)} ms [${timeFromStart}]`, ...(options.arguments ?? []));
     }
 
     get storedMeasurements(): ReadonlyArray<MeasurementResult> {
         return this._storedMeasurements;
+    }
+
+}
+
+interface SettlementEntry {
+    name: string;
+    measurement: Measurement;
+    pending: number;
+    total: number;
+}
+
+/**
+ * Tracks the settlement of async work initiated by contributions during application startup.
+ *
+ * A contribution "settles" when all promises it returned from lifecycle methods (initialize, configure, onStart, etc.)
+ * have resolved. Individual settlement is only logged when a contribution returned promises from more than one lifecycle
+ * method; otherwise the single lifecycle measurement already describes the work. An aggregate "all settled" message is
+ * logged once all tracked promises across all contributions have resolved.
+ *
+ * Typical usage:
+ * 1. Create the context at the start of the application lifecycle.
+ * 2. Before each lifecycle call, call {@link ensureEntry} to start the per-contribution clock.
+ * 3. After each lifecycle call, call {@link trackSettlement} with the return value.
+ * 4. After the startup sequence completes, call {@link armAllSettled} to enable the aggregate message.
+ */
+export class MeasurementContext<T extends object = object> {
+
+    private readonly entries = new Map<T, SettlementEntry>();
+    private readonly allSettledMeasurement: Measurement;
+    private allSettledPending = 0;
+    private allSettledArmed = false;
+
+    constructor(
+        protected readonly stopwatch: Stopwatch,
+        protected readonly owner: string,
+        protected readonly thresholdMillis: number
+    ) {
+        this.allSettledMeasurement = this.stopwatch.start(`${owner.toLowerCase()}-all-settled`);
+    }
+
+    /**
+     * Ensure that settlement tracking has been started for the given contribution.
+     * Starts the per-contribution measurement clock on the first call for each contribution.
+     */
+    ensureEntry(item: T): void {
+        if (!this.entries.has(item)) {
+            const name = item.constructor.name;
+            this.entries.set(item, {
+                name,
+                measurement: this.stopwatch.start(`${name}.settled`, { thresholdMillis: this.thresholdMillis }),
+                pending: 0,
+                total: 0
+            });
+        }
+    }
+
+    /**
+     * Track a promise returned by a contribution's lifecycle method.
+     * Must be called after the corresponding {@link Stopwatch.startAsync} has completed so that
+     * the settlement log appears after the lifecycle measurement log.
+     */
+    trackSettlement(item: T, result: MaybePromise<unknown>): void {
+        if (result instanceof Promise) {
+            const entry = this.entries.get(item)!;
+            entry.pending++;
+            entry.total++;
+            this.allSettledPending++;
+            const onSettled = (): void => {
+                this.onPromiseSettled(item);
+            };
+            result.then(onSettled, onSettled);
+        }
+    }
+
+    /**
+     * Arm the aggregate "all settled" log message. Call this after the startup sequence has finished
+     * collecting all promises. If all promises have already settled, the message is logged immediately.
+     */
+    armAllSettled(): void {
+        this.allSettledArmed = true;
+        if (this.allSettledPending === 0) {
+            this.allSettledMeasurement.info(`All ${this.owner.toLowerCase()} contributions settled`);
+        }
+    }
+
+    private onPromiseSettled(item: T): void {
+        const entry = this.entries.get(item);
+        if (entry && --entry.pending === 0) {
+            const { name, measurement, total } = entry;
+            this.entries.delete(item);
+            if (total > 1) {
+                if (measurement.stop() > this.thresholdMillis) {
+                    measurement.warn(`${this.owner} ${name} took longer than expected to settle`);
+                } else {
+                    measurement.debug(`${this.owner} ${name} settled`);
+                }
+            }
+        }
+        if (--this.allSettledPending === 0 && this.allSettledArmed) {
+            this.allSettledMeasurement.info(`All ${this.owner.toLowerCase()} contributions settled`);
+        }
     }
 
 }

--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -15,8 +15,10 @@
 // *****************************************************************************
 
 import { ContainerModule } from 'inversify';
+import { performance } from 'perf_hooks';
 import { generateUuid } from '../common/uuid';
 import { bindRootContributionProvider } from '../common/contribution-provider';
+import { Stopwatch, SimpleStopwatch } from '../common/performance';
 import { RpcConnectionHandler } from '../common/messaging/proxy-factory';
 import { ElectronSecurityToken } from '../electron-common/electron-token';
 import { ElectronMainWindowService, electronMainWindowServicePath } from '../electron-common/electron-main-window-service';
@@ -34,6 +36,7 @@ const electronSecurityToken: ElectronSecurityToken = { value: generateUuid() };
 (global as any)[ElectronSecurityToken] = electronSecurityToken;
 
 export default new ContainerModule(bind => {
+    bind(Stopwatch).toConstantValue(new SimpleStopwatch('electron main', () => performance.now()));
     bind(ElectronMainApplication).toSelf().inSingletonScope();
     bind(ElectronMessagingContribution).toSelf().inSingletonScope();
     bind(ElectronMainApplicationContribution).toService(ElectronMessagingContribution);

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -30,6 +30,7 @@ import URI from '../common/uri';
 import { FileUri } from '../common/file-uri';
 import { Deferred, timeout } from '../common/promise-util';
 import { MaybePromise } from '../common/types';
+import { Stopwatch } from '../common/performance';
 import { ContributionProvider } from '../common/contribution-provider';
 import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { ElectronSecurityToken } from '../electron-common/electron-token';
@@ -48,6 +49,8 @@ import { backendGlobal } from '../node/backend-global';
 export { ElectronMainApplicationGlobals };
 
 const createYargs: (argv?: string[], cwd?: string) => Argv = require('yargs/yargs');
+
+const ELECTRON_TIMER_WARNING_THRESHOLD = 50;
 
 /**
  * Options passed to the main/default command handler.
@@ -171,6 +174,9 @@ export class ElectronMainApplication {
     @inject(TheiaElectronWindowFactory)
     protected readonly windowFactory: TheiaElectronWindowFactory;
 
+    @inject(Stopwatch)
+    protected readonly stopwatch: Stopwatch;
+
     protected isPortable = this.makePortable();
 
     protected readonly electronStore = new Storage<{
@@ -229,15 +235,19 @@ export class ElectronMainApplication {
                         await fs.mkdir(args.electronUserData, { recursive: true });
                         app.setPath('userData', args.electronUserData);
                     }
+                    const startupMeasurement = this.stopwatch.start('electron-main-startup');
                     this.useNativeWindowFrame = this.getTitleBarStyle(config) === 'native';
                     this._config = config;
                     this.hookApplicationEvents();
                     this.showInitialWindow(argv.includes('--open-url') ? argv[argv.length - 1] : undefined);
-                    const port = await this.startBackend();
+                    const port = await this.stopwatch.startAsync('electron-main-start-backend', 'Starting backend', () => this.startBackend());
                     this._backendPort.resolve(port);
                     await app.whenReady();
-                    await this.attachElectronSecurityToken(port);
-                    await this.startContributions();
+                    await this.stopwatch.startAsync('electron-main-security-token', 'Attaching security token',
+                        () => this.attachElectronSecurityToken(port));
+                    await this.stopwatch.startAsync('electron-main-start-contributions', 'Starting contributions',
+                        () => this.startContributions());
+                    startupMeasurement.info('Startup sequence completed');
 
                     this.handleMainCommand({
                         file: args.file,
@@ -920,8 +930,14 @@ export class ElectronMainApplication {
     protected async startContributions(): Promise<void> {
         const promises = [];
         for (const contribution of this.contributions.getContributions()) {
-            if (contribution.onStart) {
-                promises.push(contribution.onStart(this));
+            const onStart = contribution.onStart;
+            if (onStart) {
+                promises.push(this.stopwatch.startAsync(
+                    `${contribution.constructor.name}.onStart`,
+                    `${contribution.constructor.name}.onStart`,
+                    () => onStart.call(contribution, this),
+                    { thresholdMillis: ELECTRON_TIMER_WARNING_THRESHOLD }
+                ));
             }
         }
         await Promise.all(promises);

--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -22,7 +22,7 @@ import * as express from 'express';
 import * as yargs from 'yargs';
 import * as fs from 'fs-extra';
 import { inject, named, injectable, postConstruct } from 'inversify';
-import { ContributionProvider, MaybePromise, Stopwatch } from '../common';
+import { ContributionProvider, LogLevel, MaybePromise, MeasurementContext, Stopwatch } from '../common';
 import { CliContribution } from './cli';
 import { Deferred } from '../common/promise-util';
 import { environment } from '../common/index';
@@ -164,6 +164,8 @@ export class BackendApplication {
 
     private _configured: Promise<void>;
 
+    private settlementContext?: MeasurementContext<BackendApplicationContribution>;
+
     constructor(
         @inject(ContributionProvider) @named(BackendApplicationContribution)
         protected readonly contributionsProvider: ContributionProvider<BackendApplicationContribution>,
@@ -195,9 +197,8 @@ export class BackendApplication {
         await Promise.all(this.contributionsProvider.getContributions().map(async contribution => {
             if (contribution.initialize) {
                 try {
-                    await this.measure(contribution.constructor.name + '.initialize',
-                        () => contribution.initialize!()
-                    );
+                    await this.measureContribution(contribution, 'initialize',
+                        () => contribution.initialize!());
                 } catch (error) {
                     console.error('Could not initialize contribution', error);
                 }
@@ -211,6 +212,7 @@ export class BackendApplication {
 
     @postConstruct()
     protected init(): void {
+        this.settlementContext = new MeasurementContext(this.stopwatch, 'Backend', TIMER_WARNING_THRESHOLD);
         this._configured = this.configure();
     }
 
@@ -232,7 +234,8 @@ export class BackendApplication {
         await Promise.all(this.contributionsProvider.getContributions().map(async contribution => {
             if (contribution.configure) {
                 try {
-                    await contribution.configure!(this.app);
+                    await this.measureContribution(contribution, 'configure',
+                        () => contribution.configure!(this.app));
                 } catch (error) {
                     console.error('Could not configure contribution', error);
                 }
@@ -246,6 +249,8 @@ export class BackendApplication {
     }
 
     async start(port?: number, hostname?: string): Promise<http.Server | https.Server> {
+        const startupMeasurement = this.stopwatch.start('backend-startup');
+
         hostname ??= this.cliParams.hostname;
         port ??= this.cliParams.port;
 
@@ -307,15 +312,17 @@ export class BackendApplication {
         for (const contribution of this.contributionsProvider.getContributions()) {
             if (contribution.onStart) {
                 try {
-                    await this.measure(contribution.constructor.name + '.onStart',
-                        () => contribution.onStart!(server)
-                    );
+                    await this.measureContribution(contribution, 'onStart',
+                        () => contribution.onStart!(server));
                 } catch (error) {
                     console.error('Could not start contribution', error);
                 }
             }
         }
-        return this.stopwatch.startAsync('server', 'Finished starting backend application', () => deferred.promise);
+        await deferred.promise;
+        startupMeasurement.info('Backend application startup sequence completed (async work may still be pending)');
+        this.settlementContext?.armAllSettled();
+        return server;
     }
 
     protected getHttpUrl({ address, port, family }: AddressInfo, ssl?: boolean): string {
@@ -358,8 +365,18 @@ export class BackendApplication {
         next();
     }
 
+    protected async measureContribution<T>(contribution: BackendApplicationContribution, hook: string, fn: () => MaybePromise<T>): Promise<T> {
+        let innerResult: MaybePromise<T>;
+        this.settlementContext?.ensureEntry(contribution);
+        const result = await this.measure(contribution.constructor.name + '.' + hook,
+            () => (innerResult = fn())
+        );
+        this.settlementContext?.trackSettlement(contribution, innerResult!);
+        return result;
+    }
+
     protected async measure<T>(name: string, fn: () => MaybePromise<T>): Promise<T> {
-        return this.stopwatch.startAsync(name, `Backend ${name}`, fn, { thresholdMillis: TIMER_WARNING_THRESHOLD });
+        return this.stopwatch.startAsync(name, `Backend ${name}`, fn, { thresholdMillis: TIMER_WARNING_THRESHOLD, defaultLogLevel: LogLevel.DEBUG });
     }
 
     protected handleUncaughtError(error: Error): void {

--- a/packages/core/src/node/performance/node-stopwatch.ts
+++ b/packages/core/src/node/performance/node-stopwatch.ts
@@ -23,7 +23,7 @@ export class NodeStopwatch extends Stopwatch {
 
     constructor() {
         super({
-            owner: 'backend',
+            owner: 'backend process',
             now: () => performance.now(),
         });
     }

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -15,6 +15,8 @@ Execute `npm run performance:startup:browser` in the root directory to startup t
 
 To run the script the Theia backend needs to be started.
 This can either be done with the `Launch Browser Backend` launch config or by running `npm run start` in the `examples/browser-app` directory.
+For the per-contribution Stopwatch breakdown to be captured, the backend must be started at debug log level (e.g. `npm run start -- --log-level=debug`); otherwise only aggregate metrics will appear in the script's summary.
+The bundled `npm run performance:startup:browser` flow already does this.
 
 ### Executing the script
 

--- a/scripts/performance/README.md
+++ b/scripts/performance/README.md
@@ -3,6 +3,7 @@
 This directory contains scripts that measure the start-up performance of the Theia frontend in both the browser and the Electron examples.
 
 The frontend's start-up time is measured using the timestamp of the last recorded `Largest contentful paint (LCP)` candidate metric.
+In addition, the scripts scrape Theia's Stopwatch log output to capture complementary metrics; see [Log-based metrics](#log-based-metrics) below.
 
 ## Running the browser start-up script
 
@@ -97,6 +98,50 @@ The following parameters are available:
 - `--yarn`: Flag to trigger a full build at script startup (e.g. to build changes to extensions)
 - `--url`: Specify a URL that Theia should be launched with (can be used to specify the workspace to be opened). _Applies only to the `browser` app_ (default: `http://localhost:3000/#/<GIT_ROOT>/scripts/performance/workspace`)
 - `--workspace`: Specify a workspace on which to launch Theia. _Applies only to the `electron` app_ (default: `/<GIT_ROOT>/scripts/performance/workspace`)
-- `--file`: Relative path to the output file (default: `./script.csv`)
+- `--file`: Relative path to the main output file (default: `./script.csv`)
+- `--detail-file`: Relative path to a second CSV that records per-contribution breakdowns (default: derived from `--file` by inserting `-details` before the `.csv` suffix)
 
 _**Note**: If no extensions are provided all extensions from the `packages` folder will be measured._
+
+### Per-contribution detail output
+
+Alongside the main LCP comparison CSV, `extension-impact.js` emits a detail CSV with one row per (extension, metric) pair.
+Metrics include the `All frontend/backend contributions settled` aggregate and every per-contribution timing that the Theia Stopwatch emitted during the runs.
+This lets you attribute an extension's startup cost to the specific contribution(s) responsible.
+
+Example detail table:
+
+| Extension Name     | Metric                                        | Mean (10 runs) (in s) | Std Dev (in s) | CV (%) |
+| ------------------ | --------------------------------------------- | --------------------- | -------------- | ------ |
+| @theia/foo:1.19.0  | All frontend contributions settled            | 2.015                 | 0.032          | 1.588  |
+| @theia/foo:1.19.0  | Frontend FooFrontendContribution.onStart      | 0.087                 | 0.006          | 6.897  |
+| @theia/foo:1.19.0  | Frontend FooFrontendContribution.initialize   | 0.004                 | 0.001          | 25.000 |
+
+## Log-based metrics
+
+The Theia Stopwatch emits startup timing logs in a well-defined format that the performance scripts scrape:
+
+```
+<activity>: <ms> ms [<seconds> s since {backend process|frontend page} start]
+```
+
+Log lines the scripts currently capture:
+
+- `All frontend contributions settled`: logged by the frontend once all contributions whose lifecycle methods returned promises have resolved (i.e. steady state, as opposed to first paint).
+- `All backend contributions settled`: the backend equivalent.
+- `Frontend <ContributionName>.<phase>`: per-contribution timing for `initialize`, `configure`, `onStart`, `initializeLayout`, and `onDidInitializeLayout`.
+- `Backend <ContributionName>.<phase>`: per-contribution timing for `initialize`, `configure`, and `onStart`.
+- `Frontend <ContributionName> settled` / `Backend <ContributionName> settled`: per-contribution settlement, logged only when a contribution returned promises from more than one lifecycle method.
+
+Where these logs are visible:
+
+| Metric                                     | Browser                  | Electron                   |
+| ------------------------------------------ | ------------------------ | -------------------------- |
+| LCP                                        | Chrome trace             | Chromium trace             |
+| `All frontend contributions settled`       | Puppeteer page console   | Electron child stdout/stderr |
+| `All backend contributions settled`        | _(parent process, n/a)_  | Electron child stdout/stderr |
+| `Frontend <Contribution>.<phase>`          | Puppeteer page console   | Electron child stdout/stderr |
+| `Backend <Contribution>.<phase>`           | _(parent process, n/a)_  | Electron child stdout/stderr |
+
+Theia's frontend logger forwards all console output to the backend over RPC, so the Electron child process's stdout/stderr contains both frontend and backend Stopwatch lines.
+The browser script cannot observe backend logs because the backend runs as a separate process whose stdout is not captured.

--- a/scripts/performance/base-package.json
+++ b/scripts/performance/base-package.json
@@ -29,7 +29,7 @@
     "bundle": "theia build --mode development",
     "compile": "tsc -b",
     "rebuild": "theia rebuild:{{app}} --cacheRoot ../..",
-    "start": "THEIA_CONFIG_DIR=./theia-config-dir theia start --plugins=local-dir:../../noPlugins --log-level=debug"
+    "start": "THEIA_CONFIG_DIR=\"{{configDir}}\" theia start --plugins=local-dir:../../noPlugins --log-level=debug"
   },
   "devDependencies": {
     "@theia/cli": "{{version}}"

--- a/scripts/performance/base-package.json
+++ b/scripts/performance/base-package.json
@@ -29,7 +29,7 @@
     "bundle": "theia build --mode development",
     "compile": "tsc -b",
     "rebuild": "theia rebuild:{{app}} --cacheRoot ../..",
-    "start": "THEIA_CONFIG_DIR=./theia-config-dir theia start --plugins=local-dir:../../noPlugins --log-level=fatal"
+    "start": "THEIA_CONFIG_DIR=./theia-config-dir theia start --plugins=local-dir:../../noPlugins --log-level=debug"
   },
   "devDependencies": {
     "@theia/cli": "{{version}}"

--- a/scripts/performance/browser-performance.js
+++ b/scripts/performance/browser-performance.js
@@ -17,7 +17,10 @@
 const puppeteer = require('puppeteer');
 const fsx = require('fs-extra');
 const { resolve } = require('path');
-const { delay, githubReporting, isLCP, lcp, measure } = require('./common-performance');
+const {
+    analyzeTrace, ContributionCollector, delay, frontendSettled, githubReporting,
+    isLCP, lcp, measureMulti, parseStopwatchLog
+} = require('./common-performance');
 
 const workspacePath = resolve('./workspace');
 const profilesPath = './profiles/';
@@ -99,27 +102,57 @@ let runs = 10;
 
 async function measurePerformance(name, url, folder, headless, runs) {
 
-    /** @type import('./common-performance').TestFunction */
+    // Collects per-contribution timings from Stopwatch log lines observed in the browser console
+    // across all runs, so that consumers like extension-impact.js can break down startup cost
+    // by contribution.
+    const contributions = new ContributionCollector();
+
     const testScenario = async (runNr) => {
         const browser = await puppeteer.launch({ headless: headless });
         const page = await browser.newPage();
 
         const file = folder + '/' + runNr + '.json';
+
+        // Listen for Stopwatch log lines in the browser console and scrape their metrics
+        let settledSeconds;
+        page.on('console', msg => {
+            const parsed = parseStopwatchLog(msg.text());
+            if (!parsed) {
+                return;
+            }
+            if (parsed.activity === frontendSettled) {
+                settledSeconds = parsed.secondsSinceStart;
+            } else if (parsed.activity.startsWith('Frontend ')) {
+                contributions.record(parsed.activity, parsed.ms / 1000);
+            }
+        });
+
         await page.tracing.start({ path: file, screenshots: true });
         await page.goto(url);
         // This selector is for the theia application, which is exposed when the loading indicator vanishes
         await page.waitForSelector('.theia-ApplicationShell', { visible: true });
-        // Prevent tracing from stopping too soon and skipping a LCP candidate
-        await delay(1000);
+        // Prevent tracing from stopping too soon and skipping a LCP candidate, and give the
+        // frontend contributions a chance to settle (their log fires after state === 'ready').
+        await delay(2000);
 
         await page.tracing.stop();
 
         await browser.close();
 
-        return file;
+        return { traceFile: file, settledSeconds };
     };
 
-    measure(name, lcp, runs, testScenario, isStart, isLCP);
+    await measureMulti(name, runs, testScenario, [
+        {
+            scenario: lcp,
+            analyze: ctx => analyzeTrace(ctx.traceFile, isStart, isLCP)
+        },
+        {
+            scenario: frontendSettled,
+            analyze: ctx => ctx.settledSeconds
+        }
+    ]);
+    contributions.logSummary(name);
 }
 
 function isStart(x) {

--- a/scripts/performance/browser-performance.js
+++ b/scripts/performance/browser-performance.js
@@ -25,6 +25,14 @@ const {
 const workspacePath = resolve('./workspace');
 const profilesPath = './profiles/';
 
+// Baseline wait after the application shell becomes visible, to give Chrome a chance
+// to emit one more LCP candidate into the trace before we stop recording.
+const LCP_GRACE_MS = 2000;
+// Maximum time (including LCP_GRACE_MS) to wait for the frontend-settled console log.
+// `armAllSettled()` is called right after state === 'ready', but the log fires only
+// once the slowest tracked contribution promise resolves — slow startups need headroom.
+const SETTLED_TIMEOUT_MS = 30000;
+
 let name = 'Browser Frontend Startup';
 let url = 'http://localhost:3000/#' + workspacePath;
 let folder = 'browser';
@@ -113,8 +121,13 @@ async function measurePerformance(name, url, folder, headless, runs) {
 
         const file = folder + '/' + runNr + '.json';
 
-        // Listen for Stopwatch log lines in the browser console and scrape their metrics
+        // Listen for Stopwatch log lines in the browser console and scrape their metrics.
+        // A dedicated promise is resolved when the frontend-settled log arrives so that
+        // the scenario can proceed as soon as the metric is captured, rather than always
+        // waiting the full timeout.
         let settledSeconds;
+        let resolveSettled;
+        const settledPromise = new Promise(resolve => { resolveSettled = resolve; });
         page.on('console', msg => {
             const parsed = parseStopwatchLog(msg.text());
             if (!parsed) {
@@ -122,6 +135,7 @@ async function measurePerformance(name, url, folder, headless, runs) {
             }
             if (parsed.activity === frontendSettled) {
                 settledSeconds = parsed.secondsSinceStart;
+                resolveSettled();
             } else if (parsed.activity.startsWith('Frontend ')) {
                 contributions.record(parsed.activity, parsed.ms / 1000);
             }
@@ -131,9 +145,11 @@ async function measurePerformance(name, url, folder, headless, runs) {
         await page.goto(url);
         // This selector is for the theia application, which is exposed when the loading indicator vanishes
         await page.waitForSelector('.theia-ApplicationShell', { visible: true });
-        // Prevent tracing from stopping too soon and skipping a LCP candidate, and give the
-        // frontend contributions a chance to settle (their log fires after state === 'ready').
-        await delay(2000);
+        // Give Chrome a chance to emit a final LCP candidate, then wait for the
+        // frontend-settled console log (up to SETTLED_TIMEOUT_MS total). If settled already
+        // fired during the baseline, the race resolves immediately.
+        await delay(LCP_GRACE_MS);
+        await Promise.race([settledPromise, delay(SETTLED_TIMEOUT_MS - LCP_GRACE_MS)]);
 
         await page.tracing.stop();
 

--- a/scripts/performance/common-performance.js
+++ b/scripts/performance/common-performance.js
@@ -285,7 +285,7 @@ function logException(name, run, metric, exception, multipleRuns = true) {
         runText = braceText(run);
     }
     console.log(performanceTag + braceText(name) + runText + ' ' + metric + ' failed to obtain a measurement: ' + exception.message);
-    console.error(`Failed to obtain a measurement. The most likely cause is that the performance trace file was incomplete because the script did not wait long enough for "${metric}".`);
+    console.error(`Failed to obtain a measurement. The most likely cause is that the performance trace file was incomplete because the script did not wait long enough for "${metric}" to be emitted or the trace to be written to disk.`);
     console.error(exception);
 }
 
@@ -341,6 +341,36 @@ function delay(time) {
 }
 
 /**
+ * Wait until a file exists and its size has stopped changing, indicating that whatever
+ * process is writing it has finished flushing. Polls the file periodically and returns
+ * when two consecutive observations agree on a non-zero size, or when the `timeoutMs`
+ * backstop is reached.
+ *
+ * @param {string} filePath the path to the file to wait for
+ * @param {number} timeoutMs the maximum total time to wait, in milliseconds
+ * @param {number} [pollIntervalMs=250] how often to poll the file, in milliseconds
+ * @returns {Promise<boolean>} `true` if the file was observed to be stable within the timeout, `false` otherwise
+ */
+async function waitForFileStable(filePath, timeoutMs, pollIntervalMs = 250) {
+    const start = Date.now();
+    let previousSize = -1;
+    while (Date.now() - start < timeoutMs) {
+        let currentSize = -1;
+        try {
+            currentSize = fs.statSync(filePath).size;
+        } catch {
+            // File does not exist yet; keep polling.
+        }
+        if (currentSize > 0 && currentSize === previousSize) {
+            return true;
+        }
+        previousSize = currentSize;
+        await delay(pollIntervalMs);
+    }
+    return false;
+}
+
+/**
  * Collects per-activity durations observed across runs of a performance test, and logs
  * MEAN/STDEV summaries in the same format as {@link logSummary} so that `extension-impact.js`
  * can discover them alongside the predeclared metrics.
@@ -382,7 +412,7 @@ module.exports = {
     measure, measureMulti, analyzeTrace,
     calculateMean, calculateStandardDeviation,
     duration, logDuration, logSummary,
-    braceText, delay,
+    braceText, delay, waitForFileStable,
     lcp, frontendSettled, backendSettled,
     isLCP, parseStopwatchLog,
     ContributionCollector

--- a/scripts/performance/common-performance.js
+++ b/scripts/performance/common-performance.js
@@ -396,12 +396,28 @@ class ContributionCollector {
     }
     /**
      * Log a summary line per observed activity, using the same format as {@link logSummary}
-     * so that downstream consumers (e.g. `extension-impact.js`) can scrape it.
+     * so that downstream consumers (e.g. `extension-impact.js`) can scrape it. Activities
+     * whose mean falls below the 1 ms measurement threshold are noise; we collapse them
+     * into a single header line listing their names instead of emitting per-activity
+     * MEAN/STDEV lines that all read as 0.000 seconds.
      *
      * @param {string} name the performance script name
      */
     logSummary(name) {
+        const subMillisecondThreshold = 0.001;
+        const subMillisecond = [];
+        const significant = [];
         for (const [activity, values] of this.observations) {
+            if (calculateMean(values) < subMillisecondThreshold) {
+                subMillisecond.push(activity);
+            } else {
+                significant.push([activity, values]);
+            }
+        }
+        if (subMillisecond.length > 0) {
+            console.log(`${performanceTag}${braceText(name)} Contributions under 1 ms: ${subMillisecond.sort().join(', ')}`);
+        }
+        for (const [activity, values] of significant) {
             logSummary(name, `Contribution ${activity}`, values);
         }
     }

--- a/scripts/performance/common-performance.js
+++ b/scripts/performance/common-performance.js
@@ -24,7 +24,7 @@
 
 /**
  * A call-back that selects an event from the performance trace.
- * 
+ *
  * @callback EventPredicate
  * @param {TraceEvent} event an event to test
  * @returns {boolean} whether the predicate selects the `event`
@@ -32,7 +32,7 @@
 
 /**
  * A call-back that runs the test scenario to be analyzed.
- * 
+ *
  * @async
  * @callback TestFunction
  * @param {number} runNr the current run index of the multiple runs being executed
@@ -44,10 +44,42 @@ const { resolve } = require('path');
 
 const performanceTag = braceText('Performance');
 const lcp = 'Largest Contentful Paint (LCP)';
+const frontendSettled = 'All frontend contributions settled';
+const backendSettled = 'All backend contributions settled';
+
+// Captures the Theia Stopwatch log suffix of the form
+//   "<activity>: 12.3 ms [4.567 s since {backend process|frontend page} start]"
+// Group 1: activity description including any upstream logger prefix
+// Group 2: duration in milliseconds
+// Group 3: seconds since the process/page started
+// Group 4: the origin keyword ("backend process" or "frontend page")
+const STOPWATCH_LOG_RE = /([^\n]*?):\s+([\d.]+)\s*ms\s+\[([\d.]+)\s*s since ([^\]]+) start\]/;
+// Strip a common Theia backend logger prefix: "<ISO-timestamp> <loggerName> <LEVEL> "
+const LOGGER_PREFIX_RE = /^\S+\s+\S+\s+(?:DEBUG|INFO|WARN|ERROR|FATAL)\s+/;
+
+/**
+ * Parse a single log line emitted by the Theia Stopwatch, if it matches the format.
+ *
+ * @param {string} line a log line to parse
+ * @returns {{activity: string, ms: number, secondsSinceStart: number, origin: string} | undefined}
+ *          the parsed measurement, or undefined if the line does not match
+ */
+function parseStopwatchLog(line) {
+    const match = STOPWATCH_LOG_RE.exec(line);
+    if (!match) {
+        return undefined;
+    }
+    return {
+        activity: match[1].replace(LOGGER_PREFIX_RE, '').trim(),
+        ms: parseFloat(match[2]),
+        secondsSinceStart: parseFloat(match[3]),
+        origin: match[4]
+    };
+}
 
 /**
  * A GitHub performance results record.
- * 
+ *
  * @typedef PerformanceResult
  * @property {string} name The performance measurement name
  * @property {string} unit The performance unit of measure
@@ -57,48 +89,85 @@ const lcp = 'Largest Contentful Paint (LCP)';
 
 /**
  * Configuration of reporting of performance test results in a GitHub build.
- * 
+ *
  * @property {boolean} enabled whether GitHub result reporting is enabled (`false` by default)
  * @property {Array<PerformanceResult>} results the performance results, if reporting is enabled
  */
 var githubReporting = { enabled: false, results: [] };
 
 /**
+ * A description of one metric to be captured from a performance test run.
+ *
+ * @typedef Metric
+ * @property {string} scenario a human-readable label for the metric
+ * @property {(context: any) => number | PromiseLike<number>} analyze a function that computes the metric (in seconds)
+ *        from the context returned by the test function. Return or throw to signal an invalid/missing measurement.
+ */
+
+/**
  * Measure the performance of a `test` function implementing some `scenario` of interest.
- * 
+ *
  * @param {string} name the application name to measure
  * @param {string} scenario a label for the scenario being measured
  * @param {number} runs the number of times to run the `test` scenario
- * @param {TestFunction} test a function that executes the `scenario` to be measured, returning the file 
+ * @param {TestFunction} test a function that executes the `scenario` to be measured, returning the file
  *        that records the performance profile trace
  * @param {EventPredicate} isStartEvent a predicate matching the trace event that marks the start of the measured scenario
  * @param {EventPredicate} isEndEvent a predicate matching the trace event that marks the end of the measured scenario
  */
 async function measure(name, scenario, runs, test, isStartEvent, isEndEvent) {
-    const durations = [];
+    return measureMulti(name, runs, test, [{
+        scenario,
+        analyze: file => analyzeTrace(file, isStartEvent, isEndEvent)
+    }]);
+}
+
+/**
+ * Measure the performance of a `test` function across multiple named metrics.
+ * Each `test` invocation produces a single context (e.g. a trace file path or a richer object)
+ * that all `metrics` analyze to extract their respective durations.
+ *
+ * @param {string} name the application name to measure
+ * @param {number} runs the number of times to run the test
+ * @param {(runNr: number) => PromiseLike<any>} test a function that runs the scenario and returns a context
+ * @param {Metric[]} metrics the list of metrics to extract from each run's context
+ */
+async function measureMulti(name, runs, test, metrics) {
+    const durations = metrics.map(() => []);
     for (let i = 0; i < runs; i++) {
         const runNr = i + 1;
-
-        const file = await test(runNr);
-        let time;
-
+        let context;
         try {
-            time = await analyzeTrace(file, isStartEvent, isEndEvent);
-
-            durations.push(time);
-            logDuration(name, runNr, scenario, time, runs > 1);
+            context = await test(runNr);
         } catch (e) {
-            logException(name, runNr, scenario, e, runs > 1);
+            for (const metric of metrics) {
+                logException(name, runNr, metric.scenario, e, runs > 1);
+            }
+            continue;
+        }
+        for (let j = 0; j < metrics.length; j++) {
+            const metric = metrics[j];
+            try {
+                const time = await metric.analyze(context);
+                if (typeof time !== 'number' || !isFinite(time)) {
+                    throw new Error('No measurement captured');
+                }
+                durations[j].push(time);
+                logDuration(name, runNr, metric.scenario, time, runs > 1);
+            } catch (e) {
+                logException(name, runNr, metric.scenario, e, runs > 1);
+            }
         }
     }
-
-    logSummary(name, scenario, durations);
+    for (let j = 0; j < metrics.length; j++) {
+        logSummary(name, metrics[j].scenario, durations[j]);
+    }
 }
 
 
 /**
  * Log a summary of the given measured `durations`.
- * 
+ *
  * @param {string} name the performance script name
  * @param {string} scenario the scenario that was measured
  * @param {number[]} durations the measurements captured for the `scenario`
@@ -124,7 +193,7 @@ function prec(value, precision = 3) {
 
 /**
  * Report the performance result for GitHub to pick up.
- * 
+ *
  * @param {PerformanceResult} result the performance result to report
  */
 function githubResult(result) {
@@ -140,7 +209,7 @@ function githubResult(result) {
 
 /**
  * Analyze a performance trace file.
- * 
+ *
  * @param {string} profilePath the profiling trace file path
  * @param {EventPredicate} isStartEvent a predicate matching the trace event that marks the start of the measured scenario
  * @param {EventPredicate} isEndEvent a predicate matching the trace event that marks the end of the measured scenario
@@ -165,7 +234,7 @@ async function analyzeTrace(profilePath, isStartEvent, isEndEvent) {
 
 /**
  * Query whether a trace `event` is a candidate for the Largest Contentful Paint.
- * 
+ *
  * @param {TraceEvent} event an event in the performance trace
  * @returns whether the `event` is an LCP candidate
  */
@@ -175,7 +244,7 @@ function isLCP(event) {
 
 /**
  * Compute the duration, in seconds, to an `event` from a start event.
- * 
+ *
  * @param {TraceEvent} event the duration end event
  * @param {TraceEvent} startEvent the duration start event
  * @returns the duration, in seconds
@@ -186,7 +255,7 @@ function duration(event, startEvent) {
 
 /**
  * Log a `duration` measured for some scenario.
- * 
+ *
  * @param {string} name the performance script name
  * @param {number|string} run the run index number, or some kind of aggregate like 'Total' or 'Avg'
  * @param {string} metric the scenario that was measured
@@ -203,7 +272,7 @@ function logDuration(name, run, metric, duration, multipleRuns = true) {
 
 /**
  * Log an `exception` in measurement of some scenario.
- * 
+ *
  * @param {string} name the performance script name
  * @param {number|string} run the run index number, or some kind of aggregate like 'Total' or 'Avg'
  * @param {string} metric the scenario that was measured
@@ -222,7 +291,7 @@ function logException(name, run, metric, exception, multipleRuns = true) {
 
 /**
  * Compute the arithmetic mean of an `array` of numbers.
- * 
+ *
  * @param {number[]} array an array of numbers to average
  * @returns the average of the `array`
  */
@@ -236,7 +305,7 @@ function calculateMean(array) {
 
 /**
  * Compute the standard deviation from the mean of an `array` of numbers.
- * 
+ *
  * @param {number[]} array an array of numbers
  * @returns the standard deviation of the `array` from its mean
  */
@@ -251,7 +320,7 @@ function calculateStandardDeviation(mean, array) {
 
 /**
  * Surround a string of `text` in square braces.
- * 
+ *
  * @param {string|number} text a string of text or a number that can be rendered as text
  * @returns the `text` in braces
  */
@@ -261,7 +330,7 @@ function braceText(text) {
 
 /**
  * Obtain a promise that resolves after some delay.
- * 
+ *
  * @param {number} time a delay, in milliseconds
  * @returns a promise that will resolve after the given number of milliseconds
  */
@@ -271,11 +340,50 @@ function delay(time) {
     });
 }
 
+/**
+ * Collects per-activity durations observed across runs of a performance test, and logs
+ * MEAN/STDEV summaries in the same format as {@link logSummary} so that `extension-impact.js`
+ * can discover them alongside the predeclared metrics.
+ */
+class ContributionCollector {
+    constructor() {
+        /** @type {Map<string, number[]>} activity -> durations (in seconds) across runs */
+        this.observations = new Map();
+    }
+    /**
+     * Record one observation of an `activity` taking the given duration.
+     *
+     * @param {string} activity the activity name (e.g. "Frontend FooContribution.onStart")
+     * @param {number} seconds the duration of that activity in seconds
+     */
+    record(activity, seconds) {
+        let arr = this.observations.get(activity);
+        if (!arr) {
+            arr = [];
+            this.observations.set(activity, arr);
+        }
+        arr.push(seconds);
+    }
+    /**
+     * Log a summary line per observed activity, using the same format as {@link logSummary}
+     * so that downstream consumers (e.g. `extension-impact.js`) can scrape it.
+     *
+     * @param {string} name the performance script name
+     */
+    logSummary(name) {
+        for (const [activity, values] of this.observations) {
+            logSummary(name, `Contribution ${activity}`, values);
+        }
+    }
+}
+
 module.exports = {
     githubReporting,
-    measure, analyzeTrace,
+    measure, measureMulti, analyzeTrace,
     calculateMean, calculateStandardDeviation,
     duration, logDuration, logSummary,
     braceText, delay,
-    lcp, isLCP
+    lcp, frontendSettled, backendSettled,
+    isLCP, parseStopwatchLog,
+    ContributionCollector
 };

--- a/scripts/performance/electron-performance.js
+++ b/scripts/performance/electron-performance.js
@@ -17,14 +17,17 @@
 const fsx = require('fs-extra');
 const { resolve } = require('path');
 const { spawn, ChildProcess } = require('child_process');
-const { delay, githubReporting, isLCP, lcp, measure } = require('./common-performance');
+const {
+    analyzeTrace, backendSettled, ContributionCollector, delay, frontendSettled, githubReporting,
+    isLCP, lcp, measureMulti, parseStopwatchLog
+} = require('./common-performance');
 const traceConfigTemplate = require('./electron-trace-config.json');
 const { exit } = require('process');
 
 const basePath = resolve(__dirname, '../..');
 const profilesPath = resolve(__dirname, './profiles/');
 const electronExample = resolve(basePath, 'examples/electron');
-const theia = resolve(electronExample, 'node_modules/.bin/theia');
+const theia = resolve(basePath, 'node_modules/.bin/theia');
 
 let name = 'Electron Frontend Startup';
 let folder = 'electron';
@@ -134,22 +137,72 @@ async function measurePerformance() {
 
     let electron;
 
-    /** @type import('./common-performance').TestFunction */
+    // Collects per-contribution timings from Stopwatch log lines observed on the Electron
+    // child process streams across all runs. Both backend and frontend contributions are
+    // observable here: Theia's frontend logger forwards console output to the backend over
+    // RPC, so the backend process's stdout/stderr contains logs from both sides.
+    const contributions = new ContributionCollector();
+
     const testScenario = async (runNr) => {
         const traceFile = traceConfigGenerator(runNr);
         electron = await launchElectron(traceConfigPath);
 
-        electron.stderr.on('data', data => analyzeStderr(data.toString()));
+        // Capture Stopwatch log lines from the child process streams. Theia routes log
+        // output through both stdout and stderr depending on log level, and the frontend
+        // logger forwards its output to the backend over RPC, so both backend and frontend
+        // Stopwatch lines appear here.
+        let backendSettledSeconds;
+        let frontendSettledSeconds;
+        const lineBuffers = { stderr: '', stdout: '' };
+        const consumeStream = (streamName, chunk) => {
+            lineBuffers[streamName] += chunk;
+            let newlineIndex;
+            while ((newlineIndex = lineBuffers[streamName].indexOf('\n')) >= 0) {
+                const line = lineBuffers[streamName].slice(0, newlineIndex);
+                lineBuffers[streamName] = lineBuffers[streamName].slice(newlineIndex + 1);
+                const parsed = parseStopwatchLog(line);
+                if (!parsed) {
+                    continue;
+                }
+                if (parsed.activity === backendSettled) {
+                    backendSettledSeconds = parsed.secondsSinceStart;
+                } else if (parsed.activity === frontendSettled) {
+                    frontendSettledSeconds = parsed.secondsSinceStart;
+                } else if (parsed.activity.startsWith('Backend ') || parsed.activity.startsWith('Frontend ')) {
+                    contributions.record(parsed.activity, parsed.ms / 1000);
+                }
+            }
+        };
+        electron.stderr.on('data', data => {
+            const chunk = data.toString();
+            analyzeStderr(chunk);
+            consumeStream('stderr', chunk);
+        });
+        electron.stdout.on('data', data => consumeStream('stdout', data.toString()));
 
         // Wait long enough to be sure that tracing has finished. Kill the process group
         // because the 'theia' child process was detached
         await delay(traceConfigTemplate.startup_duration * 1_000 * 3 / 2)
             .then(() => electron.exitCode !== null || process.kill(-electron.pid, 'SIGINT'));
         electron = undefined;
-        return traceFile;
+        return { traceFile, backendSettledSeconds, frontendSettledSeconds };
     };
 
-    measure(name, lcp, runs, testScenario, hasNonzeroTimestamp, isLCP);
+    await measureMulti(name, runs, testScenario, [
+        {
+            scenario: lcp,
+            analyze: ctx => analyzeTrace(ctx.traceFile, hasNonzeroTimestamp, isLCP)
+        },
+        {
+            scenario: backendSettled,
+            analyze: ctx => ctx.backendSettledSeconds
+        },
+        {
+            scenario: frontendSettled,
+            analyze: ctx => ctx.frontendSettledSeconds
+        }
+    ]);
+    contributions.logSummary(name);
 }
 
 /**
@@ -158,12 +211,17 @@ async function measurePerformance() {
  * to signal it to terminate when the test run is complete will not terminate the entire
  * process tree but only the root `theia` process, leaving the electron app instance
  * running until eventually this script itself exits.
- * 
+ *
  * @param {string} traceConfigPath the path to the tracing configuration file with which to initiate tracing
  * @returns {Promise<ChildProcess>} the Electron child process, if successfully launched
  */
 async function launchElectron(traceConfigPath) {
-    const args = ['start', workspace, '--plugins=local-dir:../../plugins', `--trace-config-file=${traceConfigPath}`];
+    const args = ['start', workspace, '--plugins=local-dir:../../plugins',
+        '--log-level=debug',
+        `--trace-config-file=${traceConfigPath}`,
+        // Force JSON output: since Chromium switched its default trace format to Perfetto protobuf,
+        // even a `result_file` ending in `.json` writes protobuf unless this switch is set.
+        '--trace-startup-format=json'];
     if (process.platform === 'linux') {
         args.push('--headless');
     }
@@ -180,9 +238,9 @@ function hasNonzeroTimestamp(traceEvent) {
  * If running in debug mode, this will always at least print out the `chunk` to the console.
  * In addition, the text is analyzed to look for known conditions that will invalidate the
  * test procedure and cause the script to bail. These include:
- * 
+ *
  * - the native browser modules not being built correctly for Electron
- * 
+ *
  * @param {string} chunk a chunk of standard error text from the child process
  */
 function analyzeStderr(chunk) {

--- a/scripts/performance/electron-performance.js
+++ b/scripts/performance/electron-performance.js
@@ -19,7 +19,7 @@ const { resolve } = require('path');
 const { spawn, ChildProcess } = require('child_process');
 const {
     analyzeTrace, backendSettled, ContributionCollector, delay, frontendSettled, githubReporting,
-    isLCP, lcp, measureMulti, parseStopwatchLog
+    isLCP, lcp, measureMulti, parseStopwatchLog, waitForFileStable
 } = require('./common-performance');
 const traceConfigTemplate = require('./electron-trace-config.json');
 const { exit } = require('process');
@@ -180,10 +180,19 @@ async function measurePerformance() {
         });
         electron.stdout.on('data', data => consumeStream('stdout', data.toString()));
 
-        // Wait long enough to be sure that tracing has finished. Kill the process group
-        // because the 'theia' child process was detached
-        await delay(traceConfigTemplate.startup_duration * 1_000 * 3 / 2)
-            .then(() => electron.exitCode !== null || process.kill(-electron.pid, 'SIGINT'));
+        // Wait for Chrome's capture window to finish, then poll for the trace file to be
+        // fully flushed to disk before tearing down the detached `theia` process tree.
+        // On slower systems (notably Linux), Chrome can take several seconds longer than
+        // the configured capture duration to write out the (large) trace JSON, so we apply
+        // a 30-second backstop instead of a fixed extra delay.
+        await delay(traceConfigTemplate.startup_duration * 1_000);
+        const traceFileReady = await waitForFileStable(traceFile, 30_000);
+        if (!traceFileReady) {
+            console.warn(`Trace file ${traceFile} did not stabilize within 30 seconds; analysis may fail.`);
+        }
+        if (electron.exitCode === null) {
+            process.kill(-electron.pid, 'SIGINT');
+        }
         electron = undefined;
         return { traceFile, backendSettledSeconds, frontendSettledSeconds };
     };

--- a/scripts/performance/extension-impact.js
+++ b/scripts/performance/extension-impact.js
@@ -283,7 +283,7 @@ async function calculateExtension(extensionQualifier) {
         switch (app) {
             case 'browser':
                 command = `concurrently --success first -k -r "cd scripts/performance && node browser-performance.js --name Browser --folder browser --runs ${runs}${url ? ' --url ' + url : ''}" `
-                    + `"npm run start:browser | grep -v '.*'"`
+                    + `"npm --prefix examples/browser run -s start -- --log-level=debug | grep -v '.*'"`
                 cwd = path.resolve(__dirname, '../../');
                 break;
             case 'electron':

--- a/scripts/performance/extension-impact.js
+++ b/scripts/performance/extension-impact.js
@@ -178,9 +178,14 @@ async function extensionImpact(extensions) {
 function preparePackageTemplate() {
     const core = require('../../packages/core/package.json');
     const version = core.version;
+    // THEIA_CONFIG_DIR is passed through FileUri.create() in env-variables-server.ts,
+    // which produces `/./...` for relative paths and then fails with EROFS trying to
+    // mkdir at the filesystem root. Always pass an absolute path.
+    const configDir = path.resolve(__dirname, 'theia-config-dir');
     const content = readFileSync(path.resolve(__dirname, './base-package.json'), 'utf-8')
         .replace(/\{\{app\}\}/g, hostApp)
-        .replace(/\{\{version\}\}/g, version);
+        .replace(/\{\{version\}\}/g, version)
+        .replace(/\{\{configDir\}\}/g, configDir);
     basePackage = JSON.parse(content);
     if (hostApp === 'electron') {
         basePackage.dependencies['@theia/electron'] = version;

--- a/scripts/performance/extension-impact.js
+++ b/scripts/performance/extension-impact.js
@@ -33,9 +33,16 @@ let workspace;
 let file = path.resolve('./script.csv');
 let detailFile;
 let hostApp = 'browser';
+let cancelled = false;
 
-async function sigintHandler() {
-    process.exit();
+function sigintHandler() {
+    if (cancelled) {
+        // Second Ctrl+C: the first one is still unwinding, force-quit now.
+        process.exit(130);
+    }
+    cancelled = true;
+    console.error('\nInterrupted — aborting at the next safe point. Press Ctrl+C again to force-quit.');
+    process.exit(130);
 }
 
 async function exitHandler() {
@@ -161,6 +168,9 @@ async function extensionImpact(extensions) {
     }
 
     for (const e of extensions) {
+        if (cancelled) {
+            break;
+        }
         await calculateExtension(e);
     }
 }
@@ -174,6 +184,13 @@ function preparePackageTemplate() {
     basePackage = JSON.parse(content);
     if (hostApp === 'electron') {
         basePackage.dependencies['@theia/electron'] = version;
+        // ApplicationPackageManager.prepareElectron() (in @theia/cli) requires `electron` to
+        // be declared as a devDependency with a range that satisfies @theia/electron's peer.
+        // Without it, `theia build` auto-patches package.json and aborts with
+        // `Updated dependencies, please run "install" again`, which fails every iteration.
+        const { electronRange } = require('@theia/electron');
+        basePackage.devDependencies = basePackage.devDependencies ?? {};
+        basePackage.devDependencies.electron = electronRange;
     }
     return basePackage;
 }
@@ -216,6 +233,9 @@ async function getExtensionsFromPackagesDir() {
 }
 
 async function calculateExtension(extensionQualifier) {
+    if (cancelled) {
+        return;
+    }
     const basePackageCopy = { ...basePackage };
     basePackageCopy.dependencies = { ...basePackageCopy.dependencies };
     if (extensionQualifier !== undefined) {
@@ -234,6 +254,19 @@ async function calculateExtension(extensionQualifier) {
         // Rebuild native modules if necessary
         execSync(`npm run rebuild:${hostApp}`, { cwd: '../../', stdio: 'pipe' });
     } catch (error) {
+        // execSync installs a temporary signal forwarder that consumes SIGINT/SIGTERM
+        // (routing them to the child), so our own SIGINT listener never fires during a
+        // blocking build. Detect a signal-killed child by inspecting error.signal and
+        // trigger cancellation manually.
+        if (cancelled || error.signal === 'SIGINT' || error.signal === 'SIGTERM') {
+            sigintHandler();
+            return;
+        }
+        const stdout = error.stdout?.toString() ?? '';
+        const stderr = error.stderr?.toString() ?? '';
+        if (stdout) { console.error(stdout); }
+        if (stderr) { console.error(stderr); }
+        if (!stdout && !stderr) { console.error(error.message); }
         log(`${extensionQualifier}, Error while building the package.json, -, -, -`);
         return;
     }
@@ -261,6 +294,9 @@ async function calculateExtension(extensionQualifier) {
     };
     const [command, cwd] = appCommand(hostApp);
     const output = await execCommand(command, { env: env, cwd: cwd, shell: true });
+    if (cancelled) {
+        return;
+    }
 
     const mean = parseFloat(getMeasurement(output, '[MEAN] Largest Contentful Paint (LCP):'));
     const stdev = parseFloat(getMeasurement(output, '[STDEV] Largest Contentful Paint (LCP):'));

--- a/scripts/performance/extension-impact.js
+++ b/scripts/performance/extension-impact.js
@@ -31,6 +31,7 @@ let yarn = false;
 let url;
 let workspace;
 let file = path.resolve('./script.csv');
+let detailFile;
 let hostApp = 'browser';
 
 async function sigintHandler() {
@@ -85,6 +86,10 @@ async function exitHandler() {
             desc: 'Specify the relative path to a CSV file which stores the result',
             type: 'string',
             default: file
+        }).option('detail-file', {
+            alias: 'd',
+            desc: 'Relative path to a CSV file for per-contribution breakdowns (default: <file>-details.csv, derived from --file)',
+            type: 'string'
         }).option('app', {
             alias: 'a',
             desc: 'Specify in which application to run the tests',
@@ -121,6 +126,15 @@ async function exitHandler() {
             return;
         }
     }
+    if (args.detailFile) {
+        detailFile = path.resolve(args.detailFile.toString());
+        if (!detailFile.endsWith('.csv')) {
+            console.error('--detail-file must end with .csv');
+            return;
+        }
+    } else {
+        detailFile = file.replace(/\.csv$/, '-details.csv');
+    }
     if (args.app) {
         hostApp = args.app;
     }
@@ -135,6 +149,7 @@ async function exitHandler() {
 
 async function extensionImpact(extensions) {
     logToFile(`Extension Name, Mean (${runs} runs) (in s), Std Dev (in s), CV (%), Delta (in s)`);
+    logToDetailFile(`Extension Name, Metric, Mean (${runs} runs) (in s), Std Dev (in s), CV (%)`);
     if (baseTime === undefined) {
         await calculateExtension(undefined);
     } else {
@@ -177,6 +192,8 @@ function prepareWorkspace() {
     });
     ensureFileSync(file);
     writeFileSync(file, '');
+    ensureFileSync(detailFile);
+    writeFileSync(detailFile, '');
 }
 
 function cleanWorkspace() {
@@ -261,6 +278,15 @@ async function calculateExtension(extensionQualifier) {
         }
         log(`${extensionQualifier}, ${mean.toFixed(3)}, ${stdev.toFixed(3)}, ${cv}, ${diff}`);
     }
+
+    // Emit per-metric breakdowns (everything except the LCP that's already in the main CSV).
+    for (const metric of parseAllMetrics(output)) {
+        if (metric.scenario === 'Largest Contentful Paint (LCP)') {
+            continue;
+        }
+        const metricCv = metric.mean > 0 ? ((metric.stdev / metric.mean) * 100).toFixed(3) : '-';
+        logToDetailFile(`${extensionQualifier}, ${metric.scenario}, ${metric.mean.toFixed(3)}, ${metric.stdev.toFixed(3)}, ${metricCv}`);
+    }
 }
 
 async function execCommand(command, args) {
@@ -292,10 +318,53 @@ function getMeasurement(output, identifier) {
     return output.toString().substring(firstIndex, lastIndex);
 }
 
+// Matches: "[Performance][<name>][MEAN] <scenario>: X.XXX seconds"
+const METRIC_MEAN_RE = /\[Performance\]\[[^\]]+\]\[MEAN\]\s+(.+?):\s+([\d.]+)\s+seconds/g;
+const METRIC_STDEV_RE = /\[Performance\]\[[^\]]+\]\[STDEV\]\s+(.+?):\s+([\d.]+)\s+seconds/g;
+
+/**
+ * Parse all metric summary lines out of a performance-script run's stdout, pairing each MEAN
+ * with its matching STDEV (by scenario name).
+ *
+ * @param {string} output the captured stdout of the performance script
+ * @returns {Array<{scenario: string, mean: number, stdev: number}>} one entry per metric
+ */
+function parseAllMetrics(output) {
+    const stdevs = new Map();
+    for (const match of output.toString().matchAll(METRIC_STDEV_RE)) {
+        stdevs.set(match[1].trim(), parseFloat(match[2]));
+    }
+    const results = [];
+    const seen = new Set();
+    for (const match of output.toString().matchAll(METRIC_MEAN_RE)) {
+        const scenario = match[1].trim();
+        if (seen.has(scenario)) {
+            continue;
+        }
+        seen.add(scenario);
+        const mean = parseFloat(match[2]);
+        const stdev = stdevs.get(scenario);
+        if (!isNaN(mean) && stdev !== undefined && !isNaN(stdev)) {
+            results.push({ scenario, mean, stdev });
+        }
+    }
+    return results;
+}
+
 function printFile() {
     console.log();
     const content = readFileSync(file).toString();
     console.log(content);
+    try {
+        const detailContent = readFileSync(detailFile).toString();
+        if (detailContent.trim().length > 0) {
+            console.log();
+            console.log(`Per-contribution breakdown (see ${detailFile}):`);
+            console.log(detailContent);
+        }
+    } catch (e) {
+        // Detail file may not exist if the script exited before preparing the workspace
+    }
 }
 
 function log(text) {
@@ -309,4 +378,8 @@ function logToConsole(text) {
 
 function logToFile(text) {
     appendFileSync(file, text + EOL);
+}
+
+function logToDetailFile(text) {
+    appendFileSync(detailFile, text + EOL);
 }


### PR DESCRIPTION
#### What it does

Fills gaps in start-up performance logging to give a clearer, more complete picture of application initialization time.

Fixes #17343.

Core changes:
  - Clarified confusing phrasing of log messages trying to indicate both how long an activity took and when it finished relative to the overall start-up
  - Measured individual `configure()` calls for backend contributions (was already done for `initialize()` and `onStart()`)
  - Backend contribution timings now log at `DEBUG` level by default, matching the existing frontend logs, reducing noise in normal use
  - Allow async initialization of `FrontendApplicationContribution`s as was already supported in the backend

Changes in application generator code in the **dev packages**:
  - Added startup timing to the Electron main process: overall startup, backend launch, security-token attachment, and application contributions
  - Added pre-container timing logs to generated `server.js`, `main.js`, `index.js`, and `electron-main.js`

  Performance scripts:
  - Use the new `Stopwatch` log format to capture additional startup metrics alongside LCP
  - Update the extension-impact script to produce a companion CSV with per-extension contribution startup timings (requires a change to `--log-level=debug` from fatal)
  - Fixed NPM scripts that were not correctly migrated from Yarn

#### How to test

1. Build and start the browser or Electron app
2. Open the browser/Electron DevTools and filter the backend logs (or the browser console) for timing lines. Verify the new format and phraseology
3. See that new messages appear with timings for the bootstrapping phase before the backend/electron/frontend applications are started. These don't have the timestamp prefixes like other messages because they are written before the logger service is set up
5. Run the performance scripts and see the new information that they put out:
    - `npm run performance:browser` — look for new frontend contribution timings
    - `npm run performance:electron` — look for new backend contribution timings
    - `node extension-impact.js`  — check the "details" CSV for per-extension breakdown

#### Follow-ups

There are a number of additional changes that we might consider as follow-up issues for the extension impact script:

- the `--yarn | -y` parameter correctly runs an NPM build but the name is now an anachronism. Maybe `--build | -b` would be more appropriate now
- the "baseline" Theia configuration against which the impact of an extension is measure is far from minimal. The `base-package.json` expresses a minimal-looking dependency on only `@theia/core` and `@theia/plugin-ext`, but the latter brings in a whole lot of packages. In fact, about three dozen! Including debug, terminal, SCM, notebook, AI/MCP, search, navigator, and more. That's nearly all of the Theia platform. This makes the script meaningless for measuring performance impact of changes in any of Theia's own packages. It's only useful for downstream application packages. I'm not sure what to suggest. We can't just exclude `@theia/plugin-ext` from the base config because we have to test plug-in hosting.
- we should remove the `--base-time | -b` option because this is statistically invalid. There's no way for the script to know that the conditions under which this asserted measurement was made are comparable to its own experiment. We should just always have the script compute this baseline itself (acknowledging the issues above that we have in that baseline 😉)

And some possible further improvements to all of the scripts would include

- warm-up and outlier handling: we should always do a warm-up run to allow for one-time costs such as filesystem caching, DNS resolution, JIT, etc. and also discard the hi/lo outliers. Computing the standard deviation helps, but these are effects we can anticipate that are known to skew the results, so it makes sense to handle them up front
- speaking of standard deviation, the `common-performance.js` script incorrectly computes population standard deviation (dividing by N) which is impossible for an infinite process. It should compute sample standard deviation (diving by N - 1)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

`FrontendApplicationContribution::initialize()` return type is widened from `void` to `MaybePromise<void>`. This is source-compatible (existing `void`-returning implementations continue to work), but implementations relying on the method
  being synchronous may now observe async scheduling differences if a contribution returns a promise. Nothing currently uses the return value in the Theia framework, so in practice this is non-breaking.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
