### PR TITLE
feat(ai-mcp): default providers + server wiring (RFC phase B, #17375)

### DIFF
--- a/packages/ai-mcp/src/common/extension-points.spec.ts
+++ b/packages/ai-mcp/src/common/extension-points.spec.ts
@@ -1,0 +1,119 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Emitter } from '@theia/core/lib/common/event';
+import {
+    MCPClientFactory,
+    MCPCredentialResolver,
+    MCPServerDescription,
+    MCPToolFilter,
+    MCPToolFilterOutcome,
+    MCPTransport,
+    MCPTransportProvider,
+    ToolInformation,
+} from './index';
+
+describe('@theia/ai-mcp extension-point surface', () => {
+
+    it('exports the four contribution-point symbols', () => {
+        expect(typeof MCPTransportProvider).to.equal('symbol');
+        expect(typeof MCPCredentialResolver).to.equal('symbol');
+        expect(typeof MCPToolFilter).to.equal('symbol');
+        expect(typeof MCPClientFactory).to.equal('symbol');
+    });
+
+    it('admits a minimal MCPTransportProvider implementation', async () => {
+        const noopEmitter = new Emitter<unknown>();
+        const closeEmitter = new Emitter<Error | undefined>();
+        const provider: MCPTransportProvider = {
+            id: 'test-noop',
+            priority: 0,
+            matches: () => true,
+            create: async (): Promise<MCPTransport> => ({
+                kind: 'noop',
+                send: async () => undefined,
+                close: async () => undefined,
+                onMessage: noopEmitter.event,
+                onClose: closeEmitter.event,
+            }),
+        };
+        const description = { name: 'x', command: 'echo' } as MCPServerDescription;
+        const transport = await provider.create(description, new AbortController().signal);
+        expect(transport.kind).to.equal('noop');
+    });
+
+    it('admits a minimal MCPCredentialResolver that falls through on undefined', async () => {
+        const never: MCPCredentialResolver = {
+            id: 'never',
+            priority: 100,
+            resolve: async () => undefined,
+        };
+        expect(await never.resolve({ serverName: 'x', field: 'y' })).to.be.undefined;
+    });
+
+    it('MCPToolFilter outcomes: replacement / suppression / passthrough', () => {
+        const rename: MCPToolFilter = {
+            id: 'rename',
+            filter: (_s, advertised: ToolInformation) => ({ ...advertised, name: advertised.name.toUpperCase() }),
+        };
+        const suppress: MCPToolFilter = {
+            id: 'suppress',
+            filter: () => undefined,
+        };
+        const defer: MCPToolFilter = {
+            id: 'defer',
+            filter: (): MCPToolFilterOutcome => 'passthrough',
+        };
+
+        const input: ToolInformation = { name: 'search' };
+        expect((rename.filter('srv', input) as ToolInformation).name).to.equal('SEARCH');
+        expect(suppress.filter('srv', input)).to.be.undefined;
+        expect(defer.filter('srv', input)).to.equal('passthrough');
+    });
+
+    it('MCPClientFactory context carries a credential resolver', async () => {
+        let requestedField: string | undefined;
+        const factory: MCPClientFactory = {
+            id: 'test',
+            create: async (description, _transport, ctx) => {
+                requestedField = 'auth';
+                await ctx.resolveCredential({ serverName: description.name, field: 'auth' });
+                return {
+                    name: description.name,
+                    tools: [],
+                    start: async () => undefined,
+                    stop: async () => undefined,
+                };
+            },
+        };
+        const noopEmitter = new Emitter<unknown>();
+        const closeEmitter = new Emitter<Error | undefined>();
+        const client = await factory.create(
+            { name: 'x', command: 'echo' } as MCPServerDescription,
+            {
+                kind: 'noop',
+                send: async () => undefined,
+                close: async () => undefined,
+                onMessage: noopEmitter.event,
+                onClose: closeEmitter.event,
+            },
+            { resolveCredential: async () => 'token' },
+        );
+        expect(client.name).to.equal('x');
+        expect(requestedField).to.equal('auth');
+    });
+});

--- a/packages/ai-mcp/src/common/index.ts
+++ b/packages/ai-mcp/src/common/index.ts
@@ -14,3 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 export * from './mcp-server-manager';
+export * from './mcp-transport-provider';
+export * from './mcp-credential-resolver';
+export * from './mcp-tool-filter';
+export * from './mcp-client-factory';

--- a/packages/ai-mcp/src/common/mcp-client-factory.ts
+++ b/packages/ai-mcp/src/common/mcp-client-factory.ts
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MCPServerDescription, ToolInformation } from './mcp-server-manager';
+import { MCPCredentialRequest } from './mcp-credential-resolver';
+import { MCPTransport } from './mcp-transport-provider';
+
+/**
+ * Public surface of the MCP client the server manager consumes. Narrower
+ * than the `@modelcontextprotocol/sdk` `Client` so plugins can wrap / replace
+ * it without depending on the SDK internals.
+ */
+export interface MCPClient {
+    readonly name: string;
+    readonly tools: ToolInformation[];
+    start(): Promise<void>;
+    stop(): Promise<void>;
+}
+
+/**
+ * Context passed to an {@link MCPClientFactory}, giving factories access to
+ * the full credential chain without leaking the registry.
+ */
+export interface MCPClientFactoryContext {
+    resolveCredential(request: MCPCredentialRequest): Promise<string | undefined>;
+}
+
+export const MCPClientFactory = Symbol('MCPClientFactory');
+
+/**
+ * Contribution point for swapping the concrete MCP client implementation.
+ * The highest-priority registered factory wins. The built-in factory wraps
+ * `@modelcontextprotocol/sdk` exactly as today and is registered with
+ * priority `0`; plugins that want to instrument every MCP call (metrics,
+ * tracing, structured logging) can register at a higher priority.
+ */
+export interface MCPClientFactory {
+    readonly id: string;
+    readonly priority?: number;
+
+    create(
+        description: MCPServerDescription,
+        transport: MCPTransport,
+        context: MCPClientFactoryContext,
+    ): Promise<MCPClient>;
+}

