### PR TITLE
Add way to override GitHub OAuth app configuration for copilot integration

### DIFF
--- a/packages/ai-copilot/src/browser/copilot-auth-dialog-messages.ts
+++ b/packages/ai-copilot/src/browser/copilot-auth-dialog-messages.ts
@@ -1,0 +1,55 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+
+export const CopilotAuthDialogMessages = Symbol('CopilotAuthDialogMessages');
+
+/**
+ * Localizable messages displayed in the {@link CopilotAuthDialog}.
+ * Bind this symbol to a custom value in your frontend container module to replace
+ * any message that references "Theia" with your own application name.
+ */
+export interface CopilotAuthDialogMessages {
+    /** Dialog title. */
+    readonly title: string;
+    /** Instructions shown while waiting for the user to enter the code on GitHub. */
+    readonly instructions: string;
+    /** Privacy notice shown below the authorization code. */
+    readonly privacyNotice: string;
+}
+
+/**
+ * Default messages for the built-in Theia Copilot integration.
+ */
+export const DEFAULT_COPILOT_AUTH_DIALOG_MESSAGES: CopilotAuthDialogMessages = {
+    get title(): string {
+        return nls.localize('theia/ai/copilot/commands/signIn', 'Sign in to GitHub Copilot');
+    },
+    get instructions(): string {
+        return nls.localize(
+            'theia/ai/copilot/auth/instructions',
+            'To authorize Theia to use GitHub Copilot, visit the URL below and enter the code:'
+        );
+    },
+    get privacyNotice(): string {
+        return nls.localize(
+            'theia/ai/copilot/auth/privacy',
+            'Theia is an open-source project. We only request access to your GitHub username ' +
+            'to connect to GitHub Copilot services — no other data is accessed or stored.'
+        );
+    }
+};

