### PR TITLE
fix: omit + separator from menu shortcuts on macOS

### DIFF
--- a/examples/playwright/src/tests/theia-main-menu.test.ts
+++ b/examples/playwright/src/tests/theia-main-menu.test.ts
@@ -64,7 +64,7 @@ test.describe('Theia Main Menu', () => {
         expect(label).toBe('New Text File');
 
         const shortCut = await menuItem?.shortCut();
-        expect(shortCut).toBe(OSUtil.isMacOS ? '⌥+N' : app.isElectron ? 'Ctrl+N' : 'Alt+N');
+        expect(shortCut).toBe(OSUtil.isMacOS ? '⌥N' : app.isElectron ? 'Ctrl+N' : 'Alt+N');
 
         const hasSubmenu = await menuItem?.hasSubmenu();
         expect(hasSubmenu).toBe(false);

--- a/packages/core/src/browser/keybinding.spec.ts
+++ b/packages/core/src/browser/keybinding.spec.ts
@@ -576,6 +576,30 @@ describe('keybindings', () => {
     });
 });
 
+describe('acceleratorForKeyCode', () => {
+
+    const ctrlV = KeyCode.createKeyCode({ key: Key.KEY_V, ctrl: true });
+    const metaV = KeyCode.createKeyCode({ key: Key.KEY_V, meta: true });
+
+    it('uses ASCII names with the separator on non-macOS', () => {
+        stub.value(false);
+        const accelerator = keybindingRegistry.acceleratorForKeyCode(ctrlV, '+');
+        expect(accelerator).to.equal('Ctrl+V');
+    });
+
+    it('uses macOS symbols without a separator on macOS browser', () => {
+        stub.value(true);
+        const accelerator = keybindingRegistry.acceleratorForKeyCode(metaV, '+');
+        expect(accelerator).to.equal('⌘V');
+    });
+
+    it('uses ASCII names with the separator on macOS Electron (asciiOnly)', () => {
+        stub.value(true);
+        const accelerator = keybindingRegistry.acceleratorForKeyCode(metaV, '+', true);
+        expect(accelerator).to.equal('Cmd+V');
+    });
+});
+
 const TEST_COMMAND: Command = {
     id: 'test.command'
 };

--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -399,11 +399,14 @@ export class KeybindingRegistry {
      * Get a user visible representation of a key code (a key with modifiers).
      * @returns a string representing the {@link KeyCode}
      * @param keyCode the keycode
-     * @param separator the separator used to separate keys (key and modifiers) in the returning string
+     * @param separator the separator used to separate keys (key and modifiers) in the returning string.
+     * Ignored when rendering macOS symbols (i.e. on macOS with `asciiOnly=false`), as the convention is
+     * to juxtapose modifier symbols without a separator (e.g. `⌃⌘V`).
      * @param asciiOnly if `true`, no special characters will be substituted into the string returned. Ensures correct keyboard shortcuts in Electron menus.
      */
     acceleratorForKeyCode(keyCode: KeyCode, separator: string = ' ', asciiOnly = false): string {
-        return this.componentsForKeyCode(keyCode, asciiOnly).join(separator);
+        const useSymbols = isOSX && !asciiOnly;
+        return this.componentsForKeyCode(keyCode, asciiOnly).join(useSymbols ? '' : separator);
     }
 
     componentsForKeyCode(keyCode: KeyCode, asciiOnly = false): string[] {


### PR DESCRIPTION
#### What it does

When rendering keybinding accelerators with macOS symbols (i.e. on macOS outside of Electron's native menus), join modifier symbols without a separator so that menus show like ⌃⌘V rather than ⌃+⌘+V. This matches the macOS convention and avoids confusing shortcuts like ⌘++ for magnification.

Electron menus (`asciiOnly=true`) and non-macOS platforms continue to use the caller-provided separator and render shortcuts as before.

Fixes #17374

#### How to test

Primary test: on macOS, launch the browser application and see that the pull-down menus have no + signs in their shortcut labels.

Regression test: on macOS, launch the Electron application and see that its native menus still render correctly with the correct shortcut labels.

Regression test: on Linux or Windows platform, verify that menus are rendered with the expected non-symbolic (e.g. Ctrl+V) style of shortcut label or whatever is appropriate for the platform.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
