### PR TITLE
feat: AI white label (continued)

### DIFF
--- a/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
@@ -16,6 +16,7 @@
 
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { HoverService } from '@theia/core/lib/browser';
 import { GenericCapabilitySelections } from '@theia/ai-core';
 import { AvailableGenericCapabilities, GenericCapabilityItem, GenericCapabilityGroup } from './generic-capabilities-service';
@@ -42,7 +43,9 @@ const ROOT_DESCRIPTIONS: Record<string, () => string> = {
     skills: () => nls.localize('theia/ai/chat-ui/skillsDescription', 'Reusable skill instructions that can be added to the conversation'),
     variables: () => nls.localize('theia/ai/chat-ui/variablesDescription', 'Dynamic variables that provide context information'),
     mcpFunctions: () => nls.localize('theia/ai/chat-ui/mcpFunctionsDescription', 'Model Context Protocol (MCP) functions from connected servers'),
-    functions: () => nls.localize('theia/ai/chat-ui/functionsDescription', 'Built-in functions provided by Theia extensions'),
+    functions: () => nls.localize('theia/ai/chat-ui/functionsDescription',
+        'Built-in functions provided by {0} extensions',
+        FrontendApplicationConfigProvider.get().applicationName),
     promptFragments: () => nls.localize('theia/ai/chat-ui/promptFragmentsDescription', 'Custom prompt fragments to include in the conversation'),
     agentDelegation: () => nls.localize('theia/ai/chat-ui/agentDelegationDescription', 'Other AI agents that can be delegated to')
 };

--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -22,6 +22,7 @@ import {
     UserRequest
 } from '@theia/ai-core/lib/common';
 import { generateUuid, ILogger, nls, ProgressService } from '@theia/core';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import * as monaco from '@theia/monaco-editor-core';
 import { codeCompletionPrompts } from './code-completion-prompt-template';
@@ -146,7 +147,9 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
     id = 'Code Completion';
     name = 'Code Completion';
     description =
