### PR TITLE
terminal-manager: fix view not restored on startup

### DIFF
--- a/packages/terminal-manager/src/browser/terminal-manager-frontend-contribution.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-frontend-contribution.ts
@@ -13,6 +13,7 @@ import { CommandRegistry, PreferenceService, DisposableCollection } from '@theia
 import { TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalFrontendContribution, TerminalCommands } from '@theia/terminal/lib/browser/terminal-frontend-contribution';
 import { ApplicationShell, WidgetManager, FrontendApplicationContribution, FrontendApplication } from '@theia/core/lib/browser';
+import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 import { TerminalManagerWidget } from './terminal-manager-widget';
 import { TerminalManagerFrontendViewContribution } from './terminal-manager-frontend-view-contribution';
 import { TerminalManagerPreferences } from './terminal-manager-preferences';
@@ -42,6 +43,9 @@ export class TerminalManagerFrontendContribution implements FrontendApplicationC
 
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
+
+    @inject(FrontendApplicationStateService)
+    protected readonly stateService: FrontendApplicationStateService;
 
     protected commandHandlerDisposables = new DisposableCollection();
 
@@ -176,7 +180,19 @@ export class TerminalManagerFrontendContribution implements FrontendApplicationC
     protected registerHandlers(): void {
         this.unregisterHandlers();
         this.registerCommands();
-        this.registerTerminalListener();
+        this.deferTerminalListenerUntilLayoutReady();
+    }
+
+    /**
+     * Defers the terminal creation listener until layout restoration is complete,
+     * preventing restored terminals from being mistaken for externally created ones.
+     */
+    protected deferTerminalListenerUntilLayoutReady(): void {
+        this.stateService.reachedState('initialized_layout').then(() => {
+            if (!this.commandHandlerDisposables.disposed) {
+                this.registerTerminalListener();
+            }
+        });
     }
 
     protected registerCommands(): void {

--- a/packages/terminal-manager/src/browser/terminal-manager-widget.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-widget.ts
@@ -623,8 +623,10 @@ export class TerminalManagerWidget extends BaseWidget implements StatefulWidget,
 
     restoreState(oldState: TerminalManagerWidgetState.LayoutData): void {
         const { items, widget, terminalAndTreeRelativeSizes } = oldState;
-        if (widget && terminalAndTreeRelativeSizes && items) {
-            this.setPanelSizes(terminalAndTreeRelativeSizes);
+        if (widget && items) {
+            if (terminalAndTreeRelativeSizes) {
+                this.setPanelSizes(terminalAndTreeRelativeSizes);
+            }
             try {
                 this.restoreLayoutData(items, widget);
             } catch (e) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes the terminal manager view (`terminal.grouping.mode: tree`) not being restored on startup.

Root cause: The `registerTerminalListener` in `TerminalManagerFrontendContribution` was registered during `onStart()`, before shell layout restoration. When the `ShellLayoutRestorer` re-created terminal widgets as part of the manager's stored inner state, the listener intercepted the `onDidCreateTerminal` events and called `addTerminalPage()` for each one before `restoreState()` had run. This corrupted the tree model, causing `restoreState()` to throw and fall back to a fresh default layout.

Changes:
- Defer `registerTerminalListener()` until `initialized_layout` state so restored terminals are not mistaken for externally created ones
- Relax `restoreState()` guard: missing panel sizes no longer skip the entire layout restoration

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Set `terminal.grouping.mode` to `tree` in preferences
2. Open the terminal manager, create a few terminals/pages/groups
3. Reload or reopen the application
4. Verify the terminal manager view is restored with the same layout (pages, groups, terminals)
5. After restoration, open a terminal from a plugin (e.g. from a .py file) or via the command palette and verify it is still routed into the terminal manager as a new page.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
