### PR TITLE
feat(nls): re-translate changed source strings in update workflow

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -446,7 +446,8 @@ async function theiaCli(): Promise<void> {
             deeplKey: string,
             file: string,
             languages: string[],
-            sourceLanguage?: string
+            sourceLanguage?: string,
+            forceRetranslate?: string
         }>({
             command: 'nls-localize [languages...]',
             describe: 'Localize json files using the DeepL API',
@@ -469,15 +470,21 @@ async function theiaCli(): Promise<void> {
                 'source-language': {
                     alias: 's',
                     describe: 'The source language of the translation file'
+                },
+                'force-retranslate': {
+                    describe: 'Comma-separated list of localization keys to force re-translate even if they already exist',
+                    type: 'string' as const
                 }
             },
-            handler: async ({ freeApi, deeplKey, file, sourceLanguage, languages = [] }) => {
+            handler: async ({ freeApi, deeplKey, file, sourceLanguage, languages = [], forceRetranslate }) => {
+                const forceKeys = forceRetranslate ? new Set(forceRetranslate.split(',').map((k: string) => k.trim()).filter(Boolean)) : undefined;
                 const success = await localizationManager.localize({
                     sourceFile: file,
                     freeApi: freeApi ?? true,
                     authKey: deeplKey,
                     targetLanguages: languages,
-                    sourceLanguage
+                    sourceLanguage,
+                    forceKeys
                 });
                 if (!success) {
                     process.exit(1);

--- a/dev-packages/localization-manager/src/localization-extractor.spec.ts
+++ b/dev-packages/localization-manager/src/localization-extractor.spec.ts
@@ -96,16 +96,25 @@ describe('correctly extracts from file content', () => {
         const errors: string[] = [];
         assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors, quiet), {});
         assert.deepStrictEqual(errors, [
-            "test.ts(1,14): Could not resolve reference to 'a'"
+            "test.ts(1,14): Skipping 'a': could not resolve reference (may be imported from another file)"
         ]);
     });
 
-    it('should return an error when resolving from an expression', async () => {
+    it('should return an error when resolving from a property access expression', async () => {
         const content = "nls.localize(test.value, 'value');";
         const errors: string[] = [];
         assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors, quiet), {});
         assert.deepStrictEqual(errors, [
-            "test.ts(1,14): 'test.value' is not a string constant"
+            "test.ts(1,14): Skipping 'test.value': expression cannot be statically resolved"
+        ]);
+    });
+
+    it('should silently skip call expressions used as arguments', async () => {
+        const content = "nls.localize('key', someFunction());";
+        const errors: string[] = [];
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors, quiet), {});
+        assert.deepStrictEqual(errors, [
+            "test.ts(1,20): Skipping 'someFunction()': expression cannot be statically resolved"
         ]);
     });
 
@@ -192,12 +201,33 @@ describe('correctly extracts from file content', () => {
         });
     });
 
+    it('should resolve exported const references', async () => {
+        const content = `
+        export const MY_MESSAGE = 'Hello World';
+        nls.localize('key', MY_MESSAGE);
+        `;
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'key': 'Hello World'
+        });
+    });
+
+    it('should resolve exported const with string concatenation', async () => {
+        const content = `
+        export const MY_MESSAGE = 'Hello '
+            + 'World';
+        nls.localize('key', MY_MESSAGE);
+        `;
+        assert.deepStrictEqual(await extractFromFile(TEST_FILE, content), {
+            'key': 'Hello World'
+        });
+    });
+
     it('should return an error when concatenation includes a non-string expression', async () => {
         const content = 'nls.localize("key", "hello " + someFunction())';
         const errors: string[] = [];
         assert.deepStrictEqual(await extractFromFile(TEST_FILE, content, errors, quiet), {});
         assert.deepStrictEqual(errors, [
-            "test.ts(1,31): 'someFunction()' is not a string constant"
+            "test.ts(1,31): Skipping 'someFunction()': expression cannot be statically resolved"
         ]);
     });
 