-        nls.localize('theia/ai/completion/agent/description', 'This agent provides inline code completion in the code editor in the Theia IDE.');
+        nls.localize('theia/ai/completion/agent/description',
+            'This agent provides inline code completion in the code editor in {0}.',
+            FrontendApplicationConfigProvider.get().applicationName);
     prompts: PromptVariantSet[] = codeCompletionPrompts;
     languageModelRequirements: LanguageModelRequirement[] = [
         {

--- a/packages/ai-copilot/src/browser/copilot-auth-dialog-messages.ts
+++ b/packages/ai-copilot/src/browser/copilot-auth-dialog-messages.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { nls } from '@theia/core';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
 export const CopilotAuthDialogMessages = Symbol('CopilotAuthDialogMessages');
 
@@ -42,7 +43,8 @@ export const DEFAULT_COPILOT_AUTH_DIALOG_MESSAGES: CopilotAuthDialogMessages = {
     get instructions(): string {
         return nls.localize(
             'theia/ai/copilot/auth/instructions',
-            'To authorize Theia to use GitHub Copilot, visit the URL below and enter the code:'
+            'To authorize {0} to use GitHub Copilot, visit the URL below and enter the code:',
+            FrontendApplicationConfigProvider.get().applicationName
         );
     },
     get privacyNotice(): string {

--- a/packages/ai-core/src/browser/theia-variable-contribution.ts
+++ b/packages/ai-core/src/browser/theia-variable-contribution.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { VariableRegistry, VariableResolverService } from '@theia/variable-resolver/lib/browser';
@@ -108,7 +109,9 @@ export class TheiaVariableContribution implements AIVariableContribution, AIVari
                     const newName = (mapping.name && mapping.name.trim() !== '') ? mapping.name : variable.name;
                     const newDescription = (mapping.description && mapping.description.trim() !== '') ? mapping.description
                         : (variable.description && variable.description.trim() !== '' ? variable.description
-                            : nls.localize('theia/ai/core/variable-contribution/builtInVariable', 'Theia Built-in Variable'));
+                            : nls.localize('theia/ai/core/variable-contribution/builtInVariable',
+                            '{0} Built-in Variable',
+                            FrontendApplicationConfigProvider.get().applicationName));
 
                     // For multiple mappings of the same variable, add a suffix to the ID to make it unique
                     const idSuffix = mappings.length > 1 ? `-${index}` : '';

--- a/packages/ai-core/src/browser/window-blink-service.ts
+++ b/packages/ai-core/src/browser/window-blink-service.ts
@@ -18,6 +18,7 @@ import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { environment, nls } from '@theia/core';
 import { WindowTitleService } from '@theia/core/lib/browser/window/window-title-service';
 import { SecondaryWindowService } from '@theia/core/lib/browser/window/secondary-window-service';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
 /**
  * Result of a window blink attempt
@@ -102,9 +103,10 @@ export class WindowBlinkService {
         }
 
         const originalTitle = this.windowTitleService?.title ?? document.title;
+        const appName = FrontendApplicationConfigProvider.get().applicationName;
         const alertTitle = '🔔 ' + (agentName
-            ? nls.localize('theia/ai/core/blinkTitle/namedAgentCompleted', 'Theia - Agent "{0}" Completed', agentName)
-            : nls.localize('theia/ai/core/blinkTitle/agentCompleted', 'Theia - Agent Completed'));
+            ? nls.localize('theia/ai/core/blinkTitle/namedAgentCompleted', '{0} - Agent "{1}" Completed', appName, agentName)
+            : nls.localize('theia/ai/core/blinkTitle/agentCompleted', '{0} - Agent Completed', appName));
 
         // Save original titles of secondary windows
         this.originalSecondaryTitles.clear();

--- a/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
@@ -26,6 +26,7 @@ import { DEFAULT_CHAT_AGENT_PREF, BYPASS_MODEL_REQUIREMENT_PREF } from '@theia/a
 import { ChatAgentRecommendationService, ChatAgentService } from '@theia/ai-chat/lib/common';
 import { OPEN_AI_CONFIG_VIEW } from './ai-configuration/ai-configuration-view-contribution';
 import { AIActivationService } from '@theia/ai-core/lib/browser';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-commands';
 
 const TheiaIdeAiLogo = ({ width = 120, height = 120, className = '' }) =>
@@ -214,13 +215,14 @@ export class IdeChatWelcomeMessageProvider implements ChatWelcomeMessageProvider
             <LocalizedMarkdown
                 localizationKey="theia/ai/ide/chatWelcomeMessage"
                 defaultMarkdown={`
-## Ask the Theia IDE AI
+## Ask the {7} AI
 
 Use *@AgentName* to talk to a specialized agent, like *@{0}*, *@{1}*, or *@{2}*.
 
 Attach context with *#{3}*, *#{4}*, *#{5}*, or click {6}. [Learn more](https://theia-ide.org/docs/user_ai/#chat).
 `}
-                args={['Coder', 'Architect', 'Universal', 'file', '_f', 'selectedText', '<span class="codicon codicon-attach"></span>']}
+                args={['Coder', 'Architect', 'Universal', 'file', '_f', 'selectedText', '<span class="codicon codicon-attach"></span>',
+                    FrontendApplicationConfigProvider.get().applicationName]}
                 markdownRenderer={this.markdownRenderer}
                 className="theia-WelcomeMessage-Content"
                 markdownOptions={{ supportHtml: true }}

--- a/packages/ai-ide/src/browser/review/pr-review-prompt-template.ts
+++ b/packages/ai-ide/src/browser/review/pr-review-prompt-template.ts
@@ -47,7 +47,7 @@ https://github.com/eclipse-theia/theia/discussions/new?category=prompt-template-
 
 # Identity
 
-You are a **PR Review Agent** embedded in Theia IDE. You orchestrate a full pull request review workflow: fetching PR information from GitHub, exploring the codebase, performing structured code review, interactively walking the user through findings with diff viewers, and optionally creating a pending review on GitHub.
+You are a **PR Review Agent** embedded in {{productName}}. You orchestrate a full pull request review workflow: fetching PR information from GitHub, exploring the codebase, performing structured code review, interactively walking the user through findings with diff viewers, and optionally creating a pending review on GitHub.
 
 # Tools
 

--- a/packages/ai-ide/src/common/command-chat-agents.ts
+++ b/packages/ai-ide/src/common/command-chat-agents.ts
@@ -31,6 +31,8 @@ import {
     generateUuid,
     nls,
 } from '@theia/core';
+// eslint-disable-next-line @theia/runtime-import-check
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
 import { commandTemplate } from './command-prompt-template';
 
@@ -58,12 +60,15 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
     protected defaultLanguageModelPurpose: string = 'command';
 
     override description = nls.localize('theia/ai/ide/commandAgent/description',
-        'This agent is aware of all commands that the user can execute within the Theia IDE, the tool that the user is currently working with. ' +
-        'Based on the user request, it can find the right command and then let the user execute it.');
+        'This agent is aware of all commands that the user can execute within {0}, the tool that the user is currently working with. ' +
+        'Based on the user request, it can find the right command and then let the user execute it.',
+        FrontendApplicationConfigProvider.get().applicationName);
     override prompts = [commandTemplate];
     override agentSpecificVariables = [{
         name: 'command-ids',
-        description: nls.localize('theia/ai/ide/commandAgent/vars/commandIds/description', 'The list of available commands in Theia.'),
+        description: nls.localize('theia/ai/ide/commandAgent/vars/commandIds/description',
+            'The list of available commands in {0}.',
+            FrontendApplicationConfigProvider.get().applicationName),
         usedInPrompt: true
     }];
 
@@ -103,7 +108,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
         if (parsedCommand.type === 'theia-command') {
             const theiaCommand = this.commandRegistry.getCommand(parsedCommand.commandId);
             if (theiaCommand === undefined) {
-                console.error(`No Theia Command with id ${parsedCommand.commandId}`);
+                console.error(`No ${FrontendApplicationConfigProvider.get().applicationName} Command with id ${parsedCommand.commandId}`);
                 request.cancel();
             }
             const args = parsedCommand.arguments !== undefined &&

--- a/packages/ai-ide/src/common/command-chat-agents.ts
+++ b/packages/ai-ide/src/common/command-chat-agents.ts
@@ -31,8 +31,6 @@ import {
     generateUuid,
     nls,
 } from '@theia/core';
-// eslint-disable-next-line @theia/runtime-import-check
-import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 
 import { commandTemplate } from './command-prompt-template';
 
@@ -60,15 +58,12 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
     protected defaultLanguageModelPurpose: string = 'command';
 
     override description = nls.localize('theia/ai/ide/commandAgent/description',
-        'This agent is aware of all commands that the user can execute within {0}, the tool that the user is currently working with. ' +
-        'Based on the user request, it can find the right command and then let the user execute it.',
-        FrontendApplicationConfigProvider.get().applicationName);
+        'This agent is aware of all commands that the user can execute. ' +
+        'Based on the user request, it can find the right command and then let the user execute it.');
     override prompts = [commandTemplate];
     override agentSpecificVariables = [{
         name: 'command-ids',
-        description: nls.localize('theia/ai/ide/commandAgent/vars/commandIds/description',
-            'The list of available commands in {0}.',
-            FrontendApplicationConfigProvider.get().applicationName),
+        description: nls.localize('theia/ai/ide/commandAgent/vars/commandIds/description', 'The list of available commands.'),
         usedInPrompt: true
     }];
 
@@ -108,7 +103,7 @@ export class CommandChatAgent extends AbstractTextToModelParsingChatAgent<Parsed
         if (parsedCommand.type === 'theia-command') {
             const theiaCommand = this.commandRegistry.getCommand(parsedCommand.commandId);
             if (theiaCommand === undefined) {
-                console.error(`No ${FrontendApplicationConfigProvider.get().applicationName} Command with id ${parsedCommand.commandId}`);
+                console.error(`No Theia Command with id ${parsedCommand.commandId}`);
                 request.cancel();
             }
             const args = parsedCommand.arguments !== undefined &&

--- a/packages/ai-ide/src/common/command-prompt-template.ts
+++ b/packages/ai-ide/src/common/command-prompt-template.ts
@@ -33,7 +33,7 @@ Never under any circumstances may you reply with just the command-id!
 
 ## Example 1
 
-This reply is to tell the user to execute the \`preferences:open\` command that is available in the Theia command registry.
+This reply is to tell the user to execute the \`preferences:open\` command that is available in the {{productName}} command registry.
 
 \`\`\`json
 {
@@ -44,7 +44,7 @@ This reply is to tell the user to execute the \`preferences:open\` command that 
 
 ## Example 2
 
-This reply is to tell the user to execute the \`preferences:open\` command that is available in the Theia command registry,
+This reply is to tell the user to execute the \`preferences:open\` command that is available in the {{productName}} command registry,
 when the user want to pass arguments to the command.
 
 \`\`\`json
@@ -57,7 +57,7 @@ when the user want to pass arguments to the command.
 
 ## Example 3
 
-This reply is for custom commands that are not registered in the Theia command registry.
+This reply is for custom commands that are not registered in the {{productName}} command registry.
 These commands always have the command id \`ai-chat.command-chat-response.generic\`.
 The arguments are an array and may differ, depending on the user's instructions.
 
@@ -83,11 +83,11 @@ You may use the message to explain the situation to the user.
 
 # Rules
 
-## Theia Commands
+## {{productName}} Commands
 
-If a user asks for a Theia command, or the context implies it is about a command in Theia, return a response with \`"type": "theia-command"\`.
+If a user asks for a {{productName}} command, or the context implies it is about a command in {{productName}}, return a response with \`"type": "theia-command"\`.
 You need to exchange the "commandId".
-The available command ids in Theia are in the list below. The list of commands is formatted like this:
+The available command ids in {{productName}} are in the list below. The list of commands is formatted like this:
 
 command-id1: Label1
 command-id2: Label2
@@ -102,7 +102,7 @@ If the user says that the last command was not right, try to return the next bes
 
 If there are no more command ids that seem to fit, return a response of \`"type": "no-command"\` explaining the situation.
 
-Here are the known Theia commands:
+Here are the known {{productName}} commands:
 
 Begin List:
 {{command-ids}}
@@ -114,7 +114,7 @@ If you need to do this, use the \`"type": "no-command"\`. instead
 
 ## Custom Handlers
 
-If the user asks for a command that is not a Theia command, return a response with \`"type": "custom-handler"\`.
+If the user asks for a command that is not a {{productName}} command, return a response with \`"type": "custom-handler"\`.
 
 ## Other Cases
 
@@ -195,11 +195,11 @@ We want a response of \`"type": "no-command"\` and have the message there.
 
 ### The Example
 
-There is no specific command available to "open the windows" in the provided Theia command list.
+There is no specific command available to "open the windows" in the provided {{productName}} command list.
 
 ## Invalid Response Example 6
 
-In this example we were using the following theia id command list:
+In this example we were using the following {{productName}} id command list:
 
 Begin List:
 container--theia-open-editors-widget: Hello

--- a/packages/getting-started/src/browser/getting-started-widget.tsx
+++ b/packages/getting-started/src/browser/getting-started-widget.tsx
@@ -426,7 +426,7 @@ export class GettingStartedWidget extends ReactWidget {
 
     protected renderNews(): React.ReactNode {
         return <div className='gs-section'>
-            <h3 className='gs-section-header'>🚀 {nls.localize('theia/getting-started/ai/header', 'AI Support in the Theia IDE is available!')} ✨</h3>
+            <h3 className='gs-section-header'>🚀 {nls.localize('theia/getting-started/ai/header', 'AI Support in {0} is available!', this.applicationName)} ✨</h3>
             <div className='gs-action-container'>
                 <a
                     role={'button'}
@@ -444,11 +444,11 @@ export class GettingStartedWidget extends ReactWidget {
         return <div className='gs-container gs-aifeature-container'>
             <div className='flex-grid'>
                 <div className='col'>
-                    <h3 className='gs-section-header'> 🚀 {nls.localize('theia/getting-started/ai/header', 'AI Support in the Theia IDE is available!')} ✨</h3>
+                    <h3 className='gs-section-header'> 🚀 {nls.localize('theia/getting-started/ai/header', 'AI Support in {0} is available!', this.applicationName)} ✨</h3>
                     <LocalizedMarkdown className='gs-action-container'
                         localizationKey='theia/getting-started/ai/features'
                         defaultMarkdown={`
-Theia IDE now contains AI support, offering powerful AI capabilities within your IDE.\\
+{3} now contains AI support, offering powerful AI capabilities within your IDE.\\
 Please note that these features are disabled by default, ensuring that users can opt-in at their discretion.
 For those who choose to enable AI support, it is important to be aware that these may generate continuous
 requests to the language models (LLMs) you provide access to. This might incur costs that you need to monitor closely.\\
@@ -459,7 +459,7 @@ Thank you for being part of our community!\\
 The AI features are built on the framework Theia AI. If you want to build a custom AI-powered tool or IDE, Theia AI has been published as stable release.
 Check out [the Theia AI documentation]({2})!
 `}
-                        args={[this.userAIDocUrl, this.ghProjectUrl, this.theiaAIDocUrl]}
+                        args={[this.userAIDocUrl, this.ghProjectUrl, this.theiaAIDocUrl, this.applicationName]}
                         markdownRenderer={this.markdownRenderer}
                     />
                     <div className='gs-action-container'>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Part of https://github.com/eclipse-theia/theia/issues/17442

It resolves the remaining AI agent prompt and some of the AI-related UI: 
- Replace 'Theia' / 'Theia IDE' with {{productName}} in command and PR-review prompt templates. 
- Code Completion and Command agent descriptions
- AI chat welcome screen and Getting Started AI banner
- Copilot auth dialog instructions
- Capability tree "functions" description
- TheiaVariableContribution built-in variable label
- Agent-completed window-blink titles

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Still missing from issue #17442:

AI Settings:
- ai-features.AiEnable.enableAI
- ai-features.llamafile.llamafiles
- ai-features.anthropic.AnthropicApiKey
- ai-features.chat.defaultChatAgent
- ai-features.chat.bypassModelRequirement
- ai-features.claudeCode.apiKey
- ai-features.google.apiKey
- ai-features.huggingFace.apiKey
- ai-features.vercelAi.openaiApiKey
- ai-features.vercelAi.anthropicApiKey
- ai-features.SCANOSS.apiKey
- window.secondaryWindowPlacement
- workbench.colorTheme
- workbench.iconTheme
- workbench.startupEditor

Other code (non-AI/ backend/build):
- dev-packages/application-manager/src/application-package-manager.ts
- dev-packages/application-manager/src/generator/frontend-generator.ts
- packages/ai-mcp-server/src/node/mcp-theia-server-impl.ts (backend)
- packages/core/src/browser/browser-clipboard-service.ts
- packages/core/src/browser/frontend-application-module.ts
- packages/core/src/electron-browser/menu/electron-main-menu-factory.ts
- packages/core/src/node/backend-application.ts (backend)
- packages/debug/src/browser/debug-session.tsx
- packages/metrics/src/node/extensions-metrics-contribution.ts (backend)
- packages/metrics/src/node/measurement-metrics-contribution.ts (backend)
- packages/monaco/src/browser/monaco-init.ts
- packages/plugin-dev/src/node/hosted-instance-manager.ts (THEIA_INSTANCE_REGEX, backend)
- packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts (backend)
- packages/plugin-ext-vscode/src/node/plugin-vscode-init.ts (backend)
- packages/task/src/browser/task-schema-updater.ts
- packages/workspace/src/browser/workspace-trust-dialog.tsx
- packages/workspace/src/browser/workspace-trust-service.ts
- packages/workspace/src/common/workspace-file-service.ts


Bigger work is needed for the deferred items:

1. **AI preferences**: needs either (a) moving schemas out of /common/, or (b) a frontend-side post-processor that rewrites descriptions after the backend ships them. Either is a small architectural change.
2. **Backend code**: needs a backend equivalent of productName. The application name is already available there via ApplicationPackage/ApplicationServer; just needs a small accessor.
3. **Build tooling** (application-manager, frontend-generator.ts): these run at bundle generation time, not at app runtime. They need a different mechanism (read from package.json or app config).
4. **Theme names** (Dark (Theia) etc.): these are persisted in user settings as keys. Renaming them would invalidate users' saved theme choices. Probably keep as-is or do a careful migration.


#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
