### PR TITLE
Mcp hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,5 +125,6 @@
     "vscode.github",
     "vscode.github-authentication",
     "ms-python.vscode-pylance"
-  ]
+  ],
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -201,6 +201,8 @@ function formatToolCallResult(result: ToolCallResult): ToolResultBlockParam['con
                 return { type: 'text', text: content.text };
             } else if (content.type === 'image') {
                 return { type: 'image', source: { type: 'base64', data: content.base64data, media_type: mimeTypeToMediaType(content.mimeType) } };
+            } else if (content.type === 'html') {
+                return { type: 'text', text: content.html };
             } else {
                 return { type: 'text', text: content.data };
             }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/index.ts
@@ -19,6 +19,7 @@ export * from './command-part-renderer';
 export * from './error-part-renderer';
 export * from './horizontal-layout-part-renderer';
 export * from './markdown-part-renderer';
+export * from './mcp-app-frame';
 export * from './text-part-renderer';
 export * from './toolcall-part-renderer';
 export * from './not-available-toolcall-renderer';

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/mcp-app-frame.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/mcp-app-frame.spec.ts
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+
+/**
+ * Tests for the srcDoc injection logic used by McpAppFrame.
+ * We test the pure logic without requiring a DOM/React rendering environment.
+ */
+describe('McpAppFrame srcDoc injection', () => {
+
+    const RESIZE_SCRIPT = `<script>
+new ResizeObserver(() => {
+    window.parent.postMessage({ type: 'mcp-app-resize', height: document.documentElement.scrollHeight }, '*');
+}).observe(document.documentElement);
+</script>`;
+
+    function buildSrcDoc(html: string): string {
+        return html.includes('</body>')
+            ? html.replace('</body>', `${RESIZE_SCRIPT}</body>`)
+            : `${html}${RESIZE_SCRIPT}`;
+    }
+
+    it('injects resize script before </body> when present', () => {
+        const html = '<html><body><p>Hello</p></body></html>';
+        const result = buildSrcDoc(html);
+        expect(result).to.contain('mcp-app-resize');
+        expect(result).to.contain('<p>Hello</p>');
+        expect(result.indexOf('ResizeObserver')).to.be.lessThan(result.indexOf('</body>'));
+    });
+
+    it('appends resize script when no </body> tag', () => {
+        const html = '<div>Simple content</div>';
+        const result = buildSrcDoc(html);
+        expect(result).to.equal(`<div>Simple content</div>${RESIZE_SCRIPT}`);
+    });
+
+    it('preserves original html content', () => {
+        const html = '<html><body><h1>Title</h1><p>Content</p></body></html>';
+        const result = buildSrcDoc(html);
+        expect(result).to.contain('<h1>Title</h1>');
+        expect(result).to.contain('<p>Content</p>');
+    });
+
+    it('handles empty html', () => {
+        const result = buildSrcDoc('');
+        expect(result).to.equal(RESIZE_SCRIPT);
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/mcp-app-frame.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/mcp-app-frame.tsx
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+
+export interface McpAppFrameProps {
+    html: string;
+    title?: string;
+}
+
+const RESIZE_SCRIPT = `<script>
+new ResizeObserver(() => {
+    window.parent.postMessage({ type: 'mcp-app-resize', height: document.documentElement.scrollHeight }, '*');
+}).observe(document.documentElement);
+</script>`;
+
+export const McpAppFrame: React.FC<McpAppFrameProps> = ({ html, title }) => {
+    const iframeRef = React.useRef<HTMLIFrameElement>(null);
+    const [height, setHeight] = React.useState(200);
+
+    React.useEffect(() => {
+        const handler = (event: MessageEvent) => {
+            if (iframeRef.current?.contentWindow === event.source &&
+                event.data?.type === 'mcp-app-resize' &&
+                typeof event.data.height === 'number') {
+                setHeight(event.data.height);
+            }
+        };
+        window.addEventListener('message', handler);
+        return () => window.removeEventListener('message', handler);
+    }, []);
+
+    const srcDoc = html.includes('</body>')
+        ? html.replace('</body>', `${RESIZE_SCRIPT}</body>`)
+        : `${html}${RESIZE_SCRIPT}`;
+
+    return (
+        <div className='theia-mcp-app-container'>
+            {title && <div className='theia-mcp-app-title'>{title}</div>}
+            <iframe
+                ref={iframeRef}
+                srcDoc={srcDoc}
+                sandbox='allow-scripts'
+                style={{ width: '100%', border: 'none', height: `${height}px` }}
+                title={title ?? 'MCP App'}
+            />
+        </div>
+    );
+};

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -22,6 +22,7 @@ import { nls } from '@theia/core/lib/common/nls';
 import { codicon, ContextMenuRenderer, HoverService, OpenerService } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
 import { createConfirmationHandlers, ToolConfirmation, useToolConfirmationState } from './tool-confirmation';
+import { McpAppFrame } from './mcp-app-frame';
 import { ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ResponseNode } from '../chat-tree-view';
 import { useMarkdownRendering } from './markdown-part-renderer';
@@ -108,6 +109,11 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
                         case 'text': {
                             return <div key={`content-${idx}-${content.type}`} className='theia-toolCall-text-result'>
                                 <MarkdownRender text={content.text} openerService={this.openerService} />
+                            </div>;
+                        }
+                        case 'html': {
+                            return <div key={`content-${idx}-${content.type}`} className='theia-toolCall-html-result'>
+                                <McpAppFrame html={content.html} title={content.title} />
                             </div>;
                         }
                         case 'audio':

--- a/packages/ai-claude-code/docs/hooks-design-spec.md
+++ b/packages/ai-claude-code/docs/hooks-design-spec.md
@@ -1,0 +1,378 @@
+# Claude Code Hooks Implementation Design Spec
+
+## Status Quo
+
+The `ai-claude-code` package currently implements **2 of 28** Claude Code hook events:
+
+| Hook | Type | Purpose |
+|------|------|---------|
+| `PreToolUse` | command | Backs up files before Write/Edit/MultiEdit |
+| `Stop` | command | Cleans up session backup directory |
+
+Both are hardcoded in `ClaudeCodeServiceImpl.ensureClaudeSettings()` and written to `.claude/settings.local.json`. There is no generic hook infrastructure, no UI for hook management, and no support for `http`, `mcp_tool`, `prompt`, or `agent` hook handler types.
+
+---
+
+## Architecture Overview
+
+### Proposed Design
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Browser (Frontend)                                      │
+│  ┌─────────────────┐  ┌──────────────────────────────┐  │
+│  │ Hook Config UI  │  │ Hook Status/Notification UI  │  │
+│  └────────┬────────┘  └──────────────┬───────────────┘  │
+│           │                           │                  │
+│  ┌────────▼───────────────────────────▼───────────────┐  │
+│  │         ClaudeCodeHookFrontendService              │  │
+│  └────────────────────────┬──────────────────────────┘  │
+└───────────────────────────┼──────────────────────────────┘
+                            │ RPC
+┌───────────────────────────┼──────────────────────────────┐
+│  Node (Backend)           │                              │
+│  ┌────────────────────────▼──────────────────────────┐   │
+│  │          ClaudeCodeHookService                    │   │
+│  │  ┌──────────────┐ ┌────────────────────────────┐ │   │
+│  │  │ HookRegistry │ │ HookSettingsManager        │ │   │
+│  │  │ (in-memory)  │ │ (reads/writes settings.json)│ │   │
+│  │  └──────┬───────┘ └────────────────────────────┘ │   │
+│  │         │                                         │   │
+│  │  ┌──────▼──────────────────────────────────────┐  │   │
+│  │  │         HookExecutor                        │  │   │
+│  │  │  ┌─────────┐ ┌──────┐ ┌────────┐ ┌──────┐ │  │   │
+│  │  │  │ Command │ │ HTTP │ │MCP Tool│ │Prompt│ │  │   │
+│  │  │  │ Runner  │ │Runner│ │ Runner │ │Runner│ │  │   │
+│  │  │  └─────────┘ └──────┘ └────────┘ └──────┘ │  │   │
+│  │  └────────────────────────────────────────────┘  │   │
+│  └──────────────────────────────────────────────────┘   │
+└──────────────────────────────────────────────────────────┘
+```
+
+### Key Design Decisions
+
+1. **Hooks run via Claude Code CLI natively** — The Claude Agent SDK already executes hooks defined in `settings.json`. Theia's role is to *configure* hooks and *react* to hook-related events, not to re-implement the hook execution engine.
+
+2. **Theia-managed hooks vs. user hooks** — Theia installs its own hooks (file backup, session cleanup, IDE integration) alongside user-defined hooks. Both coexist in settings files.
+
+3. **Hook configuration is declarative** — Hooks are JSON in settings files. Theia provides a UI to manage them and a programmatic API for extensions to register hooks.
+
+4. **Contribution point for extensions** — A `ClaudeCodeHookContribution` interface allows other Theia packages to register hooks without modifying `ai-claude-code` directly.
+
+---
+
+## Hook Events — Prioritized Implementation Plan
+
+### Priority 1: Critical for IDE Integration (Implement First)
+
+These hooks enable core Theia IDE features that differentiate it from CLI usage.
+
+| Hook Event | Rationale | Theia Use Case |
+|------------|-----------|----------------|
+| **`PreToolUse`** | ✅ Already implemented (file backup). Extend to support user-defined hooks and `if` conditions. | File backup, lint-before-write, block dangerous commands |
+| **`PostToolUse`** | React to completed tool calls. Essential for IDE state sync. | Auto-refresh editors after Write/Edit, trigger diagnostics, update file tree |
+| **`Stop`** | ✅ Already implemented (cleanup). Extend for user hooks. | Session cleanup, summary notifications, auto-commit |
+| **`Notification`** | Surface Claude Code notifications in Theia's notification system. | Permission prompts, idle alerts, auth events shown as Theia notifications |
+| **`SessionStart`** | Initialize IDE state when a Claude session begins. | Set up workspace context, load project-specific settings, show session indicator |
+| **`SessionEnd`** | Clean up IDE state when session terminates. | Clear session indicators, persist session metadata, cleanup temp files |
+
+### Priority 2: Enhanced Developer Experience (Implement Second)
+
+These hooks improve the workflow but aren't blocking for basic functionality.
+
+| Hook Event | Rationale | Theia Use Case |
+|------------|-----------|----------------|
+| **`UserPromptSubmit`** | Intercept/transform prompts before they reach Claude. | Add workspace context, enforce prompt templates, log prompts |
+| **`PostToolUseFailure`** | React to failed tool calls. | Show error diagnostics, suggest fixes, auto-retry logic |
+| **`PermissionRequest`** | Programmatic permission handling. | Auto-approve safe operations, custom approval UI, policy enforcement |
+| **`PostToolBatch`** | React after a batch of parallel tool calls. | Batch refresh editors, run tests after multiple file changes |
+| **`InstructionsLoaded`** | Know when CLAUDE.md files are loaded. | Show loaded instructions in UI, validate instruction files |
+| **`ConfigChange`** | React to config changes during session. | Hot-reload preferences, notify user of config drift |
+
+### Priority 3: Advanced Workflows (Implement Third)
+
+These hooks support advanced/enterprise use cases.
+
+| Hook Event | Rationale | Theia Use Case |
+|------------|-----------|----------------|
+| **`Setup`** | One-time initialization in CI/scripts. | Pre-configure workspace, install dependencies |
+| **`SubagentStart`** / **`SubagentStop`** | Track subagent lifecycle. | Show subagent activity in UI, resource monitoring |
+| **`TaskCreated`** / **`TaskCompleted`** | Track task lifecycle. | Task progress UI, time tracking, audit logging |
+| **`TeammateIdle`** | Agent team coordination. | Show team status, auto-assign work |
+| **`PermissionDenied`** | React to denied permissions. | Log denials, suggest permission changes, retry with different approach |
+| **`StopFailure`** | Handle API errors gracefully. | Show user-friendly error messages, auto-retry on rate limits |
+
+### Priority 4: Specialized/Niche (Implement Last)
+
+These hooks serve narrow use cases or are less relevant in an IDE context.
+
+| Hook Event | Rationale | Theia Use Case |
+|------------|-----------|----------------|
+| **`UserPromptExpansion`** | Slash command expansion. | Custom slash commands, macro expansion |
+| **`CwdChanged`** | Working directory changes. | Update terminal cwd, refresh file tree root |
+| **`FileChanged`** | Watch specific files. | Auto-reload configs, trigger builds on file changes |
+| **`WorktreeCreate`** / **`WorktreeRemove`** | Git worktree management. | Multi-branch UI, worktree lifecycle |
+| **`PreCompact`** / **`PostCompact`** | Context compaction. | Save/restore state around compaction, notify user |
+| **`Elicitation`** / **`ElicitationResult`** | MCP server user input. | Custom elicitation UI in Theia |
+
+---
+
+## Implementation Details
+
+### Phase 1: Hook Infrastructure
+
+**New files:**
+- `src/common/claude-code-hook-types.ts` — Hook event types, handler types, matcher types
+- `src/node/claude-code-hook-service.ts` — Hook registration, settings management, execution
+- `src/node/claude-code-hook-contribution.ts` — Extension point interface
+- `src/browser/claude-code-hook-preferences.ts` — UI preferences for hook configuration
+
+**Changes to existing files:**
+- `claude-code-service-impl.ts` — Refactor `ensureClaudeSettings` to use `ClaudeCodeHookService`
+- `claude-code-preferences.ts` — Add hook-related preferences
+
+#### Hook Types (claude-code-hook-types.ts)
+
+```typescript
+export type HookEvent =
+    | 'SessionStart' | 'Setup' | 'InstructionsLoaded'
+    | 'UserPromptSubmit' | 'UserPromptExpansion'
+    | 'PreToolUse' | 'PermissionRequest' | 'PermissionDenied'
+    | 'PostToolUse' | 'PostToolUseFailure' | 'PostToolBatch'
+    | 'Notification' | 'SubagentStart' | 'SubagentStop'
+    | 'TaskCreated' | 'TaskCompleted'
+    | 'Stop' | 'StopFailure' | 'TeammateIdle'
+    | 'ConfigChange' | 'CwdChanged' | 'FileChanged'
+    | 'WorktreeCreate' | 'WorktreeRemove'
+    | 'PreCompact' | 'PostCompact'
+    | 'Elicitation' | 'ElicitationResult'
+    | 'SessionEnd';
+
+export type HookHandlerType = 'command' | 'http' | 'mcp_tool' | 'prompt' | 'agent';
+
+export interface HookHandler {
+    type: HookHandlerType;
+    if?: string;
+    timeout?: number;
+    statusMessage?: string;
+    once?: boolean;
+}
+
+export interface CommandHookHandler extends HookHandler {
+    type: 'command';
+    command: string;
+    args?: string[];
+    async?: boolean;
+    asyncRewake?: boolean;
+}
+
+export interface HttpHookHandler extends HookHandler {
+    type: 'http';
+    url: string;
+    headers?: Record<string, string>;
+    allowedEnvVars?: string[];
+}
+
+export interface McpToolHookHandler extends HookHandler {
+    type: 'mcp_tool';
+    server: string;
+    tool: string;
+    input?: Record<string, string>;
+}
+
+export interface MatcherGroup {
+    matcher?: string;
+    hooks: HookHandler[];
+}
+
+export interface HookConfig {
+    hooks: Partial<Record<HookEvent, MatcherGroup[]>>;
+}
+```
+
+#### Hook Contribution Point (claude-code-hook-contribution.ts)
+
+```typescript
+export const ClaudeCodeHookContribution = Symbol('ClaudeCodeHookContribution');
+
+export interface ClaudeCodeHookContribution {
+    /**
+     * Register hooks that should be installed for Claude Code sessions.
+     * Called when a session starts or when hooks are reconfigured.
+     */
+    registerHooks(): HookRegistration[];
+}
+
+export interface HookRegistration {
+    event: HookEvent;
+    matcher?: string;
+    handler: HookHandler;
+    /** Where to write: 'local' (default) or 'project' */
+    scope?: 'local' | 'project';
+}
+```
+
+#### Hook Service (claude-code-hook-service.ts)
+
+```typescript
+export const ClaudeCodeHookService = Symbol('ClaudeCodeHookService');
+
+export interface ClaudeCodeHookService {
+    /** Collect all hook contributions and write to settings */
+    installHooks(cwd: string): Promise<void>;
+
+    /** Remove Theia-managed hooks from settings */
+    uninstallHooks(cwd: string): Promise<void>;
+
+    /** Get current hook configuration for a project */
+    getHookConfig(cwd: string): Promise<HookConfig>;
+
+    /** Add a user-defined hook */
+    addUserHook(cwd: string, event: HookEvent, group: MatcherGroup): Promise<void>;
+
+    /** Remove a user-defined hook */
+    removeUserHook(cwd: string, event: HookEvent, matcher: string): Promise<void>;
+}
+```
+
+### Phase 2: Priority 1 Hooks — IDE Integration
+
+#### PostToolUse: Editor Refresh
+
+```typescript
+// Registered by ClaudeCodeEditToolService
+{
+    event: 'PostToolUse',
+    matcher: 'Write|Edit|MultiEdit',
+    handler: {
+        type: 'command',
+        command: 'node ${CLAUDE_PROJECT_DIR}/.claude/hooks/theia-refresh-editors.js'
+    }
+}
+```
+
+The hook script writes a JSON file listing changed paths. The frontend service polls or watches this file to trigger editor refreshes. Alternatively, use an HTTP hook pointing to a Theia-local endpoint.
+
+#### Notification: Theia Notification Bridge
+
+```typescript
+{
+    event: 'Notification',
+    matcher: '',  // all notifications
+    handler: {
+        type: 'http',
+        url: 'http://localhost:${THEIA_HOOK_PORT}/hooks/notification'
+    }
+}
+```
+
+Theia starts a lightweight HTTP server on a random port for hook callbacks. This avoids file-based IPC and enables real-time notification forwarding.
+
+### Phase 3: Hook Callback Server
+
+For hooks that need to communicate back to Theia (Notification, PostToolUse editor refresh, etc.), implement a local HTTP server:
+
+```typescript
+@injectable()
+export class ClaudeCodeHookCallbackServer {
+    private server: http.Server;
+    private port: number;
+
+    @postConstruct()
+    async start(): Promise<void> {
+        this.server = http.createServer(this.handleRequest.bind(this));
+        this.port = await getAvailablePort();
+        this.server.listen(this.port, '127.0.0.1');
+    }
+
+    getPort(): number { return this.port; }
+
+    private handleRequest(req: IncomingMessage, res: ServerResponse): void {
+        // Route to appropriate handler based on path
+        // POST /hooks/notification -> forward to frontend notification service
+        // POST /hooks/post-tool-use -> trigger editor refresh
+        // POST /hooks/session-start -> initialize session state
+    }
+}
+```
+
+---
+
+## Hook Handler Type Support
+
+| Handler Type | Priority | Implementation Approach |
+|-------------|----------|------------------------|
+| `command` | P1 | ✅ Already works. Theia generates Node.js scripts in `.claude/hooks/`. |
+| `http` | P1 | Use `ClaudeCodeHookCallbackServer` for Theia-to-Claude communication. Users can point to any URL. |
+| `mcp_tool` | P2 | Leverage existing `ai-mcp` package. Configure MCP server name + tool in hook config. Claude Code handles execution. |
+| `prompt` | P3 | Claude Code handles execution natively. Theia just needs to write the config. |
+| `agent` | P4 | Claude Code handles execution natively. Theia just needs to write the config. |
+
+---
+
+## Configuration UI
+
+### Preferences (Phase 1)
+
+Add to `ClaudeCodePreferencesSchema`:
+
+```typescript
+'ai-features.claudeCode.hooks.enabled': {
+    type: 'boolean',
+    default: true,
+    description: 'Enable Claude Code hooks managed by Theia'
+}
+'ai-features.claudeCode.hooks.autoRefreshEditors': {
+    type: 'boolean',
+    default: true,
+    description: 'Automatically refresh editors after Claude modifies files'
+}
+'ai-features.claudeCode.hooks.notificationsEnabled': {
+    type: 'boolean',
+    default: true,
+    description: 'Show Claude Code notifications in Theia'
+}
+```
+
+### Hook Management View (Phase 2)
+
+A dedicated view in the AI configuration panel showing:
+- Active hooks per project (read from `.claude/settings.json` and `.claude/settings.local.json`)
+- Toggle Theia-managed hooks on/off
+- Add/edit/remove user-defined hooks
+- Hook execution log/history
+
+---
+
+## Migration Plan
+
+1. **Phase 1**: Refactor existing `ensureFileBackupHook` and `ensureStopHook` into the new `ClaudeCodeHookService`. No behavior change, just architectural cleanup.
+2. **Phase 2**: Add `PostToolUse` (editor refresh) and `Notification` hooks using the callback server.
+3. **Phase 3**: Add `SessionStart`/`SessionEnd` hooks for session lifecycle management.
+4. **Phase 4**: Expose hook configuration UI and contribution point for other extensions.
+
+---
+
+## Security Considerations
+
+- **Hook callback server** binds to `127.0.0.1` only — no external access.
+- **User-defined hooks** are written to `.claude/settings.local.json` (gitignored) by default.
+- **Theia-managed hooks** are clearly labeled with a `// managed by Theia` comment or a `_theia_managed: true` metadata field for identification during merge/cleanup.
+- **HTTP hooks** with `allowedEnvVars` — Theia should not expose sensitive env vars. Only explicitly listed variables are interpolated.
+- **Command hooks** run with the same permissions as the Theia backend process. Document this clearly.
+
+---
+
+## Open Questions
+
+1. **IPC mechanism**: Should Theia use HTTP callback server, Unix domain sockets, or file-based IPC for hook-to-Theia communication?
+   - *Recommendation*: HTTP on localhost. It's what Claude Code's `http` hook type supports natively, avoiding custom IPC.
+
+2. **Hook script bundling**: Should hook scripts be bundled with the Theia package or generated at runtime?
+   - *Recommendation*: Generate at runtime (current approach). Allows dynamic configuration and avoids path resolution issues.
+
+3. **Multi-root workspaces**: How to handle hooks when multiple workspace roots exist?
+   - *Recommendation*: Install hooks per-root in each root's `.claude/` directory. The `ClaudeCodeHookService` accepts `cwd` to scope operations.
+
+4. **Hook conflicts**: What happens when a user-defined hook conflicts with a Theia-managed hook on the same event+matcher?
+   - *Recommendation*: Both run. Claude Code executes all matching hooks. Document that Theia hooks run alongside user hooks.

--- a/packages/ai-claude-code/src/browser/claude-code-frontend-module.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-frontend-module.ts
@@ -43,10 +43,12 @@ import { WebFetchToolRenderer } from './renderers/web-fetch-tool-renderer';
 import { WriteToolRenderer } from './renderers/write-tool-renderer';
 import { ClaudeCodeSlashCommandsContribution } from './claude-code-slash-commands-contribution';
 import { ClaudeCodeCommandContribution } from './claude-code-command-contribution';
+import { ClaudeCodeHookFrontendContribution } from './claude-code-hook-frontend-contribution';
 
 export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: ClaudeCodePreferencesSchema });
     bind(FrontendApplicationContribution).to(ClaudeCodeSlashCommandsContribution).inSingletonScope();
+    bind(FrontendApplicationContribution).to(ClaudeCodeHookFrontendContribution).inSingletonScope();
     bind(CommandContribution).to(ClaudeCodeCommandContribution).inSingletonScope();
 
     bind(ClaudeCodeFrontendService).toSelf().inSingletonScope();

--- a/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
@@ -80,6 +80,16 @@ export class ClaudeCodeHookFrontendContribution implements FrontendApplicationCo
             case 'ConfigChange':
                 this.handleConfigChange(event);
                 break;
+            case 'PermissionDenied':
+            case 'StopFailure':
+            case 'Setup':
+            case 'SubagentStart':
+            case 'SubagentStop':
+            case 'TaskCreated':
+            case 'TaskCompleted':
+            case 'TeammateIdle':
+                this.handleGenericHookEvent(event);
+                break;
         }
     }
 
