### PR TITLE
fix(core): escape backticks in MarkdownStringImpl.appendCodeblock

### DIFF
--- a/packages/core/src/common/markdown-rendering/markdown-string.spec.ts
+++ b/packages/core/src/common/markdown-rendering/markdown-string.spec.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { MarkdownStringImpl } from './markdown-string';
+
+describe('MarkdownStringImpl#appendCodeblock', () => {
+
+    it('uses a triple-backtick fence for code without backticks', () => {
+        const md = new MarkdownStringImpl();
+        md.appendCodeblock('json', '{ "type": "adaptive" }');
+        expect(md.value).to.equal('\n```json\n{ "type": "adaptive" }\n```\n');
+    });
+
+    it('uses a longer fence when the code contains a triple-backtick run', () => {
+        const md = new MarkdownStringImpl();
+        const code = 'before\n```json\n{ "x": 1 }\n```\nafter';
+        md.appendCodeblock('', code);
+        // The fence must be at least 4 backticks so the inner ``` cannot close it.
+        expect(md.value).to.equal('\n````\n' + code + '\n````\n');
+    });
+
+    it('grows the fence to be longer than the longest backtick run inside the code', () => {
+        const md = new MarkdownStringImpl();
+        const code = 'a ```` b ``` c';
+        md.appendCodeblock('', code);
+        // Longest run is 4, so fence must be 5.
+        expect(md.value).to.equal('\n`````\n' + code + '\n`````\n');
+    });
+
+    it('still uses a triple-backtick fence when only single/double backticks appear', () => {
+        const md = new MarkdownStringImpl();
+        const code = 'inline `code` and ``double`` only';
+        md.appendCodeblock('', code);
+        expect(md.value).to.equal('\n```\n' + code + '\n```\n');
+    });
+});

--- a/packages/core/src/common/markdown-rendering/markdown-string.spec.ts
+++ b/packages/core/src/common/markdown-rendering/markdown-string.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/core/src/common/markdown-rendering/markdown-string.ts
+++ b/packages/core/src/common/markdown-rendering/markdown-string.ts
@@ -90,12 +90,34 @@ export class MarkdownStringImpl implements MarkdownString {
     }
 
     appendCodeblock(langId: string, code: string): MarkdownStringImpl {
-        this.value += '\n```';
+        // Use a fence longer than any run of backticks in the code so that triple-backtick
+        // sequences inside `code` cannot prematurely close the surrounding fenced block.
+        const fence = '`'.repeat(Math.max(3, MarkdownStringImpl._longestBacktickRun(code) + 1));
+        this.value += '\n';
+        this.value += fence;
         this.value += langId;
         this.value += '\n';
         this.value += code;
-        this.value += '\n```\n';
+        this.value += '\n';
+        this.value += fence;
+        this.value += '\n';
         return this;
+    }
+
+    private static _longestBacktickRun(value: string): number {
+        let longest = 0;
+        let current = 0;
+        for (let i = 0; i < value.length; i++) {
+            if (value.charCodeAt(i) === 96 /* ` */) {
+                current++;
+                if (current > longest) {
+                    longest = current;
+                }
+            } else {
+                current = 0;
+            }
+        }
+        return longest;
     }
 
     appendLink(target: UriComponents | string, label: string, title?: string): MarkdownStringImpl {

--- a/packages/core/src/common/markdown-rendering/markdown-string.ts
+++ b/packages/core/src/common/markdown-rendering/markdown-string.ts
@@ -92,7 +92,7 @@ export class MarkdownStringImpl implements MarkdownString {
     appendCodeblock(langId: string, code: string): MarkdownStringImpl {
         // Use a fence longer than any run of backticks in the code so that triple-backtick
         // sequences inside `code` cannot prematurely close the surrounding fenced block.
-        const fence = '`'.repeat(Math.max(3, MarkdownStringImpl._longestBacktickRun(code) + 1));
+        const fence = '`'.repeat(Math.max(3, MarkdownStringImpl.longestBacktickRun(code) + 1));
         this.value += '\n';
         this.value += fence;
         this.value += langId;
@@ -104,7 +104,7 @@ export class MarkdownStringImpl implements MarkdownString {
         return this;
     }
 
-    private static _longestBacktickRun(value: string): number {
+    private static longestBacktickRun(value: string): number {
         let longest = 0;
         let current = 0;
         for (let i = 0; i < value.length; i++) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The hardcoded triple-backtick fence in `appendCodeblock` was prematurely closed when the code value itself contained a ``` sequence (e.g. a fenced code block inside a PR body passed as a tool argument). markdown-it then rendered only the part of the value after the inner fence, while the beginning was lost and subsequent markdown output got corrupted.

Compute a fence longer than any consecutive backtick run inside the code (minimum 3) so that inner ``` sequences can no longer close the outer fence.

Fixes #17430
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Configure the GitHub MCP server in Theia AI settings.
Ask the AI to create a PR with a body that includes a fenced code block, e.g.:
Create a PR titled "Test" in repo X/Y. Use this body:

Description.

\`\`\`json { "example": true } \`\`\`

End.

Wait for the tool-call summary in the chat, hover over it, and inspect the args tooltip.

Before the fix: the tooltip's body value is partially rendered as code, then the inner \`\`\` "leaks", so you see `#### How to test` rendered as a heading and other content not formatted as code. Some leading lines are missing.
After the fix: the entire body value renders as one continuous code block, with the inner \`\`\`json shown as literal text inside the block. No missing lines, no leaked headings.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
