### PR TITLE
fix: improve chat session card UI and provider error presentation in chat UI 

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-navigation-service.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-navigation-service.ts
@@ -80,8 +80,8 @@ export class AIChatNavigationService {
         this.onDidChangeEmitter.fire();
     }
 
-    /** Called by ChatViewWidget when a query is submitted on an empty (welcome screen) session. */
-    notifyQueryFromWelcomeScreen(sessionId: string): void {
+    /** Updates navigation history when the initial query creates a concrete chat session. */
+    notifyInitialQuery(sessionId: string): void {
         if (this.isNavigating) { return; }
         if (this.canGoBack && !this.canGoForward) {
             // Welcome was pushed forward via '+' from an existing session — it is acting as a

--- a/packages/ai-chat-ui/src/browser/chat-focus-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-focus-contribution.ts
@@ -77,26 +77,6 @@ export class ChatFocusContribution implements CommandContribution, KeybindingCon
     }
 
     protected findActiveChatViewWidget(): ChatViewWidget | undefined {
-        const activeWidget = this.shell.activeWidget;
-        if (activeWidget instanceof ChatViewWidget) {
-            return activeWidget;
-        }
-        // Also check if any part of the chat view has focus
-        const activeElement = document.activeElement;
-        if (activeElement instanceof HTMLElement) {
-            const widget = this.shell.findWidgetForElement(activeElement);
-            if (widget instanceof ChatViewWidget) {
-                return widget;
-            }
-            // Check parent widgets (e.g., when input widget has focus)
-            let parent = widget?.parent;
-            while (parent) {
-                if (parent instanceof ChatViewWidget) {
-                    return parent;
-                }
-                parent = parent.parent;
-            }
-        }
-        return undefined;
+        return ChatViewWidget.findActive(this.shell);
     }
 }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/error-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/error-part-renderer.tsx
@@ -16,7 +16,8 @@
 
 import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
 import { injectable } from '@theia/core/shared/inversify';
-import { ChatResponseContent, ErrorChatResponseContent } from '@theia/ai-chat/lib/common';
+import { ChatResponseContent, ErrorChatResponseContent, formatProviderError } from '@theia/ai-chat/lib/common';
+import { nls } from '@theia/core/lib/common/nls';
 import { ReactNode } from '@theia/core/shared/react';
 import * as React from '@theia/core/shared/react';
 
@@ -29,7 +30,24 @@ export class ErrorPartRenderer implements ChatResponsePartRenderer<ErrorChatResp
         return -1;
     }
     render(response: ErrorChatResponseContent): ReactNode {
-        return <div className='theia-ChatPart-Error'><span className='codicon codicon-error' /><span>{response.error.message}</span></div>;
+        const formattedError = formatProviderError(response.error.message);
+        const prefix = formattedError.status
+            ? `${nls.localizeByDefault('Error')} ${formattedError.status}:`
+            : `${nls.localizeByDefault('Error')}:`;
+        return (
+            <div className='theia-ChatPart-Error'>
+                <div className='theia-ChatPart-Error-headline'>
+                    <div className='theia-ChatPart-Error-prefix'><span className='codicon codicon-error' />{prefix}</div>
+                    <div className='theia-ChatPart-Error-message'>{formattedError.message}</div>
+                </div>
+                {formattedError.details && (
+                    <details>
+                        <summary>{nls.localizeByDefault('Details')}</summary>
+                        <pre>{formattedError.details}</pre>
+                    </details>
+                )}
+            </div>
+        );
     }
 
 }

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -16,7 +16,7 @@
 import { CommandService, ContributionProvider, deepClone, Emitter, Event, MessageService, URI } from '@theia/core';
 import { ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings, isActiveSessionChangedEvent, MutableChatModel } from '@theia/ai-chat';
 import { GenericCapabilitySelections, AIVariableResolutionRequest } from '@theia/ai-core';
-import { BaseWidget, codicon, ExtractableWidget, Message, PanelLayout, StatefulWidget } from '@theia/core/lib/browser';
+import { ApplicationShell, BaseWidget, codicon, ExtractableWidget, Message, PanelLayout, StatefulWidget } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { AIChatInputWidget } from './chat-input-widget';
@@ -246,7 +246,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         if (chatRequest.text.length === 0) { return; }
 
         if (this.chatSession.model.isEmpty()) {
-            this.navigationService.notifyQueryFromWelcomeScreen(this.chatSession.id);
+            this.navigationService.notifyInitialQuery(this.chatSession.id);
         }
 
         // Include all variables (context + pending image attachments) in the request
@@ -331,5 +331,33 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
 
     getSettings(): ChatSessionSettings | undefined {
         return this.chatSession.model.settings;
+    }
+}
+
+export namespace ChatViewWidget {
+    /**
+     * Returns the active `ChatViewWidget` if the shell's active widget is one,
+     * or if focus is inside one of its child widgets (e.g. the input or tree).
+     */
+    export function findActive(shell: ApplicationShell): ChatViewWidget | undefined {
+        const activeWidget = shell.activeWidget;
+        if (activeWidget instanceof ChatViewWidget) {
+            return activeWidget;
+        }
+        const activeElement = document.activeElement;
+        if (activeElement instanceof HTMLElement) {
+            const widget = shell.findWidgetForElement(activeElement);
+            if (widget instanceof ChatViewWidget) {
+                return widget;
+            }
+            let parent = widget?.parent;
+            while (parent) {
+                if (parent instanceof ChatViewWidget) {
+                    return parent;
+                }
+                parent = parent.parent;
+            }
+        }
+        return undefined;
     }
 }

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -14,7 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { CommandService, ContributionProvider, deepClone, Emitter, Event, MessageService, URI } from '@theia/core';
-import { ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings, isActiveSessionChangedEvent, MutableChatModel } from '@theia/ai-chat';
+import {
+    ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings,
+    formatProviderError, formattedProviderErrorToShortString, isActiveSessionChangedEvent, MutableChatModel
+} from '@theia/ai-chat';
 import { GenericCapabilitySelections, AIVariableResolutionRequest } from '@theia/ai-core';
 import { ApplicationShell, BaseWidget, codicon, ExtractableWidget, Message, PanelLayout, StatefulWidget } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
