### PR TITLE
Add tabbed AI chat sessions with per-tab drafts

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-navigation-service.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-navigation-service.ts
@@ -41,7 +41,7 @@ export class AIChatNavigationService {
                 this.handleSessionDeleted(event.sessionId);
                 return;
             }
-            if (this.isNavigating) { return; }
+            if (this.isNavigating || (isActiveSessionChangedEvent(event) && event.skipNavigation)) { return; }
             if (isActiveSessionChangedEvent(event)) {
                 this.handleActiveChange(event.sessionId);
             }

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -721,6 +721,20 @@ export class AIChatInputWidget extends ReactWidget {
         this._initialValue = value;
     }
 
+    getInputValue(): string {
+        if (this.editorRef && !this.editorRef.document.isDisposed()) {
+            return this.editorRef.document.textEditorModel.getValue();
+        }
+        return this._initialValue ?? '';
+    }
+
+    setInputValue(value: string): void {
+        this._initialValue = value;
+        if (this.editorRef && !this.editorRef.document.isDisposed()) {
+            this.editorRef.document.textEditorModel.setValue(value);
+        }
+    }
+
     protected onDisposeForChatModel = new DisposableCollection();
     protected _chatModel: ChatModel;
 

--- a/packages/ai-chat-ui/src/browser/chat-session-input-drafts.ts
+++ b/packages/ai-chat-ui/src/browser/chat-session-input-drafts.ts
@@ -1,0 +1,31 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export class ChatSessionInputDrafts {
+    protected readonly drafts = new Map<string, string>();
+
+    get(sessionId: string): string {
+        return this.drafts.get(sessionId) ?? '';
+    }
+
+    set(sessionId: string, value: string): void {
+        this.drafts.set(sessionId, value);
+    }
+
+    delete(sessionId: string): void {
+        this.drafts.delete(sessionId);
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.spec.ts
@@ -1,0 +1,384 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import {
+    ActiveSessionChangedEvent,
+    ChatAgentLocation,
+    ChatRequest,
+    ChatRequestInvocation,
+    ChatService,
+    ChatSession,
+    MutableChatModel,
+    SessionCreatedEvent,
+    SessionDeletedEvent,
+    SessionRenamedEvent
+} from '@theia/ai-chat';
+import { Emitter, Event } from '@theia/core';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+import { ChatSessionInputDrafts } from './chat-session-input-drafts';
+
+let disableJSDOM: () => void = () => { };
+
+function enableChatWidgetJSDOM(): void {
+    disableJSDOM = enableJSDOM();
+    const testNavigator = globalThis.navigator ?? {};
+    Object.defineProperty(testNavigator, 'userAgent', {
+        value: globalThis.navigator?.userAgent ?? 'node',
+        configurable: true
+    });
+    Object.defineProperty(testNavigator, 'platform', {
+        value: globalThis.navigator?.platform ?? process.platform,
+        configurable: true
+    });
+    Object.defineProperty(globalThis, 'navigator', {
+        value: testNavigator,
+        configurable: true
+    });
+    if (globalThis.window) {
+        Object.defineProperty(globalThis.window, 'navigator', {
+            value: testNavigator,
+            configurable: true
+        });
+    }
+    Object.defineProperty(globalThis, 'Element', {
+        value: globalThis.window?.Element ?? class Element { },
+        configurable: true
+    });
+    Object.defineProperty(globalThis, 'HTMLElement', {
+        value: globalThis.window?.HTMLElement ?? class HTMLElement { },
+        configurable: true
+    });
+}
+
+type ChatViewWidgetConstructor = typeof import('./chat-view-widget').ChatViewWidget;
+type TestableChatViewWidget = InstanceType<ChatViewWidgetConstructor> & {
+    setCurrentSession(session: ChatSession): void;
+    openTab(session: ChatSession): void;
+    renderTabs(): void;
+    listen(): void;
+    showChatSession(session: ChatSession): void;
+    query(text: string): Promise<void>;
+    getDraft(sessionId: string): string;
+    getTabLabels(): string[];
+    getTabButtons(): HTMLButtonElement[];
+    getCloseButtons(): HTMLElement[];
+};
+let ChatViewWidget: ChatViewWidgetConstructor;
+
+type ChatSessionEvent = ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent;
+
+class TestChatService implements Partial<ChatService> {
+    protected readonly onSessionEventEmitter = new Emitter<ChatSessionEvent>();
+    readonly onSessionEvent = this.onSessionEventEmitter.event;
+    readonly sentRequests: Array<{ sessionId: string; request: ChatRequest }> = [];
+    activeSessionId: string | undefined;
+    activeSessionOptions: { focus?: boolean; skipNavigation?: boolean } | undefined;
+
+    constructor(protected readonly sessions: ChatSession[]) { }
+
+    getSessions(): ChatSession[] {
+        return [...this.sessions];
+    }
+
+    getSession(id: string): ChatSession | undefined {
+        return this.sessions.find(session => session.id === id);
+    }
+
+    setActiveSession(sessionId: string, options?: { focus?: boolean; skipNavigation?: boolean }): void {
+        this.activeSessionId = sessionId;
+        this.activeSessionOptions = options;
+        this.onSessionEventEmitter.fire({ type: 'activeChange', sessionId, ...options });
+    }
+
+    createSession(): ChatSession {
+        const session = createSession('created-session');
+        this.sessions.push(session);
+        return session;
+    }
+
+    async sendRequest(sessionId: string, request: ChatRequest): Promise<ChatRequestInvocation> {
+        this.sentRequests.push({ sessionId, request });
+        return {
+            requestCompleted: Promise.resolve(undefined as never),
+            responseCreated: Promise.resolve(undefined as never),
+            responseCompleted: Promise.resolve({ isError: false } as never)
+        };
+    }
+}
+
+class TestTreeWidget {
+    readonly node = document.createElement('div');
+    readonly onDidSubmitEdit: Event<ChatRequest> = Event.None;
+    trackedModel: MutableChatModel | undefined;
+
+    trackChatModel(model: MutableChatModel): void {
+        this.trackedModel = model;
+    }
+}
+
+class TestInputWidget {
+    readonly node = document.createElement('div');
+    value = '';
+    trackedModel: MutableChatModel | undefined;
+    pinnedAgent: ChatSession['pinnedAgent'];
+    clearPendingImageAttachmentsCalls = 0;
+
+    set chatModel(model: MutableChatModel) {
+        this.trackedModel = model;
+    }
+
+    getInputValue(): string {
+        return this.value;
+    }
+
+    setInputValue(value: string): void {
+        this.value = value;
+    }
+
+    getAllVariablesForRequest(): [] {
+        return [];
+    }
+
+    clearPendingImageAttachments(): void {
+        this.clearPendingImageAttachmentsCalls++;
+    }
+}
+
+function createSession(id: string, isUserVisible = true): ChatSession {
+    const model = new MutableChatModel(ChatAgentLocation.Panel);
+    return {
+        id,
+        model,
+        isActive: false,
+        isUserVisible
+    };
+}
+
+function createWidget(chatService: TestChatService, treeWidget = new TestTreeWidget(), inputWidget = new TestInputWidget()): TestableChatViewWidget {
+    class TestChatViewWidget extends ChatViewWidget {
+        constructor() {
+            super(treeWidget as never, inputWidget as never);
+            this.chatService = chatService as unknown as ChatService;
+            this.messageService = { error: () => undefined } as never;
+            Object.defineProperty(this, 'navigationService', {
+                value: { notifyQueryFromWelcomeScreen: () => undefined }
+            });
+        }
+
+        setCurrentSession(session: ChatSession): void {
+            this.chatSession = session;
+            this.openTabSessionIds.add(session.id);
+        }
+
+        openTab(session: ChatSession): void {
+            this.openTabSessionIds.add(session.id);
+        }
+
+        renderTabs(): void {
+            this.renderSessionTabs();
+        }
+
+        listen(): void {
+            this.initListeners();
+        }
+
+        showChatSession(session: ChatSession): void {
+            this.showSession(session);
+        }
+
+        async query(text: string): Promise<void> {
+            await this.onQuery(text);
+        }
+
+        getDraft(sessionId: string): string {
+            return this.sessionInputDrafts.get(sessionId);
+        }
+
+        getTabLabels(): string[] {
+            return Array.from(this.tabBarNode.querySelectorAll('.theia-AIChatTabLabel'))
+                .map(tab => tab.textContent ?? '');
+        }
+
+        getTabButtons(): HTMLButtonElement[] {
+            return Array.from(this.tabBarNode.querySelectorAll<HTMLButtonElement>('.theia-AIChatTab'));
+        }
+
+        getCloseButtons(): HTMLElement[] {
+            return Array.from(this.tabBarNode.querySelectorAll<HTMLElement>('.theia-AIChatTabClose'));
+        }
+    }
+    return new TestChatViewWidget();
+}
+
+describe('ChatSessionInputDrafts', () => {
+
+    it('keeps draft input local to each chat session', () => {
+        const drafts = new ChatSessionInputDrafts();
+
+        drafts.set('session-1', 'first draft');
+        drafts.set('session-2', 'second draft');
+
+        expect(drafts.get('session-1')).to.equal('first draft');
+        expect(drafts.get('session-2')).to.equal('second draft');
+    });
+
+    it('returns an empty draft for sessions without local input', () => {
+        const drafts = new ChatSessionInputDrafts();
+
+        expect(drafts.get('unknown-session')).to.equal('');
+    });
+
+    it('removes a session draft when the session is deleted', () => {
+        const drafts = new ChatSessionInputDrafts();
+
+        drafts.set('session-1', 'draft');
+        drafts.delete('session-1');
+
+        expect(drafts.get('session-1')).to.equal('');
+    });
+});
+
+describe('ChatViewWidget tabs', () => {
+
+    before(async () => {
+        try {
+            enableChatWidgetJSDOM();
+            ({ ChatViewWidget } = await import('./chat-view-widget'));
+        } catch (error) {
+            console.error('Failed to import ChatViewWidget in tests:', error);
+            throw error;
+        }
+    });
+
+    it('renders tabs for multiple user-visible panel sessions', () => {
+        const first = createSession('session-1');
+        const second = createSession('session-2');
+        first.title = 'First';
+        second.title = 'Second';
+        const widget = createWidget(new TestChatService([first, second]));
+        widget.setCurrentSession(first);
+        widget.openTab(second);
+
+        widget.renderTabs();
+
+        expect(widget.getTabLabels()).to.deep.equal(['First', 'Second']);
+    });
+
+    it('selecting a tab switches the tracked chat model', () => {
+        const first = createSession('session-1');
+        const second = createSession('session-2');
+        const chatService = new TestChatService([first, second]);
+        const treeWidget = new TestTreeWidget();
+        const widget = createWidget(chatService, treeWidget);
+        widget.setCurrentSession(first);
+        widget.openTab(second);
+        widget.listen();
+        widget.renderTabs();
+
+        widget.getTabButtons()[1].click();
+
+        expect(chatService.activeSessionId).to.equal(second.id);
+        expect(chatService.activeSessionOptions?.skipNavigation).to.equal(true);
+        expect(treeWidget.trackedModel).to.equal(second.model);
+    });
+
+    it('stores and restores draft input per session', () => {
+        const first = createSession('session-1');
+        const second = createSession('session-2');
+        const inputWidget = new TestInputWidget();
+        const widget = createWidget(new TestChatService([first, second]), new TestTreeWidget(), inputWidget);
+        widget.setCurrentSession(first);
+
+        inputWidget.value = 'first draft';
+        widget.showChatSession(second);
+        inputWidget.value = 'second draft';
+        widget.showChatSession(first);
+
+        expect(inputWidget.value).to.equal('first draft');
+        widget.showChatSession(second);
+        expect(inputWidget.value).to.equal('second draft');
+    });
+
+    it('submitting clears only the active session draft', async () => {
+        const first = createSession('session-1');
+        const second = createSession('session-2');
+        const inputWidget = new TestInputWidget();
+        const chatService = new TestChatService([first, second]);
+        const widget = createWidget(chatService, new TestTreeWidget(), inputWidget);
+        widget.setCurrentSession(first);
+
+        inputWidget.value = 'first draft';
+        widget.showChatSession(second);
+        inputWidget.value = 'second draft';
+
+        await widget.query('submitted prompt');
+
+        expect(widget.getDraft(second.id)).to.equal('');
+        widget.showChatSession(first);
+        expect(inputWidget.value).to.equal('first draft');
+        expect(chatService.sentRequests).to.have.lengthOf(1);
+        expect(chatService.sentRequests[0].sessionId).to.equal(second.id);
+    });
+
+    it('does not render tabs for internal delegated sessions', () => {
+        const visible = createSession('session-1');
+        const delegated = createSession('delegated-session', false);
+        visible.title = 'Visible';
+        delegated.title = 'Delegated';
+        const widget = createWidget(new TestChatService([visible, delegated]));
+        widget.setCurrentSession(visible);
+        widget.openTab(delegated);
+
+        widget.renderTabs();
+
+        expect(widget.getTabLabels()).to.deep.equal(['Visible']);
+    });
+
+    it('does not render tabs for sessions that were loaded but not opened as tabs', () => {
+        const current = createSession('current-session');
+        const previous = createSession('previous-session');
+        current.title = 'Current';
+        previous.title = 'Previous';
+        const widget = createWidget(new TestChatService([current, previous]));
+        widget.setCurrentSession(current);
+
+        widget.renderTabs();
+
+        expect(widget.getTabLabels()).to.deep.equal(['Current']);
+    });
+
+    it('closes a tab without deleting the chat session', () => {
+        const first = createSession('session-1');
+        const second = createSession('session-2');
+        first.title = 'First';
+        second.title = 'Second';
+        const chatService = new TestChatService([first, second]);
+        const widget = createWidget(chatService);
+        widget.setCurrentSession(first);
+        widget.openTab(second);
+        widget.renderTabs();
+
+        widget.getCloseButtons()[1].click();
+
+        expect(widget.getTabLabels()).to.deep.equal(['First']);
+        expect(chatService.getSession(second.id)).to.equal(second);
+    });
+});
+
+after(() => {
+    disableJSDOM();
+});

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { CommandService, ContributionProvider, deepClone, Emitter, Event, MessageService, URI } from '@theia/core';
-import { ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings, isActiveSessionChangedEvent, MutableChatModel } from '@theia/ai-chat';
+import { ChatAgentLocation, ChatRequest, ChatRequestModel, ChatService, ChatSession, ChatSessionSettings, isActiveSessionChangedEvent, MutableChatModel } from '@theia/ai-chat';
 import { GenericCapabilitySelections, AIVariableResolutionRequest } from '@theia/ai-core';
 import { BaseWidget, codicon, ExtractableWidget, Message, PanelLayout, StatefulWidget } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
@@ -26,6 +26,7 @@ import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory
 import { FrontendVariableService } from '@theia/ai-core/lib/browser';
 import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
 import { AIChatNavigationService } from './ai-chat-navigation-service';
+import { ChatSessionInputDrafts } from './chat-session-input-drafts';
 
 export namespace ChatViewWidget {
     export interface State {
@@ -68,6 +69,9 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
     protected readonly navigationService: AIChatNavigationService;
 
     protected chatSession: ChatSession;
+    protected readonly sessionInputDrafts = new ChatSessionInputDrafts();
+    protected readonly openTabSessionIds = new Set<string>();
+    protected readonly tabBarNode = document.createElement('div');
 
     protected _state: ChatViewWidget.State = { locked: false, temporaryLocked: false };
     protected readonly onStateChangedEmitter = new Emitter<ChatViewWidget.State>();
@@ -88,6 +92,8 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         this.title.iconClass = codicon('comment-discussion');
         this.title.closable = true;
         this.node.classList.add('chat-view-widget');
+        this.tabBarNode.classList.add('theia-AIChatTabs');
+        this.tabBarNode.setAttribute('role', 'tablist');
         this.update();
     }
 
@@ -103,12 +109,14 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
             })
         ]);
         const layout = this.layout = new PanelLayout();
