### PR TITLE
fix(plugin-ext): guard tabs-main against untracked widget removal

### DIFF
--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -101,8 +101,10 @@ export class TabsMainImpl implements TabsMain, Disposable {
 
         this.connectToSignal(this.toDisposeOnDestroy, this.applicationShell.mainPanel.widgetRemoved, (mainPanel, widget) => {
             if (!(widget instanceof TabBar)) {
-                const tabInfo = this.getOrRebuildModel(this.tabInfoLookup, widget.title)!;
-                this.onTabClosed(tabInfo, widget.title);
+                const tabInfo = this.getOrRebuildModel(this.tabInfoLookup, widget.title);
+                if (tabInfo) {
+                    this.onTabClosed(tabInfo, widget.title);
+                }
                 if (this.tabGroupChanged) {
                     this.tabGroupChanged = false;
                     this.createTabsModel();
@@ -268,12 +270,12 @@ export class TabsMainImpl implements TabsMain, Disposable {
             a.id === b.id;
     }
 
-    protected getOrRebuildModel<T, R>(map: Map<T, R>, key: T): R {
+    protected getOrRebuildModel<T, R>(map: Map<T, R>, key: T): R | undefined {
         // something broke so we rebuild the model
         let item = map.get(key);
         if (!item) {
             this.createTabsModel();
-            item = map.get(key)!;
+            item = map.get(key);
         }
         return item;
     }
@@ -281,6 +283,9 @@ export class TabsMainImpl implements TabsMain, Disposable {
     // #region event listeners
     private onTabCreated(tabBar: TabBar<Widget>, args: TabBar.ITabActivateRequestedArgs<Widget>): void {
         const group = this.getOrRebuildModel(this.tabGroupModel, tabBar);
+        if (!group) {
+            return;
+        }
         this.connectToSignal(this.getTitleDisposables(args.title), args.title.changed, this.onTabTitleChanged);
         const tabDto = this.createTabDto(args.title, group.groupId, true);
         this.tabInfoLookup.set(args.title, { group, tab: tabDto, tabIndex: args.index });


### PR DESCRIPTION
#### What it does

Fixes a `TypeError: Cannot read properties of undefined (reading 'group')` thrown from `TabsMainImpl.onTabClosed` when the `mainPanel.widgetRemoved` signal fires for a widget whose `Title` is no longer (or was never) tracked in `tabInfoLookup`.

`TheiaDockPanel.onChildRemoved` calls `super.onChildRemoved` *before* emitting `widgetRemoved`, so by the time the listener runs, Lumino has already detached the title from its tab bar. When `getOrRebuildModel` then rebuilds the model from `mainAreaTabBars`, the removed title is no longer found, and the helper returns `undefined` — but its return type claimed it never could, masked by `!` non-null assertions both inside the helper and at the call site. `onTabClosed(undefined, ...)` then crashed.

This change:
- Makes `getOrRebuildModel`'s return type honest (`R | undefined`) and removes the misleading `!` inside it.
- Adds a null guard in the `widgetRemoved` listener (mirrors the pattern already used in `onTabTitleChanged`).
- Adds a null guard in `onTabCreated` for the same reason.
- Keeps the existing `!` assertion in `onTabMoved`, where the moved title is always live.

#### How to test

I do not have deterministic reproduction steps for this issue. The crash is timing- and state-dependent and was observed in the browser console while opening a workspace; it appears to be triggered when a widget is added and removed from the main panel during early layout/restore, before its title is registered in `tabInfoLookup`.

To verify the guard:
- Build and run the browser example
- Exercise normal tab open/close/move/drag flows and confirm no regression tabs API behavior (active tab, dirty/pinned/preview state, tab moves, group changes).
- A code-level smoke check: `getOrRebuildModel` now returns `R | undefined`, and TypeScript compilation across `@theia/plugin-ext` is clean.

If a reviewer can produce a reliable reproduction of the original crash, I am happy to add a regression scenario.

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no user-facing text in this change)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)