### PR TITLE
feat: add multi-diff-editor

### DIFF
--- a/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
+++ b/packages/plugin-ext-vscode/src/browser/plugin-vscode-commands-contribution.ts
@@ -85,6 +85,23 @@ import { CompletionList, Range, Position as PluginPosition } from '@theia/plugin
 import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
 import { ScmContribution } from '@theia/scm/lib/browser/scm-contribution';
 import { MergeEditorOpenerOptions, MergeEditorUri } from '@theia/scm/lib/browser/merge-editor/merge-editor';
+import { MultiDiffEditorOpenerOptions, MultiDiffEditorUri } from '@theia/scm/lib/browser/multi-diff-editor/multi-diff-editor';
+
+/**
+ * Convert a VS Code {@link UriComponents} or a string URI into a Theia {@link TheiaURI}.
+ * Returns `undefined` when given `undefined`.
+ */
+function toTheiaUri(value: UriComponents | string): TheiaURI;
+function toTheiaUri(value: UriComponents | string | undefined): TheiaURI | undefined;
+function toTheiaUri(value: UriComponents | string | undefined): TheiaURI | undefined {
+    if (value === undefined) {
+        return undefined;
+    }
+    if (typeof value === 'string') {
+        return new TheiaURI(value);
+    }
+    return TheiaURI.fromComponents(value);
+}
 
 export namespace VscodeCommands {
 
@@ -1047,13 +1064,6 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
 
         commands.registerCommand({ id: '_open.mergeEditor' }, {
             execute: async (arg: OpenMergeEditorCommandArg): Promise<void> => {
-                const toTheiaUri = (o: UriComponents | string): TheiaURI => {
-                    if (typeof o === 'string') {
-                        return new TheiaURI(o);
-                    }
-                    return TheiaURI.fromComponents(o);
-                };
-
                 const baseUri = toTheiaUri(arg.base);
                 const resultUri = toTheiaUri(arg.output);
                 const side1Uri = typeof arg.input1 === 'string' ? toTheiaUri(arg.input1) : toTheiaUri(arg.input1.uri);
@@ -1076,8 +1086,6 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
             }
         });
 
-        // Temporary workaround: opens a single diff editor for the revealed resource.
-        // TODO: GH-16280 implement a proper MultiDiffEditor widget.
         commands.registerCommand({ id: '_workbench.openMultiDiffEditor' }, {
             execute: async (options: {
                 title: string;
@@ -1087,21 +1095,20 @@ export class PluginVscodeCommandsContribution implements CommandContribution {
                 if (!options.resources?.length) {
                     return;
                 }
-                const revealModified = options.reveal?.modifiedUri;
-                const revealStr = revealModified ? URI.revive(revealModified)?.toString() : undefined;
-                const target = revealStr
-                    ? options.resources.find(r => URI.revive(r.modifiedUri)?.toString() === revealStr)
-                    : undefined;
-                const resource = target ?? options.resources[0];
-                const left = URI.revive(resource.originalUri);
-                const right = URI.revive(resource.modifiedUri);
-                if (left && right) {
-                    await commands.executeCommand(VscodeCommands.DIFF.id, left, right, options.title);
-                } else if (right) {
-                    await commands.executeCommand(VscodeCommands.OPEN.id, right);
-                } else if (left) {
-                    await commands.executeCommand(VscodeCommands.OPEN.id, left);
+                const resources = options.resources
+                    .map(r => {
+                        const originalUri = toTheiaUri(r.originalUri);
+                        const modifiedUri = toTheiaUri(r.modifiedUri);
+                        return originalUri && modifiedUri ? { originalUri, modifiedUri } : undefined;
+                    })
+                    .filter((r): r is { originalUri: TheiaURI; modifiedUri: TheiaURI } => r !== undefined);
+                if (!resources.length) {
+                    return;
                 }
+                const uri = MultiDiffEditorUri.encode({ title: options.title, resources });
+                const reveal = toTheiaUri(options.reveal?.modifiedUri);
+                const openerOptions: MultiDiffEditorOpenerOptions = { reveal };
+                await open(this.openerService, uri, openerOptions);
             },
         });
     }

--- a/packages/scm/src/browser/multi-diff-editor/multi-diff-editor-module.ts
+++ b/packages/scm/src/browser/multi-diff-editor/multi-diff-editor-module.ts
@@ -1,0 +1,121 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import '../../../src/browser/style/multi-diff-editor.css';
+
+import { Container, interfaces } from '@theia/core/shared/inversify';
+import { nls, URI } from '@theia/core';
+import { DiffUris, LabelProvider, NavigatableWidgetOptions, OpenHandler, WidgetFactory } from '@theia/core/lib/browser';
+import { EditorManager, EditorWidget } from '@theia/editor/lib/browser';
+import * as monaco from '@theia/monaco-editor-core';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import { MonacoDiffEditor } from '@theia/monaco/lib/browser/monaco-diff-editor';
+import {
+    DiffEntryHeaderWidget, MultiDiffEditor, MultiDiffEditorData, MultiDiffEditorOpenHandler, MultiDiffEditorUri
+} from './multi-diff-editor';
+import { MultiDiffEditorResourcePair, MultiDiffEditorUriData } from './multi-diff-editor-uri';
+
+export function bindMultiDiffEditor(bind: interfaces.Bind): void {
+    bind(MultiDiffEditorWidgetFactory).toDynamicValue(ctx => new MultiDiffEditorWidgetFactory(ctx.container));
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: MultiDiffEditorOpenHandler.ID,
+        createWidget: (options: NavigatableWidgetOptions) => ctx.container.get(MultiDiffEditorWidgetFactory).createMultiDiffEditor(new URI(options.uri))
+    })).inSingletonScope();
+
+    bind(MultiDiffEditorOpenHandler).toSelf().inSingletonScope();
+    bind(OpenHandler).toService(MultiDiffEditorOpenHandler);
+}
+
+/** Options applied to the embedded diff/code editors. */
+const EMBEDDED_EDITOR_OPTIONS: monaco.editor.IEditorOptions = {
+    folding: false,
+    codeLens: false,
+    stickyScroll: { enabled: false },
+    minimap: { enabled: false }
+};
+
+class MultiDiffEditorWidgetFactory {
+
+    constructor(
+        protected readonly container: interfaces.Container,
+        protected readonly editorManager = container.get(EditorManager),
+        protected readonly labelProvider = container.get(LabelProvider),
+    ) { }
+
+    /**
+     * Create the multi-diff editor shell synchronously with a placeholder per resource,
+     * then load the embedded diff editors in parallel in the background. Each entry
+     * transitions from a loading indicator to either the editor or an error message
+     * as it resolves.
+     */
+    createMultiDiffEditor(uri: URI): MultiDiffEditor {
+        const data = MultiDiffEditorUri.decode(uri);
+        const editor = this.instantiateMultiDiffEditor(data);
+        for (const resource of data.resources) {
+            const headerWidget = new DiffEntryHeaderWidget(resource, this.labelProvider);
+            editor.addDiffEntry(resource, headerWidget);
+        }
+        this.loadEntryEditors(editor, data.resources);
+        return editor;
+    }
+
+    protected instantiateMultiDiffEditor(data: MultiDiffEditorUriData): MultiDiffEditor {
+        const child = new Container({ defaultScope: 'Singleton' });
+        child.parent = this.container;
+        child.bind(MultiDiffEditorData).toConstantValue(data);
+        child.bind(MultiDiffEditor).toSelf();
+        return child.get(MultiDiffEditor);
+    }
+
+    protected loadEntryEditors(editor: MultiDiffEditor, resources: readonly MultiDiffEditorResourcePair[]): void {
+        resources.forEach((resource, index) => {
+            const entry = editor.entries[index];
+            this.createEmbeddedEditorWidget(resource).then(
+                editorWidget => {
+                    if (editor.isDisposed || entry.isDisposed) {
+                        editorWidget.dispose();
+                        return;
+                    }
+                    entry.setEditor(editorWidget);
+                    editor.notifyTrackableWidgetsChanged();
+                },
+                error => {
+                    console.error('Failed to load diff editor for', resource.modifiedUri.toString(), error);
+                    if (!entry.isDisposed) {
+                        const message = error instanceof Error ? error.message : String(error);
+                        entry.setError(nls.localize('theia/scm/multiDiffEditor/loadFailed', 'Failed to load diff: {0}', message));
+                    }
+                }
+            );
+        });
+    }
+
+    protected async createEmbeddedEditorWidget(resource: MultiDiffEditorResourcePair): Promise<EditorWidget> {
+        const diffUri = DiffUris.encode(resource.originalUri, resource.modifiedUri);
+        const editorWidget = await this.editorManager.createByUri(diffUri);
+        this.configureEmbeddedEditor(editorWidget);
+        return editorWidget;
+    }
+
+    protected configureEmbeddedEditor(editorWidget: EditorWidget): void {
+        const monacoEditor = MonacoEditor.get(editorWidget);
+        if (monacoEditor instanceof MonacoDiffEditor) {
+            monacoEditor.diffEditor.updateOptions(EMBEDDED_EDITOR_OPTIONS);
+        } else if (monacoEditor) {
+            monacoEditor.getControl().updateOptions(EMBEDDED_EDITOR_OPTIONS);
+        }
+    }
+}

