### PR TITLE
fix(ai-chat-ui): remove auto-generated groups from generic capabilities functions

### DIFF
--- a/packages/ai-chat-ui/src/browser/generic-capabilities-service.spec.ts
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-service.spec.ts
@@ -1,0 +1,259 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import 'reflect-metadata';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { GenericCapabilitiesServiceImpl } from './generic-capabilities-service';
+import { ToolRequest, PromptFragment, Skill } from '@theia/ai-core';
+
+disableJSDOM();
+
+describe('GenericCapabilitiesServiceImpl', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    let service: GenericCapabilitiesServiceImpl;
+
+    beforeEach(() => {
+        // Instantiate directly to skip @postConstruct (which subscribes to service events)
+        service = new GenericCapabilitiesServiceImpl();
+    });
+
+    describe('getAvailableFunctions', () => {
+        it('returns empty array when toolInvocationRegistry is not available', () => {
+            expect(service.getAvailableFunctions()).to.deep.equal([]);
+        });
+
+        it('returns non-MCP functions', () => {
+            const mockTools: Partial<ToolRequest>[] = [
+                { id: 'myTool', name: 'My Tool', description: 'A tool', providerName: 'local' },
+                { id: 'anotherTool', name: 'Another Tool', description: 'Another', providerName: 'builtin' }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).toolInvocationRegistry = { getAllFunctions: () => mockTools };
+
+            const result = service.getAvailableFunctions();
+
+            expect(result).to.have.length(2);
+            expect(result[0]).to.deep.equal({ id: 'myTool', name: 'My Tool', description: 'A tool' });
+            expect(result[1]).to.deep.equal({ id: 'anotherTool', name: 'Another Tool', description: 'Another' });
+        });
+
+        it('filters out MCP-provided functions', () => {
+            const mockTools: Partial<ToolRequest>[] = [
+                { id: 'localTool', name: 'Local Tool', description: 'A local tool', providerName: 'local' },
+                { id: 'mcp_server1_tool1', name: 'MCP Tool 1', description: 'An MCP tool', providerName: 'mcp_server1' },
+                { id: 'mcp_server2_tool2', name: 'MCP Tool 2', description: 'Another MCP tool', providerName: 'mcp_server2' }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).toolInvocationRegistry = { getAllFunctions: () => mockTools };
+
+            const result = service.getAvailableFunctions();
+
+            expect(result).to.have.length(1);
+            expect(result[0].id).to.equal('localTool');
+        });
+
+        it('includes functions without a providerName', () => {
+            const mockTools: Partial<ToolRequest>[] = [
+                { id: 'noProvider', name: 'No Provider', description: 'No provider set' }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).toolInvocationRegistry = { getAllFunctions: () => mockTools };
+
+            const result = service.getAvailableFunctions();
+
+            expect(result).to.have.length(1);
+            expect(result[0].id).to.equal('noProvider');
+        });
+
+        it('uses id as name fallback when name is missing', () => {
+            const mockTools: Partial<ToolRequest>[] = [
+                { id: 'tool-id', name: '', description: 'desc' }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).toolInvocationRegistry = { getAllFunctions: () => mockTools };
+
+            const result = service.getAvailableFunctions();
+
+            expect(result[0].name).to.equal('tool-id');
+        });
+    });
+
+    describe('getAvailablePromptFragments', () => {
+        it('returns empty array when promptService is not available', () => {
+            expect(service.getAvailablePromptFragments()).to.deep.equal([]);
+        });
+
+        it('returns non-capability prompt fragments', () => {
+            const fragments: PromptFragment[] = [
+                { id: 'my-fragment', template: 'Hello world' },
+                { id: 'another-fragment', template: 'Some content' }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).promptService = { getActivePromptFragments: () => fragments };
+
+            const result = service.getAvailablePromptFragments();
+
+            expect(result).to.have.length(2);
+            expect(result[0].id).to.equal('my-fragment');
+            expect(result[1].id).to.equal('another-fragment');
+        });
+
+        it('filters out generic-capabilities- prefixed fragments', () => {
+            const fragments: PromptFragment[] = [
+                { id: 'generic-capabilities-skills', template: 'auto-generated' },
+                { id: 'generic-capabilities-functions', template: 'auto-generated' },
+                { id: 'user-fragment', template: 'User content' }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).promptService = { getActivePromptFragments: () => fragments };
+
+            const result = service.getAvailablePromptFragments();
+
+            expect(result).to.have.length(1);
+            expect(result[0].id).to.equal('user-fragment');
+        });
+
+        it('truncates long template descriptions', () => {
+            const longTemplate = 'A'.repeat(150);
+            const fragments: PromptFragment[] = [
+                { id: 'long-fragment', template: longTemplate }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).promptService = { getActivePromptFragments: () => fragments };
+
+            const result = service.getAvailablePromptFragments();
+
+            expect(result[0].description).to.have.length(103); // 100 chars + '...'
+            expect(result[0].description!.endsWith('...')).to.be.true;
+        });
+
+        it('does not truncate short template descriptions', () => {
+            const fragments: PromptFragment[] = [
+                { id: 'short-fragment', template: 'Short content' }
+            ];
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).promptService = { getActivePromptFragments: () => fragments };
+
+            const result = service.getAvailablePromptFragments();
+
+            expect(result[0].description).to.equal('Short content');
+        });
+    });
+
+    describe('getAvailableVariables', () => {
+        it('returns empty array when variableService is not available', () => {
+            expect(service.getAvailableVariables()).to.deep.equal([]);
+        });
+
+        it('returns non-capability variables', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).variableService = {
+                getVariables: () => [
+                    { id: 'v1', name: 'today', description: 'Current date' },
+                    { id: 'v2', name: 'file', description: 'File content' }
+                ]
+            };
+
+            const result = service.getAvailableVariables();
+
+            expect(result).to.have.length(2);
+            expect(result[0].name).to.equal('today');
+            expect(result[1].name).to.equal('file');
+        });
+
+        it('filters out selected_ prefixed variables', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).variableService = {
+                getVariables: () => [
+                    { id: 'v1', name: 'selected_skills', description: 'Selected skills' },
+                    { id: 'v2', name: 'selected_functions', description: 'Selected functions' },
+                    { id: 'v3', name: 'today', description: 'Current date' }
+                ]
+            };
+
+            const result = service.getAvailableVariables();
+
+            expect(result).to.have.length(1);
+            expect(result[0].name).to.equal('today');
+        });
+    });
+
+    describe('getAvailableAgents', () => {
+        it('returns empty array when chatAgentService is not available', () => {
+            expect(service.getAvailableAgents()).to.deep.equal([]);
+        });
+
+        it('returns all agents when no excludeAgentId is provided', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).chatAgentService = {
+                getAgents: () => [
+                    { id: 'agent1', name: 'Agent 1', description: 'First agent' },
+                    { id: 'agent2', name: 'Agent 2', description: 'Second agent' }
+                ]
+            };
+
+            const result = service.getAvailableAgents();
+
+            expect(result).to.have.length(2);
+        });
+
+        it('excludes agent with matching excludeAgentId', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).chatAgentService = {
+                getAgents: () => [
+                    { id: 'agent1', name: 'Agent 1', description: 'First agent' },
+                    { id: 'agent2', name: 'Agent 2', description: 'Second agent' }
+                ]
+            };
+
+            const result = service.getAvailableAgents('agent1');
+
+            expect(result).to.have.length(1);
+            expect(result[0].id).to.equal('agent2');
+        });
+    });
+
+    describe('getAvailableSkills', () => {
+        it('returns empty array when skillService is not available', () => {
+            expect(service.getAvailableSkills()).to.deep.equal([]);
+        });
+
+        it('maps skills to capability items', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).skillService = {
+                getSkills: () => [
+                    { name: 'git-best-practices', description: 'Git tips', location: '/path' },
+                    { name: 'code-review', description: 'Code review', location: '/path2' }
+                ] as Skill[]
+            };
+
+            const result = service.getAvailableSkills();
+
+            expect(result).to.have.length(2);
+            expect(result[0]).to.deep.equal({ id: 'git-best-practices', name: 'git-best-practices', description: 'Git tips' });
+            expect(result[1]).to.deep.equal({ id: 'code-review', name: 'code-review', description: 'Code review' });
+        });
+    });
+});

