### PR TITLE
feat(workspace,core): workspace trust follow ups and make markdown hover tooltips interactive

### DIFF
--- a/doc/coding-guidelines.md
+++ b/doc/coding-guidelines.md
@@ -602,6 +602,48 @@ console.info(``)
 
 > Why? All calls to console are intercepted on the frontend and backend and then forwarded to an `ILogger` instance already. The log level can be configured from the CLI: `theia start --log-level=debug`.
 
+## Workspace Trust
+
+Theia supports [Workspace Trust](https://theia-ide.org/docs/workspace_trust/) to protect users from potentially harmful code in untrusted repositories. Features that execute code or load external content from the workspace must be gated behind workspace trust.
+
+<a name="workspace-trust-check"></a>
+
+* [1.](#workspace-trust-check) Features that execute workspace-provided code (tasks, debug configurations, scripts) or load workspace-provided content (prompt templates, configuration files that influence behavior) must check workspace trust before proceeding. Use `WorkspaceTrustService` to check or request trust.
+
+```ts
+@inject(WorkspaceTrustService)
+protected readonly workspaceTrustService: WorkspaceTrustService;
+
+// Check current trust state
+if (!this.workspaceTrustService.isWorkspaceTrusted()) {
+    return; // disable the feature
+}
+
+// Or request trust from the user (shows dialog if not yet decided)
+const trusted = await this.workspaceTrustService.requestWorkspaceTrust();
+if (!trusted) {
+    return;
+}
+```
+
+<a name="workspace-trust-restrictions"></a>
+
+* [2.](#workspace-trust-restrictions) When a feature is restricted in untrusted workspaces, register a `WorkspaceRestrictionContribution` so that the Restricted Mode status bar tooltip can inform the user about what is disabled.
+
+```ts
+bind(WorkspaceRestrictionContribution).toDynamicValue((): WorkspaceRestrictionContribution => ({
+    getRestrictions(): WorkspaceRestriction[] {
+        return [{
+            label: nls.localize('theia/myPackage/restricted', 'My Feature is disabled in Restricted Mode')
+        }];
+    }
+})).inSingletonScope();
+```
+
+<a name="workspace-trust-context-key"></a>
+
+* [3.](#workspace-trust-context-key) Use the `isWorkspaceTrusted` context key when workspace trust should control menu or command visibility.
+
 ## "To Do" Tags
 
 There are situations where we can't properly implement some functionality at the time we merge a PR. In those cases, it is sometimes good practice to leave an indication that something needs to be fixed later in the code. This can be done by putting a "tag" string in a comment. This allows us to find the places we need to fix again later. Currently, we use two "standard" tags in Theia:

--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -18,7 +18,9 @@ import { inject, injectable } from 'inversify';
 import { Disposable, DisposableCollection, disposableTimeout, isOSX, PreferenceService } from '../common';
 import { MarkdownString } from '../common/markdown-rendering/markdown-string';
 import { animationFrame } from './browser';
+import { wireMarkdownLinkHandler } from './markdown-rendering/markdown-link-handler';
 import { CoreMarkdownRenderer, MarkdownRenderer } from './markdown-rendering/markdown-renderer';
+import { OpenerService } from './opener-service';
 
 import '../../src/browser/style/hover-service.css';
 
@@ -97,6 +99,8 @@ export class HoverService {
     // which is rebound by Monaco to a renderer that strips code block content.
     @inject(CoreMarkdownRenderer) protected readonly markdownRenderer: MarkdownRenderer;
 
+    @inject(OpenerService) protected readonly openerService: OpenerService;
+
     protected _hoverHost: HTMLElement | undefined;
     protected get hoverHost(): HTMLElement {
         if (!this._hoverHost) {
@@ -147,6 +151,7 @@ export class HoverService {
             this.disposeOnHide.push(renderedContent);
             host.appendChild(renderedContent.element);
             firstChild = renderedContent.element;
+            this.disposeOnHide.push(wireMarkdownLinkHandler(renderedContent.element, content, this.openerService));
         }
         // browsers might insert linebreaks when the hover appears at the edge of the window
         // resetting the position prevents that

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -53,4 +53,5 @@ export * from './widget-status-bar-service';
 export * from './badges';
 export * from './markdown-rendering/markdown-renderer';
 export * from './markdown-rendering/markdown';
+export * from './markdown-rendering/markdown-link-handler';
 export * from './components';

--- a/packages/core/src/browser/markdown-rendering/markdown-link-handler.ts
+++ b/packages/core/src/browser/markdown-rendering/markdown-link-handler.ts
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Disposable } from '../../common';
+import { MarkdownString } from '../../common/markdown-rendering/markdown-string';
+import URI from '../../common/uri';
+import { open, OpenerService } from '../opener-service';
+
+/**
+ * Wires up anchor clicks inside a rendered markdown element so that they are routed
+ * through the {@link OpenerService} instead of relying on default browser navigation.
+ * Honors {@link MarkdownString.isTrusted} for `command:` URIs.
+ *
+ * Also sets the `title` attribute on each anchor to its `href` (when no title is set)
+ * so users can hover to see the link target.
+ *
+ * @returns a {@link Disposable} that removes the click listener.
+ */
+export function wireMarkdownLinkHandler(
+    root: HTMLElement,
+    source: MarkdownString,
+    openerService: OpenerService
+): Disposable {
+    for (const anchor of root.querySelectorAll('a')) {
+        const href = anchor.getAttribute('href');
+        if (href && !anchor.hasAttribute('title')) {
+            anchor.setAttribute('title', href);
+        }
+    }
+    const handleClick = async (event: MouseEvent) => {
+        const href = (event.target as HTMLElement | null)?.closest('a')?.getAttribute('href');
+        if (!href) {
+            return;
+        }
+        event.preventDefault();
+        const uri = new URI(href);
+        if (uri.scheme === 'command' && !MarkdownString.isCommandAllowed(source.isTrusted, uri.path.toString())) {
+            return;
+        }
+        try {
+            await open(openerService, uri);
+        } catch (e) {
+            console.error(`Failed to open '${uri.toString()}':`, e);
+        }
+    };
+    root.addEventListener('click', handleClick);
+    return Disposable.create(() => root.removeEventListener('click', handleClick));
+}

--- a/packages/core/src/common/markdown-rendering/markdown-string.ts
+++ b/packages/core/src/common/markdown-rendering/markdown-string.ts
@@ -44,6 +44,16 @@ export namespace MarkdownString {
     export function is(candidate: unknown): candidate is MarkdownString {
         return isObject<MarkdownString>(candidate) && isString(candidate.value);
     }
+
+    /**
+     * @returns whether `commandId` is allowed to execute given the markdown string's
+     * {@link MarkdownString.isTrusted} setting. Fully trusted strings allow any command;
+     * partially trusted strings restrict execution to their `enabledCommands` list.
+     */
+    export function isCommandAllowed(isTrusted: MarkdownString['isTrusted'], commandId: string): boolean {
+        return isTrusted === true
+            || (typeof isTrusted === 'object' && isTrusted.enabledCommands.includes(commandId));
+    }
 }
 
 // Copied from https://github.com/microsoft/vscode/blob/7d9b1c37f8e5ae3772782ba3b09d827eb3fdd833/src/vs/base/common/htmlContent.ts

--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -23,14 +23,22 @@ body {
   flex: 1;
   align-items: center;
   justify-content: center;
+  min-width: 0;
 }
 
 .flex-grid {
   display: flex;
+  overflow: hidden;
 }
 
 .gs-action-container {
   line-height: 20px;
+}
+
+.gs-action-container:has(.gs-action-details) {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .gs-action-details {

--- a/packages/workspace/src/browser/style/index.css
+++ b/packages/workspace/src/browser/style/index.css
@@ -69,6 +69,7 @@
     background-color: var(--theia-editor-background);
     padding: var(--theia-ui-padding) calc(var(--theia-ui-padding) * 1.5);
     border-radius: 4px;
+    overflow-wrap: break-word;
 }
 
 .workspace-trust-dialog .dialogControl .theia-button.secondary {

--- a/packages/workspace/src/browser/workspace-trust-dialog.tsx
+++ b/packages/workspace/src/browser/workspace-trust-dialog.tsx
@@ -62,13 +62,22 @@ export class WorkspaceTrustDialog extends ReactDialog<boolean> {
                 <div className="workspace-trust-description">
                     {nls.localize(
                         'theia/workspace/trustDialogMessage',
-                        `If you trust the authors, code in this folder may be executed.
-
-                        If not, some features will be disabled.
-                        
-                        The workspace trust feature is currently under development in Theia; not all features are integrated with workspace trust yet.
-                        Check the 'Restricted Mode' indicator in the status bar for details.`
+                        'If you trust the authors, code in this folder may be executed, including tasks, debug configurations, extensions, and AI features.'
                     )}
+                </div>
+                <div className="workspace-trust-description">
+                    {nls.localize(
+                        'theia/workspace/trustDialogRestricted',
+                        "If you don't trust the authors, the workspace will open in Restricted Mode, which disables these features to protect against potentially harmful code."
+                    )}
+                </div>
+                <div className="workspace-trust-description">
+                    <a href="https://theia-ide.org/docs/workspace_trust/"
+                        title="https://theia-ide.org/docs/workspace_trust/"
+                        target="_blank"
+                        rel="noopener noreferrer">
+                        {nls.localize('theia/workspace/trustLearnMore', "Learn more about Theia's Workspace Trust")}
+                    </a>
                 </div>
                 {this.folderUris.length > 0 && (
                     <div className="workspace-trust-folder">

--- a/packages/workspace/src/browser/workspace-trust-service.ts
+++ b/packages/workspace/src/browser/workspace-trust-service.ts
@@ -500,15 +500,23 @@ export class WorkspaceTrustService {
     }
 
     protected createRestrictedModeTooltip(): MarkdownString {
-        const md = new MarkdownStringImpl('', { supportThemeIcons: true });
+        const manageTrustLink = `[${WorkspaceCommands.MANAGE_WORKSPACE_TRUST.label}](command:${WorkspaceCommands.MANAGE_WORKSPACE_TRUST.id})`;
+        const docsLink = `[${nls.localize('theia/workspace/trustLearnMore', "Learn more about Theia's Workspace Trust")}](https://theia-ide.org/docs/workspace_trust/)`;
+
+        const md = new MarkdownStringImpl('', {
+            supportThemeIcons: true,
+            isTrusted: { enabledCommands: [WorkspaceCommands.MANAGE_WORKSPACE_TRUST.id] }
+        });
 
         md.appendMarkdown(`**${nls.localizeByDefault('Restricted Mode')}**\n\n`);
 
         md.appendMarkdown(nls.localize('theia/workspace/restrictedModeDescription',
             'Some features are disabled because this workspace is not trusted.'));
         md.appendMarkdown('\n\n');
-        md.appendMarkdown(nls.localize('theia/workspace/restrictedModeNote',
-            '*Please note: The workspace trust feature is currently under development in Theia; not all features are integrated with workspace trust yet*'));
+        md.appendMarkdown(nls.localize('theia/workspace/restrictedModeFeatures',
+            'Features like task execution, debugging, extensions, and AI are disabled to protect against potentially harmful code.'));
+        md.appendMarkdown('\n\n');
+        md.appendMarkdown(manageTrustLink);
 
         const restrictions = this.collectRestrictions();
         if (restrictions.length > 0) {
@@ -525,7 +533,7 @@ export class WorkspaceTrustService {
         }
 
         md.appendMarkdown('\n\n---\n\n');
-        md.appendMarkdown(nls.localize('theia/workspace/clickToManageTrust', 'Click to manage trust settings.'));
+        md.appendMarkdown(docsLink);
 
         return md;
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Different follow ups to the workspace trust feature:

- Replace "under development" caveat in trust dialog with specific, user-friendly descriptions of what trusting/not trusting a workspace means
- Split trust dialog message into three sections: trust implications, restricted mode explanation, and a "Learn more" link
- Update restricted mode tooltip to list specific disabled features (tasks, debugging, extensions, AI) and add link to docs page and to the manage workspace trust command
- Remove separate "under development" note from restricted mode tooltip
- Add Workspace Trust section to coding guidelines covering trust checks, restriction contributions, and context key usage
- Fix CSS overflow/truncation issues in getting-started and workspace trust dialog

feat(core): allow markdown links in hover tooltips to be interactive

- Route anchor clicks through OpenerService so command: URIs invoke
  CommandOpenHandler and http(s)/mailto/etc. open via their respective
  handlers
- Honor MarkdownString.isTrusted
- Set the href as the anchor's native title attribute so hovering
  shows the link's target

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open a workspace that has not been trusted yet and verify the trust dialog shows the updated wording with three distinct sections (trust implications, restricted mode explanation, "Learn more" link)
- Click the "Learn more" link and verify it opens <https://theia-ide.org/docs/workspace_trust/>
- Open an untrusted workspace, then hover over the "Restricted Mode" indicator in the status bar. Verify the tooltip lists specific disabled features
   - Verify the newly added links to the docs and the manage command work as expected
- Verify very long workspace names are properly handled in the workspace trust dialog and the getting-started page
   -  e.g on current master this looks like this in the trust dialog
      <img height="100" alt="image" src="https://github.com/user-attachments/assets/eb49bc3a-a1c6-44a6-9a48-da1b19d47b1d" />
   - and the welcome view <img width="1345" height="51" alt="image" src="https://github.com/user-attachments/assets/cdcd5d3c-f018-4132-a6b6-57f8c3cf6c3f" />

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- Investigate unifying `MonacoMarkdownRenderer` with the new `wireMarkdownLinkHandler` helper (currently uses Monaco's `IOpenerService` interception, which carries `openToSide`/`openExternal` signals a DOM-level handler can't reconstruct).
- Other consumers of the core MarkdownRenderer (scm history tooltip, AI chat welcome message, preferences description, test result widget, terminal links, the Markdown React helpers) can opt-in the same way using the new helper.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