--- a/packages/ai-copilot/src/browser/copilot-auth-dialog.tsx
+++ b/packages/ai-copilot/src/browser/copilot-auth-dialog.tsx
@@ -66,7 +66,7 @@ export class CopilotAuthDialog extends ReactDialog<boolean> {
 
     @postConstruct()
     protected init(): void {
-        this.titleNode.textContent = this.messages.title;
+        this.titleNode.textContent = this.props.title;
         this.appendAcceptButton(nls.localize('theia/ai/copilot/auth/authorize', 'I have authorized'));
         this.appendCloseButton(nls.localizeByDefault('Cancel'));
     }

--- a/packages/ai-copilot/src/browser/copilot-auth-dialog.tsx
+++ b/packages/ai-copilot/src/browser/copilot-auth-dialog.tsx
@@ -22,6 +22,7 @@ import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { CommandService, nls } from '@theia/core';
 import { CopilotAuthService, DeviceCodeResponse } from '../common/copilot-auth-service';
+import { CopilotAuthDialogMessages } from './copilot-auth-dialog-messages';
 
 const OPEN_AI_CONFIG_VIEW_COMMAND = 'aiConfiguration:open';
 
@@ -47,6 +48,9 @@ export class CopilotAuthDialog extends ReactDialog<boolean> {
     @inject(CommandService)
     protected readonly commandService: CommandService;
 
+    @inject(CopilotAuthDialogMessages)
+    protected readonly messages: CopilotAuthDialogMessages;
+
     protected state: AuthDialogState = 'loading';
     protected deviceCodeResponse?: DeviceCodeResponse;
     protected errorMessage?: string;
@@ -62,7 +66,7 @@ export class CopilotAuthDialog extends ReactDialog<boolean> {
 
     @postConstruct()
     protected init(): void {
-        this.titleNode.textContent = this.props.title;
+        this.titleNode.textContent = this.messages.title;
         this.appendAcceptButton(nls.localize('theia/ai/copilot/auth/authorize', 'I have authorized'));
         this.appendCloseButton(nls.localizeByDefault('Cancel'));
     }
@@ -209,8 +213,7 @@ export class CopilotAuthDialog extends ReactDialog<boolean> {
         return (
             <div className="theia-copilot-auth-waiting">
                 <p className="theia-copilot-auth-instructions">
-                    {nls.localize('theia/ai/copilot/auth/instructions',
-                        'To authorize Theia to use GitHub Copilot, visit the URL below and enter the code:')}
+                    {this.messages.instructions}
                 </p>
 
                 <div className="theia-copilot-auth-code-section">
@@ -247,9 +250,7 @@ export class CopilotAuthDialog extends ReactDialog<boolean> {
 
                 <div className="theia-copilot-auth-privacy">
                     <p className="theia-copilot-auth-privacy-text">
-                        {nls.localize('theia/ai/copilot/auth/privacy',
-                            'Theia is an open-source project. We only request access to your GitHub username ' +
-                            'to connect to GitHub Copilot services — no other data is accessed or stored.')}
+                        {this.messages.privacyNotice}
                     </p>
                     <p className="theia-copilot-auth-tos-text">
                         {nls.localize('theia/ai/copilot/auth/tos',

--- a/packages/ai-copilot/src/browser/copilot-frontend-module.ts
+++ b/packages/ai-copilot/src/browser/copilot-frontend-module.ts
@@ -17,7 +17,7 @@
 import '../../src/browser/style/index.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { CommandContribution, Emitter, Event, nls, PreferenceContribution } from '@theia/core';
+import { CommandContribution, Emitter, Event, PreferenceContribution } from '@theia/core';
 import {
     FrontendApplicationContribution,
     RemoteConnectionProvider,
@@ -36,6 +36,7 @@ import { CopilotFrontendApplicationContribution } from './copilot-frontend-appli
 import { CopilotCommandContribution } from './copilot-command-contribution';
 import { CopilotStatusBarContribution } from './copilot-status-bar-contribution';
 import { CopilotAuthDialog, CopilotAuthDialogProps } from './copilot-auth-dialog';
+import { CopilotAuthDialogMessages, DEFAULT_COPILOT_AUTH_DIALOG_MESSAGES } from './copilot-auth-dialog-messages';
 
 class CopilotAuthServiceClientImpl implements CopilotAuthServiceClient {
     protected readonly onAuthStateChangedEmitter = new Emitter<CopilotAuthState>();
@@ -54,9 +55,11 @@ export default new ContainerModule(bind => {
     bind(CopilotStatusBarContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(CopilotStatusBarContribution);
 
-    bind(CopilotAuthDialogProps).toConstantValue({
-        title: nls.localize('theia/ai/copilot/commands/signIn', 'Sign in to GitHub Copilot')
-    });
+    bind(CopilotAuthDialogMessages).toConstantValue(DEFAULT_COPILOT_AUTH_DIALOG_MESSAGES);
+    bind(CopilotAuthDialogProps).toDynamicValue(ctx => {
+        const messages = ctx.container.get<CopilotAuthDialogMessages>(CopilotAuthDialogMessages);
+        return { title: messages.title };
+    }).inSingletonScope();
     bind(CopilotAuthDialog).toSelf().inSingletonScope();
 
     bind(CopilotFrontendApplicationContribution).toSelf().inSingletonScope();

--- a/packages/ai-copilot/src/browser/index.ts
+++ b/packages/ai-copilot/src/browser/index.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 export * from './copilot-auth-dialog';
+export * from './copilot-auth-dialog-messages';
 export * from './copilot-command-contribution';
 export * from './copilot-status-bar-contribution';
 export * from './copilot-frontend-application-contribution';

--- a/packages/ai-copilot/src/common/copilot-language-models-manager.ts
+++ b/packages/ai-copilot/src/common/copilot-language-models-manager.ts
@@ -19,7 +19,6 @@ export const CopilotLanguageModelsManager = Symbol('CopilotLanguageModelsManager
 
 export const COPILOT_PROVIDER_ID = 'copilot';
 export const COPILOT_API_BASE_URL = 'https://api.githubcopilot.com';
-export const COPILOT_USER_AGENT = 'Theia-Copilot/1.0.0';
 
 /**
  * Returns the Copilot API base URL, taking an optional GitHub Enterprise domain into account.

--- a/packages/ai-copilot/src/common/copilot-oauth-config.ts
+++ b/packages/ai-copilot/src/common/copilot-oauth-config.ts
@@ -1,0 +1,55 @@
+// *****************************************************************************
+// Copyright (C) 2026 Lonti.com Pty Ltd.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export const CopilotOAuthConfig = Symbol('CopilotOAuthConfig');
+
+/**
+ * Configuration for the GitHub Copilot OAuth Device Flow.
+ * Bind this symbol to a custom value in your container module to override the defaults
+ * and use your own GitHub OAuth application.
+ */
+export interface CopilotOAuthConfig {
+    /**
+     * The GitHub OAuth App client ID used to initiate the device flow.
+     * Defaults to the built-in Theia Copilot OAuth App client ID.
+     */
+    readonly clientId: string;
+    /**
+     * The User-Agent header sent with GitHub API requests.
+     * Defaults to {@link COPILOT_USER_AGENT}.
+     */
+    readonly userAgent: string;
+    /**
+     * The service name used to store credentials in the system keystore.
+     * Defaults to `'theia-copilot-auth'`.
+     */
+    readonly keystoreService: string;
+    /**
+     * The account name used to store credentials in the system keystore.
+     * Defaults to `'github-copilot'`.
+     */
+    readonly keystoreAccount: string;
+}
+
+/**
+ * Default OAuth configuration for the built-in Theia Copilot integration.
+ */
+export const DEFAULT_COPILOT_OAUTH_CONFIG: CopilotOAuthConfig = {
+    clientId: 'Ov23liS2vINy9VOAweyv',
+    userAgent: 'Theia-Copilot/1.0.0',
+    keystoreService: 'theia-copilot-auth',
+    keystoreAccount: 'github-copilot'
+};

--- a/packages/ai-copilot/src/common/copilot-oauth-config.ts
+++ b/packages/ai-copilot/src/common/copilot-oauth-config.ts
@@ -29,7 +29,7 @@ export interface CopilotOAuthConfig {
     readonly clientId: string;
     /**
      * The User-Agent header sent with GitHub API requests.
-     * Defaults to {@link COPILOT_USER_AGENT}.
+     * Defaults to `'Theia-Copilot/1.0.0'`.
      */
     readonly userAgent: string;
     /**

--- a/packages/ai-copilot/src/common/index.ts
+++ b/packages/ai-copilot/src/common/index.ts
@@ -16,4 +16,5 @@
 
 export * from './copilot-language-models-manager';
 export * from './copilot-auth-service';
+export * from './copilot-oauth-config';
 export * from './copilot-preferences';

--- a/packages/ai-copilot/src/node/copilot-auth-service-impl.spec.ts
+++ b/packages/ai-copilot/src/node/copilot-auth-service-impl.spec.ts
@@ -185,3 +185,60 @@ describe('CopilotAuthServiceImpl', () => {
         });
     });
 });
+
+describe('CopilotAuthServiceImpl with custom CopilotOAuthConfig', () => {
+
+    const customConfig: CopilotOAuthConfig = {
+        clientId: 'CustomClientId',
+        userAgent: 'MyApp/1.0.0',
+        keystoreService: 'myapp-copilot',
+        keystoreAccount: 'myapp-github'
+    };
+
+    let authService: CopilotAuthServiceImpl;
+    let getPasswordStub: sinon.SinonStub;
+    let deletePasswordStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        const container = new Container();
+
+        getPasswordStub = sinon.stub().resolves(undefined);
+        deletePasswordStub = sinon.stub().resolves(true);
+        const keyStoreService: KeyStoreService = {
+            setPassword: sinon.stub().resolves() as KeyStoreService['setPassword'],
+            getPassword: getPasswordStub as KeyStoreService['getPassword'],
+            deletePassword: deletePasswordStub as KeyStoreService['deletePassword'],
+            findPassword: sinon.stub().resolves(undefined) as KeyStoreService['findPassword'],
+            findCredentials: sinon.stub().resolves([]) as KeyStoreService['findCredentials'],
+            keys: sinon.stub().resolves([]) as KeyStoreService['keys']
+        };
+
+        container.bind(KeyStoreService).toConstantValue(keyStoreService);
+        container.bind(CopilotOAuthConfig).toConstantValue(customConfig);
+        container.bind(CopilotAuthServiceImpl).toSelf().inSingletonScope();
+
+        authService = container.get(CopilotAuthServiceImpl);
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('should read credentials from the custom keystore service and account', async () => {
+        getPasswordStub.resolves(JSON.stringify({
+            accessToken: 'gho_custom_token',
+            accountLabel: 'customuser'
+        }));
+
+        const token = await authService.getAccessToken();
+
+        expect(token).to.equal('gho_custom_token');
+        expect(getPasswordStub.calledOnceWith(customConfig.keystoreService, customConfig.keystoreAccount)).to.be.true;
+    });
+
+    it('should delete credentials from the custom keystore service and account on sign out', async () => {
+        await authService.signOut();
+
+        expect(deletePasswordStub.calledOnceWith(customConfig.keystoreService, customConfig.keystoreAccount)).to.be.true;
+    });
+});

--- a/packages/ai-copilot/src/node/copilot-auth-service-impl.spec.ts
+++ b/packages/ai-copilot/src/node/copilot-auth-service-impl.spec.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Container } from '@theia/core/shared/inversify';
 import { KeyStoreService } from '@theia/core/lib/common/key-store';
+import { CopilotOAuthConfig, DEFAULT_COPILOT_OAUTH_CONFIG } from '../common/copilot-oauth-config';
 import { CopilotAuthServiceImpl } from './copilot-auth-service-impl';
 
 describe('CopilotAuthServiceImpl', () => {
@@ -40,6 +41,7 @@ describe('CopilotAuthServiceImpl', () => {
         };
 
         container.bind(KeyStoreService).toConstantValue(keyStoreService);
+        container.bind(CopilotOAuthConfig).toConstantValue(DEFAULT_COPILOT_OAUTH_CONFIG);
         container.bind(CopilotAuthServiceImpl).toSelf().inSingletonScope();
 
         authService = container.get(CopilotAuthServiceImpl);

--- a/packages/ai-copilot/src/node/copilot-auth-service-impl.ts
+++ b/packages/ai-copilot/src/node/copilot-auth-service-impl.ts
@@ -23,13 +23,10 @@ import {
     CopilotAuthState,
     DeviceCodeResponse
 } from '../common/copilot-auth-service';
-import { COPILOT_USER_AGENT } from '../common';
+import { CopilotOAuthConfig } from '../common/copilot-oauth-config';
 
-const COPILOT_CLIENT_ID = 'Ov23liS2vINy9VOAweyv'; // 'Theia Copilot OAuth Access' Client ID
 const COPILOT_SCOPE = 'read:user';
 const COPILOT_GRANT_TYPE = 'urn:ietf:params:oauth:grant-type:device_code';
-const KEYSTORE_SERVICE = 'theia-copilot-auth';
-const KEYSTORE_ACCOUNT = 'github-copilot';
 
 /**
  * Maximum number of polling attempts for token retrieval.
@@ -52,6 +49,9 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
 
     @inject(KeyStoreService)
     protected readonly keyStoreService: KeyStoreService;
+
+    @inject(CopilotOAuthConfig)
+    protected readonly oauthConfig: CopilotOAuthConfig;
 
     protected client: CopilotAuthServiceClient | undefined;
     protected cachedState: CopilotAuthState | undefined;
@@ -87,10 +87,10 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
             headers: {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
-                'User-Agent': COPILOT_USER_AGENT
+                'User-Agent': this.oauthConfig.userAgent
             },
             body: JSON.stringify({
-                client_id: COPILOT_CLIENT_ID,
+                client_id: this.oauthConfig.clientId,
                 scope: COPILOT_SCOPE
             })
         });
@@ -117,10 +117,10 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
                 headers: {
                     'Accept': 'application/json',
                     'Content-Type': 'application/json',
-                    'User-Agent': COPILOT_USER_AGENT
+                    'User-Agent': this.oauthConfig.userAgent
                 },
                 body: JSON.stringify({
-                    client_id: COPILOT_CLIENT_ID,
+                    client_id: this.oauthConfig.clientId,
                     device_code: deviceCode,
                     grant_type: COPILOT_GRANT_TYPE
                 })
@@ -149,8 +149,8 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
                 };
 
                 await this.keyStoreService.setPassword(
-                    KEYSTORE_SERVICE,
-                    KEYSTORE_ACCOUNT,
+                    this.oauthConfig.keystoreService,
+                    this.oauthConfig.keystoreAccount,
                     JSON.stringify(credentials)
                 );
 
@@ -199,7 +199,7 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
             const response = await fetch(`${apiBaseUrl}/user`, {
                 headers: {
                     'Authorization': `Bearer ${accessToken}`,
-                    'User-Agent': COPILOT_USER_AGENT,
+                    'User-Agent': this.oauthConfig.userAgent,
                     'Accept': 'application/vnd.github.v3+json'
                 }
             });
@@ -220,13 +220,13 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
         }
 
         try {
-            const stored = await this.keyStoreService.getPassword(KEYSTORE_SERVICE, KEYSTORE_ACCOUNT);
+            const stored = await this.keyStoreService.getPassword(this.oauthConfig.keystoreService, this.oauthConfig.keystoreAccount);
             if (stored) {
                 const credentials: StoredCredentials = JSON.parse(stored);
                 // Tokens from the current OAuth App start with 'gho_'; other prefixes (e.g. 'ghu_') indicate a token from the previous GitHub App (Iv-prefixed client ID).
                 if (!credentials.accessToken.startsWith('gho_')) {
                     console.info('Copilot: clearing outdated GitHub App token. Please sign in again.');
-                    await this.keyStoreService.deletePassword(KEYSTORE_SERVICE, KEYSTORE_ACCOUNT);
+                    await this.keyStoreService.deletePassword(this.oauthConfig.keystoreService, this.oauthConfig.keystoreAccount);
                     this.cachedState = { isAuthenticated: false, migrationRequired: true };
                     return this.cachedState;
                 }
@@ -247,7 +247,7 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
 
     async getAccessToken(): Promise<string | undefined> {
         try {
-            const stored = await this.keyStoreService.getPassword(KEYSTORE_SERVICE, KEYSTORE_ACCOUNT);
+            const stored = await this.keyStoreService.getPassword(this.oauthConfig.keystoreService, this.oauthConfig.keystoreAccount);
             if (stored) {
                 const credentials: StoredCredentials = JSON.parse(stored);
                 return credentials.accessToken;
@@ -260,7 +260,7 @@ export class CopilotAuthServiceImpl implements CopilotAuthService {
 
     async signOut(): Promise<void> {
         try {
-            await this.keyStoreService.deletePassword(KEYSTORE_SERVICE, KEYSTORE_ACCOUNT);
+            await this.keyStoreService.deletePassword(this.oauthConfig.keystoreService, this.oauthConfig.keystoreAccount);
         } catch (error) {
             console.warn('Failed to delete Copilot credentials:', error);
         }

--- a/packages/ai-copilot/src/node/copilot-backend-module.ts
+++ b/packages/ai-copilot/src/node/copilot-backend-module.ts
@@ -24,6 +24,7 @@ import {
     COPILOT_AUTH_SERVICE_PATH,
     CopilotAuthServiceClient
 } from '../common';
+import { CopilotOAuthConfig, DEFAULT_COPILOT_OAUTH_CONFIG } from '../common/copilot-oauth-config';
 import { CopilotLanguageModelsManagerImpl } from './copilot-language-models-manager-impl';
 import { CopilotAuthServiceImpl } from './copilot-auth-service-impl';
 
@@ -54,5 +55,6 @@ const copilotConnectionModule = ConnectionContainerModule.create(({ bind }) => {
 });
 
 export default new ContainerModule(bind => {
+    bind(CopilotOAuthConfig).toConstantValue(DEFAULT_COPILOT_OAUTH_CONFIG);
     bind(ConnectionContainerModule).toConstantValue(copilotConnectionModule);
 });

--- a/packages/ai-copilot/src/node/copilot-language-model.ts
+++ b/packages/ai-copilot/src/node/copilot-language-model.ts
@@ -30,7 +30,7 @@ import OpenAI from 'openai';
 import { RunnableToolFunctionWithoutParse } from 'openai/lib/RunnableFunction';
 import { ChatCompletionMessageParam } from 'openai/resources';
 import { StreamingAsyncIterator } from '@theia/ai-openai/lib/node/openai-streaming-iterator';
-import { COPILOT_PROVIDER_ID, COPILOT_USER_AGENT, getCopilotApiBaseUrl } from '../common';
+import { COPILOT_PROVIDER_ID, getCopilotApiBaseUrl } from '../common';
 import type { RunnerOptions } from 'openai/lib/AbstractChatCompletionRunner';
 import type { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 
@@ -53,6 +53,7 @@ export class CopilotLanguageModel implements LanguageModel {
         public maxRetries: number,
         protected readonly accessTokenProvider: () => Promise<string | undefined>,
         protected readonly enterpriseUrlProvider: () => string | undefined,
+        protected readonly userAgentProvider: () => string,
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Record<string, unknown> {
@@ -175,7 +176,7 @@ export class CopilotLanguageModel implements LanguageModel {
             apiKey: accessToken,
             baseURL,
             defaultHeaders: {
-                'User-Agent': COPILOT_USER_AGENT,
+                'User-Agent': this.userAgentProvider(),
                 'Openai-Intent': 'conversation-edits',
                 'X-Initiator': 'user'
             }

--- a/packages/ai-copilot/src/node/copilot-language-models-manager-impl.ts
+++ b/packages/ai-copilot/src/node/copilot-language-models-manager-impl.ts
@@ -17,7 +17,8 @@
 import { LanguageModelRegistry, LanguageModelStatus } from '@theia/ai-core';
 import { Disposable, DisposableCollection } from '@theia/core';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { CopilotLanguageModelsManager, CopilotModelDescription, COPILOT_PROVIDER_ID, COPILOT_USER_AGENT, getCopilotApiBaseUrl } from '../common';
+import { CopilotLanguageModelsManager, CopilotModelDescription, COPILOT_PROVIDER_ID, getCopilotApiBaseUrl } from '../common';
+import { CopilotOAuthConfig } from '../common/copilot-oauth-config';
 import { CopilotLanguageModel } from './copilot-language-model';
 import { CopilotAuthServiceImpl } from './copilot-auth-service-impl';
 
@@ -33,6 +34,9 @@ export class CopilotLanguageModelsManagerImpl implements CopilotLanguageModelsMa
 
     @inject(CopilotAuthServiceImpl)
     protected readonly authService: CopilotAuthServiceImpl;
+
+    @inject(CopilotOAuthConfig)
+    protected readonly oauthConfig: CopilotOAuthConfig;
 
     protected enterpriseUrl: string | undefined;
     protected readonly toDispose = new DisposableCollection();
@@ -88,7 +92,8 @@ export class CopilotLanguageModelsManagerImpl implements CopilotLanguageModelsMa
                         modelDescription.supportsStructuredOutput,
                         modelDescription.maxRetries,
                         () => this.authService.getAccessToken(),
-                        () => this.enterpriseUrl
+                        () => this.enterpriseUrl,
+                        () => this.oauthConfig.userAgent
                     )
                 ]);
             }
@@ -124,7 +129,7 @@ export class CopilotLanguageModelsManagerImpl implements CopilotLanguageModelsMa
             const response = await fetch(`${baseURL}/models`, {
                 headers: {
                     'Authorization': `Bearer ${accessToken}`,
-                    'User-Agent': COPILOT_USER_AGENT,
+                    'User-Agent': this.oauthConfig.userAgent,
                     'Accept': 'application/json'
                 }
             });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR adds a way to override GitHub OAuth app configuration for the copilot integration and override the messages used in the copilot auth dialog. This is to be used by downstream adopters that want to use their own GitHub OAuth app and product name.

Closes #17299 

#### How to test

For the GitHub OAuth app:
- In a backend module, rebind the CopilotOAuthConfig to use a different configuration.
- Start Theia and try to login to GitHub.
- Check it's using the configuration you provided.

For the Copilot auth dialog:
- In a frontend module, rebind CopilotAuthDialogMessages  and provide different messages.
- Check the correct messages appear in the Copilot auth dialog.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

The exported const COPILOT_USER_AGENT was removed if it was used by downstream adopters it will break. The CopilotOAuthConfig should be used instead.

#### Attribution

Contributed on behalf of Lonti.com Pty Ltd.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
