### PR TITLE
fix(application-manager): call yargs as factory in esbuild ESM template

### DIFF
--- a/dev-packages/application-manager/package.json
+++ b/dev-packages/application-manager/package.json
@@ -65,7 +65,7 @@
     "webpack": "^5.106.2",
     "webpack-cli": "4.7.0",
     "worker-loader": "^3.0.8",
-    "yargs": "^15.4.1"
+    "yargs": "^17.7.2"
   },
   "peerDependencies": {
     "@theia/electron": "*"

--- a/dev-packages/application-manager/src/application-package-manager.ts
+++ b/dev-packages/application-manager/src/application-package-manager.ts
@@ -45,7 +45,7 @@ export class ApplicationPackageManager {
         return cli
             .option('mode', {
                 description: 'Generation mode to use',
-                choices: ['development', 'production'],
+                choices: ['development', 'production'] as const,
                 default: 'production' as const,
             })
             .option('split-frontend', {

--- a/dev-packages/application-manager/src/generator/bundler-generator.ts
+++ b/dev-packages/application-manager/src/generator/bundler-generator.ts
@@ -638,7 +638,7 @@ export function join(...parts) {
     return path.join(...parts).replace(/\\\\/g, '/');
 }
 
-const { mode, watch } = yargs.option('mode', {
+const { mode, watch } = yargs().option('mode', {
     description: "Mode to use",
     choices: ["development", "production"],
     default: "production"

--- a/dev-packages/cli/package.json
+++ b/dev-packages/cli/package.json
@@ -56,7 +56,7 @@
     "puppeteer-to-istanbul": "1.4.0",
     "temp": "^0.9.4",
     "tslib": "^2.8.1",
-    "yargs": "^15.4.1"
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",

--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -110,7 +110,7 @@ async function theiaCli(): Promise<void> {
     const projectPath = process.cwd();
     // Create a sub `yargs` parser to read `app-target` without
     // affecting the global `yargs` instance used by the CLI.
-    const { appTarget } = defineCommonOptions(yargsFactory()).help(false).parse();
+    const { appTarget } = await defineCommonOptions(yargsFactory()).help(false).parse();
     const manager = new ApplicationPackageManager({ projectPath, appTarget });
     const localizationManager = new LocalizationManager();
     const { target } = manager.pck;

--- a/dev-packages/private-re-exports/package.json
+++ b/dev-packages/private-re-exports/package.json
@@ -28,12 +28,13 @@
     "mustache": "^4.2.0",
     "semver": "^7.7.4",
     "tslib": "^2.8.1",
-    "yargs": "^15.4.1"
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@types/chai": "^4.3.0",
     "@types/mocha": "^10.0.10",
     "@types/mustache": "^4.2.6",
+    "@types/yargs": "^17",
     "typescript": "~5.9.3"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
         "tslint": "^5.12.0",
         "typedoc": "0.28.13",
         "typescript": "~5.9.3",
-        "yargs": "^15.3.1"
+        "yargs": "^17.7.2"
       },
       "engines": {
         "node": ">=22"
@@ -108,7 +108,7 @@
         "webpack": "^5.106.2",
         "webpack-cli": "4.7.0",
         "worker-loader": "^3.0.8",
-        "yargs": "^15.4.1"
+        "yargs": "^17.7.2"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.71.0"
@@ -208,7 +208,7 @@
         "puppeteer-to-istanbul": "1.4.0",
         "temp": "^0.9.4",
         "tslib": "^2.8.1",
-        "yargs": "^15.4.1"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "theia": "bin/theia.js",
@@ -335,7 +335,7 @@
         "mustache": "^4.2.0",
         "semver": "^7.7.4",
         "tslib": "^2.8.1",
-        "yargs": "^15.4.1"
+        "yargs": "^17.7.2"
       },
       "bin": {
         "theia-re-exports": "bin/theia-re-exports.js"
@@ -344,6 +344,7 @@
         "@types/chai": "^4.3.0",
         "@types/mocha": "^10.0.10",
         "@types/mustache": "^4.2.6",
+        "@types/yargs": "^17",
         "typescript": "~5.9.3"
       },
       "engines": {
@@ -3347,24 +3348,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/@grpc/grpc-js/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@grpc/proto-loader": {
       "version": "0.7.15",
       "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
@@ -3381,24 +3364,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@grpc/proto-loader/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@hono/node-server": {
@@ -6344,24 +6309,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/@puppeteer/browsers/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -7968,9 +7915,9 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "15.0.20",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.20.tgz",
-      "integrity": "sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
       "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
@@ -13861,25 +13808,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/electron-mocha/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/electron-store": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/electron-store/-/electron-store-8.2.0.tgz",
@@ -18965,25 +18893,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/lerna/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/less": {
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/less/-/less-3.13.1.tgz",
@@ -21976,25 +21885,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/nx/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/nyc": {
       "version": "17.1.0",
       "resolved": "https://registry.npmjs.org/nyc/-/nyc-17.1.0.tgz",
@@ -22035,6 +21925,18 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nyc/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
       }
     },
     "node_modules/nyc/node_modules/convert-source-map": {
@@ -22164,6 +22066,63 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/nyc/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/nyc/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/nyc/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/object-assign": {
@@ -24332,6 +24291,17 @@
         "yargs": "^15.3.1"
       }
     },
+    "node_modules/puppeteer-to-istanbul/node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
     "node_modules/puppeteer-to-istanbul/node_modules/clone": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -24339,6 +24309,31 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/puppeteer-to-istanbul/node_modules/mkdirp": {
@@ -24351,6 +24346,86 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/puppeteer-to-istanbul/node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/qs": {
@@ -30179,25 +30254,21 @@
       }
     },
     "node_modules/yargs": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
-      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "dependencies": {
-        "cliui": "^6.0.0",
-        "decamelize": "^1.2.0",
-        "find-up": "^4.1.0",
-        "get-caller-file": "^2.0.1",
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^2.0.0",
-        "set-blocking": "^2.0.0",
-        "string-width": "^4.2.0",
-        "which-module": "^2.0.0",
-        "y18n": "^4.0.0",
-        "yargs-parser": "^18.1.2"
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=12"
       }
     },
     "node_modules/yargs-parser": {
@@ -30255,100 +30326,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/cliui": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
-      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/yargs/node_modules/find-up": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^5.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/locate-path": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yargs/node_modules/p-locate": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/yargs/node_modules/y18n": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
-      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
-      "license": "ISC"
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "18.1.3",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
-      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
-      "license": "ISC",
-      "dependencies": {
-        "camelcase": "^5.0.0",
-        "decamelize": "^1.2.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/yauzl": {
@@ -30828,24 +30805,6 @@
         "node": ">=18"
       }
     },
-    "packages/ai-ide/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "packages/ai-llamafile": {
       "name": "@theia/ai-llamafile",
       "version": "1.71.0",
@@ -31126,7 +31085,7 @@
         "@types/safer-buffer": "^2.1.3",
         "@types/uuid": "^9.0.8",
         "@types/ws": "^8.18.1",
-        "@types/yargs": "^15",
+        "@types/yargs": "^17",
         "@vscode/codicons": "0.0.45",
         "ajv": "^6.15.0",
         "async-mutex": "^0.4.1",
@@ -31168,7 +31127,7 @@
         "vscode-languageserver-protocol": "3.17.5",
         "vscode-uri": "3.0.8",
         "ws": "^8.20.0",
-        "yargs": "^15.4.1"
+        "yargs": "^17.7.2"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.71.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "tslint": "^5.12.0",
     "typedoc": "0.28.13",
     "typescript": "~5.9.3",
-    "yargs": "^15.3.1"
+    "yargs": "^17.7.2"
   },
   "scripts": {
     "all": "npm -s install && npm run -s lint && npm run -s build",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -109,7 +109,7 @@ export class SomeClass {
   - `markdown-it-emoji` (from [`markdown-it-emoji@^3.0.0`](https://www.npmjs.com/package/markdown-it-emoji))
   - `react` (from [`react@^18.3.1`](https://www.npmjs.com/package/react))
   - `ws` (from [`ws@^8.20.0`](https://www.npmjs.com/package/ws))
-  - `yargs` (from [`yargs@^15.4.1`](https://www.npmjs.com/package/yargs))
+  - `yargs` (from [`yargs@^17.7.2`](https://www.npmjs.com/package/yargs))
 
 ## Logging Configuration
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,7 +32,7 @@
     "@types/safer-buffer": "^2.1.3",
     "@types/uuid": "^9.0.8",
     "@types/ws": "^8.18.1",
-    "@types/yargs": "^15",
+    "@types/yargs": "^17",
     "@vscode/codicons": "0.0.45",
     "ajv": "^6.15.0",
     "async-mutex": "^0.4.1",
@@ -74,7 +74,7 @@
     "vscode-languageserver-protocol": "3.17.5",
     "vscode-uri": "3.0.8",
     "ws": "^8.20.0",
-    "yargs": "^15.4.1"
+    "yargs": "^17.7.2"
   },
   "peerDependencies": {
     "@theia/electron": "*"

--- a/packages/core/src/node/logger-cli-contribution.spec.ts
+++ b/packages/core/src/node/logger-cli-contribution.spec.ts
@@ -67,7 +67,7 @@ describe('log-level-cli-contribution', () => {
     });
 
     it('should use --log-level flag', async () => {
-        const args: yargs.Arguments = yargs.parse(['--log-level=debug']);
+        const args: yargs.Arguments = await yargs.parse(['--log-level=debug']);
         await cli.setArguments(args);
 
         expect(cli.defaultLogLevel).eq(LogLevel.DEBUG);
@@ -85,7 +85,7 @@ describe('log-level-cli-contribution', () => {
         fs.fsyncSync(file.fd);
         fs.closeSync(file.fd);
 
-        const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
+        const args: yargs.Arguments = await yargs.parse(['--log-config', file.path]);
         await cli.setArguments(args);
 
         expect(cli.defaultLogLevel).eq(LogLevel.INFO);
@@ -96,7 +96,7 @@ describe('log-level-cli-contribution', () => {
     });
 
     it('should use info as default log level', async () => {
-        const args: yargs.Arguments = yargs.parse([]);
+        const args: yargs.Arguments = await yargs.parse([]);
         await cli.setArguments(args);
 
         expect(cli.defaultLogLevel).eq(LogLevel.INFO);
@@ -113,7 +113,7 @@ describe('log-level-cli-contribution', () => {
             }
         }));
 
-        const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
+        const args: yargs.Arguments = await yargs.parse(['--log-config', file.path]);
         await cli.setArguments(args);
         sinon.assert.calledWithMatch(consoleErrorSpy, 'Unknown default log level in');
     });
@@ -128,13 +128,13 @@ describe('log-level-cli-contribution', () => {
             }
         }));
 
-        const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
+        const args: yargs.Arguments = await yargs.parse(['--log-config', file.path]);
         await cli.setArguments(args);
         sinon.assert.calledWithMatch(consoleErrorSpy, 'Unknown log level for logger hello in');
     });
 
     it('should reject nonexistent config files', async () => {
-        const args: yargs.Arguments = yargs.parse(['--log-config', '/tmp/cacaca']);
+        const args: yargs.Arguments = await yargs.parse(['--log-config', '/tmp/cacaca']);
         await cli.setArguments(args);
         sinon.assert.calledWithMatch(consoleErrorSpy, 'no such file or directory');
     });
@@ -150,7 +150,7 @@ describe('log-level-cli-contribution', () => {
         });
         fs.writeFileSync(file.fd, '{' + text);
 
-        const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
+        const args: yargs.Arguments = await yargs.parse(['--log-config', file.path]);
         await cli.setArguments(args);
         sinon.assert.calledWithMatch(consoleErrorSpy, 'Error reading log config file');
     });
@@ -175,7 +175,7 @@ describe('log-level-cli-contribution', () => {
             fs.fsyncSync(file.fd);
             fs.closeSync(file.fd);
 
-            const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
+            const args: yargs.Arguments = await yargs.parse(['--log-config', file.path]);
             await cli.setArguments(args);
         }
 
@@ -224,7 +224,7 @@ describe('log-level-cli-contribution', () => {
         }));
         fs.fsyncSync(file.fd);
 
-        const args: yargs.Arguments = yargs.parse(['--log-config', file.path]);
+        const args: yargs.Arguments = await yargs.parse(['--log-config', file.path]);
         await cli.setArguments(args);
 
         expect(cli.defaultLogLevel).eq(LogLevel.INFO);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes GH-17491

With ESM imports, yargs 17.x default export is a factory function, not an instance. The generated gen-esbuild.browser.mjs needs yargs() to obtain the instance before chaining .option().

Discovered while testing the esbuild bundler switch in eclipse-theia/theia-ide#708.

Also bumps yargs from 15.x to ^17.7.2 (and @types/yargs to ^17) repo-wide, as the yargs() factory call requires yargs 17.x.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Build a Theia application using the esbuild bundler (e.g. theia-ide with eclipse-theia/theia-ide#708, drop the latest commit on this branch 77759c9d7de0fd28845bfc899e644b96dd4825d5 after checkout)
- Verify that the build no longer fails with `TypeError: yargs.option is not a function`
- Verify that `--mode` and `--watch` CLI options are parsed correctly

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