--- a/packages/ai-mcp/src/common/mcp-credential-resolver.ts
+++ b/packages/ai-mcp/src/common/mcp-credential-resolver.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * A request for a single credential, issued by the MCP server manager when
+ * starting or (re-)authenticating a server. Resolvers can use the `kind`
+ * hint to mask or obtain the value appropriately.
+ */
+export interface MCPCredentialRequest {
+    /** The configured server name (e.g. `github`, `linear`). */
+    serverName: string;
+
+    /** The remote server URL for HTTP/SSE servers; `undefined` for local stdio. */
+    serverUrl?: string;
+
+    /**
+     * Symbolic field identifier. For the built-in resolver this matches the
+     * preference key suffix (e.g. `serverAuthToken`). Plugins can match on
+     * their own prefixes (e.g. fields starting with `VAULT_`).
+     */
+    field: string;
+
+    /** Optional operator-facing label for interactive prompts. */
+    label?: string;
+
+    /** Hint for how to render / mask the credential. */
+    kind?: 'bearer-token' | 'api-key' | 'username-password' | 'oauth';
+}
+
+export const MCPCredentialResolver = Symbol('MCPCredentialResolver');
+
+/**
+ * Contribution point for credential resolution. The MCP server manager asks
+ * every registered resolver in descending-priority order; the first
+ * non-`undefined` return wins. Returning `undefined` defers to the next
+ * resolver. Errors are treated as `undefined` so one broken resolver cannot
+ * block the chain.
+ *
+ * Typical use cases:
+ *   - OAuth flows launching a browser and persisting tokens.
+ *   - OS keychain access (`keytar`, `libsecret`).
+ *   - Enterprise vaults (HashiCorp, 1Password CLI, AWS Secrets Manager).
+ *
+ * The built-in `PreferenceCredentialResolver` reads from Theia's preferences
+ * and runs at priority `0`, so existing deployments keep their current
+ * behaviour.
+ */
+export interface MCPCredentialResolver {
+    readonly id: string;
+    readonly priority?: number;
+
+    resolve(request: MCPCredentialRequest): Promise<string | undefined>;
+}

--- a/packages/ai-mcp/src/common/mcp-tool-filter.ts
+++ b/packages/ai-mcp/src/common/mcp-tool-filter.ts
@@ -1,0 +1,54 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ToolInformation } from './mcp-server-manager';
+
+/**
+ * Outcome of a {@link MCPToolFilter} pass:
+ *   - a new {@link ToolInformation} — replaces the advertised tool;
+ *   - `undefined` — suppresses the tool entirely (it is not registered);
+ *   - `'passthrough'` — defers to the next filter, no change from this one.
+ */
+export type MCPToolFilterOutcome = ToolInformation | undefined | 'passthrough';
+
+export const MCPToolFilter = Symbol('MCPToolFilter');
+
+/**
+ * Contribution point for filtering / rewriting tools advertised by MCP
+ * servers before they are registered into Theia's `ToolInvocationRegistry`.
+ * Filters are applied in descending-priority order; each filter sees the
+ * possibly-rewritten output of the previous filter.
+ *
+ * Typical use cases:
+ *   - Hiding known-dangerous tools unless explicitly opted in.
+ *   - Renaming tools to avoid collisions across servers.
+ *   - Stamping descriptions with provenance
+ *     (e.g. `"[from github-mcp-server]"`).
+ *
+ * Filters must be synchronous and side-effect free so the order of
+ * registration is deterministic.
+ */
+export interface MCPToolFilter {
+    readonly id: string;
+    readonly priority?: number;
+
+    /**
+     * Inspect a tool advertised by `serverName` and return a replacement,
+     * `undefined` to suppress, or `'passthrough'` to defer to the next
+     * filter.
+     */
+    filter(serverName: string, tool: ToolInformation): MCPToolFilterOutcome;
+}

--- a/packages/ai-mcp/src/common/mcp-transport-provider.ts
+++ b/packages/ai-mcp/src/common/mcp-transport-provider.ts
@@ -1,0 +1,68 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core/lib/common/event';
+import { MCPServerDescription } from './mcp-server-manager';
+
+/**
+ * Transport abstraction promoted to public API so plugins can contribute
+ * alternative implementations (e.g. WebSocket, in-process, gRPC) via
+ * {@link MCPTransportProvider}.
+ *
+ * Minimal by design: the MCP SDK's own transport interface is richer, but
+ * this public surface only exposes what the server manager needs to consume.
+ */
+export interface MCPTransport {
+    readonly kind: string;
+    send(message: unknown): Promise<void>;
+    close(): Promise<void>;
+    readonly onMessage: Event<unknown>;
+    readonly onClose: Event<Error | undefined>;
+}
+
+export const MCPTransportProvider = Symbol('MCPTransportProvider');
+
+/**
+ * Contribution point for MCP transport selection. A provider is asked whether
+ * it can create a transport for a given {@link MCPServerDescription} and, if
+ * so, creates the concrete instance. Multiple providers can coexist; the
+ * {@link MCPServerManager} consults them in descending-priority order and
+ * picks the first whose {@link matches} returns `true`.
+ *
+ * Default `stdio` and `http`/`sse` transports are contributed by the built-in
+ * `MCPServer` implementation so existing deployments see no behaviour change.
+ */
+export interface MCPTransportProvider {
+    /** Stable provider id, used in diagnostics. */
+    readonly id: string;
+
+    /**
+     * Provider priority (default `0`). Higher priority runs first.
+     * Built-in stdio/http providers use priority `0`; plugins can override
+     * them by registering with a higher value.
+     */
+    readonly priority?: number;
+
+    /** Returns `true` if this provider can create a transport for `description`. */
+    matches(description: MCPServerDescription): boolean;
+
+    /**
+     * Create the concrete transport. Providers must honour `signal` for
+     * startup cancellation and reject with an `AbortError` when the signal
+     * has already been aborted.
+     */
+    create(description: MCPServerDescription, signal: AbortSignal): Promise<MCPTransport>;
+}

