### PR TITLE
fix(application-manager): parse process.argv in esbuild yargs setup

### DIFF
--- a/dev-packages/application-manager/src/generator/bundler-generator.ts
+++ b/dev-packages/application-manager/src/generator/bundler-generator.ts
@@ -628,6 +628,7 @@ import { nodeModulesPolyfillPlugin } from 'esbuild-plugins-node-modules-polyfill
 import { copy } from 'esbuild-plugin-copy';
 import { monacoNlsPlugin, problemMatcherPlugin, sourceMapPathsPlugin } from '@theia/bundle-plugin';
 import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
 import resolvePackagePath from 'resolve-package-path';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -638,7 +639,7 @@ export function join(...parts) {
     return path.join(...parts).replace(/\\\\/g, '/');
 }
 
-const { mode, watch } = yargs().option('mode', {
+const { mode, watch } = yargs(hideBin(process.argv)).option('mode', {
     description: "Mode to use",
     choices: ["development", "production"],
     default: "production"


### PR DESCRIPTION
#### What it does

Fixes a regression introduced together with the yargs 17.x bump that silently disabled source maps for `theia build --mode development` in esbuild-based apps.

In yargs 17.x, calling `yargs()` as a factory no longer auto-reads `process.argv`, so the generated `gen-esbuild.browser.mjs` always fell back to the default `mode = "production"` regardless of the CLI flags. As a consequence:

- `sourcemap` was forced to `false` and `minify` to `true`
- no `lib/**/*.js.map` files were emitted
- bundles had no `//# sourceMappingURL=` footer
- breakpoints set in the original sources never bound, making the source map work from #17517 unreachable in practice

The fix passes `hideBin(process.argv)` to `yargs(...)` so CLI flags are actually parsed. The two webpack templates use the legacy `yargs.option(...)` form via the default export, which still auto-parses argv and is not affected. The node and electron esbuild templates re-import `watch`/`sourcemap`/`minify` from the browser template, so a single change fixes all three esbuild outputs.

#### How to test

1. `npm run build:browser` (or `build:electron`) on this branch
2. Verify in the generated output:
   - `examples/browser/lib/frontend/*.js.map` (and `lib/backend/*.js.map`) exist
   - the bundles end with `//# sourceMappingURL=...`
   - bundles are not minified
3. Start the example app, attach the debugger, set a breakpoint in a TypeScript source, and confirm it binds (filled red dot, not hollow) and is hit
4. As a regression check, run a production build (`build:production` in examples/browser) and confirm `.map` files are not emitted and bundles are minified

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/eclipse-theia/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)