--- a/packages/scm/src/browser/multi-diff-editor/multi-diff-editor-uri.ts
+++ b/packages/scm/src/browser/multi-diff-editor/multi-diff-editor-uri.ts
@@ -1,0 +1,83 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { isObject, URI } from '@theia/core';
+
+export interface MultiDiffEditorResourcePair {
+    originalUri: URI;
+    modifiedUri: URI;
+}
+
+export interface MultiDiffEditorUriData {
+    title: string;
+    resources: MultiDiffEditorResourcePair[];
+}
+
+export namespace MultiDiffEditorUri {
+
+    const SCHEME = 'multi-diff-editor';
+
+    export function isMultiDiffEditorUri(uri: URI): boolean {
+        return uri.scheme === SCHEME;
+    }
+
+    export function encode(data: MultiDiffEditorUriData): URI {
+        const payload = JSON.stringify({
+            title: data.title,
+            resources: data.resources.map(r => [r.originalUri.toString(), r.modifiedUri.toString()])
+        });
+        return new URI().withScheme(SCHEME).withQuery(payload);
+    }
+
+    export function decode(uri: URI): MultiDiffEditorUriData {
+        if (uri.scheme !== SCHEME) {
+            throw new Error(`The URI must have scheme ${SCHEME}. The URI was: ${uri}`);
+        }
+        let parsed: unknown;
+        try {
+            parsed = JSON.parse(uri.query);
+        } catch {
+            throw new Error(`The URI ${uri} is not a valid URI for scheme ${SCHEME}: query is not valid JSON`);
+        }
+        if (!isValidPayload(parsed)) {
+            throw new Error(`The URI ${uri} is not a valid URI for scheme ${SCHEME}`);
+        }
+        return {
+            title: parsed.title,
+            resources: parsed.resources.map(pair => ({
+                originalUri: new URI(pair[0]),
+                modifiedUri: new URI(pair[1])
+            }))
+        };
+    }
+
+    interface ParsedPayload {
+        title: string;
+        resources: [string, string][];
+    }
+
+    function isValidPayload(value: unknown): value is ParsedPayload {
+        if (!isObject<ParsedPayload>(value)) {
+            return false;
+        }
+        if (typeof value.title !== 'string' || !Array.isArray(value.resources)) {
+            return false;
+        }
+        return value.resources.every(pair =>
+            Array.isArray(pair) && pair.length === 2 && pair.every(s => typeof s === 'string')
+        );
+    }
+}

