### PR TITLE
fix: merge consecutive assistant messages to comply with strict role alternation

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -15,9 +15,10 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { AnthropicModel, DEFAULT_MAX_TOKENS, addCacheControlToLastMessage } from './anthropic-language-model';
+import { AnthropicModel, DEFAULT_MAX_TOKENS, addCacheControlToLastMessage, mergeConsecutiveSameRoleMessages } from './anthropic-language-model';
 import { isUsageResponsePart, LanguageModelRequest, LanguageModelStreamResponsePart, ReasoningApi, ReasoningSupport, UserRequest } from '@theia/ai-core';
 import type { Anthropic } from '@anthropic-ai/sdk';
+import type { MessageParam } from '@anthropic-ai/sdk/resources';
 
 const REASONING_SUPPORT: ReasoningSupport = {
     supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
@@ -125,6 +126,91 @@ describe('AnthropicModel', () => {
             );
 
             expect(model.url).to.equal('custom-url');
+        });
+    });
+
+    describe('mergeConsecutiveSameRoleMessages', () => {
+        it('should merge an assistant text message followed by an assistant tool_use into a single message', () => {
+            const messages: MessageParam[] = [
+                { role: 'user', content: [{ type: 'text', text: 'do something' }] },
+                { role: 'assistant', content: [{ type: 'text', text: 'let me call a tool' }] },
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'call_1', name: 'foo', input: { x: 1 } }] }
+            ];
+            const result = mergeConsecutiveSameRoleMessages(messages);
+            expect(result).to.deep.equal([
+                { role: 'user', content: [{ type: 'text', text: 'do something' }] },
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'text', text: 'let me call a tool' },
+                        { type: 'tool_use', id: 'call_1', name: 'foo', input: { x: 1 } }
+                    ]
+                }
+            ]);
+        });
+
+        it('should merge consecutive user messages with parallel tool_results into a single user message', () => {
+            const messages: MessageParam[] = [
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'r1' }] },
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_2', content: 'r2' }] }
+            ];
+            const result = mergeConsecutiveSameRoleMessages(messages);
+            expect(result).to.deep.equal([
+                {
+                    role: 'user',
+                    content: [
+                        { type: 'tool_result', tool_use_id: 'call_1', content: 'r1' },
+                        { type: 'tool_result', tool_use_id: 'call_2', content: 'r2' }
+                    ]
+                }
+            ]);
+        });
+
+        it('should reproduce the bug scenario from issue #17104 (text+tool_use after a tool_result round-trip)', () => {
+            const messages: MessageParam[] = [
+                { role: 'user', content: [{ type: 'text', text: 'first request' }] },
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'call_1', name: 'foo', input: {} }] },
+                { role: 'user', content: [{ type: 'tool_result', tool_use_id: 'call_1', content: 'r1' }] },
+                { role: 'assistant', content: [{ type: 'text', text: 'follow-up reasoning' }] },
+                { role: 'assistant', content: [{ type: 'tool_use', id: 'call_2', name: 'bar', input: {} }] }
+            ];
+            const result = mergeConsecutiveSameRoleMessages(messages);
+            // Sanity check: roles must strictly alternate after merging.
+            for (let i = 1; i < result.length; i++) {
+                expect(result[i - 1].role).to.not.equal(result[i].role);
+            }
+            expect(result).to.have.lengthOf(4);
+            expect(result[3].content).to.deep.equal([
+                { type: 'text', text: 'follow-up reasoning' },
+                { type: 'tool_use', id: 'call_2', name: 'bar', input: {} }
+            ]);
+        });
+
+        it('should leave alternating messages unchanged', () => {
+            const messages: MessageParam[] = [
+                { role: 'user', content: [{ type: 'text', text: 'a' }] },
+                { role: 'assistant', content: [{ type: 'text', text: 'b' }] },
+                { role: 'user', content: [{ type: 'text', text: 'c' }] }
+            ];
+            const result = mergeConsecutiveSameRoleMessages(messages);
+            expect(result).to.deep.equal(messages);
+        });
+
+        it('should normalize string content to a text block when merging', () => {
+            const messages: MessageParam[] = [
+                { role: 'assistant', content: 'hello' },
+                { role: 'assistant', content: [{ type: 'text', text: 'world' }] }
+            ];
+            const result = mergeConsecutiveSameRoleMessages(messages);
+            expect(result).to.deep.equal([
+                {
+                    role: 'assistant',
+                    content: [
+                        { type: 'text', text: 'hello' },
+                        { type: 'text', text: 'world' }
+                    ]
+                }
+            ]);
         });
     });
 

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -111,9 +111,32 @@ function transformToAnthropicParams(
         }));
 
     return {
-        messages: convertedMessages,
+        messages: mergeConsecutiveSameRoleMessages(convertedMessages),
         systemMessage,
     };
