### PR TITLE
fix(core): SelectComponent dropdown z-index

### DIFF
--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -15,7 +15,12 @@
  ********************************************************************************/
 
 .theia-select-component-container {
-  /* dialog overlay has a z-index of 5000 */
+  /* position is required for z-index to take effect; top/left at 0 anchors
+     the container so the absolutely-positioned dropdown resolves its
+     viewport-relative coordinates correctly. */
+  position: absolute;
+  top: 0;
+  left: 0;
   z-index: 6000;
 }
 


### PR DESCRIPTION




<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The container had z-index: 6000 but no position, so the z-index had no effect and the dropdown could be rendered behind other UI elements.

Fixes #17471

#### How to test

1. Click "Add MCP Server" in AI Configuration view
2. Click on "Server Type" dropdown
3. Observe that dropdown is now visible

You can also check the agent selection in the "AI Agent History" view or in the Toolbar customization dialog.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
