### PR TITLE
Add .tmp.cfg to top-level gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ allure-results
 license-check-summary.txt*
 .playwright-mcp/*
 /.theia/chatSessions
+.tmp.cfg


### PR DESCRIPTION


#### What it does

Adds `.tmp.cfg` to the root `.gitignore` so that the temporary config directory created by the Playwright `theia:start` script is ignored regardless of where it lands.

Prior to the yarn-to-npm migration in #14481 (00367695f), the script used `yarn --cwd ../browser start`, which didn't change the shell's working directory. `$PWD` still pointed at `examples/playwright/`, so `.tmp.cfg` was created there and covered by `examples/playwright/.gitignore`.

The npm migration replaced `yarn --cwd` with `cd ../browser && npm run start`, which shifts `$PWD` to `examples/browser/` before `$PWD` is evaluated. A subsequent fix in #16455 (c895e7445) moved `rimraf` after the `cd` so cleanup and creation were consistent, but both now target `examples/browser/` — leaving an untracked `.tmp.cfg` that the existing `.gitignore` doesn't cover.

Rather than reworking the script (npm has no cross-platform equivalent of `yarn --cwd`), this PR simply adds `.tmp.cfg` to the root `.gitignore`.

#### How to test

1. Run `npm run test:playwright` from the repository root (or `npm run ui-tests` from `examples/playwright/`).
2. Verify that `git status` no longer shows an untracked `examples/browser/.tmp.cfg/` entry.

#### Follow-ups

The `examples/playwright/.gitignore` entry for `.tmp.cfg` is now redundant but harmless. It could be removed in a follow-up.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)