--- a/dev-packages/localization-manager/src/localization-extractor.ts
+++ b/dev-packages/localization-manager/src/localization-extractor.ts
@@ -63,8 +63,10 @@ class SingleFileServiceHost implements ts.LanguageServiceHost {
 }
 
 class TypeScriptError extends Error {
-    constructor(message: string, node: ts.Node) {
+    readonly crossFileReference: boolean;
+    constructor(message: string, node: ts.Node, crossFileReference = false) {
         super(buildErrorMessage(message, node));
+        this.crossFileReference = crossFileReference;
     }
 }
 
@@ -122,11 +124,7 @@ export async function extractFromFile(file: string, content: string, errors?: st
                 insert(localization, extracted);
             }
         } catch (err) {
-            const tsError = err as Error;
-            errors?.push(tsError.message);
-            if (!options?.quiet) {
-                console.log(tsError.message);
-            }
+            reportError(err, errors, options);
         }
     }
     const localizedCommands = collect(sourceFile, node => isCommandLocalizeUtility(node));
@@ -142,14 +140,18 @@ export async function extractFromFile(file: string, content: string, errors?: st
                 insert(localization, category);
             }
         } catch (err) {
-            const tsError = err as Error;
-            errors?.push(tsError.message);
-            if (!options?.quiet) {
-                console.log(tsError.message);
-            }
+            reportError(err, errors, options);
         }
     }
     return localization;
+}
+
+function reportError(err: unknown, errors?: string[], options?: ExtractionOptions): void {
+    const tsError = err as TypeScriptError;
+    errors?.push(tsError.message);
+    if (!options?.quiet && !tsError.crossFileReference) {
+        console.log(tsError.message);
+    }
 }
 
 function isExcluded(options: ExtractionOptions | undefined, key: string): boolean {
@@ -273,11 +275,7 @@ function extractFromLocalizedCommandCall(node: ts.Node, errors?: string[], optio
             const value = extractString(property.initializer);
             propertyMap.set(name, value);
         } catch (err) {
-            const tsError = err as Error;
-            errors?.push(tsError.message);
-            if (!options?.quiet) {
-                console.log(tsError.message);
-            }
+            reportError(err, errors, options);
         }
     }
 
@@ -294,11 +292,7 @@ function extractFromLocalizedCommandCall(node: ts.Node, errors?: string[], optio
                 labelNode = args[1];
             }
         } catch (err) {
-            const tsError = err as Error;
-            errors?.push(tsError.message);
-            if (!options?.quiet) {
-                console.log(tsError.message);
-            }
+            reportError(err, errors, options);
         }
     }
 
@@ -308,11 +302,7 @@ function extractFromLocalizedCommandCall(node: ts.Node, errors?: string[], optio
             categoryKey = extractStringOrUndefined(args[2]);
             categoryNode = args[2];
         } catch (err) {
-            const tsError = err as Error;
-            errors?.push(tsError.message);
-            if (!options?.quiet) {
-                console.log(tsError.message);
-            }
+            reportError(err, errors, options);
         }
     }
 
