### PR TITLE
feat(ai-chat-ui): show description and arguments in tool confirmation

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -26,7 +26,7 @@ import { ResponseNode } from '../chat-tree-view';
 import { SubChatWidgetFactory } from '../chat-tree-view/sub-chat-widget';
 import { withToolCallConfirmation } from './tool-confirmation';
 import { extractJsonStringField } from './toolcall-utils';
-import { CompositeTreeNode, ContextMenuRenderer } from '@theia/core/lib/browser';
+import { CompositeTreeNode, ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
 import { ContributionProvider, DisposableCollection, nls } from '@theia/core';
 import * as React from '@theia/core/shared/react';
 
@@ -50,6 +50,9 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
 
     @inject(ContextMenuRenderer)
     protected contextMenuRenderer: ContextMenuRenderer;
+
+    @inject(OpenerService)
+    protected openerService: OpenerService;
 
     @inject(ContributionProvider) @named(ChatResponsePartRenderer)
     protected chatResponsePartRenderers: ContributionProvider<ChatResponsePartRenderer<ChatResponseContent>>;
@@ -106,6 +109,7 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
             toolRequest={toolRequest}
             chatId={chatId}
             requestCanceled={parentNode.response.isCanceled}
+            openerService={this.openerService}
         />;
     }
 }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -103,13 +103,16 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
             subChatWidgetFactory={this.subChatWidgetFactory}
             contextMenuRenderer={this.contextMenuRenderer}
             chatResponsePartRenderers={this.chatResponsePartRenderers}
-            response={response}
-            confirmationMode={confirmationMode}
-            toolConfirmationManager={this.toolConfirmationManager}
-            toolRequest={toolRequest}
-            chatId={chatId}
-            requestCanceled={parentNode.response.isCanceled}
-            openerService={this.openerService}
+            toolConfirmation={{
+                response,
+                confirmationMode,
+                toolConfirmationManager: this.toolConfirmationManager,
+                toolRequest,
+                chatId,
+                requestCanceled: parentNode.response.isCanceled,
+                contextMenuRenderer: this.contextMenuRenderer,
+                openerService: this.openerService
+            }}
         />;
     }
 }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -30,6 +30,21 @@ import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 import { OpenerService, open } from '@theia/core/lib/browser';
 import { URI } from '@theia/core';
 
+export interface MarkdownRenderProps {
+    text: string | MarkdownString;
+    openerService: OpenerService;
+    className?: string;
+}
+
+/**
+ * Renders the given markdown via {@link useMarkdownRendering} into a `<div>`.
+ * Shared component for use across chat response renderers.
+ */
+export const MarkdownRender: React.FC<MarkdownRenderProps> = ({ text, openerService, className }) => {
+    const ref = useMarkdownRendering(text, openerService);
+    return <div className={className} ref={ref}></div>;
+};
+
 @injectable()
 export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownChatResponseContent | InformationalChatResponseContent> {
     @inject(OpenerService) protected readonly openerService: OpenerService;
@@ -51,15 +66,9 @@ export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownCh
             return null;
         }
 
-        return <MarkdownRender response={response} openerService={this.openerService} />;
+        return <MarkdownRender text={response.content} openerService={this.openerService} />;
     }
 }
-
-const MarkdownRender = ({ response, openerService }: { response: MarkdownChatResponseContent | InformationalChatResponseContent; openerService: OpenerService }) => {
-    const ref = useMarkdownRendering(response.content, openerService);
-
-    return <div ref={ref}></div>;
-};
 
 export interface DeclaredEventsEventListenerObject extends EventListenerObject {
     handledEvents?: (keyof HTMLElementEventMap)[];

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.spec.ts
@@ -15,11 +15,12 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { ContextMenuRenderer } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
 import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ConfirmationScope, CountdownTimerProps, ToolConfirmationCallbacks, ToolConfirmationActionsProps, ToolConfirmationProps } from './tool-confirmation';
 
 const mockContextMenuRenderer = {} as ContextMenuRenderer;