+}
+
+export function mergeConsecutiveSameRoleMessages(messages: MessageParam[]): MessageParam[] {
+    const result: MessageParam[] = [];
+    for (const message of messages) {
+        const previous = result[result.length - 1];
+        if (previous?.role === message.role && (message.role === 'user' || message.role === 'assistant')) {
+            const previousContent = Array.isArray(previous.content)
+                ? previous.content
+                : [{ type: 'text', text: previous.content } as Anthropic.Messages.TextBlockParam];
+            const nextContent = Array.isArray(message.content)
+                ? message.content
+                : [{ type: 'text', text: message.content } as Anthropic.Messages.TextBlockParam];
+            result[result.length - 1] = {
+                ...previous,
+                role: message.role,
+                content: [...previousContent, ...nextContent]
+            };
+        } else {
+            result.push(message);
+        }
+    }
+    return result;
 }
 
 /**

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -120,6 +120,9 @@ export function mergeConsecutiveSameRoleMessages(messages: MessageParam[]): Mess
     const result: MessageParam[] = [];
     for (const message of messages) {
         const previous = result[result.length - 1];
+        // tool results are user messages and not tool messages and thus should be merged:
+        // assistant(tool_use_1 + tool_use_2)
+        // user(tool_result_1 + tool_result_2)
         if (previous?.role === message.role && (message.role === 'user' || message.role === 'assistant')) {
             const previousContent = Array.isArray(previous.content)
                 ? previous.content

--- a/packages/ai-copilot/src/node/copilot-language-model.spec.ts
+++ b/packages/ai-copilot/src/node/copilot-language-model.spec.ts
@@ -1,0 +1,105 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { LanguageModelMessage } from '@theia/ai-core';
+import { ChatCompletionMessageParam } from 'openai/resources';
+import { CopilotLanguageModel } from './copilot-language-model';
+
+class TestableCopilotLanguageModel extends CopilotLanguageModel {
+    constructor() {
+        super(
+            'test-id',
+            'test-model',
+            { status: 'ready' },
+            true,
+            false,
+            3,
+            async () => 'test-token',
+            () => undefined
+        );
+    }
+
+    public callProcessMessages(messages: LanguageModelMessage[]): ChatCompletionMessageParam[] {
+        return this.processMessages(messages);
+    }
+}
+
+describe('CopilotLanguageModel - processMessages', () => {
+    const model = new TestableCopilotLanguageModel();
+
+    it('should merge an assistant text message followed by an assistant tool_use into a single message', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'do something' },
+            { actor: 'ai', type: 'text', text: 'let me call a tool' },
+            { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: { x: 1 } }
+        ];
+        const result = model.callProcessMessages(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'do something' },
+            {
+                role: 'assistant',
+                content: 'let me call a tool',
+                tool_calls: [{ id: 'call_1', function: { name: 'foo', arguments: JSON.stringify({ x: 1 }) }, type: 'function' }]
+            }
+        ]);
+    });
+
+    it('should merge multiple parallel assistant tool_use messages', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'do parallel work' },
+            { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: { x: 1 } },
+            { actor: 'ai', type: 'tool_use', id: 'call_2', name: 'bar', input: { y: 2 } }
+        ];
+        const result = model.callProcessMessages(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'do parallel work' },
+            {
+                role: 'assistant',
+                tool_calls: [
+                    { id: 'call_1', function: { name: 'foo', arguments: JSON.stringify({ x: 1 }) }, type: 'function' },
+                    { id: 'call_2', function: { name: 'bar', arguments: JSON.stringify({ y: 2 }) }, type: 'function' }
+                ]
+            }
+        ]);
+    });
+
+    it('should reproduce the bug scenario from issue #17104', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'first request' },
+            { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: {} },
+            { actor: 'user', type: 'tool_result', tool_use_id: 'call_1', name: 'foo', content: 'result_1' },
+            { actor: 'ai', type: 'text', text: 'follow-up reasoning' },
+            { actor: 'ai', type: 'tool_use', id: 'call_2', name: 'bar', input: {} }
+        ];
+        const result = model.callProcessMessages(messages);
+        for (let i = 1; i < result.length; i++) {
+            expect(result[i - 1].role === 'assistant' && result[i].role === 'assistant').to.equal(false);
+        }
+        expect(result).to.have.lengthOf(4);
+    });
+
+    it('should leave non-adjacent assistant messages separate', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: {} },
+            { actor: 'user', type: 'tool_result', tool_use_id: 'call_1', name: 'foo', content: 'r' },
+            { actor: 'ai', type: 'text', text: 'final answer' }
+        ];
+        const result = model.callProcessMessages(messages);
+        expect(result).to.have.lengthOf(3);
+        expect(result[2]).to.deep.equal({ role: 'assistant', content: 'final answer' });
+    });
+});

--- a/packages/ai-copilot/src/node/copilot-language-model.spec.ts
+++ b/packages/ai-copilot/src/node/copilot-language-model.spec.ts
@@ -29,7 +29,8 @@ class TestableCopilotLanguageModel extends CopilotLanguageModel {
             false,
             3,
             async () => 'test-token',
-            () => undefined
+            () => undefined,
+            () => 'test-user-agent'
         );
     }
 

--- a/packages/ai-copilot/src/node/copilot-language-model.ts
+++ b/packages/ai-copilot/src/node/copilot-language-model.ts
@@ -28,7 +28,7 @@ import {
 import { CancellationToken } from '@theia/core';
 import OpenAI from 'openai';
 import { RunnableToolFunctionWithoutParse } from 'openai/lib/RunnableFunction';
-import { ChatCompletionMessageParam } from 'openai/resources';
+import { ChatCompletionAssistantMessageParam, ChatCompletionMessageParam } from 'openai/resources';
 import { StreamingAsyncIterator } from '@theia/ai-openai/lib/node/openai-streaming-iterator';
 import { COPILOT_PROVIDER_ID, getCopilotApiBaseUrl } from '../common';
 import type { RunnerOptions } from 'openai/lib/AbstractChatCompletionRunner';
@@ -184,7 +184,38 @@ export class CopilotLanguageModel implements LanguageModel {
     }
 
     protected processMessages(messages: LanguageModelMessage[]): ChatCompletionMessageParam[] {
-        return messages.filter(m => m.type !== 'thinking').map(m => this.toOpenAIMessage(m));
+        const converted = messages.filter(m => m.type !== 'thinking').map(m => this.toOpenAIMessage(m));
+        return this.mergeConsecutiveAssistantMessages(converted);
+    }
+
+    protected mergeConsecutiveAssistantMessages(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
+        const result: ChatCompletionMessageParam[] = [];
+        for (const message of messages) {
+            const previous = result[result.length - 1];
+            if (previous?.role === 'assistant' && message.role === 'assistant') {
+                const merged: ChatCompletionAssistantMessageParam = { ...previous, role: 'assistant' };
+
+                const previousContent = typeof previous.content === 'string' ? previous.content : undefined;
+                const nextContent = typeof message.content === 'string' ? message.content : undefined;
+                if (previousContent && nextContent) {
+                    merged.content = `${previousContent}\n${nextContent}`;
+                } else if (nextContent) {
+                    merged.content = nextContent;
+                } else if (previousContent) {
+                    merged.content = previousContent;
+                }
+
+                const toolCalls = [...(previous.tool_calls ?? []), ...(message.tool_calls ?? [])];
+                if (toolCalls.length > 0) {
+                    merged.tool_calls = toolCalls;
+                }
+
+                result[result.length - 1] = merged;
+            } else {
+                result.push(message);
+            }
+        }
+        return result;
     }
 
     protected toOpenAIMessage(message: LanguageModelMessage): ChatCompletionMessageParam {

--- a/packages/ai-copilot/src/node/copilot-language-model.ts
+++ b/packages/ai-copilot/src/node/copilot-language-model.ts
@@ -197,11 +197,11 @@ export class CopilotLanguageModel implements LanguageModel {
 
                 const previousContent = typeof previous.content === 'string' ? previous.content : undefined;
                 const nextContent = typeof message.content === 'string' ? message.content : undefined;
-                if (previousContent && nextContent) {
+                if (previousContent !== undefined && nextContent !== undefined) {
                     merged.content = `${previousContent}\n${nextContent}`;
-                } else if (nextContent) {
+                } else if (nextContent !== undefined) {
                     merged.content = nextContent;
-                } else if (previousContent) {
+                } else if (previousContent !== undefined) {
                     merged.content = previousContent;
                 }
 

--- a/packages/ai-hugging-face/src/node/huggingface-language-model.spec.ts
+++ b/packages/ai-hugging-face/src/node/huggingface-language-model.spec.ts
@@ -1,0 +1,96 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { LanguageModelMessage } from '@theia/ai-core';
+import { HuggingFaceModel } from './huggingface-language-model';
+
+/**
+ * Tests cover the message-conversion path that runs before the request leaves Theia.
+ * We exercise it by passing crafted messages to a stub HF client through the model.
+ */
+class TestableHuggingFaceModel extends HuggingFaceModel {
+    public capturedMessages: Array<{ role: string; content: string }> | undefined;
+
+    constructor() {
+        super('test-id', 'test-model', { status: 'ready' }, () => 'test-key');
+    }
+
+    // Capture the converted messages by overriding the private fetch step.
+    // We re-implement the same conversion path used in handleNonStreamingRequest, since
+    // toChatMessages and the merge step are module-private.
+    public async runConvert(messages: LanguageModelMessage[]): Promise<Array<{ role: string; content: string }>> {
+        // Use a stub client so the request never goes out. We capture the messages it receives.
+        const stubClient = {
+            chatCompletion: async (params: { messages: Array<{ role: string; content: string }> }) => {
+                this.capturedMessages = params.messages;
+                return { choices: [{ message: { content: '' } }] };
+            },
+            chatCompletionStream: undefined as unknown
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (this as any).handleNonStreamingRequest(stubClient, { messages });
+        return this.capturedMessages!;
+    }
+}
+
+describe('HuggingFaceModel - message merging', () => {
+    const model = new TestableHuggingFaceModel();
+
+    it('should merge consecutive assistant text messages with a newline separator', async () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'q' },
+            { actor: 'ai', type: 'text', text: 'part one' },
+            { actor: 'ai', type: 'text', text: 'part two' }
+        ];
+        const result = await model.runConvert(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'q' },
+            { role: 'assistant', content: 'part one\npart two' }
+        ]);
+    });
+
+    it('should leave alternating user/assistant messages unchanged', async () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'q1' },
+            { actor: 'ai', type: 'text', text: 'a1' },
+            { actor: 'user', type: 'text', text: 'q2' },
+            { actor: 'ai', type: 'text', text: 'a2' }
+        ];
+        const result = await model.runConvert(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'q1' },
+            { role: 'assistant', content: 'a1' },
+            { role: 'user', content: 'q2' },
+            { role: 'assistant', content: 'a2' }
+        ]);
+    });
+
+    it('should reproduce the bug scenario from issue #17104 (consecutive ai messages)', async () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'first request' },
+            { actor: 'ai', type: 'text', text: 'reasoning' },
+            { actor: 'ai', type: 'text', text: 'final answer' }
+        ];
+        const result = await model.runConvert(messages);
+        // Sanity check: no two consecutive assistant messages remain.
+        for (let i = 1; i < result.length; i++) {
+            expect(result[i - 1].role === 'assistant' && result[i].role === 'assistant').to.equal(false);
+        }
+        expect(result).to.have.lengthOf(2);
+        expect(result[1]).to.deep.equal({ role: 'assistant', content: 'reasoning\nfinal answer' });
+    });
+});

