### PR TITLE
fix(filesystem): show git decorations on every file when changes exceed the plugin-ext event cap

### DIFF
--- a/packages/core/src/browser/decorations-service.ts
+++ b/packages/core/src/browser/decorations-service.ts
@@ -148,6 +148,10 @@ class DecorationProviderWrapper {
             const request = new DecorationDataRequest(source, Promise.resolve(dataOrThenable).then(data => {
                 if (this.data.get(uri) === request) {
                     this.keepItem(uri, data);
+                    // Notify subscribers that a lazily-fetched decoration is now
+                    // available so renderers can re-query. Without this, decorations
+                    // dropped by event truncation never reach the UI.
+                    this.onDidChangeDecorationsEmitter.fire(this.decorations);
                 }
             }).catch(err => {
                 if (!(err instanceof Error && err.name === 'Canceled' && err.message === 'Canceled') && this.data.get(uri) === request) {

--- a/packages/filesystem/src/browser/file-tree/file-tree-decorator-adapter.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-decorator-adapter.ts
@@ -40,10 +40,7 @@ export class FileTreeDecoratorAdapter implements TreeDecorator {
 
     @postConstruct()
     protected init(): void {
-        this.decorationsService.onDidChangeDecorations(newDecorations => {
-            this.updateDecorations(this.decorationsByUri.keys(), newDecorations.keys());
-            this.fireDidChangeDecorations();
-        });
+        this.decorationsService.onDidChangeDecorations(() => this.fireDidChangeDecorations());
     }
 
     decorations(tree: Tree): MaybePromise<Map<string, TreeDecoration.Data>> {
@@ -51,19 +48,36 @@ export class FileTreeDecoratorAdapter implements TreeDecorator {
     }
 
     protected collectDecorations(tree: Tree): Map<string, TreeDecoration.Data> {
-        const decorations = new Map();
-        if (tree.root) {
-            for (const node of new TopDownTreeIterator(tree.root)) {
-                const uri = this.getUriForNode(node);
-                if (uri) {
-                    const stringified = uri.toString();
-                    const ownDecoration = this.decorationsByUri.get(stringified);
-                    const bubbledDecoration = this.parentDecorations.get(stringified);
-                    const combined = this.mergeDecorations(ownDecoration, bubbledDecoration);
-                    if (combined) {
-                        decorations.set(node.id, combined);
-                    }
-                }
+        const decorations = new Map<string, TreeDecoration.Data>();
+        if (!tree.root) {
+            return decorations;
+        }
+        this.decorationsByUri = new Map<string, TreeDecoration.Data>();
+        this.parentDecorations = new Map<string, TreeDecoration.Data>();
+        // Query the decorations service per visible URI so that decorations dropped
+        // by event truncation (see plugin-ext maxEventSize) are fetched on demand.
+        for (const node of new TopDownTreeIterator(tree.root)) {
+            const rawUri = this.getUriForNode(node);
+            if (!rawUri || this.decorationsByUri.has(rawUri)) {
+                continue;
+            }
+            const uri = new URI(rawUri);
+            const fetched = this.decorationsService.getDecoration(uri, false);
+            if (fetched.length) {
+                this.decorationsByUri.set(rawUri, this.toTheiaDecoration(fetched, false));
+                this.propagateDecorationsByUri(uri, fetched);
+            }
+        }
+        for (const node of new TopDownTreeIterator(tree.root)) {
+            const rawUri = this.getUriForNode(node);
+            if (!rawUri) {
+                continue;
+            }
+            const ownDecoration = this.decorationsByUri.get(rawUri);
+            const bubbledDecoration = this.parentDecorations.get(rawUri);
+            const combined = this.mergeDecorations(ownDecoration, bubbledDecoration);
+            if (combined) {
+                decorations.set(node.id, combined);
             }
         }
         return decorations;
@@ -81,28 +95,6 @@ export class FileTreeDecoratorAdapter implements TreeDecorator {
                 tailDecorations
             };
         }
-    }
-
-    protected updateDecorations(oldKeys: IterableIterator<string>, newKeys: IterableIterator<string>): void {
-        this.parentDecorations.clear();
-        const newDecorations = new Map<string, TreeDecoration.Data>();
-        const handleUri = (rawUri: string) => {
-            if (!newDecorations.has(rawUri)) {
-                const uri = new URI(rawUri);
-                const decorations = this.decorationsService.getDecoration(uri, false);
-                if (decorations.length) {
-                    newDecorations.set(rawUri, this.toTheiaDecoration(decorations, false));
-                    this.propagateDecorationsByUri(uri, decorations);
-                }
-            }
-        };
-        for (const rawUri of oldKeys) {
-            handleUri(rawUri);
-        }
-        for (const rawUri of newKeys) {
-            handleUri(rawUri);
-        }
-        this.decorationsByUri = newDecorations;
     }
 
     protected toTheiaDecoration(decorations: Decoration[], bubble?: boolean): TreeDecoration.Data {


### PR DESCRIPTION
#### What it does

Fixes #17507 

VS Code's `FileDecorationProvider` event protocol caps each change event at 250 URIs. When exceeded, `DecorationsExtImpl` intentionally picks one URI per folder and drops the rest, relying on the renderer to lazy-fetch per visible resource. Theia's `FileTreeDecoratorAdapter` only updated its cache from change events, so dropped URIs never received a decoration. `DecorationProviderWrapper` also did not fire a change event when an async fetch resolved, so even a lazy fetch would not trigger a re-render.

Changes:

- `FileTreeDecoratorAdapter.collectDecorations` now queries `DecorationsService.getDecoration(uri, false)` for every visible tree URI, triggering lazy fetches for unknown ones - matching VS Code's renderer behavior.
- `DecorationProviderWrapper.fetchData` fires `onDidChangeDecorations` when an async fetch resolves, so the tree re-renders once the lazy data lands.
- Removed the now-unused `updateDecorations` method on `FileTreeDecoratorAdapter`.

#### How to test

1. Open a workspace whose git status contains more than 250 changed files (e.g. in a git repo: `mkdir new && for i in $(seq 1 300); do touch new/f$i.txt; done`).
2. Expand any folder that contains several of the changed files in the Explorer.
3. Before this PR: only the first file (alphabetically) in each folder shows the `U`/`M` badge and color.
4. With this PR: every changed file shows the appropriate decoration, matching the SCM view and VS Code's behavior.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- leave empty or fill if needed -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no new user-facing text introduced)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)