@@ -264,8 +267,14 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         }
         requestProgress?.responseCompleted.then(responseModel => {
             if (responseModel.isError) {
-                this.messageService.error(responseModel.errorObject?.message ??
-                    nls.localize('theia/ai/chat-ui/errorChatInvocation', 'An error occurred during chat service invocation.'));
+                const rawError = responseModel.errorObject?.message;
+                const message = rawError
+                    ? nls.localize('theia/ai/chat-ui/chatRequestFailedWithDetail',
+                        'Chat request failed: {0}',
+                        formattedProviderErrorToShortString(formatProviderError(rawError)))
+                    : nls.localize('theia/ai/chat-ui/errorChatInvocation',
+                        'An error occurred during chat service invocation.');
+                this.messageService.error(message);
             }
         }).finally(() => {
             this.inputWidget.pinnedAgent = this.chatSession.pinnedAgent;

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -14,7 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { CommandService, ContributionProvider, deepClone, Emitter, Event, MessageService, URI } from '@theia/core';
-import { ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings, isActiveSessionChangedEvent, MutableChatModel } from '@theia/ai-chat';
+import {
+    ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings,
+    formatProviderError, formattedProviderErrorToShortString, isActiveSessionChangedEvent, MutableChatModel
+} from '@theia/ai-chat';
 import { GenericCapabilitySelections, AIVariableResolutionRequest } from '@theia/ai-core';
 import { BaseWidget, codicon, ExtractableWidget, Message, PanelLayout, StatefulWidget } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
@@ -264,8 +267,14 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         }
         requestProgress?.responseCompleted.then(responseModel => {
             if (responseModel.isError) {
-                this.messageService.error(responseModel.errorObject?.message ??
-                    nls.localize('theia/ai/chat-ui/errorChatInvocation', 'An error occurred during chat service invocation.'));
+                const rawError = responseModel.errorObject?.message;
+                const message = rawError
+                    ? nls.localize('theia/ai/chat-ui/chatRequestFailedWithDetail',
+                        'Chat request failed: {0}',
+                        formattedProviderErrorToShortString(formatProviderError(rawError)))
+                    : nls.localize('theia/ai/chat-ui/errorChatInvocation',
+                        'An error occurred during chat service invocation.');
+                this.messageService.error(message);
             }
         }).finally(() => {
             this.inputWidget.pinnedAgent = this.chatSession.pinnedAgent;

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -246,7 +246,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         if (chatRequest.text.length === 0) { return; }
 
         if (this.chatSession.model.isEmpty()) {
-            this.navigationService.notifyQueryFromWelcomeScreen(this.chatSession.id);
+            this.navigationService.notifyInitialQuery(this.chatSession.id);
         }
 
         // Include all variables (context + pending image attachments) in the request

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1243,10 +1243,40 @@ details.theia-tool-confirmation-args>summary::marker {
 }
 
 .theia-ChatPart-Error {
-  display: flex;
-  flex-direction: row;
-  gap: 0.5em;
+  margin-block: 1em;
+}
+
+.theia-ChatPart-Error-headline {
   color: var(--theia-errorForeground);
+  display: flex;
+  flex-direction: column;
+  row-gap: var(--theia-ui-padding);
+}
+
+.theia-ChatPart-Error-prefix {
+  font-weight: bold;
+  display: flex;
+  align-items: center;
+  gap: var(--theia-ui-padding);
+}
+
+.theia-ChatPart-Error details {
+  margin-top: var(--theia-ui-padding);
+  color: var(--theia-descriptionForeground);
+}
+
+.theia-ChatPart-Error details summary::marker {
+  color: var(--theia-button-background);
+}
+
+.theia-ChatPart-Error details pre {
+  cursor: text;
+  line-height: 1rem;
+  margin: 0;
+  padding: 6px;
+  background-color: var(--theia-editor-background);
+  overflow: auto;
+  text-wrap: auto;
 }
 
 .section-header {

--- a/packages/ai-chat/src/browser/chat-session-store-impl.ts
+++ b/packages/ai-chat/src/browser/chat-session-store-impl.ts
@@ -95,9 +95,14 @@ export class ChatSessionStoreImpl implements ChatSessionStore {
             }
             this.logger.debug('Starting to store sessions', { totalSessions: sessions.length, storageRoot: root.toString() });
 
-            // Normalize to SessionWithTitle and filter empty sessions
+            // Normalize to SessionWithTitle and filter empty sessions.
+            // Use the lastInteraction timestamp when available so that the
+            // displayed "time ago" reflects the last user activity, not the
+            // last auto-save.
             const nonEmptySessions = sessions
-                .map(s => this.isChatModelWithMetadata(s) ? { ...s, saveDate: Date.now() } : { model: s, saveDate: Date.now() })
+                .map(s => this.isChatModelWithMetadata(s)
+                    ? { ...s, saveDate: s.lastInteraction ?? Date.now() }
+                    : { model: s, saveDate: Date.now() })
                 .filter(s => !s.model.isEmpty());
             this.logger.debug('Filtered empty sessions', { nonEmptySessions: nonEmptySessions.length });
 

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -455,9 +455,11 @@ export class ChatServiceImpl implements ChatService {
             return Promise.resolve();
         }
 
-        // Store session with title, pinned agent info, and last interaction timestamp
+        // Store session with title, pinned agent info, last interaction timestamp, and error state
+        const lastRequest = session.model.getRequests().at(-1);
+        const hasError = lastRequest?.response.isComplete === true && lastRequest?.response.isError === true;
         return this.sessionStore.storeSessions(
-            { model: session.model, title: session.title, pinnedAgentId: session.pinnedAgent?.id, lastInteraction: session.lastInteraction?.getTime() }
+            { model: session.model, title: session.title, pinnedAgentId: session.pinnedAgent?.id, lastInteraction: session.lastInteraction?.getTime(), hasError }
         ).catch(error => {
             this.logger.error('Failed to store chat sessions', error);
         });

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -455,9 +455,9 @@ export class ChatServiceImpl implements ChatService {
             return Promise.resolve();
         }
 
-        // Store session with title and pinned agent info
+        // Store session with title, pinned agent info, and last interaction timestamp
         return this.sessionStore.storeSessions(
-            { model: session.model, title: session.title, pinnedAgentId: session.pinnedAgent?.id }
+            { model: session.model, title: session.title, pinnedAgentId: session.pinnedAgent?.id, lastInteraction: session.lastInteraction?.getTime() }
         ).catch(error => {
             this.logger.error('Failed to store chat sessions', error);
         });

--- a/packages/ai-chat/src/common/chat-session-store.ts
+++ b/packages/ai-chat/src/common/chat-session-store.ts
@@ -26,6 +26,8 @@ export interface ChatModelWithMetadata {
     pinnedAgentId?: string;
     /** Timestamp (ms since epoch) of the last user interaction. Used as the display date for session cards. */
     lastInteraction?: number;
+    /** Whether the last request ended with an error. */
+    hasError?: boolean;
 }
 
 export interface ChatSessionStore {
@@ -69,4 +71,8 @@ export interface ChatSessionMetadata {
     title: string;
     saveDate: number;
     location: ChatAgentLocation;
+    /** ID of the agent pinned to the session (used for icon and display name on cards). */
+    pinnedAgentId?: string;
+    /** Whether the last request ended with an error. */
+    hasError?: boolean;
 }

--- a/packages/ai-chat/src/common/chat-session-store.ts
+++ b/packages/ai-chat/src/common/chat-session-store.ts
@@ -24,6 +24,8 @@ export interface ChatModelWithMetadata {
     model: ChatModel;
     title?: string;
     pinnedAgentId?: string;
+    /** Timestamp (ms since epoch) of the last user interaction. Used as the display date for session cards. */
+    lastInteraction?: number;
 }
 
 export interface ChatSessionStore {

--- a/packages/ai-chat/src/common/index.ts
+++ b/packages/ai-chat/src/common/index.ts
@@ -28,3 +28,4 @@ export * from './parsed-chat-request';
 export * from './context-variables';
 export * from './chat-tool-request-service';
 export * from './chat-tool-confirmation-timeout';
+export * from './provider-error-formatter';

--- a/packages/ai-chat/src/common/provider-error-formatter.spec.ts
+++ b/packages/ai-chat/src/common/provider-error-formatter.spec.ts
@@ -1,0 +1,190 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { formatProviderError, formattedProviderErrorToShortString } from './provider-error-formatter';
+
+describe('formatProviderError', () => {
+
+    it('should handle undefined input', () => {
+        const result = formatProviderError(undefined);
+        expect(result.message).to.equal('');
+        expect(result.status).to.be.undefined;
+        expect(result.details).to.be.undefined;
+        expect(result.raw).to.equal('');
+    });
+
+    it('should handle empty string input', () => {
+        const result = formatProviderError('');
+        expect(result.message).to.equal('');
+        expect(result.status).to.be.undefined;
+        expect(result.details).to.be.undefined;
+        expect(result.raw).to.equal('');
+    });
+
+    it('should handle plain text error without JSON', () => {
+        const result = formatProviderError('Something went wrong');
+        expect(result.message).to.equal('Something went wrong');
+        expect(result.status).to.be.undefined;
+        expect(result.details).to.be.undefined;
+        expect(result.raw).to.equal('Something went wrong');
+    });
+
+    it('should extract HTTP status from leading prefix', () => {
+        const raw = '401 {"error":{"message":"Invalid API key","type":"auth_error"}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('401');
+        expect(result.message).to.equal('Invalid API key');
+        expect(result.details).to.be.a('string');
+        expect(result.raw).to.equal(raw);
+    });
+
+    it('should extract status from JSON code field when no leading prefix', () => {
+        const raw = '{"error":{"message":"Permission denied","code":403}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('403');
+        expect(result.message).to.equal('Permission denied');
+    });
+
+    it('should extract status from JSON status field', () => {
+        const raw = '{"error":{"message":"Not found","status":404}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('404');
+        expect(result.message).to.equal('Not found');
+    });
+
+    it('should prefer leading HTTP status over JSON code field', () => {
+        const raw = '500 {"error":{"message":"Server error","code":503}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('500');
+        expect(result.message).to.equal('Server error');
+    });
+
+    it('should extract the deepest message from nested JSON', () => {
+        const raw = '400 {"error":{"message":"Top level","details":{"message":"Deeper reason"}}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('400');
+        expect(result.message).to.equal('Deeper reason');
+    });
+
+    it('should handle Gemini-style errors with JSON-encoded inner body', () => {
+        const inner = JSON.stringify({ error: { message: 'API key not valid', status: 'INVALID_ARGUMENT' } });
+        const raw = `{"error":{"message":${JSON.stringify(inner)},"code":400}}`;
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('400');
+        expect(result.message).to.equal('API key not valid');
+    });
+
+    it('should fall back to remainder when JSON has no message field', () => {
+        const raw = '429 {"error":{"type":"rate_limit"}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('429');
+        expect(result.message).to.equal('{"error":{"type":"rate_limit"}}');
+    });
+
+    it('should not treat a leading 3-digit prefix as a status when no JSON body follows', () => {
+        // Avoid misreading arbitrary text that happens to start with 3 digits.
+        const raw = '404 routes were processed';
+        const result = formatProviderError(raw);
+        expect(result.status).to.be.undefined;
+        expect(result.message).to.equal('404 routes were processed');
+        expect(result.details).to.be.undefined;
+    });
+
+    it('should produce unwrapped details for nested JSON strings', () => {
+        const inner = JSON.stringify({ reason: 'quota exceeded' });
+        const raw = `{"error":{"message":"Rate limited","body":${JSON.stringify(inner)}}}`;
+        const result = formatProviderError(raw);
+        expect(result.details).to.be.a('string');
+        // The details should contain the unwrapped inner object, not the escaped JSON string
+        const parsed = JSON.parse(result.details!);
+        expect(parsed.error.body).to.deep.equal({ reason: 'quota exceeded' });
+    });
+
+    it('should not treat a message that looks like JSON as the headline', () => {
+        const raw = '{"error":{"message":"{\\"key\\":\\"value\\"}","code":400}}';
+        const result = formatProviderError(raw);
+        // The JSON-like message should be skipped; headline falls back to remainder
+        expect(result.message).to.equal('{"error":{"message":"{\\"key\\":\\"value\\"}","code":400}}');
+    });
+
+    it('should handle leading status with colon separator', () => {
+        const raw = '401: {"error":{"message":"Unauthorized"}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('401');
+        expect(result.message).to.equal('Unauthorized');
+    });
+
+    it('should extract message from an array of errors', () => {
+        const raw = '{"errors":[{"message":"Rate limit exceeded","code":429}]}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('429');
+        expect(result.message).to.equal('Rate limit exceeded');
+    });
+
+    it('should ignore non-3-digit numeric codes', () => {
+        const raw = '{"error":{"message":"Something broke","code":42}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.be.undefined;
+        expect(result.message).to.equal('Something broke');
+    });
+
+    it('should ignore non-numeric status strings', () => {
+        const raw = '{"error":{"message":"Invalid key","status":"INVALID_ARGUMENT"}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.be.undefined;
+        expect(result.message).to.equal('Invalid key');
+    });
+
+    it('should find JSON preceded by non-JSON text', () => {
+        const raw = 'Error occurred: {"error":{"message":"connection refused"}}';
+        const result = formatProviderError(raw);
+        expect(result.message).to.equal('connection refused');
+        expect(result.details).to.be.a('string');
+    });
+
+    it('should handle whitespace-only input', () => {
+        const result = formatProviderError('   ');
+        expect(result.message).to.equal('   ');
+        expect(result.status).to.be.undefined;
+    });
+
+    it('should walk into a top-level JSON array', () => {
+        const raw = '[{"error":{"message":"first"}},{"error":{"message":"second"}}]';
+        const result = formatProviderError(raw);
+        // walk visits in order, last message wins
+        expect(result.message).to.equal('second');
+    });
+
+    it('should extract 3-digit status from a longer string value', () => {
+        const raw = '{"error":{"message":"Too many requests","status":"429 RESOURCE_EXHAUSTED"}}';
+        const result = formatProviderError(raw);
+        expect(result.status).to.equal('429');
+    });
+});
+
+describe('formattedProviderErrorToShortString', () => {
+
+    it('should include status when present', () => {
+        const result = formattedProviderErrorToShortString({ status: '401', message: 'Invalid API key', raw: '' });
+        expect(result).to.equal('401: Invalid API key');
+    });
+
+    it('should return only headline when no status', () => {
+        const result = formattedProviderErrorToShortString({ message: 'Something went wrong', raw: '' });
+        expect(result).to.equal('Something went wrong');
+    });
+});

--- a/packages/ai-chat/src/common/provider-error-formatter.ts
+++ b/packages/ai-chat/src/common/provider-error-formatter.ts
@@ -1,0 +1,110 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Structured form of a provider error string. Provider errors look something
+ * like `<httpStatus> <jsonBody>` (Anthropic, OpenAI) or `<jsonBody>` (Gemini).
+ * This helper makes a best-effort guess: walk the JSON, grab the deepest
+ * `message` string and the first 3-digit `code`/`status` field.
+ */
+export interface FormattedProviderError {
+    status?: string;
+    message: string;
+    details?: string;
+    raw: string;
+}
+
+export function formatProviderError(raw: string | undefined): FormattedProviderError {
+    const safeRaw = (raw ?? '').toString();
+    const trimmed = safeRaw.trim();
+    if (!trimmed) { return { message: safeRaw, raw: safeRaw }; }
+
+    // Optional leading HTTP status followed by a JSON body, e.g. "401 {...}".
+    // The JSON-body anchor avoids misreading arbitrary text that happens to
+    // start with 3 digits (e.g. "404 routes were processed") as a status.
+    // Real provider errors (Anthropic, OpenAI) always carry a JSON body here.
+    const match = trimmed.match(/^(\d{3})\b[\s:-]*(?=[{[])/);
+    const remainder = match ? trimmed.slice(match[0].length).trim() : trimmed;
+
+    const body = parseJson(remainder);
+    if (!body || typeof body !== 'object') {
+        return { status: match?.[1], message: remainder || safeRaw, raw: safeRaw };
+    }
+
+    let message: string | undefined;
+    let code: string | undefined;
+    const walk = (node: unknown): void => {
+        if (typeof node === 'string') {
+            const inner = parseJson(node);
+            if (inner && typeof inner === 'object') { walk(inner); }
+            return;
+        }
+        if (!node || typeof node !== 'object') { return; }
+        for (const [k, v] of Object.entries(node)) {
+            if (k === 'message' && typeof v === 'string' && !looksLikeJson(v)) {
+                message = v;
+            } else if (!code && (k === 'code' || k === 'status')) {
+                code = asStatus(v);
+            }
+            walk(v);
+        }
+    };
+    walk(body);
+
+    return {
+        status: match?.[1] ?? code,
+        message: message ?? remainder,
+        details: stringifyUnwrapped(body),
+        raw: safeRaw
+    };
+}
+
+/** Compact one-liner suitable for notification toasts. */
+export function formattedProviderErrorToShortString(e: FormattedProviderError): string {
+    return e.status ? `${e.status}: ${e.message}` : e.message;
+}
+
+function parseJson(text: string): unknown {
+    const start = text.search(/[{[]/);
+    if (start < 0) { return undefined; }
+    try { return JSON.parse(text.slice(start)); } catch { return undefined; }
+}
+
+function looksLikeJson(text: string): boolean {
+    const t = text.trimStart();
+    return t.startsWith('{') || t.startsWith('[');
+}
+
+function asStatus(value: unknown): string | undefined {
+    if (typeof value === 'number' && Number.isInteger(value)) {
+        const s = String(value);
+        return /^\d{3}$/.test(s) ? s : undefined;
+    }
+    return typeof value === 'string' ? value.match(/^(\d{3})\b/)?.[1] : undefined;
+}
+
+/** Pretty-print JSON, transparently parsing any string field that itself contains JSON. */
+function stringifyUnwrapped(value: unknown): string | undefined {
+    try {
+        return JSON.stringify(value, (_, v) => {
+            if (typeof v === 'string' && looksLikeJson(v)) {
+                const inner = parseJson(v);
+                if (inner && typeof inner === 'object') { return inner; }
+            }
+            return v;
+        }, 2);
+    } catch { return undefined; }
+}

--- a/packages/ai-editor/src/browser/ai-editor-command-contribution.ts
+++ b/packages/ai-editor/src/browser/ai-editor-command-contribution.ts
@@ -23,6 +23,7 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { EditorContextMenu, EditorWidget } from '@theia/editor/lib/browser';
 import { MonacoCommandRegistry, MonacoEditorCommandHandler } from '@theia/monaco/lib/browser/monaco-command-registry';
 import { MonacoEditor } from '@theia/monaco/lib/browser/monaco-editor';
+import { AIChatNavigationService } from '@theia/ai-chat-ui/lib/browser/ai-chat-navigation-service';
 import { AskAIInputMonacoZoneWidget } from './ask-ai-input-monaco-zone-widget';
 import { AskAIInputFactory } from './ask-ai-input-widget';
 
@@ -55,6 +56,9 @@ export class AiEditorCommandContribution implements CommandContribution, MenuCon
 
     @inject(ApplicationShell)
     protected readonly shell: ApplicationShell;
+
+    @inject(AIChatNavigationService)
+    protected readonly navigationService: AIChatNavigationService;
 
     protected askAiInputWidget: AskAIInputMonacoZoneWidget | undefined;
 
@@ -120,6 +124,7 @@ export class AiEditorCommandContribution implements CommandContribution, MenuCon
 
     private createNewChatSession(request: ChatRequest): void {
         const session = this.chatService.createSession(ChatAgentLocation.Panel, { focus: true });
+        this.navigationService.notifyInitialQuery(session.id);
         this.chatService.sendRequest(session.id, {
             ...request,
             text: `${request.text} #editorContext`,

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
@@ -1,0 +1,186 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+import { expect } from 'chai';
+import { Emitter } from '@theia/core';
+import { ChatService, ChatSession } from '@theia/ai-chat';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { ApplicationShell, Widget } from '@theia/core/lib/browser';
+import { ChatSessionsWelcomeMessageProvider } from './chat-sessions-welcome-message-provider';
+disableJSDOM();
+
+/**
+ * Subclass that exposes the protected watch hook and lets tests inject fake services.
+ * We don't go through inversify here because the only behaviour under test is the
+ * unread bookkeeping; spinning up the full container would pull in unrelated
+ * services and obscure the assertion.
+ */
+class TestableProvider extends ChatSessionsWelcomeMessageProvider {
+    constructor(chatService: ChatService, shell: ApplicationShell) {
+        super();
+        (this as unknown as { chatService: ChatService }).chatService = chatService;
+        (this as unknown as { shell: ApplicationShell }).shell = shell;
+    }
+
+    watch(session: ChatSession): void {
+        this.watchSession(session);
+    }
+}
+
+interface RequestStub {
+    response: { isComplete: boolean };
+}
+
+function createFakeSession(id: string): {
+    session: ChatSession;
+    fire: () => void;
+    pushRequest: (complete: boolean) => void;
+} {
+    const requests: RequestStub[] = [];
+    const onDidChangeEmitter = new Emitter<unknown>();
+    const session = {
+        id,
+        isActive: false,
+        model: {
+            getRequests: () => requests,
+            onDidChange: onDidChangeEmitter.event,
+        }
+    } as unknown as ChatSession;
+    return {
+        session,
+        fire: () => onDidChangeEmitter.fire(undefined),
+        pushRequest: complete => requests.push({ response: { isComplete: complete } })
+    };
+}
+
+describe('ChatSessionsWelcomeMessageProvider unread state', () => {
+    let activeSessionId: string | undefined;
+    let activeWidget: unknown;
+    let widgetForActiveElement: Widget | undefined;
+    let chatService: ChatService;
+    let shell: ApplicationShell;
+    let chatViewWidget: ChatViewWidget;
+    let otherWidget: object;
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+    after(() => {
+        disableJSDOM();
+    });
+
+    beforeEach(() => {
+        activeSessionId = undefined;
+        chatViewWidget = Object.create(ChatViewWidget.prototype) as ChatViewWidget;
+        otherWidget = {};
+        activeWidget = undefined;
+        widgetForActiveElement = undefined;
+        // ChatViewWidget.findActive consults document.activeElement. Provide an HTMLElement
+        // so the lookup path through shell.findWidgetForElement is exercised.
+        const focusTarget = document.createElement('div');
+        document.body.appendChild(focusTarget);
+        focusTarget.tabIndex = -1;
+        focusTarget.focus();
+        chatService = {
+            getActiveSession: () => activeSessionId ? { id: activeSessionId } as ChatSession : undefined,
+        } as unknown as ChatService;
+        shell = {
+            get activeWidget(): unknown {
+                return activeWidget;
+            },
+            findWidgetForElement: () => widgetForActiveElement
+        } as unknown as ApplicationShell;
+    });
+
+    it('marks the session unread when a new request arrives and the chat view is not focused', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = 's1';
+        activeWidget = otherWidget;
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(true);
+    });
+
+    it('does not mark unread when the session is active AND the chat view is focused', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = 's1';
+        activeWidget = chatViewWidget;
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(false);
+    });
+
+    it('does not mark unread when focus is inside a child widget of the chat view', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = 's1';
+        // Simulate focus inside a descendant (e.g. AIChatInputWidget): the shell's
+        // activeWidget is the inner widget, but its parent chain leads to ChatViewWidget.
+        const childWidget = { parent: chatViewWidget } as unknown as Widget;
+        activeWidget = childWidget;
+        widgetForActiveElement = childWidget;
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(false);
+    });
+
+    it('marks unread when the session is not the active one, even if the chat view is focused', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = 'other';
+        activeWidget = chatViewWidget;
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(true);
+    });
+
+    it('fires onUnreadChanged once when a session transitions to unread', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = undefined;
+        activeWidget = otherWidget;
+
+        let fired = 0;
+        provider.onUnreadChanged(() => { fired++; });
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(true);
+        expect(fired).to.equal(1);
+    });
+});

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
@@ -1,0 +1,160 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+import { expect } from 'chai';
+import { Emitter } from '@theia/core';
+import { ChatService, ChatSession } from '@theia/ai-chat';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { ApplicationShell } from '@theia/core/lib/browser';
+import { ChatSessionsWelcomeMessageProvider } from './chat-sessions-welcome-message-provider';
+disableJSDOM();
+
+/**
+ * Subclass that exposes the protected watch hook and lets tests inject fake services.
+ * We don't go through inversify here because the only behaviour under test is the
+ * unread bookkeeping; spinning up the full container would pull in unrelated
+ * services and obscure the assertion.
+ */
+class TestableProvider extends ChatSessionsWelcomeMessageProvider {
+    constructor(chatService: ChatService, shell: ApplicationShell) {
+        super();
+        (this as unknown as { chatService: ChatService }).chatService = chatService;
+        (this as unknown as { shell: ApplicationShell }).shell = shell;
+    }
+
+    watch(session: ChatSession): void {
+        this.watchSession(session);
+    }
+}
+
+interface RequestStub {
+    response: { isComplete: boolean };
+}
+
+function createFakeSession(id: string): {
+    session: ChatSession;
+    fire: () => void;
+    pushRequest: (complete: boolean) => void;
+} {
+    const requests: RequestStub[] = [];
+    const onDidChangeEmitter = new Emitter<unknown>();
+    const session = {
+        id,
+        isActive: false,
+        model: {
+            getRequests: () => requests,
+            onDidChange: onDidChangeEmitter.event,
+        }
+    } as unknown as ChatSession;
+    return {
+        session,
+        fire: () => onDidChangeEmitter.fire(undefined),
+        pushRequest: complete => requests.push({ response: { isComplete: complete } })
+    };
+}
+
+describe('ChatSessionsWelcomeMessageProvider unread state', () => {
+    let activeSessionId: string | undefined;
+    let activeWidget: unknown;
+    let chatService: ChatService;
+    let shell: ApplicationShell;
+    let chatViewWidget: ChatViewWidget;
+    let otherWidget: object;
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+    after(() => {
+        disableJSDOM();
+    });
+
+    beforeEach(() => {
+        activeSessionId = undefined;
+        chatViewWidget = Object.create(ChatViewWidget.prototype) as ChatViewWidget;
+        otherWidget = {};
+        activeWidget = undefined;
+        chatService = {
+            getActiveSession: () => activeSessionId ? { id: activeSessionId } as ChatSession : undefined,
+        } as unknown as ChatService;
+        shell = {
+            get activeWidget(): unknown {
+                return activeWidget;
+            }
+        } as unknown as ApplicationShell;
+    });
+
+    it('marks the session unread when a new request arrives and the chat view is not focused', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = 's1';
+        activeWidget = otherWidget;
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(true);
+    });
+
+    it('does not mark unread when the session is active AND the chat view is focused', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = 's1';
+        activeWidget = chatViewWidget;
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(false);
+    });
+
+    it('marks unread when the session is not the active one, even if the chat view is focused', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = 'other';
+        activeWidget = chatViewWidget;
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(true);
+    });
+
+    it('fires onUnreadChanged once when a session transitions to unread', () => {
+        const provider = new TestableProvider(chatService, shell);
+        const { session, fire, pushRequest } = createFakeSession('s1');
+        activeSessionId = undefined;
+        activeWidget = otherWidget;
+
+        let fired = 0;
+        provider.onUnreadChanged(() => { fired++; });
+
+        provider.watch(session);
+        pushRequest(true);
+        fire();
+        pushRequest(true);
+        fire();
+
+        expect(provider.isUnread('s1')).to.equal(true);
+        expect(fired).to.equal(1);
+    });
+});

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -16,19 +16,37 @@
 
 import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
-import { ChatAgentService, ChatRequestModel, ChatService, ChatSession, ChatSessionMetadata } from '@theia/ai-chat';
+import {
+    ChatAgentService, ChatRequestModel, ChatResponseContent, ChatService, ChatSession, ChatSessionMetadata,
+    ThinkingChatResponseContent
+} from '@theia/ai-chat';
 import { BYPASS_MODEL_REQUIREMENT_PREF, PERSISTED_SESSION_LIMIT_PREF, SESSION_STORAGE_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
 import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
 import { ChatSessionCardActionContribution } from './chat-session-card-action-contribution';
 import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
 import { CommandRegistry, ContributionProvider, DisposableCollection, Emitter, Event, PreferenceService } from '@theia/core';
-import { Card, CardActionButton, codicon, HoverService, buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
+import { ApplicationShell, Card, CardActionButton, codicon, HoverService, buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 
 const TOOLTIP_SNIPPET_MAX_LENGTH = 1000;
+
+/** Collect display text from response content, excluding thinking parts. */
+function responseToTooltipString(content: ChatResponseContent[]): string {
+    return content
+        .filter(c => !ThinkingChatResponseContent.is(c))
+        .map(c => {
+            if (ChatResponseContent.hasAsString(c)) {
+                return c.asString();
+            }
+            return undefined;
+        })
+        .filter((text): text is string => text !== undefined && text !== '')
+        .join('\n\n');
+}
 
 /** Minimal view of the unread state that React components can subscribe to. */
 interface UnreadStateProvider {
@@ -259,15 +277,17 @@ function buildSessionTooltip(
         let messageText: string | undefined;
 
         if (lastResponse.isComplete && !lastResponse.isError) {
-            // Show the agent's response text (already markdown)
-            messageText = lastResponse.response.asString() || undefined;
+            // Show the agent's response text, excluding thinking content
+            messageText = responseToTooltipString(lastResponse.response.content) || undefined;
         } else if (!lastResponse.isComplete) {
             // Request is still pending / no response yet — show the user's request text
             messageText = lastRequest.request.text || undefined;
         } else {
             // Failure response — find the most recent successful exchange
             const lastSuccessfulRequest = requests.findLast(r => r.response.isComplete && !r.response.isError);
-            messageText = lastSuccessfulRequest?.response.response.asString() || undefined;
+            messageText = lastSuccessfulRequest
+                ? (responseToTooltipString(lastSuccessfulRequest.response.response.content) || undefined)
+                : undefined;
         }
 
         if (messageText) {
@@ -349,6 +369,9 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     @inject(FrontendLanguageModelRegistry)
     protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
 
     protected _inputEnabled = false;
 
@@ -474,7 +497,18 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         session.model.onDidChange(() => {
             const current = session.model.getRequests();
             if (current.length > state.seenRequests || this.countCompleted(current) > state.seenCompleted) {
-                if (!state.unread) {
+                // Only silently update the seen counts (instead of flashing the unread badge)
+                // when the user is actually looking at this session: it must be the active
+                // session AND the chat view must currently be the focused widget. Otherwise,
+                // the user may have switched away (e.g. to the editor) while the chat agent
+                // is still running, and we want the badge to appear so they notice the new
+                // response when they return.
+                const activeSession = this.chatService.getActiveSession();
+                const chatViewFocused = ChatViewWidget.findActive(this.shell) !== undefined;
+                if (chatViewFocused && activeSession && activeSession.id === session.id) {
+                    state.seenRequests = current.length;
+                    state.seenCompleted = this.countCompleted(current);
+                } else if (!state.unread) {
                     state.unread = true;
                     this.onUnreadChangedEmitter.fire(session.id);
                 }

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -175,13 +175,29 @@ function ChatSessionCard(
 
     const timeAgo = useTimeAgo(session.saveDate);
     const [isWorking, setIsWorking] = React.useState(false);
+    const [hasError, setHasError] = React.useState(session.hasError === true);
     const hasUnread = useUnreadMessages(session.sessionId, unreadState);
+
+    // Sync error state from metadata when it changes after initial render
+    React.useEffect(() => {
+        setHasError(session.hasError === true);
+    }, [session.hasError]);
+
+    // Resolve the agent for icon and display name
+    const agent = session.pinnedAgentId ? chatAgentService.getAgent(session.pinnedAgentId) : undefined;
+    const agentIcon = agent?.iconClass ?? codicon('comment-discussion');
+    const subtitle = agent ? `@${agent.name} \u00b7 ${timeAgo}` : timeAgo;
 
     React.useEffect(() => {
         const trash = new DisposableCollection();
 
         const attach = (s: ChatSession) => {
-            const recompute = () => setIsWorking(s.model.getRequests().some(ChatRequestModel.isInProgress));
+            const recompute = () => {
+                const requests = s.model.getRequests();
+                setIsWorking(requests.some(ChatRequestModel.isInProgress));
+                const lastReq = requests.at(-1);
+                setHasError(lastReq?.response.isComplete === true && lastReq?.response.isError === true);
+            };
             recompute();
             s.model.onDidChange(recompute, undefined, trash);
         };
@@ -217,9 +233,9 @@ function ChatSessionCard(
         }
         if (!hoverActiveRef.current || !chatSession) { return; }
 
-        const content = buildSessionTooltip(chatSession, session, chatAgentService, markdownRenderer, hasUnread);
+        const content = buildSessionTooltip(chatSession, session, chatAgentService, markdownRenderer, hasUnread, isWorking, hasError);
         hoverService.requestHover({ content, target, position: 'left' });
-    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread]);
+    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread, isWorking, hasError]);
     React.useEffect(() => () => { hoverActiveRef.current = false; }, []); // Block mouseEnter proceeding on unmount
 
     const handleMouseLeave = React.useCallback(() => {
@@ -236,20 +252,26 @@ function ChatSessionCard(
         }
     }, [hoverService]);
 
+    const wrapperClass = [
+        'theia-chat-session-card-wrapper',
+        isWorking && 'theia-chat-session-card-working',
+        hasError && !isWorking && 'theia-chat-session-card-error'
+    ].filter(Boolean).join(' ');
+
     return (
         <div ref={wrapperRef}
-            className={`theia-chat-session-card-wrapper${isWorking ? ' theia-chat-session-card-working' : ''}`}
+            className={wrapperClass}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             onMouseOver={handleMouseOver}>
             <Card
-                icon={isWorking ? `${codicon('loading')} theia-animation-spin` : codicon('comment-discussion')}
+                icon={isWorking ? `${codicon('loading')} theia-animation-spin` : agentIcon}
                 title={session.title || nls.localizeByDefault('Untitled Chat')}
-                subtitle={timeAgo}
+                subtitle={subtitle}
                 actionButtons={actionButtons}
                 onClick={onClick}
             />
-            {hasUnread && !isWorking && <div className="theia-chat-session-badge-unread" />}
+            {hasUnread && !isWorking && !hasError && <div className="theia-chat-session-badge-unread" />}
         </div>
     );
 }
@@ -257,7 +279,7 @@ function ChatSessionCard(
 function buildSessionTooltip(
     session: ChatSession, metadata: ChatSessionMetadata,
     agentService: ChatAgentService, markdownRenderer: MarkdownRenderer,
-    isUnread: boolean
+    isUnread: boolean, isRunning: boolean, hasError: boolean
 ): HTMLElement {
     const requests = session.model.getRequests();
     const lastRequest = requests.at(-1);
@@ -265,7 +287,17 @@ function buildSessionTooltip(
     const container = document.createElement('div');
     container.className = 'theia-chat-session-tooltip';
 
-    if (isUnread) {
+    if (isRunning) {
+        const badge = document.createElement('div');
+        badge.className = 'theia-chat-session-badge-running-tooltip';
+        badge.textContent = nls.localizeByDefault('Running');
+        container.appendChild(badge);
+    } else if (hasError) {
+        const badge = document.createElement('div');
+        badge.className = 'theia-chat-session-badge-error-tooltip';
+        badge.textContent = nls.localizeByDefault('Error');
+        container.appendChild(badge);
+    } else if (isUnread) {
         const badge = document.createElement('div');
         badge.className = 'theia-chat-session-badge-unread-tooltip';
         badge.textContent = nls.localize('theia/ai/ide/tooltip/unread', 'Unread');
@@ -274,21 +306,9 @@ function buildSessionTooltip(
 
     if (lastRequest) {
         const lastResponse = lastRequest.response;
-        let messageText: string | undefined;
-
-        if (lastResponse.isComplete && !lastResponse.isError) {
-            // Show the agent's response text, excluding thinking content
-            messageText = responseToTooltipString(lastResponse.response.content) || undefined;
-        } else if (!lastResponse.isComplete) {
-            // Request is still pending / no response yet — show the user's request text
-            messageText = lastRequest.request.text || undefined;
-        } else {
-            // Failure response — find the most recent successful exchange
-            const lastSuccessfulRequest = requests.findLast(r => r.response.isComplete && !r.response.isError);
-            messageText = lastSuccessfulRequest
-                ? (responseToTooltipString(lastSuccessfulRequest.response.response.content) || undefined)
-                : undefined;
-        }
+        const messageText = lastResponse.isComplete
+            ? (responseToTooltipString(lastResponse.response.content) || undefined)
+            : (lastRequest.request.text || undefined);
 
         if (messageText) {
             const snippet = messageText.length > TOOLTIP_SNIPPET_MAX_LENGTH

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -18,7 +18,7 @@ import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-t
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
 import {
     ChatAgentService, ChatRequestModel, ChatResponseContent, ChatService, ChatSession, ChatSessionMetadata,
-    ThinkingChatResponseContent
+    ErrorChatResponseContent, FormattedProviderError, formatProviderError, ThinkingChatResponseContent
 } from '@theia/ai-chat';
 import { BYPASS_MODEL_REQUIREMENT_PREF, PERSISTED_SESSION_LIMIT_PREF, SESSION_STORAGE_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
 import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
@@ -33,20 +33,6 @@ import { inject, injectable, named, postConstruct } from '@theia/core/shared/inv
 import * as React from '@theia/core/shared/react';
 
 const TOOLTIP_SNIPPET_MAX_LENGTH = 1000;
-
-/** Collect display text from response content, excluding thinking parts. */
-function responseToTooltipString(content: ChatResponseContent[]): string {
-    return content
-        .filter(c => !ThinkingChatResponseContent.is(c))
-        .map(c => {
-            if (ChatResponseContent.hasAsString(c)) {
-                return c.asString();
-            }
-            return undefined;
-        })
-        .filter((text): text is string => text !== undefined && text !== '')
-        .join('\n\n');
-}
 
 /** Minimal view of the unread state that React components can subscribe to. */
 interface UnreadStateProvider {
@@ -153,6 +139,50 @@ function useTimeAgo(date: number): string {
     }, [date]);
 
     return formatTimeAgo(date);
+}
+
+/** Read an error message from a completed-with-error response, if any. */
+function getResponseErrorMessage(response: ChatRequestModel['response']): string | undefined {
+    if (response.errorObject?.message) {
+        return response.errorObject.message;
+    }
+    const errorPart = response.response.content.find(ErrorChatResponseContent.is);
+    return errorPart?.asDisplayString?.();
+}
+
+/**
+ * Build a DOM fragment that renders a {@link FormattedProviderError} for the tooltip.
+ * Details are intentionally omitted — the hover popup is not interactive, so a
+ * <details> expander wouldn't work. The full payload is available in the chat output.
+ */
+function renderFormattedProviderError(error: FormattedProviderError): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'theia-chat-session-tooltip-error';
+    const prefix = document.createElement('span');
+    prefix.className = 'theia-chat-session-tooltip-error-prefix';
+    prefix.textContent = error.status
+        ? `${nls.localizeByDefault('Error')} ${error.status}:`
+        : `${nls.localizeByDefault('Error')}:`;
+    wrapper.appendChild(prefix);
+    const headline = error.message.length > TOOLTIP_SNIPPET_MAX_LENGTH
+        ? error.message.substring(0, TOOLTIP_SNIPPET_MAX_LENGTH) + '\u2026'
+        : error.message;
+    wrapper.appendChild(document.createTextNode(' ' + headline));
+    return wrapper;
+}
+
+/** Collect display text from response content, excluding thinking parts. */
+function responseToTooltipString(content: ChatResponseContent[]): string {
+    return content
+        .filter(c => !ThinkingChatResponseContent.is(c))
+        .map(c => {
+            if (ChatResponseContent.hasAsString(c)) {
+                return c.asString();
+            }
+            return undefined;
+        })
+        .filter((text): text is string => text !== undefined && text !== '')
+        .join('\n\n');
 }
 
 interface ChatSessionCardProps {
@@ -306,26 +336,39 @@ function buildSessionTooltip(
 
     if (lastRequest) {
         const lastResponse = lastRequest.response;
-        const messageText = lastResponse.isComplete
-            ? (responseToTooltipString(lastResponse.response.content) || undefined)
-            : (lastRequest.request.text || undefined);
+        const errorText = hasError ? getResponseErrorMessage(lastResponse) : undefined;
 
-        if (messageText) {
-            const snippet = messageText.length > TOOLTIP_SNIPPET_MAX_LENGTH
-                ? messageText.substring(0, TOOLTIP_SNIPPET_MAX_LENGTH) + '\u2026'
-                : messageText;
+        if (errorText) {
             const label = document.createElement('div');
             label.className = 'theia-chat-session-tooltip-label';
-            label.textContent = nls.localize('theia/ai/ide/tooltip/lastMessage', 'Last message');
+            label.textContent = nls.localize('theia/ai/ide/tooltip/errorMessage', 'Error message');
             container.appendChild(label);
-
-            const snippetEl = document.createElement('div');
-            snippetEl.className = 'theia-chat-session-tooltip-snippet';
-            snippetEl.appendChild(markdownRenderer.render({ value: snippet }).element);
-            container.appendChild(snippetEl);
+            container.appendChild(renderFormattedProviderError(formatProviderError(errorText)));
 
             const hr = document.createElement('hr');
             container.appendChild(hr);
+        } else {
+            const messageText = lastResponse.isComplete
+                ? (responseToTooltipString(lastResponse.response.content) || undefined)
+                : (lastRequest.request.text || undefined);
+
+            if (messageText) {
+                const snippet = messageText.length > TOOLTIP_SNIPPET_MAX_LENGTH
+                    ? messageText.substring(0, TOOLTIP_SNIPPET_MAX_LENGTH) + '\u2026'
+                    : messageText;
+                const label = document.createElement('div');
+                label.className = 'theia-chat-session-tooltip-label';
+                label.textContent = nls.localize('theia/ai/ide/tooltip/lastMessage', 'Last message');
+                container.appendChild(label);
+
+                const snippetEl = document.createElement('div');
+                snippetEl.className = 'theia-chat-session-tooltip-snippet';
+                snippetEl.appendChild(markdownRenderer.render({ value: snippet }).element);
+                container.appendChild(snippetEl);
+
+                const hr = document.createElement('hr');
+                container.appendChild(hr);
+            }
         }
     }
 

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -18,7 +18,7 @@ import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-t
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
 import {
     ChatAgentService, ChatRequestModel, ChatResponseContent, ChatService, ChatSession, ChatSessionMetadata,
-    ThinkingChatResponseContent
+    ErrorChatResponseContent, FormattedProviderError, formatProviderError, ThinkingChatResponseContent
 } from '@theia/ai-chat';
 import { BYPASS_MODEL_REQUIREMENT_PREF, PERSISTED_SESSION_LIMIT_PREF, SESSION_STORAGE_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
 import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
@@ -33,20 +33,6 @@ import { inject, injectable, named, postConstruct } from '@theia/core/shared/inv
 import * as React from '@theia/core/shared/react';
 
 const TOOLTIP_SNIPPET_MAX_LENGTH = 1000;
-
-/** Collect display text from response content, excluding thinking parts. */
-function responseToTooltipString(content: ChatResponseContent[]): string {
-    return content
-        .filter(c => !ThinkingChatResponseContent.is(c))
-        .map(c => {
-            if (ChatResponseContent.hasAsString(c)) {
-                return c.asString();
-            }
-            return undefined;
-        })
-        .filter((text): text is string => text !== undefined && text !== '')
-        .join('\n\n');
-}
 
 /** Minimal view of the unread state that React components can subscribe to. */
 interface UnreadStateProvider {
@@ -153,6 +139,50 @@ function useTimeAgo(date: number): string {
     }, [date]);
 
     return formatTimeAgo(date);
+}
+
+/** Read an error message from a completed-with-error response, if any. */
+function getResponseErrorMessage(response: ChatRequestModel['response']): string | undefined {
+    if (response.errorObject?.message) {
+        return response.errorObject.message;
+    }
+    const errorPart = response.response.content.find(ErrorChatResponseContent.is);
+    return errorPart?.asDisplayString?.();
+}
+
+/**
+ * Build a DOM fragment that renders a {@link FormattedProviderError} for the tooltip.
+ * Details are intentionally omitted — the hover popup is not interactive, so a
+ * <details> expander wouldn't work. The full payload is available in the chat output.
+ */
+function renderFormattedProviderError(error: FormattedProviderError): HTMLElement {
+    const wrapper = document.createElement('div');
+    wrapper.className = 'theia-chat-session-tooltip-error';
+    const prefix = document.createElement('span');
+    prefix.className = 'theia-chat-session-tooltip-error-prefix';
+    prefix.textContent = error.status
+        ? `${nls.localizeByDefault('Error')} ${error.status}:`
+        : `${nls.localizeByDefault('Error')}:`;
+    wrapper.appendChild(prefix);
+    const headline = error.message.length > TOOLTIP_SNIPPET_MAX_LENGTH
+        ? error.message.substring(0, TOOLTIP_SNIPPET_MAX_LENGTH) + '\u2026'
+        : error.message;
+    wrapper.appendChild(document.createTextNode(' ' + headline));
+    return wrapper;
+}
+
+/** Collect display text from response content, excluding thinking parts. */
+function responseToTooltipString(content: ChatResponseContent[]): string {
+    return content
+        .filter(c => !ThinkingChatResponseContent.is(c))
+        .map(c => {
+            if (ChatResponseContent.hasAsString(c)) {
+                return c.asString();
+            }
+            return undefined;
+        })
+        .filter((text): text is string => text !== undefined && text !== '')
+        .join('\n\n');
 }
 
 interface ChatSessionCardProps {
@@ -308,26 +338,39 @@ function buildSessionTooltip(
 
     if (lastRequest) {
         const lastResponse = lastRequest.response;
-        const messageText = lastResponse.isComplete
-            ? (responseToTooltipString(lastResponse.response.content) || undefined)
-            : (lastRequest.request.text || undefined);
+        const errorText = hasError ? getResponseErrorMessage(lastResponse) : undefined;
 
-        if (messageText) {
-            const snippet = messageText.length > TOOLTIP_SNIPPET_MAX_LENGTH
-                ? messageText.substring(0, TOOLTIP_SNIPPET_MAX_LENGTH) + '\u2026'
-                : messageText;
+        if (errorText) {
             const label = document.createElement('div');
             label.className = 'theia-chat-session-tooltip-label';
-            label.textContent = nls.localize('theia/ai/ide/tooltip/lastMessage', 'Last message');
+            label.textContent = nls.localize('theia/ai/ide/tooltip/errorMessage', 'Error message');
             container.appendChild(label);
-
-            const snippetEl = document.createElement('div');
-            snippetEl.className = 'theia-chat-session-tooltip-snippet';
-            snippetEl.appendChild(markdownRenderer.render({ value: snippet }).element);
-            container.appendChild(snippetEl);
+            container.appendChild(renderFormattedProviderError(formatProviderError(errorText)));
 
             const hr = document.createElement('hr');
             container.appendChild(hr);
+        } else {
+            const messageText = lastResponse.isComplete
+                ? (responseToTooltipString(lastResponse.response.content) || undefined)
+                : (lastRequest.request.text || undefined);
+
+            if (messageText) {
+                const snippet = messageText.length > TOOLTIP_SNIPPET_MAX_LENGTH
+                    ? messageText.substring(0, TOOLTIP_SNIPPET_MAX_LENGTH) + '\u2026'
+                    : messageText;
+                const label = document.createElement('div');
+                label.className = 'theia-chat-session-tooltip-label';
+                label.textContent = nls.localize('theia/ai/ide/tooltip/lastMessage', 'Last message');
+                container.appendChild(label);
+
+                const snippetEl = document.createElement('div');
+                snippetEl.className = 'theia-chat-session-tooltip-snippet';
+                snippetEl.appendChild(markdownRenderer.render({ value: snippet }).element);
+                container.appendChild(snippetEl);
+
+                const hr = document.createElement('hr');
+                container.appendChild(hr);
+            }
         }
     }
 

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -175,13 +175,31 @@ function ChatSessionCard(
 
     const timeAgo = useTimeAgo(session.saveDate);
     const [isWorking, setIsWorking] = React.useState(false);
+    const [hasError, setHasError] = React.useState(session.hasError === true);
     const hasUnread = useUnreadMessages(session.sessionId, unreadState);
+
+    // Sync error state from metadata when it arrives after initial render
+    React.useEffect(() => {
+        if (session.hasError) {
+            setHasError(true);
+        }
+    }, [session.hasError]);
+
+    // Resolve the agent for icon and display name
+    const agent = session.pinnedAgentId ? chatAgentService.getAgent(session.pinnedAgentId) : undefined;
+    const agentIcon = agent?.iconClass ?? codicon('comment-discussion');
+    const subtitle = agent ? `@${agent.name} \u00b7 ${timeAgo}` : timeAgo;
 
     React.useEffect(() => {
         const trash = new DisposableCollection();
 
         const attach = (s: ChatSession) => {
-            const recompute = () => setIsWorking(s.model.getRequests().some(ChatRequestModel.isInProgress));
+            const recompute = () => {
+                const requests = s.model.getRequests();
+                setIsWorking(requests.some(ChatRequestModel.isInProgress));
+                const lastReq = requests.at(-1);
+                setHasError(lastReq?.response.isComplete === true && lastReq?.response.isError === true);
+            };
             recompute();
             s.model.onDidChange(recompute, undefined, trash);
         };
@@ -217,9 +235,9 @@ function ChatSessionCard(
         }
         if (!hoverActiveRef.current || !chatSession) { return; }
 
-        const content = buildSessionTooltip(chatSession, session, chatAgentService, markdownRenderer, hasUnread);
+        const content = buildSessionTooltip(chatSession, session, chatAgentService, markdownRenderer, hasUnread, isWorking, hasError);
         hoverService.requestHover({ content, target, position: 'left' });
-    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread]);
+    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread, isWorking, hasError]);
     React.useEffect(() => () => { hoverActiveRef.current = false; }, []); // Block mouseEnter proceeding on unmount
 
     const handleMouseLeave = React.useCallback(() => {
@@ -236,20 +254,26 @@ function ChatSessionCard(
         }
     }, [hoverService]);
 
+    const wrapperClass = [
+        'theia-chat-session-card-wrapper',
+        isWorking && 'theia-chat-session-card-working',
+        hasError && !isWorking && 'theia-chat-session-card-error'
+    ].filter(Boolean).join(' ');
+
     return (
         <div ref={wrapperRef}
-            className={`theia-chat-session-card-wrapper${isWorking ? ' theia-chat-session-card-working' : ''}`}
+            className={wrapperClass}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             onMouseOver={handleMouseOver}>
             <Card
-                icon={isWorking ? `${codicon('loading')} theia-animation-spin` : codicon('comment-discussion')}
+                icon={isWorking ? `${codicon('loading')} theia-animation-spin` : agentIcon}
                 title={session.title || nls.localizeByDefault('Untitled Chat')}
-                subtitle={timeAgo}
+                subtitle={subtitle}
                 actionButtons={actionButtons}
                 onClick={onClick}
             />
-            {hasUnread && !isWorking && <div className="theia-chat-session-badge-unread" />}
+            {hasUnread && !isWorking && !hasError && <div className="theia-chat-session-badge-unread" />}
         </div>
     );
 }
@@ -257,7 +281,7 @@ function ChatSessionCard(
 function buildSessionTooltip(
     session: ChatSession, metadata: ChatSessionMetadata,
     agentService: ChatAgentService, markdownRenderer: MarkdownRenderer,
-    isUnread: boolean
+    isUnread: boolean, isRunning: boolean, hasError: boolean
 ): HTMLElement {
     const requests = session.model.getRequests();
     const lastRequest = requests.at(-1);
@@ -265,7 +289,17 @@ function buildSessionTooltip(
     const container = document.createElement('div');
     container.className = 'theia-chat-session-tooltip';
 
-    if (isUnread) {
+    if (isRunning) {
+        const badge = document.createElement('div');
+        badge.className = 'theia-chat-session-badge-running-tooltip';
+        badge.textContent = nls.localizeByDefault('Running');
+        container.appendChild(badge);
+    } else if (hasError) {
+        const badge = document.createElement('div');
+        badge.className = 'theia-chat-session-badge-error-tooltip';
+        badge.textContent = nls.localizeByDefault('Error');
+        container.appendChild(badge);
+    } else if (isUnread) {
         const badge = document.createElement('div');
         badge.className = 'theia-chat-session-badge-unread-tooltip';
         badge.textContent = nls.localize('theia/ai/ide/tooltip/unread', 'Unread');
@@ -274,21 +308,9 @@ function buildSessionTooltip(
 
     if (lastRequest) {
         const lastResponse = lastRequest.response;
-        let messageText: string | undefined;
-
-        if (lastResponse.isComplete && !lastResponse.isError) {
-            // Show the agent's response text, excluding thinking content
-            messageText = responseToTooltipString(lastResponse.response.content) || undefined;
-        } else if (!lastResponse.isComplete) {
-            // Request is still pending / no response yet — show the user's request text
-            messageText = lastRequest.request.text || undefined;
-        } else {
-            // Failure response — find the most recent successful exchange
-            const lastSuccessfulRequest = requests.findLast(r => r.response.isComplete && !r.response.isError);
-            messageText = lastSuccessfulRequest
-                ? (responseToTooltipString(lastSuccessfulRequest.response.response.content) || undefined)
-                : undefined;
-        }
+        const messageText = lastResponse.isComplete
+            ? (responseToTooltipString(lastResponse.response.content) || undefined)
+            : (lastRequest.request.text || undefined);
 
         if (messageText) {
             const snippet = messageText.length > TOOLTIP_SNIPPET_MAX_LENGTH

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -16,19 +16,37 @@
 
 import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
-import { ChatAgentService, ChatRequestModel, ChatService, ChatSession, ChatSessionMetadata } from '@theia/ai-chat';
+import {
+    ChatAgentService, ChatRequestModel, ChatResponseContent, ChatService, ChatSession, ChatSessionMetadata,
+    ThinkingChatResponseContent
+} from '@theia/ai-chat';
 import { BYPASS_MODEL_REQUIREMENT_PREF, PERSISTED_SESSION_LIMIT_PREF, SESSION_STORAGE_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
 import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
 import { ChatSessionCardActionContribution } from './chat-session-card-action-contribution';
 import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
 import { CommandRegistry, ContributionProvider, DisposableCollection, Emitter, Event, PreferenceService } from '@theia/core';
-import { Card, CardActionButton, codicon, HoverService, buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
+import { ApplicationShell, Card, CardActionButton, codicon, HoverService, buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 
 const TOOLTIP_SNIPPET_MAX_LENGTH = 1000;
+
+/** Collect display text from response content, excluding thinking parts. */
+function responseToTooltipString(content: ChatResponseContent[]): string {
+    return content
+        .filter(c => !ThinkingChatResponseContent.is(c))
+        .map(c => {
+            if (ChatResponseContent.hasAsString(c)) {
+                return c.asString();
+            }
+            return undefined;
+        })
+        .filter((text): text is string => text !== undefined && text !== '')
+        .join('\n\n');
+}
 
 /** Minimal view of the unread state that React components can subscribe to. */
 interface UnreadStateProvider {
@@ -259,15 +277,17 @@ function buildSessionTooltip(
         let messageText: string | undefined;
 
         if (lastResponse.isComplete && !lastResponse.isError) {
-            // Show the agent's response text (already markdown)
-            messageText = lastResponse.response.asString() || undefined;
+            // Show the agent's response text, excluding thinking content
+            messageText = responseToTooltipString(lastResponse.response.content) || undefined;
         } else if (!lastResponse.isComplete) {
             // Request is still pending / no response yet — show the user's request text
             messageText = lastRequest.request.text || undefined;
         } else {
             // Failure response — find the most recent successful exchange
             const lastSuccessfulRequest = requests.findLast(r => r.response.isComplete && !r.response.isError);
-            messageText = lastSuccessfulRequest?.response.response.asString() || undefined;
+            messageText = lastSuccessfulRequest
+                ? (responseToTooltipString(lastSuccessfulRequest.response.response.content) || undefined)
+                : undefined;
         }
 
         if (messageText) {
@@ -349,6 +369,9 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     @inject(FrontendLanguageModelRegistry)
     protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
 
     protected _inputEnabled = false;
 
@@ -474,7 +497,18 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         session.model.onDidChange(() => {
             const current = session.model.getRequests();
             if (current.length > state.seenRequests || this.countCompleted(current) > state.seenCompleted) {
-                if (!state.unread) {
+                // Only silently update the seen counts (instead of flashing the unread badge)
+                // when the user is actually looking at this session: it must be the active
+                // session AND the chat view must currently be the focused widget. Otherwise,
+                // the user may have switched away (e.g. to the editor) while the chat agent
+                // is still running, and we want the badge to appear so they notice the new
+                // response when they return.
+                const activeSession = this.chatService.getActiveSession();
+                const chatViewFocused = this.shell.activeWidget instanceof ChatViewWidget;
+                if (chatViewFocused && activeSession && activeSession.id === session.id) {
+                    state.seenRequests = current.length;
+                    state.seenCompleted = this.countCompleted(current);
+                } else if (!state.unread) {
                     state.unread = true;
                     this.onUnreadChangedEmitter.fire(session.id);
                 }

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1122,15 +1122,30 @@
   text-decoration: underline;
 }
 
-.theia-chat-session-badge-unread-tooltip {
+.theia-chat-session-badge-unread-tooltip,
+.theia-chat-session-badge-running-tooltip,
+.theia-chat-session-badge-error-tooltip {
   font-size: var(--theia-ui-font-size0);
   font-weight: 600;
-  color: var(--theia-activityBarBadge-foreground);
-  background-color: var(--theia-activityBarBadge-background);
   border-radius: calc(var(--theia-ui-padding) * 0.75);
   padding: 1px calc(var(--theia-ui-padding) * 0.75);
   display: inline-block;
   margin-bottom: var(--theia-ui-padding);
+}
+
+.theia-chat-session-badge-unread-tooltip {
+  color: var(--theia-activityBarBadge-foreground);
+  background-color: var(--theia-activityBarBadge-background);
+}
+
+.theia-chat-session-badge-running-tooltip {
+  color: var(--theia-activityBarBadge-foreground);
+  background-color: var(--theia-progressBar-background);
+}
+
+.theia-chat-session-badge-error-tooltip {
+  color: var(--theia-activityBarBadge-foreground);
+  background-color: var(--theia-errorForeground);
 }
 
 .theia-chat-session-tooltip-label {
@@ -1184,6 +1199,18 @@
   color: var(--theia-focusBorder);
 }
 
+.theia-chat-session-card-error .theia-Card-icon {
+  color: var(--theia-errorForeground);
+}
+
+.theia-chat-session-card-error .theia-Card-interactive:hover {
+  border-color: var(--theia-errorForeground);
+}
+
+.theia-chat-session-card-error .theia-Card-interactive:focus {
+  outline-color: var(--theia-errorForeground);
+}
+
 .theia-chat-session-badge-unread {
   position: absolute;
   top: calc(var(--theia-ui-padding) * 1.5);
@@ -1194,6 +1221,10 @@
   background-color: var(--theia-activityBarBadge-background);
   pointer-events: none;
   z-index: 1;
+}
+
+.theia-chat-session-card-error .theia-chat-session-badge-unread {
+  background-color: var(--theia-errorForeground);
 }
 
 /*

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1153,6 +1153,15 @@
   margin-bottom: calc(var(--theia-ui-padding) * 0.5);
 }
 
+.theia-chat-session-tooltip-error {
+  color: var(--theia-errorForeground);
+  word-break: break-word;
+}
+
+.theia-chat-session-tooltip-error-prefix {
+  font-weight: 600;
+}
+
 .theia-chat-session-tooltip-snippet h1,
 .theia-chat-session-tooltip-snippet h2,
 .theia-chat-session-tooltip-snippet h3,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17078

* fix: chat session card follow-ups 
  - Exclude thinking content from session card tooltips (was rendered
    as raw JSON overflowing the tooltip when thinking was enabled)
  - Clear unread state (blue dot) when response completes while the
    session is already being viewed
  - Add sessions started from the "Ask AI" editor widget to the chat
    navigation history so back/forward navigation works
  - Use last interaction timestamp as saveDate in updateIndex /
    SerializedChatData (chat-session-store-impl.ts), so saveDate and
    lastInteraction are the same and the displayed time reflects the
    last user activity rather than the last auto-save
  - Require the chat view to be the active widget (not just the
    session to be active) before silently clearing the unread badge
    on a new response. Otherwise, switching to the editor while the
    agent is still running would clear the badge for responses the
    user never saw. Add unit tests for the watch/unread logic.
* feat: improve chat session card UI 
   - Show the pinned agent's icon instead of the generic chat icon
   - Display agent name in card subtitle (`@coder . 2 hours ago`)
   - Add "Running" and "Error" status badges in session card tooltips
   - Show error indicator on cards (red icon tint, red hover border)
   - Persist hasError and pinnedAgentId in ChatSessionMetadata so
     card indicators work for cold sessions after reload
* feat(ai-chat): improve provider error presentation in chat UI 
   Provider errors (e.g. invalid API key responses from Anthropic, OpenAI,
Gemini) were shown verbatim as escaped JSON. Surface the meaningful
parts in a consistent way across chat output, session-card tooltip and
notification toast.
   - Add `formatProviderError` helper in `@theia/ai-chat`:
    - extract HTTP status from leading prefix or nested `code`/`status`
    - extract deepest readable `message`, recursing into JSON-encoded
      inner bodies (Gemini)
    - pretty-print details with nested JSON-strings unwrapped
  - `ErrorPartRenderer`: render `Error <code>: <message>` with a
    collapsible `Details` block styled like thinking/tool-call blocks
  - Session-card tooltip: surface the same `Error <code>: <message>` line
    when the last request ended with an error
  - Notification toast: use formatted headline instead of raw JSON
  - Add unit tests for provider-error-formatter

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Check the follow ups from the chat session UI in GH-17078 and check if they are resolved
- If a chat errors (e.g. if you enter an invalid API key), verify the error reporting is improved with this PR

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