--- a/packages/ai-hugging-face/src/node/huggingface-language-model.ts
+++ b/packages/ai-hugging-face/src/node/huggingface-language-model.ts
@@ -43,13 +43,42 @@ function toRole(actor: MessageActor): 'user' | 'assistant' | 'system' {
     }
 }
 
-function toChatMessages(messages: LanguageModelMessage[]): Array<{ role: 'user' | 'assistant' | 'system'; content: string }> {
-    return messages
+// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
+type HuggingFaceChatMessage = { role: 'user' | 'assistant' | 'system'; content: string };
+
+function toChatMessages(messages: LanguageModelMessage[]): HuggingFaceChatMessage[] {
+    const chatMessages = messages
         .filter(LanguageModelMessage.isTextMessage)
         .map(message => ({
             role: toRole(message.actor),
             content: message.text
         }));
+    return mergeConsecutiveAssistantMessages(chatMessages);
+}
+
+function mergeConsecutiveAssistantMessages(messages: HuggingFaceChatMessage[]): HuggingFaceChatMessage[] {
+    const result: HuggingFaceChatMessage[] = [];
+    for (const message of messages) {
+        const previous = result[result.length - 1];
+        if (previous?.role === 'assistant' && message.role === 'assistant') {
+            const merged: HuggingFaceChatMessage = { ...previous, role: 'assistant' };
+
+            const previousContent = previous.content;
+            const nextContent = message.content;
+            if (previousContent && nextContent) {
+                merged.content = `${previousContent}\n${nextContent}`;
+            } else if (nextContent) {
+                merged.content = nextContent;
+            } else if (previousContent) {
+                merged.content = previousContent;
+            }
+
+            result[result.length - 1] = merged;
+        } else {
+            result.push(message);
+        }
+    }
+    return result;
 }
 
 export class HuggingFaceModel implements LanguageModel {

--- a/packages/ai-ollama/src/node/ollama-language-model.spec.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.spec.ts
@@ -1,0 +1,123 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Message } from 'ollama';
+import { OllamaModel } from './ollama-language-model';
+
+class TestableOllamaModel extends OllamaModel {
+    constructor() {
+        super('test-id', 'test-model', { status: 'ready' }, () => 'http://localhost:11434');
+    }
+
+    public callMergeConsecutiveAssistantMessages(messages: Message[]): Message[] {
+        return this.mergeConsecutiveAssistantMessages(messages);
+    }
+}
+
+describe('OllamaModel - mergeConsecutiveAssistantMessages', () => {
+    const model = new TestableOllamaModel();
+
+    it('should merge an assistant text message followed by an assistant tool_use into a single message', () => {
+        const messages: Message[] = [
+            { role: 'user', content: 'do something' },
+            { role: 'assistant', content: 'let me call a tool' },
+            { role: 'assistant', content: '', tool_calls: [{ function: { name: 'foo', arguments: { x: 1 } } }] }
+        ];
+        const result = model.callMergeConsecutiveAssistantMessages(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'do something' },
+            {
+                role: 'assistant',
+                content: 'let me call a tool',
+                tool_calls: [{ function: { name: 'foo', arguments: { x: 1 } } }]
+            }
+        ]);
+    });
+
+    it('should merge multiple parallel assistant tool_calls into a single message', () => {
+        const messages: Message[] = [
+            { role: 'user', content: 'do parallel work' },
+            { role: 'assistant', content: '', tool_calls: [{ function: { name: 'foo', arguments: { x: 1 } } }] },
+            { role: 'assistant', content: '', tool_calls: [{ function: { name: 'bar', arguments: { y: 2 } } }] }
+        ];
+        const result = model.callMergeConsecutiveAssistantMessages(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'do parallel work' },
+            {
+                role: 'assistant',
+                content: '',
+                tool_calls: [
+                    { function: { name: 'foo', arguments: { x: 1 } } },
+                    { function: { name: 'bar', arguments: { y: 2 } } }
+                ]
+            }
+        ]);
+    });
+
+    it('should reproduce the bug scenario from issue #17104 (text+tool_use after a tool_result round-trip)', () => {
+        const messages: Message[] = [
+            { role: 'user', content: 'first request' },
+            { role: 'assistant', content: '', tool_calls: [{ function: { name: 'foo', arguments: {} } }] },
+            { role: 'tool', content: 'Tool call foo returned: r1' },
+            { role: 'assistant', content: 'follow-up reasoning' },
+            { role: 'assistant', content: '', tool_calls: [{ function: { name: 'bar', arguments: {} } }] }
+        ];
+        const result = model.callMergeConsecutiveAssistantMessages(messages);
+        // Sanity check: no two consecutive assistant messages remain.
+        for (let i = 1; i < result.length; i++) {
+            expect(result[i - 1].role === 'assistant' && result[i].role === 'assistant').to.equal(false);
+        }
+        expect(result).to.have.lengthOf(4);
+        expect(result[3]).to.deep.equal({
+            role: 'assistant',
+            content: 'follow-up reasoning',
+            tool_calls: [{ function: { name: 'bar', arguments: {} } }]
+        });
+    });
+
+    it('should not merge non-adjacent assistant messages separated by a tool result', () => {
+        const messages: Message[] = [
+            { role: 'assistant', content: '', tool_calls: [{ function: { name: 'foo', arguments: {} } }] },
+            { role: 'tool', content: 'Tool call foo returned: r' },
+            { role: 'assistant', content: 'final answer' }
+        ];
+        const result = model.callMergeConsecutiveAssistantMessages(messages);
+        expect(result).to.deep.equal(messages);
+    });
+
+    it('should join thinking text from consecutive assistant messages', () => {
+        const messages: Message[] = [
+            { role: 'assistant', content: 'hello', thinking: 'reasoning step 1' },
+            { role: 'assistant', content: 'world', thinking: 'reasoning step 2' }
+        ];
+        const result = model.callMergeConsecutiveAssistantMessages(messages);
+        expect(result).to.deep.equal([
+            { role: 'assistant', content: 'hello\nworld', thinking: 'reasoning step 1\nreasoning step 2' }
+        ]);
+    });
+
+    it('should not merge non-assistant consecutive messages', () => {
+        const messages: Message[] = [
+            { role: 'user', content: 'q1' },
+            { role: 'user', content: 'q2' },
+            { role: 'tool', content: 'result_a' },
+            { role: 'tool', content: 'result_b' }
+        ];
+        const result = model.callMergeConsecutiveAssistantMessages(messages);
+        expect(result).to.deep.equal(messages);
+    });
+});

