### PR TITLE
Improve navigator copy/paste handling

### DIFF
--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -125,8 +125,8 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
         const uris = this.model.selectedFileStatNodes.map(node => node.uri.toString());
         if (uris.length > 0 && event.clipboardData) {
             event.clipboardData.setData('text/plain', uris.join('\n'));
-            event.preventDefault();
         }
+        event.preventDefault();
     }
 
     protected handlePaste(event: ClipboardEvent): void {
@@ -139,9 +139,21 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
             if (!target) {
                 return;
             }
+            event.preventDefault();
             for (const file of raw.split('\n')) {
-                event.preventDefault();
-                const source = new URI(file);
+                const trimmed = file.trim();
+                if (!trimmed) {
+                    continue;
+                }
+                try {
+                    new URL(trimmed);
+                } catch {
+                    continue;
+                }
+                const source = new URI(trimmed);
+                if (!this.workspaceService.getWorkspaceRootUri(source)) {
+                    continue;
+                }
                 this.model.copy(source, target);
             }
         }


### PR DESCRIPTION
#### What it does

Fixes #17385

When copying and pasting files in the navigator, the `handleCopy` handler stores file URIs as plain text on the clipboard via `clipboardData.setData('text/plain', ...)`, and `handlePaste` reads them back with `clipboardData.getData('text/plain')` and parses each line as a URI using `new URI(string)`.

This is unsafe because:

1. **If `handleCopy` doesn't fire** (e.g., `selectedFileStatNodes` is empty due to stale selection state), `event.preventDefault()` is never called, so the browser's default copy behavior puts the **DOM text content** (the bare filename, e.g., `text.txt`) on the clipboard instead of a `file://` URI.

2. **When `handlePaste` later reads this bare filename**, `vscode-uri`'s `Uri.parse('text.txt')` interprets it as `file:///text.txt` — a path at the filesystem root. The copy operation then attempts to copy from `/`, traversing the entire host filesystem. Depending on the OS, this produces:
   - **Linux (Debian):** `ELOOP: too many symbolic links encountered` when hitting circular symlinks like `/usr/bin/X11` → `/usr/bin`
   - **Windows:** Creation of unwanted directories mirroring the drive root (e.g., `$RECYCLE.BIN/S-1-5-18`)
   - **macOS:** `ENOENT` errors for system files like `/.VolumeIcon.icns`

3. **Empty entries from `split('\n')`** (e.g., trailing newlines, Windows `\r\n` line endings) parse as `file:///` (the filesystem root), triggering the same issue.

This PR adds two defensive fixes:

- **`handleCopy`:** Always call `event.preventDefault()` so the browser never puts bare DOM text on the clipboard, even when no file stat nodes are selected.
- **`handlePaste`:** Trim whitespace from each entry (handles `\r\n`), skip empty strings (handles trailing newlines), and validate each entry is a well-formed URI using `new URL()` before treating it as a copy source. Also moves `event.preventDefault()` before the loop so the browser's default paste is always suppressed.

#### How to test

1. Open a workspace with a file (e.g., `test.txt`)
2. Copy the text `test.txt` to your system clipboard (e.g., from a text editor, not from the navigator)
3. Select a file or directory in the navigator and press Ctrl+V / Cmd+V
4. **Before fix:** errors appear and unwanted directories may be created at the workspace root
5. **After fix:** nothing happens — the invalid clipboard content is silently ignored

Also verify normal copy-paste still works:
1. Select `test.txt` in the navigator, press Ctrl+C / Cmd+C
2. Press Ctrl+V / Cmd+V
3. `test copy.txt` should be created as before

#### Follow-ups

- The underlying design of using `text/plain` on the clipboard for file resources is fragile. VS Code uses a dedicated custom MIME type (`web vscode-resources`) with structured JSON via `navigator.clipboard.write()`/`read()` and `ClipboardItem`, combined with an in-memory fallback. Migrating to a similar approach would eliminate this class of bugs entirely and would also enable distinguishing Theia file copies from arbitrary text on the clipboard. This should be considered as a follow-up.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)