### PR TITLE
fix(plugin-ext): derive default for plugin config props like in VSCode

### DIFF
--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.spec.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.spec.ts
@@ -20,8 +20,9 @@ import { expect } from 'chai';
 import * as os from 'os';
 import * as path from 'path';
 import * as fs from 'fs';
-import { AbstractPluginScanner } from './scanner-theia';
+import { AbstractPluginScanner, TheiaPluginScanner } from './scanner-theia';
 import { PluginPackage, PluginEntryPoint } from '../../../common/plugin-protocol';
+import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
 import URI from '@theia/core/lib/common/uri';
 
 class TestPluginScanner extends AbstractPluginScanner {
@@ -108,5 +109,100 @@ describe('AbstractPluginScanner', () => {
 
         const model = scanner.getModel(pkg);
         expect(model.untrustedWorkspacesSupport).to.equal(undefined);
+    });
+});
+
+describe('TheiaPluginScanner configuration default derivation', () => {
+    let scanner: TheiaPluginScanner;
+    let tmpDir: string;
+
+    before(() => {
+        scanner = new TheiaPluginScanner();
+        (scanner as any).pluginUriFactory = {
+            createUri: (_pkg: PluginPackage, _relativePath?: string) => new URI('file:///dummy')
+        };
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'scanner-config-test-'));
+    });
+
+    after(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    async function readProperties(properties: Record<string, any>): Promise<PreferenceSchema['properties']> {
+        const pkg: PluginPackage = {
+            name: 'test-plugin',
+            publisher: 'test-publisher',
+            version: '1.0.0',
+            engines: { theiaPlugin: '1.0.0' },
+            displayName: 'Test Plugin',
+            description: 'A test plugin',
+            packagePath: tmpDir,
+            contributes: {
+                configuration: { title: 'Test', properties }
+            }
+        } as PluginPackage;
+        const contribution = await scanner.getContribution(pkg);
+        expect(contribution?.configuration).to.have.lengthOf(1);
+        return contribution!.configuration![0].properties;
+    }
+
+    it('derives "" for typed-but-defaultless string property (VS Code parity)', async () => {
+        const props = await readProperties({ 'vue.server.path': { type: 'string' } });
+        expect(props['vue.server.path'].default).to.equal('');
+    });
+
+    it('derives false for boolean type', async () => {
+        const props = await readProperties({ 'ext.flag': { type: 'boolean' } });
+        expect(props['ext.flag'].default).to.equal(false);
+    });
+
+    it('derives 0 for number and integer types', async () => {
+        const props = await readProperties({
+            'ext.size': { type: 'number' },
+            'ext.count': { type: 'integer' }
+        });
+        expect(props['ext.size'].default).to.equal(0);
+        expect(props['ext.count'].default).to.equal(0);
+    });
+
+    it('derives [] for array type', async () => {
+        const props = await readProperties({ 'ext.list': { type: 'array' } });
+        expect(props['ext.list'].default).to.deep.equal([]);
+    });
+
+    it('derives {} for object type', async () => {
+        const props = await readProperties({ 'ext.map': { type: 'object' } });
+        expect(props['ext.map'].default).to.deep.equal({});
+    });
+
+    it('derives null for properties without a type (e.g. enum-only)', async () => {
+        const props = await readProperties({ 'ext.choice': { enum: ['a', 'b'] } });
+        expect(props['ext.choice'].default).to.equal(null);
+    });
+
+    it('uses the first entry of a type array', async () => {
+        const props = await readProperties({ 'ext.either': { type: ['string', 'null'] } });
+        expect(props['ext.either'].default).to.equal('');
+    });
+
+    it('preserves an explicit default even when a type would derive a different value', async () => {
+        const props = await readProperties({ 'ext.named': { type: 'string', default: 'foo' } });
+        expect(props['ext.named'].default).to.equal('foo');
+    });
+
+    it('preserves an explicit falsy default such as false, 0, or empty string', async () => {
+        const props = await readProperties({
+            'ext.zero': { type: 'number', default: 0 },
+            'ext.off': { type: 'boolean', default: false },
+            'ext.blank': { type: 'string', default: '' }
+        });
+        expect(props['ext.zero'].default).to.equal(0);
+        expect(props['ext.off'].default).to.equal(false);
+        expect(props['ext.blank'].default).to.equal('');
+    });
+
+    it('preserves an explicit null default', async () => {
+        const props = await readProperties({ 'ext.nullable': { type: 'string', default: null } });
+        expect(props['ext.nullable'].default).to.equal(null);
     });
 });

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -73,7 +73,8 @@ import { GrammarsReader } from './grammars-reader';
 import { CharacterPair } from '../../../common/plugin-api-rpc';
 import { isENOENT } from '../../../common/errors';
 import * as jsoncparser from 'jsonc-parser';