@@ -347,7 +337,7 @@ function extractString(node: ts.Expression): string {
     if (ts.isIdentifier(node)) {
         const reference = followReference(node);
         if (!reference) {
-            throw new TypeScriptError(`Could not resolve reference to '${node.text}'`, node);
+            throw new TypeScriptError(`Skipping '${node.text}': could not resolve reference (may be imported from another file)`, node, true);
         }
         node = reference;
     }
@@ -369,6 +359,9 @@ function extractString(node: ts.Expression): string {
     if (ts.isBinaryExpression(node) && node.operatorToken.kind === ts.SyntaxKind.PlusToken) {
         return extractString(node.left) + extractString(node.right);
     }
+    if (ts.isPropertyAccessExpression(node) || ts.isCallExpression(node)) {
+        throw new TypeScriptError(`Skipping '${node.getText()}': expression cannot be statically resolved`, node, true);
+    }
     if (!ts.isStringLiteralLike(node)) {
         throw new TypeScriptError(`'${node.getText()}' is not a string constant`, node);
     }
@@ -385,11 +378,9 @@ function followReference(node: ts.Identifier): ts.Expression | undefined {
     return next;
 }
 
-function collectScope(node: ts.Node, map: Map<string, ts.Expression> = new Map()): Map<string, ts.Expression> {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const locals = (node as any)['locals'] as Map<string, ts.Symbol>;
-    if (locals) {
-        for (const [key, value] of locals.entries()) {
+function collectSymbols(symbols: Map<string, ts.Symbol> | undefined, map: Map<string, ts.Expression>): void {
+    if (symbols) {
+        for (const [key, value] of symbols.entries()) {
             if (!map.has(key)) {
                 const declaration = value.valueDeclaration;
                 if (declaration && ts.isVariableDeclaration(declaration) && declaration.initializer) {
@@ -398,6 +389,16 @@ function collectScope(node: ts.Node, map: Map<string, ts.Expression> = new Map()
             }
         }
     }
+}
+
+function collectScope(node: ts.Node, map: Map<string, ts.Expression> = new Map()): Map<string, ts.Expression> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const locals = (node as any)['locals'] as Map<string, ts.Symbol>;
+    collectSymbols(locals, map);
+    // Exported declarations (e.g. `export const`) are stored in `symbol.exports` rather than `locals`
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const exports = (node as any)['symbol']?.exports as Map<string, ts.Symbol> | undefined;
+    collectSymbols(exports, map);
     if (node.parent) {
         collectScope(node.parent, map);
     }

--- a/dev-packages/localization-manager/src/localization-manager.spec.ts
+++ b/dev-packages/localization-manager/src/localization-manager.spec.ts
@@ -133,6 +133,36 @@ describe('localization-manager#translateLanguage', () => {
         });
     });
 
+    it('should re-translate forced keys even if they exist in target', async () => {
+        const input = { a: 'new-a' };
+        const target = { a: 'old-translation' };
+        await manager.translateLanguage(input, target, 'EN', {
+            ...defaultOptions,
+            forceKeys: new Set(['a'])
+        });
+        assert.deepStrictEqual(target, { a: '[new-a]' });
+    });
+
+    it('should re-translate nested forced keys', async () => {
+        const input = { a: { b: 'new-b' } };
+        const target = { a: { b: 'old-translation' } };
+        await manager.translateLanguage(input, target, 'EN', {
+            ...defaultOptions,
+            forceKeys: new Set(['a/b'])
+        });
+        assert.deepStrictEqual(target, { a: { b: '[new-b]' } });
+    });
+
+    it('should not re-translate keys not in force set', async () => {
+        const input = { a: 'new-a', b: 'new-b' };
+        const target = { a: 'old-a', b: 'old-b' };
+        await manager.translateLanguage(input, target, 'EN', {
+            ...defaultOptions,
+            forceKeys: new Set(['a'])
+        });
+        assert.deepStrictEqual(target, { a: '[new-a]', b: 'old-b' });
+    });
+
     it('should pass context to the localization function', async () => {
         let receivedContext: string | undefined;
         const contextCapture = new LocalizationManager(async (parameters: DeeplParameters) => {

--- a/dev-packages/localization-manager/src/localization-manager.ts
+++ b/dev-packages/localization-manager/src/localization-manager.ts
@@ -26,6 +26,7 @@ export interface LocalizationOptions {
     sourceFile: string
     sourceLanguage?: string
     targetLanguages: string[]
+    forceKeys?: Set<string>
 }
 
 export type LocalizationFunction = (parameters: DeeplParameters) => Promise<DeeplResponse>;
@@ -92,7 +93,7 @@ export class LocalizationManager {
     }
 
     async translateLanguage(source: Localization, target: Localization, targetLanguage: string, options: LocalizationOptions): Promise<boolean> {
-        const map = this.buildLocalizationMap(source, target);
+        const map = this.buildLocalizationMap(source, target, options.forceKeys);
         if (map.text.length > 0) {
             try {
                 const translationResponse = await this.localizationFn({
@@ -109,7 +110,10 @@ export class LocalizationManager {
                 translationResponse.translations.forEach(({ text }, i) => {
                     map.localize(i, this.removeIgnoreTags(text));
                 });
-                console.log(chalk.green(`Successfully translated ${map.text.length} value${map.text.length > 1 ? 's' : ''} for language "${targetLanguage}"`));
+                console.log(chalk.green(`Successfully translated ${map.text.length} value${map.text.length > 1 ? 's' : ''} for language "${targetLanguage}":`));
+                for (const key of map.keys) {
+                    console.log(chalk.green(`  - ${key}`));
+                }
                 return true;
             } catch (e) {
                 console.log(chalk.red(`Could not translate into language "${targetLanguage}"`), e);
@@ -134,10 +138,11 @@ export class LocalizationManager {
         return result.replace(/&lt;/g, '<').replace(/&gt;/g, '>').replace(/&amp;/g, '&');
     }
 
-    protected buildLocalizationMap(source: Localization, target: Localization): LocalizationMap {
+    protected buildLocalizationMap(source: Localization, target: Localization, forceKeys?: Set<string>): LocalizationMap {
         const functionMap = new Map<number, (value: string) => void>();
         const text: string[] = [];
-        const process = (s: Localization, t: Localization) => {
+        const keys: string[] = [];
+        const process = (s: Localization, t: Localization, prefix = '') => {
             // Delete all extra keys in the target translation first
             for (const key of Object.keys(t)) {
                 if (!(key in s)) {
@@ -145,20 +150,26 @@ export class LocalizationManager {
                 }
             }
             for (const [key, value] of Object.entries(s)) {
+                const currentPath = prefix ? `${prefix}/${key}` : key;
                 if (!(key in t)) {
                     if (typeof value === 'string') {
                         functionMap.set(text.length, translation => t[key] = translation);
                         text.push(value);
+                        keys.push(currentPath);
                     } else {
                         const newLocalization: Localization = {};
                         t[key] = newLocalization;
-                        process(value, newLocalization);
+                        process(value, newLocalization, currentPath);
                     }
+                } else if (typeof value === 'string' && forceKeys?.has(currentPath)) {
+                    functionMap.set(text.length, translation => t[key] = translation);
+                    text.push(value);
+                    keys.push(currentPath);
                 } else if (typeof value === 'object') {
                     if (typeof t[key] === 'string') {
                         t[key] = {};
                     }
-                    process(value, t[key] as Localization);
+                    process(value, t[key] as Localization, currentPath);
                 }
             }
         };
@@ -167,6 +178,7 @@ export class LocalizationManager {
 
         return {
             text,
+            keys,
             localize: (index, value) => functionMap.get(index)!(value)
         };
     }
@@ -174,5 +186,6 @@ export class LocalizationManager {
 
 export interface LocalizationMap {
     text: string[]
+    keys: string[]
     localize: (index: number, value: string) => void
 }

--- a/scripts/translation-update.js
+++ b/scripts/translation-update.js
@@ -1,12 +1,22 @@
 const cp = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const NLS_FILE = './packages/core/i18n/nls.json';
 
 console.log('Extracting all localization calls...');
+const previousNls = readNlsFile();
 performNlsExtract();
 if (hasNlsFileChanged()) {
     const token = getDeepLToken();
     if (token) {
+        const currentNls = readNlsFile();
+        const changedKeys = getChangedKeys(previousNls, currentNls);
+        if (changedKeys.length > 0) {
+            console.log(`Detected ${changedKeys.length} changed source string(s): ${changedKeys.join(', ')}`);
+        }
         console.log('Performing DeepL translation...');
-        performDeepLTranslation(token);
+        performDeepLTranslation(token, changedKeys);
         console.log('Translation finished successfully!');
     } else {
         console.log('No DeepL API token found in env');
@@ -19,7 +29,7 @@ if (hasNlsFileChanged()) {
 function performNlsExtract() {
     cp.spawnSync('npx', [
         'theia', 'nls-extract',
-        '-o', './packages/core/i18n/nls.json',
+        '-o', NLS_FILE,
         '-e', 'vscode',
         '-f', './packages/**/{browser,electron-browser,common}/**/*.{ts,tsx}'
     ], {
@@ -29,7 +39,7 @@ function performNlsExtract() {
 }
 
 function hasNlsFileChanged() {
-    const childProcess = cp.spawnSync('git', ['diff', '--exit-code', './packages/core/i18n/nls.json']);
+    const childProcess = cp.spawnSync('git', ['diff', '--exit-code', NLS_FILE]);
     return childProcess.status === 1;
 }
 
@@ -37,12 +47,46 @@ function getDeepLToken() {
     return process.env['DEEPL_API_TOKEN'];
 }
 
-function performDeepLTranslation(token) {
-    const childProcess = cp.spawnSync('npx', [
+function readNlsFile() {
+    try {
+        return JSON.parse(fs.readFileSync(path.resolve(NLS_FILE), 'utf-8'));
+    } catch (error) {
+        if (error && error.code === 'ENOENT') {
+            return {};
+        }
+        console.error(`Failed to read or parse ${NLS_FILE}:`, error);
+        process.exit(1);
+    }
+}
+
+function getChangedKeys(previous, current, prefix = '') {
+    const changed = [];
+    if (!previous || typeof previous !== 'object') {
+        return changed;
+    }
+    for (const [key, value] of Object.entries(current)) {
+        const currentPath = prefix ? `${prefix}/${key}` : key;
+        if (typeof value === 'string') {
+            if (key in previous && typeof previous[key] === 'string' && previous[key] !== value) {
+                changed.push(currentPath);
+            }
+        } else if (typeof value === 'object' && value !== null) {
+            changed.push(...getChangedKeys(previous[key], value, currentPath));
+        }
+    }
+    return changed;
+}
+
+function performDeepLTranslation(token, changedKeys) {
+    const args = [
         'theia', 'nls-localize',
-        '-f', './packages/core/i18n/nls.json',
+        '-f', NLS_FILE,
         '--free-api', '-k', token
-    ], {
+    ];
+    if (changedKeys && changedKeys.length > 0) {
+        args.push('--force-retranslate', changedKeys.join(','));
+    }
+    const childProcess = cp.spawnSync('npx', args, {
         shell: true,
         stdio: 'inherit'
     });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17315

- Detect changed source strings in `scripts/translation-update.js` by diffing `nls.json` before/after extraction, then pass them to the nls CLI for re-translation
- Add `--force-retranslate <keys>` option to the `nls-localize` CLI command and a corresponding `forceKeys` option on `LocalizationManager.translateLanguage` to re-translate keys whose default value changed, instead of keeping stale translations
- Log the list of translated keys per language for better visibility
- Resolve `export const` references in the localization extractor so default messages declared at module scope can be picked up
- Silently skip cross-file identifier references and unresolvable property-access / call expressions instead of logging them as errors, since they were polluting the build log without being actionable

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Change an already localized string, e.g. as mentioned in the issue, the title of the AI Configuration view
- Run the automatic translations script locally (`node ./scripts/translation-update.js`)
   - Remark: this needs a DeepL token; you can just simply comment out the actual translation call in the script (i.e. the `const childProcess = cp.spawnSync` part in performDeepLTranslation).
- Verify the changed source string(s) are reflected in the `nls.json` file and that they are logged, e.g. `Detected x changed source string(s): theia/xxxx`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
