### PR TITLE
Proposal: Plugin Polylith

### DIFF
--- a/packages/plugin-ext-headless/src/hosted/node/headless-hosted-plugin.ts
+++ b/packages/plugin-ext-headless/src/hosted/node/headless-hosted-plugin.ts
@@ -21,8 +21,8 @@
 
 import { generateUuid } from '@theia/core/lib/common/uuid';
 import { injectable, inject, named } from '@theia/core/shared/inversify';
+import { LegacyHeadlessPluginApiContribution } from '../../main/node/legacy-headless-plugin-api-contribution';
 import { getPluginId, DeployedPlugin, HostedPluginServer, PluginDeployer } from '@theia/plugin-ext/lib/common/plugin-protocol';
-import { setUpPluginApi } from '../../main/node/main-context';
 import { RPCProtocol, RPCProtocolImpl } from '@theia/plugin-ext/lib/common/rpc-protocol';
 import { ContributionProvider, Disposable, DisposableCollection, nls } from '@theia/core';
 import { environment } from '@theia/core/shared/@theia/application-package/lib/environment';
@@ -48,6 +48,9 @@ export function isHeadlessPlugin(plugin: DeployedPlugin): boolean {
 
 @injectable()
 export class HeadlessHostedPluginSupport extends AbstractHostedPluginSupport<HeadlessPluginManagerExt, HostedPluginServer> {
+
+    @inject(LegacyHeadlessPluginApiContribution)
+    protected readonly legacyPluginApi: LegacyHeadlessPluginApiContribution;
 
     @inject(HostedPluginProcess)
     protected readonly pluginProcess: HostedPluginProcess;
@@ -151,7 +154,7 @@ export class HeadlessHostedPluginSupport extends AbstractHostedPluginSupport<Hea
     protected initRpc(host: HeadlessPluginHost, pluginId: string): RPCProtocol {
         const rpc = this.createServerRpc(host);
         this.container.bind(RPCProtocol).toConstantValue(rpc);
-        setUpPluginApi(rpc, this.container);
+        this.legacyPluginApi.registerMainImplementations(rpc, this.container);
         this.mainPluginApiProviders.getContributions().forEach(p => p.initialize(rpc, this.container));
         return rpc;
     }

--- a/packages/plugin-ext-headless/src/main/node/legacy-headless-plugin-api-contribution.ts
+++ b/packages/plugin-ext-headless/src/main/node/legacy-headless-plugin-api-contribution.ts
@@ -14,8 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
-import { interfaces } from '@theia/core/shared/inversify';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
 import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
 import { InternalPluginApiContribution } from '@theia/plugin-ext/lib/common/plugin-ext-api-contribution';
 import { Plugin } from '@theia/plugin-ext/lib/common/plugin-api-rpc';

--- a/packages/plugin-ext-headless/src/main/node/legacy-headless-plugin-api-contribution.ts
+++ b/packages/plugin-ext-headless/src/main/node/legacy-headless-plugin-api-contribution.ts
@@ -1,0 +1,48 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { interfaces } from '@theia/core/shared/inversify';
+import { RPCProtocol } from '@theia/plugin-ext/lib/common/rpc-protocol';
+import { InternalPluginApiContribution } from '@theia/plugin-ext/lib/common/plugin-ext-api-contribution';
+import { Plugin } from '@theia/plugin-ext/lib/common/plugin-api-rpc';
+import { EnvMainImpl } from '@theia/plugin-ext/lib/main/common/env-main';
+import { BasicMessageRegistryMainImpl } from '@theia/plugin-ext/lib/main/common/basic-message-registry-main';
+import { BasicNotificationMainImpl } from '@theia/plugin-ext/lib/main/common/basic-notification-main';
+import { HEADLESSMAIN_RPC_CONTEXT, HEADLESSPLUGIN_RPC_CONTEXT } from '../../common/headless-plugin-rpc';
+
+@injectable()
+export class LegacyHeadlessPluginApiContribution implements InternalPluginApiContribution {
+
+    registerMainImplementations(rpc: RPCProtocol, container: interfaces.Container): void {
+        const envMain = new EnvMainImpl(rpc, container);
+        rpc.set(HEADLESSPLUGIN_RPC_CONTEXT.ENV_MAIN, envMain);
+
+        const messageRegistryMain = new BasicMessageRegistryMainImpl(container);
+        rpc.set(HEADLESSPLUGIN_RPC_CONTEXT.MESSAGE_REGISTRY_MAIN, messageRegistryMain);
+
+        const notificationMain = new BasicNotificationMainImpl(rpc, container, HEADLESSMAIN_RPC_CONTEXT.NOTIFICATION_EXT);
+        rpc.set(HEADLESSPLUGIN_RPC_CONTEXT.NOTIFICATION_MAIN, notificationMain);
+    }
+
+    registerExtImplementations(_rpc: RPCProtocol): void {
+        // No-op: headless plugins do not have ext-side API contributions
+    }
+
+    createApiNamespace(_plugin: Plugin): Record<string, unknown> {
+        return {};
+    }
+}

--- a/packages/plugin-ext-headless/src/main/node/plugin-ext-headless-main-module.ts
+++ b/packages/plugin-ext-headless/src/main/node/plugin-ext-headless-main-module.ts
@@ -22,6 +22,7 @@ import {
 } from '@theia/core';
 import { MainPluginApiProvider, PluginDeployerDirectoryHandler } from '@theia/plugin-ext';
 import { PluginTheiaHeadlessDirectoryHandler } from './handlers/plugin-theia-headless-directory-handler';
+import { LegacyHeadlessPluginApiContribution } from './legacy-headless-plugin-api-contribution';
 import { HeadlessProgressClient } from './headless-progress-client';
 
 export function bindHeadlessMain(bind: interfaces.Bind): void {
@@ -30,6 +31,7 @@ export function bindHeadlessMain(bind: interfaces.Bind): void {
 
 export function bindBackendMain(bind: interfaces.Bind, unbind: interfaces.Unbind, isBound: interfaces.IsBound, rebind: interfaces.Rebind): void {
     bindRootContributionProvider(bind, MainPluginApiProvider);
+    bind(LegacyHeadlessPluginApiContribution).toSelf().inSingletonScope();
 
     //
     // Main API dependencies

--- a/packages/plugin-ext/src/common/plugin-ext-api-contribution.ts
+++ b/packages/plugin-ext/src/common/plugin-ext-api-contribution.ts
@@ -155,11 +155,17 @@ export interface InternalPluginApiContribution {
      * Ext-side: return the API namespace properties and type exports that will be
      * merged into the `typeof theia` object given to each plugin.
      *
-     * Called once per plugin. The returned object's properties are spread into the
+     * Called once per plugin. The returned object's properties are deep-merged into the
      * final API object, so contributions can provide both namespace objects
-     * (e.g., `{ debug: { ... } }`) and type constructors (e.g., `{ TerminalLocation }`).
+     * (e.g., `{ window: { createTerminal: ... } }`) and type constructors
+     * (e.g., `{ TerminalLocation }`).
+     *
+     * Implementations should define a concrete return type (e.g., `TerminalPluginApiNamespace`)
+     * rather than using `Record<string, unknown>`, so that the assembler can verify the
+     * combined result satisfies `typeof theia` at compile time.
      *
      * @param plugin - the plugin for which the API is being created
      */
-    createApiNamespace(plugin: Plugin): Record<string, unknown>;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    createApiNamespace(plugin: Plugin): any;
 }

--- a/packages/plugin-ext/src/common/plugin-ext-api-contribution.ts
+++ b/packages/plugin-ext/src/common/plugin-ext-api-contribution.ts
@@ -113,3 +113,53 @@ export const MainPluginApiProvider = Symbol('mainPluginApi');
 export interface MainPluginApiProvider {
     initialize(rpc: RPCProtocol, container: interfaces.Container): void;
 }
+
+/**
+ * Contribution point for assembling pieces of the built-in plugin API (`theia.*` / `vscode.*` namespace).
+ *
+ * Unlike {@link ExtPluginApiProvider} and {@link MainPluginApiProvider} (which create *separate*
+ * API namespaces importable by plugins), implementations of this interface contribute to the
+ * core `theia.*` API object that every plugin receives.
+ *
+ * Each implementation is responsible for a slice of the API — for example, terminal-related
+ * functionality, debug, SCM, etc. The contribution registers its RPC implementations on both
+ * the main side and the ext (plugin-host) side, and provides the namespace properties and
+ * type exports that will be merged into the API object.
+ *
+ * Implementations are injected directly by the assembler service that composes the full API.
+ * The assembler is the typed composition point that ensures the full `typeof theia` contract
+ * is satisfied at compile time.
+ */
+export interface InternalPluginApiContribution {
+    /**
+     * Main-side: instantiate `*MainImpl` classes and register them on the RPC protocol.
+     * Called once per plugin runtime connection.
+     *
+     * Implementations should call `rpc.set(PLUGIN_RPC_CONTEXT.FOO_MAIN, new FooMainImpl(...))` for
+     * each main-side implementation they own.
+     */
+    registerMainImplementations(rpc: RPCProtocol, container: interfaces.Container): void;
+
+    /**
+     * Ext-side: instantiate `*ExtImpl` classes and register them on the RPC protocol.
+     * Called once when the plugin host initializes.
+     *
+     * Implementations should call `rpc.set(MAIN_RPC_CONTEXT.FOO_EXT, fooExtImpl)` for
+     * each ext-side implementation they own. Dependencies on other ext-side implementations
+     * (e.g., `CommandRegistryImpl`, `EditorsAndDocumentsExtImpl`) should be `@inject`ed
+     * from the DI container.
+     */
+    registerExtImplementations(rpc: RPCProtocol): void;
+
+    /**
+     * Ext-side: return the API namespace properties and type exports that will be
+     * merged into the `typeof theia` object given to each plugin.
+     *
+     * Called once per plugin. The returned object's properties are spread into the
+     * final API object, so contributions can provide both namespace objects
+     * (e.g., `{ debug: { ... } }`) and type constructors (e.g., `{ TerminalLocation }`).
+     *
+     * @param plugin - the plugin for which the API is being created
+     */
+    createApiNamespace(plugin: Plugin): Record<string, unknown>;
+}

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -27,7 +27,6 @@ import { PluginWorker } from './plugin-worker';
 import { getPluginId, DeployedPlugin, HostedPluginServer } from '../../common/plugin-protocol';
 import { HostedPluginWatcher } from './hosted-plugin-watcher';
 import { ExtensionKind, MAIN_RPC_CONTEXT, PluginManagerExt, UIKind } from '../../common/plugin-api-rpc';
-import { setUpPluginApi } from '../../main/browser/main-context';
 import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
 import {
     Disposable, DisposableCollection, isCancelled,
@@ -73,6 +72,7 @@ import {
 } from '../common/hosted-plugin';
 import { isRemote } from '@theia/core/lib/browser/browser';
 import { WorkspaceTrustService } from '@theia/workspace/lib/browser/workspace-trust-service';
+import { MainPluginApiAssembler } from '../../main/browser/main-plugin-api-assembler';
 
 export type DebugActivationEvent = 'onDebugResolve' | 'onDebugInitialConfigurations' | 'onDebugAdapterProtocolTracker' | 'onDebugDynamicConfigurations';
 
@@ -182,6 +182,9 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
 
     @inject(WorkspaceTrustService)
     protected readonly workspaceTrustService: WorkspaceTrustService;
+
+    @inject(MainPluginApiAssembler)
+    protected readonly pluginApiAssembler: MainPluginApiAssembler;
 
     constructor() {
         super(generateUuid());
@@ -362,7 +365,7 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
 
     protected initRpc(host: PluginHost, pluginId: string): RPCProtocol {
         const rpc = host === 'frontend' ? new PluginWorker().rpc : this.createServerRpc(host);
-        setUpPluginApi(rpc, this.container);
+        this.pluginApiAssembler.registerMainImplementations(rpc, this.container);
         this.mainPluginApiProviders.getContributions().forEach(p => p.initialize(rpc, this.container));
         return rpc;
     }

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -21,19 +21,15 @@ import { emptyPlugin, MAIN_RPC_CONTEXT, Plugin } from '../../../common/plugin-ap
 import { ExtPluginApi } from '../../../common/plugin-ext-api-contribution';
 import { getPluginId, PluginMetadata } from '../../../common/plugin-protocol';
 import { RPCProtocol } from '../../../common/rpc-protocol';
-import { ClipboardExt } from '../../../plugin/clipboard-ext';
+import { ExtPluginApiAssembler } from '../../../plugin/ext-plugin-api-assembler';
 import { EditorsAndDocumentsExtImpl } from '../../../plugin/editors-and-documents';
-import { MessageRegistryExt } from '../../../plugin/message-registry';
-import { createAPIFactory } from '../../../plugin/plugin-context';
+
 import { PluginManagerExtImpl } from '../../../plugin/plugin-manager';
 import { KeyValueStorageProxy } from '../../../plugin/plugin-storage';
 import { PreferenceRegistryExtImpl } from '../../../plugin/preference-registry';
 import { WebviewsExtImpl } from '../../../plugin/webviews';
 import { WorkspaceExtImpl } from '../../../plugin/workspace';
 import { loadManifest } from './plugin-manifest-loader';
-import { EnvExtImpl } from '../../../plugin/env';
-import { DebugExtImpl } from '../../../plugin/debug/debug-ext';
-import { LocalizationExtImpl } from '../../../plugin/localization-ext';
 import pluginHostModule from './worker-plugin-module';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -59,123 +55,107 @@ container.load(pluginHostModule);
 const rpc: RPCProtocol = container.get(RPCProtocol);
 const pluginManager = container.get(PluginManagerExtImpl);
 pluginManager.setPluginHost({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        loadPlugin(plugin: Plugin): any {
-            if (plugin.pluginPath) {
-                if (isElectron()) {
-                    ctx.importScripts(plugin.pluginPath);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    loadPlugin(plugin: Plugin): any {
+        if (plugin.pluginPath) {
+            if (isElectron()) {
+                ctx.importScripts(plugin.pluginPath);
+            } else {
+                if (plugin.lifecycle.frontendModuleName) {
+                    // Set current module name being imported
+                    ctx.frontendModuleName = plugin.lifecycle.frontendModuleName;
+                }
+
+                ctx.importScripts('./hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
+            }
+        }
+
+        if (plugin.lifecycle.frontendModuleName) {
+            if (!ctx[plugin.lifecycle.frontendModuleName]) {
+                console.error(`WebWorker: Cannot start plugin "${plugin.model.name}". Frontend plugin not found: "${plugin.lifecycle.frontendModuleName}"`);
+                return;
+            }
+            return ctx[plugin.lifecycle.frontendModuleName];
+        }
+    },
+    async init(rawPluginData: PluginMetadata[]): Promise<[Plugin[], Plugin[]]> {
+        const result: Plugin[] = [];
+        const foreign: Plugin[] = [];
+        // Process the plugins concurrently, making sure to keep the order.
+        const plugins = await Promise.all<{
+            /** Where to push the plugin: `result` or `foreign` */
+            target: Plugin[],
+            plugin: Plugin
+        }>(rawPluginData.map(async plg => {
+            const pluginModel = plg.model;
+            const pluginLifecycle = plg.lifecycle;
+            if (pluginModel.entryPoint!.frontend) {
+                let frontendInitPath = pluginLifecycle.frontendInitPath;
+                if (frontendInitPath) {
+                    initialize(frontendInitPath, plg);
                 } else {
-                    if (plugin.lifecycle.frontendModuleName) {
-                        // Set current module name being imported
-                        ctx.frontendModuleName = plugin.lifecycle.frontendModuleName;
-                    }
-
-                    ctx.importScripts('./hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
+                    frontendInitPath = '';
                 }
-            }
-
-            if (plugin.lifecycle.frontendModuleName) {
-                if (!ctx[plugin.lifecycle.frontendModuleName]) {
-                    console.error(`WebWorker: Cannot start plugin "${plugin.model.name}". Frontend plugin not found: "${plugin.lifecycle.frontendModuleName}"`);
-                    return;
-                }
-                return ctx[plugin.lifecycle.frontendModuleName];
-            }
-        },
-        async init(rawPluginData: PluginMetadata[]): Promise<[Plugin[], Plugin[]]> {
-            const result: Plugin[] = [];
-            const foreign: Plugin[] = [];
-            // Process the plugins concurrently, making sure to keep the order.
-            const plugins = await Promise.all<{
-                /** Where to push the plugin: `result` or `foreign` */
-                target: Plugin[],
-                plugin: Plugin
-            }>(rawPluginData.map(async plg => {
-                const pluginModel = plg.model;
-                const pluginLifecycle = plg.lifecycle;
-                if (pluginModel.entryPoint!.frontend) {
-                    let frontendInitPath = pluginLifecycle.frontendInitPath;
-                    if (frontendInitPath) {
-                        initialize(frontendInitPath, plg);
-                    } else {
-                        frontendInitPath = '';
-                    }
-                    const rawModel = await loadManifest(pluginModel);
-                    const plugin: Plugin = {
-                        pluginPath: pluginModel.entryPoint.frontend!,
+                const rawModel = await loadManifest(pluginModel);
+                const plugin: Plugin = {
+                    pluginPath: pluginModel.entryPoint.frontend!,
+                    pluginFolder: pluginModel.packagePath,
+                    pluginUri: pluginModel.packageUri,
+                    model: pluginModel,
+                    lifecycle: pluginLifecycle,
+                    rawModel,
+                    isUnderDevelopment: !!plg.isUnderDevelopment
+                };
+                const apiImpl = apiFactory(plugin);
+                pluginsApiImpl.set(plugin.model.id, apiImpl);
+                pluginsModulesNames.set(plugin.lifecycle.frontendModuleName!, plugin);
+                return { target: result, plugin };
+            } else {
+                return {
+                    target: foreign,
+                    plugin: {
+                        pluginPath: pluginModel.entryPoint.backend,
                         pluginFolder: pluginModel.packagePath,
                         pluginUri: pluginModel.packageUri,
                         model: pluginModel,
                         lifecycle: pluginLifecycle,
-                        rawModel,
+                        get rawModel(): never {
+                            throw new Error('not supported');
+                        },
                         isUnderDevelopment: !!plg.isUnderDevelopment
-                    };
-                    const apiImpl = apiFactory(plugin);
-                    pluginsApiImpl.set(plugin.model.id, apiImpl);
-                    pluginsModulesNames.set(plugin.lifecycle.frontendModuleName!, plugin);
-                    return { target: result, plugin };
-                } else {
-                    return {
-                        target: foreign,
-                        plugin: {
-                            pluginPath: pluginModel.entryPoint.backend,
-                            pluginFolder: pluginModel.packagePath,
-                            pluginUri: pluginModel.packageUri,
-                            model: pluginModel,
-                            lifecycle: pluginLifecycle,
-                            get rawModel(): never {
-                                throw new Error('not supported');
-                            },
-                            isUnderDevelopment: !!plg.isUnderDevelopment
-                        }
-                    };
-                }
-            }));
-            // Collect the ordered plugins and insert them in the target array:
-            for (const { target, plugin } of plugins) {
-                target.push(plugin);
-            }
-            return [result, foreign];
-        },
-        initExtApi(extApi: ExtPluginApi[]): void {
-            for (const api of extApi) {
-                try {
-                    if (api.frontendExtApi) {
-                        ctx.importScripts(api.frontendExtApi.initPath);
-                        ctx[api.frontendExtApi.initVariable][api.frontendExtApi.initFunction](rpc, pluginsModulesNames);
                     }
-
-                } catch (e) {
-                    console.error(e);
+                };
+            }
+        }));
+        // Collect the ordered plugins and insert them in the target array:
+        for (const { target, plugin } of plugins) {
+            target.push(plugin);
+        }
+        return [result, foreign];
+    },
+    initExtApi(extApi: ExtPluginApi[]): void {
+        for (const api of extApi) {
+            try {
+                if (api.frontendExtApi) {
+                    ctx.importScripts(api.frontendExtApi.initPath);
+                    ctx[api.frontendExtApi.initVariable][api.frontendExtApi.initFunction](rpc, pluginsModulesNames);
                 }
+
+            } catch (e) {
+                console.error(e);
             }
         }
-    });
+    }
+});
 
-const envExt = container.get(EnvExtImpl);
-const debugExt = container.get(DebugExtImpl);
 const preferenceRegistryExt = container.get(PreferenceRegistryExtImpl);
 const editorsAndDocuments = container.get(EditorsAndDocumentsExtImpl);
 const workspaceExt = container.get(WorkspaceExtImpl);
-const messageRegistryExt = container.get(MessageRegistryExt);
-const clipboardExt = container.get(ClipboardExt);
 const webviewExt = container.get(WebviewsExtImpl);
-const localizationExt = container.get(LocalizationExtImpl);
 const storageProxy = container.get(KeyValueStorageProxy);
 
-const apiFactory = createAPIFactory(
-    rpc,
-    pluginManager,
-    envExt,
-    debugExt,
-    preferenceRegistryExt,
-    editorsAndDocuments,
-    workspaceExt,
-    messageRegistryExt,
-    clipboardExt,
-    webviewExt,
-    localizationExt
-);
+const pluginApiAssembler = container.get(ExtPluginApiAssembler);
+const apiFactory = pluginApiAssembler.createApiFactory(rpc);
 let defaultApi: typeof theia;
 
 const handler = {

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-main.ts
@@ -55,98 +55,98 @@ container.load(pluginHostModule);
 const rpc: RPCProtocol = container.get(RPCProtocol);
 const pluginManager = container.get(PluginManagerExtImpl);
 pluginManager.setPluginHost({
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    loadPlugin(plugin: Plugin): any {
-        if (plugin.pluginPath) {
-            if (isElectron()) {
-                ctx.importScripts(plugin.pluginPath);
-            } else {
-                if (plugin.lifecycle.frontendModuleName) {
-                    // Set current module name being imported
-                    ctx.frontendModuleName = plugin.lifecycle.frontendModuleName;
-                }
-
-                ctx.importScripts('./hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
-            }
-        }
-
-        if (plugin.lifecycle.frontendModuleName) {
-            if (!ctx[plugin.lifecycle.frontendModuleName]) {
-                console.error(`WebWorker: Cannot start plugin "${plugin.model.name}". Frontend plugin not found: "${plugin.lifecycle.frontendModuleName}"`);
-                return;
-            }
-            return ctx[plugin.lifecycle.frontendModuleName];
-        }
-    },
-    async init(rawPluginData: PluginMetadata[]): Promise<[Plugin[], Plugin[]]> {
-        const result: Plugin[] = [];
-        const foreign: Plugin[] = [];
-        // Process the plugins concurrently, making sure to keep the order.
-        const plugins = await Promise.all<{
-            /** Where to push the plugin: `result` or `foreign` */
-            target: Plugin[],
-            plugin: Plugin
-        }>(rawPluginData.map(async plg => {
-            const pluginModel = plg.model;
-            const pluginLifecycle = plg.lifecycle;
-            if (pluginModel.entryPoint!.frontend) {
-                let frontendInitPath = pluginLifecycle.frontendInitPath;
-                if (frontendInitPath) {
-                    initialize(frontendInitPath, plg);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        loadPlugin(plugin: Plugin): any {
+            if (plugin.pluginPath) {
+                if (isElectron()) {
+                    ctx.importScripts(plugin.pluginPath);
                 } else {
-                    frontendInitPath = '';
+                    if (plugin.lifecycle.frontendModuleName) {
+                        // Set current module name being imported
+                        ctx.frontendModuleName = plugin.lifecycle.frontendModuleName;
+                    }
+
+                    ctx.importScripts('./hostedPlugin/' + getPluginId(plugin.model) + '/' + plugin.pluginPath);
                 }
-                const rawModel = await loadManifest(pluginModel);
-                const plugin: Plugin = {
-                    pluginPath: pluginModel.entryPoint.frontend!,
-                    pluginFolder: pluginModel.packagePath,
-                    pluginUri: pluginModel.packageUri,
-                    model: pluginModel,
-                    lifecycle: pluginLifecycle,
-                    rawModel,
-                    isUnderDevelopment: !!plg.isUnderDevelopment
-                };
-                const apiImpl = apiFactory(plugin);
-                pluginsApiImpl.set(plugin.model.id, apiImpl);
-                pluginsModulesNames.set(plugin.lifecycle.frontendModuleName!, plugin);
-                return { target: result, plugin };
-            } else {
-                return {
-                    target: foreign,
-                    plugin: {
-                        pluginPath: pluginModel.entryPoint.backend,
+            }
+
+            if (plugin.lifecycle.frontendModuleName) {
+                if (!ctx[plugin.lifecycle.frontendModuleName]) {
+                    console.error(`WebWorker: Cannot start plugin "${plugin.model.name}". Frontend plugin not found: "${plugin.lifecycle.frontendModuleName}"`);
+                    return;
+                }
+                return ctx[plugin.lifecycle.frontendModuleName];
+            }
+        },
+        async init(rawPluginData: PluginMetadata[]): Promise<[Plugin[], Plugin[]]> {
+            const result: Plugin[] = [];
+            const foreign: Plugin[] = [];
+            // Process the plugins concurrently, making sure to keep the order.
+            const plugins = await Promise.all<{
+                /** Where to push the plugin: `result` or `foreign` */
+                target: Plugin[],
+                plugin: Plugin
+            }>(rawPluginData.map(async plg => {
+                const pluginModel = plg.model;
+                const pluginLifecycle = plg.lifecycle;
+                if (pluginModel.entryPoint!.frontend) {
+                    let frontendInitPath = pluginLifecycle.frontendInitPath;
+                    if (frontendInitPath) {
+                        initialize(frontendInitPath, plg);
+                    } else {
+                        frontendInitPath = '';
+                    }
+                    const rawModel = await loadManifest(pluginModel);
+                    const plugin: Plugin = {
+                        pluginPath: pluginModel.entryPoint.frontend!,
                         pluginFolder: pluginModel.packagePath,
                         pluginUri: pluginModel.packageUri,
                         model: pluginModel,
                         lifecycle: pluginLifecycle,
-                        get rawModel(): never {
-                            throw new Error('not supported');
-                        },
+                        rawModel,
                         isUnderDevelopment: !!plg.isUnderDevelopment
-                    }
-                };
-            }
-        }));
-        // Collect the ordered plugins and insert them in the target array:
-        for (const { target, plugin } of plugins) {
-            target.push(plugin);
-        }
-        return [result, foreign];
-    },
-    initExtApi(extApi: ExtPluginApi[]): void {
-        for (const api of extApi) {
-            try {
-                if (api.frontendExtApi) {
-                    ctx.importScripts(api.frontendExtApi.initPath);
-                    ctx[api.frontendExtApi.initVariable][api.frontendExtApi.initFunction](rpc, pluginsModulesNames);
+                    };
+                    const apiImpl = apiFactory(plugin);
+                    pluginsApiImpl.set(plugin.model.id, apiImpl);
+                    pluginsModulesNames.set(plugin.lifecycle.frontendModuleName!, plugin);
+                    return { target: result, plugin };
+                } else {
+                    return {
+                        target: foreign,
+                        plugin: {
+                            pluginPath: pluginModel.entryPoint.backend,
+                            pluginFolder: pluginModel.packagePath,
+                            pluginUri: pluginModel.packageUri,
+                            model: pluginModel,
+                            lifecycle: pluginLifecycle,
+                            get rawModel(): never {
+                                throw new Error('not supported');
+                            },
+                            isUnderDevelopment: !!plg.isUnderDevelopment
+                        }
+                    };
                 }
+            }));
+            // Collect the ordered plugins and insert them in the target array:
+            for (const { target, plugin } of plugins) {
+                target.push(plugin);
+            }
+            return [result, foreign];
+        },
+        initExtApi(extApi: ExtPluginApi[]): void {
+            for (const api of extApi) {
+                try {
+                    if (api.frontendExtApi) {
+                        ctx.importScripts(api.frontendExtApi.initPath);
+                        ctx[api.frontendExtApi.initVariable][api.frontendExtApi.initFunction](rpc, pluginsModulesNames);
+                    }
 
-            } catch (e) {
-                console.error(e);
+                } catch (e) {
+                    console.error(e);
+                }
             }
         }
-    }
-});
+    });
 
 const preferenceRegistryExt = container.get(PreferenceRegistryExtImpl);
 const editorsAndDocuments = container.get(EditorsAndDocumentsExtImpl);

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
@@ -18,6 +18,7 @@ import 'reflect-metadata';
 import { ContainerModule } from '@theia/core/shared/inversify';
 
 import { LegacyExtPluginApiContribution } from '../../../plugin/legacy-ext-plugin-api-contribution';
+import { TerminalExtPluginApiContribution } from '../../../plugin/terminal-ext-plugin-api-contribution';
 import { ExtPluginApiAssembler } from '../../../plugin/ext-plugin-api-assembler';
 import { BasicChannel } from '@theia/core/lib/common/message-rpc/channel';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from '@theia/core/lib/common/message-rpc/uint8-array-message-buffer';
@@ -85,5 +86,6 @@ export default new ContainerModule(bind => {
     bind(MinimalTerminalServiceExt).toService(TerminalServiceExtImpl);
 
     bind(LegacyExtPluginApiContribution).toSelf().inSingletonScope();
+    bind(TerminalExtPluginApiContribution).toSelf().inSingletonScope();
     bind(ExtPluginApiAssembler).toSelf().inSingletonScope();
 });

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
@@ -16,6 +16,9 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 import 'reflect-metadata';
 import { ContainerModule } from '@theia/core/shared/inversify';
+
+import { LegacyExtPluginApiContribution } from '../../../plugin/legacy-ext-plugin-api-contribution';
+import { ExtPluginApiAssembler } from '../../../plugin/ext-plugin-api-assembler';
 import { BasicChannel } from '@theia/core/lib/common/message-rpc/channel';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from '@theia/core/lib/common/message-rpc/uint8-array-message-buffer';
 import { LocalizationExt } from '../../../common/plugin-api-rpc';
@@ -23,7 +26,7 @@ import { RPCProtocol, RPCProtocolImpl } from '../../../common/rpc-protocol';
 import { ClipboardExt } from '../../../plugin/clipboard-ext';
 import { EditorsAndDocumentsExtImpl } from '../../../plugin/editors-and-documents';
 import { MessageRegistryExt } from '../../../plugin/message-registry';
-import { MinimalTerminalServiceExt, PluginManagerExtImpl } from '../../../plugin/plugin-manager';
+import { AbstractPluginManagerExtImpl, MinimalTerminalServiceExt, PluginManagerExtImpl } from '../../../plugin/plugin-manager';
 import { InternalStorageExt, KeyValueStorageProxy } from '../../../plugin/plugin-storage';
 import { PreferenceRegistryExtImpl } from '../../../plugin/preference-registry';
 import { InternalSecretsExt, SecretsExtImpl } from '../../../plugin/secrets-ext';
@@ -57,6 +60,7 @@ export default new ContainerModule(bind => {
 
     bind(RPCProtocol).toConstantValue(rpc);
 
+    bind(AbstractPluginManagerExtImpl).toService(PluginManagerExtImpl);
     bind(PluginManagerExtImpl).toSelf().inSingletonScope();
     bind(EnvExtImpl).to(WorkerEnvExtImpl).inSingletonScope();
     bind(LocalizationExtImpl).toSelf().inSingletonScope();
@@ -79,4 +83,7 @@ export default new ContainerModule(bind => {
     bind(WebviewsExtImpl).toSelf().inSingletonScope();
     bind(TerminalServiceExtImpl).toSelf().inSingletonScope();
     bind(MinimalTerminalServiceExt).toService(TerminalServiceExtImpl);
+
+    bind(LegacyExtPluginApiContribution).toSelf().inSingletonScope();
+    bind(ExtPluginApiAssembler).toSelf().inSingletonScope();
 });

--- a/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
+++ b/packages/plugin-ext/src/hosted/browser/worker/worker-plugin-module.ts
@@ -19,6 +19,9 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 
 import { LegacyExtPluginApiContribution } from '../../../plugin/legacy-ext-plugin-api-contribution';
 import { TerminalExtPluginApiContribution } from '../../../plugin/terminal-ext-plugin-api-contribution';
+import { ScmExtPluginApiContribution } from '../../../plugin/scm-ext-plugin-api-contribution';
+import { CommandRegistryImpl } from '../../../plugin/command-registry';
+import { ScmExtImpl } from '../../../plugin/scm';
 import { ExtPluginApiAssembler } from '../../../plugin/ext-plugin-api-assembler';
 import { BasicChannel } from '@theia/core/lib/common/message-rpc/channel';
 import { Uint8ArrayReadBuffer, Uint8ArrayWriteBuffer } from '@theia/core/lib/common/message-rpc/uint8-array-message-buffer';
@@ -84,8 +87,11 @@ export default new ContainerModule(bind => {
     bind(WebviewsExtImpl).toSelf().inSingletonScope();
     bind(TerminalServiceExtImpl).toSelf().inSingletonScope();
     bind(MinimalTerminalServiceExt).toService(TerminalServiceExtImpl);
+    bind(CommandRegistryImpl).toSelf().inSingletonScope();
+    bind(ScmExtImpl).toSelf().inSingletonScope();
 
     bind(LegacyExtPluginApiContribution).toSelf().inSingletonScope();
     bind(TerminalExtPluginApiContribution).toSelf().inSingletonScope();
+    bind(ScmExtPluginApiContribution).toSelf().inSingletonScope();
     bind(ExtPluginApiAssembler).toSelf().inSingletonScope();
 });

--- a/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
@@ -16,11 +16,15 @@
 
 import '@theia/core/shared/reflect-metadata';
 import { ContainerModule } from '@theia/core/shared/inversify';
+
 import { RPCProtocol, RPCProtocolImpl } from '../../common/rpc-protocol';
 import { AbstractPluginHostRPC, PluginHostRPC, PluginContainerModuleLoader } from './plugin-host-rpc';
 import { AbstractPluginManagerExtImpl, MinimalTerminalServiceExt, PluginManagerExtImpl } from '../../plugin/plugin-manager';
 import { IPCChannel } from '@theia/core/lib/node';
 import { InternalPluginContainerModule } from '../../plugin/node/plugin-container-module';
+
+import { LegacyExtPluginApiContribution } from '../../plugin/legacy-ext-plugin-api-contribution';
+import { ExtPluginApiAssembler } from '../../plugin/ext-plugin-api-assembler';
 import { LocalizationExt } from '../../common/plugin-api-rpc';
 import { EnvExtImpl } from '../../plugin/env';
 import { EnvNodeExtImpl } from '../../plugin/node/env-node-ext';
@@ -74,4 +78,7 @@ export default new ContainerModule(bind => {
     bind(WebviewsExtImpl).toSelf().inSingletonScope();
     bind(MinimalTerminalServiceExt).toService(TerminalServiceExtImpl);
     bind(TerminalServiceExtImpl).toSelf().inSingletonScope();
+
+    bind(LegacyExtPluginApiContribution).toSelf().inSingletonScope();
+    bind(ExtPluginApiAssembler).toSelf().inSingletonScope();
 });

--- a/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
@@ -24,6 +24,7 @@ import { IPCChannel } from '@theia/core/lib/node';
 import { InternalPluginContainerModule } from '../../plugin/node/plugin-container-module';
 
 import { LegacyExtPluginApiContribution } from '../../plugin/legacy-ext-plugin-api-contribution';
+import { TerminalExtPluginApiContribution } from '../../plugin/terminal-ext-plugin-api-contribution';
 import { ExtPluginApiAssembler } from '../../plugin/ext-plugin-api-assembler';
 import { LocalizationExt } from '../../common/plugin-api-rpc';
 import { EnvExtImpl } from '../../plugin/env';
@@ -80,5 +81,6 @@ export default new ContainerModule(bind => {
     bind(TerminalServiceExtImpl).toSelf().inSingletonScope();
 
     bind(LegacyExtPluginApiContribution).toSelf().inSingletonScope();
+    bind(TerminalExtPluginApiContribution).toSelf().inSingletonScope();
     bind(ExtPluginApiAssembler).toSelf().inSingletonScope();
 });

--- a/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-module.ts
@@ -25,6 +25,9 @@ import { InternalPluginContainerModule } from '../../plugin/node/plugin-containe
 
 import { LegacyExtPluginApiContribution } from '../../plugin/legacy-ext-plugin-api-contribution';
 import { TerminalExtPluginApiContribution } from '../../plugin/terminal-ext-plugin-api-contribution';
+import { ScmExtPluginApiContribution } from '../../plugin/scm-ext-plugin-api-contribution';
+import { CommandRegistryImpl } from '../../plugin/command-registry';
+import { ScmExtImpl } from '../../plugin/scm';
 import { ExtPluginApiAssembler } from '../../plugin/ext-plugin-api-assembler';
 import { LocalizationExt } from '../../common/plugin-api-rpc';
 import { EnvExtImpl } from '../../plugin/env';
@@ -79,8 +82,11 @@ export default new ContainerModule(bind => {
     bind(WebviewsExtImpl).toSelf().inSingletonScope();
     bind(MinimalTerminalServiceExt).toService(TerminalServiceExtImpl);
     bind(TerminalServiceExtImpl).toSelf().inSingletonScope();
+    bind(CommandRegistryImpl).toSelf().inSingletonScope();
+    bind(ScmExtImpl).toSelf().inSingletonScope();
 
     bind(LegacyExtPluginApiContribution).toSelf().inSingletonScope();
     bind(TerminalExtPluginApiContribution).toSelf().inSingletonScope();
+    bind(ScmExtPluginApiContribution).toSelf().inSingletonScope();
     bind(ExtPluginApiAssembler).toSelf().inSingletonScope();
 });

--- a/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-host-rpc.ts
@@ -24,10 +24,10 @@ import {
     LocalizationExt
 } from '../../common/plugin-api-rpc';
 import { PluginMetadata, PluginModel } from '../../common/plugin-protocol';
-import { createAPIFactory } from '../../plugin/plugin-context';
 import { EnvExtImpl } from '../../plugin/env';
 import { PreferenceRegistryExtImpl } from '../../plugin/preference-registry';
 import { ExtPluginApi, ExtPluginApiBackendInitializationFn } from '../../common/plugin-ext-api-contribution';
+import { ExtPluginApiAssembler } from '../../plugin/ext-plugin-api-assembler';
 import { DebugExtImpl } from '../../plugin/debug/debug-ext';
 import { EditorsAndDocumentsExtImpl } from '../../plugin/editors-and-documents';
 import { WorkspaceExtImpl } from '../../plugin/workspace';
@@ -320,6 +320,9 @@ export class PluginHostRPC extends AbstractPluginHostRPC<PluginManagerExtImpl, P
     @inject(SecretsExtImpl)
     protected readonly secretsExt: SecretsExtImpl;
 
+    @inject(ExtPluginApiAssembler)
+    protected readonly pluginApiAssembler: ExtPluginApiAssembler;
+
     constructor() {
         super('PLUGIN_HOST', '/scanners/backend-init-theia.js',
             {
@@ -352,14 +355,8 @@ export class PluginHostRPC extends AbstractPluginHostRPC<PluginManagerExtImpl, P
         };
     }
 
-    protected createAPIFactory(extInterfaces: ExtInterfaces): PluginAPIFactory {
-        const {
-            envExt, debugExt, preferenceRegistryExt, editorsAndDocumentsExt, workspaceExt,
-            messageRegistryExt, clipboardExt, webviewExt, localizationExt
-        } = extInterfaces;
-        return createAPIFactory(this.rpc, this.pluginManager, envExt, debugExt, preferenceRegistryExt,
-            editorsAndDocumentsExt, workspaceExt, messageRegistryExt, clipboardExt, webviewExt,
-            localizationExt);
+    protected createAPIFactory(_extInterfaces: ExtInterfaces): PluginAPIFactory {
+        return this.pluginApiAssembler.createApiFactory(this.rpc);
     }
 
     protected initExtApi(extApi: ExtPluginApi): void {

--- a/packages/plugin-ext/src/main/browser/legacy-plugin-api-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/legacy-plugin-api-contribution.ts
@@ -14,15 +14,13 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
-import { interfaces } from '@theia/core/shared/inversify';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { InternalPluginApiContribution } from '../../common/plugin-ext-api-contribution';
-import { Plugin } from '../../common/plugin-api-rpc';
 import { CommandRegistryMainImpl } from './command-registry-main';
 import { PreferenceRegistryMainImpl } from './preference-registry-main';
 import { QuickOpenMainImpl } from './quick-open-main';
-import { PLUGIN_RPC_CONTEXT, LanguagesMainFactory, OutputChannelRegistryFactory, MAIN_RPC_CONTEXT } from '../../common/plugin-api-rpc';
+import { PLUGIN_RPC_CONTEXT, LanguagesMainFactory, OutputChannelRegistryFactory, MAIN_RPC_CONTEXT, Plugin } from '../../common/plugin-api-rpc';
 import { MessageRegistryMainImpl } from './message-registry-main';
 import { WindowStateMain } from './window-state-main';
 import { WorkspaceMainImpl } from './workspace-main';

--- a/packages/plugin-ext/src/main/browser/legacy-plugin-api-contribution.ts
+++ b/packages/plugin-ext/src/main/browser/legacy-plugin-api-contribution.ts
@@ -1,0 +1,231 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { interfaces } from '@theia/core/shared/inversify';
+import { RPCProtocol } from '../../common/rpc-protocol';
+import { InternalPluginApiContribution } from '../../common/plugin-ext-api-contribution';
+import { Plugin } from '../../common/plugin-api-rpc';
+import { CommandRegistryMainImpl } from './command-registry-main';
+import { PreferenceRegistryMainImpl } from './preference-registry-main';
+import { QuickOpenMainImpl } from './quick-open-main';
+import { PLUGIN_RPC_CONTEXT, LanguagesMainFactory, OutputChannelRegistryFactory, MAIN_RPC_CONTEXT } from '../../common/plugin-api-rpc';
+import { MessageRegistryMainImpl } from './message-registry-main';
+import { WindowStateMain } from './window-state-main';
+import { WorkspaceMainImpl } from './workspace-main';
+import { StatusBarMessageRegistryMainImpl } from './status-bar-message-registry-main';
+import { EnvMainImpl } from './env-main';
+import { EditorsAndDocumentsMain } from './editors-and-documents-main';
+import { TerminalServiceMainImpl } from './terminal-main';
+import { DialogsMainImpl } from './dialogs-main';
+import { TreeViewsMainImpl } from './view/tree-views-main';
+import { NotificationMainImpl } from './notification-main';
+import { ConnectionImpl } from '../../common/connection';
+import { WebviewsMainImpl } from './webviews-main';
+import { TasksMainImpl } from './tasks-main';
+import { StorageMainImpl } from './plugin-storage';
+import { DebugMainImpl } from './debug/debug-main';
+import { FileSystemMainImpl } from './file-system-main-impl';
+import { ScmMainImpl } from './scm-main';
+import { DecorationsMainImpl } from './decorations/decorations-main';
+import { ClipboardMainImpl } from './clipboard-main';
+import { DocumentsMainImpl } from './documents-main';
+import { TextEditorsMainImpl } from './text-editors-main';
+import { EditorModelService } from './text-editor-model-service';
+import { OpenerService } from '@theia/core/lib/browser/opener-service';
+import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
+import { MainFileSystemEventService } from './main-file-system-event-service';
+import { LabelServiceMainImpl } from './label-service-main';
+import { TimelineMainImpl } from './timeline-main';
+import { AuthenticationMainImpl } from './authentication-main';
+import { ThemingMainImpl } from './theming-main';
+import { CommentsMainImp } from './comments/comments-main';
+import { CustomEditorsMainImpl } from './custom-editors/custom-editors-main';
+import { SecretsMainImpl } from './secrets-main';
+import { WebviewViewsMainImpl } from './webview-views/webview-views-main';
+import { MonacoLanguages } from '@theia/monaco/lib/browser/monaco-languages';
+import { UntitledResourceResolver } from '@theia/core/lib/common/resource';
+import { ThemeService } from '@theia/core/lib/browser/theming';
+import { TabsMainImpl } from './tabs/tabs-main';
+import { NotebooksMainImpl } from './notebooks/notebooks-main';
+import { LocalizationMainImpl } from './localization-main';
+import { NotebookRenderersMainImpl } from './notebooks/notebook-renderers-main';
+import { NotebookEditorsMainImpl } from './notebooks/notebook-editors-main';
+import { NotebookDocumentsMainImpl } from './notebooks/notebook-documents-main';
+import { NotebookKernelsMainImpl } from './notebooks/notebook-kernels-main';
+import { NotebooksAndEditorsMain } from './notebooks/notebook-documents-and-editors-main';
+import { TestingMainImpl } from './test-main';
+import { UriMainImpl } from './uri-main';
+import { LoggerMainImpl } from './logger-main';
+import { McpServerDefinitionRegistryMainImpl } from './lm-main';
+
+@injectable()
+export class LegacyMainPluginApiContribution implements InternalPluginApiContribution {
+
+    registerMainImplementations(rpc: RPCProtocol, container: interfaces.Container): void {
+        const loggerMain = new LoggerMainImpl(container);
+        rpc.set(PLUGIN_RPC_CONTEXT.LOGGER_MAIN, loggerMain);
+
+        const authenticationMain = new AuthenticationMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.AUTHENTICATION_MAIN, authenticationMain);
+
+        const commandRegistryMain = new CommandRegistryMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.COMMAND_REGISTRY_MAIN, commandRegistryMain);
+
+        const quickOpenMain = new QuickOpenMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.QUICK_OPEN_MAIN, quickOpenMain);
+
+        const workspaceMain = new WorkspaceMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.WORKSPACE_MAIN, workspaceMain);
+
+        const dialogsMain = new DialogsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.DIALOGS_MAIN, dialogsMain);
+
+        const messageRegistryMain = new MessageRegistryMainImpl(container);
+        rpc.set(PLUGIN_RPC_CONTEXT.MESSAGE_REGISTRY_MAIN, messageRegistryMain);
+
+        const preferenceRegistryMain = new PreferenceRegistryMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.PREFERENCE_REGISTRY_MAIN, preferenceRegistryMain);
+
+        const tabsMain = new TabsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.TABS_MAIN, tabsMain);
+
+        const editorsAndDocuments = new EditorsAndDocumentsMain(rpc, container, tabsMain);
+
+        const notebookDocumentsMain = new NotebookDocumentsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_MAIN, notebookDocumentsMain);
+
+        const modelService = container.get(EditorModelService);
+        const openerService = container.get<OpenerService>(OpenerService);
+        const shell = container.get(ApplicationShell);
+        const untitledResourceResolver = container.get(UntitledResourceResolver);
+        const languageService = container.get(MonacoLanguages);
+        const documentsMain = new DocumentsMainImpl(editorsAndDocuments, notebookDocumentsMain, modelService, rpc,
+            openerService, shell, untitledResourceResolver, languageService);
+        rpc.set(PLUGIN_RPC_CONTEXT.DOCUMENTS_MAIN, documentsMain);
+
+        rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOKS_MAIN, new NotebooksMainImpl(rpc, container, commandRegistryMain));
+        rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_RENDERERS_MAIN, new NotebookRenderersMainImpl(rpc, container));
+        const notebookEditorsMain = new NotebookEditorsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_EDITORS_MAIN, notebookEditorsMain);
+        rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_AND_EDITORS_MAIN, new NotebooksAndEditorsMain(rpc, container, tabsMain, notebookDocumentsMain, notebookEditorsMain));
+        rpc.set(PLUGIN_RPC_CONTEXT.NOTEBOOK_KERNELS_MAIN, new NotebookKernelsMainImpl(rpc, container));
+
+        const editorsMain = new TextEditorsMainImpl(editorsAndDocuments, documentsMain, rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.TEXT_EDITORS_MAIN, editorsMain);
+
+        // start listening only after all clients are subscribed to events
+        editorsAndDocuments.listen();
+
+        const statusBarMessageRegistryMain = new StatusBarMessageRegistryMainImpl(container, rpc);
+        rpc.set(PLUGIN_RPC_CONTEXT.STATUS_BAR_MESSAGE_REGISTRY_MAIN, statusBarMessageRegistryMain);
+
+        const envMain = new EnvMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.ENV_MAIN, envMain);
+
+        const notificationMain = new NotificationMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.NOTIFICATION_MAIN, notificationMain);
+
+        const testingMain = new TestingMainImpl(rpc, container, commandRegistryMain);
+        rpc.set(PLUGIN_RPC_CONTEXT.TESTING_MAIN, testingMain);
+
+        const terminalMain = new TerminalServiceMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.TERMINAL_MAIN, terminalMain);
+
+        const treeViewsMain = new TreeViewsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.TREE_VIEWS_MAIN, treeViewsMain);
+
+        const outputChannelRegistryFactory: OutputChannelRegistryFactory = container.get(OutputChannelRegistryFactory);
+        const outputChannelRegistryMain = outputChannelRegistryFactory();
+        rpc.set(PLUGIN_RPC_CONTEXT.OUTPUT_CHANNEL_REGISTRY_MAIN, outputChannelRegistryMain);
+
+        const languagesMainFactory: LanguagesMainFactory = container.get(LanguagesMainFactory);
+        const languagesMain = languagesMainFactory(rpc);
+        rpc.set(PLUGIN_RPC_CONTEXT.LANGUAGES_MAIN, languagesMain);
+
+        const webviewsMain = new WebviewsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.WEBVIEWS_MAIN, webviewsMain);
+
+        const customEditorsMain = new CustomEditorsMainImpl(rpc, container, webviewsMain);
+        rpc.set(PLUGIN_RPC_CONTEXT.CUSTOM_EDITORS_MAIN, customEditorsMain);
+
+        const webviewViewsMain = new WebviewViewsMainImpl(rpc, container, webviewsMain);
+        rpc.set(PLUGIN_RPC_CONTEXT.WEBVIEW_VIEWS_MAIN, webviewViewsMain);
+
+        const storageMain = new StorageMainImpl(container);
+        rpc.set(PLUGIN_RPC_CONTEXT.STORAGE_MAIN, storageMain);
+
+        const connectionMain = new ConnectionImpl(rpc.getProxy(MAIN_RPC_CONTEXT.CONNECTION_EXT));
+        rpc.set(PLUGIN_RPC_CONTEXT.CONNECTION_MAIN, connectionMain);
+
+        const tasksMain = new TasksMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.TASKS_MAIN, tasksMain);
+
+        const debugMain = new DebugMainImpl(rpc, connectionMain, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.DEBUG_MAIN, debugMain);
+
+        const fs = new FileSystemMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.FILE_SYSTEM_MAIN, fs);
+
+        const fsEventService = new MainFileSystemEventService(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.FILE_SYSTEM_EVENT_SERVICE_MAIN, fsEventService);
+
+        const scmMain = new ScmMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.SCM_MAIN, scmMain);
+
+        const secretsMain = new SecretsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.SECRETS_MAIN, secretsMain);
+
+        const decorationsMain = new DecorationsMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.DECORATIONS_MAIN, decorationsMain);
+
+        const windowMain = new WindowStateMain(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.WINDOW_MAIN, windowMain);
+
+        const clipboardMain = new ClipboardMainImpl(container);
+        rpc.set(PLUGIN_RPC_CONTEXT.CLIPBOARD_MAIN, clipboardMain);
+
+        const labelServiceMain = new LabelServiceMainImpl(container);
+        rpc.set(PLUGIN_RPC_CONTEXT.LABEL_SERVICE_MAIN, labelServiceMain);
+
+        const timelineMain = new TimelineMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.TIMELINE_MAIN, timelineMain);
+
+        const themingMain = new ThemingMainImpl(rpc, container.get(ThemeService));
+        rpc.set(PLUGIN_RPC_CONTEXT.THEMING_MAIN, themingMain);
+
+        const commentsMain = new CommentsMainImp(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.COMMENTS_MAIN, commentsMain);
+
+        const localizationMain = new LocalizationMainImpl(container);
+        rpc.set(PLUGIN_RPC_CONTEXT.LOCALIZATION_MAIN, localizationMain);
+
+        const uriMain = new UriMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.URI_MAIN, uriMain);
+
+        const mcpServerDefinitionRegistryMain = new McpServerDefinitionRegistryMainImpl(rpc, container);
+        rpc.set(PLUGIN_RPC_CONTEXT.MCP_SERVER_DEFINITION_REGISTRY_MAIN, mcpServerDefinitionRegistryMain);
+    }
+
+    registerExtImplementations(_rpc: RPCProtocol): void {
+        // No-op on the main side — ext-side registration is handled separately
+    }
+
+    createApiNamespace(_plugin: Plugin): Record<string, unknown> {
+        // No-op on the main side — API namespace creation is handled separately
+        return {};
+    }
+}

