### PR TITLE
fix(plugin-ext): fix WebviewView.show TypeError and honor preserveFocus

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -522,7 +522,9 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
                 });
                 return _pendingResolution;
             },
-            show: webview.show
+            show: (preserveFocus: boolean) => {
+                this.openView(viewId, preserveFocus ? { reveal: true } : { activate: true });
+            }
         };
 
         const toDispose = this.onNewResolverRegistered(resolver => {


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/17542

#### How to test

Follow the steps in the issue above.
After this fix: no error; the view is revealed (and focused when `preserveFocus=false`).

#### Follow-ups

- A separate lifecycle issue is visible on layout reset + reload: `WebviewWidget` UUIDs are regenerated, so plugin-side calls (`$setHtml`, `$setOptions`, `$setBadge`) hit stale handles and throw `Unknown Webview` / `Unexpected parent of WebviewViewWidget`. Orthogonal to this PR; will be filed as a follow-up issue.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/eclipse-theia/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines) — n/a, no user-facing strings

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)