### PR TITLE
feat(plugin-ext): honor 'when' clause on view containers

### DIFF
--- a/packages/plugin-ext/src/common/plugin-protocol.ts
+++ b/packages/plugin-ext/src/common/plugin-protocol.ts
@@ -190,6 +190,7 @@ export interface PluginPackageViewContainer {
     id: string;
     title: string;
     icon: string;
+    when?: string;
 }
 
 export enum PluginViewType {
@@ -851,6 +852,7 @@ export interface ViewContainer {
     title: string;
     iconUrl: string;
     themeIcon?: string;
+    when?: string;
 }
 
 /**

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -838,6 +838,7 @@ export class TheiaPluginScanner extends AbstractPluginScanner {
             title: rawViewContainer.title,
             iconUrl,
             themeIcon,
+            when: rawViewContainer.when,
         };
     }
 

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -60,6 +60,7 @@ export type ViewDataProvider = (params: { state?: object, viewInfo: View }) => P
 export interface ViewContainerInfo {
     id: string
     location: string
+    when?: string
     options: ViewContainerTitleOptions
     onViewAdded: () => void
 }
@@ -108,6 +109,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     private readonly viewContainers = new Map<string, ViewContainerInfo>();
     private readonly containerViews = new Map<string, string[]>();
     private readonly viewClauseContexts = new Map<string, Set<string> | undefined>();
+    private readonly viewContainerClauseContexts = new Map<string, Set<string> | undefined>();
 
     private readonly viewDataProviders = new Map<string, ViewDataProvider>();
     private readonly viewDataState = new Map<string, object>();
@@ -202,6 +204,12 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             }
         });
         this.contextKeyService.onDidChange(e => {
+            for (const containerId of this.viewContainers.keys()) {
+                const clauseContext = this.viewContainerClauseContexts.get(containerId);
+                if (clauseContext && e.affects(clauseContext)) {
+                    this.updateViewContainerVisibility(containerId);
+                }
+            }
             for (const [, view] of this.views.values()) {
                 const clauseContext = this.viewClauseContexts.get(view.id);
                 if (clauseContext && e.affects(clauseContext)) {
@@ -328,7 +336,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             // The container class automatically sets a mask; if we're using a theme icon, we don't want one.
             iconClass: (themeIconClass || containerClass) + ' ' + iconClass,
             closeable: true
-        }));
+        }, viewContainer.when?.trim()));
         return toDispose;
     }
 
@@ -344,9 +352,16 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
     }
 
-    protected doRegisterViewContainer(id: string, location: string, options: ViewContainerTitleOptions): Disposable {
+    protected doRegisterViewContainer(id: string, location: string, options: ViewContainerTitleOptions, when?: string): Disposable {
         const toDispose = new DisposableCollection();
         toDispose.push(Disposable.create(() => this.viewContainers.delete(id)));
+        if (when && when !== 'false' && when !== 'true') {
+            const keys = this.contextKeyService.parseKeys(when);
+            if (keys) {
+                this.viewContainerClauseContexts.set(id, keys);
+                toDispose.push(Disposable.create(() => this.viewContainerClauseContexts.delete(id)));
+            }
+        }
         const toggleCommandId = `plugin.view-container.${id}.toggle`;
         // Some plugins may register empty view containers.
         // We should not register commands for them immediately, as that leads to bad UX.
@@ -361,10 +376,12 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             }));
             toDispose.push(this.menus.registerMenuAction(CommonMenus.VIEW_VIEWS, {
                 commandId: toggleCommandId,
-                label: options.label
+                label: options.label,
+                when
             }));
             toDispose.push(this.quickView?.registerItem({
                 label: options.label,
+                when,
                 open: async () => {
                     const widget = await this.openViewContainer(id);
                     if (widget) {
@@ -384,10 +401,31 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         this.viewContainers.set(id, {
             id,
             location,
+            when,
             options,
             onViewAdded: () => activate()
         });
         return toDispose;
+    }
+
+    protected isViewContainerVisible(containerId: string): boolean {
+        const info = this.viewContainers.get(containerId);
+        if (!info) {
+            return false;
+        }
+        return info.when === undefined || info.when === 'true' || this.contextKeyService.match(info.when);
+    }
+
+    protected async updateViewContainerVisibility(containerId: string): Promise<void> {
+        const widget = await this.getPluginViewContainer(containerId);
+        if (this.isViewContainerVisible(containerId)) {
+            // Becoming visible: do not auto-open. Menu and quick pick entries will become available.
+            return;
+        }
+        // Becoming hidden: dispose any attached container widget so the activity bar icon disappears.
+        if (widget) {
+            widget.dispose();
+        }
     }
 
     getContainerViews(viewContainerId: string): string[] {
@@ -671,6 +709,9 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
         const data = this.viewContainers.get(containerId);
         if (!data) {
+            return undefined;
+        }
+        if (!this.isViewContainerVisible(containerId)) {
             return undefined;
         }
         const { location } = data;


### PR DESCRIPTION
#### What it does

VS Code's `contributes.viewsContainers` entries support a `when` clause for conditional visibility. Theia silently dropped this field, so extensions that guarded their containers behind mutually exclusive context keys ended up with all of them visible — empty panels in the activity bar and duplicate menu / quick-pick entries.

This PR adds `when?: string` to `PluginPackageViewContainer` / `ViewContainer`, reads it in the scanner, and honors it in `PluginViewRegistry`: the toggle menu action and the Open View quick pick filter on it, the container widget is not attached while the clause is false, and the registry reacts to context-key changes by disposing widgets that become hidden.

Related to #17255.

#### How to test

1. Install an extension with mutually exclusive `when` clauses on its view containers (e.g. Anthropic's Claude Code, which guards `claude-sidebar` on `claude-code:doesNotSupportSecondarySidebar` and `claude-sidebar-secondary` on its negation).
2. Verify only the matching container appears in the activity bar / secondary sidebar, and that the hidden one is absent from the View menu and `View: Open View`.

#### Follow-ups

A companion PR (`fix(plugin-ext): disambiguate duplicate view entries`) disambiguates the remaining same-label entries with location descriptions.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the \`nls\` service