--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -72,7 +72,9 @@ export class OllamaModel implements LanguageModel {
             model: this.model,
             ...this.DEFAULT_REQUEST_SETTINGS,
             ...settings,
-            messages: request.messages.map(m => this.toOllamaMessage(m)).filter(m => m !== undefined) as Message[],
+            messages: this.mergeConsecutiveAssistantMessages(
+                request.messages.map(m => this.toOllamaMessage(m)).filter((m): m is Message => m !== undefined)
+            ),
             tools: request.tools?.map(t => this.toOllamaTool(t)),
             stream
         };
@@ -454,6 +456,46 @@ export class OllamaModel implements LanguageModel {
             return undefined;
         }
 
+        return result;
+    }
+
+    protected mergeConsecutiveAssistantMessages(messages: Message[]): Message[] {
+        const result: Message[] = [];
+        for (const message of messages) {
+            const previous = result[result.length - 1];
+            if (previous?.role === 'assistant' && message.role === 'assistant') {
+                const merged: Message = { ...previous, role: 'assistant' };
+
+                const previousContent = previous.content;
+                const nextContent = message.content;
+                if (previousContent && nextContent) {
+                    merged.content = `${previousContent}\n${nextContent}`;
+                } else if (nextContent) {
+                    merged.content = nextContent;
+                } else if (previousContent) {
+                    merged.content = previousContent;
+                }
+
+                const previousThinking = previous.thinking;
+                const nextThinking = message.thinking;
+                if (previousThinking && nextThinking) {
+                    merged.thinking = `${previousThinking}\n${nextThinking}`;
+                } else if (nextThinking) {
+                    merged.thinking = nextThinking;
+                } else if (previousThinking) {
+                    merged.thinking = previousThinking;
+                }
+
+                const toolCalls = [...(previous.tool_calls ?? []), ...(message.tool_calls ?? [])];
+                if (toolCalls.length > 0) {
+                    merged.tool_calls = toolCalls;
+                }
+
+                result[result.length - 1] = merged;
+            } else {
+                result.push(message);
+            }
+        }
         return result;
     }
 

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -31,7 +31,7 @@ import { injectable } from '@theia/core/shared/inversify';
 import { OpenAI, AzureOpenAI } from 'openai';
 import { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
 import { RunnableToolFunctionWithoutParse } from 'openai/lib/RunnableFunction';
-import { ChatCompletionMessageParam } from 'openai/resources';
+import { ChatCompletionAssistantMessageParam, ChatCompletionMessageParam } from 'openai/resources';
 import { StreamingAsyncIterator } from './openai-streaming-iterator';
 import { OPENAI_PROVIDER_ID } from '../common';
 import type { FinalRequestOptions } from 'openai/internal/request-options';
@@ -368,7 +368,38 @@ export class OpenAiModelUtils {
         model?: string
     ): ChatCompletionMessageParam[] {
         const processed = this.processSystemMessages(messages, developerMessageSettings);
-        return processed.filter(m => m.type !== 'thinking').map(m => this.toOpenAIMessage(m, developerMessageSettings));
+        const converted = processed.filter(m => m.type !== 'thinking').map(m => this.toOpenAIMessage(m, developerMessageSettings));
+        return this.mergeConsecutiveAssistantMessages(converted);
+    }
+
+    protected mergeConsecutiveAssistantMessages(messages: ChatCompletionMessageParam[]): ChatCompletionMessageParam[] {
+        const result: ChatCompletionMessageParam[] = [];
+        for (const message of messages) {
+            const previous = result[result.length - 1];
+            if (previous?.role === 'assistant' && message.role === 'assistant') {
+                const merged: ChatCompletionAssistantMessageParam = { ...previous, role: 'assistant' };
+
+                const previousContent = typeof previous.content === 'string' ? previous.content : undefined;
+                const nextContent = typeof message.content === 'string' ? message.content : undefined;
+                if (previousContent && nextContent) {
+                    merged.content = `${previousContent}\n${nextContent}`;
+                } else if (nextContent) {
+                    merged.content = nextContent;
+                } else if (previousContent) {
+                    merged.content = previousContent;
+                }
+
+                const toolCalls = [...(previous.tool_calls ?? []), ...(message.tool_calls ?? [])];
+                if (toolCalls.length > 0) {
+                    merged.tool_calls = toolCalls;
+                }
+
+                result[result.length - 1] = merged;
+            } else {
+                result.push(message);
+            }
+        }
+        return result;
     }
 
 }

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -381,11 +381,11 @@ export class OpenAiModelUtils {
 
                 const previousContent = typeof previous.content === 'string' ? previous.content : undefined;
                 const nextContent = typeof message.content === 'string' ? message.content : undefined;
-                if (previousContent && nextContent) {
+                if (previousContent !== undefined && nextContent !== undefined) {
                     merged.content = `${previousContent}\n${nextContent}`;
-                } else if (nextContent) {
+                } else if (nextContent !== undefined) {
                     merged.content = nextContent;
-                } else if (previousContent) {
+                } else if (previousContent !== undefined) {
                     merged.content = previousContent;
                 }
 

--- a/packages/ai-openai/src/node/openai-model-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-model-utils.spec.ts
@@ -126,6 +126,103 @@ describe('OpenAiModelUtils - processMessages', () => {
         });
     });
 
