### PR TITLE
fix(ai-anthropic): add display: 'summarized' to adaptive thinking block

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -457,7 +457,7 @@ describe('AnthropicModel', () => {
         it('maps level=minimal to effort=low', () => {
             const model = createReasoningModel('claude-opus-4-6', 'effort');
             const result = model.callGetSettings({ messages: [], reasoning: { level: 'minimal' } });
-            expect(result.thinking).to.deep.equal({ type: 'adaptive' });
+            expect(result.thinking).to.deep.equal({ type: 'adaptive', display: 'summarized' });
             expect(result.output_config).to.deep.equal({ effort: 'low' });
         });
         it('maps level=low to effort=medium', () => {
@@ -483,7 +483,7 @@ describe('AnthropicModel', () => {
         it('omits output_config on level=auto so the provider default applies', () => {
             const model = createReasoningModel('claude-opus-4-6', 'effort');
             const result = model.callGetSettings({ messages: [], reasoning: { level: 'auto' } });
-            expect(result.thinking).to.deep.equal({ type: 'adaptive' });
+            expect(result.thinking).to.deep.equal({ type: 'adaptive', display: 'summarized' });
             expect(result.output_config).to.equal(undefined);
         });
         it('omits thinking entirely when level=off', () => {

--- a/packages/ai-anthropic/src/node/anthropic-reasoning.ts
+++ b/packages/ai-anthropic/src/node/anthropic-reasoning.ts
@@ -40,7 +40,7 @@ export function anthropicReasoningFor(
         const effort = anthropicEffortForLevel(level, supportsXHighEffort);
         // On `auto`, omit `output_config` so Anthropic's own default applies.
         return {
-            thinking: { type: 'adaptive' },
+            thinking: { type: 'adaptive', display: 'summarized' },
             ...(effort ? { output_config: { effort } } : {})
         };
     }


### PR DESCRIPTION
#### What it does

Fixes #17428.

The Anthropic adaptive thinking API requires a `display` parameter on the `thinking` request fragment. We were emitting `{ "type": "adaptive" }` without it, which is rejected/handled inconsistently by the provider.

This PR updates `anthropicReasoningFor` (in `packages/ai-anthropic/src/node/anthropic-reasoning.ts`) to emit:

```json
{ "type": "adaptive", "display": "summarized" }
```

for the effort-based reasoning API used by Claude 4.6+ models. The legacy budget-based extended thinking branch (`type: "enabled"`) is unaffected.

#### How to test

1. Configure an Anthropic model that uses the effort-based reasoning API (e.g. Claude Opus 4.7).
2. Enable reasoning in the chat (any level other than `off`).
3. Send a prompt and verify the request no longer fails / behaves consistently.
4. Run `npm run test` in `packages/ai-anthropic` — the existing 26 tests pass, including the updated adaptive-thinking expectations that now assert the `display: 'summarized'` field.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)