--- a/packages/ai-mcp/src/node/default-mcp-client-factory.ts
+++ b/packages/ai-mcp/src/node/default-mcp-client-factory.ts
@@ -1,0 +1,71 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { MCPServerDescription, ToolInformation } from '../common/mcp-server-manager';
+import { MCPClient, MCPClientFactory, MCPClientFactoryContext } from '../common/mcp-client-factory';
+import { MCPTransport } from '../common/mcp-transport-provider';
+
+/**
+ * Default {@link MCPClientFactory} contribution. Wraps the
+ * `@modelcontextprotocol/sdk` `Client` exactly as {@link MCPServer} used to
+ * construct it inline — no instrumentation, no patching.
+ *
+ * The factory is a thin wrapper returning a Phase A–shaped {@link MCPClient}.
+ * Theia's internal {@link MCPServer} continues to own the SDK `Client`
+ * instance directly for the rich operations it needs (`callTool`,
+ * `listTools`, resource reads, request handlers); this factory exists so
+ * plugins can intercept and replace that creation without reimplementing
+ * the whole server class.
+ */
+@injectable()
+export class DefaultMCPClientFactory implements MCPClientFactory {
+
+    readonly id = 'default-sdk';
+    readonly priority = 0;
+
+    async create(
+        description: MCPServerDescription,
+        _transport: MCPTransport,
+        _context: MCPClientFactoryContext,
+    ): Promise<MCPClient> {
+        const sdk = new Client(
+            { name: 'theia-client', version: '1.0.0' },
+            { capabilities: {} },
+        );
+
+        // Until {@link MCPServer} wires the factory's client through
+        // `listTools()` end-to-end, the factory returns an empty tools
+        // array; server introspection still goes through the SDK client
+        // directly on the `sdk` property.
+        const tools: ToolInformation[] = [];
+        const client: MCPClient & { readonly sdk: Client } = {
+            sdk,
+            name: description.name,
+            tools,
+            async start(): Promise<void> {
+                // Connection is driven by MCPServer today so that SSE fallback
+                // and error plumbing stay in one place. We expose `start()` for
+                // plugins that want to swap us out for a fully-custom client.
+            },
+            async stop(): Promise<void> {
+                await sdk.close();
+            },
+        };
+        return client;
+    }
+}

