### PR TITLE
Fix chat capability selections resetting on refresh

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.spec.ts
@@ -1,0 +1,74 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { AIChatInputWidget } from './chat-input-widget';
+
+disableJSDOM();
+
+class TestChatInputWidget extends AIChatInputWidget {
+
+    readonly updateCalls: Array<{ agentId: string; modeId?: string; preserveOverrides?: boolean }> = [];
+
+    setReceivingAgent(agentId: string, modeId?: string): void {
+        this.receivingAgent = {
+            agentId,
+            modes: [],
+            currentModeId: modeId
+        };
+    }
+
+    refreshCapabilitiesForTest(): Promise<void> {
+        return this.refreshCapabilities();
+    }
+
+    protected override async updateCapabilitiesForAgent(agentId: string, modeId?: string, preserveOverrides?: boolean): Promise<void> {
+        this.updateCalls.push({ agentId, modeId, preserveOverrides });
+    }
+
+    override update(): void {
+        // no-op
+    }
+}
+
+describe('AIChatInputWidget', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    describe('refreshCapabilities', () => {
+        it('preserves capability selections while reloading prompt-template capabilities', async () => {
+            const widget = new TestChatInputWidget();
+            widget.setReceivingAgent('test-agent', 'test-mode');
+
+            await widget.refreshCapabilitiesForTest();
+
+            expect(widget.updateCalls).to.deep.equal([{
+                agentId: 'test-agent',
+                modeId: 'test-mode',
+                preserveOverrides: true
+            }]);
+        });
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -506,7 +506,7 @@ export class AIChatInputWidget extends ReactWidget {
      */
     protected async refreshCapabilities(): Promise<void> {
         if (this.receivingAgent) {
-            await this.updateCapabilitiesForAgent(this.receivingAgent.agentId, this.receivingAgent.currentModeId);
+            await this.updateCapabilitiesForAgent(this.receivingAgent.agentId, this.receivingAgent.currentModeId, true);
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Preserve current prompt-template capability selections when refreshing chat input capabilities after prompt changes, preventing selected chips from being reset to saved defaults after a request roundtrip.
Add a regression test for the refresh behavior.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Activate a capability for coder and send multiple messages. Sometimes the capabilities are deactivated.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
