### PR TITLE
Drop incomplete thinking blocks from LLM history

### DIFF
--- a/packages/ai-chat/src/common/chat-agents.spec.ts
+++ b/packages/ai-chat/src/common/chat-agents.spec.ts
@@ -1,0 +1,124 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { LanguageModelMessage, LanguageModelRequirement } from '@theia/ai-core';
+import { AbstractChatAgent, ChatAgentLocation } from './chat-agents';
+import {
+    MutableChatModel,
+    MutableChatRequestModel,
+    ChatModel,
+    TextChatResponseContentImpl,
+    ThinkingChatResponseContentImpl,
+} from './chat-model';
+import { ParsedChatRequest, ParsedChatRequestTextPart } from './parsed-chat-request';
+
+class TestChatAgent extends AbstractChatAgent {
+    readonly id = 'test-agent';
+    readonly name = 'Test Agent';
+    readonly languageModelRequirements: LanguageModelRequirement[] = [];
+    protected readonly defaultLanguageModelPurpose = 'chat';
+
+    protected addContentsToResponse(): Promise<void> {
+        return Promise.resolve();
+    }
+
+    public async exposeGetMessages(model: ChatModel, includeResponseInProgress = false): Promise<LanguageModelMessage[]> {
+        return this.getMessages(model, includeResponseInProgress);
+    }
+}
+
+function createParsedRequest(text: string): ParsedChatRequest {
+    return {
+        request: { text },
+        parts: [
+            new ParsedChatRequestTextPart({ start: 0, endExclusive: text.length }, text)
+        ],
+        toolRequests: new Map(),
+        variables: []
+    };
+}
+
+describe('AbstractChatAgent.getMessages', () => {
+
+    let agent: TestChatAgent;
+
+    beforeEach(() => {
+        agent = new TestChatAgent();
+    });
+
+    function addThinkingResponse(request: MutableChatRequestModel, content: string, signature: string): void {
+        request.response.response.addContent(new ThinkingChatResponseContentImpl(content, signature));
+    }
+
+    function addTextResponse(request: MutableChatRequestModel, text: string): void {
+        request.response.response.addContent(new TextChatResponseContentImpl(text));
+    }
+
+    it('filters out incomplete thinking blocks (empty signature) from a cancelled stream', async () => {
+        const model = new MutableChatModel(ChatAgentLocation.Panel);
+        const request = model.addRequest(createParsedRequest('Hello'));
+
+        addThinkingResponse(request, 'Some thinking that was cancelled', '');
+        request.response.cancel();
+
+        const messages = await agent.exposeGetMessages(model);
+
+        expect(messages.filter(LanguageModelMessage.isThinkingMessage)).to.have.lengthOf(0);
+        // The user text message should still be included
+        const userTextMessages = messages
+            .filter(LanguageModelMessage.isTextMessage)
+            .filter(m => m.actor === 'user');
+        expect(userTextMessages).to.have.lengthOf(1);
+    });
+
+    it('keeps thinking blocks with a valid signature', async () => {
+        const model = new MutableChatModel(ChatAgentLocation.Panel);
+        const request = model.addRequest(createParsedRequest('Hello'));
+
+        addThinkingResponse(request, 'Complete thought', 'sig-abc');
+        addTextResponse(request, 'Hi there');
+        request.response.complete();
+
+        const messages = await agent.exposeGetMessages(model);
+
+        const thinkingMessages = messages.filter(LanguageModelMessage.isThinkingMessage);
+        expect(thinkingMessages).to.have.lengthOf(1);
+        expect(thinkingMessages[0].thinking).to.equal('Complete thought');
+        expect(thinkingMessages[0].signature).to.equal('sig-abc');
+    });
+
+    it('filters incomplete thinking but preserves following text content from the same response', async () => {
+        const model = new MutableChatModel(ChatAgentLocation.Panel);
+        const request = model.addRequest(createParsedRequest('Hello'));
+
+        addThinkingResponse(request, 'Cancelled thought', '');
+        addTextResponse(request, 'Partial reply before cancel');
+        request.response.cancel();
+
+        const messages = await agent.exposeGetMessages(model);
+
+        expect(messages.filter(LanguageModelMessage.isThinkingMessage)).to.have.lengthOf(0);
+
+        const aiTextMessages = messages
+            .filter(LanguageModelMessage.isTextMessage)
+            .filter(m => m.actor === 'ai');
+        expect(aiTextMessages).to.have.lengthOf(1);
+        expect(aiTextMessages[0].text).to.equal('Partial reply before cancel');
+    });
+});

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -72,6 +72,7 @@ import {
     ErrorChatResponseContent,
     InformationalChatResponseContent,
     ResponseTokenUsage,
+    ThinkingChatResponseContent,
 } from './chat-model';
 import { ChatToolRequestService } from './chat-tool-request-service';
 import { parseContents } from './parse-contents';
@@ -423,6 +424,12 @@ export abstract class AbstractChatAgent implements ChatAgent {
                     .filter(c => {
                         // we do not send errors or informational content
                         if (ErrorChatResponseContent.is(c) || InformationalChatResponseContent.is(c)) {
+                            return false;
+                        }
+                        // skip incomplete thinking blocks (e.g. from a cancelled stream where the
+                        // signature_delta never arrived). Some LLMs (e.g. Anthropic) reject thinking
+                        // blocks without a signature.
+                        if (ThinkingChatResponseContent.is(c) && !c.signature) {
                             return false;
                         }
                         // content even has an own converter, definitely include it


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
When a streaming response is cancelled while a thinking block is still being emitted, the corresponding ThinkingChatResponseContent may be left with content but no signature (the signature_delta event never arrived). On a follow-up request, sending such a partial thinking block back caused Anthropic to reject the request, since it requires a valid signature on every thinking block.

Filter out thinking response content with an empty signature when assembling the message history in AbstractChatAgent.getMessages, so cancelled-but-unsigned thinking blocks are never echoed back to the LLM.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Trigger an llm request that leads to a thinking block. Cancel the request and try to continue. this show work now.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
