### PR TITLE
fix(tree): prevent node expansion when double-clicking checkbox

### DIFF
--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -671,7 +671,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
             aria-label={node.checkboxInfo.accessibilityInformation?.label}
             role={node.checkboxInfo.accessibilityInformation?.role}
             className='theia-input'
-            onClick={event => this.toggleChecked(event)} />;
+            onClick={event => this.toggleChecked(event)}
+            onDoubleClick={event => event.stopPropagation()} />;
     }
 
     protected toggleChecked(event: React.MouseEvent<HTMLElement>): void {


### PR DESCRIPTION
#### What it does

Currently, in the `TreeWidget`, rapid consecutive clicks (a double-click) on a node's checkbox will bubble up to the tree node row. Because the checkbox only stops the propagation of `onClick` but not `onDoubleClick`, the `handleDblClickEvent` of the tree row is triggered. This results in the unintended behavior where double-clicking a checkbox causes the tree node to expand or collapse.

This PR fixes the issue by adding an `onDoubleClick` event handler to the checkbox `<input>` element in `renderCheckbox` and calling `e.stopPropagation()`. This ensures that double-click events on the checkbox are consumed by the checkbox itself and do not trigger the tree node's default expansion/collapse behavior.

#### How to test

1. Open or implement any view in Theia that utilizes a `TreeWidget` with checkboxes enabled (i.e., nodes returning valid `checkboxInfo`).
2. Rapidly double-click on the checkbox of a collapsible node (a directory/folder node).
3. **Before this PR:** The checkbox state toggles, but the tree node also expands/collapses unexpectedly.
4. **After this PR:** The checkbox state toggles rapidly, and the tree node remains in its current expansion state without expanding or collapsing.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
