### PR TITLE
WIP: Add test harness for evaluating AI models

### DIFF
--- a/examples/ai-model-tests/.eslintrc.js
+++ b/examples/ai-model-tests/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/examples/ai-model-tests/.gitignore
+++ b/examples/ai-model-tests/.gitignore
@@ -1,0 +1,2 @@
+results/
+node_modules/

--- a/examples/ai-model-tests/README.md
+++ b/examples/ai-model-tests/README.md
@@ -1,0 +1,198 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - AI MODEL TESTS</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/ai-model-tests` package is a local test harness for evaluating AI model updates. It runs prompts through Theia's actual chat agents (with tool calls), then uses a Judge agent to evaluate the results. Everything runs through Theia — no separate SDK dependencies needed.
+
+The test harness uses whichever AI models are configured in the running Theia instance. You must have valid API keys set up for at least one supported provider (Anthropic, OpenAI, or Google), either through Theia's preferences (e.g. `ai-features.anthropicApiKey`) or through environment variables (e.g. `ANTHROPIC_API_KEY`).
+
+The package is for test purposes only and is not published on `npm` (`private: true`).
+
+### How It Works
+
+1. Connects to a running Theia instance via Playwright
+2. Fetches all registered models from Anthropic, OpenAI, and Google
+3. For each model: sets it on the agent via `agentSettings`, sends the prompt, waits for completion
+4. Captures the full conversation including tool calls and token usage
+5. Saves a `.patch` file of the agent's file changes, then resets the workspace between runs
+6. Sends each conversation to a Judge agent for evaluation
+7. Generates a markdown + JSON report and saves all conversations
+
+### Setup
+
+#### 1. Build and start Theia
+
+```bash
+# From the repo root
+npm run build
+npm run start:browser
+```
+
+Make sure your API keys are configured in Theia's preferences or as environment variables (see above).
+
+#### 2. Run the tests
+
+```bash
+cd examples/ai-model-tests
+npm run model-test
+# OR
+npx tsx src/run.ts
+```
+
+Pass CLI options:
+
+```bash
+npm run model-test -- -help
+# OR
+npx tsx src/run.ts --help
+```
+
+### CLI Options
+
+```bash
+Usage: npx tsx src/run.ts [options]
+
+Options:
+  -s, --scenario <id>   Run only the scenario with this ID
+  -e, --skip-eval       Skip judge evaluation (just capture agent responses)
+  -h, --headed          Show the browser window
+  -k, --keep-open       Keep browser open after tests for inspection
+      --help            Show this help message
+```
+
+### npm Scripts
+
+| Script | Command | Description |
+| --- | --- | --- |
+| `npm run model-test` | `tsx src/run.ts` | Run all scenarios |
+| `npm run model-test:headed` | `tsx src/run.ts -h` | Run all, visible browser |
+| `npm run model-test:headed:keep-open` | `tsx src/run.ts -h -k` | Run all, browser stays open |
+| `npm run model-test:skip-eval` | `tsx src/run.ts -e` | Run all, skip judge evaluation |
+| `npm run model-test:smoke` | `tsx src/run.ts -s smoke-hello` | Run smoke test only |
+| `npm run model-test:coder` | `tsx src/run.ts -s coder-reset-button` | Run Coder scenario only |
+| `npm run model-test:coder:headed` | `tsx src/run.ts -s coder-reset-button -h -k` | Run Coder scenario, browser stays open after completion |
+
+Reports are written to `results/` as both JSON and Markdown. File names include the scenario and model IDs for easy identification. Additionally:
+- All chat threads are saved as a conversations JSON file
+- Each model run's file changes are saved as `.patch` files, so you can review what each model actually changed
+
+### Test Bridge
+
+The test bridge is a `FrontendApplicationContribution` in `examples/api-samples/` that activates when Theia is opened with `?test-bridge` in the URL. It exposes `window.__theiaTestBridge` with:
+
+- `getAgents()` — list available chat agents
+- `createSession(agentId?)` — create a chat session pinned to an agent
+- `sendMessage(sessionId, text)` — send a prompt and wait for completion
+- `getConversation(sessionId)` — get the full serialized conversation
+- `getAllConversations()` — export all chat threads
+- `getModels()` — list all registered language model IDs
+- `setAgentModel(agentId, modelId)` — set the model for an agent via agentSettings
+
+### Judge Agent
+
+The Judge agent is a chat agent (also in `examples/api-samples/`) that evaluates responses. It receives the original prompt, expected behavior, and the assistant's response (including tool calls), and returns a structured JSON evaluation with score, reasoning, and issues.
+
+### Adding Scenarios
+
+Drop a `.md` file in `scenarios/`. All configuration is in the frontmatter:
+
+```markdown
+---
+id: my-scenario
+description: What this tests
+agent: Coder                     # which chat agent to use
+runs: 1                          # how many times to run per model (default: 1)
+---
+
+# Prompt
+
+Your prompt text here.
+
+# Expected Behavior
+
+- What the response should contain
+- Criteria the judge will check
+```
+
+#### Frontmatter Options
+
+| Field | Required | Default | Description |
+| --- | --- | --- | --- |
+| `id` | no | filename | Unique scenario identifier |
+| `description` | no | filename | Short description shown in output |
+| `agent` | no | Coder | Which chat agent to use |
+| `models` | no | all default | List of model IDs to test (see below) |
+| `runs` | no | 1 | Number of times to repeat per model |
+
+#### Model Selection
+
+By default, the scenario runs with all models registered in Theia from Anthropic, OpenAI, and Google (i.e., whatever you have configured in the provider model preferences). To test specific models, add a `models` list:
+
+```yaml
+---
+id: my-scenario
+description: Compare specific models
+models:
+  - anthropic/claude-opus-4-7
+  - openai/gpt-5.5
+  - google/gemini-3.1-pro-preview
+agent: Coder
+---
+```
+
+#### Repeated Runs
+
+Set `runs` in the frontmatter to repeat a scenario multiple times per model. This is useful for testing consistency. The report includes per-run results and an average summary row:
+
+```yaml
+---
+id: consistency-test
+description: Test model consistency over 5 runs
+agent: Coder
+runs: 5
+models:
+  - anthropic/claude-opus-4-7
+---
+```
+
+### Customizing Evaluation
+
+The judge prompt template lives in `evaluation/judge-quality.md`. It uses `{{prompt}}`, `{{expected_behavior}}`, and `{{response}}` placeholders.
+
+### Project Structure
+
+```bash
+scenarios/           Prompt files (markdown with YAML frontmatter)
+evaluation/          Judge prompt templates
+src/
+  config.ts          Environment and paths
+  scenario-loader.ts Parses scenario files
+  report-writer.ts   JSON + markdown report generation
+  run.ts             CLI entry point (Playwright + test bridge)
+results/             Generated reports (gitignored)
+```
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+<https://www.eclipse.org/theia>

--- a/examples/ai-model-tests/evaluation/judge-quality.md
+++ b/examples/ai-model-tests/evaluation/judge-quality.md
@@ -1,0 +1,24 @@
+You are evaluating an AI coding assistant's response to a software engineering task.
+
+## Task Given to the Assistant
+
+{{prompt}}
+
+## Expected Behavior
+
+{{expected_behavior}}
+
+## Assistant's Response
+
+{{response}}
+
+## Your Evaluation
+
+Evaluate the assistant's response on the following criteria:
+- **Correctness**: Does the response correctly address the task?
+- **Code quality**: Is the generated code syntactically correct, well-structured, and following good practices?
+- **Completeness**: Does the response cover all aspects of the expected behavior?
+- **Relevance**: Does the response stay focused on the task without unnecessary tangents?
+
+Return ONLY valid JSON with no surrounding text or markdown:
+{"score": <1-10>, "pass": <true if score >= 6>, "reasoning": "<2-3 sentences explaining the score>", "issues": ["<issue1>", "<issue2>"]}

--- a/examples/ai-model-tests/package.json
+++ b/examples/ai-model-tests/package.json
@@ -1,0 +1,30 @@
+{
+  "private": true,
+  "name": "@theia/ai-model-tests",
+  "version": "1.70.0",
+  "description": "Local test harness for evaluating AI model updates via Theia chat agents",
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "scripts": {
+    "lint": "theiaext lint",
+    "model-test": "tsx src/run.ts",
+    "model-test:headed": "tsx src/run.ts -h",
+    "model-test:headed:keep-open": "tsx src/run.ts -h -k",
+    "model-test:skip-eval": "tsx src/run.ts -e",
+    "model-test:smoke": "tsx src/run.ts -s smoke-hello",
+    "model-test:coder": "tsx src/run.ts -s coder-reset-button",
+    "model-test:coder:headed": "tsx src/run.ts -s coder-reset-button -h -k"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.70.0",
+    "playwright": "^1.59.0",
+    "tsx": "^4.19.0"
+  }
+}

--- a/examples/ai-model-tests/scenarios/coder-reset-button.md
+++ b/examples/ai-model-tests/scenarios/coder-reset-button.md
@@ -1,0 +1,30 @@
+---
+id: coder-reset-button
+description: Add a reset button to the token usage view in the AI configuration view
+agent: Coder
+---
+
+# Prompt
+
+I am working on the Eclipse Theia IDE (TypeScript, React, InversifyJS DI).
+There is a token usage view that shows how many tokens each AI model has consumed.
+It is implemented in `packages/ai-ide/src/browser/ai-configuration/token-usage-configuration-widget.tsx`.
+The widget extends `ReactWidget` and renders a table with columns: Model, Input Tokens, Output Tokens, Total Tokens, Last Used.
+Token data comes from `TokenUsageFrontendService` which is injected via InversifyJS.
+
+Please create a plan and then provide the implementation for adding a "Reset" button to this token usage view that clears all tracked token usage data.
+
+Requirements:
+- Add a button labeled "Reset Token Usage" in the widget's toolbar or header area
+- Clicking it should clear all token usage data via the service
+- The view should update immediately after reset
+- Follow Theia's coding conventions (InversifyJS, React patterns, localization with nls.localize)
+
+# Expected Behavior
+
+- Identifies the correct widget file and service
+- Proposes adding a reset method to TokenUsageFrontendService (or uses an existing one)
+- Generates TypeScript/React code for the button
+- Uses nls.localize for the button label
+- The button triggers data clearing and UI refresh
+- Code follows Theia conventions (property injection, arrow functions for event handlers)

--- a/examples/ai-model-tests/scenarios/smoke-hello.md
+++ b/examples/ai-model-tests/scenarios/smoke-hello.md
@@ -1,0 +1,21 @@
+---
+id: smoke-hello
+description: Basic connectivity and response quality check
+agent: Coder
+runs: 2
+# models:                           # uncomment to test specific models instead of all defaults
+#   - anthropic/claude-opus-4-7
+#   - openai/gpt-5.5
+#   - google/gemini-3.1-pro-preview
+---
+
+# Prompt
+
+You are an AI coding assistant integrated into an IDE called Eclipse Theia. Briefly introduce yourself and describe what kind of tasks you can help with. Keep your response under 200 words.
+
+# Expected Behavior
+
+- Acknowledges being a coding assistant
+- Mentions relevant capabilities (code generation, debugging, explanation, etc.)
+- Response is coherent and well-structured
+- Response is concise (under 200 words)

--- a/examples/ai-model-tests/src/config.ts
+++ b/examples/ai-model-tests/src/config.ts
@@ -1,0 +1,31 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as path from 'path';
+
+export interface Config {
+    scenariosDir: string;
+    evaluationDir: string;
+    resultsDir: string;
+}
+
+export function loadConfig(): Config {
+    return {
+        scenariosDir: path.resolve(__dirname, '..', 'scenarios'),
+        evaluationDir: path.resolve(__dirname, '..', 'evaluation'),
+        resultsDir: path.resolve(__dirname, '..', 'results'),
+    };
+}

--- a/examples/ai-model-tests/src/report-writer.ts
+++ b/examples/ai-model-tests/src/report-writer.ts
@@ -1,0 +1,223 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface ModelResult {
+    modelId: string;
+    responseText: string;
+    latencyMs: number;
+    tokenUsage: { input: number; output: number };
+    error?: string;
+}
+
+export interface Evaluation {
+    score: number;
+    pass: boolean;
+    reasoning: string;
+    issues: string[];
+}
+
+export interface ScenarioResult {
+    scenarioId: string;
+    description: string;
+    results: SingleResult[];
+}
+
+export interface SingleResult {
+    modelId: string;
+    run?: number;
+    modelResult: ModelResult;
+    evaluation?: Evaluation;
+    toolCalls?: Array<{ name: string; arguments: string; result?: string }>;
+    conversation?: Record<string, unknown>;
+}
+
+export interface Report {
+    timestamp: string;
+    scenarios: ScenarioResult[];
+}
+
+export function writeReport(report: Report, resultsDir: string): string {
+    fs.mkdirSync(resultsDir, { recursive: true });
+
+    const timestamp = report.timestamp.replace(/[:.]/g, '-');
+    const scenarioNames = report.scenarios.map(s => s.scenarioId).join('+');
+    const prefix = `${timestamp}_${scenarioNames}`;
+
+    // Write JSON
+    const jsonPath = path.join(resultsDir, `${prefix}_results.json`);
+    fs.writeFileSync(jsonPath, JSON.stringify(report, undefined, 2));
+
+    // Write Markdown
+    const mdPath = path.join(resultsDir, `${prefix}_report.md`);
+    fs.writeFileSync(mdPath, generateMarkdown(report));
+
+    return mdPath;
+}
+
+function generateMarkdown(report: Report): string {
+    const lines: string[] = [];
+    lines.push('# AI Model Test Report');
+    lines.push('**Date:** ${report.timestamp}\n');
+
+    const hasRuns = report.scenarios.some(s => s.results.some(r => r.run !== undefined));
+
+    // Summary table (one row per model, averages if multiple runs)
+    lines.push('## Summary\n');
+    lines.push('| Scenario | Model | Score | Pass | Latency | Tokens (in/out) | Tool Calls | Issues |');
+    lines.push('|----------|-------|-------|------|---------|-----------------|------------|--------|');
+
+    for (const scenario of report.scenarios) {
+        const modelGroups = groupByModel(scenario.results);
+        for (const [modelId, results] of Object.entries(modelGroups)) {
+            if (results.length > 1) {
+                const avg = computeAverages(results);
+                lines.push(`| ${scenario.scenarioId} | ${modelId} | ${avg.score} | ${avg.passRate} | ${avg.latency} | ${avg.tokens} | ${avg.toolCalls} | ${avg.runs} runs |`);
+            } else {
+                const result = results[0];
+                const score = result.evaluation ? `${result.evaluation.score}/10` : 'N/A';
+                const pass = result.modelResult.error ? 'ERROR'
+                    : result.evaluation ? (result.evaluation.pass ? 'yes' : 'no')
+                        : 'N/A';
+                const latency = `${(result.modelResult.latencyMs / 1000).toFixed(1)}s`;
+                const tokens = result.modelResult.error ? '-'
+                    : `${result.modelResult.tokenUsage.input}/${result.modelResult.tokenUsage.output}`;
+                const toolCallCount = result.toolCalls ? String(result.toolCalls.length) : '-';
+                const issues = result.modelResult.error
+                    ? result.modelResult.error.substring(0, 50)
+                    : result.evaluation?.issues?.join(', ') || '-';
+                lines.push(`| ${scenario.scenarioId} | ${modelId} | ${score} | ${pass} | ${latency} | ${tokens} | ${toolCallCount} | ${issues} |`);
+            }
+        }
+    }
+
+    // Per-run detail table (only when runs > 1)
+    if (hasRuns) {
+        lines.push('\n## Per-Run Details\n');
+        lines.push('| Scenario | Model | Run | Score | Pass | Latency | Tokens (in/out) | Tool Calls |');
+        lines.push('|----------|-------|-----|-------|------|---------|-----------------|------------|');
+
+        for (const scenario of report.scenarios) {
+            for (const result of scenario.results) {
+                if (result.run === undefined) {
+                    continue;
+                }
+                const score = result.evaluation ? `${result.evaluation.score}/10` : 'N/A';
+                const pass = result.modelResult.error ? 'ERROR'
+                    : result.evaluation ? (result.evaluation.pass ? 'yes' : 'no')
+                        : 'N/A';
+                const latency = `${(result.modelResult.latencyMs / 1000).toFixed(1)}s`;
+                const tokens = result.modelResult.error ? '-'
+                    : `${result.modelResult.tokenUsage.input}/${result.modelResult.tokenUsage.output}`;
+                const toolCallCount = result.toolCalls ? String(result.toolCalls.length) : '-';
+                lines.push(`| ${scenario.scenarioId} | ${result.modelId} | ${result.run} | ${score} | ${pass} | ${latency} | ${tokens} | ${toolCallCount} |`);
+            }
+        }
+    }
+
+    // Details per scenario
+    for (const scenario of report.scenarios) {
+        lines.push(`\n## ${scenario.scenarioId}\n`);
+        lines.push(`> ${scenario.description}\n`);
+
+        for (const result of scenario.results) {
+            const runSuffix = result.run !== undefined ? ` (run ${result.run})` : '';
+            lines.push(`### ${result.modelId}${runSuffix}\n`);
+
+            if (result.modelResult.error) {
+                lines.push(`**Error:** ${result.modelResult.error}\n`);
+                continue;
+            }
+
+            lines.push(`- **Latency:** ${(result.modelResult.latencyMs / 1000).toFixed(1)}s`);
+            lines.push(`- **Tokens:** ${result.modelResult.tokenUsage.input} in / ${result.modelResult.tokenUsage.output} out`);
+
+            if (result.toolCalls && result.toolCalls.length > 0) {
+                lines.push(`- **Tool Calls:** ${result.toolCalls.length}`);
+                for (const tc of result.toolCalls) {
+                    lines.push(`  - \`${tc.name}\``);
+                }
+            }
+
+            if (result.evaluation) {
+                lines.push(`- **Score:** ${result.evaluation.score}/10 (${result.evaluation.pass ? 'PASS' : 'FAIL'})`);
+                lines.push(`- **Reasoning:** ${result.evaluation.reasoning}`);
+                if (result.evaluation.issues.length > 0) {
+                    lines.push(`- **Issues:** ${result.evaluation.issues.join(', ')}`);
+                }
+            }
+
+            lines.push('\n<details><summary>Full Response</summary>\n');
+            lines.push('```');
+            lines.push(result.modelResult.responseText.substring(0, 2000));
+            if (result.modelResult.responseText.length > 2000) {
+                lines.push('... (truncated)');
+            }
+            lines.push('```');
+            lines.push('</details>\n');
+        }
+    }
+
+    return lines.join('\n');
+}
+
+function groupByModel(results: SingleResult[]): Record<string, SingleResult[]> {
+    const groups: Record<string, SingleResult[]> = {};
+    for (const r of results) {
+        if (!groups[r.modelId]) {
+            groups[r.modelId] = [];
+        }
+        groups[r.modelId].push(r);
+    }
+    return groups;
+}
+
+function computeAverages(results: SingleResult[]): {
+    score: string; passRate: string; latency: string; tokens: string; toolCalls: string; runs: number;
+} {
+    const evaluated = results.filter(r => r.evaluation);
+    const successful = results.filter(r => !r.modelResult.error);
+
+    const avgScore = evaluated.length > 0
+        ? (evaluated.reduce((sum, r) => sum + (r.evaluation?.score || 0), 0) / evaluated.length).toFixed(1) + '/10'
+        : 'N/A';
+
+    const passCount = evaluated.filter(r => r.evaluation?.pass).length;
+    const passRate = evaluated.length > 0
+        ? `${Math.round(passCount / evaluated.length * 100)}%`
+        : 'N/A';
+
+    const avgLatency = successful.length > 0
+        ? (successful.reduce((sum, r) => sum + r.modelResult.latencyMs, 0) / successful.length / 1000).toFixed(1) + 's'
+        : '-';
+
+    const avgTokensIn = successful.length > 0
+        ? Math.round(successful.reduce((sum, r) => sum + r.modelResult.tokenUsage.input, 0) / successful.length)
+        : 0;
+    const avgTokensOut = successful.length > 0
+        ? Math.round(successful.reduce((sum, r) => sum + r.modelResult.tokenUsage.output, 0) / successful.length)
+        : 0;
+    const tokens = successful.length > 0 ? `${avgTokensIn}/${avgTokensOut}` : '-';
+
+    const withToolCalls = successful.filter(r => r.toolCalls);
+    const avgToolCalls = withToolCalls.length > 0
+        ? (withToolCalls.reduce((sum, r) => sum + (r.toolCalls?.length || 0), 0) / withToolCalls.length).toFixed(1)
+        : '-';
+
+    return { score: avgScore, passRate, latency: avgLatency, tokens, toolCalls: avgToolCalls, runs: results.length };
+}

