### PR TITLE
fix(playwright): stabilize output view tests

### DIFF
--- a/examples/playwright/src/tests/theia-output-view.test.ts
+++ b/examples/playwright/src/tests/theia-output-view.test.ts
@@ -66,40 +66,52 @@ test.describe('Theia Output View', () => {
         testChannel = channel!;
         expect(await testChannel!.isDisplayed()).toBe(true);
     });
-    test('should check if the output view test channel shows the test output', async () => {
-        expect(await testChannel.textContentOfLineByLineNumber(1)).toMatch('hello info1');
-        expect(await testChannel.maxSeverityOfLineByLineNumber(1)).toMatch('info');
-        expect(await testChannel.textContentOfLineByLineNumber(2)).toMatch('hello info2');
-        expect(await testChannel.maxSeverityOfLineByLineNumber(2)).toMatch('info');
-        expect(await testChannel.textContentOfLineByLineNumber(3)).toMatch('hello error');
-        expect(await testChannel.maxSeverityOfLineByLineNumber(3)).toMatch('error');
-        expect(await testChannel.textContentOfLineByLineNumber(4)).toMatch('hello warning');
-        expect(await testChannel.maxSeverityOfLineByLineNumber(4)).toMatch('warning');
-        expect(await testChannel.textContentOfLineByLineNumber(5)).toMatch(
-            'inlineInfo1 inlineWarning inlineError inlineInfo2'
-        );
-        expect(await testChannel.maxSeverityOfLineByLineNumber(5)).toMatch('error');
-    });
-    test('should check if the output view test channel shows ANSI colored output', async () => {
-        expect(await testChannel.textContentOfLineByLineNumber(6)).toMatch('ANSI red text');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(6)).toContain('ansi-red-fg');
-        expect(await testChannel.textContentOfLineByLineNumber(7)).toMatch('ANSI green text');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(7)).toContain('ansi-green-fg');
-        expect(await testChannel.textContentOfLineByLineNumber(8)).toMatch('ANSI yellow and ANSI blue on the same line');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(8)).toContain('ansi-yellow-fg');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(8)).toContain('ansi-blue-fg');
-        expect(await testChannel.textContentOfLineByLineNumber(9)).toMatch('ANSI bold magenta');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(9)).toContain('ansi-bold');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(9)).toContain('ansi-magenta-fg');
-        expect(await testChannel.textContentOfLineByLineNumber(10)).toMatch('ANSI underlined cyan');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(10)).toContain('ansi-underline');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(10)).toContain('ansi-cyan-fg');
-        expect(await testChannel.textContentOfLineByLineNumber(11)).toMatch('Mixed: ANSI error and ANSI success in one line');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(11)).toContain('ansi-red-fg');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(11)).toContain('ansi-green-fg');
-        expect(await testChannel.textContentOfLineByLineNumber(12)).toMatch('ANSI white on red background');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(12)).toContain('ansi-white-fg');
-        expect(await testChannel.ansiClassesOfLineByLineNumber(12)).toContain('ansi-red-bg');
+
+    test.describe('Output Channel Content', () => {
+        test.beforeAll(async () => {
+            outputView = await app.openView(TheiaOutputView);
+            const testChannelName = 'API Sample: my test channel';
+            await outputView.selectOutputChannel(testChannelName);
+            const channel = await outputView.getOutputChannel(testChannelName);
+            expect(channel).toBeDefined();
+            testChannel = channel!;
+        });
+
+        test('should check if the output view test channel shows the test output', async () => {
+            expect(await testChannel.textContentOfLineByLineNumber(1)).toMatch('hello info1');
+            expect(await testChannel.maxSeverityOfLineByLineNumber(1)).toMatch('info');
+            expect(await testChannel.textContentOfLineByLineNumber(2)).toMatch('hello info2');
+            expect(await testChannel.maxSeverityOfLineByLineNumber(2)).toMatch('info');
+            expect(await testChannel.textContentOfLineByLineNumber(3)).toMatch('hello error');
+            expect(await testChannel.maxSeverityOfLineByLineNumber(3)).toMatch('error');
+            expect(await testChannel.textContentOfLineByLineNumber(4)).toMatch('hello warning');
+            expect(await testChannel.maxSeverityOfLineByLineNumber(4)).toMatch('warning');
+            expect(await testChannel.textContentOfLineByLineNumber(5)).toMatch(
+                'inlineInfo1 inlineWarning inlineError inlineInfo2'
+            );
+            expect(await testChannel.maxSeverityOfLineByLineNumber(5)).toMatch('error');
+        });
+        test('should check if the output view test channel shows ANSI colored output', async () => {
+            expect(await testChannel.textContentOfLineByLineNumber(6)).toMatch('ANSI red text');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(6)).toContain('ansi-red-fg');
+            expect(await testChannel.textContentOfLineByLineNumber(7)).toMatch('ANSI green text');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(7)).toContain('ansi-green-fg');
+            expect(await testChannel.textContentOfLineByLineNumber(8)).toMatch('ANSI yellow and ANSI blue on the same line');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(8)).toContain('ansi-yellow-fg');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(8)).toContain('ansi-blue-fg');
+            expect(await testChannel.textContentOfLineByLineNumber(9)).toMatch('ANSI bold magenta');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(9)).toContain('ansi-bold');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(9)).toContain('ansi-magenta-fg');
+            expect(await testChannel.textContentOfLineByLineNumber(10)).toMatch('ANSI underlined cyan');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(10)).toContain('ansi-underline');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(10)).toContain('ansi-cyan-fg');
+            expect(await testChannel.textContentOfLineByLineNumber(11)).toMatch('Mixed: ANSI error and ANSI success in one line');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(11)).toContain('ansi-red-fg');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(11)).toContain('ansi-green-fg');
+            expect(await testChannel.textContentOfLineByLineNumber(12)).toMatch('ANSI white on red background');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(12)).toContain('ansi-white-fg');
+            expect(await testChannel.ansiClassesOfLineByLineNumber(12)).toContain('ansi-red-bg');
+        });
     });
 
 });