+const mockOpenerService = {} as OpenerService;
 
 describe('Tool Confirmation Types', () => {
     describe('ConfirmationScope', () => {
@@ -118,6 +119,17 @@ describe('Tool Confirmation Types', () => {
                 contextMenuRenderer: mockContextMenuRenderer
             };
             expect(props.toolRequest).to.be.undefined;
+        });
+
+        it('should accept an optional openerService for rendering arguments', () => {
+            const props: ToolConfirmationProps = {
+                response: { kind: 'toolCall', id: 'test', name: 'test', arguments: '{"foo":"bar"}' } as ToolConfirmationProps['response'],
+                onAllow: () => { },
+                onDeny: () => { },
+                contextMenuRenderer: mockContextMenuRenderer,
+                openerService: mockOpenerService
+            };
+            expect(props.openerService).to.equal(mockOpenerService);
         });
     });
 });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.spec.ts
@@ -14,13 +14,31 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
 import { expect } from 'chai';
 import { ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
 import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
-import { ConfirmationScope, CountdownTimerProps, ToolConfirmationCallbacks, ToolConfirmationActionsProps, ToolConfirmationProps } from './tool-confirmation';
+import { ToolConfirmationMode as ToolConfirmationPreferenceMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
+import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { flushSync } from '@theia/core/shared/react-dom';
+import { createRoot } from '@theia/core/shared/react-dom/client';
+import * as React from '@theia/core/shared/react';
+import {
+    ConfirmationScope,
+    CountdownTimerProps,
+    ToolConfirmationCallbacks,
+    ToolConfirmationActionsProps,
+    ToolConfirmationProps,
+    withToolCallConfirmation
+} from './tool-confirmation';
 
 const mockContextMenuRenderer = {} as ContextMenuRenderer;
 const mockOpenerService = {} as OpenerService;
+
+disableJSDOM();
 
 describe('Tool Confirmation Types', () => {
     describe('ConfirmationScope', () => {
@@ -107,6 +125,50 @@ describe('Tool Confirmation Types', () => {
             const response = { kind: 'toolCall' } as ToolCallChatResponseContent;
             const props: CountdownTimerProps = { response };
             expect(props.response.confirmationTimeout).to.be.undefined;
+        });
+    });
+
+    describe('withToolCallConfirmation', () => {
+        before(() => {
+            disableJSDOM = enableJSDOM();
+        });
+
+        after(() => {
+            disableJSDOM();
+        });
+
+        it('should pass opener service through to the wrapped component', () => {
+            const Wrapped: React.FC<{ openerService: OpenerService }> = ({ openerService }) =>
+                React.createElement('span', undefined, openerService === mockOpenerService ? 'passed' : 'missing');
+            const WrappedWithConfirmation = withToolCallConfirmation(Wrapped);
+            const container = document.createElement('div');
+            const root = createRoot(container);
+            const response = {
+                kind: 'toolCall',
+                id: 'test',
+                name: 'test',
+                finished: true,
+                confirmed: Promise.resolve(true),
+                needsUserConfirmation: Promise.resolve(),
+                confirm: () => { },
+                deny: () => { }
+            } as ToolCallChatResponseContent;
+
+            flushSync(() => root.render(React.createElement(WrappedWithConfirmation, {
+                openerService: mockOpenerService,
+                toolConfirmation: {
+                    response,
+                    confirmationMode: ToolConfirmationPreferenceMode.CONFIRM,
+                    toolConfirmationManager: {} as ToolConfirmationManager,
+                    chatId: 'test-chat',
+                    requestCanceled: false,
+                    contextMenuRenderer: mockContextMenuRenderer,
+                    openerService: mockOpenerService
+                }
+            })));
+
+            expect(container.textContent).to.equal('passed');
+            root.unmount();
         });
     });
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.spec.ts
@@ -116,12 +116,13 @@ describe('Tool Confirmation Types', () => {
                 response: { kind: 'toolCall', id: 'test', name: 'test' } as ToolConfirmationProps['response'],
                 onAllow: () => { },
                 onDeny: () => { },
-                contextMenuRenderer: mockContextMenuRenderer
+                contextMenuRenderer: mockContextMenuRenderer,
+                openerService: mockOpenerService
             };
             expect(props.toolRequest).to.be.undefined;
         });
 
-        it('should accept an optional openerService for rendering arguments', () => {
+        it('should accept response arguments with an opener service', () => {
             const props: ToolConfirmationProps = {
                 response: { kind: 'toolCall', id: 'test', name: 'test', arguments: '{"foo":"bar"}' } as ToolConfirmationProps['response'],
                 onAllow: () => { },
@@ -129,6 +130,7 @@ describe('Tool Confirmation Types', () => {
                 contextMenuRenderer: mockContextMenuRenderer,
                 openerService: mockOpenerService
             };
+            expect(props.response.arguments).to.equal('{"foo":"bar"}');
             expect(props.openerService).to.equal(mockOpenerService);
         });
     });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -16,13 +16,15 @@
 
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core/lib/common/nls';
-import { codicon, ContextMenuRenderer } from '@theia/core/lib/browser';
+import { codicon, ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
 import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ToolRequest } from '@theia/ai-core';
 import { CommandMenu, ContextExpressionMatcher, MenuPath } from '@theia/core/lib/common/menu';
 import { GroupImpl } from '@theia/core/lib/browser/menu/composite-menu-node';
 import { ToolConfirmationMode as ToolConfirmationPreferenceMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { MarkdownRender } from './markdown-part-renderer';
+import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
 
 export interface CountdownTimerProps {
     response: ToolCallChatResponseContent;
@@ -430,9 +432,10 @@ export interface ToolConfirmationProps extends Pick<ToolConfirmationCallbacks, '
     onAllow: (scope?: ConfirmationScope) => void;
     onDeny: (scope?: ConfirmationScope, reason?: string) => void;
     contextMenuRenderer: ContextMenuRenderer;
+    openerService?: OpenerService;
 }
 
-export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, toolRequest, onAllow, onDeny, contextMenuRenderer }) => {
+export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, toolRequest, onAllow, onDeny, contextMenuRenderer, openerService }) => {
     const [state, setState] = React.useState<ToolConfirmationState>('waiting');
 
     const handleAllow = React.useCallback((scope: ConfirmationScope) => {
@@ -471,6 +474,14 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, to
                     <span className="label">{nls.localizeByDefault('Tool')}:</span>
                     <span className="value">{response.name}</span>
                 </div>
+                {toolRequest?.description && (
+                    <div className="theia-tool-confirmation-description">
+                        {toolRequest.description}
+                    </div>
+                )}
+                {openerService && (
+                    <ToolArgsDisplay args={response.arguments} openerService={openerService} />
+                )}
             </div>
             <ToolConfirmationActions
                 toolName={response.name ?? 'unknown'}
@@ -481,6 +492,33 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, to
             />
             <CountdownTimer response={response} />
         </div>
+    );
+};
+
+interface ToolArgsDisplayProps {
+    args: string | undefined;
+    openerService: OpenerService;
+}
+
+const ToolArgsDisplay: React.FC<ToolArgsDisplayProps> = ({ args, openerService }) => {
+    const hasArgs = !!args && !!args.trim() && args.trim() !== '{}';
+    if (!hasArgs) {
+        // eslint-disable-next-line no-null/no-null
+        return null;
+    }
+    const summaryLabel = condenseArguments(args!) ?? '\u2026';
+    return (
+        <details className="theia-tool-confirmation-args">
+            <summary>
+                <span className="label">{nls.localizeByDefault('Arguments')}:</span>
+                <span className="theia-tool-confirmation-args-summary">{summaryLabel}</span>
+            </summary>
+            <MarkdownRender
+                text={formatArgsForTooltip(args!)}
+                openerService={openerService}
+                className="theia-tool-confirmation-args-content"
+            />
+        </details>
     );
 };
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -464,20 +464,28 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, to
         );
     }
 
+    const toolNameContent = (
+        <>
+            <span className="label">{nls.localizeByDefault('Tool')}:</span>
+            <span className="value">{response.name}</span>
+        </>
+    );
+
     return (
         <div className="theia-tool-confirmation">
             <div className="theia-tool-confirmation-header">
                 <span className={codicon('shield')}></span> {nls.localize('theia/ai/chat-ui/toolconfirmation/header', 'Confirm Tool Execution')}
             </div>
             <div className="theia-tool-confirmation-info">
-                <div className="theia-tool-confirmation-name">
-                    <span className="label">{nls.localizeByDefault('Tool')}:</span>
-                    <span className="value">{response.name}</span>
-                </div>
-                {toolRequest?.description && (
-                    <div className="theia-tool-confirmation-description">
-                        {toolRequest.description}
-                    </div>
+                {toolRequest?.description ? (
+                    <details className="theia-tool-confirmation-name">
+                        <summary>{toolNameContent}</summary>
+                        <div className="theia-tool-confirmation-description">
+                            {toolRequest.description}
+                        </div>
+                    </details>
+                ) : (
+                    <div className="theia-tool-confirmation-name">{toolNameContent}</div>
                 )}
                 <ToolArgsDisplay args={response.arguments} openerService={openerService} />
             </div>
@@ -508,7 +516,6 @@ const ToolArgsDisplay: React.FC<ToolArgsDisplayProps> = ({ args, openerService }
     return (
         <details className="theia-tool-confirmation-args">
             <summary>
-                <span className={`${codicon('chevron-right')} theia-tool-confirmation-args-toggle`}></span>
                 <span className="label">{nls.localizeByDefault('Arguments')}:</span>
                 <span className="theia-tool-confirmation-args-summary">{summaryLabel}</span>
             </summary>

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -543,8 +543,12 @@ export interface WithToolCallConfirmationProps {
 
 export function withToolCallConfirmation<P extends object>(
     WrappedComponent: React.ComponentType<P>
-): React.FC<P & WithToolCallConfirmationProps> {
-    const WithConfirmation: React.FC<P & WithToolCallConfirmationProps> = props => {
+): React.FC<P & { toolConfirmation: WithToolCallConfirmationProps }> {
+    const WithConfirmation: React.FC<P & { toolConfirmation: WithToolCallConfirmationProps }> = props => {
+        const {
+            toolConfirmation,
+            ...componentProps
+        } = props;
         const {
             response,
             confirmationMode,
@@ -555,9 +559,8 @@ export function withToolCallConfirmation<P extends object>(
             showArgsTooltip,
             requestCanceled,
             contextMenuRenderer,
-            openerService,
-            ...componentProps
-        } = props;
+            openerService
+        } = toolConfirmation;
 
         const { confirmationState } = useToolConfirmationState(response, confirmationMode);
         const pendingRef = React.useRef<HTMLElement | undefined>(undefined);

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -432,7 +432,7 @@ export interface ToolConfirmationProps extends Pick<ToolConfirmationCallbacks, '
     onAllow: (scope?: ConfirmationScope) => void;
     onDeny: (scope?: ConfirmationScope, reason?: string) => void;
     contextMenuRenderer: ContextMenuRenderer;
-    openerService?: OpenerService;
+    openerService: OpenerService;
 }
 
 export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, toolRequest, onAllow, onDeny, contextMenuRenderer, openerService }) => {
@@ -479,9 +479,7 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, to
                         {toolRequest.description}
                     </div>
                 )}
-                {openerService && (
-                    <ToolArgsDisplay args={response.arguments} openerService={openerService} />
-                )}
+                <ToolArgsDisplay args={response.arguments} openerService={openerService} />
             </div>
             <ToolConfirmationActions
                 toolName={response.name ?? 'unknown'}
@@ -501,20 +499,21 @@ interface ToolArgsDisplayProps {
 }
 
 const ToolArgsDisplay: React.FC<ToolArgsDisplayProps> = ({ args, openerService }) => {
-    const hasArgs = !!args && !!args.trim() && args.trim() !== '{}';
-    if (!hasArgs) {
+    const trimmedArgs = args?.trim();
+    if (!trimmedArgs || trimmedArgs === '{}') {
         // eslint-disable-next-line no-null/no-null
         return null;
     }
-    const summaryLabel = condenseArguments(args!) ?? '\u2026';
+    const summaryLabel = condenseArguments(trimmedArgs) ?? '\u2026';
     return (
         <details className="theia-tool-confirmation-args">
             <summary>
+                <span className={`${codicon('chevron-right')} theia-tool-confirmation-args-toggle`}></span>
                 <span className="label">{nls.localizeByDefault('Arguments')}:</span>
                 <span className="theia-tool-confirmation-args-summary">{summaryLabel}</span>
             </summary>
             <MarkdownRender
-                text={formatArgsForTooltip(args!)}
+                text={formatArgsForTooltip(trimmedArgs)}
                 openerService={openerService}
                 className="theia-tool-confirmation-args-content"
             />
@@ -532,6 +531,7 @@ export interface WithToolCallConfirmationProps {
     showArgsTooltip?: (response: ToolCallChatResponseContent, target: HTMLElement | undefined) => void;
     requestCanceled: boolean;
     contextMenuRenderer: ContextMenuRenderer;
+    openerService: OpenerService;
 }
 
 export function withToolCallConfirmation<P extends object>(
@@ -548,6 +548,7 @@ export function withToolCallConfirmation<P extends object>(
             showArgsTooltip,
             requestCanceled,
             contextMenuRenderer,
+            openerService,
             ...componentProps
         } = props;
 
@@ -610,6 +611,7 @@ export function withToolCallConfirmation<P extends object>(
                     onAllow={handleAllow}
                     onDeny={handleDeny}
                     contextMenuRenderer={contextMenuRenderer}
+                    openerService={openerService}
                 />
             );
         }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -24,7 +24,7 @@ import * as React from '@theia/core/shared/react';
 import { createConfirmationHandlers, ToolConfirmation, useToolConfirmationState } from './tool-confirmation';
 import { ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ResponseNode } from '../chat-tree-view';
-import { useMarkdownRendering } from './markdown-part-renderer';
+import { MarkdownRender } from './markdown-part-renderer';
 import { ToolCallResult, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
 import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
@@ -67,6 +67,7 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
             onAllow={handleAllow}
             onDeny={handleDeny}
             contextMenuRenderer={this.contextMenuRenderer}
+            openerService={this.openerService}
         />;
     }
 
@@ -84,7 +85,8 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
             showArgsTooltip={this.showArgsTooltip.bind(this)}
             responseRenderer={this.renderResult.bind(this)}
             requestCanceled={parentNode.response.isCanceled}
-            contextMenuRenderer={this.contextMenuRenderer} />;
+            contextMenuRenderer={this.contextMenuRenderer}
+            openerService={this.openerService} />;
     }
 
     protected renderResult(response: ToolCallChatResponseContent): ReactNode {
@@ -185,6 +187,7 @@ interface ToolCallContentProps {
     responseRenderer: (response: ToolCallChatResponseContent) => ReactNode | undefined;
     requestCanceled: boolean;
     contextMenuRenderer: ContextMenuRenderer;
+    openerService: OpenerService;
 }
 
 /**
@@ -200,7 +203,8 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
     getArgumentsLabel,
     requestCanceled,
     showArgsTooltip,
-    contextMenuRenderer
+    contextMenuRenderer,
+    openerService
 }) => {
     const { confirmationState, rejectionReason } = useToolConfirmationState(response, confirmationMode);
     const summaryRef = React.useRef<HTMLElement | undefined>(undefined);
@@ -290,14 +294,10 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
                         onAllow={handleAllow}
                         onDeny={handleDeny}
                         contextMenuRenderer={contextMenuRenderer}
+                        openerService={openerService}
                     />
                 </span>
             )}
         </div>
     );
-};
-
-const MarkdownRender = ({ text, openerService }: { text: string; openerService: OpenerService }) => {
-    const ref = useMarkdownRendering(text, openerService);
-    return <div ref={ref}></div>;
 };

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1019,6 +1019,65 @@ div:last-child>.theia-ChatNode {
   overflow: auto;
 }
 
+.theia-tool-confirmation-description {
+  margin: 6px 0 8px 0;
+  color: var(--theia-descriptionForeground);
+  font-style: italic;
+}
+
+details.theia-tool-confirmation-args {
+  margin: 4px 0;
+}
+
+details.theia-tool-confirmation-args>summary {
+  cursor: pointer;
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  user-select: none;
+}
+
+details.theia-tool-confirmation-args>summary .label {
+  font-weight: bold;
+}
+
+.theia-tool-confirmation-args-summary {
+  color: var(--theia-descriptionForeground);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+  flex: 1;
+}
+
+.theia-tool-confirmation-args-content {
+  margin: 4px 0;
+  padding: 8px;
+  background-color: var(--theia-editor-background);
+  border: 1px solid var(--theia-dropdown-border);
+  border-radius: 3px;
+  max-height: 200px;
+  overflow: auto;
+  font-size: var(--theia-ui-font-size1);
+}
+
+.theia-tool-confirmation-args-content p {
+  margin: 4px 0;
+}
+
+.theia-tool-confirmation-args-content pre {
+  margin: 4px 0;
+  padding: 6px;
+  background-color: var(--theia-editorWidget-background);
+  border-radius: 3px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.theia-tool-confirmation-args-content code {
+  word-break: break-word;
+}
+
 .theia-tool-confirmation-actions {
   display: flex;
   justify-content: flex-end;

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1138,13 +1138,13 @@ details.theia-tool-confirmation-args>summary::marker {
 }
 
 .theia-tool-confirmation-status.allowed {
-  background-color: var(--theia-successBackground);
-  color: var(--theia-successForeground);
+  border-color: var(--theia-successBackground);
+  color: var(--theia-successBackground);
 }
 
 .theia-tool-confirmation-status.denied {
-  background-color: var(--theia-errorBackground);
-  color: var(--theia-errorForeground);
+  border-color: var(--theia-errorBackground);
+  color: var(--theia-errorBackground);
 }
 
 .theia-toolCall-denied,

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1010,35 +1010,31 @@ div:last-child>.theia-ChatNode {
   margin-right: 6px;
 }
 
-.theia-tool-confirmation-args pre.value {
-  margin: 6px 0;
-  padding: 8px;
-  background-color: var(--theia-editor-background);
-  border-radius: 3px;
-  max-height: 150px;
-  overflow: auto;
-}
-
 .theia-tool-confirmation-description {
   margin: 6px 0 8px 0;
   color: var(--theia-descriptionForeground);
-  font-style: italic;
-}
-
-details.theia-tool-confirmation-args {
-  margin: 4px 0;
+  font-weight: normal;
 }
 
 details.theia-tool-confirmation-args>summary {
   cursor: pointer;
   display: flex;
-  align-items: baseline;
+  align-items: center;
   gap: 6px;
   user-select: none;
 }
 
-details.theia-tool-confirmation-args>summary .label {
-  font-weight: bold;
+details.theia-tool-confirmation-args>summary::marker,
+details.theia-tool-confirmation-args>summary::-webkit-details-marker {
+  display: none;
+}
+
+.theia-tool-confirmation-args-toggle {
+  font-size: var(--theia-ui-font-size0);
+}
+
+details.theia-tool-confirmation-args[open] .theia-tool-confirmation-args-toggle {
+  transform: rotate(90deg);
 }
 
 .theia-tool-confirmation-args-summary {
@@ -1051,37 +1047,41 @@ details.theia-tool-confirmation-args>summary .label {
 }
 
 .theia-tool-confirmation-args-content {
-  margin: 4px 0;
-  padding: 8px;
-  background-color: var(--theia-editor-background);
-  border: 1px solid var(--theia-dropdown-border);
-  border-radius: 3px;
+  margin: var(--theia-ui-padding) 0;
+  padding: var(--theia-ui-padding) calc(var(--theia-ui-padding) * 2);
   max-height: 200px;
   overflow: auto;
-  font-size: var(--theia-ui-font-size1);
 }
 
 .theia-tool-confirmation-args-content p {
-  margin: 4px 0;
+  margin: var(--theia-ui-padding) 0;
 }
 
 .theia-tool-confirmation-args-content pre {
-  margin: 4px 0;
-  padding: 6px;
-  background-color: var(--theia-editorWidget-background);
+  margin: var(--theia-ui-padding) 0;
+  padding: var(--theia-ui-padding) calc(var(--theia-ui-padding) * 2);
+  background-color: var(--theia-textCodeBlock-background);
   border-radius: 3px;
   white-space: pre-wrap;
   word-break: break-word;
+  font-weight: normal;
 }
 
 .theia-tool-confirmation-args-content code {
   word-break: break-word;
+  font-weight: normal;
+}
+
+.theia-tool-confirmation-args-content hr {
+  border-top: 1px solid var(--theia-editorHoverWidgetInternalBorder);
+  border-bottom: 0;
+  margin: var(--theia-ui-padding) 0;
 }
 
 .theia-tool-confirmation-actions {
   display: flex;
   justify-content: flex-end;
-  gap: 0;
+  gap: 8px;
 }
 
 .theia-tool-confirmation-split-button {
@@ -1139,62 +1139,17 @@ details.theia-tool-confirmation-args>summary .label {
 
 .theia-tool-confirmation-status {
   margin: 10px 0;
-  padding: 12px;
+  padding: 8px;
   border: 1px solid var(--theia-dropdown-border);
   border-radius: 4px;
   background-color: var(--theia-editorWidget-background);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.14);
-}
-
-.theia-tool-confirmation-header {
-  font-weight: bold;
-  margin-bottom: 8px;
-  color: var(--theia-foreground);
   display: flex;
   align-items: center;
   gap: 6px;
 }
 
-.theia-tool-confirmation-info {
-  margin-bottom: 12px;
-}
-
-.theia-tool-confirmation-name,
-.theia-tool-confirmation-args {
-  margin-bottom: 4px;
-}
-
-.theia-tool-confirmation-name .label,
-.theia-tool-confirmation-args .label {
-  font-weight: bold;
-  margin-right: 6px;
-}
-
-.theia-tool-confirmation-args pre.value {
-  margin: 6px 0;
-  padding: 8px;
-  background-color: var(--theia-editor-background);
-  border-radius: 3px;
-  max-height: 150px;
-  overflow: auto;
-}
-
-.theia-tool-confirmation-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-
-.theia-tool-confirmation-status {
-  padding: 8px;
-  margin: 10px 0;
-  border-radius: 4px;
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.theia-tool-confirmation-status.approved {
+.theia-tool-confirmation-status.allowed {
   background-color: var(--theia-successBackground);
   color: var(--theia-successForeground);
 }

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -984,6 +984,7 @@ div:last-child>.theia-ChatNode {
   border-radius: 4px;
   background-color: var(--theia-editorWidget-background);
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.14);
+  cursor: default;
 }
 
 .theia-tool-confirmation-header {
@@ -1014,36 +1015,23 @@ div:last-child>.theia-ChatNode {
   margin: 6px 0 8px 0;
   color: var(--theia-descriptionForeground);
   font-weight: normal;
+  max-height: 200px;
+  overflow: auto;
 }
 
+details.theia-tool-confirmation-name>summary,
 details.theia-tool-confirmation-args>summary {
   cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 6px;
   user-select: none;
 }
 
-details.theia-tool-confirmation-args>summary::marker,
-details.theia-tool-confirmation-args>summary::-webkit-details-marker {
-  display: none;
-}
-
-.theia-tool-confirmation-args-toggle {
-  font-size: var(--theia-ui-font-size0);
-}
-
-details.theia-tool-confirmation-args[open] .theia-tool-confirmation-args-toggle {
-  transform: rotate(90deg);
+details.theia-tool-confirmation-name>summary::marker,
+details.theia-tool-confirmation-args>summary::marker {
+  color: var(--theia-button-background);
 }
 
 .theia-tool-confirmation-args-summary {
   color: var(--theia-descriptionForeground);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  min-width: 0;
-  flex: 1;
 }
 
 .theia-tool-confirmation-args-content {

--- a/packages/ai-ide/src/browser/todo-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/todo-tool-renderer.tsx
@@ -120,14 +120,16 @@ export class TodoToolRenderer implements ChatResponsePartRenderer<ToolCallChatRe
         return (
             <TodoListWithConfirmation
                 todos={todos}
-                response={response}
-                confirmationMode={confirmationMode}
-                toolConfirmationManager={this.toolConfirmationManager}
-                toolRequest={toolRequest}
-                chatId={chatId}
-                requestCanceled={parentNode.response.isCanceled}
-                contextMenuRenderer={this.contextMenuRenderer}
-                openerService={this.openerService}
+                toolConfirmation={{
+                    response,
+                    confirmationMode,
+                    toolConfirmationManager: this.toolConfirmationManager,
+                    toolRequest,
+                    chatId,
+                    requestCanceled: parentNode.response.isCanceled,
+                    contextMenuRenderer: this.contextMenuRenderer,
+                    openerService: this.openerService
+                }}
             />
         );
     }

--- a/packages/ai-ide/src/browser/todo-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/todo-tool-renderer.tsx
@@ -20,7 +20,7 @@ import { ResponseNode } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { ChatResponseContent, ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ReactNode } from '@theia/core/shared/react';
 import * as React from '@theia/core/shared/react';
-import { codicon, ContextMenuRenderer } from '@theia/core/lib/browser';
+import { codicon, ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
 import { nls } from '@theia/core';
 import { TODO_WRITE_FUNCTION_ID, TodoItem, isValidTodoItem } from '../common/todo-tool';
 import { withToolCallConfirmation } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/tool-confirmation';
@@ -89,6 +89,9 @@ export class TodoToolRenderer implements ChatResponsePartRenderer<ToolCallChatRe
     @inject(ContextMenuRenderer)
     protected contextMenuRenderer: ContextMenuRenderer;
 
+    @inject(OpenerService)
+    protected openerService: OpenerService;
+
     @inject(ToolInvocationRegistry)
     protected toolInvocationRegistry: ToolInvocationRegistry;
 
@@ -124,6 +127,7 @@ export class TodoToolRenderer implements ChatResponsePartRenderer<ToolCallChatRe
                 chatId={chatId}
                 requestCanceled={parentNode.response.isCanceled}
                 contextMenuRenderer={this.contextMenuRenderer}
+                openerService={this.openerService}
             />
         );
     }

--- a/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
@@ -218,8 +218,8 @@ const UserInteractionComponent: React.FC<UserInteractionComponentProps> = ({
                     // from a "waiting" state and is treated as canceled.
                     const status: 'completed' | 'canceled' | 'waiting' =
                         result?.completed === true ? 'completed' :
-                        result?.completed === false || canceled || restoredWithoutResult ? 'canceled' :
-                        'waiting';
+                            result?.completed === false || canceled || restoredWithoutResult ? 'canceled' :
+                                'waiting';
                     if (status === 'completed') {
                         return (
                             <span className='user-interaction-tool status completed'>
@@ -518,13 +518,16 @@ export class UserInteractionToolRenderer implements ChatResponsePartRenderer<Too
                 responseComplete={parentNode.response.isComplete}
                 result={parseUserInteractionResult(response.result)}
                 openerService={this.openerService}
-                response={response}
-                confirmationMode={confirmationMode}
-                toolConfirmationManager={this.toolConfirmationManager}
-                toolRequest={toolRequest}
-                chatId={chatId}
-                requestCanceled={parentNode.response.isCanceled}
-                contextMenuRenderer={this.contextMenuRenderer}
+                toolConfirmation={{
+                    response,
+                    confirmationMode,
+                    toolConfirmationManager: this.toolConfirmationManager,
+                    toolRequest,
+                    chatId,
+                    requestCanceled: parentNode.response.isCanceled,
+                    contextMenuRenderer: this.contextMenuRenderer,
+                    openerService: this.openerService
+                }}
             />
         );
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

The generic tool confirmation previously only displayed the tool name, leaving users without enough context for an informed decision. For tools like the GitHub MCP create-pull-request tool, key fields such as title, body, and target repo were hidden — effectively a "blind flight".

The confirmation now also shows:
- The tool's description (from ToolRequest.description) when available
- A collapsible <details> block for the arguments. The summary line shows a condensed one-line preview (via the existing condenseArguments helper); expanding it reveals the full, formatted arguments rendered through the same MarkdownRender pipeline used by the args hover tooltip.

Also consolidated the duplicated local MarkdownRender consts from toolcall-part-renderer.tsx and markdown-part-renderer.tsx into a single shared, exported component in markdown-part-renderer.tsx.

Fixes #17432

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Trigger any tool call that is set to confirmed and which has some arguments, eg the writeTool.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
