### PR TITLE
Add missing space between expression name and error/unavailable message

### DIFF
--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -225,7 +225,7 @@
 }
 
 .theia-debug-console-variable .value {
-  margin-left: 6px;
+  margin-left: var(--theia-ui-padding);
 }
 
 .theia-TreeNode:not(:hover) .theia-debug-console-variable .action-label {
@@ -240,12 +240,12 @@
 .theia-debug-console-variable .watch-error {
   font-style: italic;
   color: var(--theia-debugConsole-errorForeground);
-  margin-left: 6px;
+  margin-left: var(--theia-ui-padding);
 }
 
 .theia-debug-console-variable .watch-not-available {
   font-style: italic;
-  margin-left: 6px;
+  margin-left: var(--theia-ui-padding);
 }
 
 .theia-debug-watch-expression {

--- a/packages/debug/src/browser/style/index.css
+++ b/packages/debug/src/browser/style/index.css
@@ -240,10 +240,12 @@
 .theia-debug-console-variable .watch-error {
   font-style: italic;
   color: var(--theia-debugConsole-errorForeground);
+  margin-left: 6px;
 }
 
 .theia-debug-console-variable .watch-not-available {
   font-style: italic;
+  margin-left: 6px;
 }
 
 .theia-debug-watch-expression {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes spacing in Watch expressions when the variable is in an error or not-available state.

Before this change, Watch entries had proper spacing only when a variable value was available.
This updates the debug CSS so error/not-available labels also have the same left margin, resulting in consistent visual alignment.

Fixes eclipse-theia/theia#17453

#### How to test

1. Start Theia and open a workspace with a debuggable target.
2. Start a debug session and add expressions to Watch.
3. Add at least one expression that evaluates normally.
4. Add at least one expression that causes an evaluation error or is unavailable.
5. Verify all Watch entries now have consistent spacing between name and value/error text.

#### Follow-ups

None identified.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