@@ -126,6 +136,11 @@ export class ClaudeCodeHookFrontendContribution implements FrontendApplicationCo
     protected handleConfigChange(event: AgentSessionHookData): void {
         const source = event.payload?.source as string || 'unknown';
         this.getHookOutputChannel().appendLine(`[ConfigChange] Source: ${source}`);
+    }
+
+    protected handleGenericHookEvent(event: AgentSessionHookData): void {
+        const detail = event.toolName || event.payload?.reason || event.payload?.agent_type || '';
+        this.getHookOutputChannel().appendLine(`[${event.event}]${detail ? ' ' + detail : ''}`);
     }
 
     protected handleNotification(event: AgentSessionHookData): void {

--- a/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
@@ -15,13 +15,14 @@
 // *****************************************************************************
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
-import { MessageService } from '@theia/core';
+import { ILogger, MessageService } from '@theia/core';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { AgentSessionHookData, AgentSessionHookRegistry } from '@theia/ai-core';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { URI } from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { OutputChannelManager } from '@theia/output/lib/browser/output-channel';
 
 @injectable()
 export class ClaudeCodeHookFrontendContribution implements FrontendApplicationContribution {
@@ -41,6 +42,12 @@ export class ClaudeCodeHookFrontendContribution implements FrontendApplicationCo
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
+    @inject(OutputChannelManager)
+    protected readonly outputChannelManager: OutputChannelManager;
+
+    @inject(ILogger)
+    protected readonly logger: ILogger;
+
     @postConstruct()
     protected init(): void {
         this.hookRegistry.onHookEvent(event => this.handleHookEvent(event));
@@ -55,8 +62,23 @@ export class ClaudeCodeHookFrontendContribution implements FrontendApplicationCo
             case 'PostToolUse':
                 this.handlePostToolUse(event);
                 break;
+            case 'PostToolUseFailure':
+                this.handlePostToolUseFailure(event);
+                break;
+            case 'PostToolBatch':
+                this.handlePostToolBatch(event);
+                break;
             case 'Notification':
                 this.handleNotification(event);
+                break;
+            case 'PermissionRequest':
+                this.handlePermissionRequest(event);
+                break;
+            case 'InstructionsLoaded':
+                this.handleInstructionsLoaded(event);
+                break;
+            case 'ConfigChange':
+                this.handleConfigChange(event);
                 break;
         }
     }
@@ -66,23 +88,44 @@ export class ClaudeCodeHookFrontendContribution implements FrontendApplicationCo
         if (!filePath) {
             return;
         }
-        const roots = await this.workspaceService.roots;
-        if (roots.length === 0) {
+        await this.refreshFileInEditor(filePath);
+    }
+
+    protected handlePostToolUseFailure(event: AgentSessionHookData): void {
+        const toolName = event.toolName || 'unknown tool';
+        const error = event.payload?.error as string || 'unknown error';
+        this.getHookOutputChannel().appendLine(`[PostToolUseFailure] ${toolName}: ${error}`);
+    }
+
+    protected async handlePostToolBatch(event: AgentSessionHookData): Promise<void> {
+        // Refresh all files that were modified in this batch
+        const toolResults = event.payload?.tool_results as Array<{ tool_name?: string; tool_input?: Record<string, unknown> }> | undefined;
+        if (!toolResults) {
             return;
         }
-        const rootUri = roots[0].resource;
-        const fileUri = rootUri.resolve(filePath);
-        // Refresh the file in the editor if it's open
-        for (const editor of this.editorManager.all) {
-            if (editor.editor.uri.toString() === fileUri.toString()) {
-                try {
-                    await this.fileService.resolve(new URI(fileUri.toString()), { resolveMetadata: true });
-                } catch {
-                    // File may have been deleted
+        for (const result of toolResults) {
+            if (['Write', 'Edit', 'MultiEdit'].includes(result.tool_name || '')) {
+                const filePath = result.tool_input?.file_path as string | undefined;
+                if (filePath) {
+                    await this.refreshFileInEditor(filePath);
                 }
-                break;
             }
         }
+    }
+
+    protected handlePermissionRequest(event: AgentSessionHookData): void {
+        const toolName = event.payload?.tool_name as string || 'unknown';
+        this.getHookOutputChannel().appendLine(`[PermissionRequest] Tool: ${toolName}`);
+    }
+
+    protected handleInstructionsLoaded(event: AgentSessionHookData): void {
+        const filePath = event.payload?.file_path as string || event.payload?.source as string || 'unknown';
+        this.getHookOutputChannel().appendLine(`[InstructionsLoaded] ${filePath}`);
+    }
+
+    protected handleConfigChange(event: AgentSessionHookData): void {
+        const source = event.payload?.source as string || 'unknown';
+        this.getHookOutputChannel().appendLine(`[ConfigChange] Source: ${source}`);
     }
 
     protected handleNotification(event: AgentSessionHookData): void {
@@ -90,5 +133,26 @@ export class ClaudeCodeHookFrontendContribution implements FrontendApplicationCo
             || event.payload?.title as string
             || 'Claude Code notification';
         this.messageService.info(message);
+    }
+
+    protected async refreshFileInEditor(filePath: string): Promise<void> {
+        const roots = await this.workspaceService.roots;
+        if (roots.length === 0) {
+            return;
+        }
+        const rootUri = roots[0].resource;
+        const fileUri = rootUri.resolve(filePath);
+        for (const editor of this.editorManager.all) {
+            if (editor.editor.uri.toString() === fileUri.toString()) {
+                try {
+                    await this.fileService.resolve(new URI(fileUri.toString()), { resolveMetadata: true });
+                } catch { /* File may have been deleted */ }
+                break;
+            }
+        }
+    }
+
+    protected getHookOutputChannel() {
+        return this.outputChannelManager.getChannel('Claude Code Hooks');
     }
 }

--- a/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
@@ -1,0 +1,94 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and Others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { MessageService } from '@theia/core';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { AgentSessionHookData, AgentSessionHookRegistry } from '@theia/ai-core';
+import { EditorManager } from '@theia/editor/lib/browser';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { URI } from '@theia/core/lib/common/uri';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+
+@injectable()
+export class ClaudeCodeHookFrontendContribution implements FrontendApplicationContribution {
+
+    @inject(AgentSessionHookRegistry)
+    protected readonly hookRegistry: AgentSessionHookRegistry;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @postConstruct()
+    protected init(): void {
+        this.hookRegistry.onHookEvent(event => this.handleHookEvent(event));
+    }
+
+    async onStart(): Promise<void> {
+        // Registration happens in @postConstruct
+    }
+
+    protected handleHookEvent(event: AgentSessionHookData): void {
+        switch (event.event) {
+            case 'PostToolUse':
+                this.handlePostToolUse(event);
+                break;
+            case 'Notification':
+                this.handleNotification(event);
+                break;
+        }
+    }
+
+    protected async handlePostToolUse(event: AgentSessionHookData): Promise<void> {
+        const filePath = event.toolInput?.file_path as string | undefined;
+        if (!filePath) {
+            return;
+        }
+        const roots = await this.workspaceService.roots;
+        if (roots.length === 0) {
+            return;
+        }
+        const rootUri = roots[0].resource;
+        const fileUri = rootUri.resolve(filePath);
+        // Refresh the file in the editor if it's open
+        for (const editor of this.editorManager.all) {
+            if (editor.editor.uri.toString() === fileUri.toString()) {
+                try {
+                    await this.fileService.resolve(new URI(fileUri.toString()), { resolveMetadata: true });
+                } catch {
+                    // File may have been deleted
+                }
+                break;
+            }
+        }
+    }
+
+    protected handleNotification(event: AgentSessionHookData): void {
+        const message = event.payload?.message as string
+            || event.payload?.title as string
+            || 'Claude Code notification';
+        this.messageService.info(message);
+    }
+}

--- a/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
+++ b/packages/ai-claude-code/src/browser/claude-code-hook-frontend-contribution.ts
@@ -88,6 +88,15 @@ export class ClaudeCodeHookFrontendContribution implements FrontendApplicationCo
             case 'TaskCreated':
             case 'TaskCompleted':
             case 'TeammateIdle':
+            case 'UserPromptExpansion':
+            case 'CwdChanged':
+            case 'FileChanged':
+            case 'WorktreeCreate':
+            case 'WorktreeRemove':
+            case 'PreCompact':
+            case 'PostCompact':
+            case 'Elicitation':
+            case 'ElicitationResult':
                 this.handleGenericHookEvent(event);
                 break;
         }

--- a/packages/ai-claude-code/src/common/claude-code-hook-types.ts
+++ b/packages/ai-claude-code/src/common/claude-code-hook-types.ts
@@ -1,0 +1,76 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and Others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export type HookEvent =
+    | 'SessionStart' | 'Setup' | 'InstructionsLoaded'
+    | 'UserPromptSubmit' | 'UserPromptExpansion'
+    | 'PreToolUse' | 'PermissionRequest' | 'PermissionDenied'
+    | 'PostToolUse' | 'PostToolUseFailure' | 'PostToolBatch'
+    | 'Notification' | 'SubagentStart' | 'SubagentStop'
+    | 'TaskCreated' | 'TaskCompleted'
+    | 'Stop' | 'StopFailure' | 'TeammateIdle'
+    | 'ConfigChange' | 'CwdChanged' | 'FileChanged'
+    | 'WorktreeCreate' | 'WorktreeRemove'
+    | 'PreCompact' | 'PostCompact'
+    | 'Elicitation' | 'ElicitationResult'
+    | 'SessionEnd';
+
+export type HookHandlerType = 'command' | 'http';
+
+export interface HookHandler {
+    type: HookHandlerType;
+    timeout?: number;
+}
+
+export interface CommandHookHandler extends HookHandler {
+    type: 'command';
+    command: string;
+}
+
+export interface HttpHookHandler extends HookHandler {
+    type: 'http';
+    url: string;
+}
+
+export interface MatcherGroup {
+    matcher: string;
+    hooks: Array<CommandHookHandler | HttpHookHandler>;
+}
+
+export interface HooksConfig {
+    hooks: Partial<Record<HookEvent, MatcherGroup[]>>;
+}
+
+/**
+ * Callback event sent from a Claude Code hook to Theia's HTTP callback server.
+ */
+export interface HookCallbackEvent {
+    hookEvent: HookEvent;
+    payload: Record<string, unknown>;
+}
+
+export const CLAUDE_CODE_HOOK_SERVICE_PATH = '/services/claude-code-hooks';
+
+export const ClaudeCodeHookClient = Symbol('ClaudeCodeHookClient');
+export interface ClaudeCodeHookClient {
+    onHookEvent(event: HookCallbackEvent): void;
+}
+
+export const ClaudeCodeHookService = Symbol('ClaudeCodeHookService');
+export interface ClaudeCodeHookService {
+    installHooks(cwd: string): Promise<void>;
+    getCallbackPort(): number;
+}

--- a/packages/ai-claude-code/src/common/index.ts
+++ b/packages/ai-claude-code/src/common/index.ts
@@ -15,3 +15,4 @@
 // *****************************************************************************
 
 export * from './claude-code-service';
+export * from './claude-code-hook-types';

--- a/packages/ai-claude-code/src/node/claude-code-backend-module.ts
+++ b/packages/ai-claude-code/src/node/claude-code-backend-module.ts
@@ -17,12 +17,14 @@
 import { ConnectionHandler, RpcConnectionHandler } from '@theia/core';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { AgentSessionHookProvider } from '@theia/ai-core';
 import {
     CLAUDE_CODE_SERVICE_PATH,
     ClaudeCodeClient,
     ClaudeCodeService
 } from '../common/claude-code-service';
 import { ClaudeCodeServiceImpl } from './claude-code-service-impl';
+import { ClaudeCodeHookServiceImpl } from './claude-code-hook-service-impl';
 
 const claudeCodeConnectionModule = ConnectionContainerModule.create(({ bind }) => {
     bind(ClaudeCodeServiceImpl).toSelf().inSingletonScope();
@@ -39,4 +41,7 @@ const claudeCodeConnectionModule = ConnectionContainerModule.create(({ bind }) =
 
 export default new ContainerModule(bind => {
     bind(ConnectionContainerModule).toConstantValue(claudeCodeConnectionModule);
+
+    bind(ClaudeCodeHookServiceImpl).toSelf().inSingletonScope();
+    bind(AgentSessionHookProvider).toService(ClaudeCodeHookServiceImpl);
 });

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
@@ -102,6 +102,15 @@ describe('ClaudeCodeHookServiceImpl', () => {
         expect(settings.hooks).to.have.property('TaskCreated');
         expect(settings.hooks).to.have.property('TaskCompleted');
         expect(settings.hooks).to.have.property('TeammateIdle');
+        expect(settings.hooks).to.have.property('UserPromptExpansion');
+        expect(settings.hooks).to.have.property('CwdChanged');
+        expect(settings.hooks).to.have.property('FileChanged');
+        expect(settings.hooks).to.have.property('WorktreeCreate');
+        expect(settings.hooks).to.have.property('WorktreeRemove');
+        expect(settings.hooks).to.have.property('PreCompact');
+        expect(settings.hooks).to.have.property('PostCompact');
+        expect(settings.hooks).to.have.property('Elicitation');
+        expect(settings.hooks).to.have.property('ElicitationResult');
         expect(settings.hooks).to.have.property('Notification');
         expect(settings.hooks).to.have.property('SessionStart');
         expect(settings.hooks).to.have.property('SessionEnd');

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
@@ -119,6 +119,105 @@ describe('ClaudeCodeHookServiceImpl', () => {
         expect(settings.customSetting).to.equal(true);
         expect(settings.hooks).to.have.property('PreToolUse');
     });
+
+    it('should return 400 for malformed JSON', async () => {
+        const status = await postToCallback(service.getCallbackPort(), 'not json{{{');
+        expect(status).to.equal(400);
+    });
+
+    it('should handle multiple rapid events in order', async () => {
+        const received: AgentSessionHookData[] = [];
+        service.onHookEvent(e => received.push(e));
+
+        const events = ['SessionStart', 'PreToolUse', 'PostToolUse', 'Stop', 'SessionEnd'];
+        for (const hookEvent of events) {
+            const body = JSON.stringify({ hookEvent, payload: { session_id: 's1' } });
+            await postToCallback(service.getCallbackPort(), body);
+        }
+
+        expect(received).to.have.length(5);
+        expect(received.map(e => e.event)).to.deep.equal(events);
+    });
+
+    it('should overwrite theia-callback-hook.js on each install (port may change)', async () => {
+        await service.installHooks(tmpDir);
+        const hookPath = path.join(tmpDir, '.claude', 'hooks', 'theia-callback-hook.js');
+        const content1 = await fs.readFile(hookPath, 'utf8');
+        expect(content1).to.include(String(service.getCallbackPort()));
+
+        // Simulate port change by modifying the file and reinstalling
+        await fs.writeFile(hookPath, 'old content');
+        await service.installHooks(tmpDir);
+        const content2 = await fs.readFile(hookPath, 'utf8');
+        expect(content2).to.include(String(service.getCallbackPort()));
+        expect(content2).to.not.equal('old content');
+    });
+
+    it('should not overwrite file-backup-hook.js if it already exists', async () => {
+        const hooksDir = path.join(tmpDir, '.claude', 'hooks');
+        await fs.mkdir(hooksDir, { recursive: true });
+        const hookPath = path.join(hooksDir, 'file-backup-hook.js');
+        await fs.writeFile(hookPath, 'custom backup logic');
+
+        await service.installHooks(tmpDir);
+
+        const content = await fs.readFile(hookPath, 'utf8');
+        expect(content).to.equal('custom backup logic');
+    });
+
+    it('should configure PreToolUse with Write|Edit|MultiEdit matcher', async () => {
+        await service.installHooks(tmpDir);
+        const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+        const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+
+        const preToolUse = settings.hooks.PreToolUse[0];
+        expect(preToolUse.matcher).to.equal('Write|Edit|MultiEdit');
+        expect(preToolUse.hooks[0].command).to.include('file-backup-hook.js');
+        expect(preToolUse.hooks[0].timeout).to.equal(10);
+    });
+
+    it('should configure callback hooks with THEIA_HOOK_EVENT env var', async () => {
+        await service.installHooks(tmpDir);
+        const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+        const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+
+        const notification = settings.hooks.Notification[0];
+        expect(notification.hooks[0].command).to.include('THEIA_HOOK_EVENT=Notification');
+        expect(notification.hooks[0].command).to.include('theia-callback-hook.js');
+    });
+
+    it('should map payload fields to AgentSessionHookData correctly', async () => {
+        const received: AgentSessionHookData[] = [];
+        service.onHookEvent(e => received.push(e));
+
+        await postToCallback(service.getCallbackPort(), JSON.stringify({
+            hookEvent: 'PreToolUse',
+            payload: {
+                session_id: 'sess-123',
+                tool_name: 'Bash',
+                tool_input: { command: 'npm test' },
+                cwd: '/home/user/project'
+            }
+        }));
+
+        expect(received[0].sessionId).to.equal('sess-123');
+        expect(received[0].toolName).to.equal('Bash');
+        expect(received[0].toolInput).to.deep.equal({ command: 'npm test' });
+        expect(received[0].payload?.cwd).to.equal('/home/user/project');
+    });
+
+    it('should handle missing session_id gracefully', async () => {
+        const received: AgentSessionHookData[] = [];
+        service.onHookEvent(e => received.push(e));
+
+        await postToCallback(service.getCallbackPort(), JSON.stringify({
+            hookEvent: 'Notification',
+            payload: { message: 'hello' }
+        }));
+
+        expect(received[0].sessionId).to.equal('');
+        expect(received[0].payload?.message).to.equal('hello');
+    });
 });
 
 function postToCallback(port: number, body: string): Promise<number> {

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
@@ -1,0 +1,130 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and Others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as http from 'http';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import { AgentSessionHookData } from '@theia/ai-core';
+import { ClaudeCodeHookServiceImpl } from './claude-code-hook-service-impl';
+
+describe('ClaudeCodeHookServiceImpl', () => {
+
+    let service: ClaudeCodeHookServiceImpl;
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'theia-hook-test-'));
+        service = new ClaudeCodeHookServiceImpl();
+        // Mock logger
+        (service as any).logger = { info: () => { }, error: () => { }, debug: () => { } };
+        service['init']();
+        // Wait for server to start
+        await new Promise<void>(resolve => setTimeout(resolve, 50));
+    });
+
+    afterEach(async () => {
+        service['server']?.close();
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('should have id "claude-code"', () => {
+        expect(service.id).to.equal('claude-code');
+    });
+
+    it('should start callback server on a port', () => {
+        expect(service.getCallbackPort()).to.be.greaterThan(0);
+    });
+
+    it('should emit hook events when callback server receives POST', async () => {
+        const received: AgentSessionHookData[] = [];
+        service.onHookEvent(e => received.push(e));
+
+        const body = JSON.stringify({
+            hookEvent: 'PostToolUse',
+            payload: { session_id: 'test-session', tool_name: 'Write', tool_input: { file_path: 'foo.ts' } }
+        });
+
+        await postToCallback(service.getCallbackPort(), body);
+
+        expect(received).to.have.length(1);
+        expect(received[0].event).to.equal('PostToolUse');
+        expect(received[0].sessionId).to.equal('test-session');
+        expect(received[0].toolName).to.equal('Write');
+    });
+
+    it('should reject non-POST requests', async () => {
+        const status = await getFromCallback(service.getCallbackPort());
+        expect(status).to.equal(405);
+    });
+
+    it('should install hook scripts and settings', async () => {
+        // Override port so the generated script has a valid port
+        await service.installHooks(tmpDir);
+
+        const hooksDir = path.join(tmpDir, '.claude', 'hooks');
+        const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+
+        // Check scripts exist
+        await fs.access(path.join(hooksDir, 'file-backup-hook.js'));
+        await fs.access(path.join(hooksDir, 'session-cleanup-hook.js'));
+        await fs.access(path.join(hooksDir, 'theia-callback-hook.js'));
+
+        // Check settings
+        const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+        expect(settings.hooks).to.have.property('PreToolUse');
+        expect(settings.hooks).to.have.property('PostToolUse');
+        expect(settings.hooks).to.have.property('Notification');
+        expect(settings.hooks).to.have.property('SessionStart');
+        expect(settings.hooks).to.have.property('SessionEnd');
+        expect(settings.hooks).to.have.property('Stop');
+    });
+
+    it('should preserve existing settings when installing hooks', async () => {
+        const settingsPath = path.join(tmpDir, '.claude', 'settings.local.json');
+        await fs.mkdir(path.join(tmpDir, '.claude'), { recursive: true });
+        await fs.writeFile(settingsPath, JSON.stringify({ customSetting: true }));
+
+        await service.installHooks(tmpDir);
+
+        const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+        expect(settings.customSetting).to.equal(true);
+        expect(settings.hooks).to.have.property('PreToolUse');
+    });
+});
+
+function postToCallback(port: number, body: string): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const req = http.request({
+            hostname: '127.0.0.1', port, path: '/hook', method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }
+        }, res => { resolve(res.statusCode || 0); });
+        req.on('error', reject);
+        req.write(body);
+        req.end();
+    });
+}
+
+function getFromCallback(port: number): Promise<number> {
+    return new Promise((resolve, reject) => {
+        const req = http.request({
+            hostname: '127.0.0.1', port, path: '/hook', method: 'GET'
+        }, res => { resolve(res.statusCode || 0); });
+        req.on('error', reject);
+        req.end();
+    });
+}

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
@@ -88,6 +88,12 @@ describe('ClaudeCodeHookServiceImpl', () => {
         const settings = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
         expect(settings.hooks).to.have.property('PreToolUse');
         expect(settings.hooks).to.have.property('PostToolUse');
+        expect(settings.hooks).to.have.property('PostToolUseFailure');
+        expect(settings.hooks).to.have.property('PostToolBatch');
+        expect(settings.hooks).to.have.property('UserPromptSubmit');
+        expect(settings.hooks).to.have.property('PermissionRequest');
+        expect(settings.hooks).to.have.property('InstructionsLoaded');
+        expect(settings.hooks).to.have.property('ConfigChange');
         expect(settings.hooks).to.have.property('Notification');
         expect(settings.hooks).to.have.property('SessionStart');
         expect(settings.hooks).to.have.property('SessionEnd');

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
@@ -94,6 +94,14 @@ describe('ClaudeCodeHookServiceImpl', () => {
         expect(settings.hooks).to.have.property('PermissionRequest');
         expect(settings.hooks).to.have.property('InstructionsLoaded');
         expect(settings.hooks).to.have.property('ConfigChange');
+        expect(settings.hooks).to.have.property('PermissionDenied');
+        expect(settings.hooks).to.have.property('StopFailure');
+        expect(settings.hooks).to.have.property('Setup');
+        expect(settings.hooks).to.have.property('SubagentStart');
+        expect(settings.hooks).to.have.property('SubagentStop');
+        expect(settings.hooks).to.have.property('TaskCreated');
+        expect(settings.hooks).to.have.property('TaskCompleted');
+        expect(settings.hooks).to.have.property('TeammateIdle');
         expect(settings.hooks).to.have.property('Notification');
         expect(settings.hooks).to.have.property('SessionStart');
         expect(settings.hooks).to.have.property('SessionEnd');

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
@@ -200,6 +200,30 @@ main().catch(() => {});
                     matcher: 'Write|Edit|MultiEdit',
                     hooks: [{ type: 'command', command: cb('PostToolUse') }]
                 }],
+                PostToolUseFailure: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('PostToolUseFailure') }]
+                }],
+                PostToolBatch: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('PostToolBatch') }]
+                }],
+                UserPromptSubmit: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('UserPromptSubmit') }]
+                }],
+                PermissionRequest: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('PermissionRequest') }]
+                }],
+                InstructionsLoaded: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('InstructionsLoaded') }]
+                }],
+                ConfigChange: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('ConfigChange') }]
+                }],
                 Notification: [{
                     matcher: '',
                     hooks: [{ type: 'command', command: cb('Notification') }]

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
@@ -1,0 +1,231 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and Others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, ILogger } from '@theia/core';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { AgentSessionHookData, AgentSessionHookProvider } from '@theia/ai-core';
+import * as http from 'http';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { HookCallbackEvent, HookEvent, HooksConfig } from '../common/claude-code-hook-types';
+
+/**
+ * Claude Code hook provider that:
+ * 1. Starts a local HTTP callback server
+ * 2. Installs Claude Code hooks (in .claude/settings.local.json) that POST to this server
+ * 3. Translates incoming hook callbacks into generic AgentSessionHookData events
+ */
+@injectable()
+export class ClaudeCodeHookServiceImpl implements AgentSessionHookProvider {
+
+    readonly id = 'claude-code';
+
+    @inject(ILogger) @named('ClaudeCode')
+    protected readonly logger: ILogger;
+
+    protected readonly hookEmitter = new Emitter<AgentSessionHookData>();
+    readonly onHookEvent = this.hookEmitter.event;
+
+    protected server: http.Server;
+    protected port = 0;
+
+    @postConstruct()
+    protected init(): void {
+        this.startCallbackServer();
+    }
+
+    getCallbackPort(): number {
+        return this.port;
+    }
+
+    /**
+     * Install Theia-managed hooks into the project's .claude/settings.local.json.
+     * Must be called before starting a Claude Code session.
+     */
+    async installHooks(cwd: string): Promise<void> {
+        await this.ensureHookScripts(cwd);
+        await this.writeHookSettings(cwd);
+    }
+
+    protected startCallbackServer(): void {
+        this.server = http.createServer((req, res) => this.handleCallback(req, res));
+        this.server.listen(0, '127.0.0.1', () => {
+            const addr = this.server.address();
+            if (addr && typeof addr !== 'string') {
+                this.port = addr.port;
+                this.logger.info(`Claude Code hook callback server on port ${this.port}`);
+            }
+        });
+        this.server.on('error', err => this.logger.error('Hook callback server error:', err));
+    }
+
+    protected handleCallback(req: http.IncomingMessage, res: http.ServerResponse): void {
+        if (req.method !== 'POST') {
+            res.writeHead(405);
+            res.end();
+            return;
+        }
+        let body = '';
+        req.on('data', (chunk: string) => { body += chunk; });
+        req.on('end', () => {
+            try {
+                const event: HookCallbackEvent = JSON.parse(body);
+                this.hookEmitter.fire({
+                    event: event.hookEvent as AgentSessionHookData['event'],
+                    sessionId: event.payload.session_id as string || '',
+                    toolName: event.payload.tool_name as string | undefined,
+                    toolInput: event.payload.tool_input as Record<string, unknown> | undefined,
+                    payload: event.payload
+                });
+                res.writeHead(200, { 'Content-Type': 'application/json' });
+                res.end('{}');
+            } catch (err) {
+                this.logger.error('Failed to parse hook callback:', err);
+                res.writeHead(400);
+                res.end();
+            }
+        });
+    }
+
+    protected async ensureHookScripts(cwd: string): Promise<void> {
+        const hooksDir = path.join(cwd, '.claude', 'hooks');
+        await fs.mkdir(hooksDir, { recursive: true });
+        await this.writeFileBackupHook(hooksDir);
+        await this.writeSessionCleanupHook(hooksDir);
+        await this.writeTheiaCallbackHook(hooksDir);
+    }
+
+    protected async writeFileBackupHook(hooksDir: string): Promise<void> {
+        const hookPath = path.join(hooksDir, 'file-backup-hook.js');
+        try { await fs.access(hookPath); return; } catch { /* create */ }
+        await fs.writeFile(hookPath, `#!/usr/bin/env node
+const fs = require('fs').promises;
+const path = require('path');
+async function main() {
+    const input = await new Promise((resolve, reject) => {
+        let data = '';
+        process.stdin.on('data', chunk => data += chunk);
+        process.stdin.on('end', () => resolve(data));
+        process.stdin.on('error', reject);
+    });
+    const h = JSON.parse(input);
+    if (!['Write','Edit','MultiEdit'].includes(h.tool_name)) process.exit(0);
+    let fp = h.tool_name === 'MultiEdit' ? h.tool_input?.files?.[0]?.file_path : h.tool_input?.file_path;
+    if (!fp) process.exit(0);
+    const abs = path.resolve(h.cwd, fp);
+    try { await fs.access(abs); } catch { process.exit(0); }
+    const bDir = path.join(h.cwd, '.claude', '.edit-baks', h.session_id);
+    const rel = path.relative(h.cwd, abs);
+    const bak = path.join(bDir, rel);
+    await fs.mkdir(path.dirname(bak), { recursive: true });
+    try { await fs.access(bak); process.exit(0); } catch {}
+    await fs.copyFile(abs, bak);
+}
+main().catch(() => process.exit(1));
+`, { mode: 0o755 });
+    }
+
+    protected async writeSessionCleanupHook(hooksDir: string): Promise<void> {
+        const hookPath = path.join(hooksDir, 'session-cleanup-hook.js');
+        try { await fs.access(hookPath); return; } catch { /* create */ }
+        await fs.writeFile(hookPath, `#!/usr/bin/env node
+const fs = require('fs').promises;
+const path = require('path');
+async function main() {
+    const input = await new Promise((resolve, reject) => {
+        let data = '';
+        process.stdin.on('data', chunk => data += chunk);
+        process.stdin.on('end', () => resolve(data));
+        process.stdin.on('error', reject);
+    });
+    const h = JSON.parse(input);
+    const dir = path.join(h.cwd, '.claude', '.edit-baks', h.session_id);
+    try { await fs.rm(dir, { recursive: true, force: true }); } catch {}
+}
+main().catch(() => process.exit(1));
+`, { mode: 0o755 });
+    }
+
+    protected async writeTheiaCallbackHook(hooksDir: string): Promise<void> {
+        const hookPath = path.join(hooksDir, 'theia-callback-hook.js');
+        // Always overwrite — port changes between Theia restarts
+        await fs.writeFile(hookPath, `#!/usr/bin/env node
+const http = require('http');
+async function main() {
+    const input = await new Promise((resolve, reject) => {
+        let data = '';
+        process.stdin.on('data', chunk => data += chunk);
+        process.stdin.on('end', () => resolve(data));
+        process.stdin.on('error', reject);
+    });
+    const hookEvent = process.env.THEIA_HOOK_EVENT || 'Unknown';
+    const body = JSON.stringify({ hookEvent, payload: JSON.parse(input) });
+    const req = http.request({
+        hostname: '127.0.0.1', port: ${this.port}, path: '/hook', method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) }
+    });
+    req.on('error', () => {});
+    req.write(body);
+    req.end();
+}
+main().catch(() => {});
+`, { mode: 0o755 });
+    }
+
+    protected async writeHookSettings(cwd: string): Promise<void> {
+        const settingsPath = path.join(cwd, '.claude', 'settings.local.json');
+        const cb = (event: HookEvent) =>
+            `THEIA_HOOK_EVENT=${event} node $CLAUDE_PROJECT_DIR/.claude/hooks/theia-callback-hook.js`;
+
+        const hookConfig: HooksConfig = {
+            hooks: {
+                PreToolUse: [{
+                    matcher: 'Write|Edit|MultiEdit',
+                    hooks: [{ type: 'command', command: 'node $CLAUDE_PROJECT_DIR/.claude/hooks/file-backup-hook.js', timeout: 10 }]
+                }],
+                PostToolUse: [{
+                    matcher: 'Write|Edit|MultiEdit',
+                    hooks: [{ type: 'command', command: cb('PostToolUse') }]
+                }],
+                Notification: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('Notification') }]
+                }],
+                SessionStart: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('SessionStart') }]
+                }],
+                SessionEnd: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('SessionEnd') }]
+                }],
+                Stop: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: 'node $CLAUDE_PROJECT_DIR/.claude/hooks/session-cleanup-hook.js' }]
+                }]
+            }
+        };
+
+        let existing: Record<string, unknown> = {};
+        try {
+            existing = JSON.parse(await fs.readFile(settingsPath, 'utf8'));
+        } catch { /* doesn't exist */ }
+
+        const merged = { ...existing, ...hookConfig };
+        await fs.mkdir(path.dirname(settingsPath), { recursive: true });
+        await fs.writeFile(settingsPath, JSON.stringify(merged, undefined, 2));
+    }
+}

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
@@ -256,6 +256,42 @@ main().catch(() => {});
                     matcher: '',
                     hooks: [{ type: 'command', command: cb('TeammateIdle') }]
                 }],