--- a/packages/scm/src/browser/multi-diff-editor/multi-diff-editor-widget.spec.ts
+++ b/packages/scm/src/browser/multi-diff-editor/multi-diff-editor-widget.spec.ts
@@ -1,0 +1,289 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { LabelProvider } from '@theia/core/lib/browser';
+import {
+    DiffEntryErrorWidget,
+    DiffEntryHeaderWidget,
+    DiffEntryLoadingWidget,
+    DiffEntryWidget,
+    HEADER_HEIGHT,
+    MAX_ENTRY_HEIGHT,
+    MIN_ENTRY_HEIGHT,
+    MultiDiffEditorOpenHandler,
+    MultiDiffEditorState
+} from './multi-diff-editor';
+import { MultiDiffEditorResourcePair, MultiDiffEditorUri } from './multi-diff-editor-uri';
+
+disableJSDOM();
+
+describe('Multi-Diff Editor — widgets', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    // Minimal LabelProvider mock — only the methods DiffEntryHeaderWidget uses.
+    const mockLabelProvider = {
+        getIcon: (_: URI) => 'codicon codicon-file',
+        getName: (uri: URI) => uri.path.base,
+        getLongName: (uri: URI) => uri.path.toString()
+    } as unknown as LabelProvider;
+
+    const sampleResource: MultiDiffEditorResourcePair = {
+        originalUri: new URI('file:///workspace/a.ts'),
+        modifiedUri: new URI('file:///workspace/b.ts')
+    };
+
+    describe('DiffEntryHeaderWidget', () => {
+
+        it('should render icon, name and description', () => {
+            const widget = new DiffEntryHeaderWidget(sampleResource, mockLabelProvider);
+            try {
+                expect(widget.node.querySelector('.multi-diff-entry-icon')).to.exist;
+                expect(widget.node.querySelector('.multi-diff-entry-label')?.textContent).to.equal('b.ts');
+                expect(widget.node.querySelector('.multi-diff-entry-description')?.textContent).to.equal('/workspace/b.ts');
+            } finally {
+                widget.dispose();
+            }
+        });
+
+        it('should expose aria-expanded=true by default', () => {
+            const widget = new DiffEntryHeaderWidget(sampleResource, mockLabelProvider);
+            try {
+                expect(widget.node.getAttribute('aria-expanded')).to.equal('true');
+                expect(widget.node.querySelector('.codicon-chevron-down')).to.exist;
+            } finally {
+                widget.dispose();
+            }
+        });
+
+        it('should toggle chevron and aria-expanded on setCollapsed', () => {
+            const widget = new DiffEntryHeaderWidget(sampleResource, mockLabelProvider);
+            try {
+                widget.setCollapsed(true);
+                expect(widget.node.getAttribute('aria-expanded')).to.equal('false');
+                expect(widget.node.querySelector('.codicon-chevron-right')).to.exist;
+                expect(widget.node.querySelector('.codicon-chevron-down')).to.be.null;
+
+                widget.setCollapsed(false);
+                expect(widget.node.getAttribute('aria-expanded')).to.equal('true');
+                expect(widget.node.querySelector('.codicon-chevron-down')).to.exist;
+            } finally {
+                widget.dispose();
+            }
+        });
+
+        it('should fire onDidToggleCollapse when clicked', () => {
+            const widget = new DiffEntryHeaderWidget(sampleResource, mockLabelProvider);
+            try {
+                let fired = 0;
+                widget.onDidToggleCollapse(() => fired++);
+                widget.node.click();
+                expect(fired).to.equal(1);
+            } finally {
+                widget.dispose();
+            }
+        });
+    });
+
+    describe('DiffEntryWidget', () => {
+
+        function createEntry(): { entry: DiffEntryWidget; header: DiffEntryHeaderWidget } {
+            const header = new DiffEntryHeaderWidget(sampleResource, mockLabelProvider);
+            const entry = new DiffEntryWidget(sampleResource, header);
+            return { entry, header };
+        }
+
+        it('should start in loading state with MIN_ENTRY_HEIGHT', () => {
+            const { entry } = createEntry();
+            try {
+                expect(entry.editorWidget).to.be.undefined;
+                expect(entry.isCollapsed).to.be.false;
+                expect(entry.node.style.height).to.equal(`${MIN_ENTRY_HEIGHT}px`);
+                expect(entry.node.querySelector('.multi-diff-entry-loading')).to.exist;
+            } finally {
+                entry.dispose();
+            }
+        });
+
+        it('should transition to error state on setError', () => {
+            const { entry } = createEntry();
+            try {
+                entry.setError('boom');
+                expect(entry.node.querySelector('.multi-diff-entry-loading')).to.be.null;
+                expect(entry.node.querySelector('.multi-diff-entry-error')?.textContent).to.contain('boom');
+                expect(entry.editorWidget).to.be.undefined;
+            } finally {
+                entry.dispose();
+            }
+        });
+
+        it('should clamp setHeight between MIN_ENTRY_HEIGHT and MAX_ENTRY_HEIGHT', () => {
+            const { entry } = createEntry();
+            try {
+                entry.setHeight(50);
+                expect(entry.node.style.height).to.equal(`${MIN_ENTRY_HEIGHT}px`);
+
+                entry.setHeight(10_000);
+                expect(entry.node.style.height).to.equal(`${MAX_ENTRY_HEIGHT}px`);
+
+                entry.setHeight(MIN_ENTRY_HEIGHT + 42);
+                expect(entry.node.style.height).to.equal(`${MIN_ENTRY_HEIGHT + 42}px`);
+            } finally {
+                entry.dispose();
+            }
+        });
+
+        it('should shrink to HEADER_HEIGHT when collapsed and restore height when expanded', () => {
+            const { entry } = createEntry();
+            try {
+                entry.setHeight(MIN_ENTRY_HEIGHT + 100);
+                expect(entry.node.style.height).to.equal(`${MIN_ENTRY_HEIGHT + 100}px`);
+
+                entry.setCollapsed(true);
+                expect(entry.isCollapsed).to.be.true;
+                expect(entry.node.style.height).to.equal(`${HEADER_HEIGHT}px`);
+
+                entry.setCollapsed(false);
+                expect(entry.isCollapsed).to.be.false;
+                expect(entry.node.style.height).to.equal(`${MIN_ENTRY_HEIGHT + 100}px`);
+            } finally {
+                entry.dispose();
+            }
+        });
+
+        it('should remember requested height while collapsed and apply it on expand', () => {
+            const { entry } = createEntry();
+            try {
+                entry.setCollapsed(true);
+                // setHeight while collapsed updates the remembered expanded height only.
+                entry.setHeight(MIN_ENTRY_HEIGHT + 50);
+                expect(entry.node.style.height).to.equal(`${HEADER_HEIGHT}px`);
+
+                entry.setCollapsed(false);
+                expect(entry.node.style.height).to.equal(`${MIN_ENTRY_HEIGHT + 50}px`);
+            } finally {
+                entry.dispose();
+            }
+        });
+
+        it('should be a no-op when setCollapsed is called with the current value', () => {
+            const { entry } = createEntry();
+            try {
+                let fired = 0;
+                entry.onDidChangeCollapsed(() => fired++);
+                entry.setCollapsed(false);
+                expect(fired).to.equal(0);
+                entry.setCollapsed(true);
+                expect(fired).to.equal(1);
+                entry.setCollapsed(true);
+                expect(fired).to.equal(1);
+            } finally {
+                entry.dispose();
+            }
+        });
+
+        it('should toggle collapsed when the header fires onDidToggleCollapse', () => {
+            const { entry, header } = createEntry();
+            try {
+                expect(entry.isCollapsed).to.be.false;
+                header.node.click();
+                expect(entry.isCollapsed).to.be.true;
+                header.node.click();
+                expect(entry.isCollapsed).to.be.false;
+            } finally {
+                entry.dispose();
+            }
+        });
+    });
+
+    describe('DiffEntryLoadingWidget / DiffEntryErrorWidget', () => {
+
+        it('should render a spinning codicon loading indicator', () => {
+            const w = new DiffEntryLoadingWidget();
+            try {
+                const spinner = w.node.querySelector('.codicon-loading.codicon-modifier-spin');
+                expect(spinner).to.exist;
+            } finally {
+                w.dispose();
+            }
+        });
+
+        it('should render the error message', () => {
+            const w = new DiffEntryErrorWidget('oops');
+            try {
+                expect(w.node.textContent).to.contain('oops');
+                expect(w.node.querySelector('.codicon-error')).to.exist;
+            } finally {
+                w.dispose();
+            }
+        });
+    });
+
+    describe('MultiDiffEditorState', () => {
+
+        it('should accept a valid state', () => {
+            expect(MultiDiffEditorState.is({ scrollTop: 100, collapsedUris: ['file:///a.ts'] })).to.be.true;
+        });
+
+        it('should accept an empty state object', () => {
+            expect(MultiDiffEditorState.is({})).to.be.true;
+        });
+
+        it('should reject non-object values', () => {
+            expect(MultiDiffEditorState.is(undefined)).to.be.false;
+            expect(MultiDiffEditorState.is('string')).to.be.false;
+            expect(MultiDiffEditorState.is(42)).to.be.false;
+        });
+
+        it('should reject wrong scrollTop type', () => {
+            expect(MultiDiffEditorState.is({ scrollTop: '100' })).to.be.false;
+        });
+
+        it('should reject wrong collapsedUris type', () => {
+            expect(MultiDiffEditorState.is({ collapsedUris: 'file:///a.ts' })).to.be.false;
+            expect(MultiDiffEditorState.is({ collapsedUris: [1, 2] })).to.be.false;
+        });
+    });
+
+    describe('MultiDiffEditorOpenHandler', () => {
+
+        // canHandle can be exercised without DI, since it's a pure function of the URI.
+        const handler = Object.create(MultiDiffEditorOpenHandler.prototype) as MultiDiffEditorOpenHandler;
+
+        it('should return 1000 for multi-diff-editor URIs', () => {
+            const uri = MultiDiffEditorUri.encode({ title: 'x', resources: [] });
+            expect(handler.canHandle(uri)).to.equal(1000);
+        });
+
+        it('should return 0 for other URIs', () => {
+            expect(handler.canHandle(new URI('file:///a.ts'))).to.equal(0);
+            expect(handler.canHandle(new URI('diff://a/b'))).to.equal(0);
+        });
+    });
+});

