### PR TITLE
fix(scm): detect external worktree removal and related stale-state gaps

### DIFF
--- a/packages/plugin-ext/src/main/browser/scm-main.spec.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.spec.ts
@@ -1,0 +1,105 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ScmService } from '@theia/scm/lib/browser/scm-service';
+import { ScmMainImpl } from './scm-main';
+
+interface ScmMainInternals {
+    repositories: Map<number, unknown>;
+    repositoryDisposables: Map<number, { dispose(): void }>;
+}
+
+function createScmMainImpl(scmService: ScmService): ScmMainImpl {
+    // Bypass the constructor's RPC/container wiring. ScmMainImpl's $register and
+    // $unregister only touch the proxy for input box validation and selection
+    // forwarding — not exercised in this test — so we can stub those safely.
+    const proxy = new Proxy({}, {
+        get: () => (): unknown => undefined
+    });
+    const impl = Object.create(ScmMainImpl.prototype) as ScmMainImpl;
+    const anyImpl = impl as unknown as Record<string, unknown>;
+    anyImpl.proxy = proxy;
+    anyImpl.scmService = scmService;
+    anyImpl.repositories = new Map();
+    anyImpl.repositoryDisposables = new Map();
+    anyImpl.disposables = { push: (): void => { } };
+    anyImpl.colors = { toCssVariableName: (x: string) => x };
+    anyImpl.sharedStyle = { toIconClass: () => ({ object: { iconClass: '' }, dispose: () => { } }) };
+    return impl;
+}
+
+describe('ScmMainImpl - cascade dispose of children on $unregisterSourceControl', () => {
+    let scmService: ScmService;
+    let impl: ScmMainImpl;
+
+    beforeEach(() => {
+        scmService = new ScmService();
+        // Stub the optional context key dependency used by ScmService.
+        (scmService as unknown as Record<string, unknown>).contextKeys = {};
+        impl = createScmMainImpl(scmService);
+    });
+
+    it('should unregister worktree children when their parent is unregistered', async () => {
+        // Parent
+        await impl.$registerSourceControl(1, 'git', 'Main', { scheme: 'file', path: '/repo', authority: '', query: '', fragment: '' });
+        // Two worktree children pointing at the parent
+        await impl.$registerSourceControl(2, 'git', 'WT-A', { scheme: 'file', path: '/wt-a', authority: '', query: '', fragment: '' }, 1);
+        await impl.$registerSourceControl(3, 'git', 'WT-B', { scheme: 'file', path: '/wt-b', authority: '', query: '', fragment: '' }, 1);
+
+        expect(scmService.repositories).to.have.length(3);
+
+        const removed: unknown[] = [];
+        scmService.onDidRemoveRepository(r => removed.push(r));
+
+        await impl.$unregisterSourceControl(1);
+
+        // Parent and both children must be removed from the service.
+        expect(scmService.repositories).to.have.length(0);
+        expect(removed).to.have.length(3);
+
+        // Internal bookkeeping must be clean.
+        const internals = impl as unknown as ScmMainInternals;
+        expect(internals.repositories.size).to.equal(0);
+        expect(internals.repositoryDisposables.size).to.equal(0);
+    });
+
+    it('should leave unrelated repositories untouched when a parent is unregistered', async () => {
+        await impl.$registerSourceControl(1, 'git', 'Main', { scheme: 'file', path: '/repo', authority: '', query: '', fragment: '' });
+        await impl.$registerSourceControl(2, 'git', 'WT-A', { scheme: 'file', path: '/wt-a', authority: '', query: '', fragment: '' }, 1);
+        // An independent repository (no parent)
+        await impl.$registerSourceControl(3, 'git', 'Other', { scheme: 'file', path: '/other', authority: '', query: '', fragment: '' });
+
+        await impl.$unregisterSourceControl(1);
+
+        const remaining = scmService.repositories;
+        expect(remaining).to.have.length(1);
+        expect(remaining[0].provider.rootUri).to.include('/other');
+    });
+
+    it('should not crash when the child was already unregistered before the parent', async () => {
+        await impl.$registerSourceControl(1, 'git', 'Main', { scheme: 'file', path: '/repo', authority: '', query: '', fragment: '' });
+        await impl.$registerSourceControl(2, 'git', 'WT-A', { scheme: 'file', path: '/wt-a', authority: '', query: '', fragment: '' }, 1);
+
+        // Plugin-side unregister for the child arrives first (race scenario).
+        await impl.$unregisterSourceControl(2);
+        expect(scmService.repositories).to.have.length(1);
+
+        // Now the parent is unregistered — cascade should find no child and succeed.
+        await impl.$unregisterSourceControl(1);
+        expect(scmService.repositories).to.have.length(0);
+    });
+});