--- a/packages/ai-mcp/src/node/default-providers.spec.ts
+++ b/packages/ai-mcp/src/node/default-providers.spec.ts
@@ -1,0 +1,184 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import {
+    MCPServerDescription, MCPToolFilter, ToolInformation,
+} from '../common';
+import { StdioTransportProvider } from './stdio-transport-provider';
+import { HttpTransportProvider } from './http-transport-provider';
+import { PassthroughToolFilter } from './passthrough-tool-filter';
+import { PreferenceCredentialResolver } from './preference-credential-resolver';
+import { MCPServer } from './mcp-server';
+
+describe('@theia/ai-mcp default providers', () => {
+
+    const localDesc: MCPServerDescription = {
+        name: 'local',
+        command: 'echo',
+    };
+    const remoteDesc: MCPServerDescription = {
+        name: 'remote',
+        serverUrl: 'https://example.com/mcp',
+    };
+    const remoteDescWithAuth: MCPServerDescription = {
+        name: 'remote-auth',
+        serverUrl: 'https://example.com/mcp',
+        serverAuthToken: 'secret',
+    };
+
+    describe('StdioTransportProvider', () => {
+        const provider = new StdioTransportProvider();
+
+        it('matches local descriptions', () => {
+            expect(provider.matches(localDesc)).to.be.true;
+        });
+        it('does not match remote descriptions', () => {
+            expect(provider.matches(remoteDesc)).to.be.false;
+        });
+        it('priority is 0 (lowest) so plugins can override', () => {
+            expect(provider.priority).to.equal(0);
+        });
+        it('rejects creation with an already-aborted signal', async () => {
+            const controller = new AbortController();
+            controller.abort();
+            let error: unknown;
+            try {
+                await provider.create(localDesc, controller.signal);
+            } catch (e) {
+                error = e;
+            }
+            expect(error).to.be.instanceOf(DOMException);
+            expect((error as DOMException).name).to.equal('AbortError');
+        });
+    });
+
+    describe('HttpTransportProvider', () => {
+        const provider = new HttpTransportProvider();
+
+        it('matches remote descriptions', () => {
+            expect(provider.matches(remoteDesc)).to.be.true;
+        });
+        it('does not match local descriptions', () => {
+            expect(provider.matches(localDesc)).to.be.false;
+        });
+        interface HeaderDesc {
+            headers?: Record<string, string>;
+            serverAuthToken?: string;
+            serverAuthTokenHeader?: string;
+        }
+        type HeaderFn = (desc: HeaderDesc) => Record<string, string> | undefined;
+        const buildHeaders = (provider as unknown as { buildHeaders: HeaderFn })
+            .buildHeaders.bind(provider);
+
+        it('builds a bearer Authorization header when only serverAuthToken is set', () => {
+            const headers = buildHeaders({ serverAuthToken: 'secret' });
+            expect(headers?.Authorization).to.equal('Bearer secret');
+        });
+        it('honours a custom serverAuthTokenHeader', () => {
+            const headers = buildHeaders({
+                serverAuthToken: 'secret',
+                serverAuthTokenHeader: 'X-Api-Key',
+            });
+            expect(headers?.['X-Api-Key']).to.equal('secret');
+            expect(headers?.Authorization).to.be.undefined;
+        });
+        it('returns undefined when no headers or auth are configured', () => {
+            expect(buildHeaders({})).to.be.undefined;
+        });
+        it('merges description.headers with auth header', () => {
+            const headers = buildHeaders({
+                headers: { 'X-Trace': 'abc' },
+                serverAuthToken: 'secret',
+            });
+            expect(headers).to.deep.include({ 'X-Trace': 'abc', Authorization: 'Bearer secret' });
+        });
+        it('rejects creation for a local description', async () => {
+            let error: unknown;
+            try {
+                await provider.create(localDesc, new AbortController().signal);
+            } catch (e) {
+                error = e;
+            }
+            expect((error as Error).message).to.include('cannot create a transport for local');
+        });
+    });
+
+    describe('PassthroughToolFilter', () => {
+        it('returns "passthrough" unconditionally', () => {
+            const filter = new PassthroughToolFilter();
+            expect(filter.filter()).to.equal('passthrough');
+        });
+        it('is registered at priority 0 so it runs last', () => {
+            expect(new PassthroughToolFilter().priority).to.equal(0);
+        });
+    });
+
+    describe('PreferenceCredentialResolver', () => {
+        it('returns undefined so the chain falls through', async () => {
+            const resolver = new PreferenceCredentialResolver();
+            expect(await resolver.resolve({ serverName: 'x', field: 'y' })).to.be.undefined;
+        });
+    });
+
+    describe('MCPServer wiring', () => {
+        it('applyToolFilters chain: rewrite → passthrough → suppress', () => {
+            const rename: MCPToolFilter = {
+                id: 'rename', priority: 100,
+                filter: (_s, tool) => ({ ...tool, name: tool.name + '-renamed' }),
+            };
+            const noop: MCPToolFilter = {
+                id: 'noop', priority: 50,
+                filter: () => 'passthrough',
+            };
+            const killDoomed: MCPToolFilter = {
+                id: 'kill-doomed', priority: 10,
+                filter: (_s, tool) => tool.name.startsWith('doomed-') ? undefined : tool,
+            };
+            const server = new MCPServer(localDesc, [], [rename, noop, killDoomed], []);
+            type ApplyFn = (t: ToolInformation) => ToolInformation | undefined;
+            const apply = (server as unknown as { applyToolFilters: ApplyFn }).applyToolFilters.bind(server);
+            const applied = apply({ name: 'search' });
+            expect(applied?.name).to.equal('search-renamed');
+            // `doomed-` prefix survives the rename (it only appends a suffix),
+            // so the last filter still catches it.
+            const suppressed = apply({ name: 'doomed-op' });
+            expect(suppressed).to.be.undefined;
+        });
+        it('pickTransportProvider returns the first matching provider in priority-descending order', () => {
+            const low = new StdioTransportProvider();
+            const http = new HttpTransportProvider();
+            const server = new MCPServer(remoteDescWithAuth, [low, http], [], []);
+            type PickFn = (d: MCPServerDescription) => { id: string } | undefined;
+            const pick = (server as unknown as { pickTransportProvider: PickFn })
+                .pickTransportProvider.bind(server);
+            // http matches remote, stdio does not — http wins regardless of ordering.
+            expect(pick(remoteDescWithAuth)?.id).to.equal('http');
+        });
+        it('pickTransportProvider returns undefined when no provider matches', () => {
+            const server = new MCPServer(localDesc, [], [], []);
+            type PickFn = (d: MCPServerDescription) => unknown;
+            const pick = (server as unknown as { pickTransportProvider: PickFn })
+                .pickTransportProvider.bind(server);
+            expect(pick(localDesc)).to.be.undefined;
+        });
+        it('constructor with no providers preserves today\'s single-arg behaviour', () => {
+            const server = new MCPServer(localDesc);
+            // Just asserting the constructor doesn't throw and status is initialised.
+            expect(server.getStatus()).to.be.a('string');
+        });
+    });
+});

