### PR TITLE
Update default AI model versions for Anthropic and OpenAI

### DIFF
--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -36,6 +36,7 @@ const DEFAULT_MODEL_MAX_TOKENS: Record<string, number> = {
     'claude-sonnet-4-0': 64000,
     'claude-opus-4-5': 64000,
     'claude-opus-4-6': 128000,
+    'claude-opus-4-7': 128000,
     'claude-opus-4-1': 32000
 };
 

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -34,7 +34,7 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/anthropic/models/description', 'Official Anthropic models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['claude-sonnet-4-6', 'claude-sonnet-4-5', 'claude-opus-4-6', 'claude-opus-4-5'],
+            default: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-6'],
             items: {
                 type: 'string'
             }

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -34,7 +34,13 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/anthropic/models/description', 'Official Anthropic models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-6'],
+            default: [
+                'claude-opus-4-7',
+                'claude-sonnet-4-6',
+                'claude-opus-4-6',
+                'claude-sonnet-4-5',
+                'claude-opus-4-5'
+            ],
             items: {
                 type: 'string'
             }

--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -29,8 +29,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code',
             defaultModelIds: [
-                'anthropic/claude-opus-4-6',
-                'openai/gpt-5.4',
+                'anthropic/claude-opus-4-7',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code/description', 'Optimized for code understanding and generation tasks.')
@@ -38,8 +38,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/universal',
             defaultModelIds: [
-                'anthropic/claude-opus-4-6',
-                'openai/gpt-5.4',
+                'anthropic/claude-opus-4-7',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/universal/description', 'Well-balanced for both code and general language use.')
@@ -48,7 +48,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             id: 'default/code-completion',
             defaultModelIds: [
                 'anthropic/claude-sonnet-4-6',
-                'openai/gpt-5.4',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code-completion/description', 'Best suited for code autocompletion scenarios.')
@@ -56,8 +56,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/summarize',
             defaultModelIds: [
-                'anthropic/claude-opus-4-6',
-                'openai/gpt-5.4',
+                'anthropic/claude-opus-4-7',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/summarize/description', 'Models prioritized for summarization and condensation of content.')

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -38,6 +38,8 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             default: [
                 'gpt-5.5',
                 'gpt-5.5-pro',
+                'gpt-5.4',
+                'gpt-5.4-pro',
                 'gpt-5.4-mini',
                 'gpt-5.4-nano'
             ],

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -36,11 +36,10 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             description: nls.localize('theia/ai/openai/models/description', 'Official OpenAI models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
             default: [
-                'gpt-5.4',
-                'gpt-5.4-pro',
+                'gpt-5.5',
+                'gpt-5.5-pro',
                 'gpt-5.4-mini',
-                'gpt-4.1',
-                'gpt-4o'
+                'gpt-5.4-nano'
             ],
             items: {
                 type: 'string'


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Bump default models to latest versions across AI packages:
- Add Claude Opus 4.7 and set it as the preferred Anthropic model
- Update OpenAI defaults to GPT-5.5 family, add GPT-5.4-nano, and remove older models (GPT-4.1, GPT-4o)
- Update language model alias defaults to use the new model versions

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Test the main Theia AI Agents (e.g. Coder, Architect, Universal) with smaller and bigger prompts to verify no regressions occur because of the updates

See also https://github.com/eclipse-theia/theia/pull/17415

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
