### PR TITLE
ci: fix set-milestone and check-new-package workflow for github-script v9 

### DIFF
--- a/.github/workflows/check-new-package.yml
+++ b/.github/workflows/check-new-package.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Post or update checklist comment
         if: steps.detect.outputs.new_package_found == 'true'
-        uses: actions/github-script@ffc2c79a5b2490bd33e0a41c1de74b877714d736 # v3.2.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -67,7 +67,7 @@ jobs:
             const owner = context.repo.owner;
             const repo = context.repo.repo;
 
-            const comments = await github.issues.listComments({
+            const comments = await github.rest.issues.listComments({
               owner,
               repo,
               issue_number
@@ -79,7 +79,7 @@ jobs:
             );
 
             if (botComment) {
-              await github.issues.updateComment({
+              await github.rest.issues.updateComment({
                 owner,
                 repo,
                 comment_id: botComment.id,
@@ -87,7 +87,7 @@ jobs:
               });
               console.log('Updated existing comment');
             } else {
-              await github.issues.createComment({
+              await github.rest.issues.createComment({
                 owner,
                 repo,
                 issue_number,

--- a/.github/workflows/set-milestone-on-pr.yml
+++ b/.github/workflows/set-milestone-on-pr.yml
@@ -42,13 +42,13 @@ jobs:
             const issuesGetMilestonesParams = context.repo
 
             // search if milestone is already defined
-            const response = await github.issues.listMilestones(issuesGetMilestonesParams)
+            const response = await github.rest.issues.listMilestones(issuesGetMilestonesParams)
             let githubMilestone = response.data.find(milestoneResponse => milestoneResponse.title === milestone)
 
             // not defined, create it
             if (!githubMilestone) {
               const issuesCreateMilestoneParams = { owner: context.repo.owner, repo:context.repo.repo, title: milestone }
-              const createMilestoneResponse = await github.issues.createMilestone(issuesCreateMilestoneParams)
+              const createMilestoneResponse = await github.rest.issues.createMilestone(issuesCreateMilestoneParams)
               githubMilestone = createMilestoneResponse.data
             }
 
@@ -57,4 +57,4 @@ jobs:
 
             // sets the milestone from the number
             const issuesUpdateParams = { owner: context.repo.owner, repo: context.repo.repo, milestone: milestoneNumber, issue_number: context.issue.number }
-            await github.issues.update(issuesUpdateParams)
+            await github.rest.issues.update(issuesUpdateParams)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- ci: fix set-milestone workflow for github-script v9 
  - Use `github.rest.issues.*` instead of `github.issues.*` to match the Octokit API change introduced in actions/github-script v5+.
  - Failing set milestone workflow: https://github.com/eclipse-theia/theia/actions/runs/25483377045
- ci: fix check-new-package workflow for github-script v9
   - Action version bump:
      - actions/github-script: v3.2.0 > v9.0.0
   - Use `github.rest.issues.*` instead of `github.issues.*` to match the Octokit API change introduced in actions/github-script v5+.
   - Example workflow run with warning: https://github.com/eclipse-theia/theia/actions/runs/23586299602

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
