### PR TITLE
fix(ai-code-completion): disable reasoning for inline completion

### DIFF
--- a/packages/ai-code-completion/src/browser/code-completion-agent.spec.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.spec.ts
@@ -1,0 +1,207 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { UserRequest } from '@theia/ai-core/lib/common';
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { CancellationTokenSource, editor, IRange, languages, Position, Uri } from '@theia/monaco-editor-core/esm/vs/editor/editor.api';
+import { CodeCompletionAgentImpl } from './code-completion-agent';
+
+disableJSDOM();
+
+describe('CodeCompletionAgentImpl', () => {
+    let agent: CodeCompletionAgentImpl;
+    let model: editor.ITextModel;
+    let sendRequestStub: sinon.SinonStub;
+    let capturedRequest: UserRequest | undefined;
+    let postProcessStub: sinon.SinonStub;
+
+    const inlineContext: languages.InlineCompletionContext = {
+        triggerKind: languages.InlineCompletionTriggerKind.Automatic,
+        selectedSuggestionInfo: undefined,
+        includeInlineEdits: false,
+        includeInlineCompletions: false,
+        requestIssuedDateTime: Date.now(),
+        earliestShownDateTime: Date.now()
+    };
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    beforeEach(() => {
+        // Minimal stub: the agent only passes the model through to promptService (stubbed below).
+        model = { uri: Uri.file('/tmp/code-completion-agent.spec.ts') } as editor.ITextModel;
+
+        capturedRequest = undefined;
+        sendRequestStub = sinon.stub().callsFake((_lm: unknown, req: UserRequest) => {
+            capturedRequest = req;
+            return Promise.resolve({ text: 'COMPLETION' });
+        });
+        postProcessStub = sinon.stub().callsFake((text: string) => text);
+
+        agent = new CodeCompletionAgentImpl();
+        Object.assign(agent, {
+            languageModelService: { sendRequest: sendRequestStub },
+            languageModelRegistry: {
+                selectLanguageModel: sinon.stub().resolves({ id: 'fake/model' })
+            },
+            promptService: {
+                getResolvedPromptFragment: sinon.stub().resolves({ text: 'prompt text' }),
+                getPromptVariantInfo: sinon.stub().returns({ variantId: 'v1', isCustomized: false })
+            },
+            progressService: {
+                showProgress: sinon.stub().resolves({ cancel: () => { /* no-op */ } })
+            },
+            postProcessor: { postProcess: postProcessStub },
+            logger: { error: () => { /* no-op */ } }
+        });
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    it('disables reasoning on the LLM request', async () => {
+        const tokenSource = new CancellationTokenSource();
+        await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+        expect(sendRequestStub.calledOnce).to.be.true;
+        expect(capturedRequest?.reasoning).to.deep.equal({ level: 'off' });
+    });
+
+    it('disables streaming on the LLM request', async () => {
+        const tokenSource = new CancellationTokenSource();
+        await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+        expect(capturedRequest?.settings?.stream).to.equal(false);
+    });
+
+    it('forwards Monaco\'s cancellation token to the LLM request', async () => {
+        // Forwarded so explicit user cancellation (e.g. Esc) propagates to providers that honor it,
+        // such as Anthropic's `stream.abort()`.
+        const tokenSource = new CancellationTokenSource();
+        await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+        expect(capturedRequest?.cancellationToken).to.equal(tokenSource.token);
+    });
+
+    it('discards the response when the token is cancelled before returning', async () => {
+        const tokenSource = new CancellationTokenSource();
+        sendRequestStub.callsFake((_lm: unknown, req: UserRequest) => {
+            capturedRequest = req;
+            // Cancel after the request was issued so the post-`sendRequest` check fires.
+            tokenSource.cancel();
+            return Promise.resolve({ text: 'LATE_COMPLETION' });
+        });
+
+        const result = await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+
+        expect(result).to.be.undefined;
+    });
+
+    it('bails before sending the request when the token is already cancelled', async () => {
+        const tokenSource = new CancellationTokenSource();
+        tokenSource.cancel();
+
+        const result = await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+
+        expect(result).to.be.undefined;
+        expect(sendRequestStub.called).to.be.false;
+    });
+
+    it('returns undefined when no language model is available', async () => {
+        Object.assign(agent, {
+            languageModelRegistry: { selectLanguageModel: sinon.stub().resolves(undefined) }
+        });
+        const tokenSource = new CancellationTokenSource();
+
+        const result = await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+
+        expect(result).to.be.undefined;
+        expect(sendRequestStub.called).to.be.false;
+    });
+
+    it('returns undefined when no prompt is resolved', async () => {
+        Object.assign(agent, {
+            promptService: {
+                getResolvedPromptFragment: sinon.stub().resolves(undefined),
+                getPromptVariantInfo: sinon.stub().returns(undefined)
+            }
+        });
+        const tokenSource = new CancellationTokenSource();
+
+        const result = await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+
+        expect(result).to.be.undefined;
+        expect(sendRequestStub.called).to.be.false;
+    });
+
+    it('post-processes the completion text before returning it', async () => {
+        postProcessStub.callsFake((text: string) => `<<${text}>>`);
+        const tokenSource = new CancellationTokenSource();
+
+        const result = await agent.provideInlineCompletions(model, new Position(2, 3), inlineContext, tokenSource.token);
+
+        expect(postProcessStub.calledOnceWithExactly('COMPLETION')).to.be.true;
+        expect(result!.items[0].insertText).to.equal('<<COMPLETION>>');
+    });
+
+    it('uses the requested cursor position as the completion range', async () => {
+        const tokenSource = new CancellationTokenSource();
+
+        const result = await agent.provideInlineCompletions(model, new Position(5, 7), inlineContext, tokenSource.token);
+
+        const range = result!.items[0].range as IRange;
+        expect(range.startLineNumber).to.equal(5);
+        expect(range.startColumn).to.equal(7);
+        expect(range.endLineNumber).to.equal(5);
+        expect(range.endColumn).to.equal(7);
+    });
+
+    it('cancels the progress indicator regardless of outcome', async () => {
+        const progressCancel = sinon.spy();
+        Object.assign(agent, {
+            progressService: { showProgress: sinon.stub().resolves({ cancel: progressCancel }) }
+        });
+        const tokenSource = new CancellationTokenSource();
+
+        await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+
+        expect(progressCancel.calledOnce).to.be.true;
+    });
+
+    it('swallows errors and clears the progress indicator', async () => {
+        const progressCancel = sinon.spy();
+        Object.assign(agent, {
+            progressService: { showProgress: sinon.stub().resolves({ cancel: progressCancel }) }
+        });
+        sendRequestStub.rejects(new Error('boom'));
+        sinon.stub(console, 'error');
+        const tokenSource = new CancellationTokenSource();
+
+        const result = await agent.provideInlineCompletions(model, new Position(1, 1), inlineContext, tokenSource.token);
+
+        expect(result).to.be.undefined;
+        expect(progressCancel.calledOnce).to.be.true;
+    });
+});

--- a/packages/ai-code-completion/src/browser/code-completion-agent.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.ts
@@ -89,6 +89,9 @@ export class CodeCompletionAgentImpl implements CodeCompletionAgent {
                 settings: {
                     stream: false
                 },
+                // Inline completion is a one-shot text replacement; reasoning/thinking adds latency
+                // and can cause models (e.g. Anthropic adaptive thinking) to emit no text at all.
+                reasoning: { level: 'off' },
                 agentId: this.id,
                 sessionId,
                 requestId,

--- a/packages/ai-code-completion/src/browser/code-completion-variable-contribution.spec.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-variable-contribution.spec.ts
@@ -14,28 +14,55 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
-import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
-let disableJSDOM = enableJSDOM();
-FrontendApplicationConfigProvider.set({});
-
 import { PreferenceService } from '@theia/core/lib/common';
 import { Container } from '@theia/core/shared/inversify';
 import { editor, languages, Uri } from '@theia/monaco-editor-core/esm/vs/editor/editor.api';
 import { expect } from 'chai';
-import * as sinon from 'sinon';
 import { CodeCompletionVariableContext } from './code-completion-variable-context';
 import { CodeCompletionVariableContribution } from './code-completion-variable-contribution';
 import { FILE, LANGUAGE, PREFIX, SUFFIX } from './code-completion-variables';
 
-disableJSDOM();
+// A minimal fake ITextModel covering just the methods the contribution touches.
+// Avoids calling `editor.createModel`, which lazily initializes Monaco's
+// StandaloneThemeService and requires browser globals (CSS, matchMedia) that
+// JSDOM does not expose.
+function createFakeModel(text: string, languageId: string, uri: Uri): editor.ITextModel {
+    const lines = text.split('\n');
+    return {
+        uri,
+        getLanguageId: () => languageId,
+        getLineCount: () => lines.length,
+        getLineMaxColumn: (line: number) => lines[line - 1].length + 1,
+        getPositionAt: (offset: number) => {
+            let remaining = offset;
+            for (let i = 0; i < lines.length; i++) {
+                if (remaining <= lines[i].length) {
+                    return { lineNumber: i + 1, column: remaining + 1 };
+                }
+                remaining -= lines[i].length + 1; // account for '\n'
+            }
+            const last = lines.length - 1;
+            return { lineNumber: lines.length, column: lines[last].length + 1 };
+        },
+        getValueInRange: (range: { startLineNumber: number; startColumn: number; endLineNumber: number; endColumn: number }) => {
+            const parts: string[] = [];
+            for (let line = range.startLineNumber; line <= range.endLineNumber; line++) {
+                const lineText = lines[line - 1];
+                const start = line === range.startLineNumber ? range.startColumn - 1 : 0;
+                const end = line === range.endLineNumber ? range.endColumn - 1 : lineText.length;
+                parts.push(lineText.substring(start, end));
+            }
+            return parts.join('\n');
+        },
+        dispose: () => { /* no-op */ },
+    } as unknown as editor.ITextModel;
+}
 
 describe('CodeCompletionVariableContribution', () => {
     let contribution: CodeCompletionVariableContribution;
     let model: editor.ITextModel;
 
     before(() => {
-        disableJSDOM = enableJSDOM();
         const container = new Container();
         container.bind(PreferenceService).toConstantValue({
             get: () => 1000,
@@ -45,18 +72,7 @@ describe('CodeCompletionVariableContribution', () => {
     });
 
     beforeEach(() => {
-        model = editor.createModel('//line 1\nconsole.\n//line 2', 'javascript', Uri.file('/home/user/workspace/test.js'));
-        sinon.stub(model, 'getLanguageId').returns('javascript');
-    });
-
-    afterEach(() => {
-        model.dispose();
-    });
-
-    after(() => {
-        // Disable JSDOM after all tests
-        disableJSDOM();
-        model.dispose();
+        model = createFakeModel('//line 1\nconsole.\n//line 2', 'javascript', Uri.file('/home/user/workspace/test.js'));
     });
 
     describe('canResolve', () => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Inline code completion is a one-shot text replacement, but every reasoning-capable model in Theia today is configured with `defaultLevel: 'auto'`. `FrontendLanguageModelServiceImpl.sendRequest` auto-applies that default to any `UserRequest` that does not explicitly set a `reasoning` field. For Claude Sonnet 4-6 (and other models that map `'auto'` to adaptive thinking), the model spent its budget on thinking and emitted no completion text. The request appeared in the AI history view, the response was empty, and nothing showed up in the editor.

This change sets `reasoning: { level: 'off' }` on the `UserRequest` built by `CodeCompletionAgentImpl`, bypassing the auto-applied default. Reasoning is the wrong tool for inline completion regardless of provider, so this applies uniformly across Anthropic, OpenAI, and Google models.

Also adds a unit-test spec for `CodeCompletionAgentImpl`, which previously had no test coverage.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Use the current `default/code-completion` model for the Code Completion agent (resolves to `anthropic/claude-sonnet-4-6` currently)
2. Enable `ai-features.codeCompletion.automaticCodeCompletion` setting
3. Verify that typing in a TypeScript file produces a ghost-text suggestion after a short typing pause.
   - Might take a few moments to complet, check the progress indicator in the status bar
4. Independent of the auto setting: Verify that `Ctrl+Alt+Space` (explicit trigger) still works to trigger inline code completion.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