--- a/examples/ai-model-tests/src/run.ts
+++ b/examples/ai-model-tests/src/run.ts
@@ -1,0 +1,469 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { chromium, Browser, Page } from 'playwright';
+import { loadConfig } from './config';
+import { loadScenarios, Scenario } from './scenario-loader';
+import { writeReport, Report, ScenarioResult, SingleResult, Evaluation } from './report-writer';
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const THEIA_URL = process.env.THEIA_URL || 'http://localhost:3000';
+const THEIA_LOAD_TIMEOUT = 60_000;
+
+interface SerializedResponse {
+    content: Array<{ kind: string; data: unknown }>;
+    isComplete: boolean;
+    isError: boolean;
+    tokenUsage?: { inputTokens: number; outputTokens: number };
+}
+
+interface SerializedConversation {
+    sessionId: string;
+    requests: Array<{ id: string; text: string; agentId?: string }>;
+    responses: SerializedResponse[];
+}
+
+interface ParsedArgs {
+    scenario?: string;
+    skipEval: boolean;
+    headed: boolean;
+    keepOpen: boolean;
+}
+
+function printHelp(): void {
+    console.log(`Usage: npx tsx src/run.ts [options]
+
+Options:
+  -s, --scenario <id>   Run only the scenario with this ID
+  -e, --skip-eval       Skip judge evaluation (just capture agent responses)
+  -h, --headed          Show the browser window
+  -k, --keep-open       Keep browser open after tests for inspection
+      --help            Show this help message
+
+Models and repeat runs are configured in the scenario frontmatter.
+See README.md for details.
+`);
+}
+
+function parseArgs(): ParsedArgs {
+    const args = process.argv.slice(2);
+    let scenario: string | undefined;
+    let skipEval = false;
+    let headed = false;
+    let keepOpen = false;
+
+    for (let i = 0; i < args.length; i++) {
+        if (args[i] === '--help') {
+            printHelp();
+            process.exit(0);
+        } else if ((args[i] === '-s' || args[i] === '--scenario') && args[i + 1]) {
+            scenario = args[++i];
+        } else if (args[i] === '-e' || args[i] === '--skip-eval') {
+            skipEval = true;
+        } else if (args[i] === '-h' || args[i] === '--headed') {
+            headed = true;
+        } else if (args[i] === '-k' || args[i] === '--keep-open') {
+            keepOpen = true;
+        }
+    }
+
+    return { scenario, skipEval, headed, keepOpen };
+}
+
+async function waitForTheia(page: Page): Promise<void> {
+    await page.waitForSelector('.theia-ApplicationShell', { timeout: THEIA_LOAD_TIMEOUT });
+    await page.waitForTimeout(3000);
+}
+
+async function waitForTestBridge(page: Page): Promise<void> {
+    await page.waitForFunction(
+        () => (window as unknown as Record<string, unknown>).__theiaTestBridge !== undefined,
+        { timeout: THEIA_LOAD_TIMEOUT }
+    );
+}
+
+async function callBridge<T>(page: Page, method: string, ...args: unknown[]): Promise<T> {
+    return page.evaluate(
+        ({ m, a }) => {
+            const bridge = (window as unknown as Record<string, unknown>).__theiaTestBridge as Record<string, (...params: unknown[]) => unknown>;
+            return bridge[m](...a);
+        },
+        { m: method, a: args }
+    ) as Promise<T>;
+}
+
+function extractResponseText(conversation: SerializedConversation): string {
+    const parts: string[] = [];
+    for (const response of conversation.responses) {
+        for (const content of response.content) {
+            if (content.kind === 'text' || content.kind === 'markdownContent') {
+                const data = content.data as { content?: string };
+                if (data.content) {
+                    parts.push(data.content);
+                }
+            } else if (content.kind === 'code') {
+                const data = content.data as { code?: string; language?: string };
+                if (data.code) {
+                    parts.push(`\`\`\`${data.language || ''}\n${data.code}\n\`\`\``);
+                }
+            }
+        }
+    }
+    return parts.join('\n');
+}
+
+function extractToolCalls(conversation: SerializedConversation): Array<{ name: string; arguments: string; result?: string }> {
+    const toolCalls: Array<{ name: string; arguments: string; result?: string }> = [];
+    for (const response of conversation.responses) {
+        for (const content of response.content) {
+            if (content.kind === 'toolCall') {
+                const data = content.data as { name?: string; arguments?: string; result?: unknown };
+                toolCalls.push({
+                    name: data.name || 'unknown',
+                    arguments: data.arguments || '',
+                    result: data.result ? JSON.stringify(data.result).substring(0, 500) : undefined,
+                });
+            }
+        }
+    }
+    return toolCalls;
+}
+
+function getTokenUsage(conversation: SerializedConversation): { input: number; output: number } {
+    let input = 0;
+    let output = 0;
+    for (const response of conversation.responses) {
+        if (response.tokenUsage) {
+            input += response.tokenUsage.inputTokens || 0;
+            output += response.tokenUsage.outputTokens || 0;
+        }
+    }
+    return { input, output };
+}
+
+const DEFAULT_PROVIDERS = ['anthropic', 'openai', 'google'];
+
+function getDefaultModels(registeredModels: string[]): string[] {
+    return registeredModels.filter(m => DEFAULT_PROVIDERS.some(p => m.startsWith(`${p}/`)));
+}
+
+function getModelsForScenario(scenario: Scenario, defaultModels: string[]): string[] {
+    if (scenario.models.length > 0) {
+        return scenario.models;
+    }
+    return defaultModels;
+}
+
+async function evaluateViaJudge(
+    page: Page,
+    prompt: string,
+    expectedBehavior: string,
+    response: string,
+    evaluationDir: string,
+): Promise<Evaluation> {
+    const templatePath = path.join(evaluationDir, 'judge-quality.md');
+    const template = fs.readFileSync(templatePath, 'utf-8');
+
+    const judgePrompt = template
+        .replace('{{prompt}}', prompt)
+        .replace('{{expected_behavior}}', expectedBehavior)
+        .replace('{{response}}', response);
+
+    const sessionId = await callBridge<string>(page, 'createSession', 'Judge');
+    const conversation = await callBridge<SerializedConversation>(
+        page, 'sendMessage', sessionId, judgePrompt
+    );
+
+    const judgeResponse = extractResponseText(conversation);
+    return parseEvaluation(judgeResponse);
+}
+
+function parseEvaluation(responseText: string): Evaluation {
+    const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+        return {
+            score: 0, pass: false,
+            reasoning: `Could not parse judge response: ${responseText.substring(0, 200)}`,
+            issues: ['Invalid judge response format'],
+        };
+    }
+    try {
+        const parsed = JSON.parse(jsonMatch[0]);
+        return {
+            score: typeof parsed.score === 'number' ? parsed.score : 0,
+            pass: typeof parsed.pass === 'boolean' ? parsed.pass : parsed.score >= 6,
+            reasoning: parsed.reasoning || '',
+            issues: Array.isArray(parsed.issues) ? parsed.issues : [],
+        };
+    } catch {
+        return {
+            score: 0, pass: false,
+            reasoning: `Failed to parse JSON: ${responseText.substring(0, 200)}`,
+            issues: ['JSON parse error'],
+        };
+    }
+}
+
+function saveConversations(conversations: unknown[], resultsDir: string, prefix: string): string {
+    fs.mkdirSync(resultsDir, { recursive: true });
+    const filePath = path.join(resultsDir, `${prefix}_conversations.json`);
+    fs.writeFileSync(filePath, JSON.stringify(conversations, undefined, 2));
+    return filePath;
+}
+
+/**
+ * Get the git repo root directory.
+ */
+function getRepoRoot(): string {
+    return execSync('git rev-parse --show-toplevel', { encoding: 'utf-8' }).trim();
+}
+
+/**
+ * Capture the git diff of file changes the agent made, save it to a patch file,
+ * then reset the workspace for the next run.
+ * All git commands run against the repo root, not the cwd.
+ */
+function captureAndResetWorkspace(resultsDir: string, prefix: string, modelId: string, run: number): string | undefined {
+    const repoRoot = getRepoRoot();
+    const gitOpts = { encoding: 'utf-8' as const, cwd: repoRoot };
+
+    try {
+        // Capture both staged and unstaged changes, plus untracked files
+        const diff = execSync('git diff HEAD', gitOpts);
+        const untrackedFiles = execSync('git ls-files --others --exclude-standard', gitOpts).trim();
+
+        if (!diff && !untrackedFiles) {
+            return undefined;
+        }
+
+        fs.mkdirSync(resultsDir, { recursive: true });
+        const safeName = modelId.replace(/\//g, '-');
+        const patchFile = path.join(resultsDir, `${prefix}_${safeName}_run${run}.patch`);
+
+        let patchContent = '';
+        if (diff) {
+            patchContent += diff;
+        }
+        if (untrackedFiles) {
+            for (const file of untrackedFiles.split('\n').filter(Boolean)) {
+                try {
+                    const content = fs.readFileSync(path.join(repoRoot, file), 'utf-8');
+                    patchContent += `\n--- /dev/null\n+++ b/${file}\n`;
+                    patchContent += content.split('\n').map(line => `+${line}`).join('\n');
+                    patchContent += '\n';
+                } catch {
+                    // skip binary or unreadable files
+                }
+            }
+        }
+
+        if (patchContent) {
+            fs.writeFileSync(patchFile, patchContent);
+        }
+
+        // Reset: discard all tracked changes and remove untracked files
+        execSync('git checkout .', gitOpts);
+        execSync('git clean -fd', gitOpts);
+
+        return patchFile;
+    } catch {
+        // Fallback: try basic reset
+        try {
+            execSync('git checkout .', { encoding: 'utf-8', cwd: repoRoot });
+            execSync('git clean -fd', { encoding: 'utf-8', cwd: repoRoot });
+        } catch {
+            // give up
+        }
+        return undefined;
+    }
+}
+
+async function main(): Promise<void> {
+    const config = loadConfig();
+    const { scenario: scenarioFilter, skipEval, headed, keepOpen } = parseArgs();
+
+    console.log('=== AI Model Test Harness ===\n');
+    console.log(`Theia URL: ${THEIA_URL}?test-bridge`);
+    if (headed) {
+        console.log('Headed mode: browser visible');
+    }
+    if (keepOpen) {
+        console.log('Keep-open mode: browser stays open after tests');
+    }
+    if (skipEval) {
+        console.log('Evaluation skipped (--skip-eval)');
+    }
+    console.log('');
+
+    const scenarios = loadScenarios(config.scenariosDir, scenarioFilter);
+
+    if (scenarios.length === 0) {
+        console.error('No matching scenarios found.');
+        process.exit(1);
+    }
+
+    const browser: Browser = await chromium.launch({ headless: !headed });
+    const page = await browser.newPage();
+
+    console.log('Connecting to Theia...');
+    await page.goto(`${THEIA_URL}?test-bridge`);
+    await waitForTheia(page);
+    await waitForTestBridge(page);
+    console.log('Theia ready. Test bridge active.\n');
+
+    const agents = await callBridge<Array<{ id: string; name: string }>>(page, 'getAgents');
+    console.log(`Available agents: ${agents.map(a => a.id).join(', ')}`);
+
+    const registeredModels = await callBridge<string[]>(page, 'getModels');
+    const defaultModels = getDefaultModels(registeredModels);
+    console.log(`Default models: ${defaultModels.join(', ')}\n`);
+
+    const report: Report = {
+        timestamp: new Date().toISOString(),
+        scenarios: [],
+    };
+
+    // Build prefix early for patch file naming
+    const timestamp = report.timestamp.replace(/[:.]/g, '-');
+
+    for (const scenario of scenarios) {
+        console.log(`=== Scenario: ${scenario.id} ===`);
+        console.log(`  ${scenario.description}`);
+        if (scenario.agent) {
+            console.log(`  Agent: ${scenario.agent}`);
+        }
+        if (scenario.runs > 1) {
+            console.log(`  Runs per model: ${scenario.runs}`);
+        }
+        console.log('');
+
+        const modelRuns = getModelsForScenario(scenario, defaultModels);
+
+        const scenarioResult: ScenarioResult = {
+            scenarioId: scenario.id,
+            description: scenario.description,
+            results: [],
+        };
+
+        for (const modelId of modelRuns) {
+            const agentId = scenario.agent || 'Coder';
+
+            for (let run = 1; run <= scenario.runs; run++) {
+                const runLabel = scenario.runs > 1 ? ` (run ${run}/${scenario.runs})` : '';
+                const label = `${modelId}${runLabel}`;
+
+                // Set the model for this agent via agentSettings preference
+                process.stdout.write(`  [${label}] Setting model for ${agentId}... `);
+                await callBridge(page, 'setAgentModel', agentId, modelId);
+                console.log('done');
+
+                process.stdout.write(`  [${label}] Running via ${agentId} agent... `);
+
+                try {
+                    const sessionId = await callBridge<string>(page, 'createSession', agentId);
+
+                    const start = Date.now();
+                    const conversation = await callBridge<SerializedConversation>(
+                        page, 'sendMessage', sessionId, scenario.prompt
+                    );
+                    const latencyMs = Date.now() - start;
+
+                    const responseText = extractResponseText(conversation);
+                    const toolCalls = extractToolCalls(conversation);
+                    const tokenUsage = getTokenUsage(conversation);
+
+                    console.log(`done (${(latencyMs / 1000).toFixed(1)}s, ${toolCalls.length} tool calls)`);
+
+                    const singleResult: SingleResult = {
+                        modelId,
+                        run: scenario.runs > 1 ? run : undefined,
+                        modelResult: { modelId, responseText, latencyMs, tokenUsage },
+                        toolCalls,
+                        conversation: conversation as unknown as Record<string, unknown>,
+                    };
+
+                    if (!skipEval) {
+                        process.stdout.write(`  [${label}] Evaluating via Judge agent... `);
+
+                        const enrichedResponse = [
+                            responseText,
+                            '',
+                            `## Tool Calls (${toolCalls.length} total)`,
+                            ...toolCalls.map((tc, i) => `${i + 1}. ${tc.name}(${tc.arguments.substring(0, 100)})`),
+                        ].join('\n');
+
+                        const evaluation = await evaluateViaJudge(
+                            page, scenario.prompt, scenario.expectedBehavior,
+                            enrichedResponse, config.evaluationDir,
+                        );
+                        singleResult.evaluation = evaluation;
+                        const passLabel = evaluation.pass ? 'PASS' : 'FAIL';
+                        console.log(`${evaluation.score}/10 (${passLabel})`);
+                    }
+
+                    scenarioResult.results.push(singleResult);
+                } catch (err: unknown) {
+                    const message = err instanceof Error ? err.message : String(err);
+                    console.log(`ERROR: ${message}`);
+                    scenarioResult.results.push({
+                        modelId,
+                        run: scenario.runs > 1 ? run : undefined,
+                        modelResult: {
+                            modelId, responseText: '', latencyMs: 0,
+                            tokenUsage: { input: 0, output: 0 }, error: message,
+                        },
+                    });
+                }
+
+                // Save file changes as a patch, then reset workspace
+                const patchFile = captureAndResetWorkspace(config.resultsDir, `${timestamp}_${scenario.id}`, modelId, run);
+                if (patchFile) {
+                    console.log(`  [${label}] File changes saved to: ${path.basename(patchFile)}`);
+                    console.log(`  [${label}] Workspace reset`);
+                }
+
+                console.log('');
+            }
+        }
+
+        report.scenarios.push(scenarioResult);
+    }
+
+    const scenarioNames = report.scenarios.map(s => s.scenarioId).join('+');
+    const prefix = `${timestamp}_${scenarioNames}`;
+
+    // Save all conversations as JSON for later inspection
+    const allConversations = await callBridge<unknown[]>(page, 'getAllConversations');
+    const conversationsPath = saveConversations(allConversations, config.resultsDir, prefix);
+    console.log(`Conversations saved to: ${conversationsPath}`);
+
+    const reportPath = writeReport(report, config.resultsDir);
+    console.log(`Report written to: ${reportPath}`);
+
+    if (keepOpen) {
+        console.log('\nBrowser left open for inspection. Press Ctrl+C to exit.');
+        await new Promise(() => { });
+    } else {
+        await browser.close();
+    }
+}
+
+main().catch(err => {
+    console.error('Fatal error:', err);
+    process.exit(1);
+});

--- a/examples/ai-model-tests/src/scenario-loader.ts
+++ b/examples/ai-model-tests/src/scenario-loader.ts
@@ -1,0 +1,134 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+export interface Scenario {
+    id: string;
+    description: string;
+    models: string[];
+    runs: number;
+    prompt: string;
+    expectedBehavior: string;
+    agent?: string;
+}
+
+interface Frontmatter {
+    id?: string;
+    description?: string;
+    models?: string[];
+    runs?: string;
+    agent?: string;
+}
+
+export function loadScenarios(scenariosDir: string, filter?: string): Scenario[] {
+    const files = fs.readdirSync(scenariosDir).filter(f => f.endsWith('.md'));
+    const scenarios: Scenario[] = [];
+
+    for (const file of files) {
+        const content = fs.readFileSync(path.join(scenariosDir, file), 'utf-8');
+        const scenario = parseScenario(content, path.basename(file, '.md'));
+        if (filter && scenario.id !== filter) {
+            continue;
+        }
+        scenarios.push(scenario);
+    }
+
+    return scenarios;
+}
+
+function parseScenario(content: string, fallbackId: string): Scenario {
+    const frontmatter = parseFrontmatter(content);
+    const body = removeFrontmatter(content);
+
+    const prompt = extractSection(body, 'Prompt');
+    const expectedBehavior = extractSection(body, 'Expected Behavior');
+
+    const runs = Number(frontmatter.runs);
+    return {
+        id: frontmatter.id || fallbackId,
+        description: frontmatter.description || fallbackId,
+        models: frontmatter.models || [],
+        runs: isNaN(runs) || runs < 1 ? 1 : runs,
+        prompt: prompt.trim(),
+        expectedBehavior: expectedBehavior.trim(),
+        agent: frontmatter.agent,
+    };
+}
+
+function parseFrontmatter(content: string): Frontmatter {
+    const match = content.match(/^---\n([\s\S]*?)\n---/);
+    if (!match) {
+        return {};
+    }
+
+    const result: Record<string, string | string[]> = {};
+    const lines = match[1].split('\n');
+    let currentKey: string | undefined;
+    let currentArray: string[] | undefined;
+
+    for (const line of lines) {
+        const keyValue = line.match(/^(\w+):\s*(.*)$/);
+        if (keyValue) {
+            if (currentKey && currentArray) {
+                result[currentKey] = currentArray;
+            }
+            currentKey = keyValue[1];
+            const value = keyValue[2].trim();
+
+            if (value === '' || value === undefined) {
+                currentArray = [];
+            } else if (value.startsWith('[') && value.endsWith(']')) {
+                result[currentKey] = value.slice(1, -1).split(',').map(s => s.trim());
+                currentKey = undefined;
+                currentArray = undefined;
+            } else {
+                result[currentKey] = value;
+                currentKey = undefined;
+                currentArray = undefined;
+            }
+        } else if (currentArray !== undefined) {
+            const item = line.match(/^\s+-\s+(.+)$/);
+            if (item) {
+                currentArray.push(item[1].trim());
+            }
+        }
+    }
+
+    if (currentKey && currentArray) {
+        result[currentKey] = currentArray;
+    }
+
+    return result;
+}
+
+function removeFrontmatter(content: string): string {
+    return content.replace(/^---\n[\s\S]*?\n---\n*/, '');
+}
+
+function extractSection(body: string, heading: string): string {
+    // Split on markdown headings, find the one matching our heading
+    const sections = body.split(/^(?=#\s)/m);
+    for (const section of sections) {
+        const headerMatch = section.match(/^#\s+(.*)/);
+        if (headerMatch && headerMatch[1].trim() === heading) {
+            // Return everything after the heading line
+            return section.replace(/^#\s+.*\n/, '');
+        }
+    }
+    return '';
+}

--- a/examples/ai-model-tests/tsconfig.json
+++ b/examples/ai-model-tests/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2023",
+    "module": "CommonJS",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": [
+    "src"
+  ],
+  "references": []
+}

--- a/examples/api-samples/src/browser/api-samples-frontend-module.ts
+++ b/examples/api-samples/src/browser/api-samples-frontend-module.ts
@@ -43,6 +43,8 @@ import { MCPFrontendContribution } from '@theia/ai-mcp-server/lib/browser/mcp-fr
 import { SampleFrontendMCPContribution } from './mcp/sample-frontend-mcp-contribution';
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { ResolveMcpFrontendContribution } from './mcp/resolve-frontend-mcp-contribution';
+import { bindAITestBridgeContribution } from './test/ai-test-bridge-contribution';
+import { bindJudgeChatAgentContribution } from './chat/judge-chat-agent-contribution';
 
 export default new ContainerModule((
     bind: interfaces.Bind,
@@ -75,4 +77,6 @@ export default new ContainerModule((
     bind(MCPFrontendContribution).to(SampleFrontendMCPContribution).inSingletonScope();
     bind(ResolveMcpFrontendContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(ResolveMcpFrontendContribution);
+    bindAITestBridgeContribution(bind);
+    bindJudgeChatAgentContribution(bind);
 });

--- a/examples/api-samples/src/browser/chat/judge-chat-agent-contribution.ts
+++ b/examples/api-samples/src/browser/chat/judge-chat-agent-contribution.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import {
+    AbstractStreamParsingChatAgent,
+    ChatAgent,
+} from '@theia/ai-chat';
+import { Agent, BasePromptFragment } from '@theia/ai-core';
+import { injectable, interfaces } from '@theia/core/shared/inversify';
+
+export function bindJudgeChatAgentContribution(bind: interfaces.Bind): void {
+    bind(JudgeChatAgent).toSelf().inSingletonScope();
+    bind(Agent).toService(JudgeChatAgent);
+    bind(ChatAgent).toService(JudgeChatAgent);
+}
+
+const systemPrompt: BasePromptFragment = {
+    id: 'judge-system',
+    template: `You are an evaluation judge for an AI coding assistant integrated into the Eclipse Theia IDE.
+
+Your job is to evaluate how well the assistant responded to a given task. You will receive:
+- The original task prompt
+- The expected behavior criteria
+- The assistant's response (including any tool calls it made)
+
+Evaluate the response on these criteria:
+- **Correctness**: Does the response correctly address the task?
+- **Code quality**: Is the generated code syntactically correct, well-structured, and following good practices?
+- **Completeness**: Does the response cover all aspects of the expected behavior?
+- **Relevance**: Does the response stay focused on the task without unnecessary tangents?
+- **Tool usage**: Were tool calls appropriate, efficient, and non-repetitive?
+
+Return ONLY valid JSON with no surrounding text, markdown, or code blocks:
+{"score": <1-10>, "pass": <true if score >= 6>, "reasoning": "<2-3 sentences explaining the score>", "issues": ["<issue1>", "<issue2>"]}`
+};
+
+@injectable()
+export class JudgeChatAgent extends AbstractStreamParsingChatAgent {
+    id = 'Judge';
+    name = 'Judge';
+    override description = 'Evaluates AI assistant responses for quality, correctness, and tool usage.';
+    protected defaultLanguageModelPurpose = 'chat';
+    override languageModelRequirements = [
+        {
+            purpose: 'chat',
+            identifier: 'default/universal',
+        }
+    ];
+    override prompts = [{ id: systemPrompt.id, defaultVariant: systemPrompt }];
+    protected override systemPromptId: string | undefined = systemPrompt.id;
+    override iconClass: string = 'codicon codicon-check-all';
+    override functions: string[] = [];
+}

--- a/examples/api-samples/src/browser/test/ai-test-bridge-contribution.ts
+++ b/examples/api-samples/src/browser/test/ai-test-bridge-contribution.ts
@@ -1,0 +1,115 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { ChatService, ChatAgentService, ChatAgentLocation } from '@theia/ai-chat';
+import { AISettingsService, LanguageModelRegistry } from '@theia/ai-core';
+
+@injectable()
+export class AITestBridgeContribution implements FrontendApplicationContribution {
+
+    @inject(ChatService)
+    protected readonly chatService: ChatService;
+
+    @inject(ChatAgentService)
+    protected readonly chatAgentService: ChatAgentService;
+
+    @inject(AISettingsService)
+    protected readonly aiSettingsService: AISettingsService;
+
+    @inject(LanguageModelRegistry)
+    protected readonly languageModelRegistry: LanguageModelRegistry;
+
+    onStart(): void {
+        const params = new URLSearchParams(window.location.search);
+        if (!params.has('test-bridge')) {
+            return;
+        }
+
+        console.log('[AITestBridge] Test bridge activated');
+
+        // eslint-disable-next-line @typescript-eslint/no-this-alias
+        const self = this;
+        const bridge = {
+            getAgents: () => self.getAgents(),
+            createSession: (agentId?: string) => self.createSession(agentId),
+            sendMessage: (sessionId: string, text: string) => self.sendMessage(sessionId, text),
+            getConversation: (sessionId: string) => self.getConversation(sessionId),
+            getAllConversations: () => self.getAllConversations(),
+            getModels: () => self.getModels(),
+            setAgentModel: (agentId: string, modelId: string) => self.setAgentModel(agentId, modelId),
+        };
+
+        (window as unknown as Record<string, unknown>).__theiaTestBridge = bridge;
+    }
+
+    protected getAgents(): { id: string; name: string; description: string }[] {
+        return this.chatAgentService.getAgents().map(agent => ({
+            id: agent.id,
+            name: agent.name,
+            description: agent.description,
+        }));
+    }
+
+    protected createSession(agentId?: string): string {
+        const agent = agentId ? this.chatAgentService.getAgent(agentId) : undefined;
+        const session = this.chatService.createSession(ChatAgentLocation.Panel, undefined, agent);
+        this.chatService.setActiveSession(session.id);
+        return session.id;
+    }
+
+    protected async sendMessage(sessionId: string, text: string): Promise<unknown> {
+        const invocation = await this.chatService.sendRequest(sessionId, { text });
+        if (!invocation) {
+            throw new Error(`Failed to send request to session ${sessionId}`);
+        }
+        await invocation.responseCompleted;
+        return this.getConversation(sessionId);
+    }
+
+    protected getConversation(sessionId: string): unknown {
+        const session = this.chatService.getSession(sessionId);
+        if (!session) {
+            throw new Error(`Session ${sessionId} not found`);
+        }
+        return session.model.toSerializable();
+    }
+
+    protected getAllConversations(): unknown[] {
+        return this.chatService.getSessions().map(session => ({
+            title: session.title,
+            ...session.model.toSerializable(),
+        }));
+    }
+
+    protected async getModels(): Promise<string[]> {
+        const models = await this.languageModelRegistry.getLanguageModels();
+        return models.map(m => m.id);
+    }
+
+    protected async setAgentModel(agentId: string, modelId: string): Promise<void> {
+        await this.aiSettingsService.updateAgentSettings(agentId, {
+            languageModelRequirements: [{ purpose: 'chat', identifier: modelId }],
+        });
+    }
+
+}
+
+export function bindAITestBridgeContribution(bind: interfaces.Bind): void {
+    bind(AITestBridgeContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(AITestBridgeContribution);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -348,6 +348,16 @@
         "undici": "^7.16.0"
       }
     },
+    "examples/ai-model-tests": {
+      "name": "@theia/ai-model-tests",
+      "version": "1.70.0",
+      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "devDependencies": {
+        "@theia/ext-scripts": "1.70.0",
+        "playwright": "^1.59.0",
+        "tsx": "^4.19.0"
+      }
+    },
     "examples/api-provider-sample": {
       "name": "@theia/api-provider-sample",
       "version": "1.70.0",
@@ -2678,6 +2688,448 @@
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -6355,6 +6807,10 @@
     },
     "node_modules/@theia/ai-mcp-ui": {
       "resolved": "packages/ai-mcp-ui",
+      "link": true
+    },
+    "node_modules/@theia/ai-model-tests": {
+      "resolved": "examples/ai-model-tests",
       "link": true
     },
     "node_modules/@theia/ai-ollama": {
@@ -13781,6 +14237,48 @@
       "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "license": "MIT"
     },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -15666,6 +16164,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/get-uri": {
@@ -24356,6 +24867,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/resolve.exports": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
@@ -27549,6 +28070,26 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/tuf-js": {
       "version": "4.1.0",

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -36,6 +36,7 @@ const DEFAULT_MODEL_MAX_TOKENS: Record<string, number> = {
     'claude-sonnet-4-0': 64000,
     'claude-opus-4-5': 64000,
     'claude-opus-4-6': 128000,
+    'claude-opus-4-7': 128000,
     'claude-opus-4-1': 32000
 };
 

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -34,7 +34,7 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/anthropic/models/description', 'Official Anthropic models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['claude-sonnet-4-6', 'claude-sonnet-4-5', 'claude-opus-4-6', 'claude-opus-4-5'],
+            default: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-6'],
             items: {
                 type: 'string'
             }

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -34,7 +34,13 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/anthropic/models/description', 'Official Anthropic models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['claude-opus-4-7', 'claude-sonnet-4-6', 'claude-opus-4-6'],
+            default: [
+                'claude-opus-4-7',
+                'claude-sonnet-4-6',
+                'claude-opus-4-6',
+                'claude-sonnet-4-5',
+                'claude-opus-4-5'
+            ],
             items: {
                 type: 'string'
             }

--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -29,8 +29,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code',
             defaultModelIds: [
-                'anthropic/claude-opus-4-6',
-                'openai/gpt-5.4',
+                'anthropic/claude-opus-4-7',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code/description', 'Optimized for code understanding and generation tasks.')
@@ -38,8 +38,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/universal',
             defaultModelIds: [
-                'anthropic/claude-opus-4-6',
-                'openai/gpt-5.4',
+                'anthropic/claude-opus-4-7',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/universal/description', 'Well-balanced for both code and general language use.')
@@ -48,7 +48,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             id: 'default/code-completion',
             defaultModelIds: [
                 'anthropic/claude-sonnet-4-6',
-                'openai/gpt-5.4',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code-completion/description', 'Best suited for code autocompletion scenarios.')
@@ -56,8 +56,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/summarize',
             defaultModelIds: [
-                'anthropic/claude-opus-4-6',
-                'openai/gpt-5.4',
+                'anthropic/claude-opus-4-7',
+                'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/summarize/description', 'Models prioritized for summarization and condensation of content.')

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -38,6 +38,8 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             default: [
                 'gpt-5.5',
                 'gpt-5.5-pro',
+                'gpt-5.4',
+                'gpt-5.4-pro',
                 'gpt-5.4-mini',
                 'gpt-5.4-nano'
             ],

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -36,11 +36,10 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             description: nls.localize('theia/ai/openai/models/description', 'Official OpenAI models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
             default: [
-                'gpt-5.4',
-                'gpt-5.4-pro',
+                'gpt-5.5',
+                'gpt-5.5-pro',
                 'gpt-5.4-mini',
-                'gpt-4.1',
-                'gpt-4o'
+                'gpt-5.4-nano'
             ],
             items: {
                 type: 'string'


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Introduces a local test harness for evaluating AI model updates against Theia's chat agents. This can be used to verify that updated or newly added models work correctly with our agents before merging model update PRs (e.g., #17180). Runs scenario prompts through actual chat agents (e.g., Coder) via Playwright, captures full conversations including tool calls, and evaluates results with a Judge agent.

- New `examples/ai-model-tests/` package with a Playwright-based test runner
- Test bridge (`FrontendApplicationContribution` in `api-samples`) exposes `ChatService` programmatically when `?test-bridge` URL param is present
- Fetches all registered models from Anthropic, OpenAI, and Google by default
- Sets model per agent via `agentSettings` preference, runs sequentially
- Saves file changes as `.patch` files, resets workspace between model runs
- Judge chat agent evaluates responses with structured JSON scoring
- Scenario configuration via markdown frontmatter (agent, models, runs)
- Reports as markdown + JSON with summary and per-run detail tables

Remark: Should not be merged before the upcoming release and not before the esbuild PR (14144) to avoid unnecessary rebase work there.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. npm run build && npm run start:browser
2. cd examples/ai-model-tests
3. npm run test:coder (tests the coder scenario with all default models one by one)
4. Check `results/` for the generated report

As example for the smoke test, a report looks like this currently:

[2026-04-29T11-24-18-209Z_smoke-hello_report.md](https://github.com/user-attachments/files/27200384/2026-04-29T11-24-18-209Z_smoke-hello_report.md)


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- WIP, not yet stable enough for CI
- Scenarios need more variety (currently only smoke test and one coding task)
- Evaluation criteria and judge prompt need refinement based on real-world results, also think about real KO criteria or expected coding results
- Consider adding support for comparing results across different runs/branches

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