--- a/packages/plugin-ext/src/main/browser/scm-main.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.ts
@@ -388,7 +388,31 @@ export class ScmMainImpl implements ScmMain {
             return;
         }
 
-        this.repositoryDisposables.get(handle)!.dispose();
+        // Defensively cascade-dispose any children (e.g. worktrees) whose parent
+        // is being unregistered. The plugin API exposes onDidDisposeParent, but if
+        // a plugin fails to propagate it (or races with an external change like a
+        // worktree being removed on disk), children would otherwise be orphaned
+        // in the Repositories view. Children are torn down inline (not recursively)
+        // to keep the iteration over `this.repositories` safe and to tolerate a
+        // plugin-side RPC for the child arriving first.
+        const childHandles: number[] = [];
+        for (const [childHandle, childRepo] of this.repositories) {
+            if (childHandle !== handle && (childRepo.provider as PluginScmProvider).parentHandle === handle) {
+                childHandles.push(childHandle);
+            }
+        }
+        for (const childHandle of childHandles) {
+            const childRepository = this.repositories.get(childHandle);
+            if (!childRepository) {
+                continue;
+            }
+            this.repositoryDisposables.get(childHandle)?.dispose();
+            this.repositoryDisposables.delete(childHandle);
+            childRepository.dispose();
+            this.repositories.delete(childHandle);
+        }
+
+        this.repositoryDisposables.get(handle)?.dispose();
         this.repositoryDisposables.delete(handle);
 
         repository.dispose();

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -850,6 +850,24 @@ export class ScmExtImpl implements ScmExt {
         sourceControls.push(sourceControl);
         this.sourceControlsByExtension.set(extension.model.id, sourceControls);
 
+        // Clean up registries when the source control is disposed. Without this,
+        // disposed entries leak and findSourceControlImpl() may return a stale
+        // (disposed) instance as a parent for a later-created source control
+        // with the same id + rootUri (e.g. a worktree recreated after removal).
+        sourceControl.onDidDispose(() => {
+            this.sourceControls.delete(handle);
+            const list = this.sourceControlsByExtension.get(extension.model.id);
+            if (list) {
+                const index = list.indexOf(sourceControl);
+                if (index >= 0) {
+                    list.splice(index, 1);
+                }
+                if (list.length === 0) {
+                    this.sourceControlsByExtension.delete(extension.model.id);
+                }
+            }
+        });
+
         return sourceControl.apiObject;
     }
 

