### PR TITLE
Fix OpenAI Responses API token usage aggregation

### DIFF
--- a/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
@@ -1,0 +1,109 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { isUsageResponsePart, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core';
+import { OpenAiModelUtils } from './openai-language-model';
+import { OpenAiResponseApiUtils } from './openai-response-api-utils';
+
+async function* toStream(events: unknown[]): AsyncIterable<unknown> {
+    for (const event of events) {
+        yield event;
+    }
+}
+
+describe('OpenAiResponseApiUtils', () => {
+    it('emits per-iteration usage for Response API tool calls instead of accumulated usage', async () => {
+        const utils = new OpenAiResponseApiUtils();
+        const streams = [
+            [
+                {
+                    type: 'response.output_item.added',
+                    item: {
+                        id: 'item-1',
+                        call_id: 'call-1',
+                        type: 'function_call',
+                        name: 'lookup',
+                        arguments: '{"query":"test"}'
+                    }
+                },
+                {
+                    type: 'response.completed',
+                    response: {
+                        usage: {
+                            input_tokens: 100,
+                            output_tokens: 10
+                        }
+                    }
+                }
+            ],
+            [
+                {
+                    type: 'response.output_text.delta',
+                    delta: 'done'
+                },
+                {
+                    type: 'response.completed',
+                    response: {
+                        usage: {
+                            input_tokens: 200,
+                            output_tokens: 20
+                        }
+                    }
+                }
+            ]
+        ];
+        const openai = {
+            responses: {
+                stream: () => toStream(streams.shift() ?? [])
+            }
+        };
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: [{ actor: 'user', type: 'text', text: 'hello' }],
+            tools: [{
+                id: 'lookup',
+                name: 'lookup',
+                parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                handler: async () => 'result'
+            }]
+        };
+
+        const response = await utils.handleRequest(
+            openai as never,
+            request,
+            {},
+            'gpt-5',
+            new OpenAiModelUtils(),
+            'developer',
+            { maxChatCompletions: 3 },
+            'openai/gpt-5',
+            true
+        );
+        const parts: LanguageModelStreamResponsePart[] = [];
+        if ('stream' in response) {
+            for await (const part of response.stream) {
+                parts.push(part);
+            }
+        }
+
+        expect(parts.filter(isUsageResponsePart)).to.deep.equal([
+            { input_tokens: 100, output_tokens: 10 },
+            { input_tokens: 200, output_tokens: 20 }
+        ]);
+    });
+});

--- a/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-openai/src/node/openai-response-api-utils.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.ts
@@ -319,8 +319,6 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
     // Current iteration state
     protected currentInput: ResponseInputItem[];
     protected currentToolCalls = new Map<string, ToolCall>();
-    protected totalInputTokens = 0;
-    protected totalOutputTokens = 0;
     protected iteration = 0;
     protected readonly maxIterations: number;
     protected readonly tools: FunctionTool[] | undefined;
@@ -446,8 +444,10 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
 
         // Record token usage
         if (response.usage) {
-            this.totalInputTokens += response.usage.input_tokens;
-            this.totalOutputTokens += response.usage.output_tokens;
+            this.handleIncoming({
+                input_tokens: response.usage.input_tokens,
+                output_tokens: response.usage.output_tokens,
+            });
         }
 
         // First, yield any text content from the response
@@ -516,8 +516,10 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
 
             case 'response.completed':
                 if (event.response?.usage) {
-                    this.totalInputTokens += event.response.usage.input_tokens;
-                    this.totalOutputTokens += event.response.usage.output_tokens;
+                    this.handleIncoming({
+                        input_tokens: event.response.usage.input_tokens,
+                        output_tokens: event.response.usage.output_tokens,
+                    });
                 }
                 break;
 
@@ -732,14 +734,6 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
 
     protected async finalize(): Promise<void> {
         this.done = true;
-
-        // Yield final token usage as UsageResponsePart
-        if (this.totalInputTokens > 0 || this.totalOutputTokens > 0) {
-            this.handleIncoming({
-                input_tokens: this.totalInputTokens,
-                output_tokens: this.totalOutputTokens,
-            });
-        }
 
         // Resolve any outstanding requests
         if (this.terminalError) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
OpenAI Responses API tool-call iterations were accumulating usage across internal round-trips and exposing the summed value as the response token usage.
Emit usage per iteration instead, so usage history can retain all entries while the chat indicator shows the latest request context rather than an inflated cumulative prompt total.

Add a regression test covering multi-iteration Responses API tool calls.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Use Coder with an OpenAi model and see that the token usage is completely off.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