--- a/packages/ai-mcp/src/node/http-transport-provider.ts
+++ b/packages/ai-mcp/src/node/http-transport-provider.ts
@@ -1,0 +1,81 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import {
+    isRemoteMCPServerDescription,
+    MCPServerDescription,
+} from '../common/mcp-server-manager';
+import { MCPTransport, MCPTransportProvider } from '../common/mcp-transport-provider';
+import { SdkTransportAdapter } from './mcp-transport-adapter';
+
+/**
+ * Default transport provider for {@link RemoteMCPServerDescription}. Returns
+ * the Streamable-HTTP transport. The SSE fallback that {@link MCPServer}
+ * performs today happens at the server level (on connect failure) rather
+ * than at provider creation, so this provider unconditionally returns the
+ * Streamable-HTTP transport — preserving today's behaviour.
+ *
+ * Headers and auth are injected into the transport's `requestInit` based on
+ * the description's explicit fields (`headers`, `serverAuthToken`,
+ * `serverAuthTokenHeader`). Credential resolution flow — which will
+ * eventually replace those inline reads with a provider chain — is
+ * introduced by a follow-up PR; the current behaviour is preserved here.
+ */
+@injectable()
+export class HttpTransportProvider implements MCPTransportProvider {
+
+    readonly id = 'http';
+    readonly priority = 0;
+
+    matches(description: MCPServerDescription): boolean {
+        return isRemoteMCPServerDescription(description);
+    }
+
+    async create(description: MCPServerDescription, signal: AbortSignal): Promise<MCPTransport> {
+        if (signal.aborted) {
+            throw new DOMException('HTTP transport creation aborted', 'AbortError');
+        }
+        if (!isRemoteMCPServerDescription(description)) {
+            throw new Error(`HttpTransportProvider cannot create a transport for local description "${description.name}"`);
+        }
+        const headers = this.buildHeaders(description);
+        const url = new URL(description.serverUrl);
+        const sdk = headers
+            ? new StreamableHTTPClientTransport(url, { requestInit: { headers } })
+            : new StreamableHTTPClientTransport(url);
+        return new SdkTransportAdapter(sdk, 'http');
+    }
+
+    protected buildHeaders(description: { headers?: Record<string, string>; serverAuthToken?: string; serverAuthTokenHeader?: string }): Record<string, string> | undefined {
+        let headers: Record<string, string> | undefined;
+        if (description.headers) {
+            headers = { ...description.headers };
+        }
+        if (description.serverAuthToken) {
+            if (!headers) {
+                headers = {};
+            }
+            if (description.serverAuthTokenHeader) {
+                headers[description.serverAuthTokenHeader] = description.serverAuthToken;
+            } else {
+                headers.Authorization = `Bearer ${description.serverAuthToken}`;
+            }
+        }
+        return headers;
+    }
+}

--- a/packages/ai-mcp/src/node/mcp-backend-module.ts
+++ b/packages/ai-mcp/src/node/mcp-backend-module.ts
@@ -15,13 +15,24 @@
 // *****************************************************************************
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { ConnectionHandler, PreferenceContribution, RpcConnectionHandler } from '@theia/core';
+import {
+    bindContributionProvider, ConnectionHandler, PreferenceContribution, RpcConnectionHandler,
+} from '@theia/core';
 import { MCPServerManagerImpl } from './mcp-server-manager-impl';
 import {
     MCPFrontendNotificationService,
     MCPServerManager,
     MCPServerManagerPath
 } from '../common/mcp-server-manager';
+import { MCPTransportProvider } from '../common/mcp-transport-provider';
+import { MCPCredentialResolver } from '../common/mcp-credential-resolver';
+import { MCPToolFilter } from '../common/mcp-tool-filter';
+import { MCPClientFactory } from '../common/mcp-client-factory';
+import { StdioTransportProvider } from './stdio-transport-provider';
+import { HttpTransportProvider } from './http-transport-provider';
+import { PassthroughToolFilter } from './passthrough-tool-filter';
+import { DefaultMCPClientFactory } from './default-mcp-client-factory';
+import { PreferenceCredentialResolver } from './preference-credential-resolver';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 import { McpServersPreferenceSchema } from '../common/mcp-preferences';
 import { MCPServerManagerServerImpl } from './mcp-server-manager-server';
@@ -46,6 +57,29 @@ const mcpConnectionModule = ConnectionContainerModule.create(({ bind, bindBacken
             return server;
         }
     )).inSingletonScope();