--- a/packages/plugin-ext/src/main/browser/main-plugin-api-assembler.ts
+++ b/packages/plugin-ext/src/main/browser/main-plugin-api-assembler.ts
@@ -14,8 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable } from '@theia/core/shared/inversify';
-import { interfaces } from '@theia/core/shared/inversify';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { RPCProtocol } from '../../common/rpc-protocol';
 import { LegacyMainPluginApiContribution } from './legacy-plugin-api-contribution';
 

--- a/packages/plugin-ext/src/main/browser/main-plugin-api-assembler.ts
+++ b/packages/plugin-ext/src/main/browser/main-plugin-api-assembler.ts
@@ -1,0 +1,54 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { interfaces } from '@theia/core/shared/inversify';
+import { RPCProtocol } from '../../common/rpc-protocol';
+import { LegacyMainPluginApiContribution } from './legacy-plugin-api-contribution';
+
+/**
+ * Assembles the main-side plugin API by composing explicitly injected providers.
+ *
+ * Each provider is responsible for a slice of the main-side API — registering
+ * `*MainImpl` classes on the RPC protocol. This assembler is the single composition
+ * point: call sites inject only the assembler, not individual providers.
+ *
+ * Currently there is only the legacy monolithic provider. As features are extracted
+ * into their own packages (e.g. `plugin-ext-terminal`), each will export a main-side
+ * provider, and this assembler will gain an `@inject` for it. TypeScript ensures that
+ * any provider added here is actually available in the DI container.
+ *
+ * Downstream applications that want a different API surface can subclass or replace
+ * this assembler, injecting only the providers they need.
+ */
+@injectable()
+export class MainPluginApiAssembler {
+
+    @inject(LegacyMainPluginApiContribution)
+    protected readonly legacy: LegacyMainPluginApiContribution;
+
+    // Future providers will be added here as explicit @inject fields, e.g.:
+    // @inject(TerminalMainPluginApiProvider) protected readonly terminal: TerminalMainPluginApiProvider;
+
+    /**
+     * Register all main-side RPC implementations from all providers.
+     * Called once per plugin runtime connection.
+     */
+    registerMainImplementations(rpc: RPCProtocol, container: interfaces.Container): void {
+        this.legacy.registerMainImplementations(rpc, container);
+        // Future: this.terminal.registerMainImplementations(rpc, container);
+    }
+}

