### PR TITLE
Allow the mouse to summon the context menu in editor gutter on macOS

### DIFF
--- a/packages/debug/src/browser/editor/debug-editor-model.ts
+++ b/packages/debug/src/browser/editor/debug-editor-model.ts
@@ -21,7 +21,7 @@ import { StandaloneCodeEditor } from '@theia/monaco-editor-core/esm/vs/editor/st
 import { IDecorationOptions } from '@theia/monaco-editor-core/esm/vs/editor/common/editorCommon';
 import URI from '@theia/core/lib/common/uri';
 import { Disposable, DisposableCollection, MenuPath, isOSX } from '@theia/core';
-import { ContextMenuRenderer } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, isContextMenuEvent } from '@theia/core/lib/browser';
 import { BreakpointManager, SourceBreakpointsChangeEvent } from '../breakpoint/breakpoint-manager';
 import { DebugSourceBreakpoint } from '../model/debug-source-breakpoint';
 import { DebugSessionManager } from '../debug-session-manager';
@@ -428,7 +428,7 @@ export class DebugEditorModel implements Disposable {
 
     protected handleMouseDown(event: monaco.editor.IEditorMouseEvent): void {
         if (event.target && event.target.type === monaco.editor.MouseTargetType.GUTTER_GLYPH_MARGIN) {
-            if (!event.event.rightButton) {
+            if (!isContextMenuEvent(event.event.browserEvent)) {
                 this.toggleBreakpoint(event.target.position!);
             }
         }

--- a/packages/editor/src/browser/editor-linenumber-contribution.ts
+++ b/packages/editor/src/browser/editor-linenumber-contribution.ts
@@ -17,7 +17,7 @@
 import { EditorManager } from './editor-manager';
 import { EditorMouseEvent, MouseTargetType, Position, TextEditor } from './editor';
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { FrontendApplicationContribution, ContextMenuRenderer } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, ContextMenuRenderer, isContextMenuEvent } from '@theia/core/lib/browser';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { Disposable, DisposableCollection, MenuPath } from '@theia/core';
 import { EditorWidget } from './editor-widget';
@@ -53,7 +53,7 @@ export class EditorLineNumberContribution implements FrontendApplicationContribu
 
     protected handleContextMenu(editor: TextEditor, event: EditorMouseEvent): void {
         if (event.target && (event.target.type === MouseTargetType.GUTTER_LINE_NUMBERS || event.target.type === MouseTargetType.GUTTER_GLYPH_MARGIN)) {
-            if (event.event.button === 2) {
+            if (isContextMenuEvent(event.event)) {
                 editor.focus();
                 const lineNumber = lineNumberFromPosition(event.target.position);
                 const contextKeyService = this.contextKeyService.createOverlay([['editorLineNumber', lineNumber]]);


### PR DESCRIPTION
#### What it does

Replace the platform-specific gesture recognition for right mouse button with the platform-independent utility for context menu events. Make sure that a mouse down that is recognized as the context menu gesture does not also add a breakpoint.

That lets the standard macOS Ctrl+Click mouse gesture, which is critical for one-button mice, to summon the context menu in the editor gutter.

Fixes #12777

Contributed on behalf of STMicroelectronics

#### How to test

Primary test: on macOS platform, Ctrl+Click the mouse (left button if your mouse has more than one) in the gutter of an editor and check that the context menu with breakpoint/logpoint/etc. actions shows up and that a breakpoint is not created. Do not test with trackpad.

Regression test: on macOS platform, do an ordinary click of the mouse in the gutter to check that this gesture does still create or delete breakpoints as before.

Regression test: on Linux or Windows platform, check that behaviour of mouse clicks in the editor gutter is unchanged.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
