### PR TITLE
feat(ai-ide): allow read tools to access user-allowlisted external paths

### DIFF
--- a/packages/ai-ide/src/browser/context-file-validation-service-impl.spec.ts
+++ b/packages/ai-ide/src/browser/context-file-validation-service-impl.spec.ts
@@ -28,6 +28,8 @@ import { FileStat } from '@theia/filesystem/lib/common/files';
 import { ContextFileValidationService, FileValidationState } from '@theia/ai-chat/lib/browser/context-file-validation-service';
 import { ContextFileValidationServiceImpl } from './context-file-validation-service-impl';
 import { WorkspaceFunctionScope } from './workspace-functions';
+import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 
 disableJSDOM();
 
@@ -110,6 +112,18 @@ describe('ContextFileValidationService', () => {
         container.bind(FileService).toConstantValue(mockFileService);
         container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
         container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue({
+            get: <T>(_name: string, fallback?: T) => fallback,
+            ready: Promise.resolve(),
+            onDidChangeTrust: () => ({ dispose: () => { /* noop */ } })
+        } as unknown as TrustAwarePreferenceReader);
+        container.bind(EnvVariablesServer).toConstantValue({
+            getHomeDirUri: async () => 'file:///home/user',
+            getExecPath: async () => '',
+            getVariables: async () => [],
+            getValue: async () => undefined,
+            getConfigDirUri: async () => 'file:///home/user/.config'
+        } as unknown as EnvVariablesServer);
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(ContextFileValidationServiceImpl).toSelf();
         container.bind(ContextFileValidationService).toService(ContextFileValidationServiceImpl);

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -892,6 +892,116 @@ describe('FileContentFunction external paths', () => {
     });
 });
 
