### PR TITLE
fix(ai-chat): synthesize result for unfinished tool calls on restore

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -110,8 +110,10 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
                                 <MarkdownRender text={content.text} openerService={this.openerService} />
                             </div>;
                         }
+                        case 'error': {
+                            return <div key={`content-${idx}-${content.type}`} className='theia-toolCall-error-result'><pre>{content.data}</pre></div>;
+                        }
                         case 'audio':
-                        case 'error':
                         default: {
                             return <div key={`content-${idx}-${content.type}`} className='theia-toolCall-default-result'><pre>{JSON.stringify(response, undefined, 2)}</pre></div>;
                         }

--- a/packages/ai-chat/src/common/chat-content-deserializer.spec.ts
+++ b/packages/ai-chat/src/common/chat-content-deserializer.spec.ts
@@ -32,6 +32,7 @@ import {
     QuestionResponseContentImpl,
     TextChatResponseContentImpl,
     ThinkingChatResponseContentImpl,
+    ToolCallChatResponseContent,
     ToolCallChatResponseContentImpl
 } from './chat-model';
 
@@ -213,6 +214,31 @@ describe('Chat Content Serialization', () => {
 
             const deserialized = await registry.deserialize(withFallback);
             expect(deserialized.kind).to.equal('toolCall');
+        });
+
+        it('should mark an unfinished tool call as interrupted when restored', async () => {
+            const original = new ToolCallChatResponseContentImpl('id', 'toolName', '{}', false);
+
+            const serialized = original.toSerializable?.();
+            const withFallback = { ...serialized!, fallbackMessage: '' };
+            const deserialized = await registry.deserialize(withFallback) as ToolCallChatResponseContentImpl;
+
+            expect(deserialized.finished).to.be.true;
+            expect(ToolCallChatResponseContent.isErrorResult(deserialized.result)).to.be.true;
+            expect(ToolCallChatResponseContent.getErrorMessage(deserialized.result)).to.include('interrupted');
+            const [, toolResultMessage] = deserialized.toLanguageModelMessage();
+            expect(ToolCallChatResponseContent.isErrorResult(toolResultMessage.content)).to.be.true;
+        });
+
+        it('should preserve a real tool result on restore (not overwrite as interrupted)', async () => {
+            const original = new ToolCallChatResponseContentImpl('id', 'toolName', '{}', true, 'real-result');
+
+            const serialized = original.toSerializable?.();
+            const withFallback = { ...serialized!, fallbackMessage: '' };
+            const deserialized = await registry.deserialize(withFallback) as ToolCallChatResponseContentImpl;
+
+            expect(deserialized.finished).to.be.true;
+            expect(deserialized.result).to.equal('real-result');
         });
     });
 

--- a/packages/ai-chat/src/common/chat-content-deserializer.ts
+++ b/packages/ai-chat/src/common/chat-content-deserializer.ts
@@ -42,6 +42,7 @@ import {
     QuestionContentData
 } from './chat-model';
 import { SerializableChatResponseContentData } from './chat-model-serialization';
+import { createToolCallError } from '@theia/ai-core/lib/common/language-model';
 import { ContributionProvider, ILogger, MaybePromise } from '@theia/core';
 
 export const ChatContentDeserializer = Symbol('ChatContentDeserializer');
@@ -268,14 +269,21 @@ export class DefaultChatContentDeserializerContribution implements ChatContentDe
 
         registry.register({
             kind: 'toolCall',
-            deserialize: (data: ToolCallContentData) => new ToolCallChatResponseContentImpl(
-                data.id,
-                data.name,
-                data.arguments,
-                data.finished,
-                data.result,
-                data.data
-            )
+            deserialize: (data: ToolCallContentData) => {
+                const wasInterrupted = data.finished !== true && data.result === undefined;
+                const finished = wasInterrupted || data.finished;
+                const result = wasInterrupted
+                    ? createToolCallError('Tool call was interrupted. No result is available.')
+                    : data.result;
+                return new ToolCallChatResponseContentImpl(
+                    data.id,
+                    data.name,
+                    data.arguments,
+                    finished,
+                    result,
+                    data.data
+                );
+            }
         });
 
         registry.register({

--- a/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
+++ b/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
@@ -21,7 +21,7 @@ import { CopyButton, MetaRow, OutputBox, formatDuration } from '@theia/ai-chat-u
 import { ChatResponseContent, ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ToolConfirmationMode as ToolConfirmationPreferenceMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
-import { ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
+import { isToolCallContent, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 import { CommandRegistry, nls } from '@theia/core/lib/common';
 import { codicon, ContextMenuRenderer } from '@theia/core/lib/browser';
 import { GroupImpl } from '@theia/core/lib/browser/menu/composite-menu-node';
@@ -264,6 +264,19 @@ const ShellExecutionToolComponent: React.FC<ShellExecutionToolComponentProps> = 
             }
         } catch (err) {
             console.debug('Failed to parse shell execution result:', err);
+        }
+        if (!result && !canceledResult) {
+            if (typeof response.result === 'string') {
+                result = { success: false, exitCode: undefined, output: response.result, duration: 0 };
+            } else if (isToolCallContent(response.result)) {
+                const errorMessage = response.result.content
+                    .filter(item => item.type === 'error')
+                    .map(item => item.data)
+                    .join('\n');
+                if (errorMessage) {
+                    result = { success: false, exitCode: undefined, output: errorMessage, duration: 0 };
+                }
+            }
         }
     }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

An unresolved tool_use causes providers (e.g. OpenAI Response API) to reject the request when the chat is continued. The deserializer now synthesizes a stand-in result so the LLM history stays valid, and the tool call renders as interrupted in the restored chat.

#### How to test

1. Start a chat that triggers a tool call, e.g.
    ```
    @Coder ~shellExecute the command for i in $(seq 1 60); do echo "Iteration $i at $(date +%T)"; sleep 1; done`)
    ```
3. Before the tool result arrives, reload the page (in Electron use Ctrl+r)
4. Continue the chat. It should not error with "400 Missing required parameter" when using a GPT model
5. Verify the chat shows the tool call as canceled with an interrupted tool call result message

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
