### PR TITLE
Ensure the dirty-diff widget always shows the heading

### DIFF
--- a/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
+++ b/packages/scm/src/browser/dirty-diff/dirty-diff-widget.ts
@@ -282,11 +282,11 @@ class DirtyDiffPeekView extends MonacoEditorPeekViewWidget {
         try {
             this.bodyElement = document.createElement('div');
             this.bodyElement.classList.add('body');
+            super.create();
             this.diffEditorPromise = this.widget.editorProvider.createEmbeddedDiffEditor(this.editor, this.bodyElement, this.widget.previousRevisionUri);
             const diffEditor = await this.diffEditorPromise;
             this.diffEditor = diffEditor;
             this.toDispose.push(diffEditor);
-            super.create();
             return diffEditor;
         } catch (e) {
             this.dispose();


### PR DESCRIPTION
#### What it does

Fixes #17420.

#### How to test

Verify that the dirty-diff widget shows the heading correctly and there are no regressions in its appearance/behaviour.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
