### PR TITLE
ai-chat-ui: warn when chat session token usage crosses a threshold

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -31,8 +31,8 @@ import { ImageContextVariable } from '@theia/ai-chat/lib/common/image-context-va
 import { AgentCompletionNotificationService, FrontendVariableService, AIActivationService, CompletionNotificationOptions } from '@theia/ai-core/lib/browser';
 import { AISettingsService, PromptService } from '@theia/ai-core/lib/common';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
-import { DisposableCollection, Emitter, InMemoryResources, URI, nls, Disposable } from '@theia/core';
-import { ContextMenuRenderer, HoverService, LabelProvider, Message, OpenerService, ReactWidget } from '@theia/core/lib/browser';
+import { CommandService, DisposableCollection, Emitter, InMemoryResources, MessageService, URI, nls, Disposable } from '@theia/core';
+import { CommonCommands, ContextMenuRenderer, HoverService, LabelProvider, Message, OpenerService, ReactWidget } from '@theia/core/lib/browser';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
@@ -59,11 +59,21 @@ import { ChatInputFocusService } from './chat-input-focus-service';
 import { AvailableGenericCapabilities, GenericCapabilitiesService } from './generic-capabilities-service';
 import { GenericCapabilitiesSection } from './generic-capabilities-section';
 import { PreferenceService } from '@theia/core/lib/common/preferences';
-import { CHAT_VIEW_TOKEN_USAGE_ENABLED } from './chat-view-preferences';
 import {
-    computeSessionTokenUsage, getUsageColorClass,
-    getLatestTokenUsage, buildBarTooltip, CHAT_CONTEXT_WINDOW_SIZE
+    CHAT_VIEW_TOKEN_USAGE_ENABLED,
+    CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED,
+    CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE,
+    CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE_DEFAULT
+} from './chat-view-preferences';
+import {
+    buildBarTooltip,
+    CHAT_CONTEXT_WINDOW_SIZE,
+    computeSessionTokenUsage,
+    decideTokenUsageWarning,
+    getLatestTokenUsage,
+    getUsageColorClass
 } from './chat-token-usage-indicator-util';
+import { AI_CHAT_NEW_CHAT_WINDOW_COMMAND, ChatCommands } from './chat-view-commands';
 
 type Query = (query: string, mode?: string, capabilityOverrides?: Record<string, boolean>, genericCapabilitySelections?: GenericCapabilitySelections) => Promise<void>;
 type Unpin = () => void;
@@ -176,7 +186,15 @@ export class AIChatInputWidget extends ReactWidget {
     @inject(PreferenceService) @optional()
     protected readonly preferenceService: PreferenceService | undefined;
 
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
     protected tokenUsageEnabled = false;
+    /** Sessions we have already notified for the current warning cycle (re-armed when usage drops below the threshold). */
+    protected readonly notifiedSessions = new Set<string>();
 
     protected navigationState: ChatInputNavigationState;
 
@@ -727,7 +745,11 @@ export class AIChatInputWidget extends ReactWidget {
         // Restore capability overrides and generic selections from the last request in this session (if any)
         this.userCapabilityOverrides = this.getLastCapabilityOverridesFromModel(chatModel);
         this.genericCapabilitySelections = this.getLastGenericCapabilitySelectionsFromModel(chatModel);
+
         this.onDisposeForChatModel.push(chatModel.onDidChange(event => {
+            if (event.kind === 'responseChanged') {
+                this.evaluateTokenUsageWarning(chatModel);
+            }
             if (event.kind === 'addVariable') {
                 // Validate files added via any path (including LLM tool calls)
                 // Get the current variables and validate any new file variables
@@ -751,6 +773,16 @@ export class AIChatInputWidget extends ReactWidget {
             }
         }));
         this._chatModel = chatModel;
+        // Evaluate the warning on attach. `notifiedSessions` lives on this widget
+        // instance, so the warning fires at most once per (widget lifetime × session):
+        // - Within the same widget, switching between sessions that have already been
+        //   notified does not re-notify.
+        // - Closing and reopening the chat view creates a fresh widget with an empty
+        //   Set, so sessions still above the threshold will be warned about again the
+        //   first time they are shown after reopen — once per session. Accepted as a
+        //   rare corner case; promoting the state to the ChatSession would avoid it
+        //   but isn't worth the coupling today.
+        this.evaluateTokenUsageWarning(chatModel);
         this.scheduleUpdateReceivingAgent();
         this.update();
     }
@@ -796,6 +828,22 @@ export class AIChatInputWidget extends ReactWidget {
                 } else if (change.preferenceName === PREFERENCE_NAME_REASONING) {
                     // Refresh the reasoning selector display when the default preference changes.
                     this.update();
+                } else if (change.preferenceName === CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE) {
+                    // Threshold changed: clear notified sessions so users are warned again
+                    // at the new threshold (e.g. after raising it from the warning's
+                    // "Open Settings" action), and re-evaluate the current session so the
+                    // warning appears immediately if it's still above the new threshold.
+                    this.notifiedSessions.clear();
+                    if (this._chatModel) {
+                        this.evaluateTokenUsageWarning(this._chatModel);
+                    }
+                    // Re-render so the indicator's color bands reflect the new threshold.
+                    this.update();
+                } else if (change.preferenceName === CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED && this._chatModel) {
+                    // If the user just enabled warnings for a session already above threshold,
+                    // evaluate now so they get an immediate notification instead of waiting for
+                    // the next response.
+                    this.evaluateTokenUsageWarning(this._chatModel);
                 }
             }));
         }