--- a/packages/scm/src/browser/multi-diff-editor/multi-diff-editor.spec.ts
+++ b/packages/scm/src/browser/multi-diff-editor/multi-diff-editor.spec.ts
@@ -1,0 +1,189 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { MultiDiffEditorUri, MultiDiffEditorUriData } from './multi-diff-editor-uri';
+
+describe('MultiDiffEditorUri', () => {
+
+    const sampleData: MultiDiffEditorUriData = {
+        title: 'Test Changes',
+        resources: [
+            {
+                originalUri: new URI('file:///path/to/original/file1.ts'),
+                modifiedUri: new URI('file:///path/to/modified/file1.ts')
+            },
+            {
+                originalUri: new URI('file:///path/to/original/file2.ts'),
+                modifiedUri: new URI('file:///path/to/modified/file2.ts')
+            }
+        ]
+    };
+
+    describe('encode', () => {
+
+        it('should create a URI with the multi-diff-editor scheme', () => {
+            const uri = MultiDiffEditorUri.encode(sampleData);
+            expect(uri.scheme).to.equal('multi-diff-editor');
+        });
+
+        it('should encode resources in the query', () => {
+            const uri = MultiDiffEditorUri.encode(sampleData);
+            const parsed = JSON.parse(uri.query);
+            expect(parsed.title).to.equal('Test Changes');
+            expect(parsed.resources).to.have.length(2);
+        });
+
+        it('should be deterministic for the same data', () => {
+            const uri1 = MultiDiffEditorUri.encode(sampleData);
+            const uri2 = MultiDiffEditorUri.encode(sampleData);
+            expect(uri1.toString()).to.equal(uri2.toString());
+        });
+
+        it('should produce different URIs for different data', () => {
+            const uri1 = MultiDiffEditorUri.encode(sampleData);
+            const uri2 = MultiDiffEditorUri.encode({
+                ...sampleData,
+                title: 'Different Title'
+            });
+            expect(uri1.toString()).to.not.equal(uri2.toString());
+        });
+    });
+
+    describe('decode', () => {
+
+        it('should decode an encoded URI back to the original data', () => {
+            const uri = MultiDiffEditorUri.encode(sampleData);
+            const decoded = MultiDiffEditorUri.decode(uri);
+            expect(decoded.title).to.equal(sampleData.title);
+            expect(decoded.resources).to.have.length(2);
+            expect(decoded.resources[0].originalUri.toString()).to.equal(sampleData.resources[0].originalUri.toString());
+            expect(decoded.resources[0].modifiedUri.toString()).to.equal(sampleData.resources[0].modifiedUri.toString());
+            expect(decoded.resources[1].originalUri.toString()).to.equal(sampleData.resources[1].originalUri.toString());
+            expect(decoded.resources[1].modifiedUri.toString()).to.equal(sampleData.resources[1].modifiedUri.toString());
+        });
+
+        it('should throw for URIs with wrong scheme', () => {
+            const wrongUri = new URI('file:///some/path');
+            expect(() => MultiDiffEditorUri.decode(wrongUri)).to.throw('must have scheme multi-diff-editor');
+        });
+
+        it('should throw for URIs whose query is not valid JSON', () => {
+            const malformedUri = new URI().withScheme('multi-diff-editor').withQuery('not-json');
+            expect(() => MultiDiffEditorUri.decode(malformedUri)).to.throw(/is not a valid URI for scheme multi-diff-editor/);
+        });
+
+        it('should throw when the parsed payload is missing a title', () => {
+            const uri = new URI().withScheme('multi-diff-editor').withQuery(JSON.stringify({ resources: [] }));
+            expect(() => MultiDiffEditorUri.decode(uri)).to.throw(/is not a valid URI for scheme multi-diff-editor/);
+        });
+
+        it('should throw when the parsed payload is missing resources', () => {
+            const uri = new URI().withScheme('multi-diff-editor').withQuery(JSON.stringify({ title: 'x' }));
+            expect(() => MultiDiffEditorUri.decode(uri)).to.throw(/is not a valid URI for scheme multi-diff-editor/);
+        });
+
+        it('should throw when a resource entry is not a string pair', () => {
+            const uri = new URI().withScheme('multi-diff-editor').withQuery(JSON.stringify({
+                title: 'x',
+                resources: [['only-one']]
+            }));
+            expect(() => MultiDiffEditorUri.decode(uri)).to.throw(/is not a valid URI for scheme multi-diff-editor/);
+        });
+
+        it('should throw when a resource entry contains non-string values', () => {
+            const uri = new URI().withScheme('multi-diff-editor').withQuery(JSON.stringify({
+                title: 'x',
+                resources: [[123, 456]]
+            }));
+            expect(() => MultiDiffEditorUri.decode(uri)).to.throw(/is not a valid URI for scheme multi-diff-editor/);
+        });
+
+        it('should throw when the payload is a primitive value', () => {
+            const uri = new URI().withScheme('multi-diff-editor').withQuery(JSON.stringify('not-an-object'));
+            expect(() => MultiDiffEditorUri.decode(uri)).to.throw(/is not a valid URI for scheme multi-diff-editor/);
+        });
+    });
+
+    describe('isMultiDiffEditorUri', () => {
+
+        it('should return true for multi-diff-editor URIs', () => {
+            const uri = MultiDiffEditorUri.encode(sampleData);
+            expect(MultiDiffEditorUri.isMultiDiffEditorUri(uri)).to.be.true;
+        });
+
+        it('should return false for other URIs', () => {
+            const uri = new URI('file:///some/path');
+            expect(MultiDiffEditorUri.isMultiDiffEditorUri(uri)).to.be.false;
+        });
+    });
+
+    describe('roundtrip', () => {
+
+        it('should handle empty resources list', () => {
+            const data: MultiDiffEditorUriData = {
+                title: 'Empty',
+                resources: []
+            };
+            const uri = MultiDiffEditorUri.encode(data);
+            const decoded = MultiDiffEditorUri.decode(uri);
+            expect(decoded.title).to.equal('Empty');
+            expect(decoded.resources).to.have.length(0);
+        });
+
+        it('should handle single resource', () => {
+            const data: MultiDiffEditorUriData = {
+                title: 'Single Change',
+                resources: [{
+                    originalUri: new URI('file:///original/file.ts'),
+                    modifiedUri: new URI('file:///modified/file.ts')
+                }]
+            };
+            const uri = MultiDiffEditorUri.encode(data);
+            const decoded = MultiDiffEditorUri.decode(uri);
+            expect(decoded.title).to.equal('Single Change');
+            expect(decoded.resources).to.have.length(1);
+            expect(decoded.resources[0].originalUri.toString()).to.equal(data.resources[0].originalUri.toString());
+            expect(decoded.resources[0].modifiedUri.toString()).to.equal(data.resources[0].modifiedUri.toString());
+        });
+
+        it('should handle URIs with special characters', () => {
+            const data: MultiDiffEditorUriData = {
+                title: 'Special Chars: äöü & <test>',
+                resources: [{
+                    originalUri: new URI('file:///path/with spaces/file.ts'),
+                    modifiedUri: new URI('file:///path/with%20encoded/file.ts')
+                }]
+            };
+            const uri = MultiDiffEditorUri.encode(data);
+            const decoded = MultiDiffEditorUri.decode(uri);
+            expect(decoded.title).to.equal(data.title);
+            expect(decoded.resources[0].originalUri.toString()).to.equal(data.resources[0].originalUri.toString());
+            expect(decoded.resources[0].modifiedUri.toString()).to.equal(data.resources[0].modifiedUri.toString());
+        });
+
+        it('should handle a title with slashes without confusing the URI path', () => {
+            const data: MultiDiffEditorUriData = {
+                title: 'changes/in/nested/path',
+                resources: []
+            };
+            const uri = MultiDiffEditorUri.encode(data);
+            const decoded = MultiDiffEditorUri.decode(uri);
+            expect(decoded.title).to.equal('changes/in/nested/path');
+        });
+    });
+});