--- a/packages/scm/src/browser/scm-service.spec.ts
+++ b/packages/scm/src/browser/scm-service.spec.ts
@@ -1,0 +1,91 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Emitter } from '@theia/core/lib/common/event';
+import { ScmService } from './scm-service';
+import { ScmProvider } from './scm-provider';
+
+function makeProvider(id: string, rootUri: string): ScmProvider {
+    return {
+        id,
+        label: id,
+        rootUri,
+        groups: [],
+        onDidChange: new Emitter<void>().event,
+        onDidChangeCommitTemplate: new Emitter<string>().event,
+        dispose: () => { }
+    } as unknown as ScmProvider;
+}
+
+describe('ScmService - repository removal event ordering', () => {
+    let service: ScmService;
+
+    beforeEach(() => {
+        service = new ScmService();
+        // ScmService declares a ScmContextKeyService injection but does not use it
+        // in the paths exercised here. Stub it to stay resilient against future use.
+        (service as unknown as Record<string, unknown>).contextKeys = {};
+    });
+
+    it('should update selectedRepository before firing onDidRemoveRepository', () => {
+        const repoA = service.registerScmProvider(makeProvider('git', '/a'));
+        const repoB = service.registerScmProvider(makeProvider('git', '/b'));
+
+        // Select repoA explicitly (registerScmProvider auto-selects the first one).
+        service.selectedRepository = repoA;
+        expect(service.selectedRepository).to.equal(repoA);
+
+        let selectedDuringRemoveEvent: unknown;
+        service.onDidRemoveRepository(() => {
+            selectedDuringRemoveEvent = service.selectedRepository;
+        });
+
+        repoA.dispose();
+
+        // When a subscriber of onDidRemoveRepository inspects selectedRepository,
+        // it must not observe the disposed repository as still being selected.
+        expect(selectedDuringRemoveEvent).to.not.equal(repoA);
+        expect(selectedDuringRemoveEvent).to.equal(repoB);
+        expect(service.selectedRepository).to.equal(repoB);
+    });
+
+    it('should clear selectedRepository to undefined when the last repository is removed', () => {
+        const repo = service.registerScmProvider(makeProvider('git', '/a'));
+        expect(service.selectedRepository).to.equal(repo);
+
+        let selectedDuringRemoveEvent: unknown = 'unset';
+        service.onDidRemoveRepository(() => {
+            selectedDuringRemoveEvent = service.selectedRepository;
+        });
+
+        repo.dispose();
+
+        expect(selectedDuringRemoveEvent).to.be.undefined;
+        expect(service.selectedRepository).to.be.undefined;
+    });
+
+    it('should fire onDidRemoveRepository and leave _repositories empty after disposing the only repo', () => {
+        const repo = service.registerScmProvider(makeProvider('git', '/a'));
+        let removed: unknown;
+        service.onDidRemoveRepository(r => { removed = r; });
+
+        repo.dispose();
+
+        expect(removed).to.equal(repo);
+        expect(service.repositories).to.have.length(0);
+    });
+});

--- a/packages/scm/src/browser/scm-service.ts
+++ b/packages/scm/src/browser/scm-service.ts
@@ -92,10 +92,13 @@ export class ScmService {
         repository.dispose = () => {
             this._repositories.delete(key);
             dispose.bind(repository)();
-            this.onDidRemoveRepositoryEmitter.fire(repository);
+            // Update the selected repository before firing the remove event so
+            // subscribers do not observe a stale selection pointing at the just
+            // disposed repository.
             if (this._selectedRepository === repository) {
                 this.selectedRepository = this._repositories.values().next().value;
             }
+            this.onDidRemoveRepositoryEmitter.fire(repository);
         };
         this._repositories.set(key, repository);
         this.onDidAddRepositoryEmitter.fire(repository);


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
The Repositories view (ScmRepositoriesWidget) relied on the VS Code git extension to propagate every SCM lifecycle event. When a worktree was removed outside the view - via CLI, file explorer, or a parent repo being closed - it could remain in the list because intermediate cleanup was incomplete. This commit closes three gaps in the SCM wiring:

1. scm-main.ts: defensive parent -> child cascade on $unregisterSourceControl When a source control is unregistered, any child whose parentHandle matches is now also unregistered inline (delete-from-maps + dispose). Previously Theia main relied entirely on the plugin forwarding onDidDisposeParent; if the plugin failed or raced, worktree children were orphaned in ScmService._repositories and stayed visible in the Repositories view. Uses optional chaining so a child that was already unregistered before the parent (e.g. plugin-side RPC arriving first) is safely skipped.

2. scm.ts (ScmExtImpl.createSourceControl): clean up plugin-side registries on dispose. Hooks sourceControl.onDidDispose to remove the entry from sourceControls and sourceControlsByExtension. Without this, findSourceControlImpl() could return a disposed source control as a parent for a later-created source control with the same id + rootUri (e.g. a worktree recreated at the same path after removal), producing incorrect parent/child wiring.

3. scm-service.ts (registerScmProvider dispose override): update _selectedRepository before firing onDidRemoveRepository. Subscribers like ScmGroupsTreeModel.refreshOnRepositoryChange and ScmContribution.updateStatusBar no longer observe a stale selection pointing at the just-disposed repo, avoiding a transient render with stale data.

Tests:
- scm-service.spec.ts (new): 3 tests for the event-ordering fix
- scm-main.spec.ts (new): 3 tests for the cascade dispose, including the race where the child is unregistered before the parent
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Delete a worktree outside the view
2. Notice that the worktree is now properly removed from the view
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