--- a/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
+++ b/packages/plugin-ext/src/main/browser/plugin-ext-frontend-module.ts
@@ -42,6 +42,8 @@ import { PluginContributionHandler } from './plugin-contribution-handler';
 import { PluginViewRegistry, PLUGIN_VIEW_CONTAINER_FACTORY_ID, PLUGIN_VIEW_FACTORY_ID, PLUGIN_VIEW_DATA_FACTORY_ID } from './view/plugin-view-registry';
 import { TextContentResourceResolver } from './workspace-main';
 import { MainPluginApiProvider } from '../../common/plugin-ext-api-contribution';
+import { LegacyMainPluginApiContribution } from './legacy-plugin-api-contribution';
+import { MainPluginApiAssembler } from './main-plugin-api-assembler';
 import { PluginPathsService, pluginPathsServicePath } from '../common/plugin-paths-protocol';
 import { KeybindingsContributionPointHandler } from './keybindings/keybindings-contribution-handler';
 import { DebugSessionContributionRegistry } from '@theia/debug/lib/browser/debug-session-contribution';
@@ -266,6 +268,8 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(TextContentResourceResolver).toSelf().inSingletonScope();
     bind(ResourceResolver).toService(TextContentResourceResolver);
     bindRootContributionProvider(bind, MainPluginApiProvider);
