### PR TITLE
ai-chat: drive token usage indicator from the active model's context window

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -242,6 +242,7 @@
     "dev-packages/ffmpeg": {
       "name": "@theia/ffmpeg",
       "version": "1.71.0",
+      "hasInstallScript": true,
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@electron/get": "^2.0.3",
@@ -2798,29 +2799,6 @@
         "@shikijs/themes": "^3.23.0",
         "@shikijs/types": "^3.23.0",
         "@shikijs/vscode-textmate": "^10.0.2"
-      }
-    },
-    "node_modules/@google/genai": {
-      "version": "1.47.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.47.0.tgz",
-      "integrity": "sha512-0VV7AaXm5rQu3oRHNZNEubRAOL2lv5u+YA72eWnDwcOx3B1jFRbvtgL4drRHlocRHOnludvr3xmbQGbR+/RQAQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "google-auth-library": "^10.3.0",
-        "p-retry": "^4.6.2",
-        "protobufjs": "^7.5.4",
-        "ws": "^8.18.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "@modelcontextprotocol/sdk": "^1.25.2"
-      },
-      "peerDependenciesMeta": {
-        "@modelcontextprotocol/sdk": {
-          "optional": true
-        }
       }
     },
     "node_modules/@grpc/grpc-js": {
@@ -29540,7 +29518,7 @@
       "version": "1.71.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.65.0",
+        "@anthropic-ai/sdk": "^0.92.0",
         "@theia/ai-core": "1.71.0",
         "@theia/core": "1.71.0"
       },
@@ -29549,9 +29527,9 @@
       }
     },
     "packages/ai-anthropic/node_modules/@anthropic-ai/sdk": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.65.0.tgz",
-      "integrity": "sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==",
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -29766,12 +29744,36 @@
       "version": "1.71.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
-        "@google/genai": "^1.47.0",
+        "@google/genai": "^1.51.0",
         "@theia/ai-core": "1.71.0",
         "@theia/core": "1.71.0"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.71.0"
+      }
+    },
+    "packages/ai-google/node_modules/@google/genai": {
+      "version": "1.51.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.51.0.tgz",
+      "integrity": "sha512-vTZZF3CSimN7cn2zsLpW2p5WF0eZa5Gz69ITMPCNHpPrDlAstOfGifSfi0p/s9Z9400f7xJRkgvkQNrcM7pJ6w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
       }
     },
     "packages/ai-history": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30452,7 +30452,7 @@
       "version": "1.71.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
-        "@anthropic-ai/sdk": "^0.65.0",
+        "@anthropic-ai/sdk": "^0.92.0",
         "@theia/ai-core": "1.71.0",
         "@theia/core": "1.71.0"
       },
@@ -30461,9 +30461,9 @@
       }
     },
     "packages/ai-anthropic/node_modules/@anthropic-ai/sdk": {
-      "version": "0.65.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.65.0.tgz",
-      "integrity": "sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==",
+      "version": "0.92.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.92.0.tgz",
+      "integrity": "sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==",
       "license": "MIT",
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"

--- a/packages/ai-anthropic/package.json
+++ b/packages/ai-anthropic/package.json
@@ -3,7 +3,7 @@
   "version": "1.71.0",
   "description": "Theia - Anthropic Integration",
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.65.0",
+    "@anthropic-ai/sdk": "^0.92.0",
     "@theia/ai-core": "1.71.0",
     "@theia/core": "1.71.0"
   },

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -16,52 +16,12 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { ReasoningApi, ReasoningSupport } from '@theia/ai-core';
 import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../common';
 import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF } from '../common/anthropic-preferences';
 import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES } from '@theia/ai-core/lib/common/ai-core-preferences';
 import { PreferenceService } from '@theia/core';
 
 const ANTHROPIC_PROVIDER_ID = 'anthropic';
-
-// Model-specific maxTokens values
-const DEFAULT_MODEL_MAX_TOKENS: Record<string, number> = {
-    'claude-3-opus-latest': 4096,
-    'claude-3-5-haiku-latest': 8192,
-    'claude-3-5-sonnet-latest': 8192,
-    'claude-3-7-sonnet-latest': 64000,
-    'claude-opus-4-20250514': 32000,
-    'claude-sonnet-4-20250514': 64000,
-    'claude-sonnet-4-5': 64000,
-    'claude-sonnet-4-6': 64000,
-    'claude-sonnet-4-0': 64000,
-    'claude-opus-4-5': 64000,
-    'claude-opus-4-6': 128000,
-    'claude-opus-4-7': 128000,
-    'claude-opus-4-1': 32000
-};
-
-/** Claude 4.6+ (Opus/Sonnet/Haiku) use the adaptive thinking API. */
-const EFFORT_REASONING = /^claude-(?:opus|sonnet|haiku)-4-[6-9]/i;
-/** Claude 4.0–4.5 (including dated snapshots) use legacy extended thinking. */
-const BUDGET_REASONING = /^claude-(?:opus|sonnet|haiku)-4-(?:[0-5](?:-|$)|\d{4})/i;
-/** Models that accept the `xhigh` effort value. */
-const XHIGH_EFFORT = /^claude-opus-4-7(?:-|$)/i;
-
-const ANTHROPIC_REASONING_SUPPORT: ReasoningSupport = {
-    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'auto'
-};
-
-function reasoningApiFor(modelId: string): ReasoningApi | undefined {
-    if (EFFORT_REASONING.test(modelId)) {
-        return 'effort';
-    }
-    if (BUDGET_REASONING.test(modelId)) {
-        return 'budget';
-    }
-    return undefined;
-}
 
 @injectable()
 export class AnthropicFrontendApplicationContribution implements FrontendApplicationContribution {
@@ -141,9 +101,7 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                 model.apiKey === newModel.apiKey &&
                 model.maxRetries === newModel.maxRetries &&
                 model.useCaching === newModel.useCaching &&
-                model.enableStreaming === newModel.enableStreaming &&
-                model.reasoningApi === newModel.reasoningApi &&
-                model.supportsXHighEffort === newModel.supportsXHighEffort));
+                model.enableStreaming === newModel.enableStreaming));
 
         this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
         this.manager.createOrUpdateLanguageModels(...modelsToAddOrUpdate);
@@ -158,31 +116,19 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
         this.manager.createOrUpdateLanguageModels(...this.createCustomModelDescriptionsFromPreferences(customModels));
     }
 
+    /** Per-model details are resolved by the backend from the Anthropic /v1/models endpoint. */
     protected createAnthropicModelDescription(modelId: string): AnthropicModelDescription {
         const id = `${ANTHROPIC_PROVIDER_ID}/${modelId}`;
-        const maxTokens = DEFAULT_MODEL_MAX_TOKENS[modelId];
         const maxRetries = this.aiCorePreferences.get(PREFERENCE_NAME_MAX_RETRIES) ?? 3;
-        const reasoningApi = reasoningApiFor(modelId);
 
-        const description: AnthropicModelDescription = {
+        return {
             id: id,
             model: modelId,
             apiKey: true,
             enableStreaming: true,
             useCaching: true,
-            maxRetries: maxRetries,
-            reasoningSupport: reasoningApi ? ANTHROPIC_REASONING_SUPPORT : undefined,
-            reasoningApi,
-            supportsXHighEffort: XHIGH_EFFORT.test(modelId)
+            maxRetries: maxRetries
         };
-
-        if (maxTokens !== undefined) {
-            description.maxTokens = maxTokens;
-        } else {
-            description.maxTokens = 64000;
-        }
-
-        return description;
     }
 
     protected createCustomModelDescriptionsFromPreferences(preferences: Partial<AnthropicModelDescription>[]): AnthropicModelDescription[] {
@@ -191,13 +137,6 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             if (!pref.model || !pref.url || typeof pref.model !== 'string' || typeof pref.url !== 'string') {
                 return acc;
             }
-            // Default to the model-name heuristic so reasoning-capable Claude models exposed via a
-            // custom endpoint still get the selector. Users can override via the `reasoningApi` field
-            // (set to `null` to disable, or to `'effort'` / `'budget'` to force a specific shape).
-            const reasoningApi: typeof pref.reasoningApi = 'reasoningApi' in pref
-                ? (pref.reasoningApi === 'effort' || pref.reasoningApi === 'budget' ? pref.reasoningApi : undefined)
-                : reasoningApiFor(pref.model);
-            const supportsXHighEffort = typeof pref.supportsXHighEffort === 'boolean' ? pref.supportsXHighEffort : XHIGH_EFFORT.test(pref.model);
             return [
                 ...acc,
                 {
@@ -207,10 +146,7 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                     apiKey: typeof pref.apiKey === 'string' || pref.apiKey === true ? pref.apiKey : undefined,
                     enableStreaming: pref.enableStreaming ?? true,
                     useCaching: pref.useCaching ?? true,
-                    maxRetries: pref.maxRetries ?? maxRetries,
-                    reasoningSupport: reasoningApi ? ANTHROPIC_REASONING_SUPPORT : undefined,
-                    reasoningApi,
-                    supportsXHighEffort
+                    maxRetries: pref.maxRetries ?? maxRetries
                 }
             ];
         }, []);

--- a/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
+++ b/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
@@ -13,54 +13,24 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { ReasoningApi, ReasoningSupport } from '@theia/ai-core';
-
 export const ANTHROPIC_LANGUAGE_MODELS_MANAGER_PATH = '/services/anthropic/language-model-manager';
 export const AnthropicLanguageModelsManager = Symbol('AnthropicLanguageModelsManager');
 
 export interface AnthropicModelDescription {
-    /**
-     * The identifier of the model which will be shown in the UI.
-     */
+    /** The identifier of the model which will be shown in the UI. */
     id: string;
-    /**
-     * The model ID as used by the Anthropic API.
-     */
+    /** The model ID as used by the Anthropic API. */
     model: string;
-    /**
-     * The Anthropic API compatible endpoint where the model is hosted. If not provided the default Anthropic endpoint will be used.
-     */
+    /** The Anthropic API compatible endpoint where the model is hosted. If not provided the default Anthropic endpoint will be used. */
     url?: string;
-    /**
-     * The key for the model. If 'true' is provided the global Anthropic API key will be used.
-     */
+    /** The key for the model. If `true` is provided the global Anthropic API key will be used. */
     apiKey: string | true | undefined;
-    /**
-     * Indicate whether the streaming API shall be used.
-     */
+    /** Indicate whether the streaming API shall be used. */
     enableStreaming: boolean;
-    /**
-     * Indicate whether the model supports prompt caching.
-     */
+    /** Indicate whether the model supports prompt caching. */
     useCaching: boolean;
-    /**
-     * Maximum number of tokens to generate. Default is 4096.
-     */
-    maxTokens?: number;
-    /**
-     * Maximum number of retry attempts when a request fails. Default is 3.
-     */
+    /** Maximum number of retry attempts when a request fails. Default is 3. */
     maxRetries: number;
-    /** When set, the UI exposes a reasoning selector and requests are translated to {@link reasoningApi}. */
-    reasoningSupport?: ReasoningSupport;
-    /**
-     * Which Anthropic reasoning API shape to use. Required when `reasoningSupport` is set.
-     * - `'effort'`: adaptive thinking (`thinking: { type: 'adaptive' }` + `output_config: { effort }`)
-     * - `'budget'`: extended thinking (`thinking: { type: 'enabled', budget_tokens: N }`)
-     */
-    reasoningApi?: ReasoningApi;
-    /** True on models that accept the Anthropic `xhigh` effort value. */
-    supportsXHighEffort?: boolean;
 }
 export interface AnthropicLanguageModelsManager {
     apiKey: string | undefined;

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -63,10 +63,7 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             \n\
             - specify `maxRetries: <number>` to indicate the maximum number of retries when a request fails. 3 by default.\
             \n\
-            - specify `reasoningApi: "effort" | "budget"` to opt in to the reasoning selector. By default this is inferred\
-            from the `model` name (Claude 4.6+: `effort`; Claude 4.0–4.5: `budget`). Set to `null` to disable.\
-            \n\
-            - specify `supportsXHighEffort: true` for models that accept the Anthropic `xhigh` effort value.'),
+            Reasoning capabilities and the maximum output token limit are derived from the endpoint\'s `/v1/models` response.'),
             default: [],
             items: {
                 type: 'object',
@@ -102,19 +99,6 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
                         type: 'number',
                         title: nls.localize('theia/ai/anthropic/customEndpoints/maxRetries/title',
                             'Maximum number of retries when a request fails. 3 by default'),
-                    },
-                    reasoningApi: {
-                        type: ['string', 'null'],
-                        enum: ['effort', 'budget', null], // eslint-disable-line no-null/no-null
-                        title: nls.localize('theia/ai/anthropic/customEndpoints/reasoningApi/title',
-                            'Which Anthropic reasoning API shape to use: `effort` for adaptive thinking (Claude 4.6+),'
-                            + ' `budget` for legacy extended thinking (Claude 4.0–4.5), or `null` to disable.'
-                            + ' Inferred from the model name by default.'),
-                    },
-                    supportsXHighEffort: {
-                        type: 'boolean',
-                        title: nls.localize('theia/ai/anthropic/customEndpoints/supportsXHighEffort/title',
-                            'Indicates whether the model accepts the Anthropic `xhigh` effort value. Inferred from the model name by default.'),
                     }
                 }
             }

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -61,10 +61,7 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             \n\
             - specify `maxRetries: <number>` to indicate the maximum number of retries when a request fails. 3 by default.\
             \n\