+    describe('merging of consecutive assistant messages', () => {
+        it('should merge an assistant text message followed by an assistant tool_use into a single message', () => {
+            const messages: LanguageModelMessage[] = [
+                { actor: 'user', type: 'text', text: 'do something' },
+                { actor: 'ai', type: 'text', text: 'let me call a tool' },
+                { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: { x: 1 } }
+            ];
+            const result = utils.processMessages(messages, 'developer', 'gpt-4');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'do something' },
+                {
+                    role: 'assistant',
+                    content: 'let me call a tool',
+                    tool_calls: [{ id: 'call_1', function: { name: 'foo', arguments: JSON.stringify({ x: 1 }) }, type: 'function' }]
+                }
+            ]);
+        });
+
+        it('should merge multiple parallel assistant tool_use messages into a single message with multiple tool_calls', () => {
+            const messages: LanguageModelMessage[] = [
+                { actor: 'user', type: 'text', text: 'do parallel work' },
+                { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: { x: 1 } },
+                { actor: 'ai', type: 'tool_use', id: 'call_2', name: 'bar', input: { y: 2 } }
+            ];
+            const result = utils.processMessages(messages, 'developer', 'gpt-4');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'do parallel work' },
+                {
+                    role: 'assistant',
+                    tool_calls: [
+                        { id: 'call_1', function: { name: 'foo', arguments: JSON.stringify({ x: 1 }) }, type: 'function' },
+                        { id: 'call_2', function: { name: 'bar', arguments: JSON.stringify({ y: 2 }) }, type: 'function' }
+                    ]
+                }
+            ]);
+        });
+
+        it('should handle the bug scenario from issue #17104 (text+tool_use after a tool_result round-trip)', () => {
+            // Reproduces the role-alternation violation rejected by strict Jinja-template providers (e.g. llama.cpp serving Devstral).
+            const messages: LanguageModelMessage[] = [
+                { actor: 'user', type: 'text', text: 'first request' },
+                { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: {} },
+                { actor: 'user', type: 'tool_result', tool_use_id: 'call_1', name: 'foo', content: 'result_1' },
+                { actor: 'ai', type: 'text', text: 'follow-up reasoning' },
+                { actor: 'ai', type: 'tool_use', id: 'call_2', name: 'bar', input: {} }
+            ];
+            const result = utils.processMessages(messages, 'developer', 'gpt-4');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'first request' },
+                {
+                    role: 'assistant',
+                    tool_calls: [{ id: 'call_1', function: { name: 'foo', arguments: '{}' }, type: 'function' }]
+                },
+                { role: 'tool', tool_call_id: 'call_1', content: 'result_1' },
+                {
+                    role: 'assistant',
+                    content: 'follow-up reasoning',
+                    tool_calls: [{ id: 'call_2', function: { name: 'bar', arguments: '{}' }, type: 'function' }]
+                }
+            ]);
+            // Sanity check: no two consecutive assistant messages remain in the output.
+            for (let i = 1; i < result.length; i++) {
+                expect(result[i - 1].role === 'assistant' && result[i].role === 'assistant').to.equal(false);
+            }
+        });
+
+        it('should not merge non-adjacent assistant messages separated by a tool result', () => {
+            const messages: LanguageModelMessage[] = [
+                { actor: 'ai', type: 'tool_use', id: 'call_1', name: 'foo', input: {} },
+                { actor: 'user', type: 'tool_result', tool_use_id: 'call_1', name: 'foo', content: 'r' },
+                { actor: 'ai', type: 'text', text: 'final answer' }
+            ];
+            const result = utils.processMessages(messages, 'developer', 'gpt-4');
+            expect(result).to.deep.equal([
+                {
+                    role: 'assistant',
+                    tool_calls: [{ id: 'call_1', function: { name: 'foo', arguments: '{}' }, type: 'function' }]
+                },
+                { role: 'tool', tool_call_id: 'call_1', content: 'r' },
+                { role: 'assistant', content: 'final answer' }
+            ]);
+        });
+
+        it('should join multiple consecutive assistant text messages with a newline', () => {
+            const messages: LanguageModelMessage[] = [
+                { actor: 'user', type: 'text', text: 'q' },
+                { actor: 'ai', type: 'text', text: 'part one' },
+                { actor: 'ai', type: 'text', text: 'part two' }
+            ];
+            const result = utils.processMessages(messages, 'developer', 'gpt-4');
+            expect(result).to.deep.equal([
+                { role: 'user', content: 'q' },
+                { role: 'assistant', content: 'part one\npart two' }
+            ]);
+        });
+    });
+
     describe('role assignment for system messages when developerMessageSettings is one of the role strings', () => {
         it('should assign role as specified for a system message when developerMessageSettings is "user"', () => {
             const messages: LanguageModelMessage[] = [

--- a/packages/ai-vercel-ai/src/node/vercel-ai-language-model.spec.ts
+++ b/packages/ai-vercel-ai/src/node/vercel-ai-language-model.spec.ts
@@ -1,0 +1,89 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { LanguageModelMessage } from '@theia/ai-core';
+import { CoreMessage } from 'ai';
+import { VercelAiModel } from './vercel-ai-language-model';
+import { VercelAiLanguageModelFactory } from './vercel-ai-language-model-factory';
+
+class TestableVercelAiModel extends VercelAiModel {
+    constructor() {
+        super(
+            'test-id',
+            'test-model',
+            { status: 'ready' },
+            true,
+            false,
+            undefined,
+            new MockLogger(),
+            new VercelAiLanguageModelFactory(),
+            () => ({ provider: 'openai', apiKey: 'k' })
+        );
+    }
+
+    public callProcessMessages(messages: LanguageModelMessage[]): Array<CoreMessage> {
+        return this.processMessages(messages);
+    }
+}
+
+describe('VercelAiModel - processMessages', () => {
+    const model = new TestableVercelAiModel();
+
+    it('should merge consecutive assistant text messages with a newline separator', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'q' },
+            { actor: 'ai', type: 'text', text: 'part one' },
+            { actor: 'ai', type: 'text', text: 'part two' }
+        ];
+        const result = model.callProcessMessages(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'q' },
+            { role: 'assistant', content: 'part one\npart two' }
+        ]);
+    });
+
+    it('should leave alternating user/assistant messages unchanged', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'q1' },
+            { actor: 'ai', type: 'text', text: 'a1' },
+            { actor: 'user', type: 'text', text: 'q2' },
+            { actor: 'ai', type: 'text', text: 'a2' }
+        ];
+        const result = model.callProcessMessages(messages);
+        expect(result).to.deep.equal([
+            { role: 'user', content: 'q1' },
+            { role: 'assistant', content: 'a1' },
+            { role: 'user', content: 'q2' },
+            { role: 'assistant', content: 'a2' }
+        ]);
+    });
+
+    it('should reproduce the bug scenario from issue #17104 (consecutive ai messages)', () => {
+        const messages: LanguageModelMessage[] = [
+            { actor: 'user', type: 'text', text: 'first request' },
+            { actor: 'ai', type: 'text', text: 'reasoning' },
+            { actor: 'ai', type: 'text', text: 'final answer' }
+        ];
+        const result = model.callProcessMessages(messages);
+        for (let i = 1; i < result.length; i++) {
+            expect(result[i - 1].role === 'assistant' && result[i].role === 'assistant').to.equal(false);
+        }
+        expect(result).to.have.lengthOf(2);
+        expect(result[1]).to.deep.equal({ role: 'assistant', content: 'reasoning\nfinal answer' });
+    });
+});