--- a/packages/scm/src/browser/multi-diff-editor/multi-diff-editor.ts
+++ b/packages/scm/src/browser/multi-diff-editor/multi-diff-editor.ts
@@ -1,0 +1,513 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { Emitter, Event, isObject, nls, URI } from '@theia/core';
+import {
+    ApplicationShell, BaseWidget, BoxLayout, codicon, Key, LabelProvider,
+    Message, MessageLoop, Navigatable, NavigatableWidgetOpenHandler, Panel, PanelLayout, StatefulWidget,
+    Widget, WidgetOpenerOptions
+} from '@theia/core/lib/browser';
+import { EditorWidget } from '@theia/editor/lib/browser';
+import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import { MonacoDiffEditor } from '@theia/monaco/lib/browser/monaco-diff-editor';
+import { MultiDiffEditorUri, MultiDiffEditorResourcePair, MultiDiffEditorUriData } from './multi-diff-editor-uri';
+
+export { MultiDiffEditorUri, MultiDiffEditorResourcePair, MultiDiffEditorUriData };
+
+export interface MultiDiffEditorOpenerOptions extends WidgetOpenerOptions {
+    reveal?: URI;
+}
+
+/**
+ * Data required to construct a {@link MultiDiffEditor} via dependency injection.
+ */
+export const MultiDiffEditorData = Symbol('MultiDiffEditorData');
+
+/**
+ * Minimum height of a diff entry (in pixels). Ensures loading placeholders and
+ * small files still have a reasonable presence when scrolling the list of entries.
+ */
+export const MIN_ENTRY_HEIGHT = 120;
+/**
+ * Maximum height of a diff entry (in pixels). Prevents a single large file
+ * from dominating the view; content beyond this height is scrollable within
+ * the embedded editor.
+ */
+export const MAX_ENTRY_HEIGHT = 500;
+/**
+ * Height of the header bar above each embedded diff editor (in pixels).
+ * Used as the collapsed-entry height and as the sizeBasis of the BoxLayout header child.
+ */
+export const HEADER_HEIGHT = 28;
+
+/**
+ * Persisted state of a {@link MultiDiffEditor} — scroll position and per-entry
+ * collapsed state, keyed by the modified URI (stable across reloads).
+ */
+export interface MultiDiffEditorState {
+    scrollTop?: number;
+    collapsedUris?: string[];
+}
+
+export namespace MultiDiffEditorState {
+    export function is(value: unknown): value is MultiDiffEditorState {
+        if (!isObject<MultiDiffEditorState>(value)) {
+            return false;
+        }
+        if (value.scrollTop !== undefined && typeof value.scrollTop !== 'number') {
+            return false;
+        }
+        if (value.collapsedUris !== undefined
+            && (!Array.isArray(value.collapsedUris) || !value.collapsedUris.every(u => typeof u === 'string'))) {
+            return false;
+        }
+        return true;
+    }
+}
+
+/**
+ * Header widget for a single diff entry. Displays a collapse/expand toggle, file icon,
+ * name and path. Clicking anywhere on the header fires {@link onDidToggleCollapse}.
+ */
+export class DiffEntryHeaderWidget extends BaseWidget {
+
+    protected readonly onDidToggleCollapseEmitter = new Emitter<void>();
+    readonly onDidToggleCollapse: Event<void> = this.onDidToggleCollapseEmitter.event;
+
+    protected readonly chevron: HTMLElement;
+
+    constructor(resource: MultiDiffEditorResourcePair, labelProvider: LabelProvider) {
+        super();
+        this.addClass('multi-diff-entry-header');
+        this.node.setAttribute('role', 'button');
+        this.node.setAttribute('aria-expanded', 'true');
+        this.node.tabIndex = 0;
+
+        this.chevron = document.createElement('span');
+        this.chevron.className = `${codicon('chevron-down')} multi-diff-entry-chevron`;
+        this.node.appendChild(this.chevron);
+
+        const icon = document.createElement('span');
+        icon.className = `${labelProvider.getIcon(resource.modifiedUri)} file-icon multi-diff-entry-icon`;
+        this.node.appendChild(icon);
+
+        const label = document.createElement('span');
+        label.classList.add('multi-diff-entry-label');
+        label.textContent = labelProvider.getName(resource.modifiedUri);
+        this.node.appendChild(label);
+
+        const description = document.createElement('span');
+        description.classList.add('multi-diff-entry-description');
+        description.textContent = labelProvider.getLongName(resource.modifiedUri);
+        this.node.appendChild(description);
+
+        this.toDispose.push(this.onDidToggleCollapseEmitter);
+        this.addEventListener(this.node, 'click', () => this.onDidToggleCollapseEmitter.fire());
+        this.addKeyListener(this.node, [Key.ENTER, Key.SPACE], () => this.onDidToggleCollapseEmitter.fire());
+    }
+
+    setCollapsed(collapsed: boolean): void {
+        this.node.setAttribute('aria-expanded', String(!collapsed));
+        this.chevron.classList.toggle('codicon-chevron-down', !collapsed);
+        this.chevron.classList.toggle('codicon-chevron-right', collapsed);
+    }
+}
+
+/**
+ * Placeholder widget shown while a diff entry's editor is being loaded.
+ */
+export class DiffEntryLoadingWidget extends BaseWidget {
+
+    constructor() {
+        super();
+        this.addClass('multi-diff-entry-loading');
+        const spinner = document.createElement('span');
+        spinner.className = `${codicon('loading')} codicon-modifier-spin`;
+        this.node.appendChild(spinner);
+        const text = document.createElement('span');
+        text.textContent = nls.localizeByDefault('Loading...');
+        this.node.appendChild(text);
+    }
+}
+
+/**
+ * Placeholder widget shown when a diff entry's editor fails to load.
+ */
+export class DiffEntryErrorWidget extends BaseWidget {
+
+    constructor(message: string) {
+        super();
+        this.addClass('multi-diff-entry-error');
+        const icon = document.createElement('span');
+        icon.className = codicon('error');
+        this.node.appendChild(icon);
+        const text = document.createElement('span');
+        text.textContent = message;
+        this.node.appendChild(text);
+    }
+}
+
+/**
+ * A single diff entry combining a header and a content area that transitions through
+ * loading, editor, and error states. The entry's outer height is controlled via
+ * {@link DiffEntryWidget.setHeight} and, once the editor is loaded, tracks the
+ * editor's content size up to {@link MAX_ENTRY_HEIGHT}. The entry can be collapsed
+ * (showing only the header) via {@link DiffEntryWidget.setCollapsed}.
+ */
+export class DiffEntryWidget extends BaseWidget {
+
+    readonly modifiedUri: URI;
+
+    protected readonly boxLayout: BoxLayout;
+    protected readonly header: DiffEntryHeaderWidget;
+    protected currentContent: Widget;
+    protected _editorWidget?: EditorWidget;
+
+    protected _isCollapsed = false;
+    /** Height to restore when expanding from a collapsed state. */
+    protected lastExpandedHeight = MIN_ENTRY_HEIGHT;
+
+    protected readonly onDidChangeCollapsedEmitter = new Emitter<boolean>();
+    readonly onDidChangeCollapsed: Event<boolean> = this.onDidChangeCollapsedEmitter.event;
+
+    constructor(
+        resource: MultiDiffEditorResourcePair,
+        headerWidget: DiffEntryHeaderWidget
+    ) {
+        super();
+        this.addClass('multi-diff-entry');
+        this.modifiedUri = resource.modifiedUri;
+        this.header = headerWidget;
+
+        this.boxLayout = new BoxLayout({ direction: 'top-to-bottom', spacing: 0 });
+        BoxLayout.setStretch(headerWidget, 0);
+        BoxLayout.setSizeBasis(headerWidget, HEADER_HEIGHT);
+        this.boxLayout.addWidget(headerWidget);
+
+        this.currentContent = new DiffEntryLoadingWidget();
+        BoxLayout.setStretch(this.currentContent, 1);
+        this.boxLayout.addWidget(this.currentContent);
+
+        this.layout = this.boxLayout;
+        this.setHeight(MIN_ENTRY_HEIGHT);
+
+        this.toDispose.pushAll([
+            this.onDidChangeCollapsedEmitter,
+            this.header.onDidToggleCollapse(() => this.setCollapsed(!this._isCollapsed))
+        ]);
+    }
+
+    get editorWidget(): EditorWidget | undefined {
+        return this._editorWidget;
+    }
+
+    get isCollapsed(): boolean {
+        return this._isCollapsed;
+    }
+
+    setCollapsed(collapsed: boolean): void {
+        if (this._isCollapsed === collapsed) {
+            return;
+        }
+        this._isCollapsed = collapsed;
+        this.header.setCollapsed(collapsed);
+        if (collapsed) {
+            this.lastExpandedHeight = this.getCurrentHeight() || MIN_ENTRY_HEIGHT;
+            this.setNodeHeight(HEADER_HEIGHT);
+        } else {
+            this.setNodeHeight(this.lastExpandedHeight);
+        }
+        this.onDidChangeCollapsedEmitter.fire(collapsed);
+    }
+
+    setError(message: string): void {
+        this.replaceContent(new DiffEntryErrorWidget(message));
+    }
+
+    setEditor(editorWidget: EditorWidget): void {
+        // When the editor widget becomes visible, Monaco's handleVisibilityChanged calls
+        // focus() on the underlying editor, which causes the browser to scroll the entry
+        // into view. As entries load one-by-one (often out of order), each focus() jumps
+        // the viewport to the newly-loaded entry. Capture and restore the scroll offset
+        // to keep the user's viewport stable.
+        const scrollContainer = this.findScrollContainer();
+        const previousScrollTop = scrollContainer?.scrollTop;
+
+        this._editorWidget = editorWidget;
+        this.replaceContent(editorWidget);
+        this.trackContentHeight(editorWidget);
+
+        if (scrollContainer && previousScrollTop !== undefined && scrollContainer.scrollTop !== previousScrollTop) {
+            scrollContainer.scrollTop = previousScrollTop;
+        }
+    }
+
+    protected findScrollContainer(): HTMLElement | undefined {
+        let current: HTMLElement | null = this.node.parentElement;
+        while (current) {
+            const overflowY = getComputedStyle(current).overflowY;
+            if (overflowY === 'auto' || overflowY === 'scroll') {
+                return current;
+            }
+            current = current.parentElement;
+        }
+        return undefined;
+    }
+
+    /**
+     * Replace the current content widget (loading/editor/error) with a new one.
+     * Using BoxLayout directly (instead of a nested Panel) ensures that Monaco's
+     * container gets explicit `position: absolute` + `width`/`height` from Lumino's
+     * LayoutItem, which is required for Monaco to lay out correctly.
+     */
+    protected replaceContent(widget: Widget): void {
+        const old = this.currentContent;
+        if (old === widget) {
+            return;
+        }
+        BoxLayout.setStretch(widget, 1);
+        this.boxLayout.addWidget(widget);
+        this.currentContent = widget;
+        // eslint-disable-next-line no-null/no-null
+        old.parent = null;
+        old.dispose();
+    }
+
+    /**
+     * Set the outer height of this entry to fit its content. The value is clamped between
+     * {@link MIN_ENTRY_HEIGHT} and {@link MAX_ENTRY_HEIGHT}. Has no effect while the entry
+     * is collapsed; the requested height is remembered and applied on expand.
+     */
+    setHeight(height: number): void {
+        const clamped = Math.max(MIN_ENTRY_HEIGHT, Math.min(MAX_ENTRY_HEIGHT, height));
+        this.lastExpandedHeight = clamped;
+        if (!this._isCollapsed) {
+            this.setNodeHeight(clamped);
+        }
+    }
+
+    protected getCurrentHeight(): number {
+        const parsed = parseInt(this.node.style.height, 10);
+        return Number.isFinite(parsed) ? parsed : 0;
+    }
+
+    protected setNodeHeight(height: number): void {
+        if (this.node.style.height === `${height}px`) {
+            return;
+        }
+        this.node.style.height = `${height}px`;
+        if (this.isAttached) {
+            MessageLoop.sendMessage(this, Widget.ResizeMessage.UnknownSize);
+        }
+    }
+
+    /**
+     * Subscribe to the embedded editor's content size changes and size this entry accordingly.
+     * The subscriptions are disposed together with this widget.
+     */
+    protected trackContentHeight(editorWidget: EditorWidget): void {
+        const monacoEditor = MonacoEditor.get(editorWidget);
+        if (!monacoEditor) {
+            return;
+        }
+        const getContentHeight = (): number => {
+            if (monacoEditor instanceof MonacoDiffEditor) {
+                return Math.max(
+                    monacoEditor.diffEditor.getOriginalEditor().getContentHeight(),
+                    monacoEditor.diffEditor.getModifiedEditor().getContentHeight()
+                );
+            }
+            return monacoEditor.getControl().getContentHeight();
+        };
+        const updateHeight = () => this.setHeight(getContentHeight() + HEADER_HEIGHT);
+        if (monacoEditor instanceof MonacoDiffEditor) {
+            this.toDispose.push(monacoEditor.diffEditor.getOriginalEditor().onDidContentSizeChange(updateHeight));
+            this.toDispose.push(monacoEditor.diffEditor.getModifiedEditor().onDidContentSizeChange(updateHeight));
+        } else {
+            this.toDispose.push(monacoEditor.getControl().onDidContentSizeChange(updateHeight));
+        }
+        updateHeight();
+    }
+}
+
+/**
+ * Widget that displays a list of diff editors stacked vertically.
+ *
+ * **Async-loading contract:** the widget is returned immediately by the factory with
+ * placeholder entries (one per resource) showing a loading indicator. Each
+ * {@link DiffEntryWidget.editorWidget} is `undefined` until the embedded diff editor
+ * finishes loading, at which point the placeholder is replaced and
+ * {@link onDidChangeTrackableWidgets} fires so the {@link ApplicationShell} focus
+ * tracker picks up the new editor. Consumers must not assume that all embedded editors
+ * are present synchronously when this widget is returned.
+ */
+@injectable()
+export class MultiDiffEditor extends BaseWidget implements Navigatable, ApplicationShell.TrackableWidgetProvider, StatefulWidget {
+
+    @inject(MultiDiffEditorData)
+    protected readonly data: MultiDiffEditorUriData;
+
+    protected readonly entryWidgets: DiffEntryWidget[] = [];
+    protected entriesPanel: Panel;
+    protected encodedUri: URI;
+
+    protected readonly onDidChangeTrackableWidgetsEmitter = new Emitter<Widget[]>();
+    readonly onDidChangeTrackableWidgets: Event<Widget[]> = this.onDidChangeTrackableWidgetsEmitter.event;
+
+    /** Scroll position from a previous session, applied once the widget is attached. */
+    protected pendingScrollTop?: number;
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.onDidChangeTrackableWidgetsEmitter);
+        this.addClass('theia-multi-diff-editor');
+        this.encodedUri = MultiDiffEditorUri.encode(this.data);
+        this.id = MultiDiffEditorOpenHandler.ID + ':' + this.encodedUri.toString();
+        this.title.label = this.data.title;
+        this.title.caption = this.data.title;
+        this.title.closable = true;
+        this.title.iconClass = 'codicon codicon-diff-multiple file-icon';
+
+        this.entriesPanel = new Panel();
+        this.entriesPanel.addClass('multi-diff-editor-entries');
+        const layout = new PanelLayout();
+        layout.addWidget(this.entriesPanel);
+        this.layout = layout;
+    }
+
+    get entries(): readonly DiffEntryWidget[] {
+        return this.entryWidgets;
+    }
+
+    addDiffEntry(resource: MultiDiffEditorResourcePair, headerWidget: DiffEntryHeaderWidget): DiffEntryWidget {
+        const entry = new DiffEntryWidget(resource, headerWidget);
+        this.entryWidgets.push(entry);
+        this.entriesPanel.addWidget(entry);
+        return entry;
+    }
+
+    /**
+     * Notify listeners (in particular, the {@link ApplicationShell} focus tracker) that a
+     * new editor widget has been attached to one of the entries. Called by the factory
+     * after {@link DiffEntryWidget.setEditor} resolves.
+     */
+    notifyTrackableWidgetsChanged(): void {
+        this.onDidChangeTrackableWidgetsEmitter.fire(this.getTrackableWidgets());
+    }
+
+    revealResource(modifiedUri: URI): void {
+        const uriStr = modifiedUri.toString();
+        const entry = this.entryWidgets.find(e => e.modifiedUri.toString() === uriStr);
+        if (!entry) {
+            return;
+        }
+        // Defer scrolling so embedded editors have a chance to complete their initial layout.
+        requestAnimationFrame(() => {
+            if (!this.isDisposed && entry.isAttached) {
+                entry.node.scrollIntoView({ block: 'start' });
+            }
+        });
+    }
+
+    getTrackableWidgets(): Widget[] {
+        const result: Widget[] = [];
+        for (const entry of this.entryWidgets) {
+            if (entry.editorWidget) {
+                result.push(entry.editorWidget);
+            }
+        }
+        return result;
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        const loadedEntry = this.entryWidgets.find(e => e.editorWidget);
+        if (loadedEntry?.editorWidget) {
+            loadedEntry.editorWidget.activate();
+        } else {
+            this.node.tabIndex = -1;
+            this.node.focus();
+        }
+    }
+
+    protected override onAfterAttach(msg: Message): void {
+        super.onAfterAttach(msg);
+        // Restore scroll after attach so layout has produced valid scroll extents.
+        if (this.pendingScrollTop !== undefined) {
+            const scrollTop = this.pendingScrollTop;
+            this.pendingScrollTop = undefined;
+            requestAnimationFrame(() => {
+                if (!this.isDisposed && this.entriesPanel.isAttached) {
+                    this.entriesPanel.node.scrollTop = scrollTop;
+                }
+            });
+        }
+    }
+
+    storeState(): MultiDiffEditorState {
+        return {
+            scrollTop: this.entriesPanel?.node.scrollTop,
+            collapsedUris: this.entryWidgets.filter(e => e.isCollapsed).map(e => e.modifiedUri.toString())
+        };
+    }
+
+    restoreState(state: object): void {
+        if (!MultiDiffEditorState.is(state)) {
+            return;
+        }
+        if (state.collapsedUris) {
+            const collapsed = new Set(state.collapsedUris);
+            for (const entry of this.entryWidgets) {
+                if (collapsed.has(entry.modifiedUri.toString())) {
+                    entry.setCollapsed(true);
+                }
+            }
+        }
+        this.pendingScrollTop = state.scrollTop;
+    }
+
+    getResourceUri(): URI | undefined {
+        return this.encodedUri;
+    }
+
+    createMoveToUri(_resourceUri: URI): URI | undefined {
+        // Multi-diff editors represent a collection of resources, so they cannot be moved to a single resource.
+        return undefined;
+    }
+}
+
+@injectable()
+export class MultiDiffEditorOpenHandler extends NavigatableWidgetOpenHandler<MultiDiffEditor> {
+
+    static readonly ID = 'multi-diff-editor-opener';
+
+    readonly id = MultiDiffEditorOpenHandler.ID;
+
+    readonly label = nls.localizeByDefault('Multi Diff Editor');
+
+    override canHandle(uri: URI, options?: MultiDiffEditorOpenerOptions): number {
+        return MultiDiffEditorUri.isMultiDiffEditorUri(uri) ? 1000 : 0;
+    }
+
+    override async open(uri: URI, options?: MultiDiffEditorOpenerOptions): Promise<MultiDiffEditor> {
+        const widget = await super.open(uri, options);
+        if (options?.reveal) {
+            widget.revealResource(options.reveal);
+        }
+        return widget;
+    }
+}

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -44,6 +44,7 @@ import { ColorContribution } from '@theia/core/lib/browser/color-application-con
 import { LabelProviderContribution } from '@theia/core/lib/browser/label-provider';
 import { bindScmPreferences } from '../common/scm-preferences';
 import { bindMergeEditor } from './merge-editor/merge-editor-module';
