### PR TITLE
Feat/message add source view

### DIFF
--- a/packages/core/src/common/message-service-protocol.ts
+++ b/packages/core/src/common/message-service-protocol.ts
@@ -65,6 +65,7 @@ export interface MessageOptions {
      * `0` and negative values are treated as no timeout.
      */
     readonly timeout?: number;
+    readonly source?: string;
 }
 
 export interface ProgressMessageOptions extends MessageOptions {

--- a/packages/core/src/common/message-service.ts
+++ b/packages/core/src/common/message-service.ts
@@ -147,7 +147,7 @@ export class MessageService {
             const options = (typeof first === 'object' && !Array.isArray(first))
                 ? <MessageOptions>first
                 : undefined;
-            return this.client.showMessage({ type, options, text, actions });
+            return this.client.showMessage({ type, options, text, actions, source: options?.source });
         }
         return this.client.showMessage({ type, text });
     }

--- a/packages/messages/src/browser/notifications-manager.ts
+++ b/packages/messages/src/browser/notifications-manager.ts
@@ -194,7 +194,7 @@ export class NotificationManager extends MessageClient {
         const source = plainMessage.source;
         const expandable = this.isExpandable(message, source, actions);
         const collapsed = expandable;
-        const notification = { messageId, message, type, actions, expandable, collapsed };
+        const notification = { messageId, message, type, actions, expandable, collapsed, source };
         this.notifications.set(messageId, notification);
         const result = new Deferred<string | undefined>();
         this.deferredResults.set(messageId, result);

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -491,6 +491,7 @@ export enum MainMessageType {
 }
 
 export interface MainMessageOptions {
+    source?: string;
     detail?: string;
     modal?: boolean
     onCloseActionHandle?: number

--- a/packages/plugin-ext/src/main/common/basic-message-registry-main.ts
+++ b/packages/plugin-ext/src/main/common/basic-message-registry-main.ts
@@ -41,11 +41,11 @@ export class BasicMessageRegistryMainImpl implements MessageRegistryMain {
         // Modal notifications are not supported in this context
         switch (type) {
             case MainMessageType.Info:
-                return this.messageService.info(message, ...actions.map(a => a.title));
+                return this.messageService.info(message, options, ...actions.map(a => a.title));
             case MainMessageType.Warning:
-                return this.messageService.warn(message, ...actions.map(a => a.title));
+                return this.messageService.warn(message, options, ...actions.map(a => a.title));
             case MainMessageType.Error:
-                return this.messageService.error(message, ...actions.map(a => a.title));
+                return this.messageService.error(message, options, ...actions.map(a => a.title));
         }
         throw new Error(`Message type '${type}' is not supported yet!`);
     }

--- a/packages/plugin-ext/src/plugin/message-registry.ts
+++ b/packages/plugin-ext/src/plugin/message-registry.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import {
-    PLUGIN_RPC_CONTEXT as Ext, MessageRegistryMain, MainMessageOptions, MainMessageType
+    Plugin, PLUGIN_RPC_CONTEXT as Ext, MessageRegistryMain, MainMessageOptions, MainMessageType
 } from '../common/plugin-api-rpc';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { MessageItem, MessageOptions } from '@theia/plugin';
@@ -32,10 +32,13 @@ export class MessageRegistryExt {
         this.proxy = this.rpc.getProxy(Ext.MESSAGE_REGISTRY_MAIN);
     }
 
-    async showMessage(type: MainMessageType, message: string,
+    async showMessage(plugin: Plugin, type: MainMessageType, message: string,
         optionsOrFirstItem?: MessageOptions | string | MessageItem,
         ...rest: (string | MessageItem)[]): Promise<string | MessageItem | undefined> {
-        const options: MainMessageOptions = {};
+        const source = `${plugin.model.publisher}-${plugin.model.displayName || plugin.model.name}`;
+        const options: MainMessageOptions = {
+            source
+        };
         const actions: MessageItem[] = [];
         const items: (string | MessageItem)[] = [];
         const pushItem = (item: string | MessageItem) => {

--- a/packages/plugin-ext/src/plugin/message-registry.ts
+++ b/packages/plugin-ext/src/plugin/message-registry.ts
@@ -35,7 +35,7 @@ export class MessageRegistryExt {
     async showMessage(plugin: Plugin, type: MainMessageType, message: string,
         optionsOrFirstItem?: MessageOptions | string | MessageItem,
         ...rest: (string | MessageItem)[]): Promise<string | MessageItem | undefined> {
-        const source = `${plugin.model.publisher}-${plugin.model.displayName || plugin.model.name}`;
+        const source = `${plugin.model.publisher}.${plugin.model.displayName || plugin.model.name}`;
         const options: MainMessageOptions = {
             source
         };

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -457,9 +457,9 @@ export function createAPIFactory(
         };
 
         const { onDidChangeActiveTerminal, onDidChangeTerminalState, onDidCloseTerminal, onDidOpenTerminal } = terminalExt;
-        const showInformationMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Info);
-        const showWarningMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Warning);
-        const showErrorMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Error);
+        const showInformationMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, plugin, MainMessageType.Info);
+        const showWarningMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, plugin, MainMessageType.Warning);
+        const showErrorMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, plugin, MainMessageType.Error);
         const window: typeof theia.window = {
 
             get activeTerminal(): theia.Terminal | undefined {

--- a/packages/plugin-ext/src/plugin/workspace.ts
+++ b/packages/plugin-ext/src/plugin/workspace.ts
@@ -30,6 +30,7 @@ import {
     WorkspaceMain,
     PLUGIN_RPC_CONTEXT as Ext,
     MainMessageType,
+    Plugin
 } from '../common/plugin-api-rpc';
 import { Path } from '@theia/core/lib/common/path';
 import { RPCProtocol } from '../common/rpc-protocol';
@@ -454,7 +455,7 @@ export class WorkspaceExtImpl implements WorkspaceExt {
 
         // Trigger on main side
         this.proxy.$updateWorkspaceFolders(start, deleteCount, ...rootsToAdd).then(undefined, error =>
-            this.messageService.showMessage(MainMessageType.Error, `Failed to update workspace folders: ${error}`)
+            this.messageService.showMessage({} as Plugin, MainMessageType.Error, `Failed to update workspace folders: ${error}`)
         );
 
         return true;


### PR DESCRIPTION
### Title

Add support for displaying message source in the notification system

### What it does

This PR adds support for displaying the **source view** of messages by introducing a `source` field to the message system. This allows messages to be tagged with their origin (e.g., plugin name), making it easier for users to identify which extension or component sent a particular message.

### How to test

1. Open a plugin that shows messages (notifications, alerts, etc.)
2. Verify that messages now display the source information (plugin publisher and name)
3. Messages from different sources should be distinguishable in the notification center
4. Test with both core messages and plugin-generated messages to ensure source is properly tracked

#### Follow-ups

none

#### Breaking changes

none

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

### Related Issue

- Fixes #17382
---
