### PR TITLE
Block external resources in AI chat markdown

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -52,6 +52,7 @@ import {
     TypeDocSymbolSelectionResolver,
 } from './chat-response-renderer/ai-selection-resolver';
 import { QuestionPartRenderer } from './chat-response-renderer/question-part-renderer';
+import { ExternalResourceAllowlistContribution } from './chat-response-renderer/external-resource-allowlist-contribution';
 import { createChatViewTreeWidget, ChatWelcomeMessageProvider } from './chat-tree-view';
 import { ChatViewTreeWidget } from './chat-tree-view/chat-view-tree-widget';
 import { ChatViewMenuContribution } from './chat-view-contribution';
@@ -216,6 +217,8 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(TabBarToolbarContribution).toService(ChatViewWidgetToolbarContribution);
 
     bind(FrontendApplicationContribution).to(ChatViewLanguageContribution).inSingletonScope();
+    bind(ExternalResourceAllowlistContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(ExternalResourceAllowlistContribution);
     bind(ChangeSetActionService).toSelf().inSingletonScope();
     bind(ChangeSetAcceptAction).toSelf().inSingletonScope();
     bind(ChangeSetActionRenderer).toService(ChangeSetAcceptAction);

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.spec.ts
@@ -189,6 +189,56 @@ describe('blockExternalResources', () => {
         expect(placeholder.textContent).to.contain('(inline external content)');
     });
 
+    it('sandboxes restored embedded content', () => {
+        const root = createRoot('<iframe srcdoc="&lt;img src=x onerror=alert(1)&gt;"></iframe>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        const restored = restoreBlockedResource(placeholder);
+        expect(restored?.tagName).to.equal('IFRAME');
+        expect(restored?.getAttribute('sandbox')).to.equal('');
+    });
+
+    it('overrides attacker-supplied sandbox attributes on restored embedded content', () => {
+        const root = createRoot('<iframe sandbox="allow-scripts allow-same-origin" srcdoc="&lt;p&gt;hi&lt;/p&gt;"></iframe>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        const restored = restoreBlockedResource(placeholder);
+        expect(restored?.getAttribute('sandbox')).to.equal('');
+    });
+
+    it('blocks object and embed elements without external URLs', () => {
+        const root = createRoot('<object></object><embed>');
+
+        const placeholders = root.querySelectorAll(`.${BLOCKED_RESOURCE_CLASS}`);
+        expect(placeholders).to.have.length(2);
+        expect(placeholders[0].textContent).to.contain('(inline external content)');
+        expect(root.querySelector('object')).to.be.null;
+        expect(root.querySelector('embed')).to.be.null;
+    });
+
+    it('blocks objects with inline document data URLs', () => {
+        const root = createRoot('<object data="data:text/html,&lt;script&gt;fetch(1)&lt;/script&gt;"></object>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('object')).to.be.null;
+    });
+
+    it('blocks elements with external background attributes', () => {
+        const root = createRoot('<table background="https://evil.com/x.png"><tr><td>x</td></tr></table>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/x.png');
+        expect(root.querySelector('table')).to.be.null;
+    });
+
+    it('preserves HTML and SVG links', () => {
+        const root = createRoot('<a href="https://example.com">link</a><svg><a href="https://example.com"><text>svg link</text></a></svg>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelectorAll('a')).to.have.length(2);
+    });
+
     it('wraps elements with external CSS URLs and preserves safe style declarations', () => {
         const root = createRoot('<div style="background-image: url(https://x); color: red">content</div>');
 
@@ -219,6 +269,81 @@ describe('blockExternalResources', () => {
         expect(placeholder.textContent).to.contain('https://evil.com/x.png');
         expect(safeDiv).to.exist;
         expect(safeDiv?.getAttribute('style')).to.equal('color: red');
+    });
+
+    it('blocks style sheets importing external CSS via url()', () => {
+        const root = createRoot('<style>@import url("https://evil.com/main.css");</style><div class="App">content</div>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/main.css');
+        expect(root.querySelector('style')).to.be.null;
+        expect(root.querySelector('div.App')?.textContent).to.equal('content');
+    });
+
+    it('blocks style sheets importing external CSS via the string form', () => {
+        const root = createRoot("<style>@import 'https://evil.com/main.css';</style>");
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/main.css');
+        expect(root.querySelector('style')).to.be.null;
+    });
+
+    it('blocks style sheets with external CSS URLs', () => {
+        const root = createRoot('<style>.app { background: url(https://evil.com/x.png); }</style>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/x.png');
+        expect(root.querySelector('style')).to.be.null;
+    });
+
+    it('blocks style sheets with comment-obfuscated external references', () => {
+        const root = createRoot('<style>@import/**/"https://evil.com/main.css";</style>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('style')).to.be.null;
+    });
+
+    it('blocks style sheets with escape-obfuscated external references', () => {
+        const root = createRoot('<style>.app { background: \\75rl(https://evil.com/x.png); }</style>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('style')).to.be.null;
+    });
+
+    it('preserves style sheets without external references', () => {
+        const root = createRoot('<style>.app { color: red; background: url(data:image/png;base64,AA); border: 1px solid url(#pattern); }</style>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('style')).to.exist;
+    });
+
+    it('blocks external SVG paint server references', () => {
+        const root = createRoot('<svg><rect fill="url(https://evil.com/paint.svg#p)"></rect></svg>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/paint.svg#p');
+        expect(root.querySelector('rect')).to.be.null;
+    });
+
+    it('blocks external SVG filter references', () => {
+        const root = createRoot('<svg><rect filter="url(https://evil.com/filter.svg#f)"></rect></svg>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/filter.svg#f');
+        expect(root.querySelector('rect')).to.be.null;
+    });
+
+    it('preserves same-document SVG references', () => {
+        const root = createRoot('<svg><defs><linearGradient id="gradient"></linearGradient></defs><circle fill="url(#gradient)"></circle><use href="#gradient"></use></svg>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('circle')?.getAttribute('fill')).to.equal('url(#gradient)');
+        expect(root.querySelector('use')).to.exist;
     });
 
     it('preserves data CSS URLs', () => {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.spec.ts
@@ -1,0 +1,252 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { blockExternalResources, BLOCKED_RESOURCE_CLASS, restoreBlockedResource } from './block-external-resources';
+
+disableJSDOM();
+
+describe('blockExternalResources', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    const createRoot = (html: string): HTMLElement => {
+        const root = document.createElement('div');
+        root.innerHTML = html;
+        blockExternalResources(root);
+        return root;
+    };
+
+    it('replaces an external image with a placeholder that shows the URL', () => {
+        const root = createRoot('<img src="https://evil.com/x.gif">');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(root.querySelector('img')).to.be.null;
+        expect(placeholder.textContent).to.contain('https://evil.com/x.gif');
+    });
+
+    it('preserves data images', () => {
+        const root = createRoot('<img src="data:image/png;base64,AAA">');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('img')?.getAttribute('src')).to.equal('data:image/png;base64,AAA');
+    });
+
+    it('preserves images without a source', () => {
+        const root = createRoot('<img><img src="">');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelectorAll('img')).to.have.length(2);
+    });
+
+    it('blocks external image srcset entries', () => {
+        const root = createRoot('<img srcset="https://a.com/x 1x, https://b.com/y 2x">');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('img')).to.be.null;
+    });
+
+    it('lists all blocked srcset entries', () => {
+        const root = createRoot('<img srcset="https://a.com/x 1x,https://b.com/y 2x, https://c.com/z 100w">');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://a.com/x');
+        expect(placeholder.textContent).to.contain('https://b.com/y');
+        expect(placeholder.textContent).to.contain('https://c.com/z');
+        expect(placeholder.textContent).to.contain('3 resources will be enabled');
+    });
+
+    it('preserves data image srcset entries', () => {
+        const root = createRoot('<img srcset="data:image/png;base64,AAA 1x">');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('img')?.getAttribute('srcset')).to.equal('data:image/png;base64,AAA 1x');
+    });
+
+    it('lists only external srcset entries when mixed with data entries', () => {
+        const root = createRoot('<img srcset="data:image/png;base64,AAA 1x,https://evil.com/x.png 2x">');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/x.png');
+        expect(placeholder.textContent).not.to.contain('data:image/png;base64,AAA');
+    });
+
+    it('blocks external picture sources while preserving safe fallback images', () => {
+        const root = createRoot('<picture><source srcset="https://x"><img src="data:image/png;base64,AAA"></picture>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('source')).to.be.null;
+        expect(root.querySelector('img')?.getAttribute('src')).to.equal('data:image/png;base64,AAA');
+    });
+
+    it('blocks external video resources', () => {
+        const root = createRoot('<video src="https://x" poster="https://y"></video>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('video')).to.be.null;
+    });
+
+    it('blocks external audio resources', () => {
+        const root = createRoot('<audio src="https://x"></audio>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('audio')).to.be.null;
+    });
+
+    it('blocks SVG image resources', () => {
+        const root = createRoot('<svg><image href="https://evil.com/x.png"></image></svg>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/x.png');
+        expect(root.querySelector('image')).to.be.null;
+    });
+
+    it('blocks SVG use resources', () => {
+        const root = createRoot('<svg><use xlink:href="https://evil.com/icons.svg#icon"></use></svg>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/icons.svg#icon');
+        expect(root.querySelector('use')).to.be.null;
+    });
+
+    it('blocks SVG filter image resources', () => {
+        const root = createRoot('<svg><filter><feImage href="https://evil.com/filter.png"></feImage></filter></svg>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/filter.png');
+        expect(root.querySelector('feImage')).to.be.null;
+    });
+
+    it('blocks SVG filter image resources using xlink:href', () => {
+        const root = createRoot('<svg><filter><feImage xlink:href="https://evil.com/filter.png"></feImage></filter></svg>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/filter.png');
+        expect(root.querySelector('feImage')).to.be.null;
+    });
+
+    it('preserves data SVG filter image resources', () => {
+        const root = createRoot('<svg><filter><feImage href="data:image/png;base64,AAA"></feImage></filter></svg>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('feImage')?.getAttribute('href')).to.equal('data:image/png;base64,AAA');
+    });
+
+    it('blocks object and embed resources', () => {
+        const root = createRoot('<object data="https://evil.com/object.svg"></object><embed src="https://evil.com/embed.svg">');
+
+        expect(root.querySelectorAll(`.${BLOCKED_RESOURCE_CLASS}`)).to.have.length(2);
+        expect(root.querySelector('object')).to.be.null;
+        expect(root.querySelector('embed')).to.be.null;
+    });
+
+    it('shows all resources that will be enabled by allowing blocked content', () => {
+        const root = createRoot('<video src="https://evil.com/video.mp4" poster="https://evil.com/poster.png"></video>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/video.mp4');
+        expect(placeholder.textContent).to.contain('https://evil.com/poster.png');
+        expect(placeholder.textContent).to.contain('2 resources will be enabled');
+    });
+
+    it('blocks iframes unconditionally', () => {
+        const root = createRoot('<iframe src="https://x"></iframe>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('iframe')).to.be.null;
+    });
+
+    it('blocks inline iframe content', () => {
+        const root = createRoot('<iframe srcdoc="&lt;p&gt;hi&lt;/p&gt;"></iframe>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('(inline external content)');
+    });
+
+    it('wraps elements with external CSS URLs and preserves safe style declarations', () => {
+        const root = createRoot('<div style="background-image: url(https://x); color: red">content</div>');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        const div = root.querySelector('div');
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://x');
+        expect(div).to.exist;
+        expect(div?.style.backgroundImage).to.equal('');
+        expect(div?.style.color).to.equal('red');
+    });
+
+    it('blocks external CSS image-set resources and preserves safe style declarations', () => {
+        const root = document.createElement('div');
+        const div = document.createElement('div');
+        div.setAttribute('style', 'color: red');
+        const getAttribute = div.getAttribute.bind(div);
+        div.getAttribute = (qualifiedName: string) => qualifiedName === 'style'
+            ? 'background-image: image-set("https://evil.com/x.png" 1x); color: red'
+            : getAttribute(qualifiedName);
+        div.textContent = 'content';
+        root.appendChild(div);
+        blockExternalResources(root);
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        const safeDiv = root.querySelector('div');
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('https://evil.com/x.png');
+        expect(safeDiv).to.exist;
+        expect(safeDiv?.getAttribute('style')).to.equal('color: red');
+    });
+
+    it('preserves data CSS URLs', () => {
+        const root = createRoot('<div style="background-image: url(data:image/png;base64,AA)">content</div>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('div')?.style.backgroundImage).to.contain('data:image/png;base64,AA');
+    });
+
+    it('uses text content for displayed URLs', () => {
+        const root = createRoot('<img src="https://evil.com/<script>alert(1)</script>.gif">');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.querySelector('script')).to.be.null;
+        expect(placeholder.textContent).to.contain('https://evil.com/<script>alert(1)</script>.gif');
+    });
+
+    it('stores blocked resources outside forgeable DOM attributes', () => {
+        const root = createRoot('<img src="https://evil.com/x.gif" alt="tracker">');
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder.dataset.blockedHtml).to.be.undefined;
+
+        const restored = restoreBlockedResource(placeholder);
+        expect(restored?.tagName).to.equal('IMG');
+        expect(restored?.getAttribute('src')).to.equal('https://evil.com/x.gif');
+        expect(restored?.getAttribute('alt')).to.equal('tracker');
+        expect(restoreBlockedResource(placeholder)).to.be.undefined;
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.spec.ts
@@ -19,13 +19,14 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';
-import { blockExternalResources, BLOCKED_RESOURCE_CLASS, restoreBlockedResource } from './block-external-resources';
+import { blockExternalResources, BLOCKED_RESOURCE_CLASS, restoreBlockedResource, setAllowedResourceUrls } from './block-external-resources';
 
 disableJSDOM();
 
 describe('blockExternalResources', () => {
     before(() => disableJSDOM = enableJSDOM());
     after(() => disableJSDOM());
+    afterEach(() => setAllowedResourceUrls([]));
 
     const createRoot = (html: string): HTMLElement => {
         const root = document.createElement('div');
@@ -351,6 +352,77 @@ describe('blockExternalResources', () => {
 
         expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
         expect(root.querySelector('div')?.style.backgroundImage).to.contain('data:image/png;base64,AA');
+    });
+
+    it('blocks style sheets importing a data URL stylesheet that references external resources', () => {
+        const nestedCss = encodeURIComponent('.probe{background-image:url(https://evil.com/logo.svg)}');
+        const root = createRoot(`<style>@import url("data:text/css,${nestedCss}");</style><div class="probe">content</div>`);
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('style')).to.be.null;
+    });
+
+    it('preserves data URL stylesheets without external references', () => {
+        const nestedCss = encodeURIComponent('.probe{color:red;background-image:url(data:image/png;base64,AA)}');
+        const root = createRoot(`<style>@import url("data:text/css,${nestedCss}");</style>`);
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('style')).to.exist;
+    });
+
+    it('blocks a data URL stylesheet whose payload cannot be decoded', () => {
+        const root = createRoot('<style>@import url("data:text/css,%ZZurl%28https://evil.com/x.png%29");</style>');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('style')).to.be.null;
+    });
+
+    it('still inspects nested CSS when a data: prefix is allowlisted', () => {
+        setAllowedResourceUrls(['data:']);
+        const nestedCss = encodeURIComponent('.probe{background-image:url(https://evil.com/logo.svg)}');
+        const root = createRoot(`<style>@import url("data:text/css,${nestedCss}");</style>`);
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('style')).to.be.null;
+    });
+
+    it('renders external URL resources but still blocks active embedded content in trusted mode', () => {
+        const root = document.createElement('div');
+        root.innerHTML = '<img src="https://evil.com/x.gif"><iframe srcdoc="&lt;p&gt;hi&lt;/p&gt;"></iframe>';
+        blockExternalResources(root, false);
+
+        expect(root.querySelector('img')?.getAttribute('src')).to.equal('https://evil.com/x.gif');
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        expect(placeholder).to.exist;
+        expect(placeholder.textContent).to.contain('(inline external content)');
+        expect(root.querySelector('iframe')).to.be.null;
+    });
+
+    it('sandboxes embedded content restored from trusted mode', () => {
+        const root = document.createElement('div');
+        root.innerHTML = '<iframe srcdoc="&lt;img src=x onerror=alert(1)&gt;"></iframe>';
+        blockExternalResources(root, false);
+
+        const placeholder = root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`) as HTMLElement;
+        const restored = restoreBlockedResource(placeholder);
+        expect(restored?.tagName).to.equal('IFRAME');
+        expect(restored?.getAttribute('sandbox')).to.equal('');
+    });
+
+    it('renders resources whose URL matches the configured allowlist', () => {
+        setAllowedResourceUrls(['https://trusted.example.com/']);
+        const root = createRoot('<img src="https://trusted.example.com/logo.png">');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+        expect(root.querySelector('img')?.getAttribute('src')).to.equal('https://trusted.example.com/logo.png');
+    });
+
+    it('still blocks resources that do not match the configured allowlist', () => {
+        setAllowedResourceUrls(['https://trusted.example.com/']);
+        const root = createRoot('<img src="https://evil.com/x.gif">');
+
+        expect(root.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+        expect(root.querySelector('img')).to.be.null;
     });
 
     it('uses text content for displayed URLs', () => {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.ts
@@ -23,17 +23,26 @@ export const BLOCKED_RESOURCE_WRAPPER_CLASS = 'theia-blocked-resource-wrapper';
 
 const SAFE_SCHEMES = new Set(['data:']);
 const RESOURCE_SELECTORS = '*';
-const EMBEDDED_CONTENT_SELECTORS = 'iframe, frame';
-const RESOURCE_URL_ATTRIBUTES = ['src', 'poster', 'href', 'xlink:href', 'data'];
+const EMBEDDED_CONTENT_SELECTORS = 'iframe, frame, object, embed';
+const RESOURCE_URL_ATTRIBUTES = ['src', 'poster', 'href', 'xlink:href', 'data', 'background'];
+const URL_FUNCTION_ATTRIBUTES = ['fill', 'stroke', 'filter', 'clip-path', 'mask', 'marker-start', 'marker-mid', 'marker-end'];
 const INLINE_EXTERNAL_CONTENT_LABEL = nls.localize('theia/ai-chat-ui/blockedResource/inlineContent', '(inline external content)');
 const URL_PATTERN = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
 const IMAGE_SET_PATTERN = /(?:-webkit-)?image-set\(([^)]*)\)/gi;
 const IMAGE_SET_URL_PATTERN = /"([^"]*)"|'([^']*)'|(?:^|,)\s*([^,\s)]+)/gi;
+const CSS_IMPORT_PATTERN = /@import\s+(?:"([^"]*)"|'([^']*)')/gi;
+const CSS_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
+const CSS_HEX_ESCAPE_PATTERN = /\\([0-9a-fA-F]{1,6})[\t\n\f\r ]?/g;
+const CSS_CHARACTER_ESCAPE_PATTERN = /\\([\s\S])/g;
+const MAX_CODE_POINT = 0x10FFFF;
 const blockedResources = new WeakMap<HTMLElement, Element>();
 
 function isSafeUrl(rawUrl: string): boolean {
     const url = stripQuotes(rawUrl.trim());
     if (!url) {
+        return true;
+    }
+    if (url.startsWith('#')) {
         return true;
     }
     const lowerCaseUrl = url.toLowerCase();
@@ -83,7 +92,7 @@ function buildPlaceholder(doc: Document, original: Element): HTMLElement {
         resources.join(', ')
     ));
     placeholder.dataset.blockedTag = original.tagName.toLowerCase();
-    blockedResources.set(placeholder, original.cloneNode(true) as Element);
+    blockedResources.set(placeholder, sandboxEmbeddedContent(original.cloneNode(true) as Element));
 
     placeholder.innerHTML = renderBlockedResourcePlaceholder(resources);
 
@@ -99,8 +108,25 @@ export function restoreBlockedResource(placeholder: Element): Element | undefine
     return original?.cloneNode(true) as Element | undefined;
 }
 
+function sandboxEmbeddedContent(element: Element): Element {
+    // Restored iframes may carry attacker-controlled `srcdoc` content which would otherwise run
+    // with the origin of the IDE. Force full sandboxing so allowed content stays inert.
+    for (const embedded of [element, ...Array.from(element.querySelectorAll('iframe, frame'))]) {
+        const tagName = embedded.tagName.toUpperCase();
+        if (tagName === 'IFRAME' || tagName === 'FRAME') {
+            embedded.setAttribute('sandbox', '');
+        }
+    }
+    return element;
+}
+
+function isAnchor(element: Element): boolean {
+    // SVG elements keep their lower-case tag names, so normalize before comparing
+    return element.tagName.toUpperCase() === 'A';
+}
+
 function elementHasExternalReference(element: Element): boolean {
-    if (element.tagName === 'A') {
+    if (isAnchor(element)) {
         return false;
     }
     for (const attributeName of RESOURCE_URL_ATTRIBUTES) {
@@ -115,6 +141,10 @@ function elementHasExternalReference(element: Element): boolean {
         return true;
     }
 
+    if (extractUnsafeStyleSheetUrls(element).length || extractUnsafeUrlFunctionAttributeUrls(element).length) {
+        return true;
+    }
+
     return false;
 }
 
@@ -123,14 +153,14 @@ function collectExternalResourceUrls(element: Element): string[] {
     for (const candidate of [element, ...Array.from(element.querySelectorAll('*'))]) {
         collectElementExternalResourceUrls(candidate, urls);
     }
-    if (!urls.size && element.hasAttribute('srcdoc')) {
+    if (!urls.size) {
         urls.add(INLINE_EXTERNAL_CONTENT_LABEL);
     }
     return Array.from(urls);
 }
 
 function collectElementExternalResourceUrls(element: Element, urls: Set<string>): void {
-    if (element.tagName !== 'A') {
+    if (!isAnchor(element)) {
         for (const attributeName of RESOURCE_URL_ATTRIBUTES) {
             const value = element.getAttribute(attributeName);
             if (value && !isSafeUrl(value)) {
@@ -147,6 +177,14 @@ function collectElementExternalResourceUrls(element: Element, urls: Set<string>)
     }
 
     for (const url of extractUnsafeStyleUrls(element)) {
+        urls.add(url);
+    }
+
+    for (const url of extractUnsafeStyleSheetUrls(element)) {
+        urls.add(url);
+    }
+
+    for (const url of extractUnsafeUrlFunctionAttributeUrls(element)) {
         urls.add(url);
     }
 
@@ -188,6 +226,27 @@ function extractUnsafeStyleUrls(element: Element): string[] {
     return extractStyleUrls(element).filter(url => !isSafeUrl(url));
 }
 
+function extractUnsafeStyleSheetUrls(element: Element): string[] {
+    if (element.tagName.toUpperCase() !== 'STYLE' || !element.textContent) {
+        return [];
+    }
+    const styleSheet = normalizeCssText(element.textContent);
+    const urls = extractUrlsFromNormalizedCss(styleSheet);
+    urls.push(...Array.from(styleSheet.matchAll(CSS_IMPORT_PATTERN), match => (match[1] || match[2] || '').trim()).filter(url => !!url));
+    return urls.filter(url => !isSafeUrl(url));
+}
+
+function extractUnsafeUrlFunctionAttributeUrls(element: Element): string[] {
+    const urls: string[] = [];
+    for (const attributeName of URL_FUNCTION_ATTRIBUTES) {
+        const value = element.getAttribute(attributeName);
+        if (value) {
+            urls.push(...extractUrls(value).filter(url => !isSafeUrl(url)));
+        }
+    }
+    return urls;
+}
+
 function extractStyleUrls(element: Element): string[] {
     const style = element.getAttribute('style');
     if (!style) {
@@ -216,7 +275,23 @@ function removeUnsafeStyleDeclarations(element: HTMLElement): void {
     }
 }
 
-function extractUrls(styleValue: string): string[] {
+function normalizeCssText(cssText: string): string {
+    // Strip comments first (they act as token separators in CSS and could otherwise hide references),
+    // then resolve escape sequences so that obfuscated references such as `\75rl(...)` are detected.
+    return cssText
+        .replace(CSS_COMMENT_PATTERN, ' ')
+        .replace(CSS_HEX_ESCAPE_PATTERN, (_, hex) => {
+            const codePoint = parseInt(hex, 16);
+            return codePoint > 0 && codePoint <= MAX_CODE_POINT ? String.fromCodePoint(codePoint) : '\uFFFD';
+        })
+        .replace(CSS_CHARACTER_ESCAPE_PATTERN, '$1');
+}
+
+function extractUrls(rawStyleValue: string): string[] {
+    return extractUrlsFromNormalizedCss(normalizeCssText(rawStyleValue));
+}
+
+function extractUrlsFromNormalizedCss(styleValue: string): string[] {
     const urls = Array.from(styleValue.matchAll(URL_PATTERN), match => stripQuotes((match[1] || match[2] || match[3] || '').trim()));
     for (const imageSetMatch of styleValue.matchAll(IMAGE_SET_PATTERN)) {
         const imageSet = imageSetMatch[1];

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.ts
@@ -1,0 +1,233 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core/lib/common/nls';
+import { renderBlockedResourcePlaceholder } from './blocked-resource-placeholder';
+
+export const BLOCKED_RESOURCE_CLASS = 'theia-blocked-resource';
+export const BLOCKED_RESOURCE_ALLOW_CLASS = 'theia-blocked-resource-allow';
+export const BLOCKED_RESOURCE_WRAPPER_CLASS = 'theia-blocked-resource-wrapper';
+
+const SAFE_SCHEMES = new Set(['data:']);
+const RESOURCE_SELECTORS = '*';
+const EMBEDDED_CONTENT_SELECTORS = 'iframe, frame';
+const RESOURCE_URL_ATTRIBUTES = ['src', 'poster', 'href', 'xlink:href', 'data'];
+const INLINE_EXTERNAL_CONTENT_LABEL = nls.localize('theia/ai-chat-ui/blockedResource/inlineContent', '(inline external content)');
+const URL_PATTERN = /url\(\s*(?:"([^"]*)"|'([^']*)'|([^)]*))\s*\)/gi;
+const IMAGE_SET_PATTERN = /(?:-webkit-)?image-set\(([^)]*)\)/gi;
+const IMAGE_SET_URL_PATTERN = /"([^"]*)"|'([^']*)'|(?:^|,)\s*([^,\s)]+)/gi;
+const blockedResources = new WeakMap<HTMLElement, Element>();
+
+function isSafeUrl(rawUrl: string): boolean {
+    const url = stripQuotes(rawUrl.trim());
+    if (!url) {
+        return true;
+    }
+    const lowerCaseUrl = url.toLowerCase();
+    for (const scheme of SAFE_SCHEMES) {
+        if (lowerCaseUrl.startsWith(scheme)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+export function blockExternalResources(root: ParentNode & { ownerDocument: Document }): void {
+    for (const element of Array.from(root.querySelectorAll(EMBEDDED_CONTENT_SELECTORS))) {
+        element.replaceWith(buildPlaceholder(root.ownerDocument, element));
+    }
+
+    for (const element of Array.from(root.querySelectorAll(RESOURCE_SELECTORS))) {
+        if (elementHasExternalReference(element)) {
+            element.replaceWith(buildPlaceholder(root.ownerDocument, element));
+        }
+    }
+
+    for (const element of Array.from(root.querySelectorAll('[style]'))) {
+        const unsafeStyleUrls = extractUnsafeStyleUrls(element);
+        if (unsafeStyleUrls.length) {
+            const wrapper = root.ownerDocument.createElement('span');
+            wrapper.classList.add(BLOCKED_RESOURCE_WRAPPER_CLASS);
+            wrapper.appendChild(buildPlaceholder(root.ownerDocument, element));
+
+            const safeClone = element.cloneNode(true) as HTMLElement;
+            removeUnsafeStyleDeclarations(safeClone);
+            blockExternalResources(safeClone);
+            wrapper.appendChild(safeClone);
+            element.replaceWith(wrapper);
+        }
+    }
+}
+
+function buildPlaceholder(doc: Document, original: Element): HTMLElement {
+    const resources = collectExternalResourceUrls(original);
+    const placeholder = doc.createElement('span');
+    placeholder.classList.add(BLOCKED_RESOURCE_CLASS);
+    placeholder.setAttribute('role', 'group');
+    placeholder.setAttribute('aria-label', nls.localize(
+        'theia/ai-chat-ui/blockedResource/aria',
+        'Blocked external resources: {0}',
+        resources.join(', ')
+    ));
+    placeholder.dataset.blockedTag = original.tagName.toLowerCase();
+    blockedResources.set(placeholder, original.cloneNode(true) as Element);
+
+    placeholder.innerHTML = renderBlockedResourcePlaceholder(resources);
+
+    return placeholder;
+}
+
+export function restoreBlockedResource(placeholder: Element): Element | undefined {
+    if (!(placeholder instanceof HTMLElement)) {
+        return undefined;
+    }
+    const original = blockedResources.get(placeholder);
+    blockedResources.delete(placeholder);
+    return original?.cloneNode(true) as Element | undefined;
+}
+
+function elementHasExternalReference(element: Element): boolean {
+    if (element.tagName === 'A') {
+        return false;
+    }
+    for (const attributeName of RESOURCE_URL_ATTRIBUTES) {
+        const value = element.getAttribute(attributeName);
+        if (value && !isSafeUrl(value)) {
+            return true;
+        }
+    }
+
+    const srcset = element.getAttribute('srcset');
+    if (srcset && srcsetHasExternalReference(srcset)) {
+        return true;
+    }
+
+    return false;
+}
+
+function collectExternalResourceUrls(element: Element): string[] {
+    const urls = new Set<string>();
+    for (const candidate of [element, ...Array.from(element.querySelectorAll('*'))]) {
+        collectElementExternalResourceUrls(candidate, urls);
+    }
+    if (!urls.size && element.hasAttribute('srcdoc')) {
+        urls.add(INLINE_EXTERNAL_CONTENT_LABEL);
+    }
+    return Array.from(urls);
+}
+
+function collectElementExternalResourceUrls(element: Element, urls: Set<string>): void {
+    if (element.tagName !== 'A') {
+        for (const attributeName of RESOURCE_URL_ATTRIBUTES) {
+            const value = element.getAttribute(attributeName);
+            if (value && !isSafeUrl(value)) {
+                urls.add(value);
+            }
+        }
+    }
+
+    const srcset = element.getAttribute('srcset');
+    if (srcset) {
+        for (const url of extractSrcsetUrls(srcset).filter(candidate => !isSafeUrl(candidate))) {
+            urls.add(url);
+        }
+    }
+
+    for (const url of extractUnsafeStyleUrls(element)) {
+        urls.add(url);
+    }
+
+    if ((element.tagName === 'IFRAME' || element.tagName === 'FRAME') && element.hasAttribute('srcdoc')) {
+        urls.add(INLINE_EXTERNAL_CONTENT_LABEL);
+    }
+}
+
+function srcsetHasExternalReference(srcset: string): boolean {
+    return extractSrcsetUrls(srcset).some(url => !isSafeUrl(url));
+}
+
+function extractSrcsetUrls(srcset: string): string[] {
+    const urls: string[] = [];
+    let current = '';
+    for (let index = 0; index < srcset.length; index++) {
+        const character = srcset[index];
+        if (character === ',' && shouldSplitSrcsetCandidate(current)) {
+            urls.push(extractSrcsetCandidateUrl(current));
+            current = '';
+        } else {
+            current += character;
+        }
+    }
+    urls.push(extractSrcsetCandidateUrl(current));
+    return urls.filter(url => !!url);
+}
+
+function shouldSplitSrcsetCandidate(candidate: string): boolean {
+    const trimmedCandidate = candidate.trim().toLowerCase();
+    return !trimmedCandidate.startsWith('data:') || /\s+\S+$/.test(trimmedCandidate);
+}
+
+function extractSrcsetCandidateUrl(candidate: string): string {
+    return candidate.trim().split(/\s+/)[0];
+}
+
+function extractUnsafeStyleUrls(element: Element): string[] {
+    return extractStyleUrls(element).filter(url => !isSafeUrl(url));
+}
+
+function extractStyleUrls(element: Element): string[] {
+    const style = element.getAttribute('style');
+    if (!style) {
+        return [];
+    }
+    return extractUrls(style);
+}
+
+function removeUnsafeStyleDeclarations(element: HTMLElement): void {
+    const style = element.getAttribute('style');
+    if (!style) {
+        return;
+    }
+    const safeDeclarations = style.split(';').map(declaration => declaration.trim()).filter(declaration => {
+        const separator = declaration.indexOf(':');
+        if (separator === -1) {
+            return false;
+        }
+        const value = declaration.substring(separator + 1);
+        return !extractUrls(value).some(url => !isSafeUrl(url));
+    });
+    if (safeDeclarations.length) {
+        element.setAttribute('style', safeDeclarations.join('; '));
+    } else {
+        element.removeAttribute('style');
+    }
+}
+
+function extractUrls(styleValue: string): string[] {
+    const urls = Array.from(styleValue.matchAll(URL_PATTERN), match => stripQuotes((match[1] || match[2] || match[3] || '').trim()));
+    for (const imageSetMatch of styleValue.matchAll(IMAGE_SET_PATTERN)) {
+        const imageSet = imageSetMatch[1];
+        urls.push(...Array.from(imageSet.matchAll(IMAGE_SET_URL_PATTERN), match => stripQuotes((match[1] || match[2] || match[3] || '').trim())));
+    }
+    return urls.filter(url => !!url);
+}
+
+function stripQuotes(value: string): string {
+    if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith('\'') && value.endsWith('\''))) {
+        return value.slice(1, -1);
+    }
+    return value;
+}

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/block-external-resources.ts
@@ -34,8 +34,24 @@ const CSS_IMPORT_PATTERN = /@import\s+(?:"([^"]*)"|'([^']*)')/gi;
 const CSS_COMMENT_PATTERN = /\/\*[\s\S]*?\*\//g;
 const CSS_HEX_ESCAPE_PATTERN = /\\([0-9a-fA-F]{1,6})[\t\n\f\r ]?/g;
 const CSS_CHARACTER_ESCAPE_PATTERN = /\\([\s\S])/g;
+const CSS_DATA_URL_PATTERN = /^data:text\/css([^,]*),([\s\S]*)$/i;
 const MAX_CODE_POINT = 0x10FFFF;
 const blockedResources = new WeakMap<HTMLElement, Element>();
+
+let allowedResourceUrls: readonly string[] = [];
+
+/**
+ * Configures URL prefixes whose external resources may be rendered without being blocked.
+ * A resource is allowed when its URL starts with one of the configured prefixes, so entries
+ * should include the full origin (e.g. `https://example.com/`) to avoid unintended matches.
+ */
+export function setAllowedResourceUrls(urls: readonly string[]): void {
+    allowedResourceUrls = urls.map(url => url.trim()).filter(url => !!url);
+}
+
+function isAllowlistedUrl(url: string): boolean {
+    return allowedResourceUrls.some(prefix => url.startsWith(prefix));
+}
 
 function isSafeUrl(rawUrl: string): boolean {
     const url = stripQuotes(rawUrl.trim());
@@ -48,15 +64,57 @@ function isSafeUrl(rawUrl: string): boolean {
     const lowerCaseUrl = url.toLowerCase();
     for (const scheme of SAFE_SCHEMES) {
         if (lowerCaseUrl.startsWith(scheme)) {
-            return true;
+            // A `data:` URL is inert on its own, but a `data:text/css` payload can itself reference
+            // external resources, so decode and inspect such stylesheets instead of trusting them.
+            // This inspection runs before the allowlist so that allowlisting a `data:` prefix cannot
+            // disable it.
+            return scheme === 'data:' ? isSafeDataUrl(url) : true;
         }
+    }
+    if (isAllowlistedUrl(url)) {
+        return true;
     }
     return false;
 }
 
-export function blockExternalResources(root: ParentNode & { ownerDocument: Document }): void {
+function isSafeDataUrl(url: string): boolean {
+    const match = CSS_DATA_URL_PATTERN.exec(url);
+    if (!match) {
+        // Any non-CSS `data:` URL is inert on its own.
+        return true;
+    }
+    const css = decodeCssPayload(match[1], match[2]);
+    if (css === undefined) {
+        // Fail closed: if the payload cannot be decoded, the browser may still resolve the valid
+        // escape sequences and load external resources, so treat the stylesheet as unsafe.
+        return false;
+    }
+    return !extractCssUrls(css).some(nested => !isSafeUrl(nested));
+}
+
+function decodeCssPayload(parameters: string, payload: string): string | undefined {
+    try {
+        return /;\s*base64/i.test(parameters) ? atob(payload) : decodeURIComponent(payload);
+    } catch {
+        return undefined;
+    }
+}
+
+/**
+ * Neutralizes resources that would otherwise load or execute automatically.
+ *
+ * Active embedded content (`iframe`, `frame`, `object`, `embed`) is always blocked because it can
+ * run active content with the IDE's origin, which is unsafe even for trusted, user-authored Markdown.
+ * External URL resources (images, stylesheets, SVG references, ...) are only blocked when
+ * {@link blockExternalUrls} is `true`; trusted content passes `false` to render them directly.
+ */
+export function blockExternalResources(root: ParentNode & { ownerDocument: Document }, blockExternalUrls: boolean = true): void {
     for (const element of Array.from(root.querySelectorAll(EMBEDDED_CONTENT_SELECTORS))) {
         element.replaceWith(buildPlaceholder(root.ownerDocument, element));
+    }
+
+    if (!blockExternalUrls) {
+        return;
     }
 
     for (const element of Array.from(root.querySelectorAll(RESOURCE_SELECTORS))) {
@@ -230,10 +288,14 @@ function extractUnsafeStyleSheetUrls(element: Element): string[] {
     if (element.tagName.toUpperCase() !== 'STYLE' || !element.textContent) {
         return [];
     }
-    const styleSheet = normalizeCssText(element.textContent);
+    return extractCssUrls(element.textContent).filter(url => !isSafeUrl(url));
+}
+
+function extractCssUrls(cssText: string): string[] {
+    const styleSheet = normalizeCssText(cssText);
     const urls = extractUrlsFromNormalizedCss(styleSheet);
     urls.push(...Array.from(styleSheet.matchAll(CSS_IMPORT_PATTERN), match => (match[1] || match[2] || '').trim()).filter(url => !!url));
-    return urls.filter(url => !isSafeUrl(url));
+    return urls;
 }
 
 function extractUnsafeUrlFunctionAttributeUrls(element: Element): string[] {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/blocked-resource-placeholder.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/blocked-resource-placeholder.tsx
@@ -1,0 +1,44 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { renderToStaticMarkup } from 'react-dom/server';
+import { nls } from '@theia/core/lib/common/nls';
+
+export interface BlockedResourcePlaceholderProps {
+    resources: string[];
+}
+
+export const BlockedResourcePlaceholder = ({ resources }: BlockedResourcePlaceholderProps): React.ReactNode => {
+    const firstResource = resources[0] ?? nls.localize('theia/ai-chat-ui/blockedResource/inlineContent', '(inline external content)');
+    return <>
+        <span className='theia-blocked-resource-icon codicon codicon-shield'></span>
+        <span className='theia-blocked-resource-label'>
+            {nls.localize('theia/ai-chat-ui/blockedResource/label', 'External resource blocked:')}{' '}
+            <span className='theia-blocked-resource-url' title={firstResource}>{firstResource}</span>
+        </span>
+        {resources.length > 1 && <details className='theia-blocked-resource-details'>
+            <summary>{nls.localize('theia/ai-chat-ui/blockedResource/resourcesToAllow', '{0} resources will be enabled', resources.length)}</summary>
+            <ul>
+                {resources.map(resource => <li key={resource} title={resource}>{resource}</li>)}
+            </ul>
+        </details>}
+        <button type='button' className='theia-blocked-resource-allow'>{nls.localize('theia/ai-chat-ui/blockedResource/allow', 'Allow this blocked content')}</button>
+    </>;
+};
+
+export const renderBlockedResourcePlaceholder = (resources: string[]): string => renderToStaticMarkup(<BlockedResourcePlaceholder resources={resources} />);

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/external-resource-allowlist-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/external-resource-allowlist-contribution.ts
@@ -1,0 +1,42 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { CHAT_VIEW_ALLOWED_RESOURCE_URLS, ChatViewPreferences } from '../chat-view-preferences';
+import { setAllowedResourceUrls } from './block-external-resources';
+
+/**
+ * Keeps the resource allowlist used by {@link blockExternalResources} in sync with the
+ * `ai-features.chat.allowedResourceUrls` preference.
+ */
+@injectable()
+export class ExternalResourceAllowlistContribution implements FrontendApplicationContribution {
+
+    @inject(ChatViewPreferences)
+    protected readonly preferences: ChatViewPreferences;
+
+    onStart(): void {
+        this.preferences.ready.then(() => {
+            setAllowedResourceUrls(this.preferences[CHAT_VIEW_ALLOWED_RESOURCE_URLS] ?? []);
+        });
+        this.preferences.onPreferenceChanged(event => {
+            if (event.preferenceName === CHAT_VIEW_ALLOWED_RESOURCE_URLS) {
+                setAllowedResourceUrls(this.preferences[CHAT_VIEW_ALLOWED_RESOURCE_URLS] ?? []);
+            }
+        });
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.spec.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.spec.tsx
@@ -1,0 +1,160 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { createRoot, Root } from '@theia/core/shared/react-dom/client';
+import { OpenerService } from '@theia/core/lib/browser';
+import { DeclaredEventsEventListenerObject, useMarkdownRendering } from './markdown-part-renderer';
+import { BLOCKED_RESOURCE_ALLOW_CLASS, BLOCKED_RESOURCE_CLASS } from './block-external-resources';
+
+disableJSDOM();
+
+describe('useMarkdownRendering', () => {
+    let container: HTMLElement;
+    let root: Root;
+    const openerService: OpenerService = {
+        getOpener: async () => ({ open: async () => undefined }),
+        getOpeners: async () => [],
+        open: async () => undefined
+    } as unknown as OpenerService;
+
+    const Markdown = ({ markdown, eventHandler }: { markdown: string; eventHandler?: DeclaredEventsEventListenerObject }) => {
+        const ref = useMarkdownRendering(markdown, openerService, false, eventHandler);
+        return <div ref={ref}></div>;
+    };
+
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        root.unmount();
+        document.body.removeChild(container);
+    });
+
+    it('blocks external markdown images before they are mounted', done => {
+        root.render(<Markdown markdown="![](https://evil.com/x.gif)" />);
+
+        setTimeout(() => {
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+            expect(container.querySelector('img')).to.be.null;
+            done();
+        }, 50);
+    });
+
+    it('allows a blocked resource after explicit user action', done => {
+        root.render(<Markdown markdown="![](https://evil.com/x.gif)" />);
+
+        setTimeout(() => {
+            const allow = container.querySelector(`.${BLOCKED_RESOURCE_ALLOW_CLASS}`) as HTMLButtonElement;
+            expect(allow).to.exist;
+
+            allow.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+            const image = container.querySelector('img');
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+            expect(image?.getAttribute('src')).to.equal('https://evil.com/x.gif');
+            done();
+        }, 50);
+    });
+
+    it('handles allow clicks before custom event handlers', done => {
+        let handled = false;
+        const eventHandler: DeclaredEventsEventListenerObject = {
+            handleEvent: () => {
+                handled = true;
+                return true;
+            }
+        };
+        root.render(<Markdown markdown="![](https://evil.com/x.gif)" eventHandler={eventHandler} />);
+
+        setTimeout(() => {
+            const allow = container.querySelector(`.${BLOCKED_RESOURCE_ALLOW_CLASS}`) as HTMLButtonElement;
+            expect(allow).to.exist;
+
+            allow.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+            const image = container.querySelector('img');
+            expect(handled).to.be.false;
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+            expect(image?.getAttribute('src')).to.equal('https://evil.com/x.gif');
+            done();
+        }, 50);
+    });
+
+    it('does not restore forged blocked-resource placeholders', done => {
+        const forgedPlaceholder = '<span class="theia-blocked-resource" data-blocked-html="&lt;img src=x onerror=alert(1)&gt;">'
+            + '<button class="theia-blocked-resource-allow">Allow this resource</button></span>';
+        root.render(<Markdown markdown={forgedPlaceholder} />);
+
+        setTimeout(() => {
+            const allow = container.querySelector(`.${BLOCKED_RESOURCE_ALLOW_CLASS}`) as HTMLButtonElement;
+            expect(allow).to.exist;
+
+            allow.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+            expect(container.querySelector('img')).to.be.null;
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+            done();
+        }, 50);
+    });
+
+    it('shows blocked placeholders for iframe markdown', done => {
+        root.render(<Markdown markdown={'<iframe src="https://evil.com"></iframe>'} />);
+
+        setTimeout(() => {
+            const placeholder = container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`);
+            expect(placeholder).to.exist;
+            expect(placeholder?.textContent).to.contain('https://evil.com');
+            expect(container.querySelector('iframe')).to.be.null;
+            done();
+        }, 50);
+    });
+
+    it('shows blocked placeholders for SVG resource markdown', done => {
+        root.render(<Markdown markdown={'<svg><image href="https://evil.com/x.png"></image></svg>'} />);
+
+        setTimeout(() => {
+            const placeholder = container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`);
+            expect(placeholder).to.exist;
+            expect(placeholder?.textContent).to.contain('https://evil.com/x.png');
+            expect(container.querySelector('image')).to.be.null;
+            done();
+        }, 50);
+    });
+
+    it('shows blocked placeholders for SVG filter image markdown', done => {
+        root.render(<Markdown markdown={'<svg><filter><feImage href="https://evil.com/filter.png"></feImage></filter></svg>'} />);
+
+        setTimeout(() => {
+            const placeholder = container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`);
+            expect(placeholder).to.exist;
+            expect(placeholder?.textContent).to.contain('https://evil.com/filter.png');
+            expect(container.querySelector('feImage')).to.be.null;
+            done();
+        }, 50);
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.spec.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.spec.tsx
@@ -134,6 +134,22 @@ describe('useMarkdownRendering', () => {
         }, 50);
     });
 
+    it('sandboxes allowed iframes with inline content', done => {
+        root.render(<Markdown markdown={'<iframe srcdoc="&lt;img src=x onerror=alert(1)&gt;"></iframe>'} />);
+
+        setTimeout(() => {
+            const allow = container.querySelector(`.${BLOCKED_RESOURCE_ALLOW_CLASS}`) as HTMLButtonElement;
+            expect(allow).to.exist;
+
+            allow.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+
+            const iframe = container.querySelector('iframe');
+            expect(iframe).to.exist;
+            expect(iframe?.getAttribute('sandbox')).to.equal('');
+            done();
+        }, 50);
+    });
+
     it('shows blocked placeholders for SVG resource markdown', done => {
         root.render(<Markdown markdown={'<svg><image href="https://evil.com/x.png"></image></svg>'} />);
 
@@ -142,6 +158,18 @@ describe('useMarkdownRendering', () => {
             expect(placeholder).to.exist;
             expect(placeholder?.textContent).to.contain('https://evil.com/x.png');
             expect(container.querySelector('image')).to.be.null;
+            done();
+        }, 50);
+    });
+
+    it('shows blocked placeholders for style sheets importing external CSS', done => {
+        root.render(<Markdown markdown={'some text\n\n<style>@import url("https://evil.com/main.css");</style>\n<div class="App">content</div>'} />);
+
+        setTimeout(() => {
+            const placeholder = container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`);
+            expect(placeholder).to.exist;
+            expect(placeholder?.textContent).to.contain('https://evil.com/main.css');
+            expect(container.querySelector('style')).to.be.null;
             done();
         }, 50);
     });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.spec.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.spec.tsx
@@ -41,6 +41,11 @@ describe('useMarkdownRendering', () => {
         return <div ref={ref}></div>;
     };
 
+    const TrustedMarkdown = ({ markdown }: { markdown: string }) => {
+        const ref = useMarkdownRendering(markdown, openerService, false, undefined, false);
+        return <div ref={ref}></div>;
+    };
+
     before(() => disableJSDOM = enableJSDOM());
     after(() => disableJSDOM());
 
@@ -118,6 +123,16 @@ describe('useMarkdownRendering', () => {
 
             expect(container.querySelector('img')).to.be.null;
             expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+            done();
+        }, 50);
+    });
+
+    it('renders external resources directly when blocking is disabled', done => {
+        root.render(<TrustedMarkdown markdown="![](https://evil.com/x.gif)" />);
+
+        setTimeout(() => {
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+            expect(container.querySelector('img')?.getAttribute('src')).to.equal('https://evil.com/x.gif');
             done();
         }, 50);
     });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -29,6 +29,13 @@ import * as DOMPurify from '@theia/core/shared/dompurify';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 import { OpenerService, open } from '@theia/core/lib/browser';
 import { URI } from '@theia/core';
+import {
+    blockExternalResources,
+    BLOCKED_RESOURCE_ALLOW_CLASS,
+    BLOCKED_RESOURCE_CLASS,
+    BLOCKED_RESOURCE_WRAPPER_CLASS,
+    restoreBlockedResource
+} from './block-external-resources';
 
 export interface MarkdownRenderProps {
     text: string | MarkdownString;
@@ -102,17 +109,22 @@ export const useMarkdownRendering = (
     const ref = useRef<HTMLDivElement | null>(null);
     const markdownString = typeof markdown === 'string' ? markdown : markdown.value;
     useEffect(() => {
-        const markdownIt = markdownit().use(markdownitemoji.full);
+        const markdownIt = markdownit({ html: true }).use(markdownitemoji.full);
         const host = document.createElement('div');
+        const template = document.createElement('template');
 
         // markdownIt always puts the content in a paragraph element, so we remove it if we don't want that
         const html = skipSurroundingParagraph ? markdownIt.render(markdownString).replace(/^<p>|<\/p>|<p><\/p>$/g, '') : markdownIt.render(markdownString);
 
-        host.innerHTML = DOMPurify.sanitize(html, {
+        template.innerHTML = DOMPurify.sanitize(html, {
             // DOMPurify usually strips non http(s) links from hrefs
             // but we want to allow them (see handleClick via OpenerService below)
-            ALLOW_UNKNOWN_PROTOCOLS: true
+            ALLOW_UNKNOWN_PROTOCOLS: true,
+            ADD_TAGS: ['iframe', 'frame'],
+            ADD_ATTR: ['src', 'srcset', 'srcdoc', 'poster', 'href', 'xlink:href', 'data']
         });
+        blockExternalResources(template.content);
+        host.appendChild(template.content);
         while (ref?.current?.firstChild) {
             ref.current.removeChild(ref.current.firstChild);
         }
@@ -120,10 +132,28 @@ export const useMarkdownRendering = (
 
         // intercept link clicks to use the Theia OpenerService instead of the default browser behavior
         const handleClick = (event: MouseEvent) => {
+            let target = event.target instanceof HTMLElement ? event.target : event.target instanceof Node ? event.target.parentElement : undefined;
+            const allowButton = target?.closest(`.${BLOCKED_RESOURCE_ALLOW_CLASS}`);
+            if (allowButton) {
+                const placeholder = allowButton.closest(`.${BLOCKED_RESOURCE_CLASS}`);
+                const restored = placeholder ? restoreBlockedResource(placeholder) : undefined;
+                if (placeholder && restored) {
+                    const wrapper = placeholder.parentElement?.classList.contains(BLOCKED_RESOURCE_WRAPPER_CLASS)
+                        ? placeholder.parentElement
+                        : undefined;
+                    if (wrapper) {
+                        wrapper.replaceWith(restored);
+                    } else {
+                        placeholder.replaceWith(restored);
+                    }
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
             if ((eventHandler?.handleEvent(event) as unknown) === true) { return; }
-            let target = event.target as HTMLElement;
             while (target && target.tagName !== 'A') {
-                target = target.parentElement as HTMLElement;
+                target = target.parentElement ?? undefined;
             }
             if (target && target.tagName === 'A') {
                 const href = target.getAttribute('href');

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -29,6 +29,13 @@ import * as DOMPurify from '@theia/core/shared/dompurify';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 import { OpenerService, open } from '@theia/core/lib/browser';
 import { URI } from '@theia/core';
+import {
+    blockExternalResources,
+    BLOCKED_RESOURCE_ALLOW_CLASS,
+    BLOCKED_RESOURCE_CLASS,
+    BLOCKED_RESOURCE_WRAPPER_CLASS,
+    restoreBlockedResource
+} from './block-external-resources';
 
 @injectable()
 export class MarkdownPartRenderer implements ChatResponsePartRenderer<MarkdownChatResponseContent | InformationalChatResponseContent> {
@@ -93,17 +100,22 @@ export const useMarkdownRendering = (
     const ref = useRef<HTMLDivElement | null>(null);
     const markdownString = typeof markdown === 'string' ? markdown : markdown.value;
     useEffect(() => {
-        const markdownIt = markdownit().use(markdownitemoji.full);
+        const markdownIt = markdownit({ html: true }).use(markdownitemoji.full);
         const host = document.createElement('div');
+        const template = document.createElement('template');
 
         // markdownIt always puts the content in a paragraph element, so we remove it if we don't want that
         const html = skipSurroundingParagraph ? markdownIt.render(markdownString).replace(/^<p>|<\/p>|<p><\/p>$/g, '') : markdownIt.render(markdownString);
 
-        host.innerHTML = DOMPurify.sanitize(html, {
+        template.innerHTML = DOMPurify.sanitize(html, {
             // DOMPurify usually strips non http(s) links from hrefs
             // but we want to allow them (see handleClick via OpenerService below)
-            ALLOW_UNKNOWN_PROTOCOLS: true
+            ALLOW_UNKNOWN_PROTOCOLS: true,
+            ADD_TAGS: ['iframe', 'frame'],
+            ADD_ATTR: ['src', 'srcset', 'srcdoc', 'poster', 'href', 'xlink:href', 'data']
         });
+        blockExternalResources(template.content);
+        host.appendChild(template.content);
         while (ref?.current?.firstChild) {
             ref.current.removeChild(ref.current.firstChild);
         }
@@ -111,10 +123,28 @@ export const useMarkdownRendering = (
 
         // intercept link clicks to use the Theia OpenerService instead of the default browser behavior
         const handleClick = (event: MouseEvent) => {
+            let target = event.target instanceof HTMLElement ? event.target : event.target instanceof Node ? event.target.parentElement : undefined;
+            const allowButton = target?.closest(`.${BLOCKED_RESOURCE_ALLOW_CLASS}`);
+            if (allowButton) {
+                const placeholder = allowButton.closest(`.${BLOCKED_RESOURCE_CLASS}`);
+                const restored = placeholder ? restoreBlockedResource(placeholder) : undefined;
+                if (placeholder && restored) {
+                    const wrapper = placeholder.parentElement?.classList.contains(BLOCKED_RESOURCE_WRAPPER_CLASS)
+                        ? placeholder.parentElement
+                        : undefined;
+                    if (wrapper) {
+                        wrapper.replaceWith(restored);
+                    } else {
+                        placeholder.replaceWith(restored);
+                    }
+                }
+                event.preventDefault();
+                event.stopPropagation();
+                return;
+            }
             if ((eventHandler?.handleEvent(event) as unknown) === true) { return; }
-            let target = event.target as HTMLElement;
             while (target && target.tagName !== 'A') {
-                target = target.parentElement as HTMLElement;
+                target = target.parentElement ?? undefined;
             }
             if (target && target.tagName === 'A') {
                 const href = target.getAttribute('href');

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -132,7 +132,7 @@ export const useMarkdownRendering = (
 
         // intercept link clicks to use the Theia OpenerService instead of the default browser behavior
         const handleClick = (event: MouseEvent) => {
-            let target = event.target instanceof HTMLElement ? event.target : event.target instanceof Node ? event.target.parentElement : undefined;
+            let target = event.target instanceof Element ? event.target : event.target instanceof Node ? event.target.parentElement : undefined;
             const allowButton = target?.closest(`.${BLOCKED_RESOURCE_ALLOW_CLASS}`);
             if (allowButton) {
                 const placeholder = allowButton.closest(`.${BLOCKED_RESOURCE_CLASS}`);
@@ -152,11 +152,12 @@ export const useMarkdownRendering = (
                 return;
             }
             if ((eventHandler?.handleEvent(event) as unknown) === true) { return; }
-            while (target && target.tagName !== 'A') {
+            // SVG anchors keep their lower-case tag name, so normalize before comparing
+            while (target && target.tagName.toUpperCase() !== 'A') {
                 target = target.parentElement ?? undefined;
             }
-            if (target && target.tagName === 'A') {
-                const href = target.getAttribute('href');
+            if (target && target.tagName.toUpperCase() === 'A') {
+                const href = target.getAttribute('href') ?? target.getAttribute('xlink:href');
                 if (href) {
                     open(openerService, new URI(href));
                     event.preventDefault();

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/markdown-part-renderer.tsx
@@ -96,13 +96,17 @@ export interface DeclaredEventsEventListenerObject extends EventListenerObject {
  * @param eventHandler `handleEvent` will be called by default for `click` events and additionally
  * for all events enumerated in {@link DeclaredEventsEventListenerObject.handledEvents}. If `handleEvent` returns `true`,
  * no additional handlers will be run for the event.
+ * @param blockExternalResourceLoading whether external URL resources should be blocked until explicitly allowed (default: true).
+ * Trusted content authored by the user (e.g. their own chat requests) can pass `false` to render such resources directly.
+ * Active embedded content (iframes, frames, objects, embeds) is always blocked regardless of this flag.
  * @returns the ref to use in an element to render the markdown
  */
 export const useMarkdownRendering = (
     markdown: string | MarkdownString,
     openerService: OpenerService,
     skipSurroundingParagraph: boolean = false,
-    eventHandler?: DeclaredEventsEventListenerObject
+    eventHandler?: DeclaredEventsEventListenerObject,
+    blockExternalResourceLoading: boolean = true
 ) => {
     // null is valid in React
     // eslint-disable-next-line no-null/no-null
@@ -123,7 +127,9 @@ export const useMarkdownRendering = (
             ADD_TAGS: ['iframe', 'frame'],
             ADD_ATTR: ['src', 'srcset', 'srcdoc', 'poster', 'href', 'xlink:href', 'data']
         });
-        blockExternalResources(template.content);
+        // Active embedded content is always blocked; trusted content (blockExternalResourceLoading=false)
+        // still renders its external URL resources directly.
+        blockExternalResources(template.content, blockExternalResourceLoading);
         host.appendChild(template.content);
         while (ref?.current?.firstChild) {
             ref.current.removeChild(ref.current.firstChild);
@@ -171,7 +177,7 @@ export const useMarkdownRendering = (
             ref.current?.removeEventListener('click', handleClick);
             eventHandler?.handledEvents?.forEach(eventType => eventType !== 'click' && ref?.current?.removeEventListener(eventType, eventHandler));
         };
-    }, [markdownString, skipSurroundingParagraph, openerService]);
+    }, [markdownString, skipSurroundingParagraph, openerService, blockExternalResourceLoading]);
 
     return ref;
 };

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.spec.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.spec.tsx
@@ -1,0 +1,117 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { createRoot, Root } from '@theia/core/shared/react-dom/client';
+import { OpenerService } from '@theia/core/lib/browser';
+import { MarkdownRender } from '../chat-response-renderer/markdown-part-renderer';
+import { BLOCKED_RESOURCE_CLASS } from '../chat-response-renderer/block-external-resources';
+import { ChatRequestRender, RequestNode } from './chat-view-tree-widget';
+
+disableJSDOM();
+
+describe('chat-view-tree-widget resource blocking policy', () => {
+    let container: HTMLElement;
+    let root: Root;
+    const openerService: OpenerService = {
+        getOpener: async () => ({ open: async () => undefined }),
+        getOpeners: async () => [],
+        open: async () => undefined
+    } as unknown as OpenerService;
+
+    const externalImageMarkdown = '![](https://evil.com/x.gif)';
+    const inlineIframeMarkdown = '<iframe srcdoc="&lt;p&gt;hi&lt;/p&gt;"></iframe>';
+
+    const createRequestNode = (markdown: string): RequestNode => ({
+        request: {
+            message: { parts: [{ text: markdown }] },
+            context: { variables: [] }
+        },
+        branch: { items: [] }
+    } as unknown as RequestNode);
+
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    beforeEach(() => {
+        container = document.createElement('div');
+        document.body.appendChild(container);
+        root = createRoot(container);
+    });
+
+    afterEach(() => {
+        root.unmount();
+        document.body.removeChild(container);
+    });
+
+    it('renders external resources directly for user requests', done => {
+        root.render(
+            <ChatRequestRender
+                node={createRequestNode(externalImageMarkdown)}
+                hoverService={{} as never}
+                chatAgentService={{} as never}
+                variableService={{} as never}
+                openerService={openerService}
+                provideChatInputWidget={() => undefined}
+            />
+        );
+
+        setTimeout(() => {
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.be.null;
+            expect(container.querySelector('img')?.getAttribute('src')).to.equal('https://evil.com/x.gif');
+            done();
+        }, 50);
+    });
+
+    it('still blocks active embedded content for user requests', done => {
+        root.render(
+            <ChatRequestRender
+                node={createRequestNode(inlineIframeMarkdown)}
+                hoverService={{} as never}
+                chatAgentService={{} as never}
+                variableService={{} as never}
+                openerService={openerService}
+                provideChatInputWidget={() => undefined}
+            />
+        );
+
+        setTimeout(() => {
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+            expect(container.querySelector('iframe')).to.be.null;
+            done();
+        }, 50);
+    });
+
+    it('blocks external resources for assistant responses', done => {
+        root.render(<MarkdownRender text={externalImageMarkdown} openerService={openerService} />);
+
+        setTimeout(() => {
+            expect(container.querySelector(`.${BLOCKED_RESOURCE_CLASS}`)).to.exist;
+            expect(container.querySelector('img')).to.be.null;
+            done();
+        }, 50);
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -508,7 +508,7 @@ export class ChatViewTreeWidget extends TreeWidget {
                         const tokenInfo = hasTokenInfo
                             ? `${nls.localize('theia/ai/chat-ui/tokenUsageLabel', 'Token Usage')}: ${nls.localizeByDefault(
                                 'Input: {0}', formatTokenCount(tokenUsage.inputTokens))} | ${nls.localizeByDefault(
-                                'Output: {0}', formatTokenCount(tokenUsage.outputTokens))}`
+                                    'Output: {0}', formatTokenCount(tokenUsage.outputTokens))}`
                             : undefined;
                         if (agentDescription || tokenInfo) {
                             const md = new MarkdownStringImpl();
@@ -745,7 +745,7 @@ const WidgetContainer: React.FC<WidgetContainerProps> = ({ widget }) => {
     return <div ref={containerRef} />;
 };
 
-const ChatRequestRender = (
+export const ChatRequestRender = (
     {
         node, hoverService, chatAgentService, variableService, openerService,
         provideChatInputWidget
@@ -877,7 +877,10 @@ const ChatRequestRender = (
                                 .replace(/^[\r\n]+|[\r\n]+$/g, '') // remove excessive new lines
                                 .replace(/(^ )/g, '&nbsp;'), // enforce keeping space before
                             openerService,
-                            true
+                            true,
+                            undefined,
+                            // User requests are authored by the user, so their resources are trusted and rendered directly.
+                            false
                         );
                         return (
                             <span key={index} ref={ref}></span>

--- a/packages/ai-chat-ui/src/browser/chat-view-preferences.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-preferences.ts
@@ -21,6 +21,7 @@ import { interfaces } from '@theia/core/shared/inversify';
 export const CHAT_VIEW_TOKEN_USAGE_ENABLED = 'ai-features.chat.tokenUsageIndicator.enabled';
 export const CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED = 'ai-features.chat.tokenUsageWarning.enabled';
 export const CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE = 'ai-features.chat.tokenUsageWarning.defaultThresholdPercentage';
+export const CHAT_VIEW_ALLOWED_RESOURCE_URLS = 'ai-features.chat.allowedResourceUrls';
 
 export const CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE_DEFAULT = 80;
 
@@ -58,6 +59,20 @@ export const chatViewPreferenceSchema: PreferenceSchema = {
                 'Currently resolves against an assumed 200k context window; will use the real per-model context size once available.'
             ),
             tags: ['experimental']
+        },
+        [CHAT_VIEW_ALLOWED_RESOURCE_URLS]: {
+            type: 'array',
+            items: {
+                type: 'string'
+            },
+            default: [],
+            description: nls.localize(
+                'theia/ai/chat-ui/allowedResourceUrls',
+                'External resources (images, stylesheets, media, etc.) referenced in AI chat responses are blocked by default and ' +
+                'replaced with a placeholder until explicitly allowed. Resources whose URL starts with one of the configured prefixes ' +
+                'are rendered directly without being blocked. Include the full origin with a trailing slash (e.g. "https://example.com/") ' +
+                'to avoid unintended matches. Only add sources you fully trust.'
+            )
         }
     }
 };
@@ -66,6 +81,7 @@ export interface ChatViewConfiguration {
     [CHAT_VIEW_TOKEN_USAGE_ENABLED]: boolean;
     [CHAT_VIEW_TOKEN_USAGE_WARNING_ENABLED]: boolean;
     [CHAT_VIEW_TOKEN_USAGE_WARNING_THRESHOLD_PERCENTAGE]: number;
+    [CHAT_VIEW_ALLOWED_RESOURCE_URLS]: string[];
 }
 
 export const ChatViewPreferenceContribution = Symbol('ChatViewPreferenceContribution');

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1564,6 +1564,76 @@ div:last-child>.theia-ChatNode {
   color: var(--theia-button-foreground, #fff);
 }
 
+.theia-blocked-resource-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  gap: calc(var(--theia-ui-padding) / 2);
+  max-width: 100%;
+}
+
+.theia-blocked-resource {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--theia-ui-padding);
+  max-width: 100%;
+  box-sizing: border-box;
+  padding: calc(var(--theia-ui-padding) * 2 / 3) var(--theia-ui-padding);
+  border: var(--theia-border-width) solid var(--theia-input-border, var(--theia-sideBarSectionHeader-border));
+  border-radius: 4px;
+  background-color: var(--theia-editorWidget-background);
+  color: var(--theia-foreground);
+  vertical-align: middle;
+}
+
+.theia-blocked-resource-icon {
+  flex: 0 0 auto;
+  color: var(--theia-editorWarning-foreground);
+}
+
+.theia-blocked-resource-label {
+  min-width: 0;
+}
+
+.theia-blocked-resource-details {
+  min-width: 0;
+  color: var(--theia-descriptionForeground);
+}
+
+.theia-blocked-resource-details summary {
+  cursor: pointer;
+}
+
+.theia-blocked-resource-details ul {
+  margin: 2px 0 0 0;
+  padding-left: 16px;
+}
+
+.theia-blocked-resource-details li {
+  word-break: break-all;
+}
+
+.theia-blocked-resource-url {
+
+  color: var(--theia-descriptionForeground);
+  word-break: break-all;
+}
+
+.theia-blocked-resource-allow {
+  flex: 0 0 auto;
+  padding: 2px calc(var(--theia-ui-padding) * 2);
+  border: none;
+  border-radius: 3px;
+  background-color: var(--theia-button-secondaryBackground);
+  color: var(--theia-button-secondaryForeground);
+  cursor: pointer;
+  font-family: var(--theia-ui-font-family);
+  font-size: var(--theia-ui-font-size1);
+}
+
+.theia-blocked-resource-allow:hover {
+  background-color: var(--theia-button-secondaryHoverBackground);
+}
+
 /* Unknown content styles */
 .theia-chat-unknown-content {
   margin: 4px 0;

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1693,6 +1693,76 @@ details.theia-tool-confirmation-args>summary::marker {
   color: var(--theia-button-foreground, #fff);
 }
 
+.theia-blocked-resource-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  gap: calc(var(--theia-ui-padding) / 2);
+  max-width: 100%;
+}
+
+.theia-blocked-resource {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--theia-ui-padding);
+  max-width: 100%;
+  box-sizing: border-box;
+  padding: calc(var(--theia-ui-padding) * 2 / 3) var(--theia-ui-padding);
+  border: var(--theia-border-width) solid var(--theia-input-border, var(--theia-sideBarSectionHeader-border));
+  border-radius: 4px;
+  background-color: var(--theia-editorWidget-background);
+  color: var(--theia-foreground);
+  vertical-align: middle;
+}
+
+.theia-blocked-resource-icon {
+  flex: 0 0 auto;
+  color: var(--theia-editorWarning-foreground);
+}
+
+.theia-blocked-resource-label {
+  min-width: 0;
+}
+
+.theia-blocked-resource-details {
+  min-width: 0;
+  color: var(--theia-descriptionForeground);
+}
+
+.theia-blocked-resource-details summary {
+  cursor: pointer;
+}
+
+.theia-blocked-resource-details ul {
+  margin: 2px 0 0 0;
+  padding-left: 16px;
+}
+
+.theia-blocked-resource-details li {
+  word-break: break-all;
+}
+
+.theia-blocked-resource-url {
+
+  color: var(--theia-descriptionForeground);
+  word-break: break-all;
+}
+
+.theia-blocked-resource-allow {
+  flex: 0 0 auto;
+  padding: 2px calc(var(--theia-ui-padding) * 2);
+  border: none;
+  border-radius: 3px;
+  background-color: var(--theia-button-secondaryBackground);
+  color: var(--theia-button-secondaryForeground);
+  cursor: pointer;
+  font-family: var(--theia-ui-font-family);
+  font-size: var(--theia-ui-font-size1);
+}
+
+.theia-blocked-resource-allow:hover {
+  background-color: var(--theia-button-secondaryHoverBackground);
+}
+
 /* Unknown content styles */
 .theia-chat-unknown-content {
   margin: 4px 0;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Prevent AI chat markdown from automatically loading external resources by sanitizing rendered markdown into an inert template and replacing resource loads with an explicit blocked-resource placeholder before mounting.

The placeholder is rendered via React, shows the blocked URL, lists all resources that will be enabled for multi-resource content, and requires the user to explicitly allow the blocked content before it is restored.

Also cover images, srcset, media, iframes, SVG resource references, object/embed content, and CSS resource URLs, while preserving data URLs and existing opener handling for links.

Fixes #17392 

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
