### PR TITLE
fix(dev-container): implement overrideCommand for non-compose containers

### DIFF
--- a/packages/dev-container/src/electron-node/docker-container-service.ts
+++ b/packages/dev-container/src/electron-node/docker-container-service.ts
@@ -20,7 +20,7 @@ import { WorkspaceServer } from '@theia/workspace/lib/common';
 import * as fs from '@theia/core/shared/fs-extra';
 import * as Docker from 'dockerode';
 import { ContainerConnectionOptions } from '../electron-common/remote-container-connection-provider';
-import { DevContainerConfiguration } from './devcontainer-file';
+import { DevContainerConfiguration, NonComposeContainerBase } from './devcontainer-file';
 import { DevContainerFileService } from './dev-container-file-service';
 import { ContainerOutputProvider } from '../electron-common/container-output-provider';
 import { RemoteDockerContainerConnection } from './remote-container-connection-provider';
@@ -123,6 +123,15 @@ export class DockerContainerService {
 
         for (const containerCreateContrib of this.containerCreationContributions.getContributions()) {
             await containerCreateContrib.handleContainerCreation?.(containerCreateOptions, devcontainerConfig, docker, outputProvider);
+        }
+
+        // Per the devcontainer spec, overrideCommand defaults to true for non-compose containers.
+        // When true, override the image's CMD with a sleep loop to keep the container alive.
+        if (!devcontainerConfig.dockerComposeFile) {
+            const overrideCommand = (devcontainerConfig as NonComposeContainerBase).overrideCommand;
+            if (overrideCommand !== false) {
+                containerCreateOptions.Cmd = ['/bin/sh', '-c', 'while sleep 1000; do :; done'];
+            }
         }
 
         let container: Docker.Container;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- set Cmd to a sleep loop when overrideCommand is not explicitly false
- matches VS Code behavior and the devcontainer spec default (true)
- prevents "no command specified" error for images without CMD

Fixes GH-17473

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Clone a repo with devcontainer configuration, e.g. [eclipse-glsp/glsp-website-source](https://github.com/eclipse-glsp/glsp-website-source)
2. Open the workspace in the theia electron example application
3. Run `Reopen in Container` via the user notification or the command
4. Verify the container starts successfully and the workspace is available

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