+    bind(LegacyMainPluginApiContribution).toSelf().inSingletonScope();
+    bind(MainPluginApiAssembler).toSelf().inSingletonScope();
 
     bind(PluginDebugService).toSelf().inSingletonScope();
     rebind(DebugService).toService(PluginDebugService);

--- a/packages/plugin-ext/src/plugin/command-registry.ts
+++ b/packages/plugin-ext/src/plugin/command-registry.ts
@@ -24,6 +24,7 @@ import { CommandRegistryExt, PLUGIN_RPC_CONTEXT as Ext, CommandRegistryMain } fr
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Disposable, URI } from './types-impl';
 import { DisposableCollection } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { KnownCommands } from './known-commands';
 import { ArgumentProcessor } from '../common/commands';
 import { isUriComponents } from './type-converters';
@@ -31,6 +32,7 @@ import { isUriComponents } from './type-converters';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type Handler = <T>(...args: any[]) => T | PromiseLike<T | undefined>;
 
+@injectable()
 export class CommandRegistryImpl implements CommandRegistryExt {
 
     private proxy: CommandRegistryMain;
@@ -39,7 +41,7 @@ export class CommandRegistryImpl implements CommandRegistryExt {
     private readonly argumentProcessors: ArgumentProcessor[];
     private readonly commandsConverter: CommandsConverter;
 
-    constructor(rpc: RPCProtocol) {
+    constructor(@inject(RPCProtocol) rpc: RPCProtocol) {
         this.proxy = rpc.getProxy(Ext.COMMAND_REGISTRY_MAIN);
         this.argumentProcessors = [];
         this.commandsConverter = new CommandsConverter(this);

--- a/packages/plugin-ext/src/plugin/ext-plugin-api-assembler.ts
+++ b/packages/plugin-ext/src/plugin/ext-plugin-api-assembler.ts
@@ -1,0 +1,74 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import type * as theia from '@theia/plugin';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { Plugin, PluginAPIFactory } from '../common/plugin-api-rpc';
+import { LegacyExtPluginApiContribution } from './legacy-ext-plugin-api-contribution';
+
+/**
+ * Assembles the ext-side (plugin-host) plugin API by composing explicitly injected providers.
+ *
+ * Each provider is responsible for a slice of the ext-side API — registering `*ExtImpl`
+ * classes on the RPC protocol and producing the namespace properties and type exports
+ * that form the `typeof theia` object given to each plugin.
+ *
+ * This assembler is the single composition point for the ext side: call sites inject
+ * only the assembler, not individual providers.
+ *
+ * Currently there is only the legacy monolithic provider. As features are extracted
+ * into their own packages (e.g. `plugin-ext-terminal`), each will export an ext-side
+ * provider, and this assembler will gain an `@inject` for it. The `createApiFactory`
+ * method merges all providers' namespace contributions and TypeScript ensures the
+ * combined result satisfies `typeof theia`.
+ *
+ * Downstream applications that want a different API surface can subclass or replace
+ * this assembler, injecting only the providers they need.
+ */
+@injectable()
+export class ExtPluginApiAssembler {
+
+    @inject(LegacyExtPluginApiContribution)
+    protected readonly legacy: LegacyExtPluginApiContribution;
+
+    // Future providers will be added here as explicit @inject fields, e.g.:
+    // @inject(TerminalExtPluginApiProvider) protected readonly terminal: TerminalExtPluginApiProvider;
+
+    /**
+     * Register all ext-side RPC implementations and return a factory that produces
+     * a per-plugin `typeof theia` API object.
+     *
+     * This performs two phases:
+     * 1. **Registration** — calls `registerExtImplementations` on each provider,
+     *    which creates `*ExtImpl` instances and registers them on the RPC protocol.
+     * 2. **Factory** — returns a {@link PluginAPIFactory} closure. Each time a plugin
+     *    is loaded, the closure calls `createApiNamespace` on every provider and merges
+     *    the results into a single `typeof theia` object.
+     */
+    createApiFactory(rpc: RPCProtocol): PluginAPIFactory {
+        this.legacy.registerExtImplementations(rpc);
+        // Future: this.terminal.registerExtImplementations(rpc);
+
+        return (plugin: Plugin): typeof theia => {
+            const api = {
+                ...this.legacy.createApiNamespace(plugin),
+                // Future: ...this.terminal.createApiNamespace(plugin),
+            };
+            return api as typeof theia;
+        };
+    }
+}

--- a/packages/plugin-ext/src/plugin/ext-plugin-api-assembler.ts
+++ b/packages/plugin-ext/src/plugin/ext-plugin-api-assembler.ts
@@ -19,6 +19,8 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { Plugin, PluginAPIFactory } from '../common/plugin-api-rpc';
 import { LegacyExtPluginApiContribution } from './legacy-ext-plugin-api-contribution';
+import { TerminalExtPluginApiContribution } from './terminal-ext-plugin-api-contribution';
+import { deepMergeApiNamespaces } from './merge-api-namespaces';
 
 /**
  * Assembles the ext-side (plugin-host) plugin API by composing explicitly injected providers.
@@ -45,8 +47,8 @@ export class ExtPluginApiAssembler {
     @inject(LegacyExtPluginApiContribution)
     protected readonly legacy: LegacyExtPluginApiContribution;
 
-    // Future providers will be added here as explicit @inject fields, e.g.:
-    // @inject(TerminalExtPluginApiProvider) protected readonly terminal: TerminalExtPluginApiProvider;
+    @inject(TerminalExtPluginApiContribution)
+    protected readonly terminal: TerminalExtPluginApiContribution;
 
     /**
      * Register all ext-side RPC implementations and return a factory that produces
@@ -60,15 +62,12 @@ export class ExtPluginApiAssembler {
      *    the results into a single `typeof theia` object.
      */
     createApiFactory(rpc: RPCProtocol): PluginAPIFactory {
+        this.terminal.registerExtImplementations(rpc);
         this.legacy.registerExtImplementations(rpc);
-        // Future: this.terminal.registerExtImplementations(rpc);
 
-        return (plugin: Plugin): typeof theia => {
-            const api = {
-                ...this.legacy.createApiNamespace(plugin),
-                // Future: ...this.terminal.createApiNamespace(plugin),
-            };
-            return api as typeof theia;
-        };
+        return (plugin: Plugin): typeof theia => deepMergeApiNamespaces(
+            this.legacy.createApiNamespace(plugin),
+            this.terminal.createApiNamespace(plugin),
+        );
     }
 }

--- a/packages/plugin-ext/src/plugin/ext-plugin-api-assembler.ts
+++ b/packages/plugin-ext/src/plugin/ext-plugin-api-assembler.ts
@@ -20,6 +20,7 @@ import { RPCProtocol } from '../common/rpc-protocol';
 import { Plugin, PluginAPIFactory } from '../common/plugin-api-rpc';
 import { LegacyExtPluginApiContribution } from './legacy-ext-plugin-api-contribution';
 import { TerminalExtPluginApiContribution } from './terminal-ext-plugin-api-contribution';
+import { ScmExtPluginApiContribution } from './scm-ext-plugin-api-contribution';
 import { deepMergeApiNamespaces } from './merge-api-namespaces';
 
 /**
@@ -50,6 +51,9 @@ export class ExtPluginApiAssembler {
     @inject(TerminalExtPluginApiContribution)
     protected readonly terminal: TerminalExtPluginApiContribution;
 
+    @inject(ScmExtPluginApiContribution)
+    protected readonly scm: ScmExtPluginApiContribution;
+
     /**
      * Register all ext-side RPC implementations and return a factory that produces
      * a per-plugin `typeof theia` API object.
@@ -63,11 +67,13 @@ export class ExtPluginApiAssembler {
      */
     createApiFactory(rpc: RPCProtocol): PluginAPIFactory {
         this.terminal.registerExtImplementations(rpc);
+        this.scm.registerExtImplementations(rpc);
         this.legacy.registerExtImplementations(rpc);
 
         return (plugin: Plugin): typeof theia => deepMergeApiNamespaces(
             this.legacy.createApiNamespace(plugin),
             this.terminal.createApiNamespace(plugin),
+            this.scm.createApiNamespace(plugin),
         );
     }
 }

--- a/packages/plugin-ext/src/plugin/legacy-ext-plugin-api-contribution.ts
+++ b/packages/plugin-ext/src/plugin/legacy-ext-plugin-api-contribution.ts
@@ -14,11 +14,13 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import type * as theia from '@theia/plugin';
 import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { RPCProtocol } from '../common/rpc-protocol';
 import { InternalPluginApiContribution } from '../common/plugin-ext-api-contribution';
-import { Plugin, PluginAPIFactory, PluginManager, LocalizationExt } from '../common/plugin-api-rpc';
+import { Plugin, PluginManager, LocalizationExt } from '../common/plugin-api-rpc';
 import { createAPIFactory } from './plugin-context';
+import type { TerminalPluginApiNamespace } from './terminal-ext-plugin-api-contribution';
 import { EnvExtImpl } from './env';
 import { DebugExtImpl } from './debug/debug-ext';
 import { PreferenceRegistryExtImpl } from './preference-registry';
@@ -28,7 +30,31 @@ import { MessageRegistryExt } from './message-registry';
 import { ClipboardExt } from './clipboard-ext';
 import { WebviewsExtImpl } from './webviews';
 import type { LocalizationExtImpl } from './localization-ext';
+import { TerminalServiceExtImpl } from './terminal-ext';
 import { AbstractPluginManagerExtImpl } from './plugin-manager';
+
+/**
+ * The terminal-owned keys at the top level of `typeof theia`.
+ */
+type TerminalTopLevelKeys = keyof Omit<TerminalPluginApiNamespace, 'window'>;
+
+/**
+ * The terminal-owned keys within `theia.window`.
+ */
+type TerminalWindowKeys = keyof TerminalPluginApiNamespace['window'];
+
+/**
+ * The shape of the legacy contribution's return — everything in `typeof theia`
+ * except the properties owned by extracted contributions (currently just terminal).
+ *
+ * As more slices are extracted, this type narrows further: each extraction adds
+ * its keys to the `Omit` lists here. When the legacy contribution is empty,
+ * this type becomes `{}` and the contribution can be removed.
+ */
+export type LegacyPluginApiNamespace =
+    Omit<typeof theia, TerminalTopLevelKeys | 'window'> & {
+        window: Omit<typeof theia.window, TerminalWindowKeys>;
+    };
 
 /**
  * Legacy contribution that wraps the monolithic `createAPIFactory()` function from
@@ -82,7 +108,10 @@ export class LegacyExtPluginApiContribution implements InternalPluginApiContribu
     @inject(LocalizationExt)
     protected readonly localizationExt: LocalizationExtImpl;
 
-    protected apiFactory: PluginAPIFactory | undefined;
+    @inject(TerminalServiceExtImpl)
+    protected readonly terminalExt: TerminalServiceExtImpl;
+
+    protected apiFactory: ((plugin: Plugin) => LegacyPluginApiNamespace) | undefined;
 
     registerMainImplementations(_rpc: RPCProtocol, _container: interfaces.Container): void {
         // No-op on the ext side — main-side registration is handled by LegacyMainPluginApiContribution
@@ -102,17 +131,15 @@ export class LegacyExtPluginApiContribution implements InternalPluginApiContribu
             this.messageRegistryExt,
             this.clipboardExt,
             this.webviewExt,
-            this.localizationExt
+            this.localizationExt,
+            this.terminalExt
         );
     }
 
-    createApiNamespace(plugin: Plugin): Record<string, unknown> {
+    createApiNamespace(plugin: Plugin): LegacyPluginApiNamespace {
         if (!this.apiFactory) {
             throw new Error('LegacyExtPluginApiContribution: registerExtImplementations must be called before createApiNamespace');
         }
-        // The factory returns a full `typeof theia` object for the given plugin.
-        // We return it as Record<string, unknown> so the assembler can merge it
-        // with contributions from other InternalPluginApiContributions.
-        return this.apiFactory(plugin) as unknown as Record<string, unknown>;
+        return this.apiFactory(plugin);
     }
 }

--- a/packages/plugin-ext/src/plugin/legacy-ext-plugin-api-contribution.ts
+++ b/packages/plugin-ext/src/plugin/legacy-ext-plugin-api-contribution.ts
@@ -21,6 +21,7 @@ import { InternalPluginApiContribution } from '../common/plugin-ext-api-contribu
 import { Plugin, PluginManager, LocalizationExt } from '../common/plugin-api-rpc';
 import { createAPIFactory } from './plugin-context';
 import type { TerminalPluginApiNamespace } from './terminal-ext-plugin-api-contribution';
+import type { ScmPluginApiNamespace } from './scm-ext-plugin-api-contribution';
 import { EnvExtImpl } from './env';
 import { DebugExtImpl } from './debug/debug-ext';
 import { PreferenceRegistryExtImpl } from './preference-registry';
@@ -31,6 +32,8 @@ import { ClipboardExt } from './clipboard-ext';
 import { WebviewsExtImpl } from './webviews';
 import type { LocalizationExtImpl } from './localization-ext';
 import { TerminalServiceExtImpl } from './terminal-ext';
+import { CommandRegistryImpl } from './command-registry';
+import { ScmExtImpl } from './scm';
 import { AbstractPluginManagerExtImpl } from './plugin-manager';
 
 /**
@@ -44,15 +47,20 @@ type TerminalTopLevelKeys = keyof Omit<TerminalPluginApiNamespace, 'window'>;
 type TerminalWindowKeys = keyof TerminalPluginApiNamespace['window'];
 
 /**
+ * The SCM-owned keys at the top level of `typeof theia`.
+ */
+type ScmTopLevelKeys = keyof ScmPluginApiNamespace;
+
+/**
  * The shape of the legacy contribution's return — everything in `typeof theia`
- * except the properties owned by extracted contributions (currently just terminal).
+ * except the properties owned by extracted contributions (terminal, SCM, etc.).
  *
  * As more slices are extracted, this type narrows further: each extraction adds
  * its keys to the `Omit` lists here. When the legacy contribution is empty,
  * this type becomes `{}` and the contribution can be removed.
  */
 export type LegacyPluginApiNamespace =
-    Omit<typeof theia, TerminalTopLevelKeys | 'window'> & {
+    Omit<typeof theia, TerminalTopLevelKeys | ScmTopLevelKeys | 'window'> & {
         window: Omit<typeof theia.window, TerminalWindowKeys>;
     };
 
@@ -111,6 +119,12 @@ export class LegacyExtPluginApiContribution implements InternalPluginApiContribu
     @inject(TerminalServiceExtImpl)
     protected readonly terminalExt: TerminalServiceExtImpl;
 
+    @inject(CommandRegistryImpl)
+    protected readonly commandRegistry: CommandRegistryImpl;
+
+    @inject(ScmExtImpl)
+    protected readonly scmExt: ScmExtImpl;
+
     protected apiFactory: ((plugin: Plugin) => LegacyPluginApiNamespace) | undefined;
 
     registerMainImplementations(_rpc: RPCProtocol, _container: interfaces.Container): void {
@@ -132,7 +146,9 @@ export class LegacyExtPluginApiContribution implements InternalPluginApiContribu
             this.clipboardExt,
             this.webviewExt,
             this.localizationExt,
-            this.terminalExt
+            this.terminalExt,
+            this.commandRegistry,
+            this.scmExt
         );
     }
 

--- a/packages/plugin-ext/src/plugin/legacy-ext-plugin-api-contribution.ts
+++ b/packages/plugin-ext/src/plugin/legacy-ext-plugin-api-contribution.ts
@@ -1,0 +1,118 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { InternalPluginApiContribution } from '../common/plugin-ext-api-contribution';
+import { Plugin, PluginAPIFactory, PluginManager, LocalizationExt } from '../common/plugin-api-rpc';
+import { createAPIFactory } from './plugin-context';
+import { EnvExtImpl } from './env';
+import { DebugExtImpl } from './debug/debug-ext';
+import { PreferenceRegistryExtImpl } from './preference-registry';
+import { EditorsAndDocumentsExtImpl } from './editors-and-documents';
+import { WorkspaceExtImpl } from './workspace';
+import { MessageRegistryExt } from './message-registry';
+import { ClipboardExt } from './clipboard-ext';
+import { WebviewsExtImpl } from './webviews';
+import type { LocalizationExtImpl } from './localization-ext';
+import { AbstractPluginManagerExtImpl } from './plugin-manager';
+
+/**
+ * Legacy contribution that wraps the monolithic `createAPIFactory()` function from
+ * `plugin-context.ts` as an `InternalPluginApiContribution`.
+ *
+ * This is a transitional adapter. The long-term goal is to split the monolithic
+ * `createAPIFactory` into smaller, per-feature contributions (terminal, debug, SCM, etc.).
+ * In the meantime, this contribution wraps the entire existing implementation so that
+ * call sites can be migrated to the contribution-based assembly pattern without
+ * changing any runtime behaviour.
+ *
+ * Note: `createAPIFactory` both registers ext-side RPC implementations (`rpc.set(...)`)
+ * and returns a per-plugin factory closure, all in one call. We cannot separate these two
+ * concerns without refactoring the 1300-line function. So `registerExtImplementations`
+ * performs both the RPC registration AND captures the factory closure, while
+ * `createApiNamespace` delegates to that captured closure.
+ */
+@injectable()
+export class LegacyExtPluginApiContribution implements InternalPluginApiContribution {
+
+    @inject(RPCProtocol)
+    protected readonly rpc: RPCProtocol;
+
+    @inject(AbstractPluginManagerExtImpl)
+    protected readonly pluginManager: PluginManager;
+
+    @inject(EnvExtImpl)
+    protected readonly envExt: EnvExtImpl;
+
+    @inject(DebugExtImpl)
+    protected readonly debugExt: DebugExtImpl;
+
+    @inject(PreferenceRegistryExtImpl)
+    protected readonly preferenceRegistryExt: PreferenceRegistryExtImpl;
+
+    @inject(EditorsAndDocumentsExtImpl)
+    protected readonly editorsAndDocumentsExt: EditorsAndDocumentsExtImpl;
+
+    @inject(WorkspaceExtImpl)
+    protected readonly workspaceExt: WorkspaceExtImpl;
+
+    @inject(MessageRegistryExt)
+    protected readonly messageRegistryExt: MessageRegistryExt;
+
+    @inject(ClipboardExt)
+    protected readonly clipboardExt: ClipboardExt;
+
+    @inject(WebviewsExtImpl)
+    protected readonly webviewExt: WebviewsExtImpl;
+
+    @inject(LocalizationExt)
+    protected readonly localizationExt: LocalizationExtImpl;
+
+    protected apiFactory: PluginAPIFactory | undefined;
+
+    registerMainImplementations(_rpc: RPCProtocol, _container: interfaces.Container): void {
+        // No-op on the ext side — main-side registration is handled by LegacyMainPluginApiContribution
+    }
+
+    registerExtImplementations(rpc: RPCProtocol): void {
+        // createAPIFactory both registers all ext-side implementations on the RPC protocol
+        // (via rpc.set calls) and returns the per-plugin factory closure.
+        this.apiFactory = createAPIFactory(
+            rpc,
+            this.pluginManager,
+            this.envExt,
+            this.debugExt,
+            this.preferenceRegistryExt,
+            this.editorsAndDocumentsExt,
+            this.workspaceExt,
+            this.messageRegistryExt,
+            this.clipboardExt,
+            this.webviewExt,
+            this.localizationExt
+        );
+    }
+
+    createApiNamespace(plugin: Plugin): Record<string, unknown> {
+        if (!this.apiFactory) {
+            throw new Error('LegacyExtPluginApiContribution: registerExtImplementations must be called before createApiNamespace');
+        }
+        // The factory returns a full `typeof theia` object for the given plugin.
+        // We return it as Record<string, unknown> so the assembler can merge it
+        // with contributions from other InternalPluginApiContributions.
+        return this.apiFactory(plugin) as unknown as Record<string, unknown>;
+    }
+}

--- a/packages/plugin-ext/src/plugin/merge-api-namespaces.spec.ts
+++ b/packages/plugin-ext/src/plugin/merge-api-namespaces.spec.ts
@@ -17,6 +17,8 @@
 import * as assert from 'assert';
 import { deepMergeApiNamespaces, DeepMerge } from './merge-api-namespaces';
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 describe('deepMergeApiNamespaces', () => {
 
     describe('shallow merge of disjoint keys', () => {
@@ -107,7 +109,7 @@ describe('deepMergeApiNamespaces', () => {
         it('should preserve getters from target as lazy accessors', () => {
             let callCount = 0;
             const target = Object.defineProperty({}, 'activeEditor', {
-                get() {
+                get(): string {
                     callCount++;
                     return 'editor1';
                 },
@@ -130,7 +132,7 @@ describe('deepMergeApiNamespaces', () => {
             let callCount = 0;
             const target = { someOtherProp: 42 };
             const source = Object.defineProperty({}, 'activeTerminal', {
-                get() {
+                get(): string {
                     callCount++;
                     return 'terminal1';
                 },
@@ -152,13 +154,13 @@ describe('deepMergeApiNamespaces', () => {
 
             const target = {
                 window: Object.defineProperty({}, 'activeEditor', {
-                    get() { editorCalls++; return 'editor'; },
+                    get(): string { editorCalls++; return 'editor'; },
                     enumerable: true, configurable: true
                 })
             };
             const source = {
                 window: Object.defineProperty({}, 'activeTerminal', {
-                    get() { terminalCalls++; return 'terminal'; },
+                    get(): string { terminalCalls++; return 'terminal'; },
                     enumerable: true, configurable: true
                 })
             };
@@ -180,11 +182,11 @@ describe('deepMergeApiNamespaces', () => {
 
         it('should let a source getter override a target getter', () => {
             const target = Object.defineProperty({}, 'value', {
-                get() { return 'old'; },
+                get(): string { return 'old'; },
                 enumerable: true, configurable: true
             });
             const source = Object.defineProperty({}, 'value', {
-                get() { return 'new'; },
+                get(): string { return 'new'; },
                 enumerable: true, configurable: true
             });
             const result = deepMergeApiNamespaces(target, source);
@@ -273,7 +275,7 @@ describe('deepMergeApiNamespaces', () => {
                     },
                     'activeTextEditor',
                     {
-                        get() { editorGetterCalled = true; return undefined; },
+                        get(): undefined { editorGetterCalled = true; return undefined; },
                         enumerable: true, configurable: true
                     }
                 ),
@@ -288,11 +290,11 @@ describe('deepMergeApiNamespaces', () => {
                     },
                     {
                         activeTerminal: {
-                            get() { terminalGetterCalled = true; return undefined; },
+                            get(): undefined { terminalGetterCalled = true; return undefined; },
                             enumerable: true, configurable: true
                         },
                         terminals: {
-                            get() { return []; },
+                            get(): never[] { return []; },
                             enumerable: true, configurable: true
                         }
                     }
@@ -332,8 +334,8 @@ describe('DeepMerge type helper', () => {
         // This test is primarily a compile-time check.
         // If it compiles, the type helper works correctly.
 
-        type A = { x: number; nested: { a: string } };
-        type B = { y: boolean; nested: { b: number } };
+        interface A { x: number; nested: { a: string } }
+        interface B { y: boolean; nested: { b: number } }
         type Merged = DeepMerge<A, B>;
 
         // Verify the merged type has the expected shape by assigning a value
@@ -345,8 +347,8 @@ describe('DeepMerge type helper', () => {
     });
 
     it('should let source override non-object properties in the type', () => {
-        type A = { value: string; other: number };
-        type B = { value: number };
+        interface A { value: string; other: number }
+        interface B { value: number }
         type Merged = DeepMerge<A, B>;
 
         const merged: Merged = { value: 42, other: 1 };

--- a/packages/plugin-ext/src/plugin/merge-api-namespaces.spec.ts
+++ b/packages/plugin-ext/src/plugin/merge-api-namespaces.spec.ts
@@ -1,0 +1,356 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as assert from 'assert';
+import { deepMergeApiNamespaces, DeepMerge } from './merge-api-namespaces';
+
+describe('deepMergeApiNamespaces', () => {
+
+    describe('shallow merge of disjoint keys', () => {
+        it('should combine properties from both objects', () => {
+            const target = { a: 1, b: 'hello' };
+            const source = { c: true, d: 42 };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.deepStrictEqual(result, { a: 1, b: 'hello', c: true, d: 42 });
+        });
+
+        it('should return an empty object when both inputs are empty', () => {
+            const result = deepMergeApiNamespaces({}, {});
+            assert.deepStrictEqual(result, {});
+        });
+
+        it('should return source properties when target is empty', () => {
+            const result = deepMergeApiNamespaces({}, { x: 10 });
+            assert.deepStrictEqual(result, { x: 10 });
+        });
+
+        it('should return target properties when source is empty', () => {
+            const result = deepMergeApiNamespaces({ x: 10 }, {});
+            assert.deepStrictEqual(result, { x: 10 });
+        });
+    });
+
+    describe('source overrides target for non-object values', () => {
+        it('should let source override target for primitive values', () => {
+            const result = deepMergeApiNamespaces({ a: 1 }, { a: 2 });
+            assert.strictEqual(result.a, 2);
+        });
+
+        it('should let source override target when types differ', () => {
+            const result = deepMergeApiNamespaces(
+                { a: 'string' } as Record<string, unknown>,
+                { a: 42 } as Record<string, unknown>
+            );
+            assert.strictEqual(result.a, 42);
+        });
+
+        it('should let source override target for function values', () => {
+            const fn1 = (): number => 1;
+            const fn2 = (): number => 2;
+            const result = deepMergeApiNamespaces({ doStuff: fn1 }, { doStuff: fn2 });
+            assert.strictEqual(result.doStuff, fn2);
+        });
+    });
+
+    describe('deep merge of nested plain objects', () => {
+        it('should recursively merge nested plain objects', () => {
+            const target = { window: { showTextDocument: 'a', activeTextEditor: 'b' } };
+            const source = { window: { createTerminal: 'c', terminals: 'd' } };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.deepStrictEqual(result, {
+                window: {
+                    showTextDocument: 'a',
+                    activeTextEditor: 'b',
+                    createTerminal: 'c',
+                    terminals: 'd'
+                }
+            });
+        });
+
+        it('should merge deeply nested objects', () => {
+            const target = { a: { b: { c: 1 } } };
+            const source = { a: { b: { d: 2 } } };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.deepStrictEqual(result, { a: { b: { c: 1, d: 2 } } });
+        });
+
+        it('should let source override within nested objects', () => {
+            const target = { window: { theme: 'dark', fontSize: 12 } };
+            const source = { window: { theme: 'light' } };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.deepStrictEqual(result, { window: { theme: 'light', fontSize: 12 } });
+        });
+
+        it('should not mutate target or source', () => {
+            const target = { window: { a: 1 } };
+            const source = { window: { b: 2 } };
+            deepMergeApiNamespaces(target, source);
+            assert.deepStrictEqual(target, { window: { a: 1 } });
+            assert.deepStrictEqual(source, { window: { b: 2 } });
+        });
+    });
+
+    describe('getter preservation', () => {
+        it('should preserve getters from target as lazy accessors', () => {
+            let callCount = 0;
+            const target = Object.defineProperty({}, 'activeEditor', {
+                get() {
+                    callCount++;
+                    return 'editor1';
+                },
+                enumerable: true,
+                configurable: true
+            });
+            const source = { someOtherProp: 42 };
+
+            callCount = 0;
+            const result = deepMergeApiNamespaces(target, source);
+
+            // The getter should not have been invoked during merge
+            assert.strictEqual(callCount, 0);
+            // Accessing the property should invoke the getter
+            assert.strictEqual((result as any).activeEditor, 'editor1');
+            assert.strictEqual(callCount, 1);
+        });
+
+        it('should preserve getters from source as lazy accessors', () => {
+            let callCount = 0;
+            const target = { someOtherProp: 42 };
+            const source = Object.defineProperty({}, 'activeTerminal', {
+                get() {
+                    callCount++;
+                    return 'terminal1';
+                },
+                enumerable: true,
+                configurable: true
+            });
+
+            callCount = 0;
+            const result = deepMergeApiNamespaces(target, source);
+
+            assert.strictEqual(callCount, 0);
+            assert.strictEqual((result as any).activeTerminal, 'terminal1');
+            assert.strictEqual(callCount, 1);
+        });
+
+        it('should preserve getters from both sides within a merged namespace', () => {
+            let editorCalls = 0;
+            let terminalCalls = 0;
+
+            const target = {
+                window: Object.defineProperty({}, 'activeEditor', {
+                    get() { editorCalls++; return 'editor'; },
+                    enumerable: true, configurable: true
+                })
+            };
+            const source = {
+                window: Object.defineProperty({}, 'activeTerminal', {
+                    get() { terminalCalls++; return 'terminal'; },
+                    enumerable: true, configurable: true
+                })
+            };
+
+            editorCalls = 0;
+            terminalCalls = 0;
+            const result = deepMergeApiNamespaces(target, source);
+
+            // Neither getter should have been called during merge
+            assert.strictEqual(editorCalls, 0);
+            assert.strictEqual(terminalCalls, 0);
+
+            // Both should work when accessed
+            assert.strictEqual((result as any).window.activeEditor, 'editor');
+            assert.strictEqual((result as any).window.activeTerminal, 'terminal');
+            assert.strictEqual(editorCalls, 1);
+            assert.strictEqual(terminalCalls, 1);
+        });
+
+        it('should let a source getter override a target getter', () => {
+            const target = Object.defineProperty({}, 'value', {
+                get() { return 'old'; },
+                enumerable: true, configurable: true
+            });
+            const source = Object.defineProperty({}, 'value', {
+                get() { return 'new'; },
+                enumerable: true, configurable: true
+            });
+            const result = deepMergeApiNamespaces(target, source);
+            assert.strictEqual((result as any).value, 'new');
+        });
+    });
+
+    describe('class instances are not recursively merged', () => {
+        it('should treat class instances as leaves (source wins)', () => {
+            class MyClass {
+                constructor(public value: number) { }
+            }
+            const instance1 = new MyClass(1);
+            const instance2 = new MyClass(2);
+            const target = { obj: instance1 };
+            const source = { obj: instance2 };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.strictEqual((result as any).obj, instance2);
+        });
+
+        it('should not recurse into class instances even if they have overlapping keys', () => {
+            class Position {
+                constructor(public line: number, public character: number) { }
+            }
+            const target = { Position: new Position(1, 2) };
+            const source = { Position: new Position(3, 4) };
+            const result = deepMergeApiNamespaces(target, source);
+            const pos = (result as any).Position as Position;
+            assert.strictEqual(pos.line, 3);
+            assert.strictEqual(pos.character, 4);
+        });
+
+        it('should not recurse into class instances when target has a plain object', () => {
+            class Fancy { constructor(public x: number) { } }
+            const target = { thing: { x: 1, y: 2 } };
+            const source = { thing: new Fancy(10) };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.ok((result as any).thing instanceof Fancy);
+            assert.strictEqual((result as any).thing.x, 10);
+        });
+
+        it('should not recurse when target has a class instance and source has a plain object', () => {
+            class Fancy { constructor(public x: number) { } }
+            const target = { thing: new Fancy(10) };
+            const source = { thing: { x: 1, y: 2 } };
+            const result = deepMergeApiNamespaces(target, source);
+            // Source is a plain object, target is a class instance — source wins (leaf override)
+            assert.ok(!((result as any).thing instanceof Fancy));
+            assert.deepStrictEqual((result as any).thing, { x: 1, y: 2 });
+        });
+    });
+
+    describe('arrays are treated as leaves', () => {
+        it('should not merge arrays — source wins', () => {
+            const target = { items: [1, 2, 3] };
+            const source = { items: [4, 5] };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.deepStrictEqual((result as any).items, [4, 5]);
+        });
+    });
+
+    describe('functions are treated as leaves', () => {
+        it('should not recurse into functions with properties', () => {
+            const fn1 = Object.assign(() => 1, { extra: 'a' });
+            const fn2 = Object.assign(() => 2, { extra: 'b' });
+            const target = { doStuff: fn1 };
+            const source = { doStuff: fn2 };
+            const result = deepMergeApiNamespaces(target, source);
+            assert.strictEqual((result as any).doStuff, fn2);
+            assert.strictEqual((result as any).doStuff(), 2);
+        });
+    });
+
+    describe('realistic plugin API scenario', () => {
+        it('should merge a legacy and terminal contribution like the assembler does', () => {
+            let editorGetterCalled = false;
+            let terminalGetterCalled = false;
+
+            const legacy = {
+                version: '1.0.0',
+                commands: { registerCommand: () => { } },
+                window: Object.defineProperty(
+                    {
+                        showInformationMessage: () => { },
+                        showQuickPick: () => { },
+                    },
+                    'activeTextEditor',
+                    {
+                        get() { editorGetterCalled = true; return undefined; },
+                        enumerable: true, configurable: true
+                    }
+                ),
+                StatusBarAlignment: { Left: 1, Right: 2 },
+            };
+
+            const terminal = {
+                window: Object.defineProperties(
+                    {
+                        createTerminal: () => { },
+                        onDidCloseTerminal: () => { },
+                    },
+                    {
+                        activeTerminal: {
+                            get() { terminalGetterCalled = true; return undefined; },
+                            enumerable: true, configurable: true
+                        },
+                        terminals: {
+                            get() { return []; },
+                            enumerable: true, configurable: true
+                        }
+                    }
+                ),
+                TerminalLocation: { Panel: 1, Editor: 2 },
+            };
+
+            const result = deepMergeApiNamespaces(legacy, terminal) as any;
+
+            // Top-level properties from both
+            assert.strictEqual(result.version, '1.0.0');
+            assert.ok(result.commands);
+            assert.deepStrictEqual(result.StatusBarAlignment, { Left: 1, Right: 2 });
+            assert.deepStrictEqual(result.TerminalLocation, { Panel: 1, Editor: 2 });
+
+            // window namespace is merged, not overwritten
+            assert.ok(result.window.showInformationMessage);
+            assert.ok(result.window.showQuickPick);
+            assert.ok(result.window.createTerminal);
+            assert.ok(result.window.onDidCloseTerminal);
+
+            // Getters were not called during merge
+            assert.strictEqual(editorGetterCalled, false);
+            assert.strictEqual(terminalGetterCalled, false);
+
+            // Getters still work
+            result.window.activeTextEditor;
+            assert.strictEqual(editorGetterCalled, true);
+            result.window.activeTerminal;
+            assert.strictEqual(terminalGetterCalled, true);
+        });
+    });
+});
+
+describe('DeepMerge type helper', () => {
+    it('should produce correct types at compile time', () => {
+        // This test is primarily a compile-time check.
+        // If it compiles, the type helper works correctly.
+
+        type A = { x: number; nested: { a: string } };
+        type B = { y: boolean; nested: { b: number } };
+        type Merged = DeepMerge<A, B>;
+
+        // Verify the merged type has the expected shape by assigning a value
+        const merged: Merged = { x: 1, y: true, nested: { a: 'hello', b: 42 } };
+        assert.strictEqual(merged.x, 1);
+        assert.strictEqual(merged.y, true);
+        assert.strictEqual(merged.nested.a, 'hello');
+        assert.strictEqual(merged.nested.b, 42);
+    });
+
+    it('should let source override non-object properties in the type', () => {
+        type A = { value: string; other: number };
+        type B = { value: number };
+        type Merged = DeepMerge<A, B>;
+
+        const merged: Merged = { value: 42, other: 1 };
+        assert.strictEqual(merged.value, 42);
+        assert.strictEqual(merged.other, 1);
+    });
+});

--- a/packages/plugin-ext/src/plugin/merge-api-namespaces.ts
+++ b/packages/plugin-ext/src/plugin/merge-api-namespaces.ts
@@ -73,7 +73,7 @@ export function deepMergeApiNamespaces<T extends object, U extends object>(
     // getters and setters. Spread invokes getters and copies the returned value,
     // which would evaluate lazy getters like `activeTerminal` at merge time
     // instead of when the plugin accesses them.
-    const result = Object.create(null);
+    const result: Record<string, unknown> = {};
 
     // Pass 1: copy all target descriptors into result
     const targetDescs = Object.getOwnPropertyDescriptors(target);

--- a/packages/plugin-ext/src/plugin/merge-api-namespaces.ts
+++ b/packages/plugin-ext/src/plugin/merge-api-namespaces.ts
@@ -65,7 +65,22 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * Class instances, arrays, functions, and other values are treated as leaves and
  * overwritten by the second argument.
  */
-export function deepMergeApiNamespaces<T extends object, U extends object>(
+export function deepMergeApiNamespaces<T extends object, U extends object>(target: T, source: U): DeepMerge<T, U>;
+export function deepMergeApiNamespaces<T extends object, U extends object, V extends object>(target: T, source1: U, source2: V): DeepMerge<DeepMerge<T, U>, V>;
+export function deepMergeApiNamespaces<T extends object, U extends object, V extends object, W extends object>(
+    target: T, source1: U, source2: V, source3: W): DeepMerge<DeepMerge<DeepMerge<T, U>, V>, W>;
+export function deepMergeApiNamespaces(...sources: object[]): object {
+    if (sources.length === 0) {
+        return {};
+    }
+    let result = sources[0];
+    for (let i = 1; i < sources.length; i++) {
+        result = mergeTwo(result, sources[i]);
+    }
+    return result;
+}
+
+function mergeTwo<T extends object, U extends object>(
     target: T,
     source: U
 ): DeepMerge<T, U> {
@@ -95,7 +110,7 @@ export function deepMergeApiNamespaces<T extends object, U extends object>(
 
         if (isPlainObject(existingVal) && isPlainObject(sourceVal)) {
             Object.defineProperty(result, key, {
-                value: deepMergeApiNamespaces(existingVal, sourceVal),
+                value: mergeTwo(existingVal, sourceVal),
                 enumerable: true,
                 configurable: true,
                 writable: true,

--- a/packages/plugin-ext/src/plugin/merge-api-namespaces.ts
+++ b/packages/plugin-ext/src/plugin/merge-api-namespaces.ts
@@ -1,0 +1,109 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Recursively merges two object types, combining nested object properties
+ * rather than overwriting them. Non-object properties from `U` take precedence
+ * over those from `T`.
+ *
+ * This is used to compose the `typeof theia` API shape from multiple contributions
+ * where several contributions provide properties under the same namespace key
+ * (e.g., both the editor and terminal contributions add to `window`).
+ */
+export type DeepMerge<T, U> = {
+    [K in keyof T | keyof U]:
+    K extends keyof U
+    ? K extends keyof T
+    ? T[K] extends Record<string, unknown>
+    ? U[K] extends Record<string, unknown>
+    ? DeepMerge<T[K], U[K]>
+    : U[K]
+    : U[K]
+    : U[K]
+    : K extends keyof T ? T[K] : never;
+};
+
+/**
+ * Variadic version of {@link DeepMerge} that merges an arbitrary number of types
+ * left-to-right.
+ */
+export type DeepMergeAll<T extends unknown[]> =
+    T extends [infer First, infer Second, ...infer Rest]
+    ? DeepMergeAll<[DeepMerge<First, Second>, ...Rest]>
+    : T extends [infer Only]
+    ? Only
+    : {};
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object'
+        && value !== null
+        && !Array.isArray(value)
+        // Exclude class instances (Event emitters, URI, Position, etc.) —
+        // only merge bare object literals (namespace bags like `window`, `workspace`).
+        && Object.getPrototypeOf(value) === Object.prototype;
+}
+
+/**
+ * Deep-merges two API namespace objects, recursively combining nested plain objects
+ * (namespace bags like `window`, `workspace`, `env`) while letting later values
+ * override earlier ones for non-object properties.
+ *
+ * Only *plain* objects (whose prototype is `Object.prototype`) are recursively merged.
+ * Class instances, arrays, functions, and other values are treated as leaves and
+ * overwritten by the second argument.
+ */
+export function deepMergeApiNamespaces<T extends object, U extends object>(
+    target: T,
+    source: U
+): DeepMerge<T, U> {
+    // Use Object.defineProperty rather than spread/Object.assign to preserve
+    // getters and setters. Spread invokes getters and copies the returned value,
+    // which would evaluate lazy getters like `activeTerminal` at merge time
+    // instead of when the plugin accesses them.
+    const result = Object.create(null);
+
+    // Pass 1: copy all target descriptors into result
+    const targetDescs = Object.getOwnPropertyDescriptors(target);
+    for (const key of Object.keys(targetDescs)) {
+        Object.defineProperty(result, key, targetDescs[key]);
+    }
+
+    // Pass 2: merge source descriptors into result
+    const sourceDescs = Object.getOwnPropertyDescriptors(source);
+    for (const key of Object.keys(sourceDescs)) {
+        const sourceDesc = sourceDescs[key];
+        const existingDesc = Object.getOwnPropertyDescriptor(result, key);
+
+        // Only recurse when both sides are data properties holding plain objects
+        // (namespace bags like `window`, `workspace`). Getters, class instances,
+        // arrays, and functions are treated as leaves — source wins.
+        const existingVal = existingDesc && 'value' in existingDesc ? existingDesc.value : undefined;
+        const sourceVal = 'value' in sourceDesc ? sourceDesc.value : undefined;
+
+        if (isPlainObject(existingVal) && isPlainObject(sourceVal)) {
+            Object.defineProperty(result, key, {
+                value: deepMergeApiNamespaces(existingVal, sourceVal),
+                enumerable: true,
+                configurable: true,
+                writable: true,
+            });
+        } else {
+            Object.defineProperty(result, key, sourceDesc);
+        }
+    }
+
+    return result as DeepMerge<T, U>;
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -18,6 +18,7 @@
 /* tslint:disable:typedef */
 
 import type * as theia from '@theia/plugin';
+import type { LegacyPluginApiNamespace } from './legacy-ext-plugin-api-contribution';
 import { CommandRegistryImpl } from './command-registry';
 import { Emitter, Event } from '@theia/core/lib/common/event';
 import { CancellationError, CancellationToken, CancellationTokenSource } from '@theia/core/lib/common/cancellation';
@@ -26,7 +27,6 @@ import {
     MAIN_RPC_CONTEXT,
     Plugin as InternalPlugin,
     PluginManager,
-    PluginAPIFactory,
     MainMessageType,
     DebugConfigurationProviderTriggerKind,
     PLUGIN_RPC_CONTEXT
@@ -164,10 +164,6 @@ import {
     LanguageStatusSeverity,
     TextDocumentChangeReason,
     InputBoxValidationSeverity,
-    TerminalLink,
-    TerminalLocation,
-    TerminalExitReason,
-    TerminalProfile,
     InlayHint,
     InlayHintKind,
     InlayHintLabelPart,
@@ -199,7 +195,6 @@ import {
     CustomEditorTabInput,
     NotebookDiffEditorTabInput,
     NotebookEditorTabInput,
-    TerminalEditorTabInput,
     TextDiffTabInput,
     TextMergeTabInput,
     WebviewEditorTabInput,
@@ -209,9 +204,6 @@ import {
     DocumentDropOrPasteEditKind,
     ExternalUriOpenerPriority,
     EditSessionIdentityMatch,
-    TerminalOutputAnchor,
-    TerminalQuickFixTerminalCommand,
-    TerminalQuickFixOpener,
     TestResultState,
     BranchCoverage,
     DeclarationCoverage,
@@ -240,10 +232,6 @@ import {
     PortAutoForwardAction,
     PortAttributes,
     DebugVisualization,
-    TerminalShellExecutionCommandLineConfidence,
-    TerminalCompletionItem,
-    TerminalCompletionItemKind,
-    TerminalCompletionList,
     McpHttpServerDefinition,
     McpStdioServerDefinition,
     InteractiveWindowInput,
@@ -324,8 +312,12 @@ export function createAPIFactory(
     messageRegistryExt: MessageRegistryExt,
     clipboard: ClipboardExt,
     webviewExt: WebviewsExtImpl,
-    localizationExt: LocalizationExtImpl
-): PluginAPIFactory {
+    localizationExt: LocalizationExtImpl,
+    terminalExt: TerminalServiceExtImpl
+): (plugin: InternalPlugin) => LegacyPluginApiNamespace {
+    // The return type is checked via a type assertion (as LegacyPluginApiNamespace)
+    // on the return statement of the inner function, matching the original
+    // <typeof theia> pattern that was used before the polylith split.
 
     const authenticationExt = rpc.set(MAIN_RPC_CONTEXT.AUTHENTICATION_EXT, new AuthenticationExtImpl(rpc));
     const commandRegistry = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc));
@@ -341,7 +333,7 @@ export function createAPIFactory(
     const notebookKernels = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_KERNELS_EXT, new NotebookKernelsExtImpl(rpc, notebooksExt, commandRegistry, webviewExt, workspaceExt));
     const notebookDocuments = rpc.set(MAIN_RPC_CONTEXT.NOTEBOOK_DOCUMENTS_EXT, new NotebookDocumentsExtImpl(notebooksExt));
     const statusBarMessageRegistryExt = rpc.set(MAIN_RPC_CONTEXT.STATUS_BAR_MESSAGE_REGISTRY_EXT, new StatusBarMessageRegistryExtImpl(rpc, commandRegistry));
-    const terminalExt = rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, new TerminalServiceExtImpl(rpc));
+
     const outputChannelRegistryExt = rpc.set(MAIN_RPC_CONTEXT.OUTPUT_CHANNEL_REGISTRY_EXT, new OutputChannelRegistryExtImpl(rpc));
     const treeViewsExt = rpc.set(MAIN_RPC_CONTEXT.TREE_VIEWS_EXT, new TreeViewsExtImpl(rpc, commandRegistry));
     const tasksExt = rpc.set(MAIN_RPC_CONTEXT.TASKS_EXT, new TasksExtImpl(rpc, terminalExt));
@@ -366,7 +358,7 @@ export function createAPIFactory(
 
     const commandLogger = new PluginLogger(rpc, 'commands-plugin');
 
-    return function (plugin: InternalPlugin): typeof theia {
+    return function (plugin: InternalPlugin) {
         const authentication: typeof theia.authentication = {
             registerAuthenticationProvider(id: string, label: string, provider: theia.AuthenticationProvider, options?: theia.AuthenticationProviderOptions): theia.Disposable {
                 return authenticationExt.registerAuthenticationProvider(id, label, provider, options);
@@ -456,44 +448,36 @@ export function createAPIFactory(
             }
         };
 
-        const { onDidChangeActiveTerminal, onDidChangeTerminalState, onDidCloseTerminal, onDidOpenTerminal } = terminalExt;
         const showInformationMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Info);
         const showWarningMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Warning);
         const showErrorMessage = messageRegistryExt.showMessage.bind(messageRegistryExt, MainMessageType.Error);
-        const window: typeof theia.window = {
+        const window = {
 
-            get activeTerminal(): theia.Terminal | undefined {
-                return terminalExt.activeTerminal;
-            },
             get activeTextEditor(): TextEditorExt | undefined {
                 return editors.getActiveEditor();
             },
             get visibleTextEditors(): theia.TextEditor[] {
                 return editors.getVisibleTextEditors();
             },
-            get terminals(): theia.Terminal[] {
-                return terminalExt.terminals;
-            },
-            onDidChangeActiveTerminal,
-            onDidChangeActiveTextEditor(listener, thisArg?, disposables?) {
+            onDidChangeActiveTextEditor(listener: (e: theia.TextEditor | undefined) => any, thisArg?: any, disposables?: Disposable[]) {
                 return editors.onDidChangeActiveTextEditor(listener, thisArg, disposables);
             },
-            onDidChangeVisibleTextEditors(listener, thisArg?, disposables?) {
+            onDidChangeVisibleTextEditors(listener: (e: theia.TextEditor[]) => any, thisArg?: any, disposables?: Disposable[]) {
                 return editors.onDidChangeVisibleTextEditors(listener, thisArg, disposables);
             },
-            onDidChangeTextEditorSelection(listener, thisArg?, disposables?) {
+            onDidChangeTextEditorSelection(listener: (e: theia.TextEditorSelectionChangeEvent) => any, thisArg?: any, disposables?: Disposable[]) {
                 return editors.onDidChangeTextEditorSelection(listener, thisArg, disposables);
             },
-            onDidChangeTextEditorDiffInformation(listener, thisArg?, disposables?) {
+            onDidChangeTextEditorDiffInformation(listener: (e: theia.TextEditorDiffInformationChangeEvent) => any, thisArg?: any, disposables?: Disposable[]) {
                 return editors.onDidChangeTextEditorDiffInformation(listener, thisArg, disposables);
             },
-            onDidChangeTextEditorOptions(listener, thisArg?, disposables?) {
+            onDidChangeTextEditorOptions(listener: (e: theia.TextEditorOptionsChangeEvent) => any, thisArg?: any, disposables?: Disposable[]) {
                 return editors.onDidChangeTextEditorOptions(listener, thisArg, disposables);
             },
-            onDidChangeTextEditorViewColumn(listener, thisArg?, disposables?) {
+            onDidChangeTextEditorViewColumn(listener: (e: theia.TextEditorViewColumnChangeEvent) => any, thisArg?: any, disposables?: Disposable[]) {
                 return editors.onDidChangeTextEditorViewColumn(listener, thisArg, disposables);
             },
-            onDidChangeTextEditorVisibleRanges(listener, thisArg?, disposables?) {
+            onDidChangeTextEditorVisibleRanges(listener: (e: theia.TextEditorVisibleRangesChangeEvent) => any, thisArg?: any, disposables?: Disposable[]) {
                 return editors.onDidChangeTextEditorVisibleRanges(listener, thisArg, disposables);
             },
             async showTextDocument(documentArg: theia.TextDocument | URI,
@@ -529,18 +513,18 @@ export function createAPIFactory(
             get visibleNotebookEditors(): theia.NotebookEditor[] {
                 return notebooksExt.visibleApiNotebookEditors;
             },
-            onDidChangeVisibleNotebookEditors(listener, thisArg?, disposables?) {
+            onDidChangeVisibleNotebookEditors(listener: (e: readonly theia.NotebookEditor[]) => any, thisArg?: any, disposables?: Disposable[]) {
                 return notebooksExt.onDidChangeVisibleNotebookEditors(listener, thisArg, disposables);
             },
             get activeNotebookEditor(): theia.NotebookEditor | undefined {
                 return notebooksExt.activeApiNotebookEditor;
-            }, onDidChangeActiveNotebookEditor(listener, thisArg?, disposables?) {
+            }, onDidChangeActiveNotebookEditor(listener: (e: theia.NotebookEditor | undefined) => any, thisArg?: any, disposables?: Disposable[]) {
                 return notebooksExt.onDidChangeActiveNotebookEditor(listener, thisArg, disposables);
             },
-            onDidChangeNotebookEditorSelection(listener, thisArg?, disposables?) {
+            onDidChangeNotebookEditorSelection(listener: (e: theia.NotebookEditorSelectionChangeEvent) => any, thisArg?: any, disposables?: Disposable[]) {
                 return notebookEditors.onDidChangeNotebookEditorSelection(listener, thisArg, disposables);
             },
-            onDidChangeNotebookEditorVisibleRanges(listener, thisArg?, disposables?) {
+            onDidChangeNotebookEditorVisibleRanges(listener: (e: theia.NotebookEditorVisibleRangesChangeEvent) => any, thisArg?: any, disposables?: Disposable[]) {
                 return notebookEditors.onDidChangeNotebookEditorVisibleRanges(listener, thisArg, disposables);
             },
             showNotebookDocument(document: theia.NotebookDocument, options?: theia.NotebookDocumentShowOptions) {
@@ -627,17 +611,9 @@ export function createAPIFactory(
             get state(): theia.WindowState {
                 return windowStateExt.getWindowState();
             },
-            onDidChangeWindowState(listener, thisArg?, disposables?): theia.Disposable {
+            onDidChangeWindowState(listener: (e: theia.WindowState) => any, thisArg?: any, disposables?: Disposable[]): theia.Disposable {
                 return windowStateExt.onDidChangeWindowState(listener, thisArg, disposables);
             },
-            createTerminal(nameOrOptions: theia.TerminalOptions | theia.ExtensionTerminalOptions | theia.ExtensionTerminalOptions | (string | undefined),
-                shellPath?: string,
-                shellArgs?: string[] | string): theia.Terminal {
-                return terminalExt.createTerminal(plugin, nameOrOptions, shellPath, shellArgs, createAPIObject);
-            },
-            onDidChangeTerminalState,
-            onDidCloseTerminal,
-            onDidOpenTerminal,
             createTextEditorDecorationType(options: theia.DecorationRenderOptions): theia.TextEditorDecorationType {
                 return createAPIObject(editors.createTextEditorDecorationType(options));
             },
@@ -666,16 +642,10 @@ export function createAPIFactory(
             createInputBox(): theia.InputBox {
                 return createAPIObject(quickOpenExt.createInputBox(plugin));
             },
-            registerTerminalLinkProvider(provider: theia.TerminalLinkProvider): theia.Disposable {
-                return terminalExt.registerTerminalLinkProvider(provider);
-            },
-            registerTerminalProfileProvider(id: string, provider: theia.TerminalProfileProvider): theia.Disposable {
-                return terminalExt.registerTerminalProfileProvider(id, provider);
-            },
             get activeColorTheme(): theia.ColorTheme {
                 return themingExt.activeColorTheme;
             },
-            onDidChangeActiveColorTheme(listener, thisArg?, disposables?) {
+            onDidChangeActiveColorTheme(listener: (e: theia.ColorTheme) => any, thisArg?: any, disposables?: Disposable[]) {
                 return themingExt.onDidChangeActiveColorTheme(listener, thisArg, disposables);
             },
             get tabGroups(): theia.TabGroups {
@@ -689,29 +659,8 @@ export function createAPIFactory(
             registerProfileContentHandler(id: string, profileContentHandler: theia.ProfileContentHandler): theia.Disposable {
                 return Disposable.NULL;
             },
-            /** @stubbed TerminalCompletionProvider */
-            registerTerminalCompletionProvider<T extends theia.TerminalCompletionItem>(
-                provider: theia.TerminalCompletionProvider<T>, ...triggerCharacters: string[]): Disposable {
-                return Disposable.NULL;
-            },
-            /** @stubbed TerminalQuickFixProvider */
-            registerTerminalQuickFixProvider(id: string, provider: theia.TerminalQuickFixProvider): theia.Disposable {
-                return terminalExt.registerTerminalQuickFixProvider(id, provider);
-            },
-
-            /** Theia-specific TerminalObserver */
-            registerTerminalObserver(observer: theia.TerminalObserver): theia.Disposable {
-                return terminalExt.registerTerminalObserver(observer);
-            },
-
             /** @stubbed ShareProvider */
-            registerShareProvider: () => Disposable.NULL,
-            /** @stubbed Terminal Shell Ingration */
-            onDidChangeTerminalShellIntegration: Event.None,
-            /** @stubbed Terminal Shell Ingration */
-            onDidEndTerminalShellExecution: Event.None,
-            /** @stubbed Terminal Shell Ingration */
-            onDidStartTerminalShellExecution: Event.None
+            registerShareProvider: () => Disposable.NULL
         };
 
         function createFileSystemWatcher(pattern: theia.GlobPattern, ignoreCreateEvents?: boolean, ignoreChangeEvents?:
@@ -1400,7 +1349,7 @@ export function createAPIFactory(
             }
         };
 
-        return <typeof theia>{
+        return <LegacyPluginApiNamespace>{
             version: require('../../package.json').version,
             authentication,
             chat,
@@ -1550,8 +1499,6 @@ export function createAPIFactory(
             ColorThemeKind,
             SourceControlInputBoxValidationType,
             FileDecoration,
-            TerminalLink,
-            TerminalProfile,
             CancellationError,
             ExtensionMode,
             LinkedEditingRanges,
@@ -1591,16 +1538,10 @@ export function createAPIFactory(
             TabInputNotebook: NotebookEditorTabInput,
             TabInputNotebookDiff: NotebookDiffEditorTabInput,
             TabInputWebview: WebviewEditorTabInput,
-            TabInputTerminal: TerminalEditorTabInput,
-            TerminalLocation,
-            TerminalOutputAnchor,
-            TerminalExitReason,
             DocumentPasteEdit,
             DocumentPasteEditKind,
             DocumentPasteTriggerKind,
             ExternalUriOpenerPriority,
-            TerminalQuickFixTerminalCommand,
-            TerminalQuickFixOpener,
             EditSessionIdentityMatch,
             TestResultState,
             BranchCoverage,
@@ -1630,10 +1571,6 @@ export function createAPIFactory(
             PortAutoForwardAction,
             PortAttributes,
             DebugVisualization,
-            TerminalShellExecutionCommandLineConfidence,
-            TerminalCompletionItem,
-            TerminalCompletionItemKind,
-            TerminalCompletionList,
             McpHttpServerDefinition,
             McpStdioServerDefinition,
             TabInputInteractiveWindow: InteractiveWindowInput,

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -156,7 +156,6 @@ import {
     SemanticTokensEdits,
     SemanticTokensEdit,
     ColorThemeKind,
-    SourceControlInputBoxValidationType,
     URI,
     FileDecoration,
     ExtensionMode,
@@ -313,14 +312,16 @@ export function createAPIFactory(
     clipboard: ClipboardExt,
     webviewExt: WebviewsExtImpl,
     localizationExt: LocalizationExtImpl,
-    terminalExt: TerminalServiceExtImpl
+    terminalExt: TerminalServiceExtImpl,
+    commandRegistry: CommandRegistryImpl,
+    scmExt: ScmExtImpl
 ): (plugin: InternalPlugin) => LegacyPluginApiNamespace {
     // The return type is checked via a type assertion (as LegacyPluginApiNamespace)
     // on the return statement of the inner function, matching the original
     // <typeof theia> pattern that was used before the polylith split.
 
     const authenticationExt = rpc.set(MAIN_RPC_CONTEXT.AUTHENTICATION_EXT, new AuthenticationExtImpl(rpc));
-    const commandRegistry = rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, new CommandRegistryImpl(rpc));
+    rpc.set(MAIN_RPC_CONTEXT.COMMAND_REGISTRY_EXT, commandRegistry);
     const quickOpenExt = rpc.set(MAIN_RPC_CONTEXT.QUICK_OPEN_EXT, new QuickOpenExtImpl(rpc));
     const dialogsExt = new DialogsExtImpl(rpc);
     const windowStateExt = rpc.set(MAIN_RPC_CONTEXT.WINDOW_STATE_EXT, new WindowStateExtImpl(rpc));
@@ -341,7 +342,7 @@ export function createAPIFactory(
     const fileSystemExt = rpc.set(MAIN_RPC_CONTEXT.FILE_SYSTEM_EXT, new FileSystemExtImpl(rpc));
     const languagesExt = rpc.set(MAIN_RPC_CONTEXT.LANGUAGES_EXT, new LanguagesExtImpl(rpc, documents, commandRegistry, fileSystemExt));
     const extHostFileSystemEvent = rpc.set(MAIN_RPC_CONTEXT.ExtHostFileSystemEventService, new ExtHostFileSystemEventService(rpc, editorsAndDocumentsExt, workspaceExt));
-    const scmExt = rpc.set(MAIN_RPC_CONTEXT.SCM_EXT, new ScmExtImpl(rpc, commandRegistry));
+    rpc.set(MAIN_RPC_CONTEXT.SCM_EXT, scmExt);
     const decorationsExt = rpc.set(MAIN_RPC_CONTEXT.DECORATIONS_EXT, new DecorationsExtImpl(rpc));
     const labelServiceExt = rpc.set(MAIN_RPC_CONTEXT.LABEL_SERVICE_EXT, new LabelServiceExtImpl(rpc));
     const timelineExt = rpc.set(MAIN_RPC_CONTEXT.TIMELINE_EXT, new TimelineExtImpl(rpc, commandRegistry));
@@ -1226,20 +1227,6 @@ export function createAPIFactory(
             }
         };
 
-        const scm: typeof theia.scm = {
-            get inputBox(): theia.SourceControlInputBox {
-                const inputBox = scmExt.getLastInputBox(plugin);
-                if (inputBox) {
-                    return inputBox.apiObject;
-                } else {
-                    throw new Error('Input box not found!');
-                }
-            },
-            createSourceControl(id: string, label: string, rootUri?: URI, iconPath?: theia.IconPath, isHidden?: boolean, parent?: theia.SourceControl): theia.SourceControl {
-                return scmExt.createSourceControl(plugin, id, label, rootUri, iconPath, isHidden, parent);
-            }
-        };
-
         const comments: typeof theia.comments = {
             createCommentController(id: string, label: string): theia.CommentController {
                 return createAPIObject(commentsExt.createCommentController(plugin, id, label));
@@ -1363,7 +1350,6 @@ export function createAPIFactory(
             plugins,
             debug,
             tasks,
-            scm,
             notebooks,
             l10n,
             tests,
@@ -1497,7 +1483,6 @@ export function createAPIFactory(
             SemanticTokensEdit,
             TextDocumentChangeReason,
             ColorThemeKind,
-            SourceControlInputBoxValidationType,
             FileDecoration,
             CancellationError,
             ExtensionMode,

--- a/packages/plugin-ext/src/plugin/scm-ext-plugin-api-contribution.ts
+++ b/packages/plugin-ext/src/plugin/scm-ext-plugin-api-contribution.ts
@@ -1,0 +1,79 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import type * as theia from '@theia/plugin';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { InternalPluginApiContribution } from '../common/plugin-ext-api-contribution';
+import { MAIN_RPC_CONTEXT, Plugin } from '../common/plugin-api-rpc';
+import { ScmExtImpl } from './scm';
+import { SourceControlInputBoxValidationType, URI } from './types-impl';
+
+/**
+ * The shape of the SCM contribution to the plugin API namespace.
+ *
+ * This type defines exactly what properties `ScmExtPluginApiContribution`
+ * adds to the `typeof theia` object. The assembler uses `DeepMerge` to combine
+ * this with other contributions' types and verify the result against `typeof theia`.
+ */
+export interface ScmPluginApiNamespace {
+    scm: typeof theia.scm;
+    SourceControlInputBoxValidationType: typeof SourceControlInputBoxValidationType;
+}
+
+/**
+ * SCM contribution to the ext-side plugin API.
+ *
+ * Extracted from the monolithic `createAPIFactory` following the terminal
+ * extraction pattern. It handles:
+ * - Registering `ScmExtImpl` on the RPC protocol
+ * - Providing the `scm` namespace with `inputBox` and `createSourceControl`
+ * - Providing `SourceControlInputBoxValidationType` type export
+ */
+@injectable()
+export class ScmExtPluginApiContribution implements InternalPluginApiContribution {
+
+    @inject(ScmExtImpl)
+    protected readonly scmExt: ScmExtImpl;
+
+    registerMainImplementations(_rpc: RPCProtocol, _container: interfaces.Container): void {
+        // Main-side SCM registration is handled by LegacyMainPluginApiContribution.
+    }
+
+    registerExtImplementations(rpc: RPCProtocol): void {
+        rpc.set(MAIN_RPC_CONTEXT.SCM_EXT, this.scmExt);
+    }
+
+    createApiNamespace(plugin: Plugin): ScmPluginApiNamespace {
+        const scmExt = this.scmExt;
+        return {
+            scm: {
+                get inputBox(): theia.SourceControlInputBox {
+                    const inputBox = scmExt.getLastInputBox(plugin);
+                    if (inputBox) {
+                        return inputBox.apiObject;
+                    } else {
+                        throw new Error('Input box not found!');
+                    }
+                },
+                createSourceControl(id: string, label: string, rootUri?: URI, iconPath?: theia.IconPath, isHidden?: boolean, parent?: theia.SourceControl): theia.SourceControl {
+                    return scmExt.createSourceControl(plugin, id, label, rootUri, iconPath, isHidden, parent);
+                }
+            },
+            SourceControlInputBoxValidationType,
+        };
+    }
+}

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -22,6 +22,7 @@
 
 import * as theia from '@theia/plugin';
 import { Emitter, Event } from '@theia/core/lib/common/event';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import {
     Plugin, PLUGIN_RPC_CONTEXT,
     ScmExt,
@@ -801,6 +802,7 @@ class SourceControlImpl implements theia.SourceControl {
     }
 }
 
+@injectable()
 export class ScmExtImpl implements ScmExt {
 
     private static handlePool: number = 0;
@@ -814,7 +816,7 @@ export class ScmExtImpl implements ScmExt {
 
     private selectedSourceControlHandle: number | undefined;
 
-    constructor(rpc: RPCProtocol, private commands: CommandRegistryImpl) {
+    constructor(@inject(RPCProtocol) rpc: RPCProtocol, @inject(CommandRegistryImpl) private commands: CommandRegistryImpl) {
         this.proxy = rpc.getProxy(PLUGIN_RPC_CONTEXT.SCM_MAIN);
 
         commands.registerArgumentProcessor({

--- a/packages/plugin-ext/src/plugin/terminal-ext-plugin-api-contribution.ts
+++ b/packages/plugin-ext/src/plugin/terminal-ext-plugin-api-contribution.ts
@@ -1,0 +1,168 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import type * as theia from '@theia/plugin';
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { Event } from '@theia/core/lib/common/event';
+import { RPCProtocol } from '../common/rpc-protocol';
+import { InternalPluginApiContribution } from '../common/plugin-ext-api-contribution';
+import { MAIN_RPC_CONTEXT, Plugin } from '../common/plugin-api-rpc';
+import { TerminalServiceExtImpl } from './terminal-ext';
+import { createAPIObject } from './plugin-context';
+import {
+    Disposable,
+    TerminalLink,
+    TerminalLocation,
+    TerminalExitReason,
+    TerminalProfile,
+    TerminalEditorTabInput,
+    TerminalOutputAnchor,
+    TerminalQuickFixTerminalCommand,
+    TerminalQuickFixOpener,
+    TerminalShellExecutionCommandLineConfidence,
+    TerminalCompletionItem,
+    TerminalCompletionItemKind,
+    TerminalCompletionList,
+} from './types-impl';
+
+/**
+ * The shape of the terminal contribution to the plugin API namespace.
+ *
+ * This type defines exactly what properties `TerminalExtPluginApiContribution`
+ * adds to the `typeof theia` object. The assembler uses `DeepMerge` to combine
+ * this with other contributions' types and verify the result against `typeof theia`.
+ */
+export interface TerminalPluginApiNamespace {
+    window: {
+        readonly activeTerminal: theia.Terminal | undefined;
+        readonly terminals: readonly theia.Terminal[];
+        onDidChangeActiveTerminal: typeof theia.window.onDidChangeActiveTerminal;
+        onDidChangeTerminalState: typeof theia.window.onDidChangeTerminalState;
+        onDidCloseTerminal: typeof theia.window.onDidCloseTerminal;
+        onDidOpenTerminal: typeof theia.window.onDidOpenTerminal;
+        createTerminal: typeof theia.window.createTerminal;
+        registerTerminalLinkProvider: typeof theia.window.registerTerminalLinkProvider;
+        registerTerminalProfileProvider: typeof theia.window.registerTerminalProfileProvider;
+        registerTerminalCompletionProvider: typeof theia.window.registerTerminalCompletionProvider;
+        registerTerminalQuickFixProvider: typeof theia.window.registerTerminalQuickFixProvider;
+        registerTerminalObserver: typeof theia.window.registerTerminalObserver;
+        onDidChangeTerminalShellIntegration: typeof theia.window.onDidChangeTerminalShellIntegration;
+        onDidEndTerminalShellExecution: typeof theia.window.onDidEndTerminalShellExecution;
+        onDidStartTerminalShellExecution: typeof theia.window.onDidStartTerminalShellExecution;
+    };
+    TerminalLink: typeof TerminalLink;
+    TerminalProfile: typeof TerminalProfile;
+    TabInputTerminal: typeof TerminalEditorTabInput;
+    TerminalLocation: typeof TerminalLocation;
+    TerminalOutputAnchor: typeof TerminalOutputAnchor;
+    TerminalExitReason: typeof TerminalExitReason;
+    TerminalQuickFixTerminalCommand: typeof TerminalQuickFixTerminalCommand;
+    TerminalQuickFixOpener: typeof TerminalQuickFixOpener;
+    TerminalShellExecutionCommandLineConfidence: typeof TerminalShellExecutionCommandLineConfidence;
+    TerminalCompletionItem: typeof TerminalCompletionItem;
+    TerminalCompletionItemKind: typeof TerminalCompletionItemKind;
+    TerminalCompletionList: typeof TerminalCompletionList;
+}
+
+/**
+ * Terminal contribution to the ext-side plugin API.
+ *
+ * This is the first feature extracted from the monolithic `createAPIFactory`.
+ * It handles:
+ * - Registering `TerminalServiceExtImpl` on the RPC protocol
+ * - Providing terminal-related `window.*` properties
+ * - Providing terminal-related type exports for the `typeof theia` namespace
+ */
+@injectable()
+export class TerminalExtPluginApiContribution implements InternalPluginApiContribution {
+
+    @inject(TerminalServiceExtImpl)
+    protected readonly terminalExt: TerminalServiceExtImpl;
+
+    registerMainImplementations(_rpc: RPCProtocol, _container: interfaces.Container): void {
+        // Main-side terminal registration is handled separately by LegacyMainPluginApiContribution.
+    }
+
+    registerExtImplementations(rpc: RPCProtocol): void {
+        rpc.set(MAIN_RPC_CONTEXT.TERMINAL_EXT, this.terminalExt);
+    }
+
+    createApiNamespace(plugin: Plugin): TerminalPluginApiNamespace {
+        const terminalExt = this.terminalExt;
+        const { onDidChangeActiveTerminal, onDidChangeTerminalState, onDidCloseTerminal, onDidOpenTerminal } = terminalExt;
+
+        return {
+            // Terminal window.* properties — deep-merged into the `window` namespace
+            // by the assembler via deepMergeApiNamespaces
+            window: {
+                get activeTerminal(): theia.Terminal | undefined {
+                    return terminalExt.activeTerminal;
+                },
+                get terminals(): theia.Terminal[] {
+                    return terminalExt.terminals;
+                },
+                onDidChangeActiveTerminal,
+                onDidChangeTerminalState,
+                onDidCloseTerminal,
+                onDidOpenTerminal,
+                createTerminal(nameOrOptions: theia.TerminalOptions | theia.ExtensionTerminalOptions | (string | undefined),
+                    shellPath?: string,
+                    shellArgs?: string[] | string): theia.Terminal {
+                    return terminalExt.createTerminal(plugin, nameOrOptions, shellPath, shellArgs, createAPIObject);
+                },
+                registerTerminalLinkProvider(provider: theia.TerminalLinkProvider): theia.Disposable {
+                    return terminalExt.registerTerminalLinkProvider(provider);
+                },
+                registerTerminalProfileProvider(id: string, provider: theia.TerminalProfileProvider): theia.Disposable {
+                    return terminalExt.registerTerminalProfileProvider(id, provider);
+                },
+                /** @stubbed TerminalCompletionProvider */
+                registerTerminalCompletionProvider<T extends theia.TerminalCompletionItem>(
+                    _provider: theia.TerminalCompletionProvider<T>, ..._triggerCharacters: string[]): theia.Disposable {
+                    return Disposable.NULL;
+                },
+                /** @stubbed TerminalQuickFixProvider */
+                registerTerminalQuickFixProvider(id: string, provider: theia.TerminalQuickFixProvider): theia.Disposable {
+                    return terminalExt.registerTerminalQuickFixProvider(id, provider);
+                },
+                /** Theia-specific TerminalObserver */
+                registerTerminalObserver(observer: theia.TerminalObserver): theia.Disposable {
+                    return terminalExt.registerTerminalObserver(observer);
+                },
+                /** @stubbed Terminal Shell Integration */
+                onDidChangeTerminalShellIntegration: Event.None,
+                /** @stubbed Terminal Shell Integration */
+                onDidEndTerminalShellExecution: Event.None,
+                /** @stubbed Terminal Shell Integration */
+                onDidStartTerminalShellExecution: Event.None,
+            },
+
+            // Terminal type exports
+            TerminalLink,
+            TerminalProfile,
+            TabInputTerminal: TerminalEditorTabInput,
+            TerminalLocation,
+            TerminalOutputAnchor,
+            TerminalExitReason,
+            TerminalQuickFixTerminalCommand,
+            TerminalQuickFixOpener,
+            TerminalShellExecutionCommandLineConfidence,
+            TerminalCompletionItem,
+            TerminalCompletionItemKind,
+            TerminalCompletionList,
+        };
+    }
+}


### PR DESCRIPTION
#### What it does

With reference to #17174, proposes one mechanism by which we could break up our monolithic extension system into smaller parts from the menu of which downstream application could choose to construct their own API surfaces without bringing in all of Theia.

**Proposal: Plugin API polylith — modular assembly of the `@theia/plugin` API**

This PR introduces the architectural foundation for breaking `plugin-ext`'s monolithic API assembly into composable, per-feature slices. The current state is intentionally incomplete:  the goal is to validate the approach and invite architectural discussion, not to ship a final solution.

**The problem:** `plugin-ext` depends on essentially every feature package in Theia (28 `@theia/*` dependencies). A downstream app that wants editors but not terminals still pulls in the entire plugin system. The three interlocking monoliths (`plugin-api-rpc.ts`, `plugin-context.ts`/`createAPIFactory`, `main-context.ts`/`setUpPluginApi`) make it impossible to include only the API surfaces you need.

**The approach:** This PR introduces **typed assemblers** that explicitly `@inject` per-feature providers and compose the full `typeof theia` API. TypeScript verifies the combined shape at compile time via `DeepMerge<T, U>` type helpers.

Key pieces:

- **`InternalPluginApiContribution` interface** — the contract each feature slice implements (`registerMainImplementations`, `registerExtImplementations`, `createApiNamespace`)
- **`MainPluginApiAssembler`** / **`ExtPluginApiAssembler`** — typed composition points. Adding a feature means adding an `@inject` field. Removing one means removing it. No call sites outside the assembler change.
- **`deepMergeApiNamespaces`** — runtime deep merge that handles the `window` namespace problem (multiple features contribute to `window.*`). Preserves property descriptors so getters remain lazy. Full unit test coverage.
- **Legacy contributions** wrapping the existing monolith, allowing incremental extraction
- **Terminal extraction** — first feature fully extracted: RPC registration, all `window.*` terminal properties, 12 type exports. Validated end-to-end with the JavaScript Debug Terminal.
- **SCM extraction** — second feature extracted, same pattern. Required making `CommandRegistryImpl` `@injectable()`, which unblocks ~8 further extractions.
- **Typed return narrowing** — the legacy contribution's return type is `Omit<typeof theia, ...extracted keys...>`. Each extraction adds to the omit list. The assembler's `DeepMerge` of all contributions is checked against `typeof theia`.

The extractions remain within `plugin-ext` for now. Moving them to separate packages requires a `plugin-ext-infra` split (shared infrastructure without feature dependencies) to avoid circular dependencies. See the "follow-ups" section below.

#### How to test

1. Build: `npm run build`
2. Start the Electron example: `npm run start:electron`
3. Verify plugin functionality works normally — commands, extensions, SCM (open a git repo), terminals
4. Open the JavaScript Debug Terminal (Command Palette → "JavaScript Debug Terminal") — this exercises `window.createTerminal` through the extracted terminal contribution
5. Run package tests: `npx lerna run test --scope @theia/plugin-ext` — 153 tests passing, including the `deepMergeApiNamespaces` unit tests

#### Follow-ups

**Near-term (within this effort):**
- Extract additional features (debug, comments, tasks, test, notebook) using the same mechanical pattern
- Main-side feature extraction — `MainPluginApiAssembler` currently only wraps the legacy; per-feature main-side providers should follow
- `plugin-ext-infra` package split — once 3–4 features are extracted, the common import surface is clear. Infrastructure (RPC, hosting, process management, shared utilities) moves to a package with no feature dependencies and no `theiaExtensions` entry. Feature packages depend on infra; `plugin-ext` depends on both and contains the default assembler.

**Standalone improvements surfaced by this work:**
- Fix type mismatches between `types-impl.ts` and `theia.d.ts` (separate PR) — this work revealed that the old `<typeof theia>` cast hid real inconsistencies (`ConfigurationTarget`, `CompletionList`, `Location`, `TextEdit`, `TreeItem`, `SymbolInformation`, `DebugAdapterExecutable`). These are not changed in this PR. Fixing them in a follow-up would remove the need for the type assertion in the legacy contribution's return statement.
- Plugin host extensibility the ext-side (plugin host) container currently has a different and more limited extensibility model than the main-side (browser/node) containers. Main-side customization uses `theiaExtensions` with full DI module composition. Ext-side customization requires `rebind(HostedPluginProcessConfiguration)` to point at a custom entry script that duplicates `plugin-host.ts` boilerplate. Bringing the plugin host closer to the main-side model — e.g., a composable module list rather than a monolithic entry point — would let downstream apps customize the plugin host the same way they customize everything else. This is relevant to the polylith work because a downstream app that builds a custom assembler needs to load it into the plugin host container.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Attribution

Contributed on behalf of EclipseSource GmbH.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service — N/A, no user-facing text changes

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)