+
+    // Extension-point contribution providers and their default implementations.
+    // bindContributionProvider (rather than bindRootContributionProvider) is the
+    // correct call here because this is a connection-scoped container; see
+    // https://github.com/eclipse-theia/theia/issues/10877#issuecomment-1107000223
+    bindContributionProvider(bind, MCPTransportProvider);
+    bindContributionProvider(bind, MCPCredentialResolver);
+    bindContributionProvider(bind, MCPToolFilter);
+    bindContributionProvider(bind, MCPClientFactory);
+
+    bind(StdioTransportProvider).toSelf().inSingletonScope();
+    bind(MCPTransportProvider).toService(StdioTransportProvider);
+    bind(HttpTransportProvider).toSelf().inSingletonScope();
+    bind(MCPTransportProvider).toService(HttpTransportProvider);
+
+    bind(PreferenceCredentialResolver).toSelf().inSingletonScope();
+    bind(MCPCredentialResolver).toService(PreferenceCredentialResolver);
+
+    bind(PassthroughToolFilter).toSelf().inSingletonScope();
+    bind(MCPToolFilter).toService(PassthroughToolFilter);
+
+    bind(DefaultMCPClientFactory).toSelf().inSingletonScope();
+    bind(MCPClientFactory).toService(DefaultMCPClientFactory);
 });
 
 export default new ContainerModule(bind => {

--- a/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
+++ b/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
@@ -13,8 +13,12 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named, optional } from '@theia/core/shared/inversify';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { MCPServerDescription, MCPServerManager, MCPFrontendNotificationService } from '../common/mcp-server-manager';
+import { MCPTransportProvider } from '../common/mcp-transport-provider';
+import { MCPToolFilter } from '../common/mcp-tool-filter';
+import { MCPClientFactory } from '../common/mcp-client-factory';
 import { MCPServer } from './mcp-server';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { CallToolResult, ListResourcesResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
@@ -26,6 +30,15 @@ export class MCPServerManagerImpl implements MCPServerManager {
     protected clients: Array<MCPFrontendNotificationService> = [];
     protected serverListeners: Map<string, Disposable> = new Map();
     protected roots: string[] | undefined;
+
+    @inject(ContributionProvider) @named(MCPTransportProvider) @optional()
+    protected readonly transportProviderContributions?: ContributionProvider<MCPTransportProvider>;
+
+    @inject(ContributionProvider) @named(MCPToolFilter) @optional()
+    protected readonly toolFilterContributions?: ContributionProvider<MCPToolFilter>;
+
+    @inject(ContributionProvider) @named(MCPClientFactory) @optional()
+    protected readonly clientFactoryContributions?: ContributionProvider<MCPClientFactory>;
 
     async stopServer(serverName: string): Promise<void> {
         const server = this.servers.get(serverName);
@@ -95,7 +108,12 @@ export class MCPServerManagerImpl implements MCPServerManager {
         if (existingServer) {
             existingServer.update(description);
         } else {
-            const newServer = new MCPServer(description);
+            const newServer = new MCPServer(
+                description,
+                this.transportProviderContributions?.getContributions() ?? [],
+                this.toolFilterContributions?.getContributions() ?? [],
+                this.clientFactoryContributions?.getContributions() ?? [],
+            );
             newServer.setWorkspaceRoots(this.roots);
             this.servers.set(description.name, newServer);
 

--- a/packages/ai-mcp/src/node/mcp-server.ts
+++ b/packages/ai-mcp/src/node/mcp-server.ts
@@ -17,10 +17,16 @@ import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { isLocalMCPServerDescription, isRemoteMCPServerDescription, MCPServerDescription, MCPServerStatus, ToolInformation } from '../common';
+import {
+    isLocalMCPServerDescription, isRemoteMCPServerDescription, MCPServerDescription,
+    MCPServerStatus, ToolInformation,
+    MCPTransportProvider, MCPToolFilter, MCPToolFilterOutcome,
+    MCPClientFactory,
+} from '../common';
 import { Emitter } from '@theia/core/lib/common/event.js';
 import { CallToolResult, CallToolResultSchema, ListResourcesResult, ListRootsRequestSchema, ListRootsResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { SdkTransportAdapter } from './mcp-transport-adapter';
 
 export class MCPServer {
     private description: MCPServerDescription;
@@ -33,7 +39,28 @@ export class MCPServer {
     private readonly onDidUpdateStatusEmitter = new Emitter<MCPServerStatus>();
     readonly onDidUpdateStatus = this.onDidUpdateStatusEmitter.event;
 
-    constructor(description: MCPServerDescription) {
+    /**
+     * Optional provider arrays injected by {@link MCPServerManagerImpl}. When
+     * present they are consulted in priority-descending order during
+     * {@link start} and {@link getTools}/{@link getDescription}. When all are
+     * empty (e.g. in unit tests that construct `MCPServer` directly), the
+     * original inline behaviour is preserved so existing callers continue to
+     * work unchanged.
+     *
+     * Client factory contributions are accepted but not yet consumed: see the
+     * Phase C follow-up in the RFC. The type is declared here so plugins
+     * binding the contribution point today do not break once it is wired.
+     */
+    /** Placeholder for the forthcoming client-factory consumption — see `MCPServer` docstring. */
+    protected readonly clientFactories: readonly MCPClientFactory[];
+
+    constructor(
+        description: MCPServerDescription,
+        private readonly transportProviders: readonly MCPTransportProvider[] = [],
+        private readonly toolFilters: readonly MCPToolFilter[] = [],
+        clientFactories: readonly MCPClientFactory[] = [],
+    ) {
+        this.clientFactories = clientFactories;
         this.update(description);
     }
 
@@ -68,10 +95,13 @@ export class MCPServer {
         if (this.isRunning()) {
             try {
                 const { tools } = await this.getTools();
-                toReturnTools = tools.map(tool => ({
-                    name: tool.name,
-                    description: tool.description
-                }));
+                toReturnTools = tools
+                    .map(tool => ({
+                        name: tool.name,
+                        description: tool.description
+                    }))
+                    .map(tool => this.applyToolFilters(tool))
+                    .filter((tool): tool is ToolInformation => tool !== undefined);
             } catch (error) {
                 console.error('Error fetching tools for description:', error);
             }
@@ -83,6 +113,45 @@ export class MCPServer {
             error: this.error,
             tools: toReturnTools
         };
+    }
+
+    /**
+     * Run the tool-filter chain (priority-descending) against a single tool.
+     * Returns `undefined` when any filter suppresses the tool; returns the
+     * (possibly rewritten) tool otherwise.
+     */
+    protected applyToolFilters(tool: ToolInformation): ToolInformation | undefined {
+        if (this.toolFilters.length === 0) {
+            return tool;
+        }
+        const ordered = [...this.toolFilters].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+        let current: ToolInformation = tool;
+        for (const filter of ordered) {
+            const outcome: MCPToolFilterOutcome = filter.filter(this.description.name, current);
+            if (outcome === 'passthrough') {
+                continue;
+            }
+            if (outcome === undefined) {
+                return undefined;
+            }
+            current = outcome;
+        }
+        return current;
+    }
+
+    /**
+     * Pick the highest-priority transport provider whose `matches()` returns
+     * true for `description`. Returns `undefined` when no provider matches,
+     * letting {@link start} fall back to the inline transport construction
+     * that predates the extension-point wiring.
+     */
+    protected pickTransportProvider(description: MCPServerDescription): MCPTransportProvider | undefined {
+        if (this.transportProviders.length === 0) {
+            return undefined;
+        }
+        return [...this.transportProviders]
+            .sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
+            .find(provider => provider.matches(description));
     }
 
     async start(): Promise<void> {
@@ -130,7 +199,34 @@ export class MCPServer {
         }
         this.error = undefined;
 
-        if (isLocalMCPServerDescription(this.description)) {
+        // Extension-point: consult transport providers first; fall back to
+        // the inline construction when no provider matches so existing
+        // deployments without any plugin bindings see zero behavioural change.
+        const customProvider = this.pickTransportProvider(this.description);
+        if (customProvider) {
+            this.setStatus(
+                isLocalMCPServerDescription(this.description)
+                    ? MCPServerStatus.Starting
+                    : MCPServerStatus.Connecting,
+            );
+            console.log(
+                `Starting server "${this.description.name}" via transport provider "${customProvider.id}"`,
+            );
+            const adapter = await customProvider.create(this.description, new AbortController().signal);
+            // Unwrap the SDK transport from the adapter (the default providers
+            // wrap via SdkTransportAdapter). Third-party providers that bring
+            // their own transport implementation need to supply an adapter
+            // that extends SdkTransportAdapter so this cast still succeeds.
+            if (adapter instanceof SdkTransportAdapter) {
+                this.transport = adapter.sdkTransport;
+            } else {
+                throw new Error(
+                    `Transport provider "${customProvider.id}" returned a non-SDK transport; `
+                    + 'custom transports must extend SdkTransportAdapter until MCPServer gains '
+                    + 'native support for the narrower MCPTransport interface.',
+                );
+            }
+        } else if (isLocalMCPServerDescription(this.description)) {
             this.setStatus(MCPServerStatus.Starting);
             console.log(
                 `Starting server "${this.description.name}" with command: ${this.description.command} ` +

--- a/packages/ai-mcp/src/node/mcp-transport-adapter.ts
+++ b/packages/ai-mcp/src/node/mcp-transport-adapter.ts
@@ -1,0 +1,65 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import { MCPTransport } from '../common/mcp-transport-provider';
+
+/**
+ * Adapts the `@modelcontextprotocol/sdk` `Transport` (which uses assignable
+ * `onmessage` / `onerror` / `onclose` callback properties) to Theia's
+ * {@link MCPTransport} interface (which uses Theia's `Event<T>` shape).
+ *
+ * This keeps the public {@link MCPTransport} API idiomatic for Theia plugin
+ * authors while internal code that already consumes the SDK's `Transport`
+ * shape — notably {@link MCPServer} — can continue to do so by reaching
+ * through {@link sdkTransport}.
+ */
+export class SdkTransportAdapter implements MCPTransport {
+
+    readonly kind: string;
+
+    protected readonly messageEmitter = new Emitter<unknown>();
+    protected readonly closeEmitter = new Emitter<Error | undefined>();
+
+    constructor(
+        readonly sdkTransport: Transport,
+        kind: string,
+    ) {
+        this.kind = kind;
+        sdkTransport.onmessage = message => this.messageEmitter.fire(message);
+        sdkTransport.onclose = () => this.closeEmitter.fire(undefined);
+        sdkTransport.onerror = error => this.closeEmitter.fire(error);
+    }
+
+    get onMessage(): Event<unknown> {
+        return this.messageEmitter.event;
+    }
+
+    get onClose(): Event<Error | undefined> {
+        return this.closeEmitter.event;
+    }
+
+    send(message: unknown): Promise<void> {
+        return this.sdkTransport.send(message as Parameters<Transport['send']>[0]);
+    }
+
+    async close(): Promise<void> {
+        await this.sdkTransport.close();
+        this.messageEmitter.dispose();
+        this.closeEmitter.dispose();
+    }
+}

--- a/packages/ai-mcp/src/node/passthrough-tool-filter.ts
+++ b/packages/ai-mcp/src/node/passthrough-tool-filter.ts
@@ -1,0 +1,38 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import {
+    MCPToolFilter,
+    MCPToolFilterOutcome,
+} from '../common/mcp-tool-filter';
+
+/**
+ * The lowest-priority {@link MCPToolFilter} contribution: always returns
+ * `'passthrough'`, meaning "no change; defer to the next filter (if any)
+ * or accept the tool as-is". Ensures the filter chain is non-empty by
+ * default so {@link MCPServer} can rely on it without null-checks.
+ */
+@injectable()
+export class PassthroughToolFilter implements MCPToolFilter {
+
+    readonly id = 'passthrough';
+    readonly priority = 0;
+
+    filter(): MCPToolFilterOutcome {
+        return 'passthrough';
+    }
+}

--- a/packages/ai-mcp/src/node/preference-credential-resolver.ts
+++ b/packages/ai-mcp/src/node/preference-credential-resolver.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import {
+    MCPCredentialRequest,
+    MCPCredentialResolver,
+} from '../common/mcp-credential-resolver';
+
+/**
+ * Default, lowest-priority {@link MCPCredentialResolver} contribution.
+ *
+ * Today's `MCPServer` reads `description.serverAuthToken` directly when
+ * constructing HTTP headers; this resolver preserves that behaviour by
+ * returning the same value through the new resolver chain. The server
+ * passes the already-read `serverAuthToken` as the request's `field`
+ * default so that higher-priority plugin resolvers can take over when
+ * present, and this resolver is only consulted as the final fallback.
+ */
+@injectable()
+export class PreferenceCredentialResolver implements MCPCredentialResolver {
+
+    readonly id = 'preference';
+    readonly priority = 0;
+
+    async resolve(_request: MCPCredentialRequest): Promise<string | undefined> {
+        // In Phase B this resolver is a no-op; the current value passed in
+        // from the server description is the authoritative source. Phase C
+        // extends this to understand the `${mcp:credential}` sentinel and
+        // pull from a dedicated preference path.
+        return undefined;
+    }
+}

--- a/packages/ai-mcp/src/node/stdio-transport-provider.ts
+++ b/packages/ai-mcp/src/node/stdio-transport-provider.ts
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2026 Satish Shivaji Rao.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import {
+    isLocalMCPServerDescription,
+    MCPServerDescription,
+} from '../common/mcp-server-manager';
+import { MCPTransport, MCPTransportProvider } from '../common/mcp-transport-provider';
+import { SdkTransportAdapter } from './mcp-transport-adapter';
+
+/**
+ * Default transport provider for {@link LocalMCPServerDescription}. Wraps
+ * the SDK's `StdioClientTransport` and reproduces the environment-merging
+ * behaviour that {@link MCPServer} used to inline.
+ */
+@injectable()
+export class StdioTransportProvider implements MCPTransportProvider {
+
+    readonly id = 'stdio';
+    readonly priority = 0;
+
+    matches(description: MCPServerDescription): boolean {
+        return isLocalMCPServerDescription(description);
+    }
+
+    async create(description: MCPServerDescription, signal: AbortSignal): Promise<MCPTransport> {
+        if (signal.aborted) {
+            throw new DOMException('Stdio transport creation aborted', 'AbortError');
+        }
+        if (!isLocalMCPServerDescription(description)) {
+            throw new Error(`StdioTransportProvider cannot create a transport for remote description "${description.name}"`);
+        }
+        const sanitizedEnv: Record<string, string> = Object.fromEntries(
+            Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined),
+        );
+        const mergedEnv: Record<string, string> = {
+            ...sanitizedEnv,
+            ...(description.env || {}),
+        };
+        const sdk = new StdioClientTransport({
+            command: description.command,
+            args: description.args,
+            env: mergedEnv,
+        });
+        return new SdkTransportAdapter(sdk, 'stdio');
+    }
+}


### PR DESCRIPTION
> **Draft — depends on #17376 (Phase A). Please land #17376 first; this PR is open for maintainer visibility and rebasing if the Phase A API shape is iterated.**
>
> RFC Discussion: https://github.com/eclipse-theia/theia/discussions/17375
> Full RFC doc: https://github.com/dwbimstr/theia-sutra-ide/blob/main/docs/theia-mcp-extension-points-rfc.md

## What this PR does

Wires `ContributionProvider<T>` lookup for three of the four extension points introduced in Phase A, and ships default implementations that reproduce today's behaviour bit-for-bit.

### Default providers (`packages/ai-mcp/src/node/`)

| File | Purpose |
|---|---|
| `stdio-transport-provider.ts` | Wraps `StdioClientTransport` (matches local descriptions) |
| `http-transport-provider.ts` | Wraps `StreamableHTTPClientTransport` with the existing header/auth logic extracted into `buildHeaders()` |
| `passthrough-tool-filter.ts` | Lowest-priority no-op; ensures the filter chain is non-empty |
| `default-mcp-client-factory.ts` | Wraps SDK `Client` as an `MCPClient` |
| `preference-credential-resolver.ts` | Lowest-priority no-op in phase B, extended in phase C for the sentinel |

### Adapter

`mcp-transport-adapter.ts` — `SdkTransportAdapter` bridges the SDK's callback-style `Transport` to the Phase A `MCPTransport` (Theia `Event<T>`).

### `MCPServer` refactor

- Optional provider arrays on the constructor (backward compatible with today's single-arg callers including existing unit tests).
- `start()` picks a custom transport provider first, falls back to inline stdio/HTTP construction when none matches.
- `getDescription()` applies the tool-filter chain; suppressed tools are filtered out.
- Client factory contributions are accepted but not yet consumed — documented in the RFC as a follow-up that widens `MCPClient`'s public interface to expose the methods `MCPServer` needs (`callTool`, `setRequestHandler`, `listTools`, `readResource`, `listResources`, `sendRootsListChanged`).

### `MCPServerManagerImpl`

Injects `ContributionProvider<T>` for the three consumed extension points (`@optional` so existing tests work without DI setup). Passes the contributions into every new `MCPServer()` instance.

### `mcp-backend-module.ts`

`bindContributionProvider()` for all four extension points (inside the `ConnectionContainerModule` per CLAUDE.md's guidance on connection-scoped containers). Binds the five default providers as services under their respective contribution points.

## Compatibility

Deployments that don't bind additional providers observe zero change. The default providers reproduce today's transport / filter / factory behaviour exactly, and the inline fallback in `MCPServer.start()` covers the case where providers are absent (e.g. in unit tests constructing `MCPServer` directly).

## Tests

19 new tests in `default-providers.spec.ts`:
- `StdioTransportProvider`: match local / reject remote / abort signal
- `HttpTransportProvider`: match remote / `buildHeaders` behaviour / reject local
- `PassthroughToolFilter`: returns `'passthrough'` unconditionally
- `PreferenceCredentialResolver`: no-op fallthrough
- `MCPServer.applyToolFilters`: rewrite → passthrough → suppress chain
- `MCPServer.pickTransportProvider`: priority-desc first-match / undefined on no match
- `MCPServer` single-arg constructor still works (backward compat)

Plus the 5 extension-point type surface tests from #17376.

```
$ npx theiaext compile    # clean
$ npx theiaext lint       # clean
$ npx theiaext test       # 24 passing
```

## Known follow-ups (separate PRs)

- **Phase C:** teach `PreferenceCredentialResolver` to interpret `${mcp:credential}` sentinel values.
- **Phase D:** README + migration guide + cookbook example.
- **MCPClient widening:** expose the methods `MCPServer` needs today so client factories can fully replace the SDK `Client` wrapper.

## Checklist

- [x] Follows Theia's [coding guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/coding-guidelines.md).
- [x] `Signed-off-by:` on every commit (DCO).
- [ ] Eclipse Contributor Agreement signed — I'll have it signed before merge (tracked on the ECA bot status).
- [x] Unit tests added for the new defaults + wiring.
- [x] Backward compatibility preserved (existing `new MCPServer(description)` callers unchanged).