### PR TITLE
fix(core): use MarkdownRendererImpl in HoverService to fix code block rendering in tool call tooltip

### DIFF
--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1595,38 +1595,42 @@ details.theia-tool-confirmation-args>summary::marker {
 }
 
 /* Scrollable hover for large tool call arguments */
-.theia-hover.toolcall-args-hover div.rendered-markdown {
+.theia-hover.toolcall-args-hover>div {
   max-height: 400px;
   max-width: 600px;
   overflow-y: auto;
   overflow-x: hidden;
 }
 
-/* Code blocks inside tool call hovers: constrain and scroll.
-   Monaco renders fenced code blocks as div[data-code] > span > div.monaco-tokenized-source,
-   not as <pre> elements, so we target both structures. */
-.theia-hover.toolcall-args-hover div.rendered-markdown pre,
-.theia-hover.toolcall-args-hover div.rendered-markdown div[data-code] {
+/* Code blocks inside tool call hovers: constrain and scroll. */
+.theia-hover.toolcall-args-hover pre {
   max-height: 200px;
   overflow: auto;
-  white-space: pre;
+  white-space: pre-wrap;
+  word-break: break-word;
   margin: var(--theia-ui-padding) 0;
   padding: var(--theia-ui-padding) calc(var(--theia-ui-padding) * 2);
   border-radius: 3px;
   background-color: var(--theia-textCodeBlock-background);
 }
 
+/* Reset code background inside pre to avoid double semi-transparent layers
+   (.theia-hover code in hover-service.css sets the same background) */
+.theia-hover.toolcall-args-hover pre code {
+  background-color: transparent;
+}
+
 /* Inline code styling */
-.theia-hover.toolcall-args-hover div.rendered-markdown code:not(pre code) {
+.theia-hover.toolcall-args-hover code:not(pre code) {
   padding: 1px var(--theia-ui-padding);
   border-radius: 3px;
   background-color: var(--theia-textCodeBlock-background);
   word-break: break-all;
-  font-family: var(--theia-monospace-font-family);
+  font-family: var(--theia-code-font-family);
 }
 
 /* Spacing between arg sections - uses internal border like hover-service.css */
-.theia-hover.toolcall-args-hover div.rendered-markdown hr {
+.theia-hover.toolcall-args-hover hr {
   border-top: 1px solid var(--theia-editorHoverWidgetInternalBorder);
   border-bottom: 0;
   margin: var(--theia-ui-padding) 0;

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -320,7 +320,8 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
         return quickPickService;
     });
 
-    bind(MarkdownRenderer).to(MarkdownRendererImpl).inSingletonScope();
+    bind(MarkdownRendererImpl).toSelf().inSingletonScope();
+    bind(MarkdownRenderer).toService(MarkdownRendererImpl);
     bind(MarkdownRendererFactory).toFactory(({ container }) => () => container.get(MarkdownRenderer));
 
     bindRootContributionProvider(bind, QuickAccessContribution);

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -132,7 +132,7 @@ import { WindowTitleService } from './window/window-title-service';
 import { WindowTitleUpdater } from './window/window-title-updater';
 import { TheiaDockPanel } from './shell/theia-dock-panel';
 import { bindStatusBar } from './status-bar';
-import { MarkdownRenderer, MarkdownRendererFactory, MarkdownRendererImpl } from './markdown-rendering/markdown-renderer';
+import { CoreMarkdownRenderer, MarkdownRenderer, MarkdownRendererFactory, MarkdownRendererImpl } from './markdown-rendering/markdown-renderer';
 import { StylingParticipant, StylingService } from './styling-service';
 import { bindCommonStylingParticipants } from './common-styling-participants';
 import { HoverService } from './hover-service';
@@ -320,8 +320,8 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
         return quickPickService;
     });
 
-    bind(MarkdownRendererImpl).toSelf().inSingletonScope();
-    bind(MarkdownRenderer).toService(MarkdownRendererImpl);
+    bind(CoreMarkdownRenderer).to(MarkdownRendererImpl).inSingletonScope();
+    bind(MarkdownRenderer).toService(CoreMarkdownRenderer);
     bind(MarkdownRendererFactory).toFactory(({ container }) => () => container.get(MarkdownRenderer));
 
     bindRootContributionProvider(bind, QuickAccessContribution);

--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from 'inversify';
 import { Disposable, DisposableCollection, disposableTimeout, isOSX, PreferenceService } from '../common';
 import { MarkdownString } from '../common/markdown-rendering/markdown-string';
 import { animationFrame } from './browser';
-import { MarkdownRenderer, MarkdownRendererFactory } from './markdown-rendering/markdown-renderer';
+import { MarkdownRendererImpl } from './markdown-rendering/markdown-renderer';
 
 import '../../src/browser/style/hover-service.css';
 
@@ -92,13 +92,11 @@ export class HoverService {
     protected static hostClassName = 'theia-hover';
     protected static styleSheetId = 'theia-hover-style';
     @inject(PreferenceService) protected readonly preferences: PreferenceService;
-    @inject(MarkdownRendererFactory) protected readonly markdownRendererFactory: MarkdownRendererFactory;
 
-    protected _markdownRenderer: MarkdownRenderer | undefined;
-    protected get markdownRenderer(): MarkdownRenderer {
-        this._markdownRenderer ||= this.markdownRendererFactory();
-        return this._markdownRenderer;
-    }
+    // Inject MarkdownRendererImpl directly rather than the MarkdownRenderer
+    // symbol, which is rebound by Monaco to a renderer that strips code block
+    // content from the output.
+    @inject(MarkdownRendererImpl) protected readonly markdownRenderer: MarkdownRendererImpl;
 
     protected _hoverHost: HTMLElement | undefined;
     protected get hoverHost(): HTMLElement {

--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -18,7 +18,7 @@ import { inject, injectable } from 'inversify';
 import { Disposable, DisposableCollection, disposableTimeout, isOSX, PreferenceService } from '../common';
 import { MarkdownString } from '../common/markdown-rendering/markdown-string';
 import { animationFrame } from './browser';
-import { MarkdownRendererImpl } from './markdown-rendering/markdown-renderer';
+import { CoreMarkdownRenderer, MarkdownRenderer } from './markdown-rendering/markdown-renderer';
 
 import '../../src/browser/style/hover-service.css';
 
@@ -93,10 +93,9 @@ export class HoverService {
     protected static styleSheetId = 'theia-hover-style';
     @inject(PreferenceService) protected readonly preferences: PreferenceService;
 
-    // Inject MarkdownRendererImpl directly rather than the MarkdownRenderer
-    // symbol, which is rebound by Monaco to a renderer that strips code block
-    // content from the output.
-    @inject(MarkdownRendererImpl) protected readonly markdownRenderer: MarkdownRendererImpl;
+    // Inject CoreMarkdownRenderer rather than the MarkdownRenderer symbol,
+    // which is rebound by Monaco to a renderer that strips code block content.
+    @inject(CoreMarkdownRenderer) protected readonly markdownRenderer: MarkdownRenderer;
 
     protected _hoverHost: HTMLElement | undefined;
     protected get hoverHost(): HTMLElement {

--- a/packages/core/src/browser/markdown-rendering/markdown-renderer.ts
+++ b/packages/core/src/browser/markdown-rendering/markdown-renderer.ts
@@ -57,6 +57,12 @@ export interface MarkdownRenderer {
     render(markdown: MarkdownString, options?: MarkdownRenderOptions, outElement?: HTMLElement): MarkdownRenderResult;
 }
 
+/**
+ * Always resolves to the core {@link MarkdownRendererImpl} (markdown-it based),
+ * even when the {@link MarkdownRenderer} symbol has been rebound (e.g. by Monaco).
+ */
+export const CoreMarkdownRenderer = Symbol('CoreMarkdownRenderer');
+
 /** Use this to avoid circular dependencies in the Shell */
 export const MarkdownRendererFactory = Symbol('MarkdownRendererFactory');
 export interface MarkdownRendererFactory {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- HoverService injected MarkdownRenderer, which Monaco rebinds to a renderer that produces empty code blocks in hover tooltips
- Bind MarkdownRendererImpl to itself so it can be injected directly, bypassing the Monaco override
- Update toolcall args hover CSS selectors to match markdown-it output
- Fix double semi-transparent background on pre > code in hover

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open or create a new chat session with tool calls that have more complex arguments, like content or oldValue/newValue
  - e.g. writeFileContent, editTaskContext, writeFileReplacements
- Verify the tooltip renders those arguments correctly again

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
