### PR TITLE
Make DebugSession injectable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 <a name="breaking_changes_1.72.0">[Breaking Changes:](#breaking_changes_1.72.0)</a>
 
 - [ai-chat] the `'*'` magic key inside `ai-features.chat.toolConfirmation` is no longer honored; migrate to the new `ai-features.chat.defaultToolConfirmation` preference [#17452](https://github.com/eclipse-theia/theia/pull/17452)
+- [debug] the method DebugSessionFactory.get has been renamed to DebugSessionFactory.create and the manager parameter has been removed. Additionally, the binding of DebugSessionFactory is required to call setContainer.
 - [native-webpack-plugin] The `@theia/native-webpack-plugin` package has been renamed to `@theia/bundle-plugin` [#14414](https://github.com/eclipse-theia/theia/pull/14414).
 
 ## 1.71.0 - 4/30/2026

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@
 
 - [ai-core] `DefaultSkillService.getDefaultSkillsDirectoryPath()` has been renamed to `getDefaultSkillsDirectoryPaths()` and now returns `string[]` instead of `string` to include both the product configuration `skills` directory and the user's `~/.agents/skills` directory [#17553](https://github.com/eclipse-theia/theia/pull/17553)
 - [ai-core] `combineSkillDirectories` signature changed: `workspaceSkillsDir` and `defaultSkillsDir` parameters are now `string[]` (previously `string | undefined`), and the return type is now `SkillDirectoryEntry[]` (an array of `{ path, tier }` entries) instead of `string[]` [#17553](https://github.com/eclipse-theia/theia/pull/17553)
+- [debug] Made DebugSession injectable [#17510](https://github.com/eclipse-theia/theia/pull/17510)
+  - removed public constructors from DebugSession and PluginDebugSession in favor of dependency injection
+  - added container parameter to DefaultDebugSessionFactory and PluginDebugSessionFactory constructors
+  - renamed DebugSessionFactory.get to DebugSessionFactory.createSession and removed the manager parameter
 - [terminal] `TerminalWidget` gained a new abstract method `paste(text: string)`; downstream subclasses must implement it (consistent with `getSelection()` / `hasSelection()` added in [#17290](https://github.com/eclipse-theia/theia/pull/17290)) [#17603](https://github.com/eclipse-theia/theia/pull/17603)
 
 ## 1.72.0 - 5/28/2026

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -77,7 +77,12 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     ).inSingletonScope();
 
     bindRootContributionProvider(bind, DebugSessionContribution);
-    bind(DebugSessionFactory).to(DefaultDebugSessionFactory).inSingletonScope();
+    bind(DebugSessionFactory).toDynamicValue(({ container }) => {
+        const factory = container.get(DefaultDebugSessionFactory);
+        factory.setContainer(container);
+        return factory;
+    }).inSingletonScope();
+    bind(DefaultDebugSessionFactory).toSelf().inSingletonScope();
     bind(DebugSessionManager).toSelf().inSingletonScope();
 
     bind(BreakpointManager).toSelf().inSingletonScope();

--- a/packages/debug/src/browser/debug-frontend-module.ts
+++ b/packages/debug/src/browser/debug-frontend-module.ts
@@ -77,7 +77,7 @@ export default new ContainerModule((bind: interfaces.Bind) => {
     ).inSingletonScope();
 
     bindRootContributionProvider(bind, DebugSessionContribution);
-    bind(DebugSessionFactory).to(DefaultDebugSessionFactory).inSingletonScope();
+    bind(DebugSessionFactory).toDynamicValue(ctx => new DefaultDebugSessionFactory(ctx.container)).inSingletonScope();
     bind(DebugSessionManager).toSelf().inSingletonScope();
 
     bind(BreakpointManager).toSelf().inSingletonScope();

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -14,25 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject, named, postConstruct } from '@theia/core/shared/inversify';
-import { CommandService, MessageClient } from '@theia/core/lib/common';
-import { LabelProvider } from '@theia/core/lib/browser';
-import { EditorManager } from '@theia/editor/lib/browser';
-import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { DebugSession } from './debug-session';
-import { BreakpointManager } from './breakpoint/breakpoint-manager';
+import { injectable, inject, named, postConstruct, interfaces } from '@theia/core/shared/inversify';
+import { DebugSession, DebugSessionData } from './debug-session';
 import { DebugConfigurationSessionOptions, DebugSessionOptions } from './debug-session-options';
 import { OutputChannelManager, OutputChannel } from '@theia/output/lib/browser/output-channel';
 import { DebugPreferences } from '../common/debug-preferences';
 import { DebugSessionConnection } from './debug-session-connection';
 import { DebugChannel, DebugAdapterPath, ForwardingDebugChannel } from '../common/debug-service';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
-import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { DebugContribution } from './debug-contribution';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
-import { TestService } from '@theia/test/lib/browser/test-service';
-import { DebugSessionManager } from './debug-session-manager';
 
 /**
  * DebugSessionContribution symbol for DI.
@@ -92,39 +82,25 @@ export const DebugSessionFactory = Symbol('DebugSessionFactory');
  * The [debug session](#DebugSession) factory.
  */
 export interface DebugSessionFactory {
-    get(manager: DebugSessionManager, sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession;
+    createSession(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession;
 }
 
 @injectable()
 export class DefaultDebugSessionFactory implements DebugSessionFactory {
     @inject(RemoteConnectionProvider)
     protected readonly connectionProvider: ServiceConnectionProvider;
-    @inject(TerminalService)
-    protected readonly terminalService: TerminalService;
-    @inject(EditorManager)
-    protected readonly editorManager: EditorManager;
-    @inject(BreakpointManager)
-    protected readonly breakpoints: BreakpointManager;
-    @inject(LabelProvider)
-    protected readonly labelProvider: LabelProvider;
-    @inject(MessageClient)
-    protected readonly messages: MessageClient;
     @inject(OutputChannelManager)
-    protected readonly outputChannelManager: OutputChannelManager;
+    protected outputChannelManager: OutputChannelManager;
     @inject(DebugPreferences)
-    protected readonly debugPreferences: DebugPreferences;
-    @inject(FileService)
-    protected readonly fileService: FileService;
-    @inject(ContributionProvider) @named(DebugContribution)
-    protected readonly debugContributionProvider: ContributionProvider<DebugContribution>;
-    @inject(TestService)
-    protected readonly testService: TestService;
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-    @inject(CommandService)
-    protected commandService: CommandService;
+    protected debugPreferences: DebugPreferences;
 
-    get(manager: DebugSessionManager, sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
+    protected parentContainer: interfaces.Container;
+
+    setContainer(container: interfaces.Container): void {
+        this.parentContainer = container;
+    }
+
+    createSession(sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
         const connection = new DebugSessionConnection(
             sessionId,
             () => new Promise<DebugChannel>(resolve =>
@@ -133,25 +109,14 @@ export class DefaultDebugSessionFactory implements DebugSessionFactory {
                 }, false)
             ),
             this.getTraceOutputChannel());
-        return new DebugSession(
-            sessionId,
+        const data: DebugSessionData = {
+            id: sessionId,
             options,
             parentSession,
-            this.testService,
-            options.testRun,
-            manager,
-            connection,
-            this.terminalService,
-            this.editorManager,
-            this.breakpoints,
-            this.labelProvider,
-            this.messages,
-            this.fileService,
-            this.debugContributionProvider,
-            this.workspaceService,
-            this.debugPreferences,
-            this.commandService
-        );
+            testRun: options.testRun,
+        };
+        const child = DebugSession.createContainer(this.parentContainer, data, connection);
+        return child.get(DebugSession);
     }
 
     protected getTraceOutputChannel(): OutputChannel | undefined {

--- a/packages/debug/src/browser/debug-session-contribution.ts
+++ b/packages/debug/src/browser/debug-session-contribution.ts
@@ -14,25 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject, named, postConstruct } from '@theia/core/shared/inversify';
-import { CommandService, MessageClient } from '@theia/core/lib/common';
-import { LabelProvider } from '@theia/core/lib/browser';
-import { EditorManager } from '@theia/editor/lib/browser';
-import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { DebugSession } from './debug-session';
-import { BreakpointManager } from './breakpoint/breakpoint-manager';
+import { injectable, inject, named, postConstruct, interfaces } from '@theia/core/shared/inversify';
+import { DebugSession, DebugSessionData } from './debug-session';
 import { DebugConfigurationSessionOptions, DebugSessionOptions } from './debug-session-options';
 import { OutputChannelManager, OutputChannel } from '@theia/output/lib/browser/output-channel';
 import { DebugPreferences } from '../common/debug-preferences';
 import { DebugSessionConnection } from './debug-session-connection';
 import { DebugChannel, DebugAdapterPath, ForwardingDebugChannel } from '../common/debug-service';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
-import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { DebugContribution } from './debug-contribution';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
-import { TestService } from '@theia/test/lib/browser/test-service';
-import { DebugSessionManager } from './debug-session-manager';
 
 /**
  * DebugSessionContribution symbol for DI.
@@ -92,71 +82,40 @@ export const DebugSessionFactory = Symbol('DebugSessionFactory');
  * The [debug session](#DebugSession) factory.
  */
 export interface DebugSessionFactory {
-    get(manager: DebugSessionManager, sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession;
+    createSession(sessionId: string, options: DebugSessionOptions, parentSession?: DebugSession): DebugSession;
 }
 
-@injectable()
 export class DefaultDebugSessionFactory implements DebugSessionFactory {
-    @inject(RemoteConnectionProvider)
-    protected readonly connectionProvider: ServiceConnectionProvider;
-    @inject(TerminalService)
-    protected readonly terminalService: TerminalService;
-    @inject(EditorManager)
-    protected readonly editorManager: EditorManager;
-    @inject(BreakpointManager)
-    protected readonly breakpoints: BreakpointManager;
-    @inject(LabelProvider)
-    protected readonly labelProvider: LabelProvider;
-    @inject(MessageClient)
-    protected readonly messages: MessageClient;
-    @inject(OutputChannelManager)
-    protected readonly outputChannelManager: OutputChannelManager;
-    @inject(DebugPreferences)
-    protected readonly debugPreferences: DebugPreferences;
-    @inject(FileService)
-    protected readonly fileService: FileService;
-    @inject(ContributionProvider) @named(DebugContribution)
-    protected readonly debugContributionProvider: ContributionProvider<DebugContribution>;
-    @inject(TestService)
-    protected readonly testService: TestService;
-    @inject(WorkspaceService)
-    protected readonly workspaceService: WorkspaceService;
-    @inject(CommandService)
-    protected commandService: CommandService;
+    protected readonly container: interfaces.Container;
 
-    get(manager: DebugSessionManager, sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
+    constructor(container: interfaces.Container) {
+        this.container = container;
+    }
+
+    createSession(sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
+        const connectionProvider: ServiceConnectionProvider = this.container.get(RemoteConnectionProvider);
         const connection = new DebugSessionConnection(
             sessionId,
             () => new Promise<DebugChannel>(resolve =>
-                this.connectionProvider.listen(`${DebugAdapterPath}/${sessionId}`, (_, wsChannel) => {
+                connectionProvider.listen(`${DebugAdapterPath}/${sessionId}`, (_, wsChannel) => {
                     resolve(new ForwardingDebugChannel(wsChannel));
                 }, false)
             ),
             this.getTraceOutputChannel());
-        return new DebugSession(
-            sessionId,
+        const data: DebugSessionData = {
+            id: sessionId,
             options,
             parentSession,
-            this.testService,
-            options.testRun,
-            manager,
-            connection,
-            this.terminalService,
-            this.editorManager,
-            this.breakpoints,
-            this.labelProvider,
-            this.messages,
-            this.fileService,
-            this.debugContributionProvider,
-            this.workspaceService,
-            this.debugPreferences,
-            this.commandService
-        );
+        };
+        const child = DebugSession.createContainer(this.container, data, connection);
+        return child.get(DebugSession);
     }
 
     protected getTraceOutputChannel(): OutputChannel | undefined {
-        if (this.debugPreferences['debug.trace']) {
-            return this.outputChannelManager.getChannel('Debug adapters');
+        const outputChannelManager: OutputChannelManager = this.container.get(OutputChannelManager);
+        const debugPreferences: DebugPreferences = this.container.get(DebugPreferences);
+        if (debugPreferences['debug.trace']) {
+            return outputChannelManager.getChannel('Debug adapters');
         }
     }
 }

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -412,7 +412,7 @@ export class DebugSessionManager {
         const parentSession = options.configuration.parentSessionId ? this._sessions.get(options.configuration.parentSessionId) : undefined;
         const contrib = this.sessionContributionRegistry.get(options.configuration.type);
         const sessionFactory = contrib ? contrib.debugSessionFactory() : this.debugSessionFactory;
-        const session = sessionFactory.get(this, sessionId, options, parentSession);
+        const session = sessionFactory.createSession(sessionId, options, parentSession);
         this._sessions.set(sessionId, session);
 
         this.debugTypeKey.set(session.configuration.type);

--- a/packages/debug/src/browser/debug-session-manager.ts
+++ b/packages/debug/src/browser/debug-session-manager.ts
@@ -415,7 +415,7 @@ export class DebugSessionManager {
         const parentSession = options.configuration.parentSessionId ? this._sessions.get(options.configuration.parentSessionId) : undefined;
         const contrib = this.sessionContributionRegistry.get(options.configuration.type);
         const sessionFactory = contrib ? contrib.debugSessionFactory() : this.debugSessionFactory;
-        const session = sessionFactory.get(this, sessionId, options, parentSession);
+        const session = sessionFactory.createSession(sessionId, options, parentSession);
         this._sessions.set(sessionId, session);
 
         this.debugTypeKey.set(session.configuration.type);

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -96,7 +96,6 @@ export function formatMessage(format: string, variables?: { [key: string]: strin
     return variables ? format.replace(formatMessageRegexp, (match, group) => variables.hasOwnProperty(group) ? variables[group] : match) : format;
 }
 
-
 @injectable()
 export class DebugSession implements CompositeTreeElement {
 
@@ -168,7 +167,6 @@ export class DebugSession implements CompositeTreeElement {
         return this.data.parentSession;
     }
 
-
     protected readonly deferredOnDidConfigureCapabilities = new Deferred<void>();
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
@@ -196,7 +194,6 @@ export class DebugSession implements CompositeTreeElement {
 
     /** Maximum time to wait for the shell integration prompt before proceeding. */
     protected readonly PROMPT_READY_TIMEOUT_MS = 3000;
-
 
     @postConstruct()
     protected init(): void {

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -31,6 +31,7 @@ import {
     CommandService,
     CancellationError
 } from '@theia/core/lib/common';
+import { inject, injectable, named, postConstruct, interfaces } from '@theia/core/shared/inversify';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { CompositeTreeElement } from '@theia/core/lib/browser/source-tree';
@@ -56,6 +57,14 @@ import { TestService, TestServices } from '@theia/test/lib/browser/test-service'
 import { DebugSessionManager } from './debug-session-manager';
 
 import { DebugPreferences } from '../common/debug-preferences';
+
+export const DebugSessionData = Symbol('DebugSessionData');
+export interface DebugSessionData {
+    id: string;
+    options: DebugConfigurationSessionOptions;
+    parentSession: DebugSession | undefined;
+    testRun: TestRunReference | undefined;
+}
 
 export enum DebugState {
     Inactive,
@@ -87,8 +96,79 @@ export function formatMessage(format: string, variables?: { [key: string]: strin
     return variables ? format.replace(formatMessageRegexp, (match, group) => variables.hasOwnProperty(group) ? variables[group] : match) : format;
 }
 
-// FIXME: make injectable to allow easily inject services
+
+@injectable()
 export class DebugSession implements CompositeTreeElement {
+
+    static createContainer(parent: interfaces.Container, data: DebugSessionData, connection: DebugSessionConnection): interfaces.Container {
+        const child = parent.createChild();
+        child.bind(DebugSessionData).toConstantValue(data);
+        child.bind(DebugSessionConnection).toConstantValue(connection);
+        child.bind(DebugSession).toSelf();
+        return child;
+    }
+
+    @inject(DebugSessionData)
+    protected readonly data: DebugSessionData;
+
+    @inject(DebugSessionConnection)
+    protected readonly connection: DebugSessionConnection;
+
+    @inject(TestService)
+    protected readonly testService: TestService;
+
+    @inject(DebugSessionManager)
+    protected readonly sessionManager: DebugSessionManager;
+
+    @inject(TerminalService)
+    protected readonly terminalServer: TerminalService;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(BreakpointManager)
+    protected readonly breakpoints: BreakpointManager;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(MessageClient)
+    protected readonly messages: MessageClient;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(ContributionProvider)
+    @named(DebugContribution)
+    protected readonly debugContributionProvider: ContributionProvider<DebugContribution>;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(DebugPreferences)
+    protected readonly debugPreferences: DebugPreferences;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    /**
+     * Number of millis after a `stop` request times out. It's 5 seconds by default.
+     */
+    protected readonly stopTimeout = 5_000;
+
+    get id(): string {
+        return this.data.id;
+    }
+
+    get options(): DebugConfigurationSessionOptions {
+        return this.data.options;
+    }
+
+    get parentSession(): DebugSession | undefined {
+        return this.data.parentSession;
+    }
+
+
     protected readonly deferredOnDidConfigureCapabilities = new Deferred<void>();
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
@@ -117,47 +197,27 @@ export class DebugSession implements CompositeTreeElement {
     /** Maximum time to wait for the shell integration prompt before proceeding. */
     protected readonly PROMPT_READY_TIMEOUT_MS = 3000;
 
-    constructor(
-        readonly id: string,
-        readonly options: DebugConfigurationSessionOptions,
-        readonly parentSession: DebugSession | undefined,
-        testService: TestService,
-        testRun: TestRunReference | undefined,
-        sessionManager: DebugSessionManager,
-        protected readonly connection: DebugSessionConnection,
-        protected readonly terminalServer: TerminalService,
-        protected readonly editorManager: EditorManager,
-        protected readonly breakpoints: BreakpointManager,
-        protected readonly labelProvider: LabelProvider,
-        protected readonly messages: MessageClient,
-        protected readonly fileService: FileService,
-        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>,
-        protected readonly workspaceService: WorkspaceService,
-        protected readonly debugPreferences: DebugPreferences,
-        protected readonly commandService: CommandService,
-        /**
-         * Number of millis after a `stop` request times out. It's 5 seconds by default.
-         */
-        protected readonly stopTimeout = 5_000,
-    ) {
+
+    @postConstruct()
+    protected init(): void {
         this.connection.onRequest('runInTerminal', (request: DebugProtocol.RunInTerminalRequest) => this.runInTerminal(request));
         this.connection.onDidClose(() => {
             this.toDispose.dispose();
         });
-        this.registerDebugContributions(options.configuration.type, this.connection);
+        this.registerDebugContributions(this.options.configuration.type, this.connection);
 
-        if (parentSession) {
-            parentSession.childSessions.set(id, this);
+        if (this.parentSession) {
+            this.parentSession.childSessions.set(this.id, this);
             this.toDispose.push(Disposable.create(() => {
-                this.parentSession?.childSessions?.delete(id);
+                this.parentSession?.childSessions?.delete(this.id);
             }));
         }
-        if (testRun) {
+        if (this.data.testRun) {
             try {
-                const run = TestServices.withTestRun(testService, testRun.controllerId, testRun.runId);
+                const run = TestServices.withTestRun(this.testService, this.data.testRun.controllerId, this.data.testRun.runId);
                 run.onDidChangeProperty(evt => {
                     if (evt.isRunning === false) {
-                        sessionManager.terminateSession(this);
+                        this.sessionManager.terminateSession(this);
                     }
                 });
             } catch (err) {

--- a/packages/debug/src/browser/debug-session.tsx
+++ b/packages/debug/src/browser/debug-session.tsx
@@ -31,6 +31,7 @@ import {
     CommandService,
     CancellationError
 } from '@theia/core/lib/common';
+import { inject, injectable, named, postConstruct, interfaces, LazyServiceIdentifier } from '@theia/core/shared/inversify';
 import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
 import { EditorManager } from '@theia/editor/lib/browser';
 import { CompositeTreeElement } from '@theia/core/lib/browser/source-tree';
@@ -43,7 +44,7 @@ import { DebugBreakpoint } from './model/debug-breakpoint';
 import debounce = require('p-debounce');
 import URI from '@theia/core/lib/common/uri';
 import { BreakpointManager } from './breakpoint/breakpoint-manager';
-import { DebugConfigurationSessionOptions, InternalDebugSessionOptions, TestRunReference } from './debug-session-options';
+import { DebugConfigurationSessionOptions, InternalDebugSessionOptions } from './debug-session-options';
 import { DebugConfiguration, DebugConsoleMode } from '../common/debug-common';
 import { SourceBreakpoint } from './breakpoint/breakpoint-marker';
 import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
@@ -56,6 +57,14 @@ import { TestService, TestServices } from '@theia/test/lib/browser/test-service'
 import { DebugSessionManager } from './debug-session-manager';
 
 import { DebugPreferences } from '../common/debug-preferences';
+
+export const DebugSessionData = Symbol('DebugSessionData');
+export const DebugSessionStopTimeout = Symbol('DebugSessionStopTimeout');
+export interface DebugSessionData {
+    id: string;
+    options: DebugConfigurationSessionOptions;
+    parentSession: DebugSession | undefined;
+}
 
 export enum DebugState {
     Inactive,
@@ -87,8 +96,79 @@ export function formatMessage(format: string, variables?: { [key: string]: strin
     return variables ? format.replace(formatMessageRegexp, (match, group) => variables.hasOwnProperty(group) ? variables[group] : match) : format;
 }
 
-// FIXME: make injectable to allow easily inject services
+@injectable()
 export class DebugSession implements CompositeTreeElement {
+
+    static createContainer(parent: interfaces.Container, data: DebugSessionData, connection: DebugSessionConnection): interfaces.Container {
+        const child = parent.createChild();
+        child.bind(DebugSessionData).toConstantValue(data);
+        child.bind(DebugSessionStopTimeout).toConstantValue(5_000);
+        child.bind(DebugSessionConnection).toConstantValue(connection);
+        child.bind(DebugSession).toSelf().inSingletonScope();
+        return child;
+    }
+
+    @inject(DebugSessionData)
+    protected readonly data: DebugSessionData;
+
+    @inject(DebugSessionConnection)
+    protected readonly connection: DebugSessionConnection;
+
+    @inject(TestService)
+    protected readonly testService: TestService;
+
+    @inject(new LazyServiceIdentifier(() => DebugSessionManager))
+    protected readonly sessionManager: DebugSessionManager;
+
+    @inject(TerminalService)
+    protected readonly terminalServer: TerminalService;
+
+    @inject(EditorManager)
+    protected readonly editorManager: EditorManager;
+
+    @inject(BreakpointManager)
+    protected readonly breakpoints: BreakpointManager;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    @inject(MessageClient)
+    protected readonly messages: MessageClient;
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(ContributionProvider)
+    @named(DebugContribution)
+    protected readonly debugContributionProvider: ContributionProvider<DebugContribution>;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    @inject(DebugPreferences)
+    protected readonly debugPreferences: DebugPreferences;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    /**
+     * Number of millis after a `stop` request times out. It's 5 seconds by default.
+     */
+    @inject(DebugSessionStopTimeout)
+    protected readonly stopTimeout: number;
+
+    get id(): string {
+        return this.data.id;
+    }
+
+    get options(): DebugConfigurationSessionOptions {
+        return this.data.options;
+    }
+
+    get parentSession(): DebugSession | undefined {
+        return this.data.parentSession;
+    }
+
     protected readonly deferredOnDidConfigureCapabilities = new Deferred<void>();
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
@@ -117,47 +197,26 @@ export class DebugSession implements CompositeTreeElement {
     /** Maximum time to wait for the shell integration prompt before proceeding. */
     protected readonly PROMPT_READY_TIMEOUT_MS = 3000;
 
-    constructor(
-        readonly id: string,
-        readonly options: DebugConfigurationSessionOptions,
-        readonly parentSession: DebugSession | undefined,
-        testService: TestService,
-        testRun: TestRunReference | undefined,
-        sessionManager: DebugSessionManager,
-        protected readonly connection: DebugSessionConnection,
-        protected readonly terminalServer: TerminalService,
-        protected readonly editorManager: EditorManager,
-        protected readonly breakpoints: BreakpointManager,
-        protected readonly labelProvider: LabelProvider,
-        protected readonly messages: MessageClient,
-        protected readonly fileService: FileService,
-        protected readonly debugContributionProvider: ContributionProvider<DebugContribution>,
-        protected readonly workspaceService: WorkspaceService,
-        protected readonly debugPreferences: DebugPreferences,
-        protected readonly commandService: CommandService,
-        /**
-         * Number of millis after a `stop` request times out. It's 5 seconds by default.
-         */
-        protected readonly stopTimeout = 5_000,
-    ) {
+    @postConstruct()
+    protected init(): void {
         this.connection.onRequest('runInTerminal', (request: DebugProtocol.RunInTerminalRequest) => this.runInTerminal(request));
         this.connection.onDidClose(() => {
             this.toDispose.dispose();
         });
-        this.registerDebugContributions(options.configuration.type, this.connection);
+        this.registerDebugContributions(this.options.configuration.type, this.connection);
 
-        if (parentSession) {
-            parentSession.childSessions.set(id, this);
+        if (this.parentSession) {
+            this.parentSession.childSessions.set(this.id, this);
             this.toDispose.push(Disposable.create(() => {
-                this.parentSession?.childSessions?.delete(id);
+                this.parentSession?.childSessions?.delete(this.id);
             }));
         }
-        if (testRun) {
+        if (this.options.testRun) {
             try {
-                const run = TestServices.withTestRun(testService, testRun.controllerId, testRun.runId);
+                const run = TestServices.withTestRun(this.testService, this.options.testRun.controllerId, this.options.testRun.runId);
                 run.onDidChangeProperty(evt => {
                     if (evt.isRunning === false) {
-                        sessionManager.terminateSession(this);
+                        this.sessionManager.terminateSession(this);
                     }
                 });
             } catch (err) {

--- a/packages/plugin-ext/src/main/browser/debug/debug-main.ts
+++ b/packages/plugin-ext/src/main/browser/debug/debug-main.ts
@@ -26,8 +26,6 @@ import {
 } from '../../../common/plugin-api-rpc';
 import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
 import { Breakpoint, DebugStackFrameDTO, DebugThreadDTO, WorkspaceFolder } from '../../../common/plugin-api-rpc-model';
-import { LabelProvider } from '@theia/core/lib/browser';
-import { EditorManager } from '@theia/editor/lib/browser';
 import { BreakpointManager, BreakpointsChangeEvent } from '@theia/debug/lib/browser/breakpoint/breakpoint-manager';
 import { URI as Uri } from '@theia/core/shared/vscode-uri';
 import { SourceBreakpoint, FunctionBreakpoint, BaseBreakpoint } from '@theia/debug/lib/browser/breakpoint/breakpoint-marker';
@@ -35,10 +33,6 @@ import { DebugConfiguration, DebugSessionOptions } from '@theia/debug/lib/common
 import { DebuggerDescription } from '@theia/debug/lib/common/debug-service';
 import { DebugProtocol } from '@vscode/debugprotocol';
 import { DebugConfigurationManager } from '@theia/debug/lib/browser/debug-configuration-manager';
-import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { MessageClient } from '@theia/core/lib/common/message-service-protocol';
-import { OutputChannelManager } from '@theia/output/lib/browser/output-channel';
-import { DebugPreferences } from '@theia/debug/lib/common/debug-preferences';
 import { PluginDebugAdapterContribution } from './plugin-debug-adapter-contribution';
 import { PluginDebugConfigurationProvider } from './plugin-debug-configuration-provider';
 import { PluginDebugSessionContributionRegistrator, PluginDebugSessionContributionRegistry } from './plugin-debug-session-contribution-registry';
@@ -46,17 +40,12 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 import { PluginDebugSessionFactory } from './plugin-debug-session-factory';
 import { PluginDebugService } from './plugin-debug-service';
 import { HostedPluginSupport } from '../../../hosted/browser/hosted-plugin';
-import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { ConsoleSessionManager } from '@theia/console/lib/browser/console-session-manager';
 import { DebugConsoleSession } from '@theia/debug/lib/browser/console/debug-console-session';
-import { CommandService, ContributionProvider } from '@theia/core/lib/common';
-import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
 import { ConnectionImpl } from '../../../common/connection';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { DebugSessionOptions as TheiaDebugSessionOptions } from '@theia/debug/lib/browser/debug-session-options';
 import { DebugStackFrame } from '@theia/debug/lib/browser/model/debug-stack-frame';
 import { DebugThread } from '@theia/debug/lib/browser/model/debug-thread';
-import { TestService } from '@theia/test/lib/browser/test-service';
 import { DebugBreakpoint } from '@theia/debug/lib/browser/model/debug-breakpoint';
 
 function toOrigin<T extends BaseBreakpoint>(input: DebugBreakpoint<T>): T {
@@ -75,24 +64,14 @@ function eventToOrigins<T extends BaseBreakpoint>({ added, removed, changed, uri
 export class DebugMainImpl implements DebugMain, Disposable {
     private readonly debugExt: DebugExt;
 
+    private readonly container: interfaces.Container;
     private readonly sessionManager: DebugSessionManager;
-    private readonly labelProvider: LabelProvider;
-    private readonly editorManager: EditorManager;
     private readonly breakpointsManager: BreakpointManager;
     private readonly consoleSessionManager: ConsoleSessionManager;
     private readonly configurationManager: DebugConfigurationManager;
-    private readonly terminalService: TerminalService;
-    private readonly messages: MessageClient;
-    private readonly outputChannelManager: OutputChannelManager;
-    private readonly debugPreferences: DebugPreferences;
     private readonly sessionContributionRegistrator: PluginDebugSessionContributionRegistrator;
     private readonly pluginDebugService: PluginDebugService;
-    private readonly fileService: FileService;
     private readonly pluginService: HostedPluginSupport;
-    private readonly debugContributionProvider: ContributionProvider<DebugContribution>;
-    private readonly testService: TestService;
-    private readonly workspaceService: WorkspaceService;
-    private readonly commandService: CommandService;
 
     private readonly debuggerContributions = new Map<string, DisposableCollection>();
     private readonly configurationProviders = new Map<number, DisposableCollection>();
@@ -100,24 +79,14 @@ export class DebugMainImpl implements DebugMain, Disposable {
 
     constructor(rpc: RPCProtocol, readonly connectionMain: ConnectionImpl, container: interfaces.Container) {
         this.debugExt = rpc.getProxy(MAIN_RPC_CONTEXT.DEBUG_EXT);
+        this.container = container;
         this.sessionManager = container.get(DebugSessionManager);
-        this.labelProvider = container.get(LabelProvider);
-        this.editorManager = container.get(EditorManager);
         this.breakpointsManager = container.get(BreakpointManager);
         this.consoleSessionManager = container.get(ConsoleSessionManager);
         this.configurationManager = container.get(DebugConfigurationManager);
-        this.terminalService = container.get(TerminalService);
-        this.messages = container.get(MessageClient);
-        this.outputChannelManager = container.get(OutputChannelManager);
-        this.debugPreferences = container.get(DebugPreferences);
         this.pluginDebugService = container.get(PluginDebugService);
         this.sessionContributionRegistrator = container.get(PluginDebugSessionContributionRegistry);
-        this.debugContributionProvider = container.getNamed(ContributionProvider, DebugContribution);
-        this.fileService = container.get(FileService);
         this.pluginService = container.get(HostedPluginSupport);
-        this.testService = container.get(TestService);
-        this.workspaceService = container.get(WorkspaceService);
-        this.commandService = container.get(CommandService);
 
         const fireDidChangeBreakpoints = ({ added, removed, changed }: BreakpointsChangeEvent<SourceBreakpoint | FunctionBreakpoint>) => {
             this.debugExt.$breakpointsDidChange(
@@ -168,23 +137,12 @@ export class DebugMainImpl implements DebugMain, Disposable {
         }
 
         const debugSessionFactory = new PluginDebugSessionFactory(
-            this.terminalService,
-            this.editorManager,
-            this.breakpointsManager,
-            this.labelProvider,
-            this.messages,
-            this.outputChannelManager,
-            this.debugPreferences,
             async (sessionId: string) => {
                 const connection = await this.connectionMain.ensureConnection(sessionId);
                 return connection;
             },
-            this.fileService,
             terminalOptionsExt,
-            this.debugContributionProvider,
-            this.testService,
-            this.workspaceService,
-            this.commandService,
+            this.container,
         );
 
         const toDispose = new DisposableCollection(

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -14,52 +14,33 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { injectable, inject, interfaces } from '@theia/core/shared/inversify';
 import { DefaultDebugSessionFactory } from '@theia/debug/lib/browser/debug-session-contribution';
-import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
-import { BreakpointManager } from '@theia/debug/lib/browser/breakpoint/breakpoint-manager';
-import { LabelProvider } from '@theia/core/lib/browser/label-provider';
-import { MessageClient } from '@theia/core/lib/common/message-service-protocol';
 import { OutputChannelManager } from '@theia/output/lib/browser/output-channel';
 import { DebugPreferences } from '@theia/debug/lib/common/debug-preferences';
-import { DebugConfigurationSessionOptions, TestRunReference } from '@theia/debug/lib/browser/debug-session-options';
-import { DebugSession } from '@theia/debug/lib/browser/debug-session';
+import { DebugConfigurationSessionOptions } from '@theia/debug/lib/browser/debug-session-options';
+import { DebugSession, DebugSessionData } from '@theia/debug/lib/browser/debug-session';
 import { DebugSessionConnection } from '@theia/debug/lib/browser/debug-session-connection';
 import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalOptionsExt } from '../../../common/plugin-api-rpc';
-import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
-import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { PluginChannel } from '../../../common/connection';
-import { TestService } from '@theia/test/lib/browser/test-service';
-import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
-import { CommandService } from '@theia/core';
 
+export const PluginTerminalOptionsExt = Symbol('PluginTerminalOptionsExt');
+
+@injectable()
 export class PluginDebugSession extends DebugSession {
-    constructor(
-        override readonly id: string,
-        override readonly options: DebugConfigurationSessionOptions,
-        override readonly parentSession: DebugSession | undefined,
-        testService: TestService,
-        testRun: TestRunReference | undefined,
-        sessionManager: DebugSessionManager,
-        protected override readonly connection: DebugSessionConnection,
-        protected override readonly terminalServer: TerminalService,
-        protected override readonly editorManager: EditorManager,
-        protected override readonly breakpoints: BreakpointManager,
-        protected override readonly labelProvider: LabelProvider,
-        protected override readonly messages: MessageClient,
-        protected override readonly fileService: FileService,
-        protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>,
-        protected override readonly workspaceService: WorkspaceService,
-        debugPreferences: DebugPreferences,
-        protected override readonly commandService: CommandService) {
-        super(id, options, parentSession, testService, testRun, sessionManager, connection, terminalServer, editorManager, breakpoints,
-            labelProvider, messages, fileService, debugContributionProvider,
-            workspaceService, debugPreferences, commandService);
+
+    static override createContainer(
+        parent: interfaces.Container, data: DebugSessionData, connection: DebugSessionConnection, terminalOptionsExt?: TerminalOptionsExt
+    ): interfaces.Container {
+        const child = DebugSession.createContainer(parent, data, connection);
+        child.rebind(DebugSession).to(PluginDebugSession);
+        child.bind(PluginTerminalOptionsExt).toConstantValue(terminalOptionsExt);
+        return child;
     }
+
+    @inject(PluginTerminalOptionsExt)
+    protected readonly terminalOptionsExt: TerminalOptionsExt | undefined;
 
     protected override async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
         terminalWidgetOptions = Object.assign({}, terminalWidgetOptions, this.terminalOptionsExt);
@@ -73,49 +54,28 @@ export class PluginDebugSession extends DebugSession {
  */
 export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
     constructor(
-        protected override readonly terminalService: TerminalService,
-        protected override readonly editorManager: EditorManager,
-        protected override readonly breakpoints: BreakpointManager,
-        protected override readonly labelProvider: LabelProvider,
-        protected override readonly messages: MessageClient,
-        protected override readonly outputChannelManager: OutputChannelManager,
-        protected override readonly debugPreferences: DebugPreferences,
         protected readonly connectionFactory: (sessionId: string) => Promise<PluginChannel>,
-        protected override readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>,
-        protected override readonly testService: TestService,
-        protected override readonly workspaceService: WorkspaceService,
-        protected override readonly commandService: CommandService,
+        container: interfaces.Container,
     ) {
         super();
+        this.setContainer(container);
+        this.outputChannelManager = container.get(OutputChannelManager);
+        this.debugPreferences = container.get(DebugPreferences);
     }
 
-    override get(manager: DebugSessionManager, sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
+    override createSession(sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
         const connection = new DebugSessionConnection(
             sessionId,
             this.connectionFactory,
             this.getTraceOutputChannel());
-
-        return new PluginDebugSession(
-            sessionId,
+        const data: DebugSessionData = {
+            id: sessionId,
             options,
             parentSession,
-            this.testService,
-            options.testRun,
-            manager,
-            connection,
-            this.terminalService,
-            this.editorManager,
-            this.breakpoints,
-            this.labelProvider,
-            this.messages,
-            this.fileService,
-            this.terminalOptionsExt,
-            this.debugContributionProvider,
-            this.workspaceService,
-            this.debugPreferences,
-            this.commandService
-        );
+            testRun: options.testRun,
+        };
+        const child = PluginDebugSession.createContainer(this.parentContainer, data, connection, this.terminalOptionsExt);
+        return child.get(DebugSession);
     }
 }

--- a/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
+++ b/packages/plugin-ext/src/main/browser/debug/plugin-debug-session-factory.ts
@@ -14,52 +14,31 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { injectable, inject, interfaces } from '@theia/core/shared/inversify';
 import { DefaultDebugSessionFactory } from '@theia/debug/lib/browser/debug-session-contribution';
-import { TerminalService } from '@theia/terminal/lib/browser/base/terminal-service';
-import { EditorManager } from '@theia/editor/lib/browser/editor-manager';
-import { BreakpointManager } from '@theia/debug/lib/browser/breakpoint/breakpoint-manager';
-import { LabelProvider } from '@theia/core/lib/browser/label-provider';
-import { MessageClient } from '@theia/core/lib/common/message-service-protocol';
-import { OutputChannelManager } from '@theia/output/lib/browser/output-channel';
-import { DebugPreferences } from '@theia/debug/lib/common/debug-preferences';
-import { DebugConfigurationSessionOptions, TestRunReference } from '@theia/debug/lib/browser/debug-session-options';
-import { DebugSession } from '@theia/debug/lib/browser/debug-session';
+import { DebugConfigurationSessionOptions } from '@theia/debug/lib/browser/debug-session-options';
+import { DebugSession, DebugSessionData } from '@theia/debug/lib/browser/debug-session';
 import { DebugSessionConnection } from '@theia/debug/lib/browser/debug-session-connection';
 import { TerminalWidgetOptions, TerminalWidget } from '@theia/terminal/lib/browser/base/terminal-widget';
 import { TerminalOptionsExt } from '../../../common/plugin-api-rpc';
-import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { DebugContribution } from '@theia/debug/lib/browser/debug-contribution';
-import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
-import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { PluginChannel } from '../../../common/connection';
-import { TestService } from '@theia/test/lib/browser/test-service';
-import { DebugSessionManager } from '@theia/debug/lib/browser/debug-session-manager';
-import { CommandService } from '@theia/core';
 
+export const PluginTerminalOptionsExt = Symbol('PluginTerminalOptionsExt');
+
+@injectable()
 export class PluginDebugSession extends DebugSession {
-    constructor(
-        override readonly id: string,
-        override readonly options: DebugConfigurationSessionOptions,
-        override readonly parentSession: DebugSession | undefined,
-        testService: TestService,
-        testRun: TestRunReference | undefined,
-        sessionManager: DebugSessionManager,
-        protected override readonly connection: DebugSessionConnection,
-        protected override readonly terminalServer: TerminalService,
-        protected override readonly editorManager: EditorManager,
-        protected override readonly breakpoints: BreakpointManager,
-        protected override readonly labelProvider: LabelProvider,
-        protected override readonly messages: MessageClient,
-        protected override readonly fileService: FileService,
-        protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>,
-        protected override readonly workspaceService: WorkspaceService,
-        debugPreferences: DebugPreferences,
-        protected override readonly commandService: CommandService) {
-        super(id, options, parentSession, testService, testRun, sessionManager, connection, terminalServer, editorManager, breakpoints,
-            labelProvider, messages, fileService, debugContributionProvider,
-            workspaceService, debugPreferences, commandService);
+
+    static override createContainer(
+        parent: interfaces.Container, data: DebugSessionData, connection: DebugSessionConnection, terminalOptionsExt?: TerminalOptionsExt
+    ): interfaces.Container {
+        const child = DebugSession.createContainer(parent, data, connection);
+        child.rebind(DebugSession).to(PluginDebugSession);
+        child.bind(PluginTerminalOptionsExt).toConstantValue(terminalOptionsExt);
+        return child;
     }
+
+    @inject(PluginTerminalOptionsExt)
+    protected readonly terminalOptionsExt: TerminalOptionsExt | undefined;
 
     protected override async doCreateTerminal(terminalWidgetOptions: TerminalWidgetOptions): Promise<TerminalWidget> {
         terminalWidgetOptions = Object.assign({}, terminalWidgetOptions, this.terminalOptionsExt);
@@ -73,49 +52,24 @@ export class PluginDebugSession extends DebugSession {
  */
 export class PluginDebugSessionFactory extends DefaultDebugSessionFactory {
     constructor(
-        protected override readonly terminalService: TerminalService,
-        protected override readonly editorManager: EditorManager,
-        protected override readonly breakpoints: BreakpointManager,
-        protected override readonly labelProvider: LabelProvider,
-        protected override readonly messages: MessageClient,
-        protected override readonly outputChannelManager: OutputChannelManager,
-        protected override readonly debugPreferences: DebugPreferences,
         protected readonly connectionFactory: (sessionId: string) => Promise<PluginChannel>,
-        protected override readonly fileService: FileService,
         protected readonly terminalOptionsExt: TerminalOptionsExt | undefined,
-        protected override readonly debugContributionProvider: ContributionProvider<DebugContribution>,
-        protected override readonly testService: TestService,
-        protected override readonly workspaceService: WorkspaceService,
-        protected override readonly commandService: CommandService,
+        container: interfaces.Container,
     ) {
-        super();
+        super(container);
     }
 
-    override get(manager: DebugSessionManager, sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
+    override createSession(sessionId: string, options: DebugConfigurationSessionOptions, parentSession?: DebugSession): DebugSession {
         const connection = new DebugSessionConnection(
             sessionId,
             this.connectionFactory,
             this.getTraceOutputChannel());
-
-        return new PluginDebugSession(
-            sessionId,
+        const data: DebugSessionData = {
+            id: sessionId,
             options,
             parentSession,
-            this.testService,
-            options.testRun,
-            manager,
-            connection,
-            this.terminalService,
-            this.editorManager,
-            this.breakpoints,
-            this.labelProvider,
-            this.messages,
-            this.fileService,
-            this.terminalOptionsExt,
-            this.debugContributionProvider,
-            this.workspaceService,
-            this.debugPreferences,
-            this.commandService
-        );
+        };
+        const child = PluginDebugSession.createContainer(this.container, data, connection, this.terminalOptionsExt);
+        return child.get(DebugSession);
     }
 }


### PR DESCRIPTION
#### What it does

DebugSession is a central class for debugging. To make small adjustments in the debugging experience, it would be easier, if it could be replaced via dependency injection. Previously, we only could replace DebugSessionFactory via dependency injection and used monkey patching to adapt the DebugSession from DebugSessionFactory.get.

In this PR, I also removed the now unneeded manager parameter from DebugSessionFactory.get (the DebugSessionManager is acquired by dependency injection now)
Furthermore, as the signature changes anyway, I renamed the DebugSessionFactory.get to createSession to be more similar with other factories.

I'm not sure, if the proposal is the best solution to use dependency injection in DebugSessionFactory and PluginDebugSessionFactory, so I'm open for other suggestions.

#### How to test

* debugging should work as before

#### Follow-ups

* I'm not sure, if using setContainer is a good solution to pass the dependency injection container to the factory.

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of MVTec

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
