### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/discussion-welcome.yml
+++ b/.github/workflows/discussion-welcome.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add welcome comment
-        uses: actions/github-script@e69ef5462fd455e02edcaf4dd7708eda96b9eda0 # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -24,7 +24,7 @@ jobs:
               '',
               'The Theia community will take a look soon. In the meantime, you might find helpful information in:',
               '- 📖 [Theia Documentation](https://theia-ide.org/docs/)',
-              '- ❓ [FAQ](https://theia-ide.org/docs/faq/)',
+              '- ❓ [FAQ](https://theia-ide.org/docs/faq/)',  
               '- 💬 [Previous Discussions](https://github.com/eclipse-theia/theia/discussions)',
               '',
               '---',

--- a/.github/workflows/native-dependencies.yml
+++ b/.github/workflows/native-dependencies.yml
@@ -81,7 +81,7 @@ jobs:
       contents: write
     steps:
       - name: Download native-dependencies artifacts
-        uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: native-dependencies-*
           merge-multiple: true

--- a/.github/workflows/publish-api-doc-gh-pages.yml
+++ b/.github/workflows/publish-api-doc-gh-pages.yml
@@ -48,7 +48,7 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
 
       - name: Publish GH Pages
-        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # v3.9.3
+        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./gh-pages

--- a/.github/workflows/set-milestone-on-pr.yml
+++ b/.github/workflows/set-milestone-on-pr.yml
@@ -31,7 +31,7 @@ jobs:
           export THEIA_CORE_VERSION=$(node -p "require(\"./packages/core/package.json\").version")
           echo "MILESTONE_NUMBER=$(npx -q semver@7 --increment minor $THEIA_CORE_VERSION)" >> $GITHUB_ENV
       - id: set
-        uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3.2.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/translation.yml
+++ b/.github/workflows/translation.yml
@@ -44,7 +44,7 @@ jobs:
           DEEPL_API_TOKEN: ${{ secrets.DEEPL_API_TOKEN }}
 
       - name: Get Actor User Data
-        uses: octokit/request-action@dad4362715b7fb2ddedf9772c8670824af564f0d # v2.4.0
+        uses: octokit/request-action@b91aabaa861c777dcdb14e2387e30eddf04619ae # v3.0.0
         id: actor_user_data
         with:
           route: GET /users/{user}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Some workflows were remaining in this repo that still show the node 20 warning, see their latest runs: 
- Automatic translation: https://github.com/eclipse-theia/theia/actions/runs/25160064162
- Native dependencies: https://github.com/eclipse-theia/theia/actions/runs/25410361372
- Set milestone: https://github.com/eclipse-theia/theia/actions/runs/25424327945
- Publish api documentation (not yet resolved though but at least newer version): https://github.com/eclipse-theia/theia/actions/runs/25166278804
   - due to this, the gh-pages deployment shows the same warning https://github.com/eclipse-theia/theia/actions/runs/25166814544
- Welcome discussion: https://github.com/eclipse-theia/theia/actions/runs/25311080036

Update remaining workflow action references to resolve Node.js 20 deprecation warnings. Node.js 20 actions will be forced to run on Node.js 24 starting June 2nd, 2026.

Action version bumps:
- octokit/request-action: v2.4.0 > v3.0.0
- actions/download-artifact: v6.0.0 > v8.0.1
- actions/github-script: v3.2.0 > v9.0.0
- peaceiris/actions-gh-pages: v3.9.3 > v4.0.0 (not yet supporting node 24, but at least newer version)

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Check the warnings are gone and the workflows still work as expected

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