+                UserPromptExpansion: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('UserPromptExpansion') }]
+                }],
+                CwdChanged: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('CwdChanged') }]
+                }],
+                FileChanged: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('FileChanged') }]
+                }],
+                WorktreeCreate: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('WorktreeCreate') }]
+                }],
+                WorktreeRemove: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('WorktreeRemove') }]
+                }],
+                PreCompact: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('PreCompact') }]
+                }],
+                PostCompact: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('PostCompact') }]
+                }],
+                Elicitation: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('Elicitation') }]
+                }],
+                ElicitationResult: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('ElicitationResult') }]
+                }],
                 Notification: [{
                     matcher: '',
                     hooks: [{ type: 'command', command: cb('Notification') }]

--- a/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
+++ b/packages/ai-claude-code/src/node/claude-code-hook-service-impl.ts
@@ -224,6 +224,38 @@ main().catch(() => {});
                     matcher: '',
                     hooks: [{ type: 'command', command: cb('ConfigChange') }]
                 }],
+                PermissionDenied: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('PermissionDenied') }]
+                }],
+                StopFailure: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('StopFailure') }]
+                }],
+                Setup: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('Setup') }]
+                }],
+                SubagentStart: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('SubagentStart') }]
+                }],
+                SubagentStop: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('SubagentStop') }]
+                }],
+                TaskCreated: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('TaskCreated') }]
+                }],
+                TaskCompleted: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('TaskCompleted') }]
+                }],
+                TeammateIdle: [{
+                    matcher: '',
+                    hooks: [{ type: 'command', command: cb('TeammateIdle') }]
+                }],
                 Notification: [{
                     matcher: '',
                     hooks: [{ type: 'command', command: cb('Notification') }]

--- a/packages/ai-claude-code/src/node/claude-code-service-impl.ts
+++ b/packages/ai-claude-code/src/node/claude-code-service-impl.ts
@@ -18,7 +18,6 @@ import { ILogger, generateUuid, nls } from '@theia/core';
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { execSync } from 'child_process';
 import { existsSync, realpathSync } from 'fs';
-import * as fs from 'fs/promises';
 import * as path from 'path';
 import {
     ClaudeCodeBackendRequest,
@@ -27,6 +26,7 @@ import {
     ToolApprovalRequestMessage,
     ToolApprovalResponseMessage
 } from '../common/claude-code-service';
+import { ClaudeCodeHookServiceImpl } from './claude-code-hook-service-impl';
 
 interface ToolApprovalResult {
     behavior: 'allow' | 'deny';
@@ -39,6 +39,9 @@ export class ClaudeCodeServiceImpl implements ClaudeCodeService {
 
     @inject(ILogger) @named('ClaudeCode')
     private logger: ILogger;
+
+    @inject(ClaudeCodeHookServiceImpl)
+    private hookService: ClaudeCodeHookServiceImpl;
 
     private client: ClaudeCodeClient;
     private abortControllers = new Map<string, AbortController>();
@@ -108,9 +111,7 @@ export class ClaudeCodeServiceImpl implements ClaudeCodeService {
 
         try {
             const cwd = request.options?.cwd || process.cwd();
-            await this.ensureFileBackupHook(cwd);
-            await this.ensureStopHook(cwd);
-            await this.ensureClaudeSettings(cwd);
+            await this.hookService.installHooks(cwd);
 
             let done = (_?: unknown) => { };
             const receivedResult = new Promise(resolve => {
@@ -300,233 +301,4 @@ export class ClaudeCodeServiceImpl implements ClaudeCodeService {
         return result;
     }
 
-    protected async ensureStopHook(cwd: string): Promise<void> {
-        const hookPath = path.join(cwd, '.claude', 'hooks', 'session-cleanup-hook.js');
-
-        try {
-            await fs.access(hookPath);
-            return;
-        } catch {
-            // Hook doesn't exist, create it
-        }
-
-        await fs.mkdir(path.dirname(hookPath), { recursive: true });
-
-        const hookContent = `#!/usr/bin/env node
-
-const fs = require('fs').promises;
-const path = require('path');
-
-async function main() {
-    try {
-        const input = await new Promise((resolve, reject) => {
-            let data = '';
-            process.stdin.on('data', chunk => data += chunk);
-            process.stdin.on('end', () => resolve(data));
-            process.stdin.on('error', reject);
-        });
-
-        const hookData = JSON.parse(input);
-
-        // Delete backup directory for this session
-        const backupDir = path.join(hookData.cwd, '.claude', '.edit-baks', hookData.session_id);
-
-        try {
-            await fs.rm(backupDir, { recursive: true, force: true });
-            console.log(\`Cleaned up session backups: \${hookData.session_id}\`);
-        } catch (error) {
-            // Directory might not exist, which is fine
-            console.log(\`No backups to clean for session: \${hookData.session_id}\`);
-        }
-
-    } catch (error) {
-        console.error(\`Cleanup failed: \${error.message}\`, process.stderr);
-        process.exit(1);
-    }
-}
-
-main();
-`;
-
-        await fs.writeFile(hookPath, hookContent, { mode: 0o755 });
-    }
-
-    protected async ensureFileBackupHook(cwd: string): Promise<void> {
-        const hookPath = path.join(cwd, '.claude', 'hooks', 'file-backup-hook.js');
-
-        try {
-            await fs.access(hookPath);
-            // Hook already exists, no need to create it
-            return;
-        } catch {
-            // Hook doesn't exist, create it
-        }
-
-        // Ensure the hooks directory exists
-        await fs.mkdir(path.dirname(hookPath), { recursive: true });
-
-        const hookContent = `#!/usr/bin/env node
-
-const fs = require('fs').promises;
-const path = require('path');
-
-async function main() {
-    try {
-        // Read input from stdin
-        const input = await new Promise((resolve, reject) => {
-            let data = '';
-            process.stdin.on('data', chunk => data += chunk);
-            process.stdin.on('end', () => resolve(data));
-            process.stdin.on('error', reject);
-        });
-
-        const hookData = JSON.parse(input);
-
-        // Only backup for file modification tools
-        const fileModifyingTools = ['Write', 'Edit', 'MultiEdit'];
-        if (!fileModifyingTools.includes(hookData.tool_name)) {
-            process.exit(0);
-        }
-
-        // Extract file path from tool input
-        let filePath;
-        if (hookData.tool_name === 'Write' || hookData.tool_name === 'Edit') {
-            filePath = hookData.tool_input?.file_path;
-        } else if (hookData.tool_name === 'MultiEdit') {
-            // MultiEdit has multiple files - we'll handle the first one for now
-            // You might want to extend this to handle all files
-            filePath = hookData.tool_input?.files?.[0]?.file_path;
-        }
-
-        if (!filePath) {
-            process.exit(0);
-        }
-
-        // Resolve absolute path
-        const absoluteFilePath = path.resolve(hookData.cwd, filePath);
-
-        // Check if file exists (can't backup what doesn't exist)
-        try {
-            await fs.access(absoluteFilePath);
-        } catch {
-            // File doesn't exist, nothing to backup
-            process.exit(0);
-        }
-
-        // Create backup directory structure
-        const backupDir = path.join(hookData.cwd, '.claude', '.edit-baks', hookData.session_id);
-        await fs.mkdir(backupDir, { recursive: true });
-
-        // Create backup file path (maintain relative structure)
-        const relativePath = path.relative(hookData.cwd, absoluteFilePath);
-        const backupFilePath = path.join(backupDir, relativePath);
-
-        // Ensure backup subdirectories exist
-        await fs.mkdir(path.dirname(backupFilePath), { recursive: true });
-
-        // Only create backup if it doesn't already exist for this session
-        try {
-            await fs.access(backupFilePath);
-            // Backup already exists for this session, don't overwrite
-            process.exit(0);
-        } catch {
-            // Backup doesn't exist, create it
-        }
-
-        // Copy the file
-        await fs.copyFile(absoluteFilePath, backupFilePath);
-
-        // Optional: Log the backup (visible in transcript mode with Ctrl-R)
-        console.log(\`Backed up: \${relativePath}\`);
-
-    } catch (error) {
-        console.error(\`Backup failed: \${error.message}\`, process.stderr);
-        process.exit(1); // Non-blocking error
-    }
-}
-
-main();
-`;
-
-        await fs.writeFile(hookPath, hookContent, { mode: 0o755 });
-    }
-
-    private async ensureClaudeSettings(cwd: string): Promise<void> {
-        const settingsPath = path.join(cwd, '.claude', 'settings.local.json');
-
-        const hookConfig = {
-            hooks: {
-                PreToolUse: [
-                    {
-                        matcher: 'Write|Edit|MultiEdit',
-                        hooks: [
-                            {
-                                type: 'command',
-                                command: 'node $CLAUDE_PROJECT_DIR/.claude/hooks/file-backup-hook.js',
-                                timeout: 10
-                            }
-                        ]
-                    }
-                ],
-                Stop: [
-                    {
-                        matcher: '',
-                        hooks: [
-                            {
-                                type: 'command',
-                                command: 'node $CLAUDE_PROJECT_DIR/.claude/hooks/session-cleanup-hook.js'
-                            }
-                        ]
-                    }
-                ]
-            }
-        };
-
-        try {
-            // Try to read existing settings
-            const existingContent = await fs.readFile(settingsPath, 'utf8');
-            const existingSettings = JSON.parse(existingContent);
-
-            // Check if hooks already exist and are properly configured
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const hasPreHook = existingSettings.hooks?.PreToolUse?.some((hook: any) =>
-                hook.matcher === 'Write|Edit|MultiEdit' &&
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                hook.hooks?.some((h: any) => h.command?.includes('file-backup-hook.js'))
-            );
-
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            const hasStopHook = existingSettings.hooks?.Stop?.some((hook: any) =>
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                hook.hooks?.some((h: any) => h.command?.includes('session-cleanup-hook.js'))
-            );
-
-            if (hasPreHook && hasStopHook) {
-                // Hooks already configured, no need to modify
-                return;
-            }
-
-            // Merge with existing settings
-            const mergedSettings = {
-                ...existingSettings,
-                hooks: {
-                    ...existingSettings.hooks,
-                    PreToolUse: [
-                        ...(existingSettings.hooks?.PreToolUse || []),
-                        ...(hasPreHook ? [] : hookConfig.hooks.PreToolUse)
-                    ],
-                    Stop: [
-                        ...(existingSettings.hooks?.Stop || []),
-                        ...(hasStopHook ? [] : hookConfig.hooks.Stop)
-                    ]
-                }
-            };
-
-            await fs.writeFile(settingsPath, JSON.stringify(mergedSettings, undefined, 2));
-        } catch {
-            // File doesn't exist or is invalid JSON, create new one
-            await fs.mkdir(path.dirname(settingsPath), { recursive: true });
-            await fs.writeFile(settingsPath, JSON.stringify(hookConfig, undefined, 2));
-        }
-    }
 }

--- a/packages/ai-copilot/src/node/copilot-language-model.ts
+++ b/packages/ai-copilot/src/node/copilot-language-model.ts
@@ -16,6 +16,7 @@
 
 import {
     ImageContent,
+    isToolCallContent,
     LanguageModel,
     LanguageModelMessage,
     LanguageModelParsedResponse,
@@ -23,6 +24,7 @@ import {
     LanguageModelResponse,
     LanguageModelStatus,
     LanguageModelTextResponse,
+    ToolCallResult,
     UserRequest
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
@@ -33,6 +35,18 @@ import { StreamingAsyncIterator } from '@theia/ai-openai/lib/node/openai-streami
 import { COPILOT_PROVIDER_ID, getCopilotApiBaseUrl } from '../common';
 import type { RunnerOptions } from 'openai/lib/AbstractChatCompletionRunner';
 import type { ChatCompletionStream } from 'openai/lib/ChatCompletionStream';
+
+function formatToolCallContent(result: ToolCallResult): string {
+    if (isToolCallContent(result)) {
+        return result.content.map(c => {
+            if (c.type === 'text') { return c.text; }
+            if (c.type === 'html') { return c.html; }
+            if (c.type === 'error') { return c.data; }
+            return JSON.stringify(c);
+        }).join('\n');
+    }
+    return JSON.stringify(result);
+}
 
 /**
  * Language model implementation for GitHub Copilot.
@@ -242,7 +256,7 @@ export class CopilotLanguageModel implements LanguageModel {
             return {
                 role: 'tool',
                 tool_call_id: message.tool_use_id,
-                content: typeof message.content === 'string' ? message.content : JSON.stringify(message.content)
+                content: typeof message.content === 'string' ? message.content : formatToolCallContent(message.content)
             };
         }
         if (LanguageModelMessage.isImageMessage(message) && message.actor === 'user') {

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -87,10 +87,15 @@ import { AIVariableUriLabelProvider } from './ai-variable-uri-label-provider';
 import { AgentCompletionNotificationService } from './agent-completion-notification-service';
 import { OSNotificationService } from './os-notification-service';
 import { WindowBlinkService } from './window-blink-service';
+import { AgentSessionHookProvider, AgentSessionHookRegistry } from '../common/agent-session-hooks';
+import { AgentSessionHookRegistryImpl } from '../common/agent-session-hooks-impl';
 
 export default new ContainerModule(bind => {
     bindRootContributionProvider(bind, Agent);
     bindRootContributionProvider(bind, LanguageModelProvider);
+    bindRootContributionProvider(bind, AgentSessionHookProvider);
+    bind(AgentSessionHookRegistryImpl).toSelf().inSingletonScope();
+    bind(AgentSessionHookRegistry).toService(AgentSessionHookRegistryImpl);
 
     bind(FrontendLanguageModelRegistryImpl).toSelf().inSingletonScope();
     bind(FrontendLanguageModelRegistry).toService(FrontendLanguageModelRegistryImpl);

--- a/packages/ai-core/src/browser/frontend-language-model-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-registry.ts
@@ -48,6 +48,7 @@ import {
     ToolCallResult,
     ToolInvocationContext
 } from '../common';
+import { AgentSessionHookRegistry } from '../common/agent-session-hooks';
 
 @injectable()
 export class LanguageModelDelegateClientImpl
@@ -141,6 +142,9 @@ export class FrontendLanguageModelRegistryImpl
 
     @inject(AISettingsService)
     protected settingsService: AISettingsService;
+
+    @inject(AgentSessionHookRegistry)
+    protected hookRegistry: AgentSessionHookRegistry;
 
     private static requestCounter: number = 0;
 
@@ -318,14 +322,32 @@ export class FrontendLanguageModelRegistryImpl
         const request = this.requests.get(id)!;
         const tool = request.tools?.find(t => t.id === toolId);
         if (tool) {
+            let toolInput: Record<string, unknown> | undefined;
+            try { toolInput = JSON.parse(arg_string); } catch { /* not JSON */ }
+
+            this.fireHookEvent('PreToolUse', id, toolId, toolInput);
             try {
-                return await tool.handler(arg_string, ToolInvocationContext.create(toolCallId));
+                const result = await tool.handler(arg_string, ToolInvocationContext.create(toolCallId));
+                this.fireHookEvent('PostToolUse', id, toolId, toolInput);
+                return result;
             } catch (error) {
                 const errorMessage = error instanceof Error ? error.message : String(error);
+                this.fireHookEvent('PostToolUseFailure', id, toolId, toolInput, errorMessage);
                 return createToolCallError(`Error executing tool '${toolId}': ${errorMessage}`);
             }
         }
         return createToolCallError(`Tool '${toolId}' not found in the available tools for this request.`, 'tool-not-available');
+    }
+
+    protected fireHookEvent(
+        event: 'PreToolUse' | 'PostToolUse' | 'PostToolUseFailure',
+        sessionId: string, toolName: string,
+        toolInput?: Record<string, unknown>, error?: string
+    ): void {
+        this.hookRegistry.fireEvent({
+            event, sessionId, toolName, toolInput,
+            payload: error ? { error } : undefined
+        });
     }
 
     // called by backend via the "delegate client" with the error to use for rejection

--- a/packages/ai-core/src/common/agent-session-hooks-impl.ts
+++ b/packages/ai-core/src/common/agent-session-hooks-impl.ts
@@ -33,4 +33,8 @@ export class AgentSessionHookRegistryImpl implements AgentSessionHookRegistry {
             provider.onHookEvent(event => this.emitter.fire(event));
         }
     }
+
+    fireEvent(data: AgentSessionHookData): void {
+        this.emitter.fire(data);
+    }
 }

--- a/packages/ai-core/src/common/agent-session-hooks-impl.ts
+++ b/packages/ai-core/src/common/agent-session-hooks-impl.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and Others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContributionProvider, Emitter } from '@theia/core';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { AgentSessionHookData, AgentSessionHookProvider, AgentSessionHookRegistry } from './agent-session-hooks';
+
+@injectable()
+export class AgentSessionHookRegistryImpl implements AgentSessionHookRegistry {
+
+    @inject(ContributionProvider) @named(AgentSessionHookProvider)
+    protected readonly providers: ContributionProvider<AgentSessionHookProvider>;
+
+    protected readonly emitter = new Emitter<AgentSessionHookData>();
+    readonly onHookEvent = this.emitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        for (const provider of this.providers.getContributions()) {
+            provider.onHookEvent(event => this.emitter.fire(event));
+        }
+    }
+}

--- a/packages/ai-core/src/common/agent-session-hooks.spec.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.spec.ts
@@ -121,10 +121,12 @@ describe('AgentSessionHookRegistryImpl', () => {
         const allEvents: AgentSessionHookData['event'][] = [
             'SessionStart', 'SessionEnd', 'PreToolUse', 'PostToolUse',
             'PostToolUseFailure', 'PostToolBatch', 'UserPromptSubmit',
-            'PermissionRequest', 'PermissionDenied', 'InstructionsLoaded',
-            'ConfigChange', 'Notification', 'Stop', 'StopFailure',
-            'Setup', 'SubagentStart', 'SubagentStop',
-            'TaskCreated', 'TaskCompleted', 'TeammateIdle'
+            'UserPromptExpansion', 'PermissionRequest', 'PermissionDenied',
+            'InstructionsLoaded', 'ConfigChange', 'Notification', 'Stop',
+            'StopFailure', 'Setup', 'SubagentStart', 'SubagentStop',
+            'TaskCreated', 'TaskCompleted', 'TeammateIdle',
+            'CwdChanged', 'FileChanged', 'WorktreeCreate', 'WorktreeRemove',
+            'PreCompact', 'PostCompact', 'Elicitation', 'ElicitationResult'
         ];
 
         for (const event of allEvents) {

--- a/packages/ai-core/src/common/agent-session-hooks.spec.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.spec.ts
@@ -1,0 +1,81 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and Others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Emitter } from '@theia/core';
+import { AgentSessionHookData, AgentSessionHookProvider } from './agent-session-hooks';
+import { AgentSessionHookRegistryImpl } from './agent-session-hooks-impl';
+
+describe('AgentSessionHookRegistryImpl', () => {
+
+    function createProvider(id: string): AgentSessionHookProvider & { fire: (data: AgentSessionHookData) => void } {
+        const emitter = new Emitter<AgentSessionHookData>();
+        return { id, onHookEvent: emitter.event, fire: data => emitter.fire(data) };
+    }
+
+    it('should forward events from a single provider', () => {
+        const provider = createProvider('test');
+        const registry = new AgentSessionHookRegistryImpl();
+        (registry as any).providers = { getContributions: () => [provider] };
+        registry['init']();
+
+        const received: AgentSessionHookData[] = [];
+        registry.onHookEvent(e => received.push(e));
+
+        provider.fire({ event: 'SessionStart', sessionId: 's1' });
+        expect(received).to.have.length(1);
+        expect(received[0].event).to.equal('SessionStart');
+        expect(received[0].sessionId).to.equal('s1');
+    });
+
+    it('should aggregate events from multiple providers', () => {
+        const p1 = createProvider('claude-code');
+        const p2 = createProvider('ollama');
+        const registry = new AgentSessionHookRegistryImpl();
+        (registry as any).providers = { getContributions: () => [p1, p2] };
+        registry['init']();
+
+        const received: AgentSessionHookData[] = [];
+        registry.onHookEvent(e => received.push(e));
+
+        p1.fire({ event: 'PreToolUse', sessionId: 's1', toolName: 'Bash' });
+        p2.fire({ event: 'PostToolUse', sessionId: 's2', toolName: 'read_file' });
+
+        expect(received).to.have.length(2);
+        expect(received[0].event).to.equal('PreToolUse');
+        expect(received[1].event).to.equal('PostToolUse');
+    });
+
+    it('should pass tool metadata through', () => {
+        const provider = createProvider('test');
+        const registry = new AgentSessionHookRegistryImpl();
+        (registry as any).providers = { getContributions: () => [provider] };
+        registry['init']();
+
+        const received: AgentSessionHookData[] = [];
+        registry.onHookEvent(e => received.push(e));
+
+        provider.fire({
+            event: 'PostToolUse',
+            sessionId: 's1',
+            toolName: 'Write',
+            toolInput: { file_path: 'src/index.ts' }
+        });
+
+        expect(received[0].toolName).to.equal('Write');
+        expect(received[0].toolInput).to.deep.equal({ file_path: 'src/index.ts' });
+    });
+});

--- a/packages/ai-core/src/common/agent-session-hooks.spec.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.spec.ts
@@ -78,4 +78,60 @@ describe('AgentSessionHookRegistryImpl', () => {
         expect(received[0].toolName).to.equal('Write');
         expect(received[0].toolInput).to.deep.equal({ file_path: 'src/index.ts' });
     });
+
+    it('should handle provider with no events fired', () => {
+        const provider = createProvider('silent');
+        const registry = new AgentSessionHookRegistryImpl();
+        (registry as any).providers = { getContributions: () => [provider] };
+        registry['init']();
+
+        const received: AgentSessionHookData[] = [];
+        registry.onHookEvent(e => received.push(e));
+
+        expect(received).to.have.length(0);
+    });
+
+    it('should pass payload through', () => {
+        const provider = createProvider('test');
+        const registry = new AgentSessionHookRegistryImpl();
+        (registry as any).providers = { getContributions: () => [provider] };
+        registry['init']();
+
+        const received: AgentSessionHookData[] = [];
+        registry.onHookEvent(e => received.push(e));
+
+        provider.fire({
+            event: 'Notification',
+            sessionId: 's1',
+            payload: { message: 'Task complete', type: 'info' }
+        });
+
+        expect(received[0].payload).to.deep.equal({ message: 'Task complete', type: 'info' });
+    });
+
+    it('should support all P1-P3 event types', () => {
+        const provider = createProvider('test');
+        const registry = new AgentSessionHookRegistryImpl();
+        (registry as any).providers = { getContributions: () => [provider] };
+        registry['init']();
+
+        const received: AgentSessionHookData[] = [];
+        registry.onHookEvent(e => received.push(e));
+
+        const allEvents: AgentSessionHookData['event'][] = [
+            'SessionStart', 'SessionEnd', 'PreToolUse', 'PostToolUse',
+            'PostToolUseFailure', 'PostToolBatch', 'UserPromptSubmit',
+            'PermissionRequest', 'PermissionDenied', 'InstructionsLoaded',
+            'ConfigChange', 'Notification', 'Stop', 'StopFailure',
+            'Setup', 'SubagentStart', 'SubagentStop',
+            'TaskCreated', 'TaskCompleted', 'TeammateIdle'
+        ];
+
+        for (const event of allEvents) {
+            provider.fire({ event, sessionId: 's1' });
+        }
+
+        expect(received).to.have.length(allEvents.length);
+        expect(received.map(e => e.event)).to.deep.equal(allEvents);
+    });
 });

--- a/packages/ai-core/src/common/agent-session-hooks.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.ts
@@ -29,10 +29,18 @@ export type AgentSessionHookEvent =
     | 'PostToolBatch'
     | 'UserPromptSubmit'
     | 'PermissionRequest'
+    | 'PermissionDenied'
     | 'InstructionsLoaded'
     | 'ConfigChange'
     | 'Notification'
-    | 'Stop';
+    | 'Stop'
+    | 'StopFailure'
+    | 'Setup'
+    | 'SubagentStart'
+    | 'SubagentStop'
+    | 'TaskCreated'
+    | 'TaskCompleted'
+    | 'TeammateIdle';
 
 export interface AgentSessionHookData {
     /** Which lifecycle event fired */

--- a/packages/ai-core/src/common/agent-session-hooks.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.ts
@@ -26,6 +26,11 @@ export type AgentSessionHookEvent =
     | 'PreToolUse'
     | 'PostToolUse'
     | 'PostToolUseFailure'
+    | 'PostToolBatch'
+    | 'UserPromptSubmit'
+    | 'PermissionRequest'
+    | 'InstructionsLoaded'
+    | 'ConfigChange'
     | 'Notification'
     | 'Stop';
 

--- a/packages/ai-core/src/common/agent-session-hooks.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.ts
@@ -86,4 +86,6 @@ export const AgentSessionHookRegistry = Symbol('AgentSessionHookRegistry');
 export interface AgentSessionHookRegistry {
     /** Unified event stream from all registered providers */
     readonly onHookEvent: Event<AgentSessionHookData>;
+    /** Fire an event directly (for core components like tool invocation) */
+    fireEvent(data: AgentSessionHookData): void;
 }

--- a/packages/ai-core/src/common/agent-session-hooks.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.ts
@@ -28,6 +28,7 @@ export type AgentSessionHookEvent =
     | 'PostToolUseFailure'
     | 'PostToolBatch'
     | 'UserPromptSubmit'
+    | 'UserPromptExpansion'
     | 'PermissionRequest'
     | 'PermissionDenied'
     | 'InstructionsLoaded'
@@ -40,7 +41,15 @@ export type AgentSessionHookEvent =
     | 'SubagentStop'
     | 'TaskCreated'
     | 'TaskCompleted'
-    | 'TeammateIdle';
+    | 'TeammateIdle'
+    | 'CwdChanged'
+    | 'FileChanged'
+    | 'WorktreeCreate'
+    | 'WorktreeRemove'
+    | 'PreCompact'
+    | 'PostCompact'
+    | 'Elicitation'
+    | 'ElicitationResult';
 
 export interface AgentSessionHookData {
     /** Which lifecycle event fired */

--- a/packages/ai-core/src/common/agent-session-hooks.ts
+++ b/packages/ai-core/src/common/agent-session-hooks.ts
@@ -1,0 +1,67 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and Others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core';
+
+/**
+ * Generic lifecycle events that any AI agent backend can emit.
+ * Backend-specific implementations map their native hook/event systems to these.
+ */
+export type AgentSessionHookEvent =
+    | 'SessionStart'
+    | 'SessionEnd'
+    | 'PreToolUse'
+    | 'PostToolUse'
+    | 'PostToolUseFailure'
+    | 'Notification'
+    | 'Stop';
+
+export interface AgentSessionHookData {
+    /** Which lifecycle event fired */
+    event: AgentSessionHookEvent;
+    /** The session/stream identifier */
+    sessionId: string;
+    /** Tool name, if this is a tool-related event */
+    toolName?: string;
+    /** Tool input, if this is a tool-related event */
+    toolInput?: Record<string, unknown>;
+    /** Arbitrary backend-specific payload */
+    payload?: Record<string, unknown>;
+}
+
+/**
+ * Contribution point for agent backends to emit lifecycle hook events.
+ * Each backend (Claude Code, Ollama, Gemini, etc.) can provide its own implementation
+ * that maps its native event system to these generic events.
+ */
+export const AgentSessionHookProvider = Symbol('AgentSessionHookProvider');
+export interface AgentSessionHookProvider {
+    /** Unique identifier for this provider (e.g. 'claude-code', 'ollama') */
+    readonly id: string;
+
+    /** Fired when a hook event occurs */
+    readonly onHookEvent: Event<AgentSessionHookData>;
+}
+
+/**
+ * Registry that aggregates all AgentSessionHookProvider contributions
+ * and exposes a unified event stream.
+ */
+export const AgentSessionHookRegistry = Symbol('AgentSessionHookRegistry');
+export interface AgentSessionHookRegistry {
+    /** Unified event stream from all registered providers */
+    readonly onHookEvent: Event<AgentSessionHookData>;
+}

--- a/packages/ai-core/src/common/index.ts
+++ b/packages/ai-core/src/common/index.ts
@@ -39,3 +39,4 @@ export * from './notification-types';
 export * from './skill';
 export * from './capability-utils';
 export * from './tool-constants';
+export * from './agent-session-hooks';

--- a/packages/ai-core/src/common/language-model.spec.ts
+++ b/packages/ai-core/src/common/language-model.spec.ts
@@ -103,10 +103,66 @@ describe('isToolCallHtmlAppResult', () => {
     });
 
     it('returns false for null', () => {
-        expect(isToolCallHtmlAppResult(null)).to.be.false;
+        expect(isToolCallHtmlAppResult(undefined)).to.be.false;
     });
 
     it('returns false for undefined', () => {
         expect(isToolCallHtmlAppResult(undefined)).to.be.false;
+    });
+
+    it('returns true for full iframe-ready html app result', () => {
+        const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>Animated Unit Test Sandbox</title>
+<style>
+ html, body { margin: 0; height: 100%; overflow: hidden; background: #0f172a; font-family: Inter, Arial, sans-serif; }
+ .scene { position: relative; width: 100%; height: 100%; background: radial-gradient(circle at top, #1e293b 0%, #020617 70%); overflow: hidden; }
+ .grid { position: absolute; inset: 0; background-size: 40px 40px; animation: drift 12s linear infinite;
+  background-image: linear-gradient(rgba(255,255,255,0.04) 1px, transparent 1px),
+  linear-gradient(90deg, rgba(255,255,255,0.04) 1px, transparent 1px); }
+ @keyframes drift { from { transform: translateY(0px); } to { transform: translateY(40px); } }
+ .panel { position: absolute; top: 50%; left: 50%; width: 340px;
+  transform: translate(-50%, -50%); background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(255,255,255,0.1); border-radius: 20px; padding: 24px;
+  box-shadow: 0 0 50px rgba(59,130,246,0.3), inset 0 0 30px rgba(255,255,255,0.03);
+  backdrop-filter: blur(10px); }
+ .title { color: white; font-size: 24px; font-weight: 700; margin-bottom: 8px; }
+ .subtitle { color: #94a3b8; margin-bottom: 24px; }
+ .test { display: flex; align-items: center; gap: 12px; margin-bottom: 16px;
+  color: white; font-size: 14px; opacity: 0; transform: translateX(-10px);
+  animation: reveal 0.5s forwards; }
+ .test:nth-child(3) { animation-delay: 0.2s; }
+ .test:nth-child(4) { animation-delay: 0.5s; }
+ .test:nth-child(5) { animation-delay: 0.8s; }
+ .test:nth-child(6) { animation-delay: 1.1s; }
+ @keyframes reveal { to { opacity: 1; transform: translateX(0); } }
+ .dot { width: 12px; height: 12px; border-radius: 50%; background: #22c55e; box-shadow: 0 0 12px #22c55e; animation: pulse 1.5s infinite; }
+ .warn { background: #f59e0b; box-shadow: 0 0 12px #f59e0b; }
+ .fail { background: #ef4444; box-shadow: 0 0 12px #ef4444; }
+ @keyframes pulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(1.4); opacity: 0.7; } }
+ .particle { position: absolute; border-radius: 50%; background: rgba(96,165,250,0.25); animation: float linear infinite; }
+ @keyframes float { from { transform: translateY(100vh) scale(0.5); } to { transform: translateY(-120px) scale(1.2); } }
+ .footer { margin-top: 20px; color: #64748b; font-size: 12px; text-align: center; }
+</style>
+</head>
+<body>
+<div class="scene">
+ <div class="grid"></div>
+ <div class="panel">
+  <div class="title">Unit Test Runner</div>
+  <div class="subtitle">Simulated CI Environment</div>
+  <div class="test"><div class="dot"></div>auth.service.spec.ts</div>
+  <div class="test"><div class="dot"></div>payments.integration.spec.ts</div>
+  <div class="test"><div class="dot warn"></div>websocket.reconnect.spec.ts</div>
+  <div class="test"><div class="dot fail"></div>cache.invalidation.spec.ts</div>
+  <div class="footer">24 passed • 1 flaky • 1 failed</div>
+ </div>
+</div>
+</body>
+</html>`;
+        expect(isToolCallHtmlAppResult({ type: 'html', html, title: 'Animated Unit Test Sandbox' })).to.be.true;
     });
 });

--- a/packages/ai-core/src/common/language-model.spec.ts
+++ b/packages/ai-core/src/common/language-model.spec.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { isModelMatching, LanguageModel, LanguageModelSelector } from './language-model';
+import { isModelMatching, LanguageModel, LanguageModelSelector, isToolCallHtmlAppResult } from './language-model';
 import { expect } from 'chai';
 
 describe('isModelMatching', () => {
@@ -82,5 +82,31 @@ describe('isModelMatching', () => {
                 }
             )
         ).eql(true);
+    });
+});
+
+describe('isToolCallHtmlAppResult', () => {
+    it('returns true for valid html app result', () => {
+        expect(isToolCallHtmlAppResult({ type: 'html', html: '<div>Hello</div>' })).to.be.true;
+    });
+
+    it('returns true with optional title', () => {
+        expect(isToolCallHtmlAppResult({ type: 'html', html: '<p>App</p>', title: 'My App' })).to.be.true;
+    });
+
+    it('returns false for text result', () => {
+        expect(isToolCallHtmlAppResult({ type: 'text', text: 'hello' })).to.be.false;
+    });
+
+    it('returns false for missing html field', () => {
+        expect(isToolCallHtmlAppResult({ type: 'html' })).to.be.false;
+    });
+
+    it('returns false for null', () => {
+        expect(isToolCallHtmlAppResult(null)).to.be.false;
+    });
+
+    it('returns false for undefined', () => {
+        expect(isToolCallHtmlAppResult(undefined)).to.be.false;
     });
 });

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -384,12 +384,16 @@ export const isThinkingResponsePart = (part: unknown): part is ThinkingResponseP
 export interface ToolCallTextResult { type: 'text', text: string; };
 export interface ToolCallImageResult extends Base64ImageContent { type: 'image' };
 export interface ToolCallAudioResult { type: 'audio', data: string; mimeType: string };
+export interface ToolCallHtmlAppResult { type: 'html'; html: string; title?: string };
 export type ToolCallErrorKind = 'tool-not-available';
 export interface ToolCallErrorResult { type: 'error', data: string; errorKind?: ToolCallErrorKind; };
-export type ToolCallContentResult = ToolCallTextResult | ToolCallImageResult | ToolCallAudioResult | ToolCallErrorResult;
+export type ToolCallContentResult = ToolCallTextResult | ToolCallImageResult | ToolCallAudioResult | ToolCallHtmlAppResult | ToolCallErrorResult;
 export interface ToolCallContent {
     content: ToolCallContentResult[];
 }
+
+export const isToolCallHtmlAppResult = (item: unknown): item is ToolCallHtmlAppResult =>
+    !!(item && typeof item === 'object' && 'type' in item && (item as ToolCallHtmlAppResult).type === 'html' && 'html' in item);
 
 export const isToolCallContent = (result: unknown): result is ToolCallContent =>
     !!(result && typeof result === 'object' && 'content' in result && Array.isArray((result as ToolCallContent).content));

--- a/packages/ai-google/src/node/google-language-model.ts
+++ b/packages/ai-google/src/node/google-language-model.ts
@@ -16,6 +16,7 @@
 import {
     createToolCallError,
     ImageContent,
+    isToolCallContent,
     LanguageModel,
     LanguageModelMessage,
     LanguageModelRequest,
@@ -49,6 +50,15 @@ interface ToolCallback {
 function toFunctionResponse(content: ToolCallResult): FunctionResponse['response'] {
     if (content === undefined) {
         return {};
+    }
+    if (isToolCallContent(content)) {
+        const text = content.content.map(c => {
+            if (c.type === 'text') { return c.text; }
+            if (c.type === 'html') { return c.html; }
+            if (c.type === 'error') { return c.data; }
+            return JSON.stringify(c);
+        }).join('\n');
+        return { result: text };
     }
     if (Array.isArray(content)) {
         return { result: content };

--- a/packages/ai-mcp/src/browser/mcp-frontend-service.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-service.spec.ts
@@ -1,0 +1,63 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ericsson and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ToolCallContentResult } from '@theia/ai-core';
+
+describe('MCPFrontendServiceImpl html content mapping', () => {
+
+    // Simulates the mapping logic from convertToToolRequest's default case
+    function mapContent(callContent: Record<string, unknown>): ToolCallContentResult {
+        const type = callContent.type as string;
+        switch (type) {
+            case 'image':
+                return { type: 'image', base64data: callContent.data as string, mimeType: callContent.mimeType as string };
+            case 'text':
+                return { type: 'text', text: callContent.text as string };
+            default:
+                if ('html' in callContent && typeof callContent.html === 'string') {
+                    return { type: 'html', html: callContent.html, title: callContent.title as string | undefined };
+                }
+                return { type: 'text', text: JSON.stringify(callContent) };
+        }
+    }
+
+    it('maps html content with title', () => {
+        const result = mapContent({ type: 'html', html: '<div>App</div>', title: 'My App' });
+        expect(result).to.deep.equal({ type: 'html', html: '<div>App</div>', title: 'My App' });
+    });
+
+    it('maps html content without title', () => {
+        const result = mapContent({ type: 'html', html: '<p>Hello</p>' });
+        expect(result).to.deep.equal({ type: 'html', html: '<p>Hello</p>', title: undefined });
+    });
+
+    it('falls back to text for unknown type without html field', () => {
+        const result = mapContent({ type: 'unknown', data: 'foo' });
+        expect(result.type).to.equal('text');
+        expect((result as { text: string }).text).to.equal(JSON.stringify({ type: 'unknown', data: 'foo' }));
+    });
+
+    it('still maps text content normally', () => {
+        const result = mapContent({ type: 'text', text: 'hello world' });
+        expect(result).to.deep.equal({ type: 'text', text: 'hello world' });
+    });
+
+    it('still maps image content normally', () => {
+        const result = mapContent({ type: 'image', data: 'base64data', mimeType: 'image/png' });
+        expect(result).to.deep.equal({ type: 'image', base64data: 'base64data', mimeType: 'image/png' });
+    });
+});

--- a/packages/ai-mcp/src/browser/mcp-frontend-service.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-service.ts
@@ -142,6 +142,9 @@ export class MCPFrontendServiceImpl implements MCPFrontendService {
                                 return { type: 'text', text: JSON.stringify(callContent.resource) };
                             }
                             default: {
+                                if ('html' in callContent && typeof (callContent as { html: unknown }).html === 'string') {
+                                    return { type: 'html', html: (callContent as { html: string }).html, title: (callContent as { title?: string }).title };
+                                }
                                 return { type: 'text', text: JSON.stringify(callContent) };
                             }
                         }

--- a/packages/ai-mcp/src/browser/mcp-frontend-service.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-service.ts
@@ -136,8 +136,18 @@ export class MCPFrontendServiceImpl implements MCPFrontendService {
                         switch (callContent.type) {
                             case 'image':
                                 return { type: 'image', base64data: callContent.data, mimeType: callContent.mimeType };
-                            case 'text':
-                                return { type: 'text', text: callContent.text };
+                            case 'text': {
+                                const text = callContent.text;
+                                if (text.startsWith('{')) {
+                                    try {
+                                        const parsed = JSON.parse(text);
+                                        if (parsed && parsed.type === 'html' && typeof parsed.html === 'string') {
+                                            return { type: 'html', html: parsed.html, title: parsed.title };
+                                        }
+                                    } catch { /* not JSON, fall through */ }
+                                }
+                                return { type: 'text', text };
+                            }
                             case 'resource': {
                                 return { type: 'text', text: JSON.stringify(callContent.resource) };
                             }

--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -28,15 +28,30 @@ import {
     ToolRequestParameterProperty,
     ToolRequestParametersProperties,
     ImageContent,
+    isToolCallContent,
     LanguageModelRequest,
     LanguageModelStatus,
     LanguageModelTextResponse,
+    ToolCallResult,
     UserRequest
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { ChatRequest, Message, Ollama, Options, Tool, ToolCall as OllamaToolCall } from 'ollama';
 import { createProxyFetch } from '@theia/ai-core/lib/node';
 import { ollamaThinkParamFor } from './ollama-reasoning';
+
+function formatToolCallContent(result: ToolCallResult): string {
+    if (isToolCallContent(result)) {
+        return result.content.map(c => {
+            if (c.type === 'text') { return c.text; }
+            if (c.type === 'html') { return c.html; }
+            if (c.type === 'error') { return c.data; }
+            return JSON.stringify(c);
+        }).join('\n');
+    }
+    if (typeof result === 'string') { return result; }
+    return JSON.stringify(result);
+}
 
 export const OllamaModelIdentifier = Symbol('OllamaModelIdentifier');
 
@@ -456,7 +471,7 @@ export class OllamaModel implements LanguageModel {
         } else if (LanguageModelMessage.isToolUseMessage(message)) {
             result.tool_calls = [{ function: { name: message.name, arguments: message.input as Record<string, unknown> } }];
         } else if (LanguageModelMessage.isToolResultMessage(message)) {
-            result.content = `Tool call ${message.name} returned: ${message.content}`;
+            result.content = `Tool call ${message.name} returned: ${formatToolCallContent(message.content)}`;
         } else if (LanguageModelMessage.isThinkingMessage(message)) {
             result.thinking = message.thinking;
         } else if (LanguageModelMessage.isImageMessage(message) && ImageContent.isBase64(message.image)) {

--- a/packages/ai-ollama/src/node/ollama-language-model.ts
+++ b/packages/ai-ollama/src/node/ollama-language-model.ts
@@ -25,6 +25,7 @@ import {
     ReasoningSupport,
     ToolCall,
     ToolRequest,
+    ToolRequestParameterProperty,
     ToolRequestParametersProperties,
     ImageContent,
     LanguageModelRequest,
@@ -400,6 +401,17 @@ export class OllamaModel implements LanguageModel {
     }
 
     protected toOllamaTool(tool: ToolRequest): ToolWithHandler {
+        const resolveType = (prop: ToolRequestParameterProperty): string | undefined => {
+            if (prop.type) {
+                return prop.type;
+            }
+            if (prop.anyOf) {
+                const nonNull = prop.anyOf.find(p => p.type && p.type !== 'null');
+                return nonNull?.type ?? undefined;
+            }
+            return undefined;
+        };
+
         const transform = (props: ToolRequestParametersProperties | undefined) => {
             if (!props) {
                 return undefined;
@@ -407,15 +419,13 @@ export class OllamaModel implements LanguageModel {
 
             const result: Record<string, { type: string, description: string, enum?: string[] }> = {};
             for (const [key, prop] of Object.entries(props)) {
-                const type = prop.type;
+                const type = resolveType(prop);
                 if (type) {
                     const description = typeof prop.description == 'string' ? prop.description : '';
                     result[key] = {
                         type: type,
                         description: description
                     };
-                } else {
-                    // TODO: Should handle anyOf, but this is not supported by the Ollama type yet
                 }
             }
             return result;

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -24,7 +24,9 @@ import {
     UserRequest,
     ImageContent,
     LanguageModelStatus,
-    ReasoningSupport
+    ReasoningSupport,
+    isToolCallContent,
+    ToolCallResult
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { injectable } from '@theia/core/shared/inversify';
@@ -39,6 +41,18 @@ import type { RunnerOptions } from 'openai/lib/AbstractChatCompletionRunner';
 import { OpenAiResponseApiUtils, processSystemMessages } from './openai-response-api-utils';
 import { openAiReasoningFor } from './openai-reasoning';
 import { createProxyFetch } from '@theia/ai-core/lib/node';
+
+function formatToolCallContent(result: ToolCallResult): string {
+    if (isToolCallContent(result)) {
+        return result.content.map(c => {
+            if (c.type === 'text') { return c.text; }
+            if (c.type === 'html') { return c.html; }
+            if (c.type === 'error') { return c.data; }
+            return JSON.stringify(c);
+        }).join('\n');
+    }
+    return JSON.stringify(result);
+}
 
 export class MistralFixedOpenAI extends OpenAI {
     protected override async prepareOptions(options: FinalRequestOptions): Promise<void> {
@@ -330,8 +344,7 @@ export class OpenAiModelUtils {
             return {
                 role: 'tool',
                 tool_call_id: message.tool_use_id,
-                // content only supports text content so we need to stringify any potential data we have, e.g., images
-                content: typeof message.content === 'string' ? message.content : JSON.stringify(message.content)
+                content: typeof message.content === 'string' ? message.content : formatToolCallContent(message.content)
             };
         }
         if (LanguageModelMessage.isImageMessage(message) && message.actor === 'user') {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
  
#17497

  Implements a generic agent session hooks infrastructure in @theia/ai-core and a Claude Code-specific hook service in @theia/ai-claude-code, supporting all 28 Claude Code hook events.
  
  Key changes:
  
  - @theia/ai-core: New AgentSessionHookProvider / AgentSessionHookRegistry contribution point that allows any AI backend to emit lifecycle events (PreToolUse, PostToolUse, SessionStart, etc.) through a unified event stream.
  - @theia/ai-core: Fires PreToolUse/PostToolUse/PostToolUseFailure hooks at the tool invocation layer (FrontendLanguageModelRegistryImpl.toolCall()), so hook events are emitted for ALL backends (Ollama, Gemini, OpenAI, etc.) — not just Claude Code.
  - @theia/ai-claude-code: New ClaudeCodeHookService (backend) that installs hooks into .claude/settings.local.json and runs a local HTTP callback server for hook-to-Theia communication.
  - @theia/ai-claude-code: New ClaudeCodeHookFrontendContribution (frontend) that listens for hook callback events and surfaces them in the IDE (notifications, editor refresh, etc.).
  - Defines all 28 hook event types: SessionStart/End, PreToolUse, PostToolUse, PostToolUseFailure, PostToolBatch, UserPromptSubmit, PermissionRequest, PermissionDenied, Notification, Stop, StopFailure, Setup, SubagentStart/Stop, TaskCreated/Completed, TeammateIdle,
  InstructionsLoaded, ConfigChange, CwdChanged, FileChanged, WorktreeCreate/Remove, PreCompact/PostCompact, Elicitation/ElicitationResult, UserPromptExpansion.
  
  Design spec: packages/ai-claude-code/docs/hooks-design-spec.md

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
  
  1. Enable the Claude Code agent and start a session.
  2. Verify that .claude/settings.local.json is populated with Theia-managed hooks.
  3. Trigger a tool call (e.g., file write) and verify PreToolUse/PostToolUse events fire (visible in AI History view or via debug logging).
  4. Run the unit tests:
  
     npx mocha packages/ai-core/src/common/agent-session-hooks.spec.ts
     npx mocha packages/ai-claude-code/src/node/claude-code-hook-service-impl.spec.ts
  
  5. Verify that non-Claude backends (e.g., Ollama with MCP tools) also emit hook events when tools are invoked.
  

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

  - Hook management UI in the AI Configuration view (add/edit/remove user-defined hooks)
  - Support for mcp_tool, prompt, and agent hook handler types (currently only command and http)
  - Hook execution log/history view
  - Per-workspace hook configuration preferences

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