-            - specify `reasoningApi: "effort" | "budget"` to opt in to the reasoning selector. By default this is inferred\
-            from the `model` name (Claude 4.6+: `effort`; Claude 4.0–4.5: `budget`). Set to `null` to disable.\
-            \n\
-            - specify `supportsXHighEffort: true` for models that accept the Anthropic `xhigh` effort value.'),
+            Reasoning capabilities and the maximum output token limit are derived from the endpoint\'s `/v1/models` response.'),
             default: [],
             items: {
                 type: 'object',
@@ -100,19 +97,6 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
                         type: 'number',
                         title: nls.localize('theia/ai/anthropic/customEndpoints/maxRetries/title',
                             'Maximum number of retries when a request fails. 3 by default'),
-                    },
-                    reasoningApi: {
-                        type: ['string', 'null'],
-                        enum: ['effort', 'budget', null], // eslint-disable-line no-null/no-null
-                        title: nls.localize('theia/ai/anthropic/customEndpoints/reasoningApi/title',
-                            'Which Anthropic reasoning API shape to use: `effort` for adaptive thinking (Claude 4.6+),'
-                            + ' `budget` for legacy extended thinking (Claude 4.0–4.5), or `null` to disable.'
-                            + ' Inferred from the model name by default.'),
-                    },
-                    supportsXHighEffort: {
-                        type: 'boolean',
-                        title: nls.localize('theia/ai/anthropic/customEndpoints/supportsXHighEffort/title',
-                            'Indicates whether the model accepts the Anthropic `xhigh` effort value. Inferred from the model name by default.'),
                     }
                 }
             }

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -211,7 +211,8 @@ export class AnthropicModel implements LanguageModel {
         public proxy?: string,
         public reasoningSupport?: ReasoningSupport,
         public reasoningApi?: ReasoningApi,
-        public supportsXHighEffort?: boolean
+        public supportsXHighEffort?: boolean,
+        public maxInputTokens?: number
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -237,7 +237,8 @@ export class AnthropicModel implements LanguageModel {
         public proxy?: string,
         public reasoningSupport?: ReasoningSupport,
         public reasoningApi?: ReasoningApi,
-        public supportsXHighEffort?: boolean
+        public supportsXHighEffort?: boolean,
+        public maxInputTokens?: number
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.spec.ts
@@ -1,0 +1,240 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import type { ModelInfo } from '@anthropic-ai/sdk/resources/models';
+import { ReasoningApi } from '@theia/ai-core';
+import { AnthropicLanguageModelsManagerImpl } from './anthropic-language-models-manager-impl';
+import { AnthropicModelDescription } from '../common';
+
+class TestableAnthropicManager extends AnthropicLanguageModelsManagerImpl {
+    public retrieveCalls: string[] = [];
+    public stubbedInfo: ModelInfo | Error | undefined;
+
+    public callDeriveReasoningApi(info: ModelInfo | undefined): ReasoningApi | undefined {
+        return this.deriveReasoningApi(info);
+    }
+
+    public callDeriveSupportsXHighEffort(info: ModelInfo | undefined): boolean | undefined {
+        return this.deriveSupportsXHighEffort(info);
+    }
+
+    public callFetchModelInfo(
+        desc: AnthropicModelDescription,
+        apiKey: string | undefined,
+        proxyUrl: string | undefined
+    ): Promise<ModelInfo | undefined> {
+        return this.fetchModelInfo(desc, apiKey, proxyUrl);
+    }
+
+    protected override async retrieveModelInfo(
+        modelDescription: AnthropicModelDescription,
+        _apiKey: string,
+        _proxyUrl: string | undefined
+    ): Promise<ModelInfo> {
+        this.retrieveCalls.push(`${modelDescription.url ?? ''}::${modelDescription.model}`);
+        if (this.stubbedInfo instanceof Error) {
+            throw this.stubbedInfo;
+        }
+        if (!this.stubbedInfo) {
+            throw new Error('No stub configured');
+        }
+        return this.stubbedInfo;
+    }
+}
+
+function description(model: string, url?: string): AnthropicModelDescription {
+    return {
+        id: `anthropic/${model}`,
+        model,
+        apiKey: true,
+        enableStreaming: true,
+        useCaching: true,
+        maxRetries: 3,
+        url
+    };
+}
+
+function modelInfo(overrides: Partial<ModelInfo> = {}): ModelInfo {
+    return ({
+        id: overrides.id ?? 'claude-test',
+        type: 'model',
+        ...overrides
+    }) as unknown as ModelInfo;
+}
+
+describe('AnthropicLanguageModelsManagerImpl - metadata derivation', () => {
+    let manager: TestableAnthropicManager;
+
+    beforeEach(() => {
+        manager = new TestableAnthropicManager();
+    });
+
+    describe('deriveReasoningApi', () => {
+        it('returns undefined when info is missing', () => {
+            expect(manager.callDeriveReasoningApi(undefined)).to.equal(undefined);
+        });
+
+        it('returns undefined when capabilities are missing', () => {
+            expect(manager.callDeriveReasoningApi(modelInfo())).to.equal(undefined);
+        });
+
+        it('returns undefined when thinking is not supported', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: false, types: { adaptive: { supported: false }, enabled: { supported: false } } }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningApi(info)).to.equal(undefined);
+        });
+
+        it('returns "effort" when adaptive thinking is supported (newer Claude models)', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: true }, enabled: { supported: true } } }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningApi(info)).to.equal('effort');
+        });
+
+        it('prefers "effort" over "budget" when both are reported supported', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: true }, enabled: { supported: true } } }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningApi(info)).to.equal('effort');
+        });
+
+        it('returns "budget" when only enabled thinking is supported (legacy 4.x extended thinking)', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: false }, enabled: { supported: true } } }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningApi(info)).to.equal('budget');
+        });
+
+        it('returns undefined when thinking is supported but neither type is', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: false }, enabled: { supported: false } } }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningApi(info)).to.equal(undefined);
+        });
+    });
+
+    describe('deriveSupportsXHighEffort', () => {
+        it('returns undefined when info is missing', () => {
+            expect(manager.callDeriveSupportsXHighEffort(undefined)).to.equal(undefined);
+        });
+
+        it('returns undefined when effort capability is absent', () => {
+            expect(manager.callDeriveSupportsXHighEffort(modelInfo())).to.equal(undefined);
+        });
+
+        it('reflects the supported flag when effort.xhigh is reported', () => {
+            const supported = modelInfo({
+                capabilities: { effort: { xhigh: { supported: true } } }
+            } as Partial<ModelInfo>);
+            const unsupported = modelInfo({
+                capabilities: { effort: { xhigh: { supported: false } } }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveSupportsXHighEffort(supported)).to.equal(true);
+            expect(manager.callDeriveSupportsXHighEffort(unsupported)).to.equal(false);
+        });
+    });
+});
+
+describe('AnthropicLanguageModelsManagerImpl - fetchModelInfo cache', () => {
+    let manager: TestableAnthropicManager;
+
+    beforeEach(() => {
+        manager = new TestableAnthropicManager();
+    });
+
+    it('returns undefined and skips the network when no API key is provided', async () => {
+        manager.stubbedInfo = modelInfo();
+        const result = await manager.callFetchModelInfo(description('claude-x'), undefined, undefined);
+        expect(result).to.equal(undefined);
+        expect(manager.retrieveCalls).to.deep.equal([]);
+    });
+
+    it('fetches once per (baseURL, model) and reuses the cached result', async () => {
+        manager.stubbedInfo = modelInfo({ id: 'claude-x' });
+        const desc = description('claude-x');
+
+        const first = await manager.callFetchModelInfo(desc, 'key', undefined);
+        const second = await manager.callFetchModelInfo(desc, 'key', undefined);
+
+        expect(first).to.equal(manager.stubbedInfo);
+        expect(second).to.equal(manager.stubbedInfo);
+        expect(manager.retrieveCalls).to.deep.equal(['::claude-x']);
+    });
+
+    it('keys the cache by both baseURL and model id', async () => {
+        manager.stubbedInfo = modelInfo();
+        const a = description('claude-x');
+        const b = description('claude-y');
+        const c = description('claude-x', 'https://proxy.example.com');
+
+        await manager.callFetchModelInfo(a, 'key', undefined);
+        await manager.callFetchModelInfo(b, 'key', undefined);
+        await manager.callFetchModelInfo(c, 'key', undefined);
+
+        expect(manager.retrieveCalls).to.deep.equal([
+            '::claude-x',
+            '::claude-y',
+            'https://proxy.example.com::claude-x'
+        ]);
+    });
+
+    it('does not cache failures (next call retries)', async () => {
+        manager.stubbedInfo = new Error('boom');
+        const desc = description('claude-x');
+
+        const first = await manager.callFetchModelInfo(desc, 'key', undefined);
+        expect(first).to.equal(undefined);
+
+        manager.stubbedInfo = modelInfo({ id: 'claude-x' });
+        const second = await manager.callFetchModelInfo(desc, 'key', undefined);
+
+        expect(second).to.equal(manager.stubbedInfo);
+        expect(manager.retrieveCalls).to.deep.equal(['::claude-x', '::claude-x']);
+    });
+
+    it('shares an in-flight fetch between concurrent callers', async () => {
+        let resolve: (info: ModelInfo) => void = () => undefined;
+        const pending = new Promise<ModelInfo>(r => { resolve = r; });
+        (manager as unknown as { retrieveModelInfo: (...args: unknown[]) => Promise<ModelInfo> })
+            .retrieveModelInfo = (modelDescription: AnthropicModelDescription) => {
+                manager.retrieveCalls.push(`${modelDescription.url ?? ''}::${modelDescription.model}`);
+                return pending;
+            };
+        const desc = description('claude-x');
+
+        const p1 = manager.callFetchModelInfo(desc, 'key', undefined);
+        const p2 = manager.callFetchModelInfo(desc, 'key', undefined);
+        const expectedInfo = modelInfo({ id: 'claude-x' });
+        resolve(expectedInfo);
+
+        const [r1, r2] = await Promise.all([p1, p2]);
+        expect(r1).to.equal(expectedInfo);
+        expect(r2).to.equal(expectedInfo);
+        expect(manager.retrieveCalls).to.deep.equal(['::claude-x']);
+    });
+});

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -14,17 +14,34 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelRegistry, LanguageModelStatus } from '@theia/ai-core';
-import { getProxyUrl } from '@theia/ai-core/lib/node';
+import { LanguageModelRegistry, LanguageModelStatus, ReasoningApi, ReasoningSupport } from '@theia/ai-core';
+import { createProxyFetch, getProxyUrl } from '@theia/ai-core/lib/node';
 import { inject, injectable } from '@theia/core/shared/inversify';
