### PR TITLE
fix(vsx-registry): show disabled extensions as installed

### DIFF
--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -375,7 +375,8 @@
   margin-left: calc(var(--theia-ui-padding) * 5 / 3);
 }
 
-.theia-vsx-extension-editor .header .details .title .restricted {
+.theia-vsx-extension-editor .header .details .title .restricted,
+.theia-vsx-extension-editor .header .details .title .disabled {
   font-size: var(--theia-ui-font-size0);
   color: var(--theia-statusBarItem-prominentForeground);
   background-color: var(--theia-statusBarItem-prominentBackground);

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -244,7 +244,7 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get displayName(): string | undefined {
-        return this.getData('displayName') || this.name;
+        return this.getData('displayName') || this.name || this.id;
     }
 
     get description(): string | undefined {
@@ -318,8 +318,21 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get tooltip(): string {
-        let md = `__${this.displayName}__ ${VSXExtension.formatVersion(this.version)}\n\n${this.description}\n_____\n\n${nls.localizeByDefault('Publisher: {0}', this.publisher)}`;
-
+        const version = VSXExtension.formatVersion(this.version);
+        let md = `__${this.displayName}__`;
+        if (version) {
+            md += ` ${version}`;
+        }
+        if (this.disabled && this.installed) {
+            md += ` (${nls.localizeByDefault('Disabled')})`;
+        }
+        if (this.description) {
+            md += `\n\n${this.description}`;
+        }
+        md += '\n_____\n\n';
+        if (this.publisher) {
+            md += nls.localizeByDefault('Publisher: {0}', this.publisher);
+        }
         if (this.license) {
             md += `  \r${nls.localize('theia/vsx-registry/license', 'License: {0}', this.license)}`;
         }

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -179,16 +179,19 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get installed(): boolean {
-        return !!this.version && this.model
-            .isInstalledAtSpecificVersion(PluginIdentifiers.idAndVersionToVersionedId({ id: this.id as PluginIdentifiers.UnversionedId, version: this.version }));
+        return this.model.isInstalled(this.id);
     }
 
     get uninstalled(): boolean {
-        return !!this.version && this.model.isUninstalled(PluginIdentifiers.idAndVersionToVersionedId({ id: this.id as PluginIdentifiers.UnversionedId, version: this.version }));
+        const installedVersion = this.installedVersion;
+        return !!installedVersion && this.model
+            .isUninstalled(PluginIdentifiers.idAndVersionToVersionedId({ id: this.id as PluginIdentifiers.UnversionedId, version: installedVersion }));
     }
 
     get deployed(): boolean {
-        return !!this.version && this.model.isDeployed(PluginIdentifiers.idAndVersionToVersionedId({ id: this.id as PluginIdentifiers.UnversionedId, version: this.version }));
+        const installedVersion = this.installedVersion;
+        return !!installedVersion && this.model
+            .isDeployed(PluginIdentifiers.idAndVersionToVersionedId({ id: this.id as PluginIdentifiers.UnversionedId, version: installedVersion }));
     }
 
     get disabled(): boolean {
@@ -634,7 +637,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
     override render(): React.ReactNode {
         const {
             builtin, preview, id, iconUrl, publisher, displayName, description, version,
-            averageRating, downloadCount, repository, license, readme, disabledByTrust
+            averageRating, downloadCount, repository, license, readme, disabled, installed, disabledByTrust
         } = this.props.extension;
 
         const sanitizedReadme = !!readme ? DOMPurify.sanitize(readme) : undefined;
@@ -650,6 +653,7 @@ export class VSXExtensionEditorComponent extends AbstractVSXExtensionComponent {
                         <span title='Extension identifier' className='identifier'>{id}</span>
                         {preview && <span className='preview'>Preview</span>}
                         {builtin && <span className='builtin'>Built-in</span>}
+                        {disabled && installed && <span className='disabled'>{nls.localizeByDefault('Disabled')}</span>}
                         {disabledByTrust && <span className='restricted'>{nls.localizeByDefault('Restricted Mode')}</span>}
                     </div>
                     <div className='subtitle'>

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -502,7 +502,7 @@ export class VSXExtensionsModel {
 
     protected onDidFailRefresh(id: string, error: unknown): VSXExtension | undefined {
         const cached = this.getExtension(id);
-        if (cached && cached.deployed) {
+        if (cached && (cached.deployed || cached.installed)) {
             return cached;
         }
         console.error(`[${id}]: failed to refresh, reason:`, error);


### PR DESCRIPTION
#### What it does

Disabled extensions now stay visible as installed in the Extensions view after a window reload.

Fixes https://github.com/eclipse-theia/theia/issues/17539

Previously the `installed` / `uninstalled` / `deployed` getters in `VSXExtension` gated on `!!this.version`, which is `undefined` for a disabled plugin when the Open VSX `refresh()` doesn't return the installed version (engine/target mismatch, VSIX install, missing from the configured registry, etc.). The disabled extension then rendered the prominent **Install** action button and the right-click menu lost the **Enable** entry, leaving no way to re-enable or uninstall it from the UI.

Regression from #16513.

Changes:
- `installed` getter uses `model.isInstalled(id)` (unversioned), matching pre-#16513 behavior. `uninstalled` / `deployed` keep version-specific semantics via `installedVersion` for the outOfSync logic.
- Added a `Disabled` badge in the extension editor header, styled like the existing `Restricted Mode` badge.
- `onDidFailRefresh` keeps the cached extension when `installed` (not only when `deployed`), so disabled extensions with no Open VSX metadata no longer disappear and clicking them no longer throws `Failed to resolve … extension`.
- `displayName` falls back to the extension id so rows render the identifier instead of being blank when metadata is missing.
- Tooltip skips fields whose data is missing (no more literal `undefined`) and appends `(Disabled)` when applicable.

#### How to test

1. Install an extension whose specific installed version isn't on the configured Open VSX registry (e.g. install from VSIX).
2. Disable it from the Extensions view, then reload the window.
3. Verify:
   - The row shows **Uninstall** with an inline `(disabled)` label.
   - Right-click offers **Enable**.
   - Opening the editor shows a **Disabled** badge and does not throw.
   - Tooltip shows the id and `(Disabled)`, no `undefined` text.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)