### PR TITLE
doc: suggest using npm upgrade --save in publishing guide

### DIFF
--- a/doc/Publishing.md
+++ b/doc/Publishing.md
@@ -602,9 +602,8 @@ Perform a `npm upgrade` on the repository after the release to update the `packa
 
 To perform the upgrade:
 
-- Run `npm upgrade` at the root of the repository.
+- Run `npm upgrade --save` at the root of the repository. Besides updating the `package-lock.json`, it will align dependency version ranges in all `package.json` files (root and sub-packages) to match the resolved versions in package-lock.json. This ensures that adopters with existing lockfiles are forced to pull at least the minimum compatible version, rather than staying on an older locked version (that may be incompatible with the updated code if the upgrade required code changes).
 - Fix any compilation errors, typing errors, and failing tests.
-- Align dependency version ranges in all `package.json` files (root and sub-packages) to match the resolved versions in package-lock.json, especially if the upgrade required code changes. This ensures that adopters with existing lockfiles are forced to pull at least the minimum compatible version, rather than staying on an older locked version that may be incompatible with the updated code.
 - Open a PR with the changes ([example](https://github.com/eclipse-theia/theia/pull/15688)).
 - Run the license check review locally
 - Wait for the "IP Check" to complete ([example](https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/9377)).


### PR DESCRIPTION
#### What it does

As part of #17151, the publishing guide was updated to include a reminder to align package.json ranges after npm upgrade. This PR suggests running npm upgrade with the `--save` parameter to ensure that.

#### How to test

Try running `npm upgrade --save` at the root of the repository and review the modified files.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