--- a/packages/ai-vercel-ai/src/node/vercel-ai-language-model.ts
+++ b/packages/ai-vercel-ai/src/node/vercel-ai-language-model.ts
@@ -377,7 +377,7 @@ export class VercelAiModel implements LanguageModel {
     }
 
     protected processMessages(messages: LanguageModelMessage[]): Array<CoreMessage> {
-        return messages.map(message => {
+        const converted = messages.map(message => {
             const content = LanguageModelMessage.isTextMessage(message) ? message.text : '';
             let role: 'user' | 'assistant' | 'system';
             switch (message.actor) {
@@ -398,5 +398,31 @@ export class VercelAiModel implements LanguageModel {
                 content,
             };
         });
+        return this.mergeConsecutiveAssistantMessages(converted);
+    }
+
+    protected mergeConsecutiveAssistantMessages(messages: Array<CoreMessage>): Array<CoreMessage> {
+        const result: Array<CoreMessage> = [];
+        for (const message of messages) {
+            const previous = result[result.length - 1];
+            if (previous?.role === 'assistant' && message.role === 'assistant') {
+                const merged: CoreMessage = { ...previous, role: 'assistant' };
+
+                const previousContent = typeof previous.content === 'string' ? previous.content : undefined;
+                const nextContent = typeof message.content === 'string' ? message.content : undefined;
+                if (previousContent && nextContent) {
+                    merged.content = `${previousContent}\n${nextContent}`;
+                } else if (nextContent) {
+                    merged.content = nextContent;
+                } else if (previousContent) {
+                    merged.content = previousContent;
+                }
+
+                result[result.length - 1] = merged;
+            } else {
+                result.push(message);
+            }
+        }
+        return result;
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
A Theia AI turn with text plus tool calls translates to consecutive `assistant` messages, which strict Jinja chat templates (e.g. llama.cpp serving Devstral / Mistral-Small) reject. Squash them into a single assistant message carrying both `content` and `tool_calls`.

Fixes #17104
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check the steps in the initial ticket.
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