+describe('GetWorkspaceFileList / GetWorkspaceDirectoryStructure with external paths', () => {
+    let container: Container;
+    let allowedPaths: string[];
+
+    const FS_TREE: Record<string, { isDirectory: boolean; children?: string[] }> = {
+        'file:///workspace': { isDirectory: true, children: ['file:///workspace/a.ts', 'file:///workspace/sub'] },
+        'file:///workspace/a.ts': { isDirectory: false },
+        'file:///workspace/sub': { isDirectory: true, children: [] },
+        'file:///external/configs': {
+            isDirectory: true,
+            children: ['file:///external/configs/myapp.json', 'file:///external/configs/sub']
+        },
+        'file:///external/configs/myapp.json': { isDirectory: false },
+        'file:///external/configs/sub': { isDirectory: true, children: [] }
+    };
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        allowedPaths = [];
+
+        const mockWorkspaceService = {
+            roots: [{ resource: new URI('file:///workspace') }]
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            exists: async () => true,
+            resolve: async (uri: URI) => {
+                const node = FS_TREE[uri.toString()];
+                if (!node) {
+                    throw new Error('not found');
+                }
+                return {
+                    isDirectory: node.isDirectory,
+                    isFile: !node.isDirectory,
+                    resource: uri,
+                    children: node.children?.map(child => ({
+                        isDirectory: !!FS_TREE[child]?.isDirectory,
+                        isFile: !FS_TREE[child]?.isDirectory,
+                        resource: new URI(child),
+                        path: { base: child.split('/').pop() }
+                    })) ?? []
+                };
+            },
+            read: async () => ({ value: '' })
+        } as unknown as FileService;
+
+        const mockPreferenceService = {
+            get: <T>(_path: string, defaultValue: T) => defaultValue
+        };
+
+        const trustAwareReader = {
+            get: <T>(_name: string, _fallback?: T) => allowedPaths as unknown as T,
+            ready: Promise.resolve(),
+            onDidChangeTrust: () => ({ dispose: () => { /* noop */ } })
+        } as unknown as TrustAwarePreferenceReader;
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(trustAwareReader);
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(GetWorkspaceFileList).toSelf();
+        container.bind(GetWorkspaceDirectoryStructure).toSelf();
+    });
+
+    it('GetWorkspaceFileList rejects absolute path outside the allow-list', async () => {
+        const tool = container.get(GetWorkspaceFileList).getTool();
+        const result = await tool.handler(JSON.stringify({ path: '/external/configs' }), undefined) as string;
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    it('GetWorkspaceFileList lists an allow-listed external directory', async () => {
+        allowedPaths = ['/external/configs'];
+        const tool = container.get(GetWorkspaceFileList).getTool();
+        const result = await tool.handler(JSON.stringify({ path: '/external/configs' }), undefined);
+        expect(result).to.deep.equal(['myapp.json', 'sub/']);
+    });
+
+    it('GetWorkspaceFileList still lists workspace-relative paths', async () => {
+        const tool = container.get(GetWorkspaceFileList).getTool();
+        const result = await tool.handler(JSON.stringify({ path: '' }), undefined);
+        expect(result).to.deep.equal(['a.ts', 'sub/']);
+    });
+
+    it('GetWorkspaceDirectoryStructure rejects external root not in the allow-list', async () => {
+        const tool = container.get(GetWorkspaceDirectoryStructure).getTool();
+        const result = await tool.handler(JSON.stringify({ root: '/external/configs' }), undefined) as Record<string, unknown>;
+        expect(result.error).to.include('not allowed');
+    });
+
+    it('GetWorkspaceDirectoryStructure walks an allow-listed external root', async () => {
+        allowedPaths = ['/external/configs'];
+        const tool = container.get(GetWorkspaceDirectoryStructure).getTool();
+        const result = await tool.handler(JSON.stringify({ root: '/external/configs' }), undefined);
+        expect(result).to.deep.equal({ sub: {} });
+    });
+
+    it('GetWorkspaceDirectoryStructure preserves prior workspace-only behavior when root omitted', async () => {
+        const tool = container.get(GetWorkspaceDirectoryStructure).getTool();
+        const result = await tool.handler('', undefined);
+        expect(result).to.deep.equal({ sub: {} });
+    });
+});
+
 describe('FindFilesByPattern with searchRoot', () => {
     let container: Container;
     let findFilesByPattern: FindFilesByPattern;

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -30,7 +30,9 @@ import {
     FindFilesByPattern
 } from './workspace-functions';
 import { ToolInvocationContext } from '@theia/ai-core';
+import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
 import { Container } from '@theia/core/shared/inversify';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
 import { URI } from '@theia/core/lib/common/uri';
@@ -38,6 +40,20 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ProblemManager } from '@theia/markers/lib/browser';
 import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+
+const makeTrustAwareReader = (overrides: { [pref: string]: unknown } = {}): TrustAwarePreferenceReader => ({
+    get: <T>(name: string, fallback?: T) => (name in overrides ? overrides[name] as T : fallback),
+    ready: Promise.resolve(),
+    onDidChangeTrust: () => ({ dispose: () => { /* noop */ } })
+} as unknown as TrustAwarePreferenceReader);
+
+const makeEnvVariablesServer = (homeDirUri: string = 'file:///home/test'): EnvVariablesServer => ({
+    getHomeDirUri: async () => homeDirUri,
+    getExecPath: async () => '',
+    getVariables: async () => [],
+    getValue: async () => undefined,
+    getConfigDirUri: async () => 'file:///home/test/.config'
+} as unknown as EnvVariablesServer);
 
 disableJSDOM();
 
@@ -116,6 +132,8 @@ describe('Workspace Functions Cancellation Tests', () => {
         container.bind(MonacoWorkspace).toConstantValue(mockMonacoWorkspace);
         container.bind(ProblemManager).toConstantValue(mockProblemManager);
         container.bind(MonacoTextModelService).toConstantValue(mockMonacoTextModelService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(GetWorkspaceDirectoryStructure).toSelf();
         container.bind(FileContentFunction).toSelf();
@@ -233,6 +251,8 @@ describe('FileContentFunction.getArgumentsShortLabel', () => {
         container.bind(FileService).toConstantValue(mockFileService);
         container.bind(PreferenceService).toConstantValue(mockPreferenceService);
         container.bind(MonacoWorkspace).toConstantValue(mockMonacoWorkspace);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(FileContentFunction).toSelf();
 
@@ -347,6 +367,8 @@ describe('FileContentFunction handler', () => {
         container.bind(FileService).toConstantValue(mockFileService);
         container.bind(PreferenceService).toConstantValue(mockPreferenceService);
         container.bind(MonacoWorkspace).toConstantValue(mockMonacoWorkspace);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(FileContentFunction).toSelf();
 
@@ -707,6 +729,8 @@ describe('FindFilesByPattern.getArgumentsShortLabel', () => {
         container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
         container.bind(FileService).toConstantValue(mockFileService);
         container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(FindFilesByPattern).toSelf();
 
@@ -733,5 +757,239 @@ describe('FindFilesByPattern.getArgumentsShortLabel', () => {
     it('returns undefined when pattern key is missing', () => {
         const result = getArgumentsShortLabel(JSON.stringify({ glob: '**/*.ts' }));
         expect(result).to.be.undefined;
+    });
+});
+
+describe('FileContentFunction external paths', () => {
+    let container: Container;
+    let fileContentFunction: FileContentFunction;
+    let allowedPaths: string[];
+    let trustedScopeOnly: boolean;
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        allowedPaths = [];
+        trustedScopeOnly = false;
+
+        const mockWorkspaceService = {
+            roots: [{ resource: new URI('file:///workspace') }]
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            exists: async () => true,
+            resolve: async (uri: URI) => ({
+                isFile: true,
+                isDirectory: false,
+                size: 1024,
+                resource: uri
+            }),
+            read: async (uri: URI) => ({ value: `content-of-${uri.path.toString()}` }),
+            readStream: async () => { throw new Error('not used'); }
+        } as unknown as FileService;
+
+        const mockPreferenceService = {
+            get: <T>(_path: string, defaultValue: T) => defaultValue
+        };
+
+        const mockMonacoWorkspace = {
+            getTextDocument: () => undefined
+        } as unknown as MonacoWorkspace;
+
+        const trustAwareReader = {
+            get: <T>(_name: string, fallback?: T) => (trustedScopeOnly ? fallback : (allowedPaths as unknown as T)),
+            ready: Promise.resolve(),
+            onDidChangeTrust: () => ({ dispose: () => { /* noop */ } })
+        } as unknown as TrustAwarePreferenceReader;
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(MonacoWorkspace).toConstantValue(mockMonacoWorkspace);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(trustAwareReader);
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer('file:///home/test'));
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(FileContentFunction).toSelf();
+
+        fileContentFunction = container.get(FileContentFunction);
+    });
+
+    const callTool = (file: string) =>
+        fileContentFunction.getTool().handler(JSON.stringify({ file }), undefined) as Promise<string>;
+
+    it('rejects absolute path outside the workspace when allow-list is empty', async () => {
+        const result = await callTool('/etc/hosts');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+        expect(parsed.error).to.include('allowedExternalPaths');
+    });
+
+    it('allows absolute path inside an allow-listed directory', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callTool('/external/configs/myapp.json');
+        expect(result).to.equal('content-of-/external/configs/myapp.json');
+    });
+
+    it('allows file:// URI inside an allow-listed directory', async () => {
+        allowedPaths = ['file:///external/configs'];
+        const result = await callTool('file:///external/configs/myapp.json');
+        expect(result).to.equal('content-of-/external/configs/myapp.json');
+    });
+
+    it('rejects sibling that shares the prefix but is not a child', async () => {
+        // /external/configs-other must NOT be matched by /external/configs
+        allowedPaths = ['/external/configs'];
+        const result = await callTool('/external/configs-other/myapp.json');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    it('rejects path with .. traversal', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callTool('/external/configs/../secrets.txt');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('Invalid file path');
+    });
+
+    it('expands ~ in allow-list entries', async () => {
+        allowedPaths = ['~/configs'];
+        const result = await callTool('/home/test/configs/myapp.json');
+        expect(result).to.equal('content-of-/home/test/configs/myapp.json');
+    });
+
+    it('still allows workspace-relative paths', async () => {
+        allowedPaths = [];
+        const result = await callTool('src/index.ts');
+        expect(result).to.equal('content-of-/workspace/src/index.ts');
+    });
+
+    it('accepts Windows-style absolute paths in the allow-list', async () => {
+        // Mixed: backslash separators in the entry, forward-slash in the file argument
+        allowedPaths = ['C:\\external\\configs'];
+        const result = await callTool('C:/external/configs/myapp.json');
+        // The mock returns content keyed off the resolved URI's path. Both forms
+        // normalize to the same `file:///c:/external/configs/myapp.json`.
+        expect(result).to.match(/^content-of-/);
+        expect(result).to.include('external/configs/myapp.json');
+    });
+
+    it('accepts Windows drive paths as the tool argument', async () => {
+        allowedPaths = ['C:/external'];
+        const result = await callTool('C:\\external\\file.txt');
+        expect(result).to.match(/^content-of-/);
+        expect(result).to.include('external/file.txt');
+    });
+
+    it('drops workspace-scoped allow-list values when workspace is untrusted', async () => {
+        // simulate trust-aware reader behavior: when untrusted, only user/default scope is returned
+        trustedScopeOnly = true;
+        const result = await callTool('/external/configs/myapp.json');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+});
+
+describe('FindFilesByPattern with searchRoot', () => {
+    let container: Container;
+    let findFilesByPattern: FindFilesByPattern;
+    let allowedPaths: string[];
+
+    const FS_TREE: Record<string, { isDirectory: boolean; children?: string[] }> = {
+        'file:///workspace': { isDirectory: true, children: ['file:///workspace/a.ts'] },
+        'file:///workspace/a.ts': { isDirectory: false },
+        'file:///external/configs': { isDirectory: true, children: ['file:///external/configs/myapp.json', 'file:///external/configs/other.txt'] },
+        'file:///external/configs/myapp.json': { isDirectory: false },
+        'file:///external/configs/other.txt': { isDirectory: false }
+    };
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        allowedPaths = [];
+
+        const mockWorkspaceService = {
+            roots: [{ resource: new URI('file:///workspace') }]
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            exists: async () => true,
+            resolve: async (uri: URI) => {
+                const node = FS_TREE[uri.toString()];
+                if (!node) {
+                    throw new Error('not found');
+                }
+                return {
+                    isDirectory: node.isDirectory,
+                    isFile: !node.isDirectory,
+                    resource: uri,
+                    children: node.children?.map(child => ({
+                        isDirectory: !!FS_TREE[child]?.isDirectory,
+                        isFile: !FS_TREE[child]?.isDirectory,
+                        resource: new URI(child),
+                        path: { base: child.split('/').pop() }
+                    })) ?? []
+                };
+            },
+            read: async () => ({ value: '' })
+        } as unknown as FileService;
+
+        const mockPreferenceService = {
+            get: <T>(_path: string, defaultValue: T) => defaultValue
+        };
+
+        const trustAwareReader = {
+            get: <T>(_name: string, _fallback?: T) => allowedPaths as unknown as T,
+            ready: Promise.resolve(),
+            onDidChangeTrust: () => ({ dispose: () => { /* noop */ } })
+        } as unknown as TrustAwarePreferenceReader;
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(trustAwareReader);
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(FindFilesByPattern).toSelf();
+
+        findFilesByPattern = container.get(FindFilesByPattern);
+    });
+
+    const callTool = (args: object) =>
+        findFilesByPattern.getTool().handler(JSON.stringify(args), undefined) as Promise<string>;
+
+    it('searches the workspace by default and returns relative paths', async () => {
+        const result = await callTool({ pattern: '**/*.ts' });
+        const parsed = JSON.parse(result);
+        expect(parsed.files).to.deep.equal(['a.ts']);
+    });
+
+    it('rejects searchRoot that is not in the allow-list', async () => {
+        const result = await callTool({ pattern: '**/*.json', searchRoot: '/external/configs' });
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    it('searches an allow-listed external root and returns absolute paths', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callTool({ pattern: '**/*.json', searchRoot: '/external/configs' });
+        const parsed = JSON.parse(result);
+        expect(parsed.files).to.deep.equal(['/external/configs/myapp.json']);
+    });
+
+    it('honors exclude patterns when using an external searchRoot', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callTool({
+            pattern: '**/*',
+            exclude: ['**/*.txt'],
+            searchRoot: '/external/configs'
+        });
+        const parsed = JSON.parse(result);
+        expect(parsed.files).to.deep.equal(['/external/configs/myapp.json']);
     });
 });

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -1240,20 +1240,24 @@ describe('WorkspaceFunctionScope path-traversal hardening', () => {
         expect(result).to.equal('content-of-/external/configs/myapp.json');
     });
 
-    // Item 2 — On case-insensitive filesystems (Windows) the allow-list match
-    // must be case-insensitive. The check ran against `OS.backend.isWindows`,
-    // so flip that flag for the test and restore it afterwards.
-    describe('case-insensitive match on Windows', () => {
+    // Item 2 — On case-insensitive filesystems (Windows, macOS by default)
+    // the allow-list match must be case-insensitive. Stub OS.backend flags
+    // for the test and restore them afterwards.
+    describe('case-insensitive match on case-insensitive filesystems', () => {
         let originalIsWindows: boolean;
+        let originalIsOSX: boolean;
         beforeEach(() => {
             originalIsWindows = OS.backend.isWindows;
-            OS.backend.isWindows = true;
+            originalIsOSX = OS.backend.isOSX;
         });
         afterEach(() => {
             OS.backend.isWindows = originalIsWindows;
+            OS.backend.isOSX = originalIsOSX;
         });
 
-        it('admits a case-mismatched target when allow-list entry is mixed-case', async () => {
+        it('admits a case-mismatched Windows target when allow-list entry is mixed-case', async () => {
+            OS.backend.isWindows = true;
+            OS.backend.isOSX = false;
             allowedPaths = ['C:\\External\\Configs'];
             const result = await callContent('c:/external/configs/myapp.json');
             // The mock returns the URI's path; both forms canonicalize to the
@@ -1261,6 +1265,24 @@ describe('WorkspaceFunctionScope path-traversal hardening', () => {
             // but the path segments differ in case.
             expect(result).to.match(/^content-of-/);
             expect(result.toLowerCase()).to.include('external/configs/myapp.json');
+        });
+
+        it('admits a case-mismatched macOS target when allow-list entry is mixed-case', async () => {
+            OS.backend.isWindows = false;
+            OS.backend.isOSX = true;
+            allowedPaths = ['/Users/safi/External/Configs'];
+            const result = await callContent('/users/safi/external/configs/myapp.json');
+            expect(result).to.match(/^content-of-/);
+            expect(result.toLowerCase()).to.include('/users/safi/external/configs/myapp.json');
+        });
+
+        it('keeps Linux case-sensitive: rejects a case-mismatched target', async () => {
+            OS.backend.isWindows = false;
+            OS.backend.isOSX = false;
+            allowedPaths = ['/home/safi/External/Configs'];
+            const result = await callContent('/home/safi/external/configs/myapp.json');
+            const parsed = JSON.parse(result);
+            expect(parsed.error).to.include('not allowed');
         });
     });
 

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -860,6 +860,25 @@ describe('FileContentFunction external paths', () => {
         expect(result).to.equal('content-of-/home/test/configs/myapp.json');
     });
 
+    it('expands ~ in tool input paths', async () => {
+        allowedPaths = ['/home/test/configs'];
+        const result = await callTool('~/configs/myapp.json');
+        expect(result).to.equal('content-of-/home/test/configs/myapp.json');
+    });
+
+    it('expands ~ in both allow-list entries and tool input paths', async () => {
+        allowedPaths = ['~/configs'];
+        const result = await callTool('~/configs/myapp.json');
+        expect(result).to.equal('content-of-/home/test/configs/myapp.json');
+    });
+
+    it('rejects ~-prefixed tool input that escapes via .. traversal', async () => {
+        allowedPaths = ['/home/test/configs'];
+        const result = await callTool('~/configs/../secrets.txt');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('Invalid file path');
+    });
+
     it('still allows workspace-relative paths', async () => {
         allowedPaths = [];
         const result = await callTool('src/index.ts');

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -20,7 +20,7 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
-import { CancellationTokenSource, PreferenceService } from '@theia/core';
+import { CancellationTokenSource, OS, PreferenceService } from '@theia/core';
 import {
     GetWorkspaceDirectoryStructure,
     FileContentFunction,
@@ -1101,5 +1101,180 @@ describe('FindFilesByPattern with searchRoot', () => {
         });
         const parsed = JSON.parse(result);
         expect(parsed.files).to.deep.equal(['/external/configs/myapp.json']);
+    });
+});
+
+describe('WorkspaceFunctionScope path-traversal hardening', () => {
+    let container: Container;
+    let fileContentFunction: FileContentFunction;
+    let allowedPaths: string[];
+    let trustReady: Promise<void>;
+    let trustAwareGet: <T>(name: string, fallback?: T) => T | undefined;
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        allowedPaths = [];
+        trustReady = Promise.resolve();
+        trustAwareGet = <T>(_name: string, _fallback?: T) => allowedPaths as unknown as T;
+
+        const mockWorkspaceService = {
+            roots: [{ resource: new URI('file:///workspace/project') }]
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            exists: async () => true,
+            resolve: async (uri: URI) => ({
+                isFile: true,
+                isDirectory: false,
+                size: 1024,
+                resource: uri
+            }),
+            read: async (uri: URI) => ({ value: `content-of-${uri.path.toString()}` }),
+            readStream: async () => { throw new Error('not used'); }
+        } as unknown as FileService;
+
+        const mockPreferenceService = {
+            get: <T>(_path: string, defaultValue: T) => defaultValue
+        };
+
+        const mockMonacoWorkspace = {
+            getTextDocument: () => undefined
+        } as unknown as MonacoWorkspace;
+
+        const trustAwareReader = {
+            get: <T>(name: string, fallback?: T) => trustAwareGet<T>(name, fallback),
+            get ready(): Promise<void> { return trustReady; },
+            onDidChangeTrust: () => ({ dispose: () => { /* noop */ } })
+        } as unknown as TrustAwarePreferenceReader;
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(MonacoWorkspace).toConstantValue(mockMonacoWorkspace);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(trustAwareReader);
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer('file:///home/test'));
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(FileContentFunction).toSelf();
+        container.bind(FileDiagnosticProvider).toSelf();
+        const mockProblemManager = {
+            findMarkers: () => [],
+            onDidChangeMarkers: () => ({ dispose: () => { /* noop */ } })
+        } as unknown as ProblemManager;
+        container.bind(ProblemManager).toConstantValue(mockProblemManager);
+        const mockMonacoTextModelService = {
+            createModelReference: async () => ({
+                object: { lineCount: 10, getText: () => '' },
+                dispose: () => { /* noop */ }
+            })
+        } as unknown as MonacoTextModelService;
+        container.bind(MonacoTextModelService).toConstantValue(mockMonacoTextModelService);
+
+        fileContentFunction = container.get(FileContentFunction);
+    });
+
+    const callContent = (file: string) =>
+        fileContentFunction.getTool().handler(JSON.stringify({ file }), undefined) as Promise<string>;
+
+    // Item 1 — URL-encoded and literal `..` in file:// URIs must be normalized
+    // before the allow-list check; otherwise the path-component prefix admits
+    // the traversal.
+    it('rejects file:// URI with literal .. traversal', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callContent('file:///external/configs/../secrets.txt');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    it('rejects file:// URI with percent-encoded %2e%2e traversal', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callContent('file:///external/configs/%2e%2e/secrets.txt');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    it('rejects file:// URI with upper-case percent-encoded traversal', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callContent('file:///external/configs/%2E%2E/secrets.txt');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    // Item 4 — A filename that contains `..` as a substring but is not a
+    // traversal segment must be accepted.
+    it('accepts a valid filename whose name contains ".." as a substring', async () => {
+        allowedPaths = ['/external/configs'];
+        const result = await callContent('/external/configs/my..file.json');
+        expect(result).to.equal('content-of-/external/configs/my..file.json');
+    });
+
+    // Item 3 — Non-file allow-list entries are documented as unsupported.
+    it('rejects http:// allow-list entry even if target path appears to match', async () => {
+        allowedPaths = ['http://example.com/external/configs'];
+        const result = await callContent('/external/configs/myapp.json');
+        const parsed = JSON.parse(result);
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    // Item 7 — getAllowedExternalUris must await TrustAwarePreferenceReader.ready
+    // so that preference reads see the resolved trust state.
+    it('awaits TrustAwarePreferenceReader.ready before reading the allow-list', async () => {
+        let preferenceVisible = false;
+        let resolveReady: () => void = () => { /* noop */ };
+        trustReady = new Promise<void>(r => { resolveReady = r; });
+        trustAwareGet = <T>(_name: string, _fallback?: T) =>
+            (preferenceVisible ? ['/external/configs'] : []) as unknown as T;
+
+        const promise = callContent('/external/configs/myapp.json');
+
+        // Simulate trust state becoming available after a microtask: the
+        // allow-list is only readable once `ready` resolves.
+        await Promise.resolve();
+        preferenceVisible = true;
+        resolveReady();
+
+        const result = await promise;
+        expect(result).to.equal('content-of-/external/configs/myapp.json');
+    });
+
+    // Item 2 — On case-insensitive filesystems (Windows) the allow-list match
+    // must be case-insensitive. The check ran against `OS.backend.isWindows`,
+    // so flip that flag for the test and restore it afterwards.
+    describe('case-insensitive match on Windows', () => {
+        let originalIsWindows: boolean;
+        beforeEach(() => {
+            originalIsWindows = OS.backend.isWindows;
+            OS.backend.isWindows = true;
+        });
+        afterEach(() => {
+            OS.backend.isWindows = originalIsWindows;
+        });
+
+        it('admits a case-mismatched target when allow-list entry is mixed-case', async () => {
+            allowedPaths = ['C:\\External\\Configs'];
+            const result = await callContent('c:/external/configs/myapp.json');
+            // The mock returns the URI's path; both forms canonicalize to the
+            // same file:///c:/... URI (drive letter is lowercased by URI.fromFilePath),
+            // but the path segments differ in case.
+            expect(result).to.match(/^content-of-/);
+            expect(result.toLowerCase()).to.include('external/configs/myapp.json');
+        });
+    });
+
+    // Item 6 — `ensureWithinWorkspace` is the gate used by getFileDiagnostics
+    // for relative path inputs. A sibling that merely shares the workspace
+    // root's string prefix must not pass.
+    it('FileDiagnosticProvider rejects sibling-prefix path outside the workspace', async () => {
+        const diag = container.get(FileDiagnosticProvider);
+        const handler = diag.getTool().handler;
+        // Workspace root is file:///workspace/project. With a raw string-prefix
+        // check the resolved URI file:///workspace/project-other/file.txt
+        // would be (incorrectly) admitted.
+        const result = await handler(JSON.stringify({ file: '../project-other/file.txt' }), undefined);
+        const parsed = JSON.parse(result as string);
+        expect(parsed.error).to.include('outside of the workspace');
     });
 });

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -14,7 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
+import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
 import { CancellationToken, Disposable, PreferenceService, URI, Path } from '@theia/core';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat, FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
@@ -27,7 +29,12 @@ import {
 import { extractJsonStringField } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/toolcall-utils';
 import ignore from 'ignore';
 import { Minimatch } from 'minimatch';
-import { CONSIDER_GITIGNORE_PREF, FILE_CONTENT_MAX_SIZE_KB_PREF, USER_EXCLUDE_PATTERN_PREF } from '../common/workspace-preferences';
+import {
+    ALLOWED_EXTERNAL_PATHS_PREF,
+    CONSIDER_GITIGNORE_PREF,
+    FILE_CONTENT_MAX_SIZE_KB_PREF,
+    USER_EXCLUDE_PATTERN_PREF
+} from '../common/workspace-preferences';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { ProblemManager } from '@theia/markers/lib/browser';
@@ -46,8 +53,15 @@ export class WorkspaceFunctionScope {
     @inject(PreferenceService)
     protected readonly preferences: PreferenceService;
 
+    @inject(TrustAwarePreferenceReader)
+    protected readonly trustAwarePreferences: TrustAwarePreferenceReader;
+
+    @inject(EnvVariablesServer)
+    protected readonly envVariablesServer: EnvVariablesServer;
+
     private gitignoreMatcher: ReturnType<typeof ignore> | undefined;
     private gitignoreWatcherInitialized = false;
+    private homeDirUri: Promise<URI | undefined> | undefined;
 
     async getWorkspaceRoot(): Promise<URI> {
         const wsRoots = await this.workspaceService.roots;
@@ -61,6 +75,111 @@ export class WorkspaceFunctionScope {
         if (!targetUri.toString().startsWith(workspaceRootUri.toString())) {
             throw new Error('Access outside of the workspace is not allowed');
         }
+    }
+
+    /**
+     * Asserts the target URI is reachable by AI tools that honor the external
+     * allow-list. Allowed when the URI is inside any workspace root, or when it
+     * is covered by an entry of the `ai-features.workspaceFunctions.allowedExternalPaths`
+     * preference. Workspace-scoped overrides of that preference are dropped when
+     * the workspace is not trusted.
+     *
+     * Note: symlinks within allow-listed directories are NOT canonicalized
+     * before the check. Only allow-list directories whose contents you trust.
+     */
+    async ensureAccessible(targetUri: URI): Promise<void> {
+        const roots = (await this.workspaceService.roots) ?? [];
+        for (const root of roots) {
+            if (root.resource.scheme === targetUri.scheme && root.resource.isEqualOrParent(targetUri)) {
+                return;
+            }
+        }
+        const allowed = await this.getAllowedExternalUris();
+        if (allowed.some(allowedUri => allowedUri.isEqualOrParent(targetUri))) {
+            return;
+        }
+        throw new Error(
+            `Access to '${targetUri.path.toString()}' is not allowed. ` +
+            `Path is outside the workspace and not covered by the '${ALLOWED_EXTERNAL_PATHS_PREF}' preference.`
+        );
+    }
+
+    /**
+     * Resolves the configured external allow-list to URIs. Reads via the
+     * trust-aware preference reader so workspace-scoped overrides are dropped
+     * when the workspace is untrusted. Invalid entries (empty strings, paths
+     * containing `..`) are filtered out.
+     */
+    async getAllowedExternalUris(resourceUri?: string): Promise<URI[]> {
+        const raw = this.trustAwarePreferences.get<string[]>(ALLOWED_EXTERNAL_PATHS_PREF, [], resourceUri) ?? [];
+        const result: URI[] = [];
+        for (const entry of raw) {
+            if (typeof entry !== 'string') {
+                continue;
+            }
+            const trimmed = entry.trim();
+            if (!trimmed || trimmed.includes('..')) {
+                continue;
+            }
+            const uri = await this.toExternalUri(trimmed);
+            if (uri) {
+                result.push(uri);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Converts a user-supplied allow-list entry (absolute POSIX path, Windows
+     * drive path, `~`-prefixed path, or `file://` URI) into a normalized URI.
+     * Returns undefined for invalid input (relative paths, malformed URIs).
+     */
+    protected async toExternalUri(entry: string): Promise<URI | undefined> {
+        if (entry.includes('://')) {
+            try {
+                return new URI(entry);
+            } catch {
+                return undefined;
+            }
+        }
+        if (entry === '~' || entry.startsWith('~/') || entry.startsWith('~\\')) {
+            const home = await this.getHomeDirUri();
+            if (!home) {
+                return undefined;
+            }
+            if (entry === '~') {
+                return home;
+            }
+            // Resolve the remainder in URI space to avoid Windows drive-letter
+            // round-tripping issues with URI.fromFilePath.
+            const remainder = Path.normalizePathSeparator(entry.substring(2));
+            return home.resolve(remainder);
+        }
+        const normalized = Path.normalizePathSeparator(entry);
+        if (!WorkspaceFunctionScope.isAbsolutePath(normalized)) {
+            return undefined;
+        }
+        return URI.fromFilePath(normalized);
+    }
+
+    /**
+     * Whether an already-separator-normalized path is absolute on either
+     * platform: POSIX `/foo`, UNC `//host/share`, or Windows drive `C:/foo`.
+     */
+    static isAbsolutePath(normalized: string): boolean {
+        if (normalized.startsWith('/')) {
+            return true;
+        }
+        return /^[A-Za-z]:\//.test(normalized);
+    }
+
+    protected getHomeDirUri(): Promise<URI | undefined> {
+        if (!this.homeDirUri) {
+            this.homeDirUri = this.envVariablesServer.getHomeDirUri()
+                .then(value => value ? new URI(value) : undefined)
+                .catch(() => undefined);
+        }
+        return this.homeDirUri;
     }
 
     async resolveRelativePath(relativePath: string): Promise<URI> {
@@ -122,13 +241,12 @@ export class WorkspaceFunctionScope {
         }
 
         const normalizedPath = Path.normalizePathSeparator(pathOrUri);
-        const path = new Path(normalizedPath);
 
         if (normalizedPath.includes('..')) {
             return undefined;
         }
 
-        if (path.isAbsolute) {
+        if (WorkspaceFunctionScope.isAbsolutePath(normalizedPath)) {
             return URI.fromFilePath(normalizedPath);
         }
 
@@ -275,9 +393,10 @@ export class FileContentFunction implements ToolProvider {
         return {
             id: FileContentFunction.ID,
             name: FileContentFunction.ID,
-            description: 'Returns the content of a specified file within the workspace as a raw string. ' +
-                'The file path must be provided relative to the workspace root. Only files within ' +
-                'workspace boundaries are accessible; attempting to access files outside the workspace will return an error. ' +
+            description: 'Returns the content of a specified file as a raw string. ' +
+                'Relative paths resolve against the workspace root. ' +
+                'Absolute paths and `file://` URIs are accepted only when the target is inside the workspace ' +
+                'or covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference; otherwise an error is returned. ' +
                 'If the file is currently open in an editor with unsaved changes, returns the editor\'s current content (not the saved file on disk). ' +
                 'Binary files may not be readable and will return an error. ' +
                 'Use this tool to read file contents before making any edits with replacement functions. ' +
@@ -292,8 +411,9 @@ export class FileContentFunction implements ToolProvider {
                 properties: {
                     file: {
                         type: 'string',
-                        description: 'The relative path to the target file within the workspace (e.g., "src/index.ts", "package.json"). ' +
-                            'Must be relative to the workspace root. Absolute paths and paths outside the workspace will result in an error.',
+                        description: 'Path to the target file. May be relative to the workspace root (e.g., "src/index.ts"), ' +
+                            'an absolute path, or a `file://` URI. Absolute / URI forms must point inside the workspace ' +
+                            'or inside a directory listed in the `allowedExternalPaths` preference.',
                     },
                     offset: {
                         type: 'number',
@@ -361,9 +481,12 @@ export class FileContentFunction implements ToolProvider {
 
         let targetUri: URI | undefined;
         try {
-            const workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
-            targetUri = workspaceRoot.resolve(file);
-            this.workspaceScope.ensureWithinWorkspace(targetUri, workspaceRoot);
+            const resolved = await this.workspaceScope.resolveToUri(file);
+            if (!resolved) {
+                return JSON.stringify({ error: `Invalid file path: '${file}'` });
+            }
+            targetUri = resolved;
+            await this.workspaceScope.ensureAccessible(targetUri);
         } catch (error) {
             return JSON.stringify({ error: error.message });
         }
@@ -801,10 +924,12 @@ export class FindFilesByPattern implements ToolProvider {
         return {
             id: FindFilesByPattern.ID,
             name: FindFilesByPattern.ID,
-            description: 'Find files in the workspace that match a given glob pattern. ' +
+            description: 'Find files matching a given glob pattern. ' +
+                'By default searches the workspace; pass `searchRoot` to search a directory listed in the ' +
+                '`ai-features.workspaceFunctions.allowedExternalPaths` preference instead. ' +
                 'This function allows efficient discovery of files using patterns like \'**/*.ts\' for all TypeScript files or ' +
                 '\'src/**/*.js\' for JavaScript files in the src directory. The function respects gitignore patterns and user exclusions, ' +
-                'returns relative paths from the workspace root, and limits results to 200 files maximum. ' +
+                'returns paths relative to the search root, and limits results to 200 files maximum. ' +
                 'Performance note: This traverses directories recursively which may be slow in large workspaces. ' +
                 'For better performance, use specific subdirectory patterns (e.g., \'src/**/*.ts\' instead of \'**/*.ts\'). ' +
                 'Use this to find files by name/extension. Do NOT use this for searching file contents - use searchInWorkspace instead.',
@@ -824,13 +949,20 @@ export class FindFilesByPattern implements ToolProvider {
                         description: 'Optional glob patterns to exclude. ' +
                             'Examples: [\'**/*.spec.ts\', \'**/node_modules/**\']. ' +
                             'Common exclusions (node_modules, .git) are applied automatically via gitignore.'
+                    },
+                    searchRoot: {
+                        type: 'string',
+                        description: 'Optional absolute path or `file://` URI to search instead of the workspace. ' +
+                            'Must be inside, or equal to, an entry of the `allowedExternalPaths` preference. ' +
+                            'When set, results are returned as absolute paths so they can be passed back to getFileContent. ' +
+                            'When omitted (default), the workspace root is searched and results are workspace-relative.'
                     }
                 },
                 required: ['pattern']
             },
             handler: (arg_string: string, ctx?: ToolInvocationContext) => {
                 const args = JSON.parse(arg_string);
-                return this.findFiles(args.pattern, args.exclude, ctx?.cancellationToken);
+                return this.findFiles(args.pattern, args.exclude, args.searchRoot, ctx?.cancellationToken);
             },
             providerName: undefined,
             getArgumentsShortLabel: (args: string): { label: string; hasMore: boolean } | undefined => {
@@ -851,21 +983,39 @@ export class FindFilesByPattern implements ToolProvider {
         };
     }
 
-    private async findFiles(pattern: string, excludePatterns?: string[], cancellationToken?: CancellationToken): Promise<string> {
+    private async findFiles(
+        pattern: string,
+        excludePatterns?: string[],
+        searchRoot?: string,
+        cancellationToken?: CancellationToken
+    ): Promise<string> {
         if (cancellationToken?.isCancellationRequested) {
             return JSON.stringify({ error: 'Operation cancelled by user' });
         }
 
-        let workspaceRoot;
+        let rootUri: URI;
+        let isExternalRoot = false;
         try {
-            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+            if (searchRoot) {
+                const resolved = await this.workspaceScope.resolveToUri(searchRoot);
+                if (!resolved) {
+                    return JSON.stringify({ error: `Invalid searchRoot: '${searchRoot}'` });
+                }
+                rootUri = resolved;
+                isExternalRoot = !this.workspaceScope.isInWorkspace(rootUri);
+                await this.workspaceScope.ensureAccessible(rootUri);
+            } else {
+                rootUri = await this.workspaceScope.getWorkspaceRoot();
+            }
         } catch (error) {
             return JSON.stringify({ error: error.message });
         }
 
         try {
-            // Build ignore patterns from gitignore and user preferences
-            const ignorePatterns = await this.buildIgnorePatterns(workspaceRoot);
+            // Build ignore patterns from gitignore (workspace only) and user preferences
+            const ignorePatterns = isExternalRoot
+                ? this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, [])
+                : await this.buildIgnorePatterns(rootUri);
 
             const allExcludes = [...ignorePatterns];
             if (excludePatterns && excludePatterns.length > 0) {
@@ -881,7 +1031,7 @@ export class FindFilesByPattern implements ToolProvider {
             const files: string[] = [];
             const maxResults = 200;
 
-            await this.traverseDirectory(workspaceRoot, workspaceRoot, patternMatcher, excludeMatchers, files, maxResults, cancellationToken);
+            await this.traverseDirectory(rootUri, rootUri, patternMatcher, excludeMatchers, files, maxResults, cancellationToken, isExternalRoot);
 
             if (cancellationToken?.isCancellationRequested) {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
@@ -931,12 +1081,13 @@ export class FindFilesByPattern implements ToolProvider {
 
     private async traverseDirectory(
         currentUri: URI,
-        workspaceRoot: URI,
+        searchRoot: URI,
         patternMatcher: Minimatch,
         excludeMatchers: Minimatch[],
         results: string[],
         maxResults: number,
-        cancellationToken?: CancellationToken
+        cancellationToken?: CancellationToken,
+        emitAbsolutePaths = false
     ): Promise<void> {
         if (cancellationToken?.isCancellationRequested || results.length >= maxResults) {
             return;
@@ -953,7 +1104,7 @@ export class FindFilesByPattern implements ToolProvider {
                     break;
                 }
 
-                const relativePath = workspaceRoot.relative(child.resource)?.toString();
+                const relativePath = searchRoot.relative(child.resource)?.toString();
                 if (!relativePath) {
                     continue;
                 }
@@ -966,9 +1117,10 @@ export class FindFilesByPattern implements ToolProvider {
                 }
 
                 if (child.isDirectory) {
-                    await this.traverseDirectory(child.resource, workspaceRoot, patternMatcher, excludeMatchers, results, maxResults, cancellationToken);
+                    await this.traverseDirectory(child.resource, searchRoot, patternMatcher, excludeMatchers,
+                        results, maxResults, cancellationToken, emitAbsolutePaths);
                 } else if (patternMatcher.match(relativePath)) {
-                    results.push(relativePath);
+                    results.push(emitAbsolutePaths ? child.resource.path.toString() : relativePath);
                 }
             }
         } catch {

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -325,16 +325,35 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
         return {
             id: GetWorkspaceDirectoryStructure.ID,
             name: GetWorkspaceDirectoryStructure.ID,
-            description: 'Retrieves the complete directory tree structure of the workspace as a nested JSON object. ' +
+            description: 'Retrieves the directory tree structure as a nested JSON object. ' +
+                'By default operates on the workspace; pass `root` to inspect a directory listed in the ' +
+                '`ai-features.workspaceFunctions.allowedExternalPaths` preference instead. ' +
                 'Lists only directories (no files), excluding common non-essential directories (node_modules, hidden files, etc.). ' +
                 'Useful for getting a high-level overview of project organization. ' +
                 'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
                 'For finding specific files, use findFilesByPattern.',
             parameters: {
                 type: 'object',
-                properties: {},
+                properties: {
+                    root: {
+                        type: 'string',
+                        description: 'Optional absolute path or `file://` URI to inspect instead of the workspace. ' +
+                            'Must be inside, or equal to, an entry of the `allowedExternalPaths` preference. ' +
+                            'When omitted, the workspace root is used.'
+                    }
+                },
             },
-            handler: (_: string, ctx?: ToolInvocationContext) => this.getDirectoryStructure(ctx?.cancellationToken),
+            handler: (arg_string: string, ctx?: ToolInvocationContext) => {
+                let root: string | undefined;
+                if (arg_string) {
+                    try {
+                        root = JSON.parse(arg_string).root;
+                    } catch {
+                        // tolerate empty or non-JSON input — keep prior behavior
+                    }
+                }
+                return this.getDirectoryStructure(root, ctx?.cancellationToken);
+            },
         };
     }
 
@@ -344,19 +363,28 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
     @inject(WorkspaceFunctionScope)
     protected workspaceScope: WorkspaceFunctionScope;
 
-    private async getDirectoryStructure(cancellationToken?: CancellationToken): Promise<Record<string, unknown>> {
+    private async getDirectoryStructure(root?: string, cancellationToken?: CancellationToken): Promise<Record<string, unknown>> {
         if (cancellationToken?.isCancellationRequested) {
             return { error: 'Operation cancelled by user' };
         }
 
-        let workspaceRoot;
+        let rootUri: URI;
         try {
-            workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
+            if (root) {
+                const resolved = await this.workspaceScope.resolveToUri(root);
+                if (!resolved) {
+                    return { error: `Invalid root: '${root}'` };
+                }
+                rootUri = resolved;
+                await this.workspaceScope.ensureAccessible(rootUri);
+            } else {
+                rootUri = await this.workspaceScope.getWorkspaceRoot();
+            }
         } catch (error) {
             return { error: error.message };
         }
 
-        return this.buildDirectoryStructure(workspaceRoot, cancellationToken);
+        return this.buildDirectoryStructure(rootUri, cancellationToken);
     }
 
     private async buildDirectoryStructure(uri: URI, cancellationToken?: CancellationToken): Promise<Record<string, unknown>> {
@@ -675,13 +703,17 @@ export class GetWorkspaceFileList implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'Relative path to a directory within the workspace (e.g., "src", "src/components"). ' +
-                            'Use "" or "." to list the workspace root. Paths outside the workspace will result in an error.'
+                        description: 'Path to a directory. Relative paths resolve against the workspace root ' +
+                            '(e.g., "src", "src/components"); use "" or "." for the workspace root. ' +
+                            'Absolute paths and `file://` URIs are accepted only when the target is inside the workspace ' +
+                            'or covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference.'
                     }
                 },
                 required: ['path']
             },
-            description: 'Lists files and directories within a specified workspace directory. ' +
+            description: 'Lists files and directories within a specified directory. ' +
+                'By default operates within the workspace; absolute paths or `file://` URIs may be passed ' +
+                'when they target a location covered by the `allowedExternalPaths` preference. ' +
                 'Returns an array of names where directories are suffixed with "/" (e.g., ["src/", "package.json", "README.md"]). ' +
                 'Use this to explore directory structure step by step. ' +
                 'For finding specific files by pattern, use findFilesByPattern instead. ' +
@@ -704,15 +736,28 @@ export class GetWorkspaceFileList implements ToolProvider {
             return JSON.stringify({ error: 'Operation cancelled by user' });
         }
 
-        let workspaceRoot;
+        let targetUri: URI;
+        let workspaceRoot: URI;
         try {
             workspaceRoot = await this.workspaceScope.getWorkspaceRoot();
         } catch (error) {
             return JSON.stringify({ error: error.message });
         }
 
-        const targetUri = path ? workspaceRoot.resolve(path) : workspaceRoot;
-        this.workspaceScope.ensureWithinWorkspace(targetUri, workspaceRoot);
+        try {
+            if (!path || path === '.') {
+                targetUri = workspaceRoot;
+            } else {
+                const resolved = await this.workspaceScope.resolveToUri(path);
+                if (!resolved) {
+                    return JSON.stringify({ error: `Invalid path: '${path}'` });
+                }
+                targetUri = resolved;
+                await this.workspaceScope.ensureAccessible(targetUri);
+            }
+        } catch (error) {
+            return JSON.stringify({ error: error.message });
+        }
 
         try {
             if (cancellationToken?.isCancellationRequested) {

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 import { ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
 import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
-import { CancellationToken, Disposable, PreferenceService, URI, Path } from '@theia/core';
+import { CancellationToken, Disposable, OS, PreferenceService, URI, Path } from '@theia/core';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
@@ -72,7 +72,9 @@ export class WorkspaceFunctionScope {
     }
 
     ensureWithinWorkspace(targetUri: URI, workspaceRootUri: URI): void {
-        if (!targetUri.toString().startsWith(workspaceRootUri.toString())) {
+        const normalized = targetUri.normalizePath();
+        if (workspaceRootUri.scheme !== normalized.scheme
+            || !workspaceRootUri.isEqualOrParent(normalized, WorkspaceFunctionScope.pathCaseSensitive)) {
             throw new Error('Access outside of the workspace is not allowed');
         }
     }
@@ -84,22 +86,28 @@ export class WorkspaceFunctionScope {
      * preference. Workspace-scoped overrides of that preference are dropped when
      * the workspace is not trusted.
      *
+     * The target URI is normalized before the check so that literal `..`
+     * segments and percent-encoded equivalents (e.g. `%2e%2e`) are resolved
+     * away — otherwise the path-prefix comparison would admit traversals.
+     *
      * Note: symlinks within allow-listed directories are NOT canonicalized
      * before the check. Only allow-list directories whose contents you trust.
      */
     async ensureAccessible(targetUri: URI): Promise<void> {
+        const normalized = targetUri.normalizePath();
+        const caseSensitive = WorkspaceFunctionScope.pathCaseSensitive;
         const roots = (await this.workspaceService.roots) ?? [];
         for (const root of roots) {
-            if (root.resource.scheme === targetUri.scheme && root.resource.isEqualOrParent(targetUri)) {
+            if (root.resource.scheme === normalized.scheme && root.resource.isEqualOrParent(normalized, caseSensitive)) {
                 return;
             }
         }
         const allowed = await this.getAllowedExternalUris();
-        if (allowed.some(allowedUri => allowedUri.isEqualOrParent(targetUri))) {
+        if (allowed.some(allowedUri => allowedUri.scheme === normalized.scheme && allowedUri.isEqualOrParent(normalized, caseSensitive))) {
             return;
         }
         throw new Error(
-            `Access to '${targetUri.path.toString()}' is not allowed. ` +
+            `Access to '${normalized.path.toString()}' is not allowed. ` +
             `Path is outside the workspace and not covered by the '${ALLOWED_EXTERNAL_PATHS_PREF}' preference.`
         );
     }
@@ -107,10 +115,13 @@ export class WorkspaceFunctionScope {
     /**
      * Resolves the configured external allow-list to URIs. Reads via the
      * trust-aware preference reader so workspace-scoped overrides are dropped
-     * when the workspace is untrusted. Invalid entries (empty strings, paths
-     * containing `..`) are filtered out.
+     * when the workspace is untrusted. Awaits the reader's `ready` promise so
+     * that the trust state is resolved before the first preference read.
+     * Non-string entries, blanks, and entries that don't parse to a `file://`
+     * URI are filtered out; URIs are returned in normalized form.
      */
     async getAllowedExternalUris(resourceUri?: string): Promise<URI[]> {
+        await this.trustAwarePreferences.ready;
         const raw = this.trustAwarePreferences.get<string[]>(ALLOWED_EXTERNAL_PATHS_PREF, [], resourceUri) ?? [];
         const result: URI[] = [];
         for (const entry of raw) {
@@ -118,15 +129,24 @@ export class WorkspaceFunctionScope {
                 continue;
             }
             const trimmed = entry.trim();
-            if (!trimmed || trimmed.includes('..')) {
+            if (!trimmed) {
                 continue;
             }
             const uri = await this.toExternalUri(trimmed);
-            if (uri) {
-                result.push(uri);
+            if (uri && uri.scheme === 'file') {
+                result.push(uri.normalizePath());
             }
         }
         return result;
+    }
+
+    /**
+     * Whether path comparisons should be case-sensitive on the current
+     * backend. Windows file systems are case-insensitive; everything else is
+     * treated as case-sensitive (matches the rest of Theia's path handling).
+     */
+    static get pathCaseSensitive(): boolean {
+        return !OS.backend.isWindows;
     }
 
     /**
@@ -242,7 +262,11 @@ export class WorkspaceFunctionScope {
 
         const normalizedPath = Path.normalizePathSeparator(pathOrUri);
 
-        if (normalizedPath.includes('..')) {
+        // Reject `..` only when it appears as a path SEGMENT. A filename like
+        // `my..file.json` is a legitimate name. `ensureAccessible` normalizes
+        // URI-form inputs separately as defense-in-depth (e.g. against
+        // percent-encoded `%2e%2e` that bypasses the string-form check).
+        if (WorkspaceFunctionScope.hasParentSegment(normalizedPath)) {
             return undefined;
         }
 
@@ -251,6 +275,14 @@ export class WorkspaceFunctionScope {
         }
 
         return this.resolveRelativePath(normalizedPath);
+    }
+
+    /**
+     * Whether the already-separator-normalized path contains `..` as a path
+     * segment (not merely as a substring of a filename like `my..file.json`).
+     */
+    static hasParentSegment(normalizedPath: string): boolean {
+        return normalizedPath.split('/').some(segment => segment === '..');
     }
 
     private async initializeGitignoreWatcher(workspaceRoot: URI): Promise<void> {

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -165,24 +165,37 @@ export class WorkspaceFunctionScope {
                 return undefined;
             }
         }
-        if (entry === '~' || entry.startsWith('~/') || entry.startsWith('~\\')) {
-            const home = await this.getHomeDirUri();
-            if (!home) {
-                return undefined;
-            }
-            if (entry === '~') {
-                return home;
-            }
-            // Resolve the remainder in URI space to avoid Windows drive-letter
-            // round-tripping issues with URI.fromFilePath.
-            const remainder = Path.normalizePathSeparator(entry.substring(2));
-            return home.resolve(remainder);
-        }
         const normalized = Path.normalizePathSeparator(entry);
+        const tilde = await this.resolveTildePath(normalized);
+        if (tilde) {
+            return tilde;
+        }
         if (!WorkspaceFunctionScope.isAbsolutePath(normalized)) {
             return undefined;
         }
         return URI.fromFilePath(normalized);
+    }
+
+    /**
+     * If the given separator-normalized path is `~` or starts with `~/`,
+     * expands the leading `~` against the user's home directory and returns
+     * the resulting URI. Returns undefined if the path does not start with
+     * `~` or the home directory cannot be resolved. The remainder is
+     * resolved in URI space to avoid Windows drive-letter round-tripping
+     * issues with `URI.fromFilePath`.
+     */
+    protected async resolveTildePath(normalizedPath: string): Promise<URI | undefined> {
+        if (normalizedPath !== '~' && !normalizedPath.startsWith('~/')) {
+            return undefined;
+        }
+        const home = await this.getHomeDirUri();
+        if (!home) {
+            return undefined;
+        }
+        if (normalizedPath === '~') {
+            return home;
+        }
+        return home.resolve(normalizedPath.substring(2));
     }
 
     /**
@@ -271,6 +284,11 @@ export class WorkspaceFunctionScope {
         // percent-encoded `%2e%2e` that bypasses the string-form check).
         if (WorkspaceFunctionScope.hasParentSegment(normalizedPath)) {
             return undefined;
+        }
+
+        const tilde = await this.resolveTildePath(normalizedPath);
+        if (tilde) {
+            return tilde;
         }
 
         if (WorkspaceFunctionScope.isAbsolutePath(normalizedPath)) {

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -142,11 +142,14 @@ export class WorkspaceFunctionScope {
 
     /**
      * Whether path comparisons should be case-sensitive on the current
-     * backend. Windows file systems are case-insensitive; everything else is
-     * treated as case-sensitive (matches the rest of Theia's path handling).
+     * backend. Windows and macOS default to case-insensitive file systems
+     * (NTFS, HFS+, APFS); Linux is treated as case-sensitive. This is a
+     * heuristic — a case-sensitive APFS volume on macOS or a case-insensitive
+     * volume mounted on Linux will be misclassified, but querying the actual
+     * file system would require a backend round-trip.
      */
     static get pathCaseSensitive(): boolean {
-        return !OS.backend.isWindows;
+        return !OS.backend.isWindows && !OS.backend.isOSX;
     }
 
     /**

--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -110,8 +110,8 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
             description: nls.localize('theia/ai/workspace/allowedExternalPaths/description',
                 'List of absolute paths or file URIs (directories or files) outside the workspace that AI tools may read. ' +
                 'Supports `~` to refer to the user home directory. Empty by default; opt-in only. ' +
-                'Currently honored by getFileContent and findFilesByPattern. Workspace-scoped values are ignored ' +
-                'when the workspace is not trusted.'),
+                'Honored by getFileContent, findFilesByPattern, getWorkspaceFileList, and getWorkspaceDirectoryStructure. ' +
+                'Workspace-scoped values are ignored when the workspace is not trusted.'),
             default: [],
             items: {
                 type: 'string'

--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -24,6 +24,7 @@ export const PROMPT_TEMPLATE_ADDITIONAL_EXTENSIONS_PREF = 'ai-features.promptTem
 export const PROMPT_TEMPLATE_WORKSPACE_FILES_PREF = 'ai-features.promptTemplates.WorkspaceTemplateFiles';
 export const TASK_CONTEXT_STORAGE_DIRECTORY_PREF = 'ai-features.promptTemplates.taskContextStorageDirectory';
 export const FILE_CONTENT_MAX_SIZE_KB_PREF = 'ai-features.workspaceFunctions.fileContentMaxSizeKB';
+export const ALLOWED_EXTERNAL_PATHS_PREF = 'ai-features.workspaceFunctions.allowedExternalPaths';
 
 const CONFLICT_RESOLUTION_DESCRIPTION = 'When templates with the same ID (filename) exist in multiple locations, conflicts are resolved by priority: specific template files \
 (highest) > workspace directories > global directories (lowest).';
@@ -102,6 +103,19 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
                 'When using offset and limit, only the requested range is checked against this limit.'),
             default: 256,
             minimum: 1
+        },
+        [ALLOWED_EXTERNAL_PATHS_PREF]: {
+            type: 'array',
+            title: nls.localize('theia/ai/workspace/allowedExternalPaths/title', 'Allowed External Paths'),
+            description: nls.localize('theia/ai/workspace/allowedExternalPaths/description',
+                'List of absolute paths or file URIs (directories or files) outside the workspace that AI tools may read. ' +
+                'Supports `~` to refer to the user home directory. Empty by default; opt-in only. ' +
+                'Currently honored by getFileContent and findFilesByPattern. Workspace-scoped values are ignored ' +
+                'when the workspace is not trusted.'),
+            default: [],
+            items: {
+                type: 'string'
+            }
         }
     }
 };

--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -111,7 +111,9 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
                 'List of absolute paths or file URIs (directories or files) outside the workspace that AI tools may read. ' +
                 'Supports `~` to refer to the user home directory. Empty by default; opt-in only. ' +
                 'Honored by getFileContent, findFilesByPattern, getWorkspaceFileList, and getWorkspaceDirectoryStructure. ' +
-                'Workspace-scoped values are ignored when the workspace is not trusted.'),
+                'Workspace-scoped values are ignored when the workspace is not trusted. ' +
+                'Symbolic links inside allow-listed directories are followed and may point to files outside the allow-list; ' +
+                'only add directories whose contents you trust.'),
             default: [],
             items: {
                 type: 'string'


### PR DESCRIPTION
#### What it does

Resolves #17390.

Adds an opt-in allow-list of paths outside the workspace that read-only AI tools may access. Empty by default — preserves prior workspace-only behavior.

- New preference `ai-features.workspaceFunctions.allowedExternalPaths` (array of absolute paths or `file://` URIs; supports `~`).
- `WorkspaceFunctionScope.ensureAccessible(uri)` admits any workspace root or any path covered by the allow-list. Reads the new preference via `TrustAwarePreferenceReader`, so workspace-scoped overrides are dropped when the workspace is untrusted (consistent with #17364).
- Tools that honor the allow-list:
    - `getFileContent` — accepts absolute paths and `file://` URIs in addition to workspace-relative paths.
    - `getWorkspaceFileList` — accepts absolute paths and `file://` URIs in the `path` argument.
    - `getWorkspaceDirectoryStructure` — gains an optional `root` parameter to walk an allow-listed external directory.
    - `findFilesByPattern` — gains an optional `searchRoot` parameter to scope the search to an allow-listed external directory; results are returned as absolute paths in that case, workspace-relative otherwise.
- `getFileDiagnostics` and the write tools (`SuggestFileContent`, `WriteFileContent`) remain strictly workspace-scoped.
- Windows: recognize drive-letter paths (`C:/foo`) as absolute and perform `~` expansion in URI space to avoid `URI.fromFilePath` round-tripping.

Symlinks within allow-listed directories are not canonicalized before the check (the frontend `FileService` exposes no `realpath`); the JSDoc on `ensureAccessible` documents the limitation. Same posture as the shell-command allow-list.

#### How to test

1. Enable AI features (`ai-features.AiEnable.enableAI: true`) and grant workspace trust.
2. Without setting the new preference, ask an AI agent to read a file outside the workspace. Verify the tool returns an error mentioning `allowedExternalPaths`.
3. In **user settings** add an entry to the allow-list.
4. Verify each tool now works on the allow-listed path:
    - `getFileContent` with an absolute path inside the allow-listed directory returns content.
    - `getWorkspaceFileList` with the absolute path returns the directory listing.
    - `getWorkspaceDirectoryStructure` called with `{ "root": "<absolute path>" }` returns the nested structure.
    - `findFilesByPattern` called with `{ "pattern": "**/*.json", "searchRoot": "<absolute path>" }` returns absolute file paths.
5. Deny workspace trust (Restricted Mode). Confirm AI tools are disabled (gated by `canRun` from #17364) regardless of the preference value.
6. Re-grant trust, then put the same allow-list entry in **workspace settings** (`.theia/settings.json`) instead of user settings. Deny trust again. Confirm the workspace-scoped value is ignored — i.e., the tool still rejects the external path because the trust-aware reader drops workspace scope when untrusted.
7. Sibling-prefix safety: with `["/external/configs"]` allow-listed, verify a request for `/external/configs-other/file.txt` is rejected (path-component check, not raw string prefix).
8. Path-traversal safety: verify that a request like `/external/configs/../secrets.txt` is rejected.
9. Verify write tools (`writeFileContent`, `suggestFileContent`) and `getFileDiagnostics` still reject paths outside the workspace regardless of the allow-list.

#### Follow-ups

- Symlink canonicalization within allow-listed directories. Frontend `FileService` does not expose `realpath`; adding a backend RPC was out of scope. Documented in the JSDoc on `ensureAccessible`. Mitigation: only allow-list directories whose contents the user trusts. Consistent with the existing shell-command allow-list, which also does not canonicalize.
- Centralizing trust-aware preference reads inside `PreferenceService` itself, as already noted in #17364, would let `WorkspaceFunctionScope` drop the explicit `TrustAwarePreferenceReader` dependency.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