+        this.node.appendChild(this.tabBarNode);
 
         this.treeWidget.node.classList.add('chat-tree-view-widget');
         layout.addWidget(this.treeWidget);
         this.inputWidget.node.classList.add('chat-input-widget');
         layout.addWidget(this.inputWidget);
         this.chatSession = this.chatService.createSession();
+        this.openTabSessionIds.add(this.chatSession.id);
 
         this.inputWidget.onQuery = this.onQuery.bind(this);
         this.inputWidget.onUnpin = this.onUnpin.bind(this);
@@ -119,6 +127,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         this.inputWidget.onDeleteChangeSetElement = this.onDeleteChangeSetElement.bind(this);
         this.treeWidget.trackChatModel(this.chatSession.model);
         this.treeWidget.onScrollLockChange = this.onScrollLockChange.bind(this);
+        this.renderSessionTabs();
 
         this.initListeners();
 
@@ -180,17 +189,22 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
     protected initListeners(): void {
         this.toDispose.pushAll([
             this.chatService.onSessionEvent(event => {
-                if (!isActiveSessionChangedEvent(event)) {
-                    return;
-                }
-                const session = event.sessionId ? this.chatService.getSession(event.sessionId) : this.chatService.createSession();
-                if (session) {
-                    this.chatSession = session;
-                    this.treeWidget.trackChatModel(this.chatSession.model);
-                    this.inputWidget.chatModel = this.chatSession.model;
-                    this.inputWidget.pinnedAgent = this.chatSession.pinnedAgent;
+                if (isActiveSessionChangedEvent(event)) {
+                    const session = event.sessionId ? this.chatService.getSession(event.sessionId) : this.chatService.createSession(ChatAgentLocation.Panel);
+                    if (session && this.isUserVisiblePanelSession(session)) {
+                        this.openTabSessionIds.add(session.id);
+                        this.showSession(session);
+                    } else if (session) {
+                        this.renderSessionTabs();
+                    } else {
+                        console.warn(`Session with ${event.sessionId} not found.`);
+                    }
                 } else {
-                    console.warn(`Session with ${event.sessionId} not found.`);
+                    if (event.type === 'deleted') {
+                        this.sessionInputDrafts.delete(event.sessionId);
+                        this.openTabSessionIds.delete(event.sessionId);
+                    }
+                    this.renderSessionTabs();
                 }
             }),
             // The chat view needs to handle the submission of the edit request
@@ -203,6 +217,84 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
     protected override onActivateRequest(msg: Message): void {
         super.onActivateRequest(msg);
         this.inputWidget.activate();
+    }
+
+    protected getPanelSessions(): ChatSession[] {
+        return this.chatService.getSessions().filter(session => this.isUserVisiblePanelSession(session) && this.openTabSessionIds.has(session.id));
+    }
+
+    protected isUserVisiblePanelSession(session: ChatSession): boolean {
+        return session.model.location === ChatAgentLocation.Panel && session.isUserVisible !== false;
+    }
+
+    protected showSession(session: ChatSession): void {
+        if (this.chatSession?.id === session.id) {
+            this.inputWidget.pinnedAgent = session.pinnedAgent;
+            this.renderSessionTabs();
+            return;
+        }
+        this.storeCurrentInputDraft();
+        this.chatSession = session;
+        this.treeWidget.trackChatModel(this.chatSession.model);
+        this.inputWidget.chatModel = this.chatSession.model;
+        this.inputWidget.pinnedAgent = this.chatSession.pinnedAgent;
+        this.inputWidget.setInputValue(this.sessionInputDrafts.get(this.chatSession.id));
+        this.renderSessionTabs();
+    }
+
+    protected storeCurrentInputDraft(): void {
+        if (this.chatSession) {
+            this.sessionInputDrafts.set(this.chatSession.id, this.inputWidget.getInputValue());
+        }
+    }
+
+    protected renderSessionTabs(): void {
+        this.tabBarNode.replaceChildren();
+        const sessions = this.getPanelSessions();
+        sessions.forEach((session, index) => {
+            const tab = document.createElement('button');
+            tab.type = 'button';
+            tab.classList.add('theia-AIChatTab');
+            if (session.id === this.chatSession?.id) {
+                tab.classList.add('theia-AIChatTab-active');
+            }
+            tab.setAttribute('role', 'tab');
+            tab.setAttribute('aria-selected', String(session.id === this.chatSession?.id));
+            const label = session.title ?? nls.localize('theia/ai/chat-ui/chatTabDefaultTitle', 'Chat {0}', index + 1);
+            const labelNode = document.createElement('span');
+            labelNode.classList.add('theia-AIChatTabLabel');
+            labelNode.textContent = label;
+            tab.title = label;
+            tab.appendChild(labelNode);
+            tab.onclick = () => this.chatService.setActiveSession(session.id, { focus: true, skipNavigation: true });
+
+            const closeButton = document.createElement('span');
+            closeButton.classList.add('theia-AIChatTabClose', ...codicon('close').split(' '));
+            closeButton.title = nls.localizeByDefault('Close');
+            closeButton.setAttribute('role', 'button');
+            closeButton.setAttribute('aria-label', nls.localizeByDefault('Close'));
+            closeButton.onclick = event => {
+                event.stopPropagation();
+                this.closeTab(session.id);
+            };
+            tab.appendChild(closeButton);
+            this.tabBarNode.appendChild(tab);
+        });
+    }
+
+    protected closeTab(sessionId: string): void {
+        this.storeCurrentInputDraft();
+        this.openTabSessionIds.delete(sessionId);
+        if (this.chatSession?.id === sessionId) {
+            const nextSession = this.getPanelSessions().at(-1);
+            if (nextSession) {
+                this.chatService.setActiveSession(nextSession.id, { focus: true, skipNavigation: true });
+            } else {
+                this.chatService.createSession(ChatAgentLocation.Panel, { focus: true, skipNavigation: true }, this.chatSession?.pinnedAgent);
+            }
+        } else {
+            this.renderSessionTabs();
+        }
     }
 
     storeState(): object {
@@ -245,8 +337,11 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
                 : { ...query, capabilityOverrides, genericCapabilitySelections };
         if (chatRequest.text.length === 0) { return; }
 
-        if (this.chatSession.model.isEmpty()) {
-            this.navigationService.notifyQueryFromWelcomeScreen(this.chatSession.id);
+        const session = this.chatSession;
+        this.sessionInputDrafts.set(session.id, '');
+
+        if (session.model.isEmpty()) {
+            this.navigationService.notifyQueryFromWelcomeScreen(session.id);
         }
 
         // Include all variables (context + pending image attachments) in the request
@@ -257,7 +352,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
 
         let requestProgress;
         try {
-            requestProgress = await this.chatService.sendRequest(this.chatSession.id, requestWithVariables);
+            requestProgress = await this.chatService.sendRequest(session.id, requestWithVariables);
         } finally {
             // Clear pending image attachments now that they're included in the request
             this.inputWidget.clearPendingImageAttachments();
@@ -268,13 +363,17 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
                     nls.localize('theia/ai/chat-ui/errorChatInvocation', 'An error occurred during chat service invocation.'));
             }
         }).finally(() => {
-            this.inputWidget.pinnedAgent = this.chatSession.pinnedAgent;
+            if (this.chatSession.id === session.id) {
+                this.inputWidget.pinnedAgent = session.pinnedAgent;
+            }
+            this.renderSessionTabs();
         });
         if (!requestProgress) {
             this.messageService.error(nls.localize('theia/ai/chat-ui/couldNotSendRequestToSession',
-                'Was not able to send request "{0}" to session {1}', chatRequest.text, this.chatSession.id));
+                'Was not able to send request "{0}" to session {1}', chatRequest.text, session.id));
             return;
         }
+        this.renderSessionTabs();
         // Tree Widget currently tracks the ChatModel itself. Therefore no notification necessary.
     }
 

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -7,6 +7,57 @@
   flex: 1;
 }
 