-import { IJSONSchema } from '@theia/core/lib/common/json-schema';
+import { IJSONSchema, JsonType } from '@theia/core/lib/common/json-schema';
+import { JSONValue } from '@theia/core/shared/@lumino/coreutils';
 import { deepClone } from '@theia/core/lib/common/objects';
 import { PreferenceSchema, PreferenceDataProperty } from '@theia/core/lib/common/preferences/preference-schema';
 import { TaskDefinition } from '@theia/task/lib/common/task-protocol';
@@ -88,6 +89,22 @@ const iconIdPattern = `^${CSSIcon.iconNameSegment}(-${CSSIcon.iconNameSegment})+
 function getFileExtension(filePath: string): string {
     const index = filePath.lastIndexOf('.');
     return index === -1 ? '' : filePath.substring(index + 1);
+}
+
+/**
+ * Mirrors VS Code's `ConfigurationRegistry.getDefaultValue(type)`: plugins expect typed-but-defaultless properties to read as a type-based default, not `undefined`.
+ */
+function deriveDefaultForType(type: JsonType | JsonType[] | undefined): JSONValue {
+    const t = Array.isArray(type) ? type[0] : type;
+    switch (t) {
+        case 'boolean': return false;
+        case 'integer':
+        case 'number': return 0;
+        case 'string': return '';
+        case 'array': return [];
+        case 'object': return {};
+        default: return null;
+    }
 }
 
 type PluginPackageWithContributes = PluginPackage & { contributes: PluginPackageContribution };
@@ -774,7 +791,8 @@ export class TheiaPluginScanner extends AbstractPluginScanner {
                 const schemaProperty: PreferenceDataProperty = {
                     ...property,
                     scope: scopeInfo.scope,
-                    overridable: scopeInfo.overridable
+                    overridable: scopeInfo.overridable,
+                    default: property.default !== undefined ? property.default : deriveDefaultForType(property.type)
                 };
 
                 schema.properties[key] = schemaProperty;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Aligns Theia with VS Code's behavior of auto-deriving a type-based default for plugin-contributed configuration properties that declare a `type` but no `default`.

VS Code's `ConfigurationRegistry` derives `''` for `string`, `false` for `boolean`, `0` for `number`/`integer`, `[]` for `array`, `{}` for `object`, and `null` otherwise (see `src/vs/platform/configuration/common/configurationRegistry.ts`). Theia previously did not, so plugin-side reads via `workspace.getConfiguration(<section>).get(<key>)` returned `undefined` for typed-but-defaultless properties — breaking plugins that rely on VS Code semantics.

The fix is applied at the plugin scanner boundary in `TheiaPluginScanner.readConfiguration` (`packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts`). When a contributed property has no explicit `default`, the scanner fills in a type-derived value before the property is registered with the preference schema service. Once `property.default` is no longer `undefined`, every step of the existing cascade (schema registration, `getDefaultValues()`, `DefaultsPreferenceProvider`, `PreferenceRegistryMainImpl.getPreferences`, plugin-side `Configuration` model) just works.

The change is scoped to plugin-contributed configurations only:

- Theia's core `PreferenceSchemaService`, `DefaultsPreferenceProvider`, JSON schema generation, Settings UI, and `inspectDefaultValue` semantics are untouched.
- Theia preferences registered via `PreferenceContribution` are unaffected, avoiding regressions in non-plugin code.

fix #17458

#### How to test

1. `npm run start:browser`
2. Install the [Vue (Official) extension](https://open-vsx.org/extension/Vue/volar) and open a `.vue` file.
3. Verify that `Configuration key "vue.server.path" is not defined.` error notification does not appear.
4. Open a vue file. Support won't work too well due to further issues but on-hover doc over css in `<style>` should work as well as on-hover doc for root level SFC elements such as `<template>` or `<script>`
5. Verify the Settings UI for `vue.server.path` is unchanged: the field appears, is editable, and emits change events.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->
- Consider whether other Theia preferences should exhibit the same behavior.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

**Note:** Plugin-contributed properties without an explicit `default` will now expose a derived default (e.g. `''` instead of `undefined`) via `inspect()` and to `get()`. This matches VS Code and is the intended bug fix; it is not a breaking change for any documented Theia API but is a behavioral change worth and might be worth noting in release notes.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