@@ -871,6 +919,88 @@ export class AIChatInputWidget extends ReactWidget {
 
         this.chatInputFirstLineKey.set(isFirstVisualOverall);
         this.chatInputLastLineKey.set(isLastVisualOverall);
+    }
+
+    /**
+     * Resolve the configured token usage warning threshold as an absolute token count.
+     * The preference is stored as a percentage of the context window; this method
+     * converts it using the current assumed context window size.
+     */
+    protected getTokenUsageWarningThreshold(): number {
+        const percentage = this.getTokenUsageWarningThresholdPercentage();
+        return Math.round((percentage / 100) * CHAT_CONTEXT_WINDOW_SIZE);
+    }
+
+    protected getTokenUsageWarningThresholdPercentage(): number {
+        const value = this.preferenceService?.get<number>(
+            CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE,
+            CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE_DEFAULT
+        );
+        if (typeof value !== 'number' || !Number.isFinite(value) || value < 1 || value > 100) {
+            return CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE_DEFAULT;
+        }
+        return value;
+    }
+
+    protected isTokenUsageWarningEnabled(): boolean {
+        return this.preferenceService?.get<boolean>(CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED, false) ?? false;
+    }
+
+    /**
+     * Called after a response changes on the currently attached session. Shows a
+     * warning the first time the total crosses the threshold, and re-arms when
+     * usage drops back below it.
+     */
+    protected evaluateTokenUsageWarning(chatModel: ChatModel): void {
+        // No point doing any work if the feature is off.
+        if (!this.isTokenUsageWarningEnabled()) {
+            return;
+        }
+        // `responseChanged` fires on every streaming tick, but providers typically
+        // only set `tokenUsage` at completion. Skip in-progress responses so we do
+        // the walk + decision once per response rather than per chunk.
+        const lastRequest = chatModel.getRequests().at(-1);
+        if (lastRequest && !lastRequest.response.isComplete) {
+            return;
+        }
+        const decision = decideTokenUsageWarning({
+            totalTokens: computeSessionTokenUsage(chatModel),
+            threshold: this.getTokenUsageWarningThreshold(),
+            alreadyNotified: this.notifiedSessions.has(chatModel.id)
+        });
+        if (decision === 'reset') {
+            this.notifiedSessions.delete(chatModel.id);
+        } else if (decision === 'notify') {
+            this.notifiedSessions.add(chatModel.id);
+            this.showTokenUsageWarning();
+        }
+    }
+
+    protected async showTokenUsageWarning(): Promise<void> {
+        const percentage = this.getTokenUsageWarningThresholdPercentage();
+        const message = nls.localize(
+            'theia/ai/chat-ui/tokenUsageWarningMessage',
+            'Chat session token usage has reached {0}% of the context window. ' +
+            'Consider summarizing this session or starting a new one to avoid hitting the limit.',
+            percentage
+        );
+        const summarizeAction = nls.localize('theia/ai/chat-ui/tokenUsageWarningSummarizeAction', 'Summarize Current Session');
+        const newSessionAction = nls.localize('theia/ai/chat-ui/tokenUsageWarningNewSessionAction', 'Start New Chat');
+        const openSettingsAction = nls.localizeByDefault('Open Settings');
+        const selected = await this.messageService.warn(message, summarizeAction, newSessionAction, openSettingsAction);
+        if (selected === summarizeAction) {
+            this.commandService.executeCommand(ChatCommands.AI_CHAT_NEW_WITH_TASK_CONTEXT.id).catch(error => {
+                console.error(`Failed to execute '${ChatCommands.AI_CHAT_NEW_WITH_TASK_CONTEXT.id}' from token usage warning`, error);
+            });
+        } else if (selected === newSessionAction) {
+            this.commandService.executeCommand(AI_CHAT_NEW_CHAT_WINDOW_COMMAND.id).catch(error => {
+                console.error(`Failed to execute '${AI_CHAT_NEW_CHAT_WINDOW_COMMAND.id}' from token usage warning`, error);
+            });
+        } else if (selected === openSettingsAction) {
+            this.commandService.executeCommand(CommonCommands.OPEN_PREFERENCES.id, CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE).catch(error => {
+                console.error(`Failed to execute '${CommonCommands.OPEN_PREFERENCES.id}' from token usage warning`, error);
+            });
+        }
     }
 
     protected scheduleUpdateReceivingAgent(): void {
@@ -1202,6 +1332,7 @@ export class AIChatInputWidget extends ReactWidget {
                     hoverService: this.hoverService,
                 }}
                 tokenUsageEnabled={this.tokenUsageEnabled}
