### PR TITLE
task-terminal-history-fix

### DIFF
--- a/packages/process/src/node/task-terminal-process.ts
+++ b/packages/process/src/node/task-terminal-process.ts
@@ -17,6 +17,8 @@
 import { injectable } from '@theia/core/shared/inversify';
 import { TerminalProcess, TerminalProcessOptions } from './terminal-process';
 
+const TASK_TERMINAL_EXIT_EVENT_DELAY = 50;
+
 export const TaskTerminalProcessFactory = Symbol('TaskTerminalProcessFactory');
 export interface TaskTerminalProcessFactory {
     (options: TerminalProcessOptions): TaskTerminalProcess;
@@ -56,12 +58,19 @@ export class TaskTerminalProcess extends TerminalProcess {
 
     protected override onTerminalExit(code: number | undefined, signal: string | undefined): void {
         this.injectCommandEndOsc();
-        this.emitOnExit(code, signal);
-        this.exited = true;
-        // Unregister process only if task terminal already attached (or failed attach),
-        // Fixes https://github.com/eclipse-theia/theia/issues/2961
-        if (this.attachmentAttempted) {
-            this.unregisterProcess();
+        const emitExit = () => {
+            this.emitOnExit(code, signal);
+            this.exited = true;
+            // Unregister process only if task terminal already attached (or failed attach),
+            // Fixes https://github.com/eclipse-theia/theia/issues/2961
+            if (this.attachmentAttempted) {
+                this.unregisterProcess();
+            }
+        };
+        if (this._enableCommandHistory) {
+            setTimeout(emitExit, TASK_TERMINAL_EXIT_EVENT_DELAY);
+        } else {
+            emitExit();
         }
     }
 

--- a/packages/process/src/node/task-terminal-process.ts
+++ b/packages/process/src/node/task-terminal-process.ts
@@ -17,8 +17,6 @@
 import { injectable } from '@theia/core/shared/inversify';
 import { TerminalProcess, TerminalProcessOptions } from './terminal-process';
 
-const TASK_TERMINAL_EXIT_EVENT_DELAY = 50;
-
 export const TaskTerminalProcessFactory = Symbol('TaskTerminalProcessFactory');
 export interface TaskTerminalProcessFactory {
     (options: TerminalProcessOptions): TaskTerminalProcess;
@@ -58,19 +56,12 @@ export class TaskTerminalProcess extends TerminalProcess {
 
     protected override onTerminalExit(code: number | undefined, signal: string | undefined): void {
         this.injectCommandEndOsc();
-        const emitExit = () => {
-            this.emitOnExit(code, signal);
-            this.exited = true;
-            // Unregister process only if task terminal already attached (or failed attach),
-            // Fixes https://github.com/eclipse-theia/theia/issues/2961
-            if (this.attachmentAttempted) {
-                this.unregisterProcess();
-            }
-        };
-        if (this._enableCommandHistory) {
-            setTimeout(emitExit, TASK_TERMINAL_EXIT_EVENT_DELAY);
-        } else {
-            emitExit();
+        this.emitOnExit(code, signal);
+        this.exited = true;
+        // Unregister process only if task terminal already attached (or failed attach),
+        // Fixes https://github.com/eclipse-theia/theia/issues/2961
+        if (this.attachmentAttempted) {
+            this.unregisterProcess();
         }
     }
 

--- a/packages/task/src/browser/task-terminal-widget-manager.ts
+++ b/packages/task/src/browser/task-terminal-widget-manager.ts
@@ -171,15 +171,14 @@ export class TaskTerminalWidgetManager {
                 widget.clearOutput();
             }
         }
-        this.terminalService.open(widget, openerOptions);
-        if (TaskTerminalWidgetOpenerOptions.echoExecutedCommand(openerOptions) &&
-            taskInfo && ProcessTaskInfo.is(taskInfo) && taskInfo.command && taskInfo.command.length > 0
-        ) {
+        const command = taskInfo && ProcessTaskInfo.is(taskInfo) ? taskInfo.command : undefined;
+        if (TaskTerminalWidgetOpenerOptions.echoExecutedCommand(openerOptions) && command && command.length > 0) {
             if (widget.commandHistoryState) {
-                widget.writeLine('\x1b]133;prompt_started\x07');
+                widget.write('\x1b]133;prompt_started\x07');
             }
-            widget.writeLine('\x1b[1m> ' + nls.localizeByDefault('Executing task: {0}', taskInfo.command) + ' <\x1b[0m\n');
+            widget.writeLine('\x1b[1m> ' + nls.localizeByDefault('Executing task: {0}', command) + ' <\x1b[0m\n');
         }
+        this.terminalService.open(widget, openerOptions);
         return widget;
     }
 

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -111,7 +111,7 @@ describe('Task server / back-end', function (): void {
             setup.connectionProvider.listen(`${terminalsPath}/${terminalId}`, (path, channel) => {
                 channel.onMessage(e => stringBuffer.push(e().readString()));
                 channel.onError(reject);
-                channel.onClose(() => reject(new Error('Channel has been closed')));
+                // onClose is not used to reject: the server now closes the channel after process exit (expected behavior).
             }, false);
             stringBuffer.onData(currentMessage => {
                 // Instead of waiting for one message from the terminal, we wait for several ones as the very first message can be something unexpected.

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -306,13 +306,8 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 } else {
                     this.exitStatus = { code, reason: TerminalExitReason.Process };
                 }
-                // Ensure any in-progress command block is closed even if the process exits
-                // before its OSC prompt_started bytes are flushed from the ring buffer.
-                if (this._commandHistoryState?.currentCommand) {
-                    this.finishCurrentCommand();
-                }
                 if (!attached) {
-                    this.dispose();
+                    this.deferredFinalizeCommandHistory();
                 }
             }
         }));
@@ -523,6 +518,28 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         this._commandHistoryState.finishCommand(block);
         this.outputStartMarker = undefined;
         this.promptStartMarker = undefined;
+    }
+
+    protected connectionClosed = false;
+    protected waitingForConnectionCloseToDispose = false;
+
+    protected finalizeAndDispose(): void {
+        // enqueue a callback after all pending xterm writes drain
+        this.term.write('', () => {
+            if (this.isDisposed) { return; }
+            if (this._commandHistoryState?.currentCommand) {
+                this.finishCurrentCommand();
+            }
+            this.dispose();
+        });
+    }
+
+    protected deferredFinalizeCommandHistory(): void {
+        if (this.connectionClosed) {
+            this.finalizeAndDispose();
+        } else {
+            this.waitingForConnectionCloseToDispose = true;
+        }
     }
 
     private addCommandSeparator(): void {
@@ -902,6 +919,8 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         }
         this.toDisposeOnConnect.dispose();
         this.toDispose.push(this.toDisposeOnConnect);
+        this.connectionClosed = false;
+        this.waitingForConnectionCloseToDispose = false;
         const waitForConnection = this.waitForConnection = new Deferred<Channel>();
         this.connectionProvider.listen(
             `${terminalsPath}/${this.terminalId}`,
@@ -921,7 +940,13 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
                 disposable.push(this.term.onData(sendData));
                 disposable.push(this.term.onBinary(sendData));
 
-                connection.onClose(() => disposable.dispose());
+                connection.onClose(() => {
+                    disposable.dispose();
+                    this.connectionClosed = true;
+                    if (this.waitingForConnectionCloseToDispose) {
+                        this.finalizeAndDispose();
+                    }
+                });
 
                 if (waitForConnection) {
                     waitForConnection.resolve(connection);

--- a/packages/terminal/src/node/buffering-stream.spec.ts
+++ b/packages/terminal/src/node/buffering-stream.spec.ts
@@ -40,6 +40,36 @@ describe('BufferringStream', () => {
         expect(await waitForChunk(buffer)).deep.eq(Buffer.from([4, 5]));
     });
 
+    it('should flush with buffer bigger than maxChunkSize', () => {
+        const buffer = new BufferBufferingStream({ maxChunkSize: 2 });
+        const chunks: Buffer[] = [];
+        buffer.onData(c => chunks.push(c));
+        buffer.push(Buffer.from([0, 1, 2, 3, 4, 5]));
+        buffer.flush();
+        expect(chunks).deep.eq([Buffer.from([0, 1]), Buffer.from([2, 3]), Buffer.from([4, 5])]);
+    });
+
+    it('should flush with empty buffer', () => {
+        const buffer = new BufferBufferingStream({ maxChunkSize: 2 });
+        const chunks: Buffer[] = [];
+        buffer.onData(c => chunks.push(c));
+        buffer.flush();
+        expect(chunks).to.be.empty;
+    });
+
+    it('should not let push during a flush affect the result of flush', async () => {
+        const buffer = new BufferBufferingStream({ maxChunkSize: 2 });
+        const chunks: Buffer[] = [];
+        buffer.onData(c => {
+            chunks.push(c);
+            buffer.push(Buffer.from([99]));
+        });
+        buffer.push(Buffer.from([0, 1, 2, 3]));
+        buffer.flush();
+        expect(chunks).deep.eq([Buffer.from([0, 1]), Buffer.from([2, 3])]);
+        expect(await waitForChunk(buffer)).deep.eq(Buffer.from([99, 99]));
+    });
+
     function waitForChunk(buffer: BufferBufferingStream): Promise<Buffer> {
         return new Promise(resolve => buffer.onData(resolve));
     }

--- a/packages/terminal/src/node/buffering-stream.ts
+++ b/packages/terminal/src/node/buffering-stream.ts
@@ -65,6 +65,19 @@ export class BufferingStream<T> {
         }
     }
 
+    /** Immediately drains all buffered data, cancelling any pending timed flush. */
+    flush(): void {
+        if (this.buffer !== undefined) {
+            clearTimeout(this.timeout);
+            const snapshot = this.buffer;
+            this.buffer = undefined;
+            const totalLength = this.length(snapshot);
+            for (let offset = 0; offset < totalLength; offset += this.maxChunkSize) {
+                this.onDataEmitter.fire(this.slice(snapshot, offset, offset + this.maxChunkSize));
+            }
+        }
+    }
+
     dispose(): void {
         clearTimeout(this.timeout);
         this.buffer = undefined;

--- a/packages/terminal/src/node/terminal-backend-contribution.ts
+++ b/packages/terminal/src/node/terminal-backend-contribution.ts
@@ -50,7 +50,12 @@ export class TerminalBackendContribution implements MessagingService.Contributio
                 output.on('data', chunk => {
                     buffer.push(chunk);
                 });
+                const toDisposeOnProcessClose = termProcess.onClose(() => {
+                    buffer.flush();
+                    channel.close();
+                });
                 channel.onClose(() => {
+                    toDisposeOnProcessClose.dispose();
                     buffer.dispose();
                     output.dispose();
                 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

<!-- Include relevant issues and describe how they are addressed. -->
#### What it does

Fixes command history capture for task terminals when command history is enabled.

Task terminals inject OSC command-boundary markers into the terminal output stream. For short-running tasks, the task exit notification could reach the frontend before the final `prompt_started` OSC marker had been delivered and parsed through the terminal output channel. This could cause command history to finalize too early and record empty or incomplete task output.

This PR delays the task terminal exit notification briefly after injecting the final command-end OSC marker, giving the terminal output stream time to deliver the marker first.

It also writes the task execution banner before opening/attaching the terminal stream so the banner is not captured as part of the command output.

#### How to test
You can test this with this [repo](https://github.com/fangoling/ai-terminal-demo)
It contains a java example codebase and two tasks (one for building and one for running the java code)

1. Enable terminal command history in the settings.
2. Run a task
3. Verify that command history records:
   - the correct command
   - the actual task output
   - no `> Executing task: ... <` banner as command output

Example expected history entries:

```text
command: javac Main.java, output:
command: java Main, output: === Fibonacci Number ===
Enter a number: 3
Fibonacci: 2
```

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
