### PR TITLE
fix: editor context menu filtering and Monaco widget styling

### DIFF
--- a/packages/core/src/browser/style/hover-service.css
+++ b/packages/core/src/browser/style/hover-service.css
@@ -30,6 +30,8 @@
   padding: var(--theia-ui-padding);
   max-width: var(--theia-hover-max-width);
   user-select: text;
+  --vscode-scmGraph-historyItemHoverAdditionsForeground: var(--theia-scmGraph-historyItemHoverAdditionsForeground);
+  --vscode-scmGraph-historyItemHoverDeletionsForeground: var(--theia-scmGraph-historyItemHoverDeletionsForeground);
 }
 
 /* overwrite potentially different default user agent styles */
@@ -58,6 +60,11 @@
 
 .theia-hover .hover-row .actions {
   background-color: var(--theia-editorHoverWidget-statusBarBackground);
+}
+
+.theia-hover .codicon {
+  vertical-align: middle;
+  margin-bottom: 2px;
 }
 
 .theia-hover code {

--- a/packages/monaco/src/browser/monaco-menu.ts
+++ b/packages/monaco/src/browser/monaco-menu.ts
@@ -139,7 +139,8 @@ export class MonacoEditorMenuContribution implements MenuContribution {
         const title = typeof item.command.title === 'string' ? item.command.title : item.command.title.value;
         const label = this.removeMnemonic(title);
         const order = item.order ? String(item.order) : '';
-        return { commandId, order, label };
+        const when = item.when?.serialize();
+        return { commandId, order, label, when };
     }
 
     protected removeMnemonic(label: string): string {

--- a/packages/monaco/src/browser/style/index.css
+++ b/packages/monaco/src/browser/style/index.css
@@ -295,3 +295,46 @@
 .monaco-diff-editor .gutter .gutterItem .background {
   display: none;
 }
+
+/* Code Action Widget (Source Action, Quick Fix, Refactor) */
+.action-widget {
+  font-family: var(--theia-ui-font-family);
+}
+
+.action-widget .monaco-list .monaco-list-row.action.focused:not(.option-disabled) .codicon {
+  color: inherit !important;
+}
+
+.action-widget .monaco-list-row.action {
+  min-width: max-content;
+}
+
+/* Editor hover widget and overlay messages.
+   Alias --vscode- to --theia- for git blame hover addition/deletion colors
+   since the git extension uses --vscode- prefixed variables in inline styles. */
+.monaco-editor .monaco-hover {
+  font-family: var(--theia-ui-font-family);
+  --vscode-scmGraph-historyItemHoverAdditionsForeground: var(--theia-scmGraph-historyItemHoverAdditionsForeground);
+  --vscode-scmGraph-historyItemHoverDeletionsForeground: var(--theia-scmGraph-historyItemHoverDeletionsForeground);
+}
+
+.monaco-editor .monaco-hover p {
+  margin: 0.5em 0;
+}
+
+.monaco-editor .monaco-hover code {
+  font-family: var(--monaco-monospace-font, var(--theia-code-font-family));
+}
+
+.monaco-editor .monaco-hover pre,
+.monaco-editor .monaco-hover .monaco-tokenized-source {
+  font-family: var(--monaco-monospace-font, var(--theia-code-font-family));
+}
+
+.monaco-editor .monaco-hover hr {
+  margin-bottom: 0px;
+}
+
+.monaco-editor .monaco-editor-overlaymessage .message {
+  font-family: var(--theia-ui-font-family);
+}

--- a/packages/scm/src/browser/scm-contribution.ts
+++ b/packages/scm/src/browser/scm-contribution.ts
@@ -482,6 +482,22 @@ export class ScmContribution extends AbstractViewContribution<ScmWidget> impleme
                     hcDark: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6),
                     hcLight: Color.transparent(ScmColors.editorGutterDeletedBackground, 0.6)
                 }, description: 'Overview ruler marker color for deleted content.'
+            },
+            {
+                id: 'scmGraph.historyItemHoverAdditionsForeground', defaults: {
+                    dark: '#81B88B',
+                    light: '#587C0C',
+                    hcDark: '#A1E3AD',
+                    hcLight: '#374E06'
+                }, description: 'History item hover additions foreground color.'
+            },
+            {
+                id: 'scmGraph.historyItemHoverDeletionsForeground', defaults: {
+                    dark: '#C74E39',
+                    light: '#AD0707',
+                    hcDark: '#C74E39',
+                    hcLight: '#AD0707'
+                }, description: 'History item hover deletions foreground color.'
             }
         );
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Follow-up fixes after the Monaco editor update.

Editor context menu filtering:
- Pass `item.when` through `buildMenuAction()` so editor context menu entries respect their `when` clause, filtering out inapplicable actions (e.g. language-specific items no longer appear in unrelated file types)

Monaco widget font and styling fixes:
- Set UI font on code action widget, hover widget, and overlay messages; restore monospace for `code`, `pre`, and tokenized source in hovers
- Fix code action icon color on focus, label truncation with keybindings
- Fix hover `hr` separator overlap with UI font metrics
- Adjust hover paragraph spacing for more natural layout

Git blame hover colors:
- Register git blame hover addition/deletion foreground colors in the ColorRegistry (matching VS Code's default values) and alias `--vscode-` to `--theia-` so they render correctly in both editor decoration and status bar hovers
- Align codicon vertical positioning in the status bar hover

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Context menu filtering:
1. Open a TypeScript file and right-click in the editor to open the context menu
2. Note the available actions (e.g. "Go to Implementations" or "Go to Type Definition")
3. Open a Markdown or JSON file and right-click in the editor
4. Verify that language-specific actions that don't apply are no longer shown

Code action / hover widget font:
1. Open any file with available code actions (e.g. a TypeScript file with a quick fix)
2. Trigger the code action widget (lightbulb or Ctrl+.)
3. Verify the widget text uses the workbench UI font, not the editor's monospace font
4. Hover over a symbol to show the hover widget
5. Verify the hover content uses the UI font for prose, but `code` spans and code blocks still render in monospace

Git blame hover colors:
1. Open a file tracked by git and hover over a blame annotation (both from the editor decoration and from the status bar item, enable both via the toggle commands: `Git: Toggle Git Blame *`)
2. Verify the insertion count is shown in green and the deletion count in red
3. Verify this works in both dark and light themes

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- The `--vscode-` to `--theia-` CSS variable prefix mismatch is a broader issue that affects any VS Code extension using inline `--vscode-` CSS variables. A systematic solution (e.g. setting both prefixes in `ColorApplicationContribution`) could be considered separately.
- The `TypeHierarchyCommands` commands (`Supertype/Subtype Hierarchy`) do not have proper when clauses and are always shown, we should investigate if they are still needed and if so, add proper clauses.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
