### PR TITLE
fix(ai-code-completion): fix unit tests

### DIFF
--- a/packages/ai-code-completion/src/browser/code-completion-agent.spec.ts
+++ b/packages/ai-code-completion/src/browser/code-completion-agent.spec.ts
@@ -45,6 +45,7 @@ describe('CodeCompletionAgentImpl', () => {
 
     before(() => {
         disableJSDOM = enableJSDOM();
+        FrontendApplicationConfigProvider.set({});
     });
 
     beforeEach(() => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

After #17447 was merged on top of #17521, CodeCompletionAgentImpl's description property initializer now reads FrontendApplicationConfigProvider.get() at construction time, but the spec's module-level set({}) is stored on a JSDOM window that gets torn down before before() re-enables JSDOM. Calling set({}) again inside before() registers the config against the window that's actually live when new CodeCompletionAgentImpl() runs.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Verify the unit tests `Test (headless)` in the CI checks are successful again.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Will bring up the proposal for merge queues in next developer meeting (https://github.com/eclipse-theia/theia/wiki/Dev-Meetings).

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