+import { Anthropic } from '@anthropic-ai/sdk';
+import type { ModelInfo } from '@anthropic-ai/sdk/resources/models';
 import { AnthropicModel, DEFAULT_MAX_TOKENS } from './anthropic-language-model';
 import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../common';
+
+const ANTHROPIC_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+interface ResolvedModelMetadata {
+    maxInputTokens?: number;
+    maxTokens: number;
+    reasoningSupport?: ReasoningSupport;
+    reasoningApi?: ReasoningApi;
+    supportsXHighEffort?: boolean;
+}
 
 @injectable()
 export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageModelsManager {
 
     protected _apiKey: string | undefined;
     protected _proxyUrl: string | undefined;
+    /** Cached `/v1/models` lookups keyed by `${baseURL}::${model}`. Failed lookups are evicted so the next call retries. */
+    protected readonly modelInfoCache = new Map<string, Promise<ModelInfo>>();
 
     @inject(LanguageModelRegistry)
     protected readonly languageModelRegistry: LanguageModelRegistry;
@@ -34,61 +51,141 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
     }
 
     async createOrUpdateLanguageModels(...modelDescriptions: AnthropicModelDescription[]): Promise<void> {
-        for (const modelDescription of modelDescriptions) {
-            const model = await this.languageModelRegistry.getLanguageModel(modelDescription.id);
-            const apiKeyProvider = () => {
-                if (modelDescription.apiKey === true) {
-                    return this.apiKey;
-                }
-                if (modelDescription.apiKey) {
-                    return modelDescription.apiKey;
-                }
-                return undefined;
-            };
-            const proxyUrl = getProxyUrl(modelDescription.url ?? 'https://api.anthropic.com', this._proxyUrl);
+        await Promise.all(modelDescriptions.map(description => this.createOrUpdateLanguageModel(description)));
+    }
 
-            // Determine status based on API key and custom url presence
-            const status = this.calculateStatus(modelDescription, apiKeyProvider());
-
-            if (model) {
-                if (!(model instanceof AnthropicModel)) {
-                    console.warn(`Anthropic: model ${modelDescription.id} is not an Anthropic model`);
-                    continue;
-                }
-                await this.languageModelRegistry.patchLanguageModel<AnthropicModel>(modelDescription.id, {
-                    model: modelDescription.model,
-                    enableStreaming: modelDescription.enableStreaming,
-                    url: modelDescription.url,
-                    useCaching: modelDescription.useCaching,
-                    apiKey: apiKeyProvider,
-                    status,
-                    maxTokens: modelDescription.maxTokens !== undefined ? modelDescription.maxTokens : DEFAULT_MAX_TOKENS,
-                    maxRetries: modelDescription.maxRetries,
-                    proxy: proxyUrl,
-                    reasoningSupport: modelDescription.reasoningSupport,
-                    reasoningApi: modelDescription.reasoningApi,
-                    supportsXHighEffort: modelDescription.supportsXHighEffort
-                });
-            } else {
-                this.languageModelRegistry.addLanguageModels([
-                    new AnthropicModel(
-                        modelDescription.id,
-                        modelDescription.model,
-                        status,
-                        modelDescription.enableStreaming,
-                        modelDescription.useCaching,
-                        apiKeyProvider,
-                        modelDescription.url,
-                        modelDescription.maxTokens,
-                        modelDescription.maxRetries,
-                        proxyUrl,
-                        modelDescription.reasoningSupport,
-                        modelDescription.reasoningApi,
-                        modelDescription.supportsXHighEffort
-                    )
-                ]);
+    protected async createOrUpdateLanguageModel(modelDescription: AnthropicModelDescription): Promise<void> {
+        const model = await this.languageModelRegistry.getLanguageModel(modelDescription.id);
+        const apiKeyProvider = () => {
+            if (modelDescription.apiKey === true) {
+                return this.apiKey;
             }
+            if (modelDescription.apiKey) {
+                return modelDescription.apiKey;
+            }
+            return undefined;
+        };
+        const proxyUrl = getProxyUrl(modelDescription.url ?? 'https://api.anthropic.com', this._proxyUrl);
+
+        const apiKey = apiKeyProvider();
+        const status = this.calculateStatus(modelDescription, apiKey);
+        const metadata = await this.resolveMetadata(modelDescription, apiKey, proxyUrl);
+
+        if (model) {
+            if (!(model instanceof AnthropicModel)) {
+                console.warn(`Anthropic: model ${modelDescription.id} is not an Anthropic model`);
+                return;
+            }
+            await this.languageModelRegistry.patchLanguageModel<AnthropicModel>(modelDescription.id, {
+                model: modelDescription.model,
+                enableStreaming: modelDescription.enableStreaming,
+                url: modelDescription.url,
+                useCaching: modelDescription.useCaching,
+                apiKey: apiKeyProvider,
+                status,
+                maxTokens: metadata.maxTokens,
+                maxRetries: modelDescription.maxRetries,
+                proxy: proxyUrl,
+                reasoningSupport: metadata.reasoningSupport,
+                reasoningApi: metadata.reasoningApi,
+                supportsXHighEffort: metadata.supportsXHighEffort,
+                maxInputTokens: metadata.maxInputTokens
+            });
+        } else {
+            this.languageModelRegistry.addLanguageModels([
+                new AnthropicModel(
+                    modelDescription.id,
+                    modelDescription.model,
+                    status,
+                    modelDescription.enableStreaming,
+                    modelDescription.useCaching,
+                    apiKeyProvider,
+                    modelDescription.url,
+                    metadata.maxTokens,
+                    modelDescription.maxRetries,
+                    proxyUrl,
+                    metadata.reasoningSupport,
+                    metadata.reasoningApi,
+                    metadata.supportsXHighEffort,
+                    metadata.maxInputTokens
+                )
+            ]);
         }
+    }
+
+    /** `maxTokens` falls back to {@link DEFAULT_MAX_TOKENS} since the Messages API requires it. */
+    protected async resolveMetadata(
+        description: AnthropicModelDescription,
+        apiKey: string | undefined,
+        proxyUrl: string | undefined
+    ): Promise<ResolvedModelMetadata> {
+        const info = await this.fetchModelInfo(description, apiKey, proxyUrl);
+        const reasoningApi = this.deriveReasoningApi(info);
+        return {
+            maxInputTokens: info?.max_input_tokens ?? undefined,
+            maxTokens: info?.max_tokens ?? DEFAULT_MAX_TOKENS,
+            reasoningSupport: reasoningApi ? ANTHROPIC_REASONING_SUPPORT : undefined,
+            reasoningApi,
+            supportsXHighEffort: this.deriveSupportsXHighEffort(info)
+        };
+    }
+
+    protected async fetchModelInfo(
+        modelDescription: AnthropicModelDescription,
+        apiKey: string | undefined,
+        proxyUrl: string | undefined
+    ): Promise<ModelInfo | undefined> {
+        if (!apiKey) {
+            return undefined;
+        }
+        const cacheKey = `${modelDescription.url ?? ''}::${modelDescription.model}`;
+        const cached = this.modelInfoCache.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+        const fetchPromise = this.retrieveModelInfo(modelDescription, apiKey, proxyUrl);
+        this.modelInfoCache.set(cacheKey, fetchPromise);
+        try {
+            return await fetchPromise;
+        } catch (error) {
+            this.modelInfoCache.delete(cacheKey);
+            console.warn(`Anthropic: failed to retrieve model info for '${modelDescription.id}':`,
+                error instanceof Error ? error.message : error);
+            return undefined;
+        }
+    }
+
+    protected retrieveModelInfo(
+        modelDescription: AnthropicModelDescription,
+        apiKey: string,
+        proxyUrl: string | undefined
+    ): Promise<ModelInfo> {
+        const anthropic = new Anthropic({
+            apiKey,
+            baseURL: modelDescription.url,
+            fetch: createProxyFetch(proxyUrl)
+        });
+        return anthropic.models.retrieve(modelDescription.model);
+    }
+
+    /** Adaptive thinking (`effort`) is preferred when available; older 4.x models only support the legacy extended thinking (`budget`) API. */
+    protected deriveReasoningApi(info: ModelInfo | undefined): ReasoningApi | undefined {
+        const thinking = info?.capabilities?.thinking;
+        if (!thinking?.supported) {
+            return undefined;
+        }
+        if (thinking.types.adaptive.supported) {
+            return 'effort';
+        }
+        if (thinking.types.enabled.supported) {
+            return 'budget';
+        }
+        return undefined;
+    }
+
+    protected deriveSupportsXHighEffort(info: ModelInfo | undefined): boolean | undefined {
+        const xhigh = info?.capabilities?.effort?.xhigh;
+        return xhigh ? xhigh.supported : undefined;
     }
 
     removeLanguageModels(...modelIds: string[]): void {
@@ -111,11 +208,8 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
         }
     }
 
-    /**
-     * Returns the status for a language model based on the presence of an API key or custom url.
-     */
     protected calculateStatus(modelDescription: AnthropicModelDescription, effectiveApiKey: string | undefined): LanguageModelStatus {
-        // Always mark custom models (models with url) as ready for now as we do not know about API Key requirements
+        // Custom endpoints have unknown auth requirements, so we cannot derive a meaningful status.
         if (modelDescription.url) {
             return { status: 'ready' };
         }

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -40,7 +40,8 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
 
     protected _apiKey: string | undefined;
     protected _proxyUrl: string | undefined;
-    /** Cached `/v1/models` lookups keyed by `${baseURL}::${model}`. Failed lookups are evicted so the next call retries. */
+    // Cached `/v1/models` lookups keyed by `${baseURL}::${model}`. Successful lookups are kept for the process lifetime;
+    // failed lookups are evicted so the next call retries.
     protected readonly modelInfoCache = new Map<string, Promise<ModelInfo>>();
 
     @inject(LanguageModelRegistry)

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -67,7 +67,7 @@ import {
 } from './chat-view-preferences';
 import {
     buildBarTooltip,
-    CHAT_CONTEXT_WINDOW_SIZE,
+    CHAT_CONTEXT_WINDOW_SIZE_FALLBACK,
     computeSessionTokenUsage,
     decideTokenUsageWarning,
     getLatestTokenUsage,
@@ -266,6 +266,8 @@ export class AIChatInputWidget extends ReactWidget {
     protected currentReasoningSupport?: ReasoningSupport;
     /** Id (`provider/model`) of the model that backs {@link currentReasoningSupport}; used to resolve preference defaults. */
     protected currentLanguageModelId?: string;
+    /** Context window (max input tokens) of the receiving agent's primary model; falls back to {@link CHAT_CONTEXT_WINDOW_SIZE_FALLBACK} when unknown. */
+    protected currentMaxInputTokens?: number;
     /** Saved reasoning selection for the receiving agent (loaded from {@link AISettingsService}); kept in sync with the persisted value. */
     protected savedReasoning?: ReasoningSettings;
 
@@ -333,13 +335,22 @@ export class AIChatInputWidget extends ReactWidget {
     protected async updateReasoningSupport(agentId: string | undefined): Promise<void> {
         let support: ReasoningSupport | undefined;
         let modelId: string | undefined;
+        let maxInputTokens: number | undefined;
         if (agentId) {
             const agent = this.chatAgentService.getAgent(agentId);
             if (agent) {
                 for (const requirement of agent.languageModelRequirements ?? []) {
                     try {
                         const model = await this.languageModelRegistry.selectLanguageModel({ agent: agent.id, ...requirement });
-                        if (model?.reasoningSupport) {
+                        if (!model) {
+                            continue;
+                        }
+                        // The token usage indicator scales to the first resolved model's context window,
+                        // independent of which model carries the reasoning support.
+                        if (maxInputTokens === undefined) {
+                            maxInputTokens = model.maxInputTokens;
+                        }
+                        if (model.reasoningSupport) {
                             support = model.reasoningSupport;
                             modelId = model.id;
                             break;
@@ -350,9 +361,12 @@ export class AIChatInputWidget extends ReactWidget {
                 }
             }
         }
-        if (support !== this.currentReasoningSupport || modelId !== this.currentLanguageModelId) {
+        if (support !== this.currentReasoningSupport
+            || modelId !== this.currentLanguageModelId
+            || maxInputTokens !== this.currentMaxInputTokens) {
             this.currentReasoningSupport = support;
             this.currentLanguageModelId = modelId;
+            this.currentMaxInputTokens = maxInputTokens;
             this.update();
         }
     }
@@ -921,14 +935,14 @@ export class AIChatInputWidget extends ReactWidget {
         this.chatInputLastLineKey.set(isLastVisualOverall);
     }
 
-    /**
-     * Resolve the configured token usage warning threshold as an absolute token count.
-     * The preference is stored as a percentage of the context window; this method
-     * converts it using the current assumed context window size.
-     */
+    protected getContextWindowSize(): number {
+        return this.currentMaxInputTokens ?? CHAT_CONTEXT_WINDOW_SIZE_FALLBACK;
+    }
+
+    /** Converts the percentage-based preference to an absolute token count. */
     protected getTokenUsageWarningThreshold(): number {
         const percentage = this.getTokenUsageWarningThresholdPercentage();
-        return Math.round((percentage / 100) * CHAT_CONTEXT_WINDOW_SIZE);
+        return Math.round((percentage / 100) * this.getContextWindowSize());
     }
 
     protected getTokenUsageWarningThresholdPercentage(): number {
@@ -1333,6 +1347,7 @@ export class AIChatInputWidget extends ReactWidget {
                 }}
                 tokenUsageEnabled={this.tokenUsageEnabled}
                 tokenUsageWarningThreshold={this.getTokenUsageWarningThreshold()}
+                contextWindowSize={this.getContextWindowSize()}
             />
         );
     }
@@ -1671,6 +1686,7 @@ interface ChatInputProperties {
     };
     tokenUsageEnabled?: boolean;
     tokenUsageWarningThreshold: number;
+    contextWindowSize: number;
 }
 
 // Utility to check if we have task context in the chat model
@@ -2101,9 +2117,11 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
     // Token usage computation (cheap pure function walking the model's request list)
     const totalTokens = props.tokenUsageEnabled ? computeSessionTokenUsage(props.chatModel) : 0;
     const showTokenUsage = props.tokenUsageEnabled && totalTokens > 0;
-    const tokenColorClass = showTokenUsage ? getUsageColorClass(totalTokens, props.tokenUsageWarningThreshold) : '';
+    const tokenColorClass = showTokenUsage ? getUsageColorClass(totalTokens, props.tokenUsageWarningThreshold, props.contextWindowSize) : '';
     const tokenIsWarningOrError = tokenColorClass === 'token-usage-yellow' || tokenColorClass === 'token-usage-red';
-    const tokenTooltip = showTokenUsage ? buildBarTooltip(getLatestTokenUsage(props.chatModel), totalTokens, props.tokenUsageWarningThreshold) : undefined;
+    const tokenTooltip = showTokenUsage
+        ? buildBarTooltip(getLatestTokenUsage(props.chatModel), totalTokens, props.tokenUsageWarningThreshold, props.contextWindowSize)
+        : undefined;
 
     return (
         <div className="theia-ChatInput" data-ai-disabled={!props.isEnabled} onDragOver={props.onDragOver} onDrop={props.onDrop} ref={containerRef}>
@@ -2141,7 +2159,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
                     isEnabled={props.isEnabled}
                     hoverService={props.hoverService}
                     tokenUsage={showTokenUsage ? {
-                        percent: Math.min((totalTokens / CHAT_CONTEXT_WINDOW_SIZE) * 100, 100),
+                        percent: Math.min((totalTokens / props.contextWindowSize) * 100, 100),
                         colorClass: tokenColorClass,
                         tooltip: tokenTooltip,
                     } : undefined}

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -345,14 +345,14 @@ export class AIChatInputWidget extends ReactWidget {
                         if (!model) {
                             continue;
                         }
-                        // The token usage indicator scales to the first resolved model's context window,
-                        // independent of which model carries the reasoning support.
-                        if (maxInputTokens === undefined) {
+                        if (maxInputTokens === undefined && model.maxInputTokens !== undefined) {
                             maxInputTokens = model.maxInputTokens;
                         }
-                        if (model.reasoningSupport) {
+                        if (!support && model.reasoningSupport) {
                             support = model.reasoningSupport;
                             modelId = model.id;
+                        }
+                        if (support && maxInputTokens !== undefined) {
                             break;
                         }
                     } catch (error) {

--- a/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.spec.ts
@@ -18,6 +18,7 @@ import { expect } from 'chai';
 import { Emitter, Event } from '@theia/core';
 import { ChatModel, ChatRequestModel, ResponseTokenUsage } from '@theia/ai-chat';
 import {
+    buildBarTooltip,
     computeSessionTokenUsage,
     decideTokenUsageWarning,
     formatTokenCount,
@@ -218,6 +219,36 @@ describe('ChatTokenUsageIndicator', () => {
 
         it('is true for tokens above the threshold', () => {
             expect(isAboveTokenUsageWarningThreshold(THRESHOLD + 1, THRESHOLD)).to.equal(true);
+        });
+    });
+
+    describe('buildBarTooltip', () => {
+        it('returns undefined when no usage is provided', () => {
+            expect(buildBarTooltip(undefined, 0, THRESHOLD, CONTEXT_WINDOW)).to.equal(undefined);
+        });
+
+        it('uses the provided contextWindowSize as denominator in the total line', () => {
+            const tooltip = buildBarTooltip(
+                { inputTokens: 50, outputTokens: 50 },
+                100,
+                THRESHOLD,
+                CONTEXT_WINDOW
+            );
+            expect(tooltip).to.not.equal(undefined);
+            // 100 / 200 -> 50%, formatted as "100 / 200"
+            expect(tooltip!.value).to.contain('100');
+            expect(tooltip!.value).to.contain('200');
+            expect(tooltip!.value).to.contain('50%');
+        });
+
+        it('falls back to the default context window when none is provided', () => {
+            const tooltip = buildBarTooltip(
+                { inputTokens: 100, outputTokens: 100 },
+                200,
+                THRESHOLD
+            );
+            // The fallback (200k) should appear in the total line.
+            expect(tooltip!.value).to.contain('200.0k');
         });
     });
 

--- a/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.ts
+++ b/packages/ai-chat-ui/src/browser/chat-token-usage-indicator-util.ts
@@ -18,12 +18,8 @@ import { ChatModel, ResponseTokenUsage } from '@theia/ai-chat';
 import { nls } from '@theia/core/lib/common/nls';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 
-/**
- * Provisional context window size used as the denominator for the indicator bar
- * fill and the tooltip's "Total: X / Y" display until per-model context sizes
- * are available. See issue #17323 comments for context.
- */
-export const CHAT_CONTEXT_WINDOW_SIZE = 200000;
+/** Fallback denominator for the token usage indicator when the active model does not report its own input limit. */
+export const CHAT_CONTEXT_WINDOW_SIZE_FALLBACK = 200000;
 
 export type TokenUsageWarningDecision = 'notify' | 'reset' | 'skip';
 
@@ -69,7 +65,7 @@ export function formatTokenCount(count: number | undefined): string {
  * total, the configured warning threshold, and the assumed context window size.
  * Yellow band: [threshold, contextWindowSize). Red band: [contextWindowSize, ∞).
  */
-export function getUsageColorClass(totalTokens: number, threshold: number, contextWindowSize: number = CHAT_CONTEXT_WINDOW_SIZE): string {
+export function getUsageColorClass(totalTokens: number, threshold: number, contextWindowSize: number = CHAT_CONTEXT_WINDOW_SIZE_FALLBACK): string {
     if (totalTokens === 0) {
         return 'token-usage-none';
     }
@@ -113,14 +109,19 @@ export function getLatestTokenUsage(chatModel?: ChatModel): ResponseTokenUsage |
     return undefined;
 }
 
-export function buildBarTooltip(usage: ResponseTokenUsage | undefined, totalTokens: number, threshold: number): MarkdownString | undefined {
+export function buildBarTooltip(
+    usage: ResponseTokenUsage | undefined,
+    totalTokens: number,
+    threshold: number,
+    contextWindowSize: number = CHAT_CONTEXT_WINDOW_SIZE_FALLBACK
+): MarkdownString | undefined {
     if (!usage) {
         return undefined;
     }
     const lines: string[] = [
         `**${nls.localize('theia/ai/chat-ui/tokenUsageLabel', 'Token Usage')}**`
     ];
-    const colorClass = getUsageColorClass(totalTokens, threshold);
+    const colorClass = getUsageColorClass(totalTokens, threshold, contextWindowSize);
     if (colorClass === 'token-usage-yellow') {
         lines.push(`⚠ ${nls.localize('theia/ai/chat-ui/tokenUsageWarning', 'Token usage warning threshold reached.')}`, '');
     } else if (colorClass === 'token-usage-red') {
@@ -139,12 +140,12 @@ export function buildBarTooltip(usage: ResponseTokenUsage | undefined, totalToke
     if (cacheParts.length > 0) {
         lines.push(cacheParts.join(' | '));
     }
-    const percentage = Math.round((totalTokens / CHAT_CONTEXT_WINDOW_SIZE) * 100);
+    const percentage = Math.round((totalTokens / contextWindowSize) * 100);
     lines.push(nls.localize(
         'theia/ai/chat-ui/tokenUsageTooltipTotal',
         'Total: {0} / {1} ({2}%)',
         formatTokenCount(totalTokens),
-        formatTokenCount(CHAT_CONTEXT_WINDOW_SIZE),
+        formatTokenCount(contextWindowSize),
         percentage
     ));
     return { value: lines.join('  \n') };

--- a/packages/ai-google/package.json
+++ b/packages/ai-google/package.json
@@ -3,7 +3,7 @@
   "version": "1.71.0",
   "description": "Theia - Google AI Integration",
   "dependencies": {
-    "@google/genai": "^1.47.0",
+    "@google/genai": "^1.51.0",
     "@theia/ai-core": "1.71.0",
     "@theia/core": "1.71.0"
   },

--- a/packages/ai-google/src/browser/google-frontend-application-contribution.ts
+++ b/packages/ai-google/src/browser/google-frontend-application-contribution.ts
@@ -16,32 +16,11 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { ReasoningApi, ReasoningSupport } from '@theia/ai-core';
 import { GoogleLanguageModelsManager, GoogleModelDescription } from '../common';
 import { API_KEY_PREF, MODELS_PREF, MAX_RETRIES, RETRY_DELAY_OTHER_ERRORS, RETRY_DELAY_RATE_LIMIT } from '../common/google-preferences';
 import { PreferenceService } from '@theia/core';
 
 const GOOGLE_PROVIDER_ID = 'google';
-
-/** Gemini 3 uses `thinkingConfig.thinkingLevel`. */
-const EFFORT_REASONING = /^gemini-3(?:\.|-)/i;
-/** Gemini 2.5 uses `thinkingConfig.thinkingBudget` (integer; `-1` dynamic, `0` off). */
-const BUDGET_REASONING = /^gemini-2\.5(?:-|$)/i;
-
-const GEMINI_REASONING_SUPPORT: ReasoningSupport = {
-    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'auto'
-};
-
-function reasoningApiFor(modelId: string): ReasoningApi | undefined {
-    if (EFFORT_REASONING.test(modelId)) {
-        return 'effort';
-    }
-    if (BUDGET_REASONING.test(modelId)) {
-        return 'budget';
-    }
-    return undefined;
-}
 
 @injectable()
 export class GoogleFrontendApplicationContribution implements FrontendApplicationContribution {
@@ -85,9 +64,6 @@ export class GoogleFrontendApplicationContribution implements FrontendApplicatio
         });
     }
 
-    /**
-     * Called when the API key changes. Updates all Google models on the manager to ensure the new key is used.
-     */
     protected handleKeyChange(newApiKey: string | undefined): void {
         if (this.prevModels && this.prevModels.length > 0) {
             this.manager.createOrUpdateLanguageModels(...this.prevModels.map(modelId => this.createGeminiModelDescription(modelId)));
@@ -106,19 +82,14 @@ export class GoogleFrontendApplicationContribution implements FrontendApplicatio
         this.prevModels = newModels;
     }
 
+    /** Reasoning capabilities are resolved by the backend from the Gemini /v1beta/models response. */
     protected createGeminiModelDescription(modelId: string): GoogleModelDescription {
         const id = `${GOOGLE_PROVIDER_ID}/${modelId}`;
-        const reasoningApi = reasoningApiFor(modelId);
-
-        const description: GoogleModelDescription = {
+        return {
             id: id,
             model: modelId,
             apiKey: true,
-            enableStreaming: true,
-            reasoningSupport: reasoningApi ? GEMINI_REASONING_SUPPORT : undefined,
-            reasoningApi
+            enableStreaming: true
         };
-
-        return description;
     }
 }

--- a/packages/ai-google/src/node/google-language-model.ts
+++ b/packages/ai-google/src/node/google-language-model.ts
@@ -151,7 +151,8 @@ export class GoogleModel implements LanguageModel {
         public apiKey: () => string | undefined,
         public retrySettings: () => GoogleLanguageModelRetrySettings,
         public reasoningSupport?: ReasoningSupport,
-        public reasoningApi?: ReasoningApi
+        public reasoningApi?: ReasoningApi,
+        public maxInputTokens?: number
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {

--- a/packages/ai-google/src/node/google-language-models-manager-impl.spec.ts
+++ b/packages/ai-google/src/node/google-language-models-manager-impl.spec.ts
@@ -1,0 +1,183 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import type { Model } from '@google/genai';
+import { ReasoningApi } from '@theia/ai-core';
+import { GoogleLanguageModelsManagerImpl, reasoningApiFromModelId } from './google-language-models-manager-impl';
+import { GoogleModelDescription } from '../common';
+
+class TestableGoogleManager extends GoogleLanguageModelsManagerImpl {
+    public retrieveCalls: string[] = [];
+    public stubbedInfo: Model | Error | undefined;
+
+    public callDeriveReasoningApi(modelId: string, info: Model | undefined): ReasoningApi | undefined {
+        return this.deriveReasoningApi(modelId, info);
+    }
+
+    public callFetchModelInfo(
+        desc: GoogleModelDescription,
+        apiKey: string | undefined
+    ): Promise<Model | undefined> {
+        return this.fetchModelInfo(desc, apiKey);
+    }
+
+    protected override async retrieveModelInfo(modelDescription: GoogleModelDescription, _apiKey: string): Promise<Model> {
+        this.retrieveCalls.push(modelDescription.model);
+        if (this.stubbedInfo instanceof Error) {
+            throw this.stubbedInfo;
+        }
+        if (!this.stubbedInfo) {
+            throw new Error('No stub configured');
+        }
+        return this.stubbedInfo;
+    }
+}
+
+function description(model: string): GoogleModelDescription {
+    return {
+        id: `google/${model}`,
+        model,
+        apiKey: true,
+        enableStreaming: true
+    };
+}
+
+describe('reasoningApiFromModelId', () => {
+    it('maps Gemini 3 family ids to "effort"', () => {
+        expect(reasoningApiFromModelId('gemini-3-pro')).to.equal('effort');
+        expect(reasoningApiFromModelId('gemini-3.0-pro')).to.equal('effort');
+        expect(reasoningApiFromModelId('gemini-3-flash')).to.equal('effort');
+    });
+
+    it('maps Gemini 2.5 family ids to "budget"', () => {
+        expect(reasoningApiFromModelId('gemini-2.5-pro')).to.equal('budget');
+        expect(reasoningApiFromModelId('gemini-2.5-flash')).to.equal('budget');
+        expect(reasoningApiFromModelId('gemini-2.5')).to.equal('budget');
+    });
+
+    it('returns undefined for non-reasoning families', () => {
+        expect(reasoningApiFromModelId('gemini-1.5-pro')).to.equal(undefined);
+        expect(reasoningApiFromModelId('gemini-2.0-flash')).to.equal(undefined);
+        expect(reasoningApiFromModelId('gemini-pro')).to.equal(undefined);
+        expect(reasoningApiFromModelId('text-bison')).to.equal(undefined);
+    });
+
+    it('does not match prefixes that only happen to start with gemini-2 or gemini-3', () => {
+        expect(reasoningApiFromModelId('gemini-30-foo')).to.equal(undefined);
+        expect(reasoningApiFromModelId('gemini-2.55')).to.equal(undefined);
+    });
+});
+
+describe('GoogleLanguageModelsManagerImpl - deriveReasoningApi', () => {
+    let manager: TestableGoogleManager;
+
+    beforeEach(() => {
+        manager = new TestableGoogleManager();
+    });
+
+    it('falls back to the model-id heuristic when info is missing', () => {
+        expect(manager.callDeriveReasoningApi('gemini-3-pro', undefined)).to.equal('effort');
+        expect(manager.callDeriveReasoningApi('gemini-2.5-pro', undefined)).to.equal('budget');
+        expect(manager.callDeriveReasoningApi('gemini-1.5-pro', undefined)).to.equal(undefined);
+    });
+
+    it('uses the model-id heuristic when the API does not report thinking', () => {
+        const info = { thinking: undefined } as unknown as Model;
+        expect(manager.callDeriveReasoningApi('gemini-3-pro', info)).to.equal('effort');
+    });
+
+    it('respects an explicit thinking=true from the API', () => {
+        const info = { thinking: true } as unknown as Model;
+        expect(manager.callDeriveReasoningApi('gemini-2.5-pro', info)).to.equal('budget');
+    });
+
+    it('disables reasoning when the API explicitly reports thinking=false (overrides the model-id heuristic)', () => {
+        const info = { thinking: false } as unknown as Model;
+        expect(manager.callDeriveReasoningApi('gemini-3-pro', info)).to.equal(undefined);
+    });
+});
+
+describe('GoogleLanguageModelsManagerImpl - fetchModelInfo cache', () => {
+    let manager: TestableGoogleManager;
+
+    beforeEach(() => {
+        manager = new TestableGoogleManager();
+    });
+
+    it('returns undefined and skips the network when no API key is provided', async () => {
+        manager.stubbedInfo = { thinking: true } as unknown as Model;
+        const result = await manager.callFetchModelInfo(description('gemini-3-pro'), undefined);
+        expect(result).to.equal(undefined);
+        expect(manager.retrieveCalls).to.deep.equal([]);
+    });
+
+    it('fetches once per model and reuses the cached result', async () => {
+        manager.stubbedInfo = { thinking: true } as unknown as Model;
+        const desc = description('gemini-3-pro');
+
+        const first = await manager.callFetchModelInfo(desc, 'key');
+        const second = await manager.callFetchModelInfo(desc, 'key');
+
+        expect(first).to.equal(manager.stubbedInfo);
+        expect(second).to.equal(manager.stubbedInfo);
+        expect(manager.retrieveCalls).to.deep.equal(['gemini-3-pro']);
+    });
+
+    it('keys the cache by model id', async () => {
+        manager.stubbedInfo = { thinking: true } as unknown as Model;
+
+        await manager.callFetchModelInfo(description('gemini-3-pro'), 'key');
+        await manager.callFetchModelInfo(description('gemini-2.5-pro'), 'key');
+
+        expect(manager.retrieveCalls).to.deep.equal(['gemini-3-pro', 'gemini-2.5-pro']);
+    });
+
+    it('does not cache failures (next call retries)', async () => {
+        manager.stubbedInfo = new Error('boom');
+        const desc = description('gemini-3-pro');
+
+        const first = await manager.callFetchModelInfo(desc, 'key');
+        expect(first).to.equal(undefined);
+
+        manager.stubbedInfo = { thinking: true } as unknown as Model;
+        const second = await manager.callFetchModelInfo(desc, 'key');
+
+        expect(second).to.equal(manager.stubbedInfo);
+        expect(manager.retrieveCalls).to.deep.equal(['gemini-3-pro', 'gemini-3-pro']);
+    });
+
+    it('shares an in-flight fetch between concurrent callers', async () => {
+        let resolve: (info: Model) => void = () => undefined;
+        const pending = new Promise<Model>(r => { resolve = r; });
+        (manager as unknown as { retrieveModelInfo: (...args: unknown[]) => Promise<Model> })
+            .retrieveModelInfo = (modelDescription: GoogleModelDescription) => {
+                manager.retrieveCalls.push(modelDescription.model);
+                return pending;
+            };
+        const desc = description('gemini-3-pro');
+
+        const p1 = manager.callFetchModelInfo(desc, 'key');
+        const p2 = manager.callFetchModelInfo(desc, 'key');
+        const expectedInfo = { thinking: true } as unknown as Model;
+        resolve(expectedInfo);
+
+        const [r1, r2] = await Promise.all([p1, p2]);
+        expect(r1).to.equal(expectedInfo);
+        expect(r2).to.equal(expectedInfo);
+        expect(manager.retrieveCalls).to.deep.equal(['gemini-3-pro']);
+    });
+});

--- a/packages/ai-google/src/node/google-language-models-manager-impl.ts
+++ b/packages/ai-google/src/node/google-language-models-manager-impl.ts
@@ -14,8 +14,9 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelRegistry, LanguageModelStatus } from '@theia/ai-core';
+import { LanguageModelRegistry, LanguageModelStatus, ReasoningApi, ReasoningSupport } from '@theia/ai-core';
 import { inject, injectable } from '@theia/core/shared/inversify';
+import { GoogleGenAI, Model } from '@google/genai';
 import { GoogleModel } from './google-language-model';
 import { GoogleLanguageModelsManager, GoogleModelDescription } from '../common';
 
@@ -23,6 +24,31 @@ export interface GoogleLanguageModelRetrySettings {
     maxRetriesOnErrors: number;
     retryDelayOnRateLimitError: number;
     retryDelayOnOtherErrors: number;
+}
+
+const GEMINI_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+/**
+ * Maps a Gemini model id to its reasoning API shape (Gemini 3 → `effort`, Gemini 2.5 → `budget`).
+ * Inferred from the id because /v1beta/models only exposes a single `thinking` boolean.
+ */
+export function reasoningApiFromModelId(modelId: string): ReasoningApi | undefined {
+    if (/^gemini-3(?:\.|-)/i.test(modelId)) {
+        return 'effort';
+    }
+    if (/^gemini-2\.5(?:-|$)/i.test(modelId)) {
+        return 'budget';
+    }
+    return undefined;
+}
+
+interface ResolvedModelMetadata {
+    maxInputTokens?: number;
+    reasoningSupport?: ReasoningSupport;
+    reasoningApi?: ReasoningApi;
 }
 
 @injectable()
@@ -33,6 +59,8 @@ export class GoogleLanguageModelsManagerImpl implements GoogleLanguageModelsMana
         retryDelayOnRateLimitError: 60,
         retryDelayOnOtherErrors: -1
     };
+    /** Cached `/v1beta/models` lookups keyed by model id. Failed lookups are evicted so the next call retries. */
+    protected readonly modelInfoCache = new Map<string, Promise<Model>>();
 
     @inject(LanguageModelRegistry)
     protected readonly languageModelRegistry: LanguageModelRegistry;
@@ -48,51 +76,101 @@ export class GoogleLanguageModelsManagerImpl implements GoogleLanguageModelsMana
     }
 
     async createOrUpdateLanguageModels(...modelDescriptions: GoogleModelDescription[]): Promise<void> {
-        for (const modelDescription of modelDescriptions) {
-            const model = await this.languageModelRegistry.getLanguageModel(modelDescription.id);
-            const apiKeyProvider = () => {
-                if (modelDescription.apiKey === true) {
-                    return this.apiKey;
-                }
-                if (modelDescription.apiKey) {
-                    return modelDescription.apiKey;
-                }
-                return undefined;
-            };
-            const retrySettingsProvider = () => this.retrySettings;
+        await Promise.all(modelDescriptions.map(description => this.createOrUpdateLanguageModel(description)));
+    }
 
-            // Determine the effective API key for status
-            const status = this.calculateStatus(apiKeyProvider());
-
-            if (model) {
-                if (!(model instanceof GoogleModel)) {
-                    console.warn(`Gemini: model ${modelDescription.id} is not a Gemini model`);
-                    continue;
-                }
-                await this.languageModelRegistry.patchLanguageModel<GoogleModel>(modelDescription.id, {
-                    model: modelDescription.model,
-                    enableStreaming: modelDescription.enableStreaming,
-                    apiKey: apiKeyProvider,
-                    retrySettings: retrySettingsProvider,
-                    status,
-                    reasoningSupport: modelDescription.reasoningSupport,
-                    reasoningApi: modelDescription.reasoningApi
-                });
-            } else {
-                this.languageModelRegistry.addLanguageModels([
-                    new GoogleModel(
-                        modelDescription.id,
-                        modelDescription.model,
-                        status,
-                        modelDescription.enableStreaming,
-                        apiKeyProvider,
-                        retrySettingsProvider,
-                        modelDescription.reasoningSupport,
-                        modelDescription.reasoningApi
-                    )
-                ]);
+    protected async createOrUpdateLanguageModel(modelDescription: GoogleModelDescription): Promise<void> {
+        const model = await this.languageModelRegistry.getLanguageModel(modelDescription.id);
+        const apiKeyProvider = () => {
+            if (modelDescription.apiKey === true) {
+                return this.apiKey;
             }
+            if (modelDescription.apiKey) {
+                return modelDescription.apiKey;
+            }
+            return undefined;
+        };
+        const retrySettingsProvider = () => this.retrySettings;
+
+        const apiKey = apiKeyProvider();
+        const status = this.calculateStatus(apiKey);
+        const metadata = await this.resolveMetadata(modelDescription, apiKey);
+
+        if (model) {
+            if (!(model instanceof GoogleModel)) {
+                console.warn(`Gemini: model ${modelDescription.id} is not a Gemini model`);
+                return;
+            }
+            await this.languageModelRegistry.patchLanguageModel<GoogleModel>(modelDescription.id, {
+                model: modelDescription.model,
+                enableStreaming: modelDescription.enableStreaming,
+                apiKey: apiKeyProvider,
+                retrySettings: retrySettingsProvider,
+                status,
+                reasoningSupport: metadata.reasoningSupport,
+                reasoningApi: metadata.reasoningApi,
+                maxInputTokens: metadata.maxInputTokens
+            });
+        } else {
+            this.languageModelRegistry.addLanguageModels([
+                new GoogleModel(
+                    modelDescription.id,
+                    modelDescription.model,
+                    status,
+                    modelDescription.enableStreaming,
+                    apiKeyProvider,
+                    retrySettingsProvider,
+                    metadata.reasoningSupport,
+                    metadata.reasoningApi,
+                    metadata.maxInputTokens
+                )
+            ]);
         }
+    }
+
+    /** Description overrides win over the values derived from /v1beta/models. */
+    protected async resolveMetadata(description: GoogleModelDescription, apiKey: string | undefined): Promise<ResolvedModelMetadata> {
+        const info = await this.fetchModelInfo(description, apiKey);
+        const reasoningApi = description.reasoningApi ?? this.deriveReasoningApi(description.model, info);
+        return {
+            maxInputTokens: info?.inputTokenLimit,
+            reasoningSupport: description.reasoningSupport ?? (reasoningApi ? GEMINI_REASONING_SUPPORT : undefined),
+            reasoningApi
+        };
+    }
+
+    protected async fetchModelInfo(modelDescription: GoogleModelDescription, apiKey: string | undefined): Promise<Model | undefined> {
+        if (!apiKey) {
+            return undefined;
+        }
+        const cacheKey = modelDescription.model;
+        const cached = this.modelInfoCache.get(cacheKey);
+        if (cached) {
+            return cached;
+        }
+        const fetchPromise = this.retrieveModelInfo(modelDescription, apiKey);
+        this.modelInfoCache.set(cacheKey, fetchPromise);
+        try {
+            return await fetchPromise;
+        } catch (error) {
+            this.modelInfoCache.delete(cacheKey);
+            console.warn(`Gemini: failed to retrieve model info for '${modelDescription.id}':`,
+                error instanceof Error ? error.message : error);
+            return undefined;
+        }
+    }
+
+    protected retrieveModelInfo(modelDescription: GoogleModelDescription, apiKey: string): Promise<Model> {
+        const genAI = new GoogleGenAI({ apiKey, vertexai: false });
+        return genAI.models.get({ model: modelDescription.model });
+    }
+
+    /** API `thinking=false` disables reasoning even when the model id suggests support. */
+    protected deriveReasoningApi(modelId: string, info: Model | undefined): ReasoningApi | undefined {
+        if (info?.thinking === false) {
+            return undefined;
+        }
+        return reasoningApiFromModelId(modelId);
     }
 
     removeLanguageModels(...modelIds: string[]): void {

--- a/packages/ai-google/src/node/google-language-models-manager-impl.ts
+++ b/packages/ai-google/src/node/google-language-models-manager-impl.ts
@@ -59,7 +59,8 @@ export class GoogleLanguageModelsManagerImpl implements GoogleLanguageModelsMana
         retryDelayOnRateLimitError: 60,
         retryDelayOnOtherErrors: -1
     };
-    /** Cached `/v1beta/models` lookups keyed by model id. Failed lookups are evicted so the next call retries. */
+    // Cached `/v1beta/models` lookups keyed by model id. Successful lookups are kept for the process lifetime;
+    // failed lookups are evicted so the next call retries.
     protected readonly modelInfoCache = new Map<string, Promise<Model>>();
 
     @inject(LanguageModelRegistry)

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -121,6 +121,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
         this.manager.createOrUpdateLanguageModels(...this.createCustomModelDescriptionsFromPreferences(customModels));
     }
 
+    /** Per-model capabilities are resolved by the backend from the model id; see `openai-model-defaults.ts`. */
     protected createOpenAIModelDescription(modelId: string): OpenAiModelDescription {
         const id = `${OPENAI_PROVIDER_ID}/${modelId}`;
         const maxRetries = this.aiCorePreferences.get(PREFERENCE_NAME_MAX_RETRIES) ?? 3;
@@ -130,12 +131,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             model: modelId,
             apiKey: true,
             apiVersion: true,
-            developerMessageSettings: openAIModelsNotSupportingDeveloperMessages.includes(modelId) ? 'user' : 'developer',
-            enableStreaming: !openAIModelsWithDisabledStreaming.includes(modelId),
-            supportsStructuredOutput: !openAIModelsWithoutStructuredOutput.includes(modelId),
             maxRetries: maxRetries,
-            useResponseApi: useResponseApi,
-            reasoningSupport: reasoningSupportFor(modelId)
+            useResponseApi: useResponseApi
         };
     }
 
@@ -147,13 +144,6 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             if (!pref.model || !pref.url || typeof pref.model !== 'string' || typeof pref.url !== 'string') {
                 return acc;
             }
-            // Default to the model-name heuristic so reasoning-capable GPT-5 / o-series models exposed via
-            // a custom endpoint still get the selector. Users can override via `reasoningSupport`
-            // (set to `null` to disable, or to a full `ReasoningSupport` object to customize).
-            const reasoningSupport: ReasoningSupport | undefined = 'reasoningSupport' in pref
-                ? (isReasoningSupport(pref.reasoningSupport) ? pref.reasoningSupport : undefined)
-                : reasoningSupportFor(pref.model);
-
             return [
                 ...acc,
                 {
@@ -163,12 +153,12 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     deployment: typeof pref.deployment === 'string' && pref.deployment ? pref.deployment : undefined,
                     apiKey: typeof pref.apiKey === 'string' || pref.apiKey === true ? pref.apiKey : undefined,
                     apiVersion: typeof pref.apiVersion === 'string' || pref.apiVersion === true ? pref.apiVersion : undefined,
-                    developerMessageSettings: pref.developerMessageSettings ?? 'developer',
-                    supportsStructuredOutput: pref.supportsStructuredOutput ?? true,
-                    enableStreaming: pref.enableStreaming ?? true,
+                    developerMessageSettings: pref.developerMessageSettings,
+                    supportsStructuredOutput: pref.supportsStructuredOutput,
+                    enableStreaming: pref.enableStreaming,
                     maxRetries: pref.maxRetries ?? maxRetries,
                     useResponseApi: pref.useResponseApi ?? false,
-                    reasoningSupport
+                    reasoningSupport: isReasoningSupport(pref.reasoningSupport) ? pref.reasoningSupport : undefined
                 }
             ];
         }, []);
@@ -179,12 +169,7 @@ function isReasoningSupport(value: unknown): value is ReasoningSupport {
     return !!value && typeof value === 'object' && Array.isArray((value as ReasoningSupport).supportedLevels);
 }
 
-/**
- * Structural equality for {@link ReasoningSupport}. Used by {@link handleCustomModelChanges} to avoid
- * needless model re-creation when the user supplies an explicit `reasoningSupport` object via
- * preferences — each JSON deserialization yields a fresh object reference, so a `===` check would
- * always report a change even when the contents are identical.
- */
+/** Structural equality — preference reads yield fresh objects, so identity comparison would always report a change. */
 function reasoningSupportEquals(a: ReasoningSupport | undefined, b: ReasoningSupport | undefined): boolean {
     if (a === b) {
         return true;
@@ -195,33 +180,4 @@ function reasoningSupportEquals(a: ReasoningSupport | undefined, b: ReasoningSup
     return a.defaultLevel === b.defaultLevel
         && a.supportedLevels.length === b.supportedLevels.length
         && a.supportedLevels.every((level, index) => level === b.supportedLevels[index]);
-}
-
-const openAIModelsWithDisabledStreaming: string[] = [];
-const openAIModelsNotSupportingDeveloperMessages = ['o1-preview', 'o1-mini'];
-const openAIModelsWithoutStructuredOutput = ['o1-preview', 'gpt-4-turbo', 'gpt-4', 'gpt-3.5-turbo', 'o1-mini', 'gpt-4o-2024-05-13'];
-
-/** GPT-5 family: supports `minimal` in addition to `low | medium | high`. */
-const GPT5_REASONING = /^gpt-5(?:\.|-|$)/i;
-/** o-series reasoning models (o1, o3, o4): `low | medium | high`. */
-const O_SERIES_REASONING = /^o[134](?:-|$)/i;
-
-const GPT5_REASONING_SUPPORT: ReasoningSupport = {
-    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'auto'
-};
-
-const O_SERIES_REASONING_SUPPORT: ReasoningSupport = {
-    supportedLevels: ['off', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'auto'
-};
-
-function reasoningSupportFor(modelId: string): ReasoningSupport | undefined {
-    if (GPT5_REASONING.test(modelId)) {
-        return GPT5_REASONING_SUPPORT;
-    }
-    if (O_SERIES_REASONING.test(modelId)) {
-        return O_SERIES_REASONING_SUPPORT;
-    }
-    return undefined;
 }

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -21,56 +21,34 @@ export const OpenAiLanguageModelsManager = Symbol('OpenAiLanguageModelsManager')
 export const OPENAI_PROVIDER_ID = 'openai';
 
 export interface OpenAiModelDescription {
-    /**
-     * The identifier of the model which will be shown in the UI.
-     */
+    /** The identifier of the model which will be shown in the UI. */
     id: string;
-    /**
-     * The model ID as used by the OpenAI API.
-     */
+    /** The model ID as used by the OpenAI API. */
     model: string;
-    /**
-     * The OpenAI API compatible endpoint where the model is hosted. If not provided the default OpenAI endpoint will be used.
-     */
+    /** The OpenAI API compatible endpoint where the model is hosted. If not provided the default OpenAI endpoint will be used. */
     url?: string;
-    /**
-     * The key for the model. If 'true' is provided the global OpenAI API key will be used.
-     */
+    /** The key for the model. If `true` is provided the global OpenAI API key will be used. */
     apiKey: string | true | undefined;
-    /**
-     * The version for the api. If 'true' is provided the global OpenAI version will be used.
-     */
+    /** The version for the api. If `true` is provided the global OpenAI version will be used. */
     apiVersion: string | true | undefined;
-    /**
-     * Optional deployment name for Azure OpenAI.
-     */
+    /** Optional deployment name for Azure OpenAI. */
     deployment?: string;
+    /** Maximum number of retry attempts when a request fails. Default is 3. */
+    maxRetries: number;
+    /** Use the newer OpenAI Response API instead of the Chat Completion API. Default is `false`. */
+    useResponseApi?: boolean;
+    /** Indicate whether the streaming API shall be used. Defaults from the model id when unset. */
+    enableStreaming?: boolean;
     /**
-     * Indicate whether the streaming API shall be used.
-     */
-    enableStreaming: boolean;
-    /**
-     * Property to configure the developer message of the model. Setting this property to 'user', 'system', or 'developer' will use that string as the role for the system message.
-     * Setting it to 'mergeWithFollowingUserMessage' will prefix the following user message with the system message or convert the system message to user if the following message
-     * is not a user message. 'skip' will remove the system message altogether.
-     * Defaults to 'developer'.
+     * Configures how system messages are handled. `'user' | 'system' | 'developer'` use that role for
+     * the system message; `'mergeWithFollowingUserMessage'` prepends the system message to the next
+     * user message (creating one when needed); `'skip'` removes system messages. Defaults from the
+     * model id when unset (typically `'developer'`).
      */
     developerMessageSettings?: 'user' | 'system' | 'developer' | 'mergeWithFollowingUserMessage' | 'skip';
-    /**
-     * Flag to configure whether the OpenAPI model supports structured output. Default is `true`.
-     */
-    supportsStructuredOutput: boolean;
-    /**
-     * Maximum number of retry attempts when a request fails. Default is 3.
-     */
-    maxRetries: number;
-    /**
-     * Flag to configure whether to use the newer OpenAI Response API instead of the Chat Completion API.
-     * For official OpenAI models, this defaults to `true`. For custom providers, users must explicitly enable it.
-     * Default is `false` for custom models.
-     */
-    useResponseApi?: boolean;
-    /** When set, the UI exposes a reasoning selector and the level is translated to the OpenAI reasoning parameter. */
+    /** Whether the model supports structured output (`response_format` JSON schemas). Defaults from the model id when unset. */
+    supportsStructuredOutput?: boolean;
+    /** When set, the UI exposes a reasoning selector. Defaults from the model id when unset. */
     reasoningSupport?: ReasoningSupport;
 }
 export interface OpenAiLanguageModelsManager {

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -86,9 +86,8 @@ Best effort is made to convert non-conformant schemas, but errors are still poss
             \n\
             - specify `useResponseApi: true` to use the newer OpenAI Response API instead of the Chat Completion API (requires compatible endpoint).\
             \n\
-            - specify `reasoningSupport` to opt in to the chat reasoning selector. By default this is inferred from the\
-            `model` name (GPT-5 / o-series). Set to `null` to disable, or to an object with `supportedLevels` (e.g.\
-            `["off", "low", "medium", "high", "auto"]`) and an optional `defaultLevel` to customize.\
+            - specify `reasoningSupport` to opt in to the chat reasoning selector. Provide an object with\
+            `supportedLevels` (e.g. `["off", "low", "medium", "high", "auto"]`) and an optional `defaultLevel`.\
             \n\
             Refer to [our documentation](https://theia-ide.org/docs/user_ai/#openai-compatible-models-eg-via-vllm) for more information.'),
             default: [],
@@ -148,10 +147,9 @@ Best effort is made to convert non-conformant schemas, but errors are still poss
                             + 'Note: Will automatically fall back to Chat Completions API when tools are used.'),
                     },
                     reasoningSupport: {
-                        type: ['object', 'null'],
+                        type: 'object',
                         title: nls.localize('theia/ai/openai/customEndpoints/reasoningSupport/title',
-                            'Declares the model\'s reasoning capabilities. When set the chat shows a reasoning selector'
-                            + ' for this model. Set to `null` to disable. Inferred from the model name by default.'),
+                            'Declares the model\'s reasoning capabilities. When set the chat shows a reasoning selector for this model.'),
                         properties: {
                             supportedLevels: {
                                 type: 'array',

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -106,7 +106,8 @@ export class OpenAiModel implements LanguageModel {
         public maxRetries: number = 3,
         public useResponseApi: boolean = false,
         public proxy?: string,
-        public reasoningSupport?: ReasoningSupport
+        public reasoningSupport?: ReasoningSupport,
+        public maxInputTokens?: number
     ) { }
 
     /** Reasoning-level translation lives in {@link openAiReasoningFor}. */

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -14,12 +14,21 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelRegistry, LanguageModelStatus } from '@theia/ai-core';
+import { LanguageModelRegistry, LanguageModelStatus, ReasoningSupport } from '@theia/ai-core';
 import { getProxyUrl } from '@theia/ai-core/lib/node';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { OpenAiModel, OpenAiModelUtils } from './openai-language-model';
+import { DeveloperMessageSettings, OpenAiModel, OpenAiModelUtils } from './openai-language-model';
 import { OpenAiResponseApiUtils } from './openai-response-api-utils';
+import { getOpenAiModelDefaults } from './openai-model-defaults';
 import { OpenAiLanguageModelsManager, OpenAiModelDescription } from '../common';
+
+interface ResolvedModelMetadata {
+    maxInputTokens?: number;
+    reasoningSupport?: ReasoningSupport;
+    developerMessageSettings: DeveloperMessageSettings;
+    enableStreaming: boolean;
+    supportsStructuredOutput: boolean;
+}
 
 @injectable()
 export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsManager {
@@ -46,7 +55,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
     }
 
     protected calculateStatus(modelDescription: OpenAiModelDescription, effectiveApiKey: string | undefined): LanguageModelStatus {
-        // Always mark custom models (models with url) as ready for now as we do not know about API Key requirements
+        // Custom models (with `url`) are always marked ready since their API key requirements are unknown.
         if (modelDescription.url) {
             return { status: 'ready' };
         }
@@ -80,8 +89,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
             };
             const proxyUrl = getProxyUrl(modelDescription.url ?? 'https://api.openai.com', this._proxyUrl);
 
-            // Determine the effective API key for status
             const status = this.calculateStatus(modelDescription, apiKeyProvider());
+            const metadata = this.resolveMetadata(modelDescription);
 
             if (model) {
                 if (!(model instanceof OpenAiModel)) {
@@ -90,18 +99,19 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 }
                 await this.languageModelRegistry.patchLanguageModel<OpenAiModel>(modelDescription.id, {
                     model: modelDescription.model,
-                    enableStreaming: modelDescription.enableStreaming,
+                    enableStreaming: metadata.enableStreaming,
                     url: modelDescription.url,
                     apiKey: apiKeyProvider,
                     apiVersion: apiVersionProvider,
                     deployment: modelDescription.deployment,
-                    developerMessageSettings: modelDescription.developerMessageSettings || 'developer',
-                    supportsStructuredOutput: modelDescription.supportsStructuredOutput,
+                    developerMessageSettings: metadata.developerMessageSettings,
+                    supportsStructuredOutput: metadata.supportsStructuredOutput,
                     status,
                     maxRetries: modelDescription.maxRetries,
                     useResponseApi: modelDescription.useResponseApi ?? false,
                     proxy: proxyUrl,
-                    reasoningSupport: modelDescription.reasoningSupport
+                    reasoningSupport: metadata.reasoningSupport,
+                    maxInputTokens: metadata.maxInputTokens
                 });
             } else {
                 this.languageModelRegistry.addLanguageModels([
@@ -109,23 +119,41 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         modelDescription.id,
                         modelDescription.model,
                         status,
-                        modelDescription.enableStreaming,
+                        metadata.enableStreaming,
                         apiKeyProvider,
                         apiVersionProvider,
-                        modelDescription.supportsStructuredOutput,
+                        metadata.supportsStructuredOutput,
                         modelDescription.url,
                         modelDescription.deployment,
                         this.openAiModelUtils,
                         this.responseApiUtils,
-                        modelDescription.developerMessageSettings,
+                        metadata.developerMessageSettings,
                         modelDescription.maxRetries,
                         modelDescription.useResponseApi ?? false,
                         proxyUrl,
-                        modelDescription.reasoningSupport
+                        metadata.reasoningSupport,
+                        metadata.maxInputTokens
                     )
                 ]);
             }
         }
+    }
+
+    /**
+     * Merges description overrides with model-id-based defaults from {@link getOpenAiModelDefaults}.
+     * Description fields win, allowing custom-endpoint preferences to override capabilities for
+     * non-OpenAI models. Custom endpoints (with a `url`) skip the context window lookup since we
+     * don't know which model is actually behind the endpoint.
+     */
+    protected resolveMetadata(description: OpenAiModelDescription): ResolvedModelMetadata {
+        const defaults = getOpenAiModelDefaults(description.model);
+        return {
+            maxInputTokens: description.url ? undefined : defaults.contextWindow,
+            reasoningSupport: description.reasoningSupport ?? defaults.reasoningSupport,
+            developerMessageSettings: description.developerMessageSettings ?? defaults.developerMessageSettings ?? 'developer',
+            enableStreaming: description.enableStreaming ?? defaults.supportsStreaming ?? true,
+            supportsStructuredOutput: description.supportsStructuredOutput ?? defaults.supportsStructuredOutput ?? true
+        };
     }
 
     removeLanguageModels(...modelIds: string[]): void {

--- a/packages/ai-openai/src/node/openai-model-defaults.spec.ts
+++ b/packages/ai-openai/src/node/openai-model-defaults.spec.ts
@@ -1,0 +1,141 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { getOpenAiModelDefaults } from './openai-model-defaults';
+
+describe('getOpenAiModelDefaults', () => {
+    it('returns empty defaults for unknown models', () => {
+        expect(getOpenAiModelDefaults('totally-made-up-model')).to.deep.equal({});
+    });
+
+    describe('GPT-5.5', () => {
+        it('matches base and pro at 1,050,000 with GPT-5 reasoning', () => {
+            for (const id of ['gpt-5.5', 'gpt-5.5-pro']) {
+                const d = getOpenAiModelDefaults(id);
+                expect(d.contextWindow, id).to.equal(1_050_000);
+                expect(d.reasoningSupport?.supportedLevels, id).to.include('minimal');
+            }
+        });
+    });
+
+    describe('GPT-5.4', () => {
+        it('matches base and pro at 1,050,000', () => {
+            expect(getOpenAiModelDefaults('gpt-5.4').contextWindow).to.equal(1_050_000);
+            expect(getOpenAiModelDefaults('gpt-5.4-pro').contextWindow).to.equal(1_050_000);
+        });
+
+        it('matches mini and nano at 400,000 (specific prefix wins over `gpt-5.4`)', () => {
+            expect(getOpenAiModelDefaults('gpt-5.4-mini').contextWindow).to.equal(400_000);
+            expect(getOpenAiModelDefaults('gpt-5.4-nano').contextWindow).to.equal(400_000);
+        });
+    });
+
+    describe('GPT-5', () => {
+        it('matches base, pro, mini, nano, codex at 400,000', () => {
+            for (const id of ['gpt-5', 'gpt-5-pro', 'gpt-5-mini', 'gpt-5-nano', 'gpt-5-codex']) {
+                expect(getOpenAiModelDefaults(id).contextWindow, id).to.equal(400_000);
+            }
+        });
+
+        it('exposes GPT-5 reasoning support (incl. `minimal`)', () => {
+            const d = getOpenAiModelDefaults('gpt-5');
+            expect(d.reasoningSupport?.supportedLevels).to.include('minimal');
+            expect(d.reasoningSupport?.defaultLevel).to.equal('auto');
+        });
+    });
+
+    describe('GPT-4.1', () => {
+        it('matches the family at 1,047,576 with no reasoning', () => {
+            for (const id of ['gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano']) {
+                const d = getOpenAiModelDefaults(id);
+                expect(d.contextWindow, id).to.equal(1_047_576);
+                expect(d.reasoningSupport, id).to.equal(undefined);
+            }
+        });
+    });
+
+    describe('GPT-4o', () => {
+        it('matches base, mini, and most snapshots at 128,000 with structured output enabled', () => {
+            for (const id of ['gpt-4o', 'gpt-4o-mini', 'gpt-4o-2024-08-06']) {
+                const d = getOpenAiModelDefaults(id);
+                expect(d.contextWindow, id).to.equal(128_000);
+                expect(d.supportsStructuredOutput, id).to.equal(undefined); // default true at the manager
+            }
+        });
+
+        it('flags the gpt-4o-2024-05-13 snapshot as not supporting structured output', () => {
+            const d = getOpenAiModelDefaults('gpt-4o-2024-05-13');
+            expect(d.contextWindow).to.equal(128_000);
+            expect(d.supportsStructuredOutput).to.equal(false);
+        });
+    });
+
+    describe('GPT-4 turbo / 32k / base', () => {
+        it('matches gpt-4-turbo at 128,000 (no structured output)', () => {
+            const d = getOpenAiModelDefaults('gpt-4-turbo-2024-04-09');
+            expect(d.contextWindow).to.equal(128_000);
+            expect(d.supportsStructuredOutput).to.equal(false);
+        });
+
+        it('matches gpt-4-32k at 32,768 (no structured output)', () => {
+            const d = getOpenAiModelDefaults('gpt-4-32k');
+            expect(d.contextWindow).to.equal(32_768);
+            expect(d.supportsStructuredOutput).to.equal(false);
+        });
+
+        it('falls back to gpt-4 (8,192) for the base model', () => {
+            const d = getOpenAiModelDefaults('gpt-4-0613');
+            expect(d.contextWindow).to.equal(8_192);
+            expect(d.supportsStructuredOutput).to.equal(false);
+        });
+    });
+
+    describe('GPT-3.5', () => {
+        it('matches gpt-3.5-turbo and snapshots at 16,385 (no structured output)', () => {
+            for (const id of ['gpt-3.5-turbo', 'gpt-3.5-turbo-16k', 'gpt-3.5-turbo-0125']) {
+                const d = getOpenAiModelDefaults(id);
+                expect(d.contextWindow, id).to.equal(16_385);
+                expect(d.supportsStructuredOutput, id).to.equal(false);
+            }
+        });
+    });
+
+    describe('o-series', () => {
+        it('matches o4 and o3 families at 200,000 with o-series reasoning', () => {
+            for (const id of ['o4-mini', 'o3', 'o3-mini', 'o3-pro']) {
+                const d = getOpenAiModelDefaults(id);
+                expect(d.contextWindow, id).to.equal(200_000);
+                expect(d.reasoningSupport?.supportedLevels, id).to.not.include('minimal');
+            }
+        });
+
+        it('matches o1 / o1-pro at 200,000', () => {
+            expect(getOpenAiModelDefaults('o1').contextWindow).to.equal(200_000);
+            expect(getOpenAiModelDefaults('o1-pro').contextWindow).to.equal(200_000);
+        });
+
+        it('matches o1-preview / o1-mini at 128,000 with the legacy "user" role and no structured output', () => {
+            for (const id of ['o1-preview', 'o1-mini']) {
+                const d = getOpenAiModelDefaults(id);
+                expect(d.contextWindow, id).to.equal(128_000);
+                expect(d.developerMessageSettings, id).to.equal('user');
+                expect(d.supportsStructuredOutput, id).to.equal(false);
+                expect(d.reasoningSupport, id).to.not.equal(undefined);
+            }
+        });
+    });
+});

--- a/packages/ai-openai/src/node/openai-model-defaults.ts
+++ b/packages/ai-openai/src/node/openai-model-defaults.ts
@@ -1,0 +1,82 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ReasoningSupport } from '@theia/ai-core';
+import { DeveloperMessageSettings } from './openai-language-model';
+
+/**
+ * Per-model defaults inferred from the OpenAI model id. Sourced from
+ * https://developers.openai.com/api/docs/models. The `/v1/models/{id}` endpoint does not expose
+ * this data, so it is maintained client-side. User overrides on the model description take
+ * precedence over these values.
+ */
+export interface OpenAiModelDefaults {
+    contextWindow?: number;
+    reasoningSupport?: ReasoningSupport;
+    developerMessageSettings?: DeveloperMessageSettings;
+    supportsStructuredOutput?: boolean;
+    supportsStreaming?: boolean;
+}
+
+const GPT5_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+const O_SERIES_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+/**
+ * First matching prefix wins, so more specific prefixes must come before broader ones
+ * (e.g. `gpt-5.4-mini` before `gpt-5.4`). Snapshots inherit their family value
+ * (e.g. `gpt-4o-2024-08-06` matches `gpt-4o`).
+ */
+const OPENAI_MODEL_FAMILIES: ReadonlyArray<readonly [prefix: string, defaults: OpenAiModelDefaults]> = [
+    ['gpt-5.5', { contextWindow: 1_050_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
+    ['gpt-5.4-mini', { contextWindow: 400_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
+    ['gpt-5.4-nano', { contextWindow: 400_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
+    ['gpt-5.4', { contextWindow: 1_050_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
+    ['gpt-5', { contextWindow: 400_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
+    ['gpt-4.1', { contextWindow: 1_047_576 }],
+    // gpt-4o-2024-05-13 predates structured output support; later snapshots support it.
+    ['gpt-4o-2024-05-13', { contextWindow: 128_000, supportsStructuredOutput: false }],
+    ['gpt-4o', { contextWindow: 128_000 }],
+    ['gpt-4-turbo', { contextWindow: 128_000, supportsStructuredOutput: false }],
+    ['gpt-4-32k', { contextWindow: 32_768, supportsStructuredOutput: false }],
+    ['gpt-4', { contextWindow: 8_192, supportsStructuredOutput: false }],
+    ['gpt-3.5', { contextWindow: 16_385, supportsStructuredOutput: false }],
+    ['o4', { contextWindow: 200_000, reasoningSupport: O_SERIES_REASONING_SUPPORT }],
+    ['o3', { contextWindow: 200_000, reasoningSupport: O_SERIES_REASONING_SUPPORT }],
+    ['o1-preview', {
+        contextWindow: 128_000,
+        reasoningSupport: O_SERIES_REASONING_SUPPORT,
+        developerMessageSettings: 'user',
+        supportsStructuredOutput: false
+    }],
+    ['o1-mini', {
+        contextWindow: 128_000,
+        reasoningSupport: O_SERIES_REASONING_SUPPORT,
+        developerMessageSettings: 'user',
+        supportsStructuredOutput: false
+    }],
+    ['o1', { contextWindow: 200_000, reasoningSupport: O_SERIES_REASONING_SUPPORT }],
+];
+
+export function getOpenAiModelDefaults(model: string): OpenAiModelDefaults {
+    return OPENAI_MODEL_FAMILIES.find(([prefix]) => model.startsWith(prefix))?.[1] ?? {};
+}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The indicator now scales to the receiving agent's primary model's `maxInputTokens` instead of a hardcoded 200k. Each provider populates the value:

* Anthropic — fetched from /v1/models (also covers max_tokens, reasoning capabilities, xhigh effort). Replaces the static per-model token map and the regex-based reasoning detection in the frontend.
* Google — fetched from /v1beta/models. Still uses a model-id heuristic for the effort vs budget API shape (Gemini's API doesn't expose it).
* OpenAI — model-id-keyed table (openai-model-defaults.ts) covering context window, reasoning, dev-message role, structured-output and streaming. Consolidates four separate arrays/regexes from the frontend.

Each manager has a single resolveMetadata entry point.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

The UI should now show correct progress based not on the 200k hardcoded window but based on the actual input token size (context window) of the model.
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
