### PR TITLE
ai-chat: make tool confirmation default a dedicated preference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## 1.72.0 - tbd
+
+<a name="breaking_changes_1.72.0">[Breaking Changes:](#breaking_changes_1.72.0)</a>
+
+- [ai-chat] the `'*'` magic key inside `ai-features.chat.toolConfirmation` is no longer honored; migrate to the new `ai-features.chat.defaultToolConfirmation` preference [#17452](https://github.com/eclipse-theia/theia/pull/17452)
+
 ## 1.71.0 - 4/30/2026
 
 - [ai] replaced the per-model thinking-mode toggle with a provider-agnostic reasoning selector and `ReasoningSettings` abstraction; the chosen level can be persisted per agent via the chat capabilities save action [#17363](https://github.com/eclipse-theia/theia/pull/17363)

--- a/packages/ai-chat/src/browser/chat-tool-preference-bindings.spec.ts
+++ b/packages/ai-chat/src/browser/chat-tool-preference-bindings.spec.ts
@@ -18,22 +18,30 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Container } from '@theia/core/shared/inversify';
 import { ToolConfirmationManager } from './chat-tool-preference-bindings';
-import { ToolConfirmationMode } from '../common/chat-tool-preferences';
+import {
+    DEFAULT_TOOL_CONFIRMATION_PREFERENCE,
+    TOOL_CONFIRMATION_PREFERENCE,
+    ToolConfirmationMode
+} from '../common/chat-tool-preferences';
 import { ToolRequest } from '@theia/ai-core';
 import { PreferenceService } from '@theia/core/lib/common/preferences';
 import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
+
+interface InspectResult<T> {
+    defaultValue?: T;
+    globalValue?: T;
+    workspaceValue?: T;
+}
 
 describe('ToolConfirmationManager', () => {
     let manager: ToolConfirmationManager;
     let preferenceServiceMock: sinon.SinonStubbedInstance<PreferenceService>;
     let trustAwareReaderMock: sinon.SinonStubbedInstance<TrustAwarePreferenceReader>;
-    let storedPreferences: { [toolId: string]: ToolConfirmationMode };
+    let storedPerToolPreferences: { [toolId: string]: ToolConfirmationMode };
+    let storedDefaultMode: ToolConfirmationMode | undefined;
     let trusted: boolean;
-    let inspectResult: {
-        defaultValue?: { [toolId: string]: ToolConfirmationMode };
-        globalValue?: { [toolId: string]: ToolConfirmationMode };
-        workspaceValue?: { [toolId: string]: ToolConfirmationMode };
-    } | undefined;
+    let perToolInspectResult: InspectResult<{ [toolId: string]: ToolConfirmationMode }> | undefined;
+    let defaultInspectResult: InspectResult<ToolConfirmationMode> | undefined;
 
     const createToolRequest = (id: string, confirmAlwaysAllow?: boolean | string): ToolRequest => ({
         id,
@@ -44,26 +52,49 @@ describe('ToolConfirmationManager', () => {
     });
 
     beforeEach(() => {
-        storedPreferences = {};
+        storedPerToolPreferences = {};
+        storedDefaultMode = undefined;
         trusted = true;
-        inspectResult = undefined;
+        perToolInspectResult = undefined;
+        defaultInspectResult = undefined;
 
         preferenceServiceMock = {
-            updateValue: sinon.stub().callsFake((_key: string, value: { [toolId: string]: ToolConfirmationMode }) => {
-                storedPreferences = value;
+            updateValue: sinon.stub().callsFake((key: string, value: unknown) => {
+                if (key === TOOL_CONFIRMATION_PREFERENCE) {
+                    storedPerToolPreferences = value as { [toolId: string]: ToolConfirmationMode };
+                } else if (key === DEFAULT_TOOL_CONFIRMATION_PREFERENCE) {
+                    storedDefaultMode = value as ToolConfirmationMode;
+                }
                 return Promise.resolve();
             }),
-            inspect: sinon.stub().callsFake(() => inspectResult)
+            inspect: sinon.stub().callsFake((name: string) => {
+                if (name === TOOL_CONFIRMATION_PREFERENCE) {
+                    return perToolInspectResult;
+                }
+                if (name === DEFAULT_TOOL_CONFIRMATION_PREFERENCE) {
+                    return defaultInspectResult;
+                }
+                return undefined;
+            })
         } as unknown as sinon.SinonStubbedInstance<PreferenceService>;
 
         trustAwareReaderMock = {
-            get: sinon.stub().callsFake(<T>(_name: string, fallback?: T): T | undefined => {
-                if (trusted) {
-                    return (storedPreferences as unknown as T) ?? fallback;
+            get: sinon.stub().callsFake(<T>(name: string, fallback?: T): T | undefined => {
+                if (name === TOOL_CONFIRMATION_PREFERENCE) {
+                    if (trusted) {
+                        return (storedPerToolPreferences as unknown as T) ?? fallback;
+                    }
+                    const value = perToolInspectResult?.globalValue ?? perToolInspectResult?.defaultValue;
+                    return ((value as unknown as T) ?? fallback);
                 }
-                const insp = inspectResult;
-                const value = insp?.globalValue ?? insp?.defaultValue;
-                return ((value as unknown as T) ?? fallback);
+                if (name === DEFAULT_TOOL_CONFIRMATION_PREFERENCE) {
+                    if (trusted) {
+                        return (storedDefaultMode as unknown as T) ?? fallback;
+                    }
+                    const value = defaultInspectResult?.globalValue ?? defaultInspectResult?.defaultValue;
+                    return ((value as unknown as T) ?? fallback);
+                }
+                return fallback;
             })
         } as unknown as sinon.SinonStubbedInstance<TrustAwarePreferenceReader>;
 
@@ -74,81 +105,115 @@ describe('ToolConfirmationManager', () => {
         manager = container.get(ToolConfirmationManager);
     });
 
-    describe('getConfirmationMode', () => {
-        it('should return ALWAYS_ALLOW for regular tools by default', () => {
-            const mode = manager.getConfirmationMode('regularTool', 'chat-1');
-            expect(mode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+    describe('getDefaultConfirmationMode', () => {
+        it('returns CONFIRM when nothing is set', () => {
+            expect(manager.getDefaultConfirmationMode()).to.equal(ToolConfirmationMode.CONFIRM);
         });
 
-        it('should return CONFIRM for confirmAlwaysAllow tools by default', () => {
+        it('returns the value stored in the user preference', () => {
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
+            expect(manager.getDefaultConfirmationMode()).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+        });
+
+        it('falls back to the schema-level default when no user value is set', () => {
+            defaultInspectResult = { defaultValue: ToolConfirmationMode.DISABLED };
+            expect(manager.getDefaultConfirmationMode()).to.equal(ToolConfirmationMode.DISABLED);
+        });
+    });
+
+    describe('setDefaultConfirmationMode', () => {
+        it('persists the new default through the preference service', () => {
+            manager.setDefaultConfirmationMode(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
+            expect(preferenceServiceMock.updateValue.firstCall.args[0]).to.equal(DEFAULT_TOOL_CONFIRMATION_PREFERENCE);
+            expect(preferenceServiceMock.updateValue.firstCall.args[1]).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(storedDefaultMode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+        });
+    });
+
+    describe('getConfirmationMode', () => {
+        it('returns CONFIRM for regular tools by default', () => {
+            const mode = manager.getConfirmationMode('regularTool', 'chat-1');
+            expect(mode).to.equal(ToolConfirmationMode.CONFIRM);
+        });
+
+        it('returns CONFIRM for confirmAlwaysAllow tools by default', () => {
             const toolRequest = createToolRequest('dangerousTool', true);
             const mode = manager.getConfirmationMode('dangerousTool', 'chat-1', toolRequest);
             expect(mode).to.equal(ToolConfirmationMode.CONFIRM);
         });
 
-        it('should return tool-specific preference when set', () => {
-            storedPreferences['myTool'] = ToolConfirmationMode.DISABLED;
+        it('returns the global default for regular tools when set', () => {
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
+            const mode = manager.getConfirmationMode('regularTool', 'chat-1');
+            expect(mode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+        });
+
+        it('returns tool-specific preference when set', () => {
+            storedPerToolPreferences['myTool'] = ToolConfirmationMode.DISABLED;
             const mode = manager.getConfirmationMode('myTool', 'chat-1');
             expect(mode).to.equal(ToolConfirmationMode.DISABLED);
         });
 
-        it('should return session override when set', () => {
+        it('returns session override when set', () => {
             manager.setSessionConfirmationMode('myTool', ToolConfirmationMode.ALWAYS_ALLOW, 'chat-1');
             const mode = manager.getConfirmationMode('myTool', 'chat-1');
             expect(mode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
         });
 
-        it('should not inherit global ALWAYS_ALLOW for confirmAlwaysAllow tools', () => {
-            storedPreferences['*'] = ToolConfirmationMode.ALWAYS_ALLOW;
+        it('does not inherit global ALWAYS_ALLOW for confirmAlwaysAllow tools', () => {
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
             const toolRequest = createToolRequest('dangerousTool', true);
             const mode = manager.getConfirmationMode('dangerousTool', 'chat-1', toolRequest);
             expect(mode).to.equal(ToolConfirmationMode.CONFIRM);
         });
 
-        it('should inherit global DISABLED for confirmAlwaysAllow tools', () => {
-            storedPreferences['*'] = ToolConfirmationMode.DISABLED;
+        it('inherits global DISABLED for confirmAlwaysAllow tools', () => {
+            storedDefaultMode = ToolConfirmationMode.DISABLED;
             const toolRequest = createToolRequest('dangerousTool', true);
             const mode = manager.getConfirmationMode('dangerousTool', 'chat-1', toolRequest);
             expect(mode).to.equal(ToolConfirmationMode.DISABLED);
         });
+
+        it('respects an explicit per-tool ALWAYS_ALLOW for confirmAlwaysAllow tools', () => {
+            storedPerToolPreferences['dangerousTool'] = ToolConfirmationMode.ALWAYS_ALLOW;
+            const toolRequest = createToolRequest('dangerousTool', true);
+            const mode = manager.getConfirmationMode('dangerousTool', 'chat-1', toolRequest);
+            expect(mode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+        });
     });
 
     describe('workspace trust', () => {
-        it('ignores workspace {"*": "always_allow"} when workspace is untrusted', () => {
+        it('ignores a workspace-scoped default of ALWAYS_ALLOW when workspace is untrusted', () => {
             trusted = false;
-            // Simulate the effective (workspace-merged) preference containing always_allow,
-            // while the user/global scope is not set and the schema default prescribes
-            // CONFIRM. If the workspace override were honoured the mode would be
-            // ALWAYS_ALLOW; because trust filters the workspace scope out, the default
-            // (CONFIRM) wins, which demonstrably proves the override was dropped.
-            storedPreferences['*'] = ToolConfirmationMode.ALWAYS_ALLOW;
-            inspectResult = {
-                defaultValue: { '*': ToolConfirmationMode.CONFIRM },
-                workspaceValue: { '*': ToolConfirmationMode.ALWAYS_ALLOW }
+            // Simulate the effective (workspace-merged) default being ALWAYS_ALLOW while
+            // the user/global scope is unset and the schema default is CONFIRM. With trust
+            // disabled the workspace value must be dropped, so CONFIRM wins.
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
+            defaultInspectResult = {
+                defaultValue: ToolConfirmationMode.CONFIRM,
+                workspaceValue: ToolConfirmationMode.ALWAYS_ALLOW
             };
 
             const mode = manager.getConfirmationMode('someTool', 'chat-1');
             expect(mode).to.equal(ToolConfirmationMode.CONFIRM);
         });
 
-        it('blocks confirmAlwaysAllow bypass via workspace {"*": "always_allow"} when untrusted', () => {
+        it('blocks confirmAlwaysAllow bypass via workspace ALWAYS_ALLOW default when untrusted', () => {
             trusted = false;
-            storedPreferences['*'] = ToolConfirmationMode.ALWAYS_ALLOW;
-            inspectResult = {
-                defaultValue: {},
-                workspaceValue: { '*': ToolConfirmationMode.ALWAYS_ALLOW }
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
+            defaultInspectResult = {
+                workspaceValue: ToolConfirmationMode.ALWAYS_ALLOW
             };
 
             const toolRequest = createToolRequest('dangerousTool', true);
             const mode = manager.getConfirmationMode('dangerousTool', 'chat-1', toolRequest);
-            // Without the workspace value the map is empty, so the default for a
-            // confirmAlwaysAllow tool (CONFIRM) is used.
             expect(mode).to.equal(ToolConfirmationMode.CONFIRM);
         });
 
-        it('honours workspace {"*": "always_allow"} when workspace is trusted', () => {
+        it('honours a workspace-scoped ALWAYS_ALLOW default when workspace is trusted', () => {
             trusted = true;
-            storedPreferences['*'] = ToolConfirmationMode.ALWAYS_ALLOW;
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
 
             const mode = manager.getConfirmationMode('regularTool', 'chat-1');
             expect(mode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
@@ -156,139 +221,164 @@ describe('ToolConfirmationManager', () => {
     });
 
     describe('setConfirmationMode', () => {
-        it('should persist ALWAYS_ALLOW for regular tools when different from default', () => {
-            storedPreferences['*'] = ToolConfirmationMode.CONFIRM;
+        it('persists ALWAYS_ALLOW for a regular tool when default is CONFIRM', () => {
             manager.setConfirmationMode('regularTool', ToolConfirmationMode.ALWAYS_ALLOW);
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['regularTool']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(storedPerToolPreferences['regularTool']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
         });
 
-        it('should persist ALWAYS_ALLOW for confirmAlwaysAllow tools', () => {
+        it('persists ALWAYS_ALLOW for confirmAlwaysAllow tools', () => {
             const toolRequest = createToolRequest('dangerousTool', true);
             manager.setConfirmationMode('dangerousTool', ToolConfirmationMode.ALWAYS_ALLOW, toolRequest);
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['dangerousTool']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(storedPerToolPreferences['dangerousTool']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
         });
 
-        it('should not persist ALWAYS_ALLOW for regular tools when it matches default', () => {
+        it('does not persist when mode matches the global default', () => {
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
             manager.setConfirmationMode('regularTool', ToolConfirmationMode.ALWAYS_ALLOW);
             expect(preferenceServiceMock.updateValue.called).to.be.false;
         });
 
-        it('should not persist when mode matches the global preference default', () => {
-            inspectResult = {
-                defaultValue: { '*': ToolConfirmationMode.CONFIRM }
-            };
+        it('does not persist CONFIRM for a regular tool when default is CONFIRM', () => {
             manager.setConfirmationMode('regularTool', ToolConfirmationMode.CONFIRM);
             expect(preferenceServiceMock.updateValue.called).to.be.false;
         });
 
-        it('should persist when mode differs from the global preference default', () => {
-            inspectResult = {
-                defaultValue: { '*': ToolConfirmationMode.CONFIRM }
-            };
+        it('persists DISABLED when default is CONFIRM', () => {
             manager.setConfirmationMode('regularTool', ToolConfirmationMode.DISABLED);
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['regularTool']).to.equal(ToolConfirmationMode.DISABLED);
+            expect(storedPerToolPreferences['regularTool']).to.equal(ToolConfirmationMode.DISABLED);
         });
 
-        it('should not persist when mode matches the tool-specific preference default', () => {
-            inspectResult = {
+        it('does not persist when mode matches a tool-specific schema default', () => {
+            perToolInspectResult = {
                 defaultValue: { 'myTool': ToolConfirmationMode.DISABLED }
             };
             manager.setConfirmationMode('myTool', ToolConfirmationMode.DISABLED);
             expect(preferenceServiceMock.updateValue.called).to.be.false;
         });
 
-        it('should remove entry when mode matches the tool-specific preference default and entry exists', () => {
-            inspectResult = {
+        it('removes an existing entry when mode matches the tool-specific schema default', () => {
+            perToolInspectResult = {
                 defaultValue: { 'myTool': ToolConfirmationMode.DISABLED }
             };
-            storedPreferences['myTool'] = ToolConfirmationMode.ALWAYS_ALLOW;
+            storedPerToolPreferences['myTool'] = ToolConfirmationMode.ALWAYS_ALLOW;
             manager.setConfirmationMode('myTool', ToolConfirmationMode.DISABLED);
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['myTool']).to.be.undefined;
+            expect(storedPerToolPreferences['myTool']).to.be.undefined;
         });
 
-        it('should not persist CONFIRM for confirmAlwaysAllow tool when global preference default is CONFIRM', () => {
-            inspectResult = {
-                defaultValue: { '*': ToolConfirmationMode.CONFIRM }
-            };
+        it('does not persist CONFIRM for confirmAlwaysAllow tools (matches effective default)', () => {
             const toolRequest = createToolRequest('dangerousTool', true);
             manager.setConfirmationMode('dangerousTool', ToolConfirmationMode.CONFIRM, toolRequest);
             expect(preferenceServiceMock.updateValue.called).to.be.false;
         });
 
-        it('should persist ALWAYS_ALLOW for confirmAlwaysAllow tool when global preference default is CONFIRM', () => {
-            inspectResult = {
-                defaultValue: { '*': ToolConfirmationMode.CONFIRM }
-            };
+        it('persists ALWAYS_ALLOW for a confirmAlwaysAllow tool when global default is ALWAYS_ALLOW', () => {
+            // The effective default for confirmAlwaysAllow tools is CONFIRM even when
+            // the global default is ALWAYS_ALLOW, so ALWAYS_ALLOW must still be persisted.
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
             const toolRequest = createToolRequest('dangerousTool', true);
             manager.setConfirmationMode('dangerousTool', ToolConfirmationMode.ALWAYS_ALLOW, toolRequest);
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['dangerousTool']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(storedPerToolPreferences['dangerousTool']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
         });
 
-        it('should remove entry when setting mode that matches effective default', () => {
-            storedPreferences['regularTool'] = ToolConfirmationMode.CONFIRM;
-            manager.setConfirmationMode('regularTool', ToolConfirmationMode.ALWAYS_ALLOW);
-            expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['regularTool']).to.be.undefined;
-        });
-
-        it('should persist DISABLED for any tool', () => {
-            manager.setConfirmationMode('anyTool', ToolConfirmationMode.DISABLED);
-            expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['anyTool']).to.equal(ToolConfirmationMode.DISABLED);
-        });
-
-        it('should remove entry when setting CONFIRM for confirmAlwaysAllow tools (matches effective default)', () => {
+        it('removes an existing entry when setting CONFIRM for a confirmAlwaysAllow tool', () => {
             const toolRequest = createToolRequest('dangerousTool', true);
-            storedPreferences['dangerousTool'] = ToolConfirmationMode.ALWAYS_ALLOW;
+            storedPerToolPreferences['dangerousTool'] = ToolConfirmationMode.ALWAYS_ALLOW;
             manager.setConfirmationMode('dangerousTool', ToolConfirmationMode.CONFIRM, toolRequest);
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['dangerousTool']).to.be.undefined;
+            expect(storedPerToolPreferences['dangerousTool']).to.be.undefined;
+        });
+
+        it('persists DISABLED for any tool when default is CONFIRM', () => {
+            manager.setConfirmationMode('anyTool', ToolConfirmationMode.DISABLED);
+            expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
+            expect(storedPerToolPreferences['anyTool']).to.equal(ToolConfirmationMode.DISABLED);
         });
     });
 
     describe('setSessionConfirmationMode', () => {
-        it('should set session override for specific chat', () => {
+        it('sets a session override for a specific chat', () => {
             manager.setSessionConfirmationMode('myTool', ToolConfirmationMode.ALWAYS_ALLOW, 'chat-1');
             expect(manager.getConfirmationMode('myTool', 'chat-1')).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
-            expect(manager.getConfirmationMode('myTool', 'chat-2')).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(manager.getConfirmationMode('myTool', 'chat-2')).to.equal(ToolConfirmationMode.CONFIRM);
         });
 
-        it('should prioritize session override over persisted preference', () => {
-            storedPreferences['myTool'] = ToolConfirmationMode.DISABLED;
+        it('prioritizes session override over persisted preference', () => {
+            storedPerToolPreferences['myTool'] = ToolConfirmationMode.DISABLED;
             manager.setSessionConfirmationMode('myTool', ToolConfirmationMode.ALWAYS_ALLOW, 'chat-1');
             expect(manager.getConfirmationMode('myTool', 'chat-1')).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
         });
     });
 
     describe('clearSessionOverrides', () => {
-        it('should clear overrides for specific chat', () => {
+        it('clears overrides for a specific chat', () => {
             manager.setSessionConfirmationMode('myTool', ToolConfirmationMode.ALWAYS_ALLOW, 'chat-1');
             manager.setSessionConfirmationMode('myTool', ToolConfirmationMode.DISABLED, 'chat-2');
 
             manager.clearSessionOverrides('chat-1');
 
-            expect(manager.getConfirmationMode('myTool', 'chat-1')).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(manager.getConfirmationMode('myTool', 'chat-1')).to.equal(ToolConfirmationMode.CONFIRM);
             expect(manager.getConfirmationMode('myTool', 'chat-2')).to.equal(ToolConfirmationMode.DISABLED);
         });
 
-        it('should clear all overrides when no chatId provided', () => {
+        it('clears all overrides when no chatId is given', () => {
             manager.setSessionConfirmationMode('myTool', ToolConfirmationMode.ALWAYS_ALLOW, 'chat-1');
             manager.setSessionConfirmationMode('myTool', ToolConfirmationMode.DISABLED, 'chat-2');
 
             manager.clearSessionOverrides();
 
-            expect(manager.getConfirmationMode('myTool', 'chat-1')).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
-            expect(manager.getConfirmationMode('myTool', 'chat-2')).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(manager.getConfirmationMode('myTool', 'chat-1')).to.equal(ToolConfirmationMode.CONFIRM);
+            expect(manager.getConfirmationMode('myTool', 'chat-2')).to.equal(ToolConfirmationMode.CONFIRM);
+        });
+    });
+
+    describe('getAllConfirmationSettings', () => {
+        it('returns the per-tool record from the trust-aware reader', () => {
+            storedPerToolPreferences['toolA'] = ToolConfirmationMode.ALWAYS_ALLOW;
+            storedPerToolPreferences['toolB'] = ToolConfirmationMode.DISABLED;
+
+            const settings = manager.getAllConfirmationSettings();
+
+            expect(settings).to.deep.equal({
+                toolA: ToolConfirmationMode.ALWAYS_ALLOW,
+                toolB: ToolConfirmationMode.DISABLED
+            });
+        });
+
+        it('returns an empty record when no tool-specific entries are configured', () => {
+            const settings = manager.getAllConfirmationSettings();
+            expect(settings).to.deep.equal({});
+        });
+    });
+
+    describe('resetAllConfirmationModeSettings', () => {
+        it('clears all per-tool entries', () => {
+            storedPerToolPreferences['toolA'] = ToolConfirmationMode.ALWAYS_ALLOW;
+            storedPerToolPreferences['toolB'] = ToolConfirmationMode.DISABLED;
+
+            manager.resetAllConfirmationModeSettings();
+
+            expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
+            expect(preferenceServiceMock.updateValue.firstCall.args[0]).to.equal(TOOL_CONFIRMATION_PREFERENCE);
+            expect(preferenceServiceMock.updateValue.firstCall.args[1]).to.deep.equal({});
+        });
+
+        it('does not modify the default-confirmation preference', () => {
+            storedDefaultMode = ToolConfirmationMode.ALWAYS_ALLOW;
+            storedPerToolPreferences['toolA'] = ToolConfirmationMode.DISABLED;
+
+            manager.resetAllConfirmationModeSettings();
+
+            expect(storedDefaultMode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
         });
     });
 
     describe('confirmAlwaysAllow tools - "Always Approve" workflow', () => {
-        it('should persist "Always Allow" for confirmAlwaysAllow tools', () => {
+        it('persists "Always Allow" for confirmAlwaysAllow tools', () => {
             const toolRequest = createToolRequest('shellExecute', 'This tool has full system access.');
 
             let mode = manager.getConfirmationMode('shellExecute', 'chat-1', toolRequest);
@@ -297,19 +387,19 @@ describe('ToolConfirmationManager', () => {
             manager.setConfirmationMode('shellExecute', ToolConfirmationMode.ALWAYS_ALLOW, toolRequest);
 
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['shellExecute']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(storedPerToolPreferences['shellExecute']).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
 
             mode = manager.getConfirmationMode('shellExecute', 'chat-1', toolRequest);
             expect(mode).to.equal(ToolConfirmationMode.ALWAYS_ALLOW);
         });
 
-        it('should persist "Disabled" for confirmAlwaysAllow tools', () => {
+        it('persists "Disabled" for confirmAlwaysAllow tools', () => {
             const toolRequest = createToolRequest('shellExecute', true);
 
             manager.setConfirmationMode('shellExecute', ToolConfirmationMode.DISABLED, toolRequest);
 
             expect(preferenceServiceMock.updateValue.calledOnce).to.be.true;
-            expect(storedPreferences['shellExecute']).to.equal(ToolConfirmationMode.DISABLED);
+            expect(storedPerToolPreferences['shellExecute']).to.equal(ToolConfirmationMode.DISABLED);
 
             const mode = manager.getConfirmationMode('shellExecute', 'chat-1', toolRequest);
             expect(mode).to.equal(ToolConfirmationMode.DISABLED);

--- a/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
+++ b/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
@@ -18,7 +18,11 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import {
     PreferenceService,
 } from '@theia/core/lib/common/preferences';
-import { ToolConfirmationMode, TOOL_CONFIRMATION_PREFERENCE } from '../common/chat-tool-preferences';
+import {
+    ToolConfirmationMode,
+    TOOL_CONFIRMATION_PREFERENCE,
+    DEFAULT_TOOL_CONFIRMATION_PREFERENCE
+} from '../common/chat-tool-preferences';
 import { ToolRequest } from '@theia/ai-core';
 import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-aware-preference-reader';
 
@@ -37,11 +41,29 @@ export class ToolConfirmationManager {
     protected sessionOverrides: Map<string, Map<string, ToolConfirmationMode>> = new Map();
 
     /**
+     * Get the global default confirmation mode (used when no tool-specific entry exists).
+     *
+     * Read through the trust-aware reader so that an untrusted workspace cannot override
+     * the default to a more permissive value.
+     */
+    getDefaultConfirmationMode(): ToolConfirmationMode {
+        const value = this.trustAwareReader.get<ToolConfirmationMode>(DEFAULT_TOOL_CONFIRMATION_PREFERENCE);
+        return value ?? this.getDefaultPreferenceSchemaDefault();
+    }
+
+    /**
+     * Set the global default confirmation mode.
+     */
+    setDefaultConfirmationMode(mode: ToolConfirmationMode): void {
+        this.preferenceService.updateValue(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, mode);
+    }
+
+    /**
      * Get the confirmation mode for a specific tool, considering session overrides first (per chat).
      *
      * For tools with `confirmAlwaysAllow` flag:
-     * - They default to CONFIRM mode instead of ALWAYS_ALLOW
-     * - They don't inherit global ALWAYS_ALLOW from the '*' preference
+     * - They default to CONFIRM mode instead of inheriting ALWAYS_ALLOW from the global default.
+     * - Tool-specific preference entries are still respected (informed user consent).
      *
      * @param toolId - The tool identifier
      * @param chatId - The chat session identifier
@@ -55,21 +77,15 @@ export class ToolConfirmationManager {
         const toolConfirmation = this.trustAwareReader.get<Record<string, ToolConfirmationMode>>(
             TOOL_CONFIRMATION_PREFERENCE, {}
         ) ?? {};
-        if (toolConfirmation[toolId]) {
+        if (toolId in toolConfirmation) {
             return toolConfirmation[toolId];
         }
-        if (toolConfirmation['*']) {
-            // For confirmAlwaysAllow tools, don't inherit global ALWAYS_ALLOW
-            if (toolRequest?.confirmAlwaysAllow && toolConfirmation['*'] === ToolConfirmationMode.ALWAYS_ALLOW) {
-                return ToolConfirmationMode.CONFIRM;
-            }
-            return toolConfirmation['*'];
+        const defaultMode = this.getDefaultConfirmationMode();
+        // For confirmAlwaysAllow tools, don't inherit a global ALWAYS_ALLOW default
+        if (toolRequest?.confirmAlwaysAllow && defaultMode === ToolConfirmationMode.ALWAYS_ALLOW) {
+            return ToolConfirmationMode.CONFIRM;
         }
-
-        // Default: ALWAYS_ALLOW for normal tools, CONFIRM for confirmAlwaysAllow tools
-        return toolRequest?.confirmAlwaysAllow
-            ? ToolConfirmationMode.CONFIRM
-            : ToolConfirmationMode.ALWAYS_ALLOW;
+        return defaultMode;
     }
 
     /**
@@ -80,20 +96,10 @@ export class ToolConfirmationManager {
      * @param toolRequest - Optional ToolRequest to check for confirmAlwaysAllow flag
      */
     setConfirmationMode(toolId: string, mode: ToolConfirmationMode, toolRequest?: ToolRequest): void {
-        const defaultPref = this.preferenceService.inspect(TOOL_CONFIRMATION_PREFERENCE)?.defaultValue as {
-            [toolId: string]: ToolConfirmationMode;
-        } || {};
         const current = this.trustAwareReader.get<Record<string, ToolConfirmationMode>>(
             TOOL_CONFIRMATION_PREFERENCE, {}
         ) ?? {};
-        let starMode = current['*'];
-        if (starMode === undefined) {
-            starMode = defaultPref['*'] ?? ToolConfirmationMode.ALWAYS_ALLOW;
-        }
-        // For confirmAlwaysAllow tools, the effective default is CONFIRM, not ALWAYS_ALLOW
-        const effectiveDefault = (toolRequest?.confirmAlwaysAllow && starMode === ToolConfirmationMode.ALWAYS_ALLOW)
-            ? ToolConfirmationMode.CONFIRM
-            : defaultPref[toolId] ?? starMode;
+        const effectiveDefault = this.computeEffectiveDefaultForTool(toolId, toolRequest);
         if (mode === effectiveDefault) {
             if (toolId in current) {
                 const { [toolId]: _, ...rest } = current;
@@ -138,13 +144,36 @@ export class ToolConfirmationManager {
     }
 
     resetAllConfirmationModeSettings(): void {
-        const current = this.trustAwareReader.get<Record<string, ToolConfirmationMode>>(
-            TOOL_CONFIRMATION_PREFERENCE, {}
-        ) ?? {};
-        if ('*' in current) {
-            this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, { '*': current['*'] });
-        } else {
-            this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, {});
+        this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, {});
+    }
+
+    /**
+     * Compute the effective default for a given tool, taking the schema-level default,
+     * any product-shipped per-tool default, and the confirmAlwaysAllow flag into account.
+     */
+    protected computeEffectiveDefaultForTool(toolId: string, toolRequest?: ToolRequest): ToolConfirmationMode {
+        const perToolDefaults = this.preferenceService.inspect(TOOL_CONFIRMATION_PREFERENCE)?.defaultValue as
+            | { [toolId: string]: ToolConfirmationMode }
+            | undefined;
+        const perToolDefault = perToolDefaults?.[toolId];
+        if (perToolDefault) {
+            return perToolDefault;
         }
+        const globalDefault = this.getDefaultConfirmationMode();
+        if (toolRequest?.confirmAlwaysAllow && globalDefault === ToolConfirmationMode.ALWAYS_ALLOW) {
+            return ToolConfirmationMode.CONFIRM;
+        }
+        return globalDefault;
+    }
+
+    /**
+     * Read the schema-level default for the default-confirmation preference.
+     * Falls back to CONFIRM if the preference service has not registered the schema yet.
+     */
+    protected getDefaultPreferenceSchemaDefault(): ToolConfirmationMode {
+        const schemaDefault = this.preferenceService.inspect(DEFAULT_TOOL_CONFIRMATION_PREFERENCE)?.defaultValue as
+            | ToolConfirmationMode
+            | undefined;
+        return schemaDefault ?? ToolConfirmationMode.CONFIRM;
     }
 }

--- a/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
+++ b/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
@@ -53,9 +53,12 @@ export class ToolConfirmationManager {
 
     /**
      * Set the global default confirmation mode.
+     *
+     * Returns the promise produced by the underlying preference update so callers can
+     * `await` completion and react to errors (e.g. show a notification on failure).
      */
-    setDefaultConfirmationMode(mode: ToolConfirmationMode): void {
-        this.preferenceService.updateValue(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, mode);
+    setDefaultConfirmationMode(mode: ToolConfirmationMode): Promise<void> {
+        return this.preferenceService.updateValue(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, mode);
     }
 
     /**
@@ -95,7 +98,7 @@ export class ToolConfirmationManager {
      * @param mode - The confirmation mode to set
      * @param toolRequest - Optional ToolRequest to check for confirmAlwaysAllow flag
      */
-    setConfirmationMode(toolId: string, mode: ToolConfirmationMode, toolRequest?: ToolRequest): void {
+    setConfirmationMode(toolId: string, mode: ToolConfirmationMode, toolRequest?: ToolRequest): Promise<void> {
         const current = this.trustAwareReader.get<Record<string, ToolConfirmationMode>>(
             TOOL_CONFIRMATION_PREFERENCE, {}
         ) ?? {};
@@ -103,12 +106,12 @@ export class ToolConfirmationManager {
         if (mode === effectiveDefault) {
             if (toolId in current) {
                 const { [toolId]: _, ...rest } = current;
-                this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, rest);
+                return this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, rest);
             }
-        } else {
-            const updated = { ...current, [toolId]: mode };
-            this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, updated);
+            return Promise.resolve();
         }
+        const updated = { ...current, [toolId]: mode };
+        return this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, updated);
     }
 
     /**
@@ -143,8 +146,8 @@ export class ToolConfirmationManager {
         ) ?? {};
     }
 
-    resetAllConfirmationModeSettings(): void {
-        this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, {});
+    resetAllConfirmationModeSettings(): Promise<void> {
+        return this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, {});
     }
 
     /**

--- a/packages/ai-chat/src/common/chat-tool-preferences.ts
+++ b/packages/ai-chat/src/common/chat-tool-preferences.ts
@@ -54,25 +54,45 @@ export enum ToolConfirmationMode {
 }
 
 export const TOOL_CONFIRMATION_PREFERENCE = 'ai-features.chat.toolConfirmation';
+export const DEFAULT_TOOL_CONFIRMATION_PREFERENCE = 'ai-features.chat.defaultToolConfirmation';
 export const TOOL_CONFIRMATION_TIMEOUT_PREFERENCE = 'ai-features.chat.toolConfirmationTimeout';
+
+const TOOL_CONFIRMATION_MODE_VALUES = [
+    ToolConfirmationMode.ALWAYS_ALLOW,
+    ToolConfirmationMode.CONFIRM,
+    ToolConfirmationMode.DISABLED
+];
+
+const TOOL_CONFIRMATION_MODE_DESCRIPTIONS = [
+    nls.localize('theia/ai/chat/toolConfirmation/alwaysAllow/description', 'Execute tools automatically without confirmation'),
+    nls.localize('theia/ai/chat/toolConfirmation/confirm/description', 'Ask for confirmation before executing tools'),
+    nls.localize('theia/ai/chat/toolConfirmation/disabled/description', 'Disable tool execution')
+];
 
 export const chatToolPreferences: PreferenceSchema = {
     properties: {
+        [DEFAULT_TOOL_CONFIRMATION_PREFERENCE]: {
+            type: 'string',
+            enum: TOOL_CONFIRMATION_MODE_VALUES,
+            enumDescriptions: TOOL_CONFIRMATION_MODE_DESCRIPTIONS,
+            default: ToolConfirmationMode.CONFIRM,
+            description: nls.localize('theia/ai/chat/defaultToolConfirmation/description',
+                'Default confirmation behavior used for tools that do not have a tool-specific entry under ' +
+                '"ai-features.chat.toolConfirmation". Tools that explicitly require confirmation before being auto-approved ' +
+                'always default to "confirm" regardless of this setting.'),
+            title: AI_CORE_PREFERENCES_TITLE,
+        },
         [TOOL_CONFIRMATION_PREFERENCE]: {
             type: 'object',
             additionalProperties: {
                 type: 'string',
-                enum: [ToolConfirmationMode.ALWAYS_ALLOW, ToolConfirmationMode.CONFIRM, ToolConfirmationMode.DISABLED],
-                enumDescriptions: [
-                    nls.localize('theia/ai/chat/toolConfirmation/yolo/description', 'Execute tools automatically without confirmation'),
-                    nls.localize('theia/ai/chat/toolConfirmation/confirm/description', 'Ask for confirmation before executing tools'),
-                    nls.localize('theia/ai/chat/toolConfirmation/disabled/description', 'Disable tool execution')
-                ]
+                enum: TOOL_CONFIRMATION_MODE_VALUES,
+                enumDescriptions: TOOL_CONFIRMATION_MODE_DESCRIPTIONS
             },
             default: {},
             description: nls.localize('theia/ai/chat/toolConfirmation/description',
-                'Configure confirmation behavior for different tools. Key is the tool ID, value is the confirmation mode. ' +
-                'Use "*" as the key to set a global default for all tools.'),
+                'Configure confirmation behavior for individual tools. Key is the tool ID, value is the confirmation mode. ' +
+                'To change the default for all tools, use "ai-features.chat.defaultToolConfirmation".'),
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [TOOL_CONFIRMATION_TIMEOUT_PREFERENCE]: {
@@ -89,5 +109,6 @@ export const chatToolPreferences: PreferenceSchema = {
 
 export interface ChatToolConfiguration {
     [TOOL_CONFIRMATION_PREFERENCE]: { [toolId: string]: ToolConfirmationMode };
+    [DEFAULT_TOOL_CONFIRMATION_PREFERENCE]: ToolConfirmationMode;
     [TOOL_CONFIRMATION_TIMEOUT_PREFERENCE]: number;
 }

--- a/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
@@ -191,7 +191,7 @@ export class AIToolsConfigurationWidget extends AITableConfigurationWidget<ToolI
         });
         const shouldReset = await dialog.open();
         if (shouldReset) {
-            this.confirmationManager.resetAllConfirmationModeSettings();
+            await this.confirmationManager.resetAllConfirmationModeSettings();
         }
     }
 

--- a/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
@@ -21,7 +21,11 @@ import { ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 import { nls, PreferenceService } from '@theia/core';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
 import { ShellCommandPermissionService } from '@theia/ai-terminal/lib/browser/shell-command-permission-service';
-import { ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
+import {
+    DEFAULT_TOOL_CONFIRMATION_PREFERENCE,
+    TOOL_CONFIRMATION_PREFERENCE,
+    ToolConfirmationMode
+} from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { SHELL_COMMAND_ALLOWLIST_PREFERENCE, SHELL_COMMAND_DENYLIST_PREFERENCE } from '@theia/ai-terminal/lib/common/shell-command-preferences';
 import { AITableConfigurationWidget, TableColumn } from './base/ai-table-configuration-widget';
 
@@ -71,7 +75,8 @@ export class AIToolsConfigurationWidget extends AITableConfigurationWidget<ToolI
         this.loadData().then(() => this.update());
         this.toDispose.pushAll([
             this.preferenceService.onPreferenceChanged(async e => {
-                if (e.preferenceName === 'ai-features.chat.toolConfirmation') {
+                if (e.preferenceName === TOOL_CONFIRMATION_PREFERENCE
+                    || e.preferenceName === DEFAULT_TOOL_CONFIRMATION_PREFERENCE) {
                     this.defaultState = await this.loadDefaultConfirmation();
                     this.toolConfirmationModes = await this.loadToolConfigurationModes();
                     this.update();
@@ -119,7 +124,7 @@ export class AIToolsConfigurationWidget extends AITableConfigurationWidget<ToolI
         return item.name;
     }
     protected async loadDefaultConfirmation(): Promise<ToolConfirmationMode> {
-        return this.confirmationManager.getConfirmationMode('*', 'doesNotMatter');
+        return this.confirmationManager.getDefaultConfirmationMode();
     }
     protected async loadToolConfigurationModes(): Promise<Record<string, ToolConfirmationMode>> {
         return this.confirmationManager.getAllConfirmationSettings();
@@ -128,7 +133,7 @@ export class AIToolsConfigurationWidget extends AITableConfigurationWidget<ToolI
         await this.confirmationManager.setConfirmationMode(tool, state, toolRequest);
     }
     protected async updateDefaultConfirmation(state: ToolConfirmationMode): Promise<void> {
-        await this.confirmationManager.setConfirmationMode('*', state);
+        await this.confirmationManager.setDefaultConfirmationMode(state);
     }
 
     protected handleToolConfirmationModeChange = async (toolName: string, event: React.ChangeEvent<HTMLSelectElement>): Promise<void> => {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Replace the '*' magic-key inside ai-features.chat.toolConfirmation with a dedicated preference ai-features.chat.defaultToolConfirmation. The new preference is surfaced in the standard settings UI and defaults to 'confirm' instead of 'always_allow', so tools require user approval unless explicitly opted in.

- Add ai-features.chat.defaultToolConfirmation (string enum, default 'confirm') alongside the existing per-tool record preference.
- Extend ToolConfirmationManager with getDefaultConfirmationMode and setDefaultConfirmationMode; drop the '*' branch from getConfirmationMode and reset behaviour. Read the new preference via TrustAwarePreferenceReader to keep the workspace-trust hardening.
- Preserve confirmAlwaysAllow semantics: such tools default to 'confirm', never inherit 'always_allow' from the global default; explicit per-tool entries are still respected.
- Update the tools configuration widget to use the new APIs and listen for changes on the new preference.
- Deduplicate the schema by sharing enum values and descriptions between the two preferences; remove the leftover 'yolo' NLS key.
- Rewrite the unit tests to cover the new public API surface, workspace-trust on the new preference, and the confirmAlwaysAllow edge cases.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
- Open the settings.json, settings and AI config view (Tools Tab) side by side and manipulate the relevant settings in all ways possible. Check that everything stays up to date.
- Trigger some functions from the chat to see that the correct confirmation mode is active.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