--- a/examples/playwright/src/theia-monaco-editor.ts
+++ b/examples/playwright/src/theia-monaco-editor.ts
@@ -54,10 +54,8 @@ export class TheiaMonacoEditor extends TheiaPageObject {
 
     async waitForVisible(): Promise<void> {
         await this.locator.waitFor({ state: 'visible' });
-        // wait until lines are created
-        await this.locator.evaluate(editor =>
-            editor.querySelectorAll(this.LINES_SELECTOR).length > 0
-        );
+        // wait until at least one line is rendered
+        await this.locator.locator(this.LINES_SELECTOR).first().waitFor({ state: 'visible' });
     }
 
     /**
@@ -108,21 +106,14 @@ export class TheiaMonacoEditor extends TheiaPageObject {
 
         // Line not in viewport, scroll to reveal it
         await this.locator.click();
-        await this.page.keyboard.press('Control+Home');
-        await this.locator.locator(this.LINES_SELECTOR).first().waitFor({ state: 'visible' });
-
-        index = await this.findLineIndex(lineNumber);
-        if (index >= 0) {
-            return this.locator.locator(this.LINES_SELECTOR).nth(index);
-        }
-
-        // Line might be near the end, try scrolling there
-        await this.page.keyboard.press('Control+End');
-        await this.locator.locator(this.LINES_SELECTOR).first().waitFor({ state: 'visible' });
-
-        index = await this.findLineIndex(lineNumber);
-        if (index >= 0) {
-            return this.locator.locator(this.LINES_SELECTOR).nth(index);
+        for (const key of ['Control+Home', 'Control+End']) {
+            await this.page.keyboard.press(key);
+            // Allow Monaco to re-render after scrolling
+            await this.page.waitForTimeout(200);
+            index = await this.findLineIndex(lineNumber);
+            if (index >= 0) {
+                return this.locator.locator(this.LINES_SELECTOR).nth(index);
+            }
         }
 
         throw new Error(`Could not find line number ${lineNumber}`);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17462

- Fix TheiaMonacoEditor.waitForVisible() where the closure reference to this.LINES_SELECTOR was inaccessible in the browser context, making the "wait for lines" check a no-op
- Fix TheiaMonacoEditor.line() scroll handling: wait for Monaco to re-render after Control+Home/Control+End instead of checking immediately
- Wrap content tests in a nested describe with its own beforeAll so testChannel is set up even when Playwright retries individual tests in a new worker

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Run the output view Playwright tests repeatedly: `npx playwright test --config configs/playwright.config.ts --grep "Output View" --repeat-each 15`
- All iterations should pass consistently

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