--- a/packages/ai-chat-ui/src/browser/generic-capabilities-service.ts
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-service.ts
@@ -43,7 +43,7 @@ export { GenericCapabilityItem, GenericCapabilityGroup, GenericCapabilitiesContr
 export interface AvailableGenericCapabilities {
     skills: GenericCapabilityItem[];
     mcpFunctions: GenericCapabilityGroup[];
-    functions: GenericCapabilityGroup[];
+    functions: GenericCapabilityItem[];
     promptFragments: GenericCapabilityItem[];
     agentDelegation: GenericCapabilityItem[];
     variables: GenericCapabilityItem[];
@@ -66,8 +66,8 @@ export interface GenericCapabilitiesService {
     /** Get all available MCP functions grouped by server */
     getAvailableMCPFunctions(): Promise<GenericCapabilityGroup[]>;
 
-    /** Get all available functions (non-MCP) grouped by provider */
-    getAvailableFunctions(): GenericCapabilityGroup[];
+    /** Get all available functions (non-MCP) */
+    getAvailableFunctions(): GenericCapabilityItem[];
 
     /** Get all available prompt fragments */
     getAvailablePromptFragments(): GenericCapabilityItem[];
@@ -167,39 +167,18 @@ export class GenericCapabilitiesServiceImpl implements GenericCapabilitiesServic
         return results;
     }
 
-    getAvailableFunctions(): GenericCapabilityGroup[] {
+    getAvailableFunctions(): GenericCapabilityItem[] {
         if (!this.toolInvocationRegistry) {
             return [];
         }
 
-        const allFunctions = this.toolInvocationRegistry.getAllFunctions();
-        const groupMap = new Map<string, GenericCapabilityItem[]>();
-
-        for (const fn of allFunctions) {
-            // Skip MCP functions - they are handled separately
-            if (fn.providerName?.startsWith('mcp_')) {
-                continue;
-            }
-
-            const groupName = fn.providerName || 'Other';
-            if (!groupMap.has(groupName)) {
-                groupMap.set(groupName, []);
-            }
-
-            groupMap.get(groupName)!.push({
+        return this.toolInvocationRegistry.getAllFunctions()
+            .filter(fn => !fn.providerName?.startsWith('mcp_'))
+            .map(fn => ({
                 id: fn.id,
                 name: fn.name || fn.id,
-                group: groupName,
                 description: fn.description
-            });
-        }
-
-        const groups: GenericCapabilityGroup[] = [];
-        for (const [name, items] of groupMap) {
-            groups.push({ name, items });
-        }
-
-        return groups;
+            }));
     }
 
     getAvailablePromptFragments(): GenericCapabilityItem[] {

--- a/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-tree.tsx
@@ -204,7 +204,7 @@ export const GenericCapabilitiesTree: React.FunctionComponent<GenericCapabilitie
             buildFlatRootNode('skills', nls.localizeByDefault('Skills'), 'skills', availableCapabilities.skills),
             buildGroupedRootNode('mcp', nls.localizeByDefault('MCP'), 'mcpFunctions', availableCapabilities.mcpFunctions),
             buildFlatRootNode('agents', nls.localizeByDefault('Agents'), 'agentDelegation', availableCapabilities.agentDelegation),
-            buildGroupedRootNode('functions', nls.localize('theia/ai/chat-ui/functions', 'Functions'), 'functions', availableCapabilities.functions),
+            buildFlatRootNode('functions', nls.localize('theia/ai/chat-ui/functions', 'Functions'), 'functions', availableCapabilities.functions),
             buildFlatRootNode('prompts', nls.localizeByDefault('Prompts'), 'promptFragments', availableCapabilities.promptFragments),
             buildFlatRootNode('variables', nls.localizeByDefault('Variables'), 'variables', availableCapabilities.variables),
         ].filter((node): node is TreeNodeData => node !== undefined);
@@ -420,7 +420,7 @@ export const GenericCapabilitiesTree: React.FunctionComponent<GenericCapabilitie
             case 'skills': return getItems(availableCapabilities.skills);
             case 'variables': return getItems(availableCapabilities.variables);
             case 'mcpFunctions': return getGroupItems(availableCapabilities.mcpFunctions, groupName);
-            case 'functions': return getGroupItems(availableCapabilities.functions, groupName);
+            case 'functions': return getItems(availableCapabilities.functions);
             case 'promptFragments': return getItems(availableCapabilities.promptFragments);
             case 'agentDelegation': return getItems(availableCapabilities.agentDelegation);
             default: return [];

--- a/packages/ai-core/src/common/capability-utils.ts
+++ b/packages/ai-core/src/common/capability-utils.ts
@@ -40,8 +40,6 @@ export interface GenericCapabilityItem {
     id: string;
     /** Display name for the capability */
     name: string;
-    /** Optional group name for grouping related items */
-    group?: string;
     /** Optional description */
     description?: string;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Return functions as a flat list instead of grouping by providerName
- Render functions tree as flat items (like skills, agents, etc.)
- MCP functions remain grouped by server as before

Resolves GH-17102

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open the AI Chat View and then the capabilities panel in the input area.
- For the Functions in the Generic Capabilities section, the sub headers should be gone. Since we have filter via search anyway the sub headers are not that important.

Before this change we had artificial, unintuitive sub headers like this:
<img height="300" alt="image" src="https://github.com/user-attachments/assets/95479082-748e-4665-9364-654f67b1dfc5" />


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