+                tokenUsageWarningThreshold={this.getTokenUsageWarningThreshold()}
             />
         );
     }
@@ -1539,6 +1670,7 @@ interface ChatInputProperties {
         hoverService: HoverService;
     };
     tokenUsageEnabled?: boolean;
+    tokenUsageWarningThreshold: number;
 }
 
 // Utility to check if we have task context in the chat model
@@ -1966,12 +2098,12 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     // Show mode selector if agent has multiple modes
     const showModeSelector = (props.modeSelectorProps.receivingAgentModes?.length ?? 0) > 1;
 
-    // Token usage computation
+    // Token usage computation (cheap pure function walking the model's request list)
     const totalTokens = props.tokenUsageEnabled ? computeSessionTokenUsage(props.chatModel) : 0;
     const showTokenUsage = props.tokenUsageEnabled && totalTokens > 0;
-    const tokenColorClass = showTokenUsage ? getUsageColorClass(totalTokens) : '';
+    const tokenColorClass = showTokenUsage ? getUsageColorClass(totalTokens, props.tokenUsageWarningThreshold) : '';
     const tokenIsWarningOrError = tokenColorClass === 'token-usage-yellow' || tokenColorClass === 'token-usage-red';
-    const tokenTooltip = showTokenUsage ? buildBarTooltip(getLatestTokenUsage(props.chatModel), totalTokens) : undefined;
+    const tokenTooltip = showTokenUsage ? buildBarTooltip(getLatestTokenUsage(props.chatModel), totalTokens, props.tokenUsageWarningThreshold) : undefined;
 
     return (
         <div className="theia-ChatInput" data-ai-disabled={!props.isEnabled} onDragOver={props.onDragOver} onDrop={props.onDrop} ref={containerRef}>

--- a/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.spec.ts
@@ -18,13 +18,15 @@ import { expect } from 'chai';
 import { Emitter, Event } from '@theia/core';
 import { ChatModel, ChatRequestModel, ResponseTokenUsage } from '@theia/ai-chat';
 import {
-    CHAT_CONTEXT_WINDOW_SIZE,
     computeSessionTokenUsage,
+    decideTokenUsageWarning,
     formatTokenCount,
-    getUsageColorClass
+    getUsageColorClass,
+    isAboveTokenUsageWarningThreshold
 } from './chat-token-usage-indicator-util';
 
-const CHAT_CONTEXT_WINDOW_WARNING_THRESHOLD = 0.9 * CHAT_CONTEXT_WINDOW_SIZE;
+const THRESHOLD = 100;
+const CONTEXT_WINDOW = 200;
 
 function createMockRequest(tokenUsage?: ResponseTokenUsage, isComplete = true): Partial<ChatRequestModel> {
     return {
@@ -68,23 +70,23 @@ describe('ChatTokenUsageIndicator', () => {
     });
 
     describe('getUsageColorClass', () => {
-        it('should return none for 0 tokens', () => {
-            expect(getUsageColorClass(0)).to.equal('token-usage-none');
+        it('returns none for 0 tokens regardless of threshold', () => {
+            expect(getUsageColorClass(0, THRESHOLD, CONTEXT_WINDOW)).to.equal('token-usage-none');
         });
 
-        it('should return green for tokens below threshold', () => {
-            expect(getUsageColorClass(1)).to.equal('token-usage-green');
-            expect(getUsageColorClass(CHAT_CONTEXT_WINDOW_WARNING_THRESHOLD - 1)).to.equal('token-usage-green');
+        it('returns green for tokens below the threshold', () => {
+            expect(getUsageColorClass(1, THRESHOLD, CONTEXT_WINDOW)).to.equal('token-usage-green');
+            expect(getUsageColorClass(THRESHOLD - 1, THRESHOLD, CONTEXT_WINDOW)).to.equal('token-usage-green');
         });
 
-        it('should return yellow for tokens at or above threshold but below budget', () => {
-            expect(getUsageColorClass(CHAT_CONTEXT_WINDOW_WARNING_THRESHOLD)).to.equal('token-usage-yellow');
-            expect(getUsageColorClass(CHAT_CONTEXT_WINDOW_SIZE - 1)).to.equal('token-usage-yellow');
+        it('returns yellow for tokens at or above the threshold but below the context window size', () => {
+            expect(getUsageColorClass(THRESHOLD, THRESHOLD, CONTEXT_WINDOW)).to.equal('token-usage-yellow');
+            expect(getUsageColorClass(CONTEXT_WINDOW - 1, THRESHOLD, CONTEXT_WINDOW)).to.equal('token-usage-yellow');
         });
 
-        it('should return red for tokens at or above budget', () => {
-            expect(getUsageColorClass(CHAT_CONTEXT_WINDOW_SIZE)).to.equal('token-usage-red');
-            expect(getUsageColorClass(CHAT_CONTEXT_WINDOW_SIZE + 1)).to.equal('token-usage-red');
+        it('returns red for tokens at or above the context window size', () => {
+            expect(getUsageColorClass(CONTEXT_WINDOW, THRESHOLD, CONTEXT_WINDOW)).to.equal('token-usage-red');
+            expect(getUsageColorClass(CONTEXT_WINDOW + 1, THRESHOLD, CONTEXT_WINDOW)).to.equal('token-usage-red');
         });
     });
 
@@ -198,6 +200,63 @@ describe('ChatTokenUsageIndicator', () => {
             ]);
             // Last request with usage: 3000+1000 = 4000
             expect(computeSessionTokenUsage(model)).to.equal(4000);
+        });
+    });
+
+    describe('isAboveTokenUsageWarningThreshold', () => {
+        it('is false for 0 tokens', () => {
+            expect(isAboveTokenUsageWarningThreshold(0, THRESHOLD)).to.equal(false);
+        });
+
+        it('is false for tokens below the threshold', () => {
+            expect(isAboveTokenUsageWarningThreshold(THRESHOLD - 1, THRESHOLD)).to.equal(false);
+        });
+
+        it('is true for tokens at the threshold', () => {
+            expect(isAboveTokenUsageWarningThreshold(THRESHOLD, THRESHOLD)).to.equal(true);
+        });
+
+        it('is true for tokens above the threshold', () => {
+            expect(isAboveTokenUsageWarningThreshold(THRESHOLD + 1, THRESHOLD)).to.equal(true);
+        });
+    });
+
+    describe('decideTokenUsageWarning', () => {
+        it('resets when usage is below the threshold', () => {
+            expect(decideTokenUsageWarning({
+                totalTokens: 50,
+                threshold: THRESHOLD,
+                alreadyNotified: true
+            })).to.equal('reset');
+        });
+
+        it('resets when usage is zero', () => {
+            expect(decideTokenUsageWarning({
+                totalTokens: 0,
+                threshold: THRESHOLD,
+                alreadyNotified: true
+            })).to.equal('reset');
+        });
+
+        it('skips when the session has already been notified', () => {
+            expect(decideTokenUsageWarning({
+                totalTokens: THRESHOLD + 50,
+                threshold: THRESHOLD,
+                alreadyNotified: true
+            })).to.equal('skip');
+        });
+
+        it('notifies when usage crosses the threshold and the session has not been notified yet', () => {
+            expect(decideTokenUsageWarning({
+                totalTokens: THRESHOLD,
+                threshold: THRESHOLD,
+                alreadyNotified: false
+            })).to.equal('notify');
+            expect(decideTokenUsageWarning({
+                totalTokens: THRESHOLD * 2,
+                threshold: THRESHOLD,
+                alreadyNotified: false
+            })).to.equal('notify');
         });
     });
 });

--- a/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.ts
+++ b/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.ts
@@ -18,8 +18,41 @@ import { ChatModel, ResponseTokenUsage } from '@theia/ai-chat';
 import { nls } from '@theia/core/lib/common/nls';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 
+/**
+ * Provisional context window size used as the denominator for the indicator bar
+ * fill and the tooltip's "Total: X / Y" display until per-model context sizes
+ * are available. See issue #17323 comments for context.
+ */
 export const CHAT_CONTEXT_WINDOW_SIZE = 200000;
-const CHAT_CONTEXT_WINDOW_WARNING_THRESHOLD = 0.9 * CHAT_CONTEXT_WINDOW_SIZE;
+
+export type TokenUsageWarningDecision = 'notify' | 'reset' | 'skip';
+
+/** Returns true when the given total has crossed (>=) the configured warning threshold. */
+export function isAboveTokenUsageWarningThreshold(totalTokens: number, threshold: number): boolean {
+    return totalTokens > 0 && totalTokens >= threshold;
+}
+
+/**
+ * Pure decision function for whether to show the token usage warning for a session.
+ * Callers are expected to short-circuit before invoking this when the warning feature
+ * is disabled, so this helper is not concerned with the enabled state.
+ * - `reset`: usage is below the threshold; any prior "already notified" state for this session should be cleared.
+ * - `skip`:  we already notified for this session while still above the threshold.
+ * - `notify`: warning should be shown now and the session marked as notified.
+ */
+export function decideTokenUsageWarning(args: {
+    totalTokens: number;
+    threshold: number;
+    alreadyNotified: boolean;
+}): TokenUsageWarningDecision {
+    if (!isAboveTokenUsageWarningThreshold(args.totalTokens, args.threshold)) {
+        return 'reset';
+    }
+    if (args.alreadyNotified) {
+        return 'skip';
+    }
+    return 'notify';
+}
 
 export function formatTokenCount(count: number | undefined): string {
     if (count === undefined || count === 0) {
@@ -31,14 +64,19 @@ export function formatTokenCount(count: number | undefined): string {
     return count.toString();
 }
 
-export function getUsageColorClass(totalTokens: number): string {
+/**
+ * Returns the CSS class for the token usage indicator based on the current
+ * total, the configured warning threshold, and the assumed context window size.
+ * Yellow band: [threshold, contextWindowSize). Red band: [contextWindowSize, ∞).
+ */
+export function getUsageColorClass(totalTokens: number, threshold: number, contextWindowSize: number = CHAT_CONTEXT_WINDOW_SIZE): string {
     if (totalTokens === 0) {
         return 'token-usage-none';
     }
-    if (totalTokens < CHAT_CONTEXT_WINDOW_WARNING_THRESHOLD) {
+    if (totalTokens < threshold) {
         return 'token-usage-green';
     }
-    if (totalTokens < CHAT_CONTEXT_WINDOW_SIZE) {
+    if (totalTokens < contextWindowSize) {
         return 'token-usage-yellow';
     }
     return 'token-usage-red';
@@ -75,22 +113,22 @@ export function getLatestTokenUsage(chatModel?: ChatModel): ResponseTokenUsage |
     return undefined;
 }
 
-export function buildBarTooltip(usage: ResponseTokenUsage | undefined, totalTokens: number): MarkdownString | undefined {
+export function buildBarTooltip(usage: ResponseTokenUsage | undefined, totalTokens: number, threshold: number): MarkdownString | undefined {
     if (!usage) {
         return undefined;
     }
     const lines: string[] = [
         `**${nls.localize('theia/ai/chat-ui/tokenUsageLabel', 'Token Usage')}**`
     ];
-    const colorClass = getUsageColorClass(totalTokens);
+    const colorClass = getUsageColorClass(totalTokens, threshold);
     if (colorClass === 'token-usage-yellow') {
-        lines.push(`⚠ ${nls.localize('theia/ai/chat-ui/tokenUsageWarning', 'Approaching context window limit.')}`, '');
+        lines.push(`⚠ ${nls.localize('theia/ai/chat-ui/tokenUsageWarning', 'Token usage warning threshold reached.')}`, '');
     } else if (colorClass === 'token-usage-red') {
-        lines.push(`⚠ ${nls.localize('theia/ai/chat-ui/tokenUsageOverflow', 'Context window limit reached. Consider starting a new session.')}`, '');
+        lines.push(`⚠ ${nls.localize('theia/ai/chat-ui/tokenUsageOverflow', 'Token usage well past the warning threshold. Consider compacting or starting a new session.')}`, '');
     }
     lines.push(`${nls.localizeByDefault('Input: {0}',
         formatTokenCount(usage.inputTokens))} | ${nls.localizeByDefault('Output: {0}',
-        formatTokenCount(usage.outputTokens))}`);
+            formatTokenCount(usage.outputTokens))}`);
     const cacheParts: string[] = [];
     if (usage.cacheReadInputTokens) {
         cacheParts.push(nls.localize('theia/ai/chat-ui/tokenUsageTooltipCacheRead', 'Cache read: {0}', formatTokenCount(usage.cacheReadInputTokens)));
@@ -101,8 +139,13 @@ export function buildBarTooltip(usage: ResponseTokenUsage | undefined, totalToke
     if (cacheParts.length > 0) {
         lines.push(cacheParts.join(' | '));
     }
-    const pct = Math.round((totalTokens / CHAT_CONTEXT_WINDOW_SIZE) * 100);
-    lines.push(nls.localize('theia/ai/chat-ui/tokenUsageTooltipTotal', 'Total: {0} / {1} ({2}%)', formatTokenCount(totalTokens), formatTokenCount(CHAT_CONTEXT_WINDOW_SIZE), pct));
+    const percentage = Math.round((totalTokens / CHAT_CONTEXT_WINDOW_SIZE) * 100);
+    lines.push(nls.localize(
+        'theia/ai/chat-ui/tokenUsageTooltipTotal',
+        'Total: {0} / {1} ({2}%)',
+        formatTokenCount(totalTokens),
+        formatTokenCount(CHAT_CONTEXT_WINDOW_SIZE),
+        percentage
+    ));
     return { value: lines.join('  \n') };
 }
-

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-input-widget.tsx
@@ -19,7 +19,7 @@ import { AIChatInputWidget, type AIChatInputConfiguration } from '../chat-input-
 import type { EditableRequestNode } from './chat-view-tree-widget';
 import { URI } from '@theia/core';
 import { CHAT_VIEW_LANGUAGE_EXTENSION } from '../chat-view-language-contribution';
-import type { ChatRequestModel, EditableChatRequestModel, ChatHierarchyBranch } from '@theia/ai-chat';
+import type { ChatModel, ChatRequestModel, EditableChatRequestModel, ChatHierarchyBranch } from '@theia/ai-chat';
 import type { AIVariableResolutionRequest } from '@theia/ai-core';
 import { Key } from '@theia/core/lib/browser';
 
@@ -119,5 +119,13 @@ export class AIChatTreeInputWidget extends AIChatInputWidget {
 
     protected override deleteContextElement(index: number): void {
         this.request.editContextManager.deleteVariables(index);
+    }
+
+    /**
+     * No-op in edit mode: the token usage warning is owned by the main chat input
+     * widget so we avoid double-notifying when an edit widget is open alongside it.
+     */
+    protected override evaluateTokenUsageWarning(_chatModel: ChatModel): void {
+        // Intentionally empty.
     }
 }

--- a/packages/ai-chat-ui/src/browser/chat-view-preferences.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-preferences.ts
@@ -19,6 +19,10 @@ import { nls } from '@theia/core/lib/common/nls';
 import { interfaces } from '@theia/core/shared/inversify';
 
 export const CHAT_VIEW_TOKEN_USAGE_ENABLED = 'ai-features.chat.tokenUsageIndicator.enabled';
+export const CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED = 'ai-features.chat.tokenUsageWarning.enabled';
+export const CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE = 'ai-features.chat.tokenUsageWarning.defaultThresholdPercentage';
+
+export const CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE_DEFAULT = 80;
 
 export const chatViewPreferenceSchema: PreferenceSchema = {
     properties: {
@@ -31,12 +35,37 @@ export const chatViewPreferenceSchema: PreferenceSchema = {
                 'This feature is experimental and token counts may be inaccurate depending on the model and provider.'
             ),
             tags: ['experimental']
+        },
+        [CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED]: {
+            type: 'boolean',
+            default: false,
+            description: nls.localize(
+                'theia/ai/chat-ui/tokenUsageWarningEnabled',
+                'Controls whether a notification is shown when a chat session\'s token usage crosses the configured threshold. ' +
+                'Requires the language model provider to report token usage.'
+            ),
+            tags: ['experimental']
+        },
+        [CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE]: {
+            type: 'number',
+            minimum: 1,
+            maximum: 100,
+            default: CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE_DEFAULT,
+            description: nls.localize(
+                'theia/ai/chat-ui/tokenUsageWarningThresholdPercentage',
+                'Percentage of the model\'s context window at which the token usage warning is triggered. ' +
+                'This value also drives the warning/error color bands of the token usage indicator. ' +
+                'Currently resolves against an assumed 200k context window; will use the real per-model context size once available.'
+            ),
+            tags: ['experimental']
         }
     }
 };
 
 export interface ChatViewConfiguration {
     [CHAT_VIEW_TOKEN_USAGE_ENABLED]: boolean;
+    [CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED]: boolean;
+    [CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE]: number;
 }
 
 export const ChatViewPreferenceContribution = Symbol('ChatViewPreferenceContribution');


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Adds a dismissable notification that alerts users when a chat session's total token usage reaches a user-configured absolute threshold, with quick actions to compact the current session (summarize-and-continue) or start a new chat.

The warning fires once per threshold crossing and re-arms when usage drops below the threshold and crosses again (e.g. after compacting). Closing and reopening the chat view re-creates the widget and will re-notify if the session is still above threshold — accepted as a rare corner case.

The token usage indicator's color bands and tooltip now derive from the same absolute threshold instead of a hardcoded 200k context window, so visual feedback aligns with the warning trigger regardless of the actual model's context size. The CHAT_CONTEXT_WINDOW_SIZE constant is removed.

New preferences:
  ai-features.chat.tokenUsageWarning.enabled        (boolean, default: false)
  ai-features.chat.tokenUsageWarning.tokenThreshold (number,  default: 160000)

Threshold detection lives on the chat input widget — it already listens to the session model's responseChanged events and the active-session semantics match the "notify for the session the user is engaged with" UX contract. A pure decideTokenUsageWarning helper keeps the threshold/notified-state logic unit-testable. The transient tree-view edit input widget opts out of emitting warnings to avoid duplicate toasts while editing a past request.

Closes #17323
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Enable the warning, set a treshold and generate something so you go over the threshold.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