+.theia-AIChatTabs {
+  align-items: center;
+  border-bottom: 1px solid var(--theia-sideBarSectionHeader-border);
+  display: flex;
+  flex-shrink: 0;
+  gap: 2px;
+  overflow-x: auto;
+  padding: 4px 6px 0;
+}
+
+.theia-AIChatTab {
+  align-items: center;
+  background: transparent;
+  border: 0;
+  border-bottom: 2px solid transparent;
+  color: var(--theia-foreground);
+  cursor: pointer;
+  display: flex;
+  flex: 0 1 auto;
+  font-family: var(--theia-ui-font-family);
+  font-size: var(--theia-ui-font-size1);
+  gap: 4px;
+  min-width: 0;
+  padding: 4px 6px 4px 8px;
+  white-space: nowrap;
+}
+
+.theia-AIChatTab:hover {
+  background: var(--theia-toolbar-hoverBackground);
+}
+
+.theia-AIChatTab-active {
+  border-bottom-color: var(--theia-focusBorder);
+  font-weight: 600;
+}
+
+.theia-AIChatTabLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.theia-AIChatTabClose {
+  border-radius: 3px;
+  flex: 0 0 auto;
+  padding: 1px;
+}
+
+.theia-AIChatTabClose:hover {
+  background: var(--theia-toolbar-hoverBackground);
+}
+
 .chat-input-widget>.ps__rail-x,
 .chat-input-widget>.ps__rail-y {
   display: none !important;

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -118,8 +118,6 @@ export class AgentDelegationTool implements ToolProvider {
             let newSession;
             let childModelDisposable: Disposable | undefined;
             try {
-                // FIXME: this creates a new conversation visible in the UI (Panel), which we don't want
-                // It is not possible to start a session without specifying a location (default=Panel)
                 const chatService = this.getChatService();
 
                 // Store the current active session to restore it after delegation
@@ -127,7 +125,7 @@ export class AgentDelegationTool implements ToolProvider {
 
                 newSession = chatService.createSession(
                     undefined,
-                    { focus: false },
+                    { focus: false, isUserVisible: false },
                     agent
                 );
 

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -71,6 +71,7 @@ export interface ChatSession {
     model: ChatModel;
     isActive: boolean;
     pinnedAgent?: ChatAgent;
+    isUserVisible?: boolean;
     /** ID of the root session in the delegation chain. For delegated sessions, this points to the topmost session where task contexts are stored. */
     rootSessionId?: string;
 }
@@ -79,6 +80,7 @@ export interface ActiveSessionChangedEvent {
     type: 'activeChange';
     sessionId: string | undefined;
     focus?: boolean;
+    skipNavigation?: boolean;
 }
 
 export function isActiveSessionChangedEvent(obj: unknown): obj is ActiveSessionChangedEvent {
@@ -113,6 +115,8 @@ export interface SessionRenamedEvent {
 
 export interface SessionOptions {
     focus?: boolean;
+    isUserVisible?: boolean;
+    skipNavigation?: boolean;
 }
 
 export const PinChatAgent = Symbol('PinChatAgent');
@@ -214,7 +218,8 @@ export class ChatServiceImpl implements ChatService {
             lastInteraction: new Date(),
             model,
             isActive: true,
-            pinnedAgent
+            pinnedAgent,
+            isUserVisible: options?.isUserVisible ?? true
         };
         this._sessions.push(session);
         this.setupAutoSaveForSession(session);
@@ -515,7 +520,8 @@ export class ChatServiceImpl implements ChatService {
             lastInteraction: new Date(serialized.saveDate),
             model,
             isActive: false,
-            pinnedAgent
+            pinnedAgent,
+            isUserVisible: true
         };
         this._sessions.push(session);
         this.setupAutoSaveForSession(session);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Render user-visible chat sessions as tabs
- Keep input drafts local to each tab/session
- Hide delegated/internal sessions from the tab strip
- Allow closing tabs without deleting chat sessions
- Avoid adding tab switches to chat back/forward history
- Prevent restored sessions from opening as tabs on startup
- Add widget-level tests for tab behavior
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open the chat ui see that there are tabs.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