+import { bindMultiDiffEditor } from './multi-diff-editor/multi-diff-editor-module';
 import { ScmRepositoriesWidget } from './scm-repositories-widget';
 
 export default new ContainerModule(bind => {
@@ -135,6 +136,8 @@ export default new ContainerModule(bind => {
     bindScmPreferences(bind);
 
     bindMergeEditor(bind);
+
+    bindMultiDiffEditor(bind);
 });
 
 export function createScmTreeContainer(parent: interfaces.Container): Container {

--- a/packages/scm/src/browser/style/multi-diff-editor.css
+++ b/packages/scm/src/browser/style/multi-diff-editor.css
@@ -1,0 +1,106 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource and others.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+.theia-multi-diff-editor {
+    height: 100%;
+    width: 100%;
+}
+
+/* Override Lumino PanelLayout default absolute positioning to enable document flow. */
+.theia-multi-diff-editor>.multi-diff-editor-entries {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    overflow-y: auto;
+    overflow-x: hidden;
+}
+
+/* Override Lumino default: children use normal flow instead of absolute positioning.
+ * The inline `height` is set dynamically by DiffEntryWidget.setHeight based on the
+ * embedded editor content (clamped between MIN_ENTRY_HEIGHT and MAX_ENTRY_HEIGHT). */
+.theia-multi-diff-editor .multi-diff-editor-entries>.multi-diff-entry {
+    position: relative;
+    width: 100%;
+    margin-bottom: 4px;
+    border: 1px solid var(--theia-panel-border);
+}
+
+.theia-multi-diff-editor .multi-diff-entry-header {
+    display: flex;
+    align-items: center;
+    padding: 4px 10px;
+    background-color: var(--theia-editorGroupHeader-tabsBackground);
+    border-bottom: 1px solid var(--theia-panel-border);
+    user-select: none;
+    overflow: hidden;
+    cursor: pointer;
+    outline: none;
+}
+
+.theia-multi-diff-editor .multi-diff-entry-header:focus-visible {
+    outline: 1px solid var(--theia-focusBorder);
+    outline-offset: -1px;
+}
+
+.theia-multi-diff-editor .multi-diff-entry-chevron {
+    flex-shrink: 0;
+    margin-right: 4px;
+    color: var(--theia-foreground);
+}
+
+.theia-multi-diff-editor .multi-diff-entry-icon {
+    flex-shrink: 0;
+    margin-right: 6px;
+}
+
+.theia-multi-diff-editor .multi-diff-entry-label {
+    flex-shrink: 0;
+    margin-right: 8px;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.theia-multi-diff-editor .multi-diff-entry-description {
+    flex-shrink: 1;
+    color: var(--theia-descriptionForeground);
+    font-size: 0.9em;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.theia-multi-diff-editor .multi-diff-entry-loading,
+.theia-multi-diff-editor .multi-diff-entry-error {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 16px;
+    height: 100%;
+    box-sizing: border-box;
+}
+
+.theia-multi-diff-editor .multi-diff-entry-loading {
+    color: var(--theia-descriptionForeground);
+}
+
+.theia-multi-diff-editor .multi-diff-entry-error {
+    color: var(--theia-errorForeground);
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Add a dedicated widget that stacks all diff
editors vertically. The widget opens immediately with a loading placeholder per resource and resolves the embedded editors in parallel in the background, so large change sets don't block the UI. The viewport stays stable while entries load.

Each entry has a collapsible header with keyboard and ARIA support. Entry height follows the editor's content size, clamped to reasonable bounds to keep a single large file from dominating the view. Scroll position and collapsed state are persisted across sessions.

Fixes #17313
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open a full commit, eg from the status bar and see that the new editor is used.
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
