### PR TITLE
fix(plugin-ext): disambiguate duplicate view entries (#17255)

### DIFF
--- a/packages/core/src/browser/quick-input/quick-view-service.spec.ts
+++ b/packages/core/src/browser/quick-input/quick-view-service.spec.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2026 SAP SE or an SAP affiliate company and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as chai from 'chai';
+import { CancellationToken } from '../../common';
+import { QuickPickItem } from './quick-input-service';
+import { QuickViewService } from './quick-view-service';
+
+const expect = chai.expect;
+
+describe('quick-view-service', () => {
+
+    describe('#getPicks', () => {
+
+        function labelsOf(service: QuickViewService): (string | undefined)[] {
+            return service.getPicks('', CancellationToken.None).map(pick => (pick as QuickPickItem).label);
+        }
+
+        it('returns registered items with a non-empty label', () => {
+            const service = new QuickViewService();
+            service.registerItem({ label: 'Explorer', open: () => { } });
+
+            expect(labelsOf(service)).to.deep.equal(['Explorer']);
+        });
+
+        it('omits items with an empty or whitespace-only label', () => {
+            const service = new QuickViewService();
+            service.registerItem({ label: 'Explorer', open: () => { } });
+            service.registerItem({ label: '', open: () => { } });
+            service.registerItem({ label: '   ', open: () => { } });
+
+            expect(labelsOf(service)).to.deep.equal(['Explorer']);
+        });
+
+    });
+
+});

--- a/packages/core/src/browser/quick-input/quick-view-service.spec.ts
+++ b/packages/core/src/browser/quick-input/quick-view-service.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 SAP SE or an SAP affiliate company and others.
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/core/src/browser/quick-input/quick-view-service.ts
+++ b/packages/core/src/browser/quick-input/quick-view-service.ts
@@ -22,6 +22,7 @@ import { filterItems, QuickPickItem, QuickPicks } from './quick-input-service';
 
 export interface QuickViewItem {
     readonly label: string;
+    readonly description?: string;
     readonly when?: string;
     readonly open: () => void;
 }
@@ -42,6 +43,7 @@ export class QuickViewService implements QuickAccessContribution, QuickAccessPro
     registerItem(item: QuickViewItem): Disposable {
         const quickOpenItem = {
             label: item.label,
+            description: item.description,
             execute: () => item.open(),
             when: item.when
         };

--- a/packages/core/src/browser/quick-input/quick-view-service.ts
+++ b/packages/core/src/browser/quick-input/quick-view-service.ts
@@ -77,6 +77,9 @@ export class QuickViewService implements QuickAccessContribution, QuickAccessPro
 
     getPicks(filter: string, token: CancellationToken): QuickPicks {
         const items = this.items.filter(item =>
+            // Some contributions register entries without a label (e.g. an empty view name);
+            // those would otherwise sort to the top and appear as a blank row.
+            item.label.trim().length > 0 &&
             (item.when === undefined || this.contextKexService.match(item.when)) &&
             (!this.hiddenItemLabels.has(item.label))
         );

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -86,6 +86,14 @@ import { PreferenceScope } from '@theia/core/lib/common/preferences/preference-s
 const colorIdPattern = '^\\w+[.\\w+]*$';
 const iconIdPattern = `^${CSSIcon.iconNameSegment}(-${CSSIcon.iconNameSegment})+$`;
 
+/** Maps the view container locations used by VS Code extensions to the Theia shell locations. */
+const VIEW_CONTAINER_LOCATION_ALIASES: Record<string, string> = {
+    activitybar: 'left',
+    panel: 'bottom',
+    secondarySidebar: 'right',
+    auxiliarybar: 'right'
+};
+
 function getFileExtension(filePath: string): string {
     const index = filePath.lastIndexOf('.');
     return index === -1 ? '' : filePath.substring(index + 1);
@@ -357,10 +365,7 @@ export class TheiaPluginScanner extends AbstractPluginScanner {
 
                 for (const location of Object.keys(viewsContainers)) {
                     const containers = this.readViewsContainers(viewsContainers[location], rawPlugin);
-                    const loc = location === 'activitybar' ? 'left'
-                        : location === 'panel' ? 'bottom'
-                            : location === 'secondarySidebar' || location === 'auxiliarybar' ? 'right'
-                                : location;
+                    const loc = VIEW_CONTAINER_LOCATION_ALIASES[location] ?? location;
                     if (contributions.viewsContainers[loc]) {
                         contributions.viewsContainers[loc] = contributions.viewsContainers[loc].concat(containers);
                     } else {

--- a/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
+++ b/packages/plugin-ext/src/hosted/node/scanners/scanner-theia.ts
@@ -357,7 +357,10 @@ export class TheiaPluginScanner extends AbstractPluginScanner {
 
                 for (const location of Object.keys(viewsContainers)) {
                     const containers = this.readViewsContainers(viewsContainers[location], rawPlugin);
-                    const loc = location === 'activitybar' ? 'left' : location === 'panel' ? 'bottom' : location;
+                    const loc = location === 'activitybar' ? 'left'
+                        : location === 'panel' ? 'bottom'
+                            : location === 'secondarySidebar' || location === 'auxiliarybar' ? 'right'
+                                : location;
                     if (contributions.viewsContainers[loc]) {
                         contributions.viewsContainers[loc] = contributions.viewsContainers[loc].concat(containers);
                     } else {

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.spec.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 SAP SE or an SAP affiliate company and others.
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.spec.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.spec.ts
@@ -1,0 +1,105 @@
+// *****************************************************************************
+// Copyright (C) 2026 SAP SE or an SAP affiliate company and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// PluginViewRegistry transitively imports browser widgets (Lumino) that touch `document` at load time.
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+// Some transitively imported modules read the frontend config at load time.
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { Disposable } from '@theia/core/lib/common';
+import { PluginViewRegistry, ViewContainerInfo } from './plugin-view-registry';
+
+disableJSDOM();
+
+interface RegisteredMenuAction {
+    commandId: string;
+    label: string;
+    when?: string;
+}
+
+/**
+ * Minimal stand-in for {@link MenuModelRegistry} that records the menu actions registered for the
+ * "Views" menu and removes them again when the returned disposable is disposed. This lets us assert
+ * on the labels {@link PluginViewRegistry} ends up showing without wiring the full DI container.
+ */
+class RecordingMenuModelRegistry {
+    readonly actions = new Map<string, RegisteredMenuAction>();
+
+    registerMenuAction(_menuPath: unknown, action: RegisteredMenuAction): Disposable {
+        this.actions.set(action.commandId, { ...action });
+        return Disposable.create(() => this.actions.delete(action.commandId));
+    }
+}
+
+describe('PluginViewRegistry - view menu labels', () => {
+
+    let registry: PluginViewRegistry;
+    let menus: RecordingMenuModelRegistry;
+
+    const toggleCommandId = (id: string): string => `plugin.view-container.${id}.toggle`;
+    const internals = (): {
+        viewContainers: Map<string, ViewContainerInfo>;
+        registerViewMenuAction(containerId: string, label: string): Disposable;
+    } => registry as unknown as {
+        viewContainers: Map<string, ViewContainerInfo>;
+        registerViewMenuAction(containerId: string, label: string): Disposable;
+    };
+
+    function registerContainer(id: string, label: string, location: string): Disposable {
+        internals().viewContainers.set(id, { id, location, options: { label }, onViewAdded: () => { } });
+        return internals().registerViewMenuAction(id, label);
+    }
+
+    beforeEach(() => {
+        registry = new PluginViewRegistry();
+        menus = new RecordingMenuModelRegistry();
+        (registry as unknown as { menus: unknown }).menus = menus;
+    });
+
+    it('uses the plain label for a single container', () => {
+        registerContainer('a', 'Claude Code', 'left');
+        expect(menus.actions.get(toggleCommandId('a'))?.label).to.equal('Claude Code');
+    });
+
+    it('leaves distinct labels unsuffixed', () => {
+        registerContainer('a', 'Explorer', 'left');
+        registerContainer('b', 'Claude Code', 'right');
+        expect(menus.actions.get(toggleCommandId('a'))?.label).to.equal('Explorer');
+        expect(menus.actions.get(toggleCommandId('b'))?.label).to.equal('Claude Code');
+    });
+
+    it('suffixes the location when two containers share a label', () => {
+        registerContainer('a', 'Claude Code', 'left');
+        registerContainer('b', 'Claude Code', 'right');
+        expect(menus.actions.get(toggleCommandId('a'))?.label).to.equal('Claude Code (Side Bar)');
+        expect(menus.actions.get(toggleCommandId('b'))?.label).to.equal('Claude Code (Secondary Side Bar)');
+    });
+
+    it('drops the suffix from the remaining container once the duplicate is removed', () => {
+        registerContainer('a', 'Claude Code', 'left');
+        const disposeB = registerContainer('b', 'Claude Code', 'right');
+
+        disposeB.dispose();
+
+        expect(menus.actions.get(toggleCommandId('a'))?.label).to.equal('Claude Code');
+        expect(menus.actions.has(toggleCommandId('b'))).to.equal(false);
+    });
+
+});

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -111,6 +111,9 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
     private readonly viewClauseContexts = new Map<string, Set<string> | undefined>();
     private readonly viewContainerClauseContexts = new Map<string, Set<string> | undefined>();
 
+    private readonly viewMenuLabelToContainerIds = new Map<string, Set<string>>();
+    private readonly viewMenuDisposables = new Map<string, Disposable>();
+
     private readonly viewDataProviders = new Map<string, ViewDataProvider>();
     private readonly viewDataState = new Map<string, object>();
 
@@ -374,13 +377,10 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             }, {
                 execute: () => this.toggleViewContainer(id)
             }));
-            toDispose.push(this.menus.registerMenuAction(CommonMenus.VIEW_VIEWS, {
-                commandId: toggleCommandId,
-                label: options.label,
-                when
-            }));
+            toDispose.push(this.registerViewMenuAction(id, options.label));
             toDispose.push(this.quickView?.registerItem({
                 label: options.label,
+                description: this.getLocationDescription(location),
                 when,
                 open: async () => {
                     const widget = await this.openViewContainer(id);
@@ -406,6 +406,88 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
             onViewAdded: () => activate()
         });
         return toDispose;
+    }
+
+    protected getLocationDescription(location: string | undefined): string | undefined {
+        switch (location) {
+            case 'left': return nls.localizeByDefault('Side Bar');
+            case 'right': return nls.localizeByDefault('Secondary Side Bar');
+            case 'bottom': return nls.localizeByDefault('Panel');
+            default: return undefined;
+        }
+    }
+
+    protected getContainerLocation(viewContainerId: string): string | undefined {
+        if (PluginViewRegistry.BUILTIN_VIEW_CONTAINERS.has(viewContainerId)) {
+            return 'left';
+        }
+        return this.viewContainers.get(viewContainerId)?.location;
+    }
+
+    protected getViewQuickPickDescription(viewContainerId: string): string | undefined {
+        const locationDescription = this.getLocationDescription(this.getContainerLocation(viewContainerId));
+        const containerLabel = this.viewContainers.get(viewContainerId)?.options.label;
+        if (locationDescription && containerLabel) {
+            return `${locationDescription} / ${containerLabel}`;
+        }
+        return locationDescription;
+    }
+
+    protected registerViewMenuAction(containerId: string, label: string): Disposable {
+        let ids = this.viewMenuLabelToContainerIds.get(label);
+        if (!ids) {
+            ids = new Set();
+            this.viewMenuLabelToContainerIds.set(label, ids);
+        }
+        ids.add(containerId);
+        this.refreshViewMenuLabel(label);
+        return Disposable.create(() => {
+            const set = this.viewMenuLabelToContainerIds.get(label);
+            if (set) {
+                set.delete(containerId);
+                if (set.size === 0) {
+                    this.viewMenuLabelToContainerIds.delete(label);
+                }
+            }
+            const disposable = this.viewMenuDisposables.get(containerId);
+            if (disposable) {
+                disposable.dispose();
+                this.viewMenuDisposables.delete(containerId);
+            }
+            this.refreshViewMenuLabel(label);
+        });
+    }
+
+    protected refreshViewMenuLabel(label: string): void {
+        const ids = this.viewMenuLabelToContainerIds.get(label);
+        if (!ids) {
+            return;
+        }
+        const useSuffix = ids.size > 1;
+        for (const id of ids) {
+            const existing = this.viewMenuDisposables.get(id);
+            if (existing) {
+                existing.dispose();
+                this.viewMenuDisposables.delete(id);
+            }
+            const containerInfo = this.viewContainers.get(id);
+            if (!containerInfo) {
+                continue;
+            }
+            let menuLabel = label;
+            if (useSuffix) {
+                const description = this.getLocationDescription(containerInfo.location);
+                if (description) {
+                    menuLabel = `${label} (${description})`;
+                }
+            }
+            const disposable = this.menus.registerMenuAction(CommonMenus.VIEW_VIEWS, {
+                commandId: `plugin.view-container.${id}.toggle`,
+                label: menuLabel,
+                when: containerInfo.when
+            });
+            this.viewMenuDisposables.set(id, disposable);
+        }
     }
 
     protected isViewContainerVisible(containerId: string): boolean {
@@ -471,6 +553,7 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         }
         toDispose.push(this.quickView?.registerItem({
             label: view.name,
+            description: this.getViewQuickPickDescription(viewContainerId),
             when: view.when,
             open: () => this.openView(view.id, { activate: true })
         }));


### PR DESCRIPTION
#### What it does

Closes #17255.

Plugin-contributed view containers/views that share the same label (e.g. the three "Claude Code" containers contributed by Anthropic's extension across the Side Bar, Secondary Side Bar, and Panel) appeared as indistinguishable duplicates in the View menu and the `View: Open View` quick pick.

This PR follows VS Code's pattern:
- Adds an optional `description` to `QuickViewItem`.
- Open View quick pick — containers get their shell location as the description; views get `<location> / <container-title>`.
- View menu — when multiple containers share a label, each entry is suffixed with `(<location>)`; the suffix is removed dynamically when only one remains.
- Normalizes the previously unmapped `secondarySidebar` / `auxiliarybar` locations to `right` in the plugin scanner.

#### How to test

With Anthropic's Claude Code extension installed:
1. Open the View menu — entries titled "Claude Code" are suffixed with their location.
2. Run `View: Open View` and filter "claude" — each entry shows its shell location as description; views inside a container show `<location> / <container-title>`.

#### Follow-ups

A companion PR (#17536, `feat(plugin-ext): honor 'when' clause on view containers`) hides containers whose `when` evaluates to false, further reducing the visible duplicate count.

Create 2 follow ups from https://github.com/eclipse-theia/theia/pull/17537#pullrequestreview-4375024158:
- View menu entries for plugin view containers should activate the container instead of disposing it when already attached, matching the behavior of built-in views via AbstractViewContribution.
- Group entries in Open View dropdown: Open View by location (Side Bar / Secondary Side Bar / Panel) using QuickPickSeparator, removing the need for the dynamic (<location>) suffix.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the \`nls\` service