### PR TITLE
Bind filesystem proxy as singleton

### DIFF
--- a/packages/filesystem/src/browser/filesystem-frontend-module.ts
+++ b/packages/filesystem/src/browser/filesystem-frontend-module.ts
@@ -44,7 +44,7 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
 
     bind(RemoteFileSystemServer).toDynamicValue(ctx =>
         WebSocketConnectionProvider.createProxy(ctx.container, remoteFileSystemPath, new RemoteFileSystemProxyFactory())
-    );
+    ).inSingletonScope();
     bind(RemoteFileSystemProvider).toSelf().inSingletonScope();
     bind(RemoteFileServiceContribution).toSelf().inSingletonScope();
     bind(FileServiceContribution).toService(RemoteFileServiceContribution);

--- a/packages/remote/src/electron-browser/remote-frontend-module.ts
+++ b/packages/remote/src/electron-browser/remote-frontend-module.ts
@@ -34,7 +34,7 @@ import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/ser
 import '../../src/electron-browser/style/port-forwarding-widget.css';
 import { UserStorageContribution } from '@theia/userstorage/lib/browser/user-storage-contribution';
 import { RemoteUserStorageContribution } from './remote-user-storage-provider';
-import { remoteFileSystemPath, RemoteFileSystemProxyFactory, RemoteFileSystemServer } from '@theia/filesystem/lib/common/remote-file-system-provider';
+import { RemoteFileSystemProvider, remoteFileSystemPath, RemoteFileSystemProxyFactory, RemoteFileSystemServer } from '@theia/filesystem/lib/common/remote-file-system-provider';
 import { LocalEnvVariablesServer, LocalRemoteFileSystemContribution, LocalRemoteFileSystemProvider, LocalRemoteFileSytemServer } from './local-backend-services';
 import { envVariablesPath, EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { WorkspaceHandlingContribution, WorkspaceOpenHandlerContribution } from '@theia/workspace/lib/browser';
@@ -73,15 +73,17 @@ export default new ContainerModule((bind, _, __, rebind) => {
     bind(RemotePortForwardingProvider).toDynamicValue(ctx =>
         ServiceConnectionProvider.createLocalProxy<RemotePortForwardingProvider>(ctx.container, RemoteRemotePortForwardingProviderPath)).inSingletonScope();
 
-    bind(LocalRemoteFileSytemServer).toDynamicValue(ctx =>
-        isRemote ?
-            ServiceConnectionProvider.createLocalProxy(ctx.container, remoteFileSystemPath, new RemoteFileSystemProxyFactory()) :
-            ctx.container.get(RemoteFileSystemServer));
-    bind(LocalEnvVariablesServer).toDynamicValue(ctx =>
-        isRemote ?
-            ServiceConnectionProvider.createLocalProxy<EnvVariablesServer>(ctx.container, envVariablesPath) :
-            ctx.container.get(EnvVariablesServer));
-    bind(LocalRemoteFileSystemProvider).toSelf().inSingletonScope();
+    if (isRemote) {
+        bind(LocalRemoteFileSytemServer).toDynamicValue(ctx =>
+            ServiceConnectionProvider.createLocalProxy(ctx.container, remoteFileSystemPath, new RemoteFileSystemProxyFactory()));
+        bind(LocalEnvVariablesServer).toDynamicValue(ctx =>
+            ServiceConnectionProvider.createLocalProxy<EnvVariablesServer>(ctx.container, envVariablesPath));
+        bind(LocalRemoteFileSystemProvider).toSelf().inSingletonScope();
+    } else {
+        bind(LocalRemoteFileSytemServer).toService(RemoteFileSystemServer);
+        bind(LocalEnvVariablesServer).toService(EnvVariablesServer);
+        bind(LocalRemoteFileSystemProvider).toService(RemoteFileSystemProvider);
+    }
     rebind(UserStorageContribution).to(RemoteUserStorageContribution);
 
     if (isRemote) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

On startup, an error is logged indicating that the service path `'/services/remote-filesystem'` is resolved multiple times. This PR binds the relevant proxy in singleton scope that we don't attempt to create a second instance of the proxy on the same path.

#### How to test

1. Start the application.
2. See no error logged about a service already existing on path `'/services/remote-filesystem'`
3. Observe that file operations work as expected.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
