### PR TITLE
feat(ai-registry): add support for AI Registry

### DIFF
--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -42,6 +42,7 @@
     "@theia/ai-mcp-ui": "1.72.0",
     "@theia/ai-ollama": "1.72.0",
     "@theia/ai-openai": "1.72.0",
+    "@theia/ai-registry": "1.72.0",
     "@theia/ai-scanoss": "1.72.0",
     "@theia/ai-terminal": "1.72.0",
     "@theia/ai-vercel-ai": "1.72.0",

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -41,6 +41,7 @@
     "@theia/ai-mcp-server": "1.71.0",
     "@theia/ai-mcp-ui": "1.71.0",
     "@theia/ai-ollama": "1.71.0",
+    "@theia/ai-registry": "1.71.0",
     "@theia/ai-openai": "1.71.0",
     "@theia/ai-scanoss": "1.71.0",
     "@theia/ai-terminal": "1.71.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -69,6 +69,9 @@
       "path": "../../packages/ai-openai"
     },
     {
+      "path": "../../packages/ai-registry"
+    },
+    {
       "path": "../../packages/ai-scanoss"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -46,6 +46,7 @@
     "@theia/ai-mcp-ui": "1.72.0",
     "@theia/ai-ollama": "1.72.0",
     "@theia/ai-openai": "1.72.0",
+    "@theia/ai-registry": "1.72.0",
     "@theia/ai-scanoss": "1.72.0",
     "@theia/ai-terminal": "1.72.0",
     "@theia/ai-vercel-ai": "1.72.0",

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -45,6 +45,7 @@
     "@theia/ai-mcp-server": "1.71.0",
     "@theia/ai-mcp-ui": "1.71.0",
     "@theia/ai-ollama": "1.71.0",
+    "@theia/ai-registry": "1.71.0",
     "@theia/ai-openai": "1.71.0",
     "@theia/ai-scanoss": "1.71.0",
     "@theia/ai-terminal": "1.71.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -72,6 +72,9 @@
       "path": "../../packages/ai-openai"
     },
     {
+      "path": "../../packages/ai-registry"
+    },
+    {
       "path": "../../packages/ai-scanoss"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -438,6 +438,7 @@
         "@theia/ai-mcp-ui": "1.72.0",
         "@theia/ai-ollama": "1.72.0",
         "@theia/ai-openai": "1.72.0",
+        "@theia/ai-registry": "1.72.0",
         "@theia/ai-scanoss": "1.72.0",
         "@theia/ai-terminal": "1.72.0",
         "@theia/ai-vercel-ai": "1.72.0",
@@ -585,6 +586,7 @@
         "@theia/ai-mcp-ui": "1.72.0",
         "@theia/ai-ollama": "1.72.0",
         "@theia/ai-openai": "1.72.0",
+        "@theia/ai-registry": "1.72.0",
         "@theia/ai-scanoss": "1.72.0",
         "@theia/ai-terminal": "1.72.0",
         "@theia/ai-vercel-ai": "1.72.0",
@@ -6797,6 +6799,10 @@
     },
     "node_modules/@theia/ai-openai": {
       "resolved": "packages/ai-openai",
+      "link": true
+    },
+    "node_modules/@theia/ai-registry": {
+      "resolved": "packages/ai-registry",
       "link": true
     },
     "node_modules/@theia/ai-scanoss": {
@@ -31249,6 +31255,19 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "packages/ai-registry": {
+      "name": "@theia/ai-registry",
+      "version": "1.72.0",
+      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "dependencies": {
+        "@theia/ai-mcp": "1.72.0",
+        "@theia/core": "1.72.0",
+        "@theia/vsx-registry": "1.72.0"
+      },
+      "devDependencies": {
+        "@theia/ext-scripts": "1.72.0"
       }
     },
     "packages/ai-scanoss": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -449,6 +449,7 @@
         "@theia/ai-mcp-ui": "1.71.0",
         "@theia/ai-ollama": "1.71.0",
         "@theia/ai-openai": "1.71.0",
+        "@theia/ai-registry": "1.71.0",
         "@theia/ai-scanoss": "1.71.0",
         "@theia/ai-terminal": "1.71.0",
         "@theia/ai-vercel-ai": "1.71.0",
@@ -596,6 +597,7 @@
         "@theia/ai-mcp-ui": "1.71.0",
         "@theia/ai-ollama": "1.71.0",
         "@theia/ai-openai": "1.71.0",
+        "@theia/ai-registry": "1.71.0",
         "@theia/ai-scanoss": "1.71.0",
         "@theia/ai-terminal": "1.71.0",
         "@theia/ai-vercel-ai": "1.71.0",
@@ -5605,9 +5607,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5622,9 +5621,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5639,9 +5635,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5656,9 +5649,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6007,9 +5997,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6029,9 +6016,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6053,9 +6037,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6075,9 +6056,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6099,9 +6077,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6121,9 +6096,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6830,6 +6802,10 @@
     },
     "node_modules/@theia/ai-openai": {
       "resolved": "packages/ai-openai",
+      "link": true
+    },
+    "node_modules/@theia/ai-registry": {
+      "resolved": "packages/ai-registry",
       "link": true
     },
     "node_modules/@theia/ai-scanoss": {
@@ -30924,6 +30900,19 @@
         "zod": {
           "optional": true
         }
+      }
+    },
+    "packages/ai-registry": {
+      "name": "@theia/ai-registry",
+      "version": "1.71.0",
+      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "dependencies": {
+        "@theia/ai-mcp": "1.71.0",
+        "@theia/core": "1.71.0",
+        "@theia/vsx-registry": "1.71.0"
+      },
+      "devDependencies": {
+        "@theia/ext-scripts": "1.71.0"
       }
     },
     "packages/ai-scanoss": {

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-widget.tsx
@@ -23,7 +23,7 @@ import { AIToolsConfigurationWidget } from './tools-configuration-widget';
 import { AISkillsConfigurationWidget } from './skills-configuration-widget';
 import { AIConfigurationSelectionService } from './ai-configuration-service';
 import { nls } from '@theia/core';
-import { AIMCPConfigurationWidget } from './mcp-configuration-widget';
+import { AIMCPConfigurationWidget } from '@theia/ai-mcp/lib/browser/mcp-configuration-widget';
 import { AITokenUsageConfigurationWidget } from './token-usage-configuration-widget';
 import { AIPromptFragmentsConfigurationWidget } from './prompt-fragments-configuration-widget';
 import { ModelAliasesConfigurationWidget } from './model-aliases-configuration-widget';

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -76,7 +76,6 @@ import { ContextFilesVariableContribution } from '../common/context-files-variab
 import { AIToolsConfigurationWidget } from './ai-configuration/tools-configuration-widget';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { TemplatePreferenceContribution } from './template-preference-contribution';
-import { AIMCPConfigurationWidget } from './ai-configuration/mcp-configuration-widget';
 import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { IdeChatWelcomeMessageProvider } from './ide-chat-welcome-message-provider';
 import { ChatSessionsWelcomeMessageProvider } from './chat-sessions-welcome-message-provider';
@@ -294,13 +293,6 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(FrontendApplicationContribution).to(TemplatePreferenceContribution);
 
-    bind(AIMCPConfigurationWidget).toSelf();
-    bind(WidgetFactory)
-        .toDynamicValue(ctx => ({
-            id: AIMCPConfigurationWidget.ID,
-            createWidget: () => ctx.container.get(AIMCPConfigurationWidget)
-        }))
-        .inSingletonScope();
     // Register the token usage configuration widget
     bind(AITokenUsageConfigurationWidget).toSelf();
     bind(WidgetFactory)

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -76,7 +76,6 @@ import { ContextFilesVariableContribution } from '../common/context-files-variab
 import { AIToolsConfigurationWidget } from './ai-configuration/tools-configuration-widget';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { TemplatePreferenceContribution } from './template-preference-contribution';
-import { AIMCPConfigurationWidget } from './ai-configuration/mcp-configuration-widget';
 import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { IdeChatWelcomeMessageProvider } from './ide-chat-welcome-message-provider';
 import { ChatSessionsWelcomeMessageProvider } from './chat-sessions-welcome-message-provider';
@@ -292,13 +291,6 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(FrontendApplicationContribution).to(TemplatePreferenceContribution);
 
-    bind(AIMCPConfigurationWidget).toSelf();
-    bind(WidgetFactory)
-        .toDynamicValue(ctx => ({
-            id: AIMCPConfigurationWidget.ID,
-            createWidget: () => ctx.container.get(AIMCPConfigurationWidget)
-        }))
-        .inSingletonScope();
     // Register the token usage configuration widget
     bind(AITokenUsageConfigurationWidget).toSelf();
     bind(WidgetFactory)

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -23,7 +23,6 @@
 
 /* Import widget-specific styles */
 @import "./widgets/model-aliases-configuration.css";
-@import "./widgets/mcp-configuration.css";
 
 /* Override preferences grid layout for AI Configuration widgets */
 .ai-configuration-widget.theia-settings-container {

--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
@@ -17,7 +17,13 @@
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJSDOM = enableJSDOM();
-FrontendApplicationConfigProvider.set({});
+// Another spec in this package may have already set the configuration; mocha loads all
+// specs into one process and `set` throws if called twice, so guard it.
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
 
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
@@ -138,7 +144,7 @@ describe('InstallMcpUriHandler.open', () => {
 
     it('reports an error when the registry has no entry for the given id', async () => {
         const bridge = new FakeRegistryBridge();
-        // Bridge has no entries — `getInstallEntry` returns undefined.
+        // Bridge has no entries - `getInstallEntry` returns undefined.
         const { handler, messages } = buildHandler({ bridge });
 
         await handler.open(new URI('theia://install-mcp?id=io.example/unknown'));

--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
@@ -31,7 +31,8 @@ import { MessageService, PreferenceService } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
 import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
 import { MCPFrontendService } from '../common/mcp-server-manager';
-import { MCPServerEditor, MCPInstallEntry } from './mcp-server-editor';
+import { MCPServerEditor, MCPServerEditorImpl, MCPServerEditDialogFactory, MCPInstallEntry } from './mcp-server-editor';
+import { MCPServerInstallDialogFactory } from './mcp-server-install-dialog';
 import { MCPInstallUriConfiguration } from './mcp-install-uri-configuration';
 import { MCPRegistryUiBridge } from './mcp-registry-ui-bridge';
 import { InstallMcpUriHandler } from './install-mcp-uri-handler';
@@ -93,7 +94,15 @@ function buildHandler(options: {
     container.bind(PreferenceService).toConstantValue(prefs as unknown as PreferenceService);
     container.bind(MessageService).toConstantValue(messages as unknown as MessageService);
     container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
-    container.bind(MCPServerEditor).toSelf().inSingletonScope();
+    // The error-path tests never open a dialog; bind factories that fail loudly if used.
+    container.bind(MCPServerEditDialogFactory).toConstantValue(() => {
+        throw new Error('MCPServerEditDialogFactory should not be invoked in these tests');
+    });
+    container.bind(MCPServerInstallDialogFactory).toConstantValue(() => {
+        throw new Error('MCPServerInstallDialogFactory should not be invoked in these tests');
+    });
+    container.bind(MCPServerEditorImpl).toSelf().inSingletonScope();
+    container.bind(MCPServerEditor).toService(MCPServerEditorImpl);
     container.bind(MCPInstallUriConfiguration).toConstantValue(new FakeConfiguration(options.scheme ?? 'theia'));
     if (options.bridge) {
         container.bind(MCPRegistryUiBridge).toConstantValue(options.bridge);

--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
@@ -1,0 +1,157 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { MessageService, PreferenceService } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
+import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
+import { MCPFrontendService } from '../common/mcp-server-manager';
+import { MCPServerEditor, MCPInstallEntry } from './mcp-server-editor';
+import { MCPInstallUriConfiguration } from './mcp-install-uri-configuration';
+import { MCPRegistryUiBridge } from './mcp-registry-ui-bridge';
+import { InstallMcpUriHandler } from './install-mcp-uri-handler';
+
+after(() => disableJSDOM());
+
+class FakePreferenceService {
+    private readonly store = new Map<string, unknown>();
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return (this.store.has(key) ? this.store.get(key) : defaultValue) as T | undefined;
+    }
+    async set(key: string, value: unknown): Promise<void> {
+        this.store.set(key, value);
+    }
+}
+
+class FakeMessageService {
+    public errors: string[] = [];
+    public infos: string[] = [];
+    error(message: string): void {
+        this.errors.push(message);
+    }
+    info(message: string): void {
+        this.infos.push(message);
+    }
+}
+
+class FakeRegistryBridge implements MCPRegistryUiBridge {
+    readonly onDidChange = () => ({ dispose: () => undefined });
+    private readonly entries = new Map<string, MCPInstallEntry>();
+    setEntry(serverId: string, entry: MCPInstallEntry): void {
+        this.entries.set(serverId, entry);
+    }
+    async ready(): Promise<void> { /* immediate */ }
+    hasServer(serverId: string): boolean {
+        return this.entries.has(serverId);
+    }
+    getInstallEntry(serverId: string): MCPInstallEntry | undefined {
+        return this.entries.get(serverId);
+    }
+    async openRegistry(): Promise<void> { /* no-op */ }
+}
+
+class FakeConfiguration extends MCPInstallUriConfiguration {
+    constructor(private readonly scheme: string, private readonly authority: string = 'install-mcp') { super(); }
+    override getScheme(): string { return this.scheme; }
+    override getAuthority(): string { return this.authority; }
+}
+
+function buildHandler(options: {
+    bridge?: FakeRegistryBridge;
+    scheme?: string;
+    prefs?: FakePreferenceService;
+    messages?: FakeMessageService;
+} = {}): { handler: InstallMcpUriHandler; messages: FakeMessageService; prefs: FakePreferenceService; bridge: FakeRegistryBridge | undefined } {
+    const container = new Container();
+    const prefs = options.prefs ?? new FakePreferenceService();
+    const messages = options.messages ?? new FakeMessageService();
+    container.bind(PreferenceService).toConstantValue(prefs as unknown as PreferenceService);
+    container.bind(MessageService).toConstantValue(messages as unknown as MessageService);
+    container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
+    container.bind(MCPServerEditor).toSelf().inSingletonScope();
+    container.bind(MCPInstallUriConfiguration).toConstantValue(new FakeConfiguration(options.scheme ?? 'theia'));
+    if (options.bridge) {
+        container.bind(MCPRegistryUiBridge).toConstantValue(options.bridge);
+    }
+    container.bind(InstallMcpUriHandler).toSelf().inSingletonScope();
+    return { handler: container.get(InstallMcpUriHandler), messages, prefs, bridge: options.bridge };
+}
+
+describe('InstallMcpUriHandler.canHandle', () => {
+
+    it('claims URIs whose scheme and authority both match the configuration', () => {
+        const { handler } = buildHandler();
+        expect(handler.canHandle(new URI('theia://install-mcp?id=foo'))).to.equal(500);
+    });
+
+    it('does not claim URIs whose scheme does not match the configuration', () => {
+        const { handler } = buildHandler({ scheme: 'theia-next' });
+        // Configured scheme is `theia-next`; a `theia://` URI must not be claimed.
+        expect(handler.canHandle(new URI('theia://install-mcp?id=foo'))).to.equal(0);
+    });
+
+    it('does not claim URIs whose authority does not match the configuration', () => {
+        const { handler } = buildHandler();
+        expect(handler.canHandle(new URI('theia://something-else?id=foo'))).to.equal(0);
+    });
+});
+
+describe('InstallMcpUriHandler.open', () => {
+
+    it('reports an error and does not write the preference when the URI carries no id', async () => {
+        const { handler, messages, prefs } = buildHandler({ bridge: new FakeRegistryBridge() });
+
+        await handler.open(new URI('theia://install-mcp'));
+
+        expect(messages.errors).to.have.length(1);
+        expect(messages.errors[0]).to.match(/missing the required "id"/i);
+        expect(prefs.get(MCP_SERVERS_PREF)).to.be.undefined;
+    });
+
+    it('reports an error when no AI registry bridge is bound', async () => {
+        const { handler, messages } = buildHandler(); // no bridge
+
+        await handler.open(new URI('theia://install-mcp?id=io.example/foo'));
+
+        expect(messages.errors).to.have.length(1);
+        expect(messages.errors[0]).to.match(/no AI registry is configured/i);
+    });
+
+    it('reports an error when the registry has no entry for the given id', async () => {
+        const bridge = new FakeRegistryBridge();
+        // Bridge has no entries — `getInstallEntry` returns undefined.
+        const { handler, messages } = buildHandler({ bridge });
+
+        await handler.open(new URI('theia://install-mcp?id=io.example/unknown'));
+
+        expect(messages.errors).to.have.length(1);
+        expect(messages.errors[0]).to.match(/is not listed in your AI registry/i);
+    });
+
+    it('trims whitespace around the id parameter and treats an empty id as missing', async () => {
+        const { handler, messages } = buildHandler({ bridge: new FakeRegistryBridge() });
+
+        await handler.open(new URI('theia://install-mcp?id=%20%20'));
+
+        expect(messages.errors[0]).to.match(/missing the required "id"/i);
+    });
+});

--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
@@ -1,0 +1,154 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MessageService, nls, PreferenceService } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
+import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
+import { OpenHandler } from '@theia/core/lib/browser/opener-service';
+import { inject, injectable, optional } from '@theia/core/shared/inversify';
+import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
+import { MCPInstallEntry, MCPServerEditor } from './mcp-server-editor';
+import { MCPInstallUriConfiguration } from './mcp-install-uri-configuration';
+import { MCPRegistryUiBridge } from './mcp-registry-ui-bridge';
+import { MCPServerInstallDialog, MCPServerInstallTrust } from './mcp-server-install-dialog';
+
+const ID_PARAM = 'id';
+
+/**
+ * Handles `theia://install-mcp?id=<serverId>` deep links. The URL is intentionally
+ * minimal: the install configuration, version, display name and content hash are all
+ * read from the configured AI registry by id. This guarantees the user installs exactly
+ * what the registry currently publishes and keeps install links short and stable.
+ *
+ * Lives in `@theia/ai-mcp` so products without the registry package still receive the
+ * URL — but installation only succeeds when an `MCPRegistryUiBridge` is bound and the
+ * id exists in the registry. The bridge is consulted via `@optional()`.
+ */
+@injectable()
+export class InstallMcpUriHandler implements OpenHandler {
+
+    readonly id = 'install-mcp-uri-handler';
+
+    @inject(MCPInstallUriConfiguration)
+    protected readonly configuration: MCPInstallUriConfiguration;
+
+    @inject(MCPServerEditor)
+    protected readonly editor: MCPServerEditor;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(MCPRegistryUiBridge) @optional()
+    protected readonly registryBridge?: MCPRegistryUiBridge;
+
+    canHandle(uri: URI): number {
+        // Validate both scheme (must match the product's electron URI scheme) and authority
+        // so we don't accidentally claim URIs from unrelated protocols.
+        return uri.scheme === this.configuration.getScheme()
+            && uri.authority === this.configuration.getAuthority()
+            ? 500
+            : 0;
+    }
+
+    async open(uri: URI): Promise<object | undefined> {
+        const serverId = this.extractServerId(uri);
+        if (!serverId) {
+            this.messageService.error(nls.localize(
+                'theia/ai-mcp/installUri/missingId',
+                'Install link is missing the required "id" parameter.'
+            ));
+            return undefined;
+        }
+        if (!this.registryBridge) {
+            this.messageService.error(nls.localize(
+                'theia/ai-mcp/installUri/noRegistry',
+                'Cannot install MCP server "{0}" — no AI registry is configured in this product.',
+                serverId
+            ));
+            return undefined;
+        }
+        // Wait for the bridge's first fetch so an id click immediately after startup
+        // doesn't race the registry load and produce a false "not found".
+        await this.registryBridge.ready();
+        const entry = this.registryBridge.getInstallEntry(serverId);
+        if (!entry) {
+            this.messageService.error(nls.localize(
+                'theia/ai-mcp/installUri/unknownId',
+                'MCP server "{0}" is not listed in your AI registry.',
+                serverId
+            ));
+            return undefined;
+        }
+        if (this.isAlreadyInstalled(entry.localSlug) && !await this.confirmOverwrite(entry.localSlug)) {
+            return undefined;
+        }
+        const dialog = new MCPServerInstallDialog({
+            name: entry.localSlug,
+            autostart: true,
+            requireAuthToken: 'serverAuthToken' in entry.config,
+            // Bridge already resolved this id, so trust is always "verified" here.
+            trust: { status: 'verified', serverId } satisfies MCPServerInstallTrust
+        });
+        const result = await dialog.open();
+        if (!result) {
+            return undefined;
+        }
+        await this.editor.installFromEntry(entry, result);
+        // Deep-link installs may originate from a browser tab the user has since switched
+        // away from; close success can otherwise be silent because the dialog dismisses on
+        // confirm. A confirmation toast makes the outcome explicit.
+        this.messageService.info(nls.localize(
+            'theia/ai-mcp/installUri/success',
+            'Installed MCP server "{0}" from the AI registry.',
+            entry.localSlug
+        ));
+        return undefined;
+    }
+
+    /** True if a server with this slug is already in `ai-features.mcp.mcpServers`. */
+    protected isAlreadyInstalled(localSlug: string): boolean {
+        const stored = this.preferenceService.get<Record<string, unknown>>(MCP_SERVERS_PREF, {}) ?? {};
+        return Object.prototype.hasOwnProperty.call(stored, localSlug);
+    }
+
+    /**
+     * Acknowledge prompt for already-installed servers. We don't try to be clever about
+     * "is this the same registry entry?" — the user may have edited the local config
+     * and any overwrite should be an explicit decision.
+     */
+    protected async confirmOverwrite(localSlug: string): Promise<boolean> {
+        const dialog = new ConfirmDialog({
+            title: nls.localize('theia/ai-mcp/installUri/alreadyInstalled/title', 'MCP server already installed'),
+            msg: nls.localize(
+                'theia/ai-mcp/installUri/alreadyInstalled/msg',
+                'An MCP server named "{0}" is already configured. Continuing will overwrite the existing entry with the configuration from the registry.',
+                localSlug
+            ),
+            ok: nls.localizeByDefault('Continue'),
+            cancel: nls.localizeByDefault('Cancel')
+        });
+        return !!await dialog.open();
+    }
+
+    protected extractServerId(uri: URI): string | undefined {
+        return new URLSearchParams(uri.query).get(ID_PARAM)?.trim() || undefined;
+    }
+}
+
+export type { MCPInstallEntry };

--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
@@ -20,7 +20,7 @@ import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
-import { MCPInstallEntry, MCPServerEditor } from './mcp-server-editor';
+import { MCPServerEditor } from './mcp-server-editor';
 import { MCPInstallUriConfiguration } from './mcp-install-uri-configuration';
 import { MCPRegistryUiBridge } from './mcp-registry-ui-bridge';
 import { MCPServerInstallDialog, MCPServerInstallTrust } from './mcp-server-install-dialog';
@@ -34,7 +34,7 @@ const ID_PARAM = 'id';
  * what the registry currently publishes and keeps install links short and stable.
  *
  * Lives in `@theia/ai-mcp` so products without the registry package still receive the
- * URL — but installation only succeeds when an `MCPRegistryUiBridge` is bound and the
+ * URL - but installation only succeeds when an `MCPRegistryUiBridge` is bound and the
  * id exists in the registry. The bridge is consulted via `@optional()`.
  */
 @injectable()
@@ -78,7 +78,7 @@ export class InstallMcpUriHandler implements OpenHandler {
         if (!this.registryBridge) {
             this.messageService.error(nls.localize(
                 'theia/ai-mcp/installUri/noRegistry',
-                'Cannot install MCP server "{0}" — no AI registry is configured in this product.',
+                'Cannot install MCP server "{0}" - no AI registry is configured in this product.',
                 serverId
             ));
             return undefined;
@@ -129,7 +129,7 @@ export class InstallMcpUriHandler implements OpenHandler {
 
     /**
      * Acknowledge prompt for already-installed servers. We don't try to be clever about
-     * "is this the same registry entry?" — the user may have edited the local config
+     * "is this the same registry entry?" - the user may have edited the local config
      * and any overwrite should be an explicit decision.
      */
     protected async confirmOverwrite(localSlug: string): Promise<boolean> {
@@ -150,5 +150,3 @@ export class InstallMcpUriHandler implements OpenHandler {
         return new URLSearchParams(uri.query).get(ID_PARAM)?.trim() || undefined;
     }
 }
-
-export type { MCPInstallEntry };

--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
@@ -23,7 +23,7 @@ import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
 import { MCPServerEditor } from './mcp-server-editor';
 import { MCPInstallUriConfiguration } from './mcp-install-uri-configuration';
 import { MCPRegistryUiBridge } from './mcp-registry-ui-bridge';
-import { MCPServerInstallDialog, MCPServerInstallTrust } from './mcp-server-install-dialog';
+import { MCPServerInstallDialogFactory, MCPServerInstallTrust } from './mcp-server-install-dialog';
 
 const ID_PARAM = 'id';
 
@@ -56,6 +56,9 @@ export class InstallMcpUriHandler implements OpenHandler {
 
     @inject(MCPRegistryUiBridge) @optional()
     protected readonly registryBridge?: MCPRegistryUiBridge;
+
+    @inject(MCPServerInstallDialogFactory)
+    protected readonly installDialogFactory: MCPServerInstallDialogFactory;
 
     canHandle(uri: URI): number {
         // Validate both scheme (must match the product's electron URI scheme) and authority
@@ -95,11 +98,11 @@ export class InstallMcpUriHandler implements OpenHandler {
             ));
             return undefined;
         }
-        if (this.isAlreadyInstalled(entry.localSlug) && !await this.confirmOverwrite(entry.localSlug)) {
+        if (this.isAlreadyInstalled(entry.localName) && !await this.confirmOverwrite(entry.localName)) {
             return undefined;
         }
-        const dialog = new MCPServerInstallDialog({
-            name: entry.localSlug,
+        const dialog = this.installDialogFactory({
+            name: entry.localName,
             autostart: true,
             requireAuthToken: 'serverAuthToken' in entry.config,
             // Bridge already resolved this id, so trust is always "verified" here.
@@ -116,15 +119,15 @@ export class InstallMcpUriHandler implements OpenHandler {
         this.messageService.info(nls.localize(
             'theia/ai-mcp/installUri/success',
             'Installed MCP server "{0}" from the AI registry.',
-            entry.localSlug
+            entry.localName
         ));
         return undefined;
     }
 
-    /** True if a server with this slug is already in `ai-features.mcp.mcpServers`. */
-    protected isAlreadyInstalled(localSlug: string): boolean {
+    /** True if a server with this name is already in `ai-features.mcp.mcpServers`. */
+    protected isAlreadyInstalled(localName: string): boolean {
         const stored = this.preferenceService.get<Record<string, unknown>>(MCP_SERVERS_PREF, {}) ?? {};
-        return Object.prototype.hasOwnProperty.call(stored, localSlug);
+        return Object.prototype.hasOwnProperty.call(stored, localName);
     }
 
     /**
@@ -132,13 +135,13 @@ export class InstallMcpUriHandler implements OpenHandler {
      * "is this the same registry entry?" - the user may have edited the local config
      * and any overwrite should be an explicit decision.
      */
-    protected async confirmOverwrite(localSlug: string): Promise<boolean> {
+    protected async confirmOverwrite(localName: string): Promise<boolean> {
         const dialog = new ConfirmDialog({
             title: nls.localize('theia/ai-mcp/installUri/alreadyInstalled/title', 'MCP server already installed'),
             msg: nls.localize(
                 'theia/ai-mcp/installUri/alreadyInstalled/msg',
                 'An MCP server named "{0}" is already configured. Continuing will overwrite the existing entry with the configuration from the registry.',
-                localSlug
+                localName
             ),
             ok: nls.localizeByDefault('Continue'),
             cancel: nls.localizeByDefault('Cancel')

--- a/packages/ai-mcp/src/browser/mcp-configuration-command-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-configuration-command-contribution.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Command, CommandContribution, CommandRegistry } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { MCPServerEditor } from './mcp-server-editor';
+
+/**
+ * Public command id for opening the "Add MCP Server" dialog. Exposed as a string
+ * so consumers (e.g. `@theia/ai-registry`) can trigger it without depending on
+ * `@theia/ai-mcp`'s implementation details.
+ */
+export const ADD_MCP_SERVER_COMMAND: Command = Command.toLocalizedCommand({
+    id: 'aiConfiguration.mcp.addServer',
+    label: 'Add local MCP config...',
+    category: 'AI'
+}, 'theia/ai/mcpConfiguration/command/addServer');
+
+@injectable()
+export class MCPConfigurationCommandContribution implements CommandContribution {
+
+    @inject(MCPServerEditor)
+    protected readonly editor: MCPServerEditor;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(ADD_MCP_SERVER_COMMAND, {
+            execute: () => this.editor.openAddServer()
+        });
+    }
+}

--- a/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
+++ b/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
@@ -15,248 +15,22 @@
 // *****************************************************************************
 
 import { codicon, ConfirmDialog, ReactWidget } from '@theia/core/lib/browser';
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, optional, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import { HoverService } from '@theia/core/lib/browser/hover-service';
 import {
     isLocalMCPServerDescription,
     isRemoteMCPServerDescription,
-    LocalMCPServerDescription,
     MCPFrontendNotificationService,
     MCPFrontendService,
     MCPServerDescription,
-    MCPServerStatus,
-    RemoteMCPServerDescription
-} from '@theia/ai-mcp/lib/common/mcp-server-manager';
+    MCPServerStatus
+} from '../common/mcp-server-manager';
+import { MCPRegistryUiBridge } from './mcp-registry-ui-bridge';
 import { MessageService, nls, PreferenceScope, PreferenceService } from '@theia/core';
 import { PROMPT_VARIABLE } from '@theia/ai-core/lib/browser/prompt-variable-contribution';
-import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
-import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
-import { DialogProps } from '@theia/core/lib/browser/dialogs';
-import { SelectComponent } from '@theia/core/lib/browser/widgets/select-component';
-
-type ServerType = 'local' | 'remote';
-
-interface MCPServerFormData {
-    name: string;
-    serverType: ServerType;
-    command: string;
-    args: string;
-    env: string;
-    serverUrl: string;
-    serverAuthToken: string;
-    serverAuthTokenHeader: string;
-    headers: string;
-    autostart: boolean;
-}
-
-const DEFAULT_FORM_DATA: MCPServerFormData = {
-    name: '',
-    serverType: 'local',
-    command: '',
-    args: '',
-    env: '',
-    serverUrl: '',
-    serverAuthToken: '',
-    serverAuthTokenHeader: '',
-    headers: '',
-    autostart: true
-};
-
-class MCPServerDialog extends ReactDialog<MCPServerFormData | undefined> {
-    protected formData: MCPServerFormData;
-    protected existingServerNames: string[];
-    protected isEditing: boolean;
-
-    constructor(
-        props: DialogProps,
-        initialData: MCPServerFormData,
-        existingServerNames: string[],
-        isEditing: boolean
-    ) {
-        super(props);
-        this.formData = { ...initialData };
-        this.existingServerNames = existingServerNames;
-        this.isEditing = isEditing;
-        this.appendCloseButton(nls.localizeByDefault('Cancel'));
-        this.appendAcceptButton(isEditing
-            ? nls.localize('theia/ai/mcpConfiguration/form/saveChanges', 'Save Changes')
-            : nls.localizeByDefault('Add Server'));
-    }
-
-    get value(): MCPServerFormData | undefined {
-        return this.formData;
-    }
-
-    protected override isValid(): string {
-        const errors: string[] = [];
-
-        if (!this.formData.name.trim()) {
-            errors.push(nls.localize('theia/ai/mcpConfiguration/form/nameRequired', 'Server name is required'));
-        } else if (!this.isEditing && this.existingServerNames.includes(this.formData.name.trim())) {
-            errors.push(nls.localize('theia/ai/mcpConfiguration/form/nameExists', 'A server with this name already exists'));
-        }
-
-        if (this.formData.serverType === 'local') {
-            if (!this.formData.command.trim()) {
-                errors.push(nls.localize('theia/ai/mcpConfiguration/form/commandRequired', 'Command is required for local servers'));
-            }
-        } else {
-            if (!this.formData.serverUrl.trim()) {
-                errors.push(nls.localize('theia/ai/mcpConfiguration/form/serverUrlRequired', 'Server URL is required for remote servers'));
-            }
-        }
-
-        return errors.join('. ');
-    }
-
-    protected handleFormChange = (field: keyof MCPServerFormData, value: string | boolean): void => {
-        this.formData = { ...this.formData, [field]: value };
-        this.update();
-    };
-
-    protected render(): React.ReactNode {
-        return (
-            <div className="mcp-dialog-form">
-                <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/form/serverName', 'Server Name')}:</label>
-                    <input
-                        type="text"
-                        className="theia-input"
-                        value={this.formData.name}
-                        onChange={e => this.handleFormChange('name', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/serverNamePlaceholder', 'e.g., my-mcp-server')}
-                        disabled={this.isEditing}
-                        spellCheck={false}
-                    />
-                </div>
-
-                <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/form/serverType', 'Server Type')}:</label>
-                    <SelectComponent
-                        className="theia-select"
-                        defaultValue={this.formData.serverType}
-                        options={[
-                            { value: 'local', label: nls.localize('theia/ai/mcpConfiguration/form/localServer', 'Local (Command)') },
-                            { value: 'remote', label: nls.localize('theia/ai/mcpConfiguration/form/remoteServer', 'Remote (URL)') }
-                        ]}
-                        onChange={option => this.handleFormChange('serverType', option.value as ServerType)}
-                    />
-                </div>
-
-                {this.formData.serverType === 'local' ? this.renderLocalServerFields() : this.renderRemoteServerFields()}
-
-                <div className="mcp-form-field mcp-form-checkbox">
-                    <label>
-                        <input
-                            type="checkbox"
-                            className='theia-input'
-                            checked={this.formData.autostart}
-                            onChange={e => this.handleFormChange('autostart', e.target.checked)}
-                        />
-                        {nls.localize('theia/ai/mcpConfiguration/form/autostart', 'Autostart')}
-                    </label>
-                </div>
-            </div>
-        );
-    }
-
-    protected renderLocalServerFields(): React.ReactNode {
-        return (
-            <>
-                <div className="mcp-form-field">
-                    <label>{nls.localizeByDefault('Command')}:</label>
-                    <input
-                        type="text"
-                        className="theia-input"
-                        value={this.formData.command}
-                        onChange={e => this.handleFormChange('command', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/commandPlaceholder', 'e.g., npx or uvx')}
-                        spellCheck={false}
-                    />
-                </div>
-
-                <div className="mcp-form-field">
-                    <label>{nls.localizeByDefault('Arguments')}:</label>
-                    <input
-                        type="text"
-                        className="theia-input"
-                        value={this.formData.args}
-                        onChange={e => this.handleFormChange('args', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/argsPlaceholder', 'Space-separated, e.g., -y @modelcontextprotocol/server-brave-search')}
-                        spellCheck={false}
-                    />
-                </div>
-
-                <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/environmentVariables', 'Environment Variables')}:</label>
-                    <textarea
-                        className="theia-input"
-                        value={this.formData.env}
-                        onChange={e => this.handleFormChange('env', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/envPlaceholder', 'KEY=value (one per line)')}
-                        rows={3}
-                        spellCheck={false}
-                    />
-                </div>
-            </>
-        );
-    }
-
-    protected renderRemoteServerFields(): React.ReactNode {
-        return (
-            <>
-                <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/serverUrl', 'Server URL')}:</label>
-                    <input
-                        type="text"
-                        className="theia-input"
-                        value={this.formData.serverUrl}
-                        onChange={e => this.handleFormChange('serverUrl', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/serverUrlPlaceholder', 'e.g., https://mcp.example.com')}
-                        spellCheck={false}
-                    />
-                </div>
-
-                <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/serverAuthToken', 'Auth Token')}:</label>
-                    <input
-                        type="password"
-                        className="theia-input"
-                        value={this.formData.serverAuthToken}
-                        onChange={e => this.handleFormChange('serverAuthToken', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/authTokenPlaceholder', 'Optional authentication token')}
-                        spellCheck={false}
-                    />
-                </div>
-
-                <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/serverAuthTokenHeader', 'Auth Header Name')}:</label>
-                    <input
-                        type="text"
-                        className="theia-input"
-                        value={this.formData.serverAuthTokenHeader}
-                        onChange={e => this.handleFormChange('serverAuthTokenHeader', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/authHeaderPlaceholder', 'Default: Authorization with Bearer')}
-                        spellCheck={false}
-                    />
-                </div>
-
-                <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/headers', 'Headers')}:</label>
-                    <textarea
-                        className="theia-input"
-                        value={this.formData.headers}
-                        onChange={e => this.handleFormChange('headers', e.target.value)}
-                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/headersPlaceholder', 'Header-Name=value (one per line)')}
-                        rows={3}
-                        spellCheck={false}
-                    />
-                </div>
-            </>
-        );
-    }
-}
+import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
+import { MCPServerEditor } from './mcp-server-editor';
 
 @injectable()
 export class AIMCPConfigurationWidget extends ReactWidget {
@@ -281,6 +55,16 @@ export class AIMCPConfigurationWidget extends ReactWidget {
 
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
+
+    @inject(MCPServerEditor)
+    protected readonly serverEditor: MCPServerEditor;
+
+    /**
+     * Registry integration is optional — `@theia/ai-registry` binds it. When absent
+     * (registry package not in the bundle), all registry-specific affordances are hidden.
+     */
+    @inject(MCPRegistryUiBridge) @optional()
+    protected readonly registryBridge?: MCPRegistryUiBridge;
 
     @postConstruct()
     protected init(): void {
@@ -403,7 +187,10 @@ export class AIMCPConfigurationWidget extends ReactWidget {
 
         return (
             <div className="mcp-server-header">
-                <div className="mcp-server-name">{server.name}</div>
+                <div className="mcp-server-name">
+                    {server.name}
+                    {this.renderRegistryAffordance(server)}
+                </div>
                 <div className="mcp-server-header-controls">
                     {this.renderStatusBadge(server)}
                     {isStartable && (
@@ -657,126 +444,12 @@ export class AIMCPConfigurationWidget extends ReactWidget {
         );
     }
 
-    protected async openAddServerDialog(): Promise<void> {
-        const dialog = new MCPServerDialog(
-            { title: nls.localizeByDefault('Add MCP Server'), maxWidth: 500 },
-            { ...DEFAULT_FORM_DATA },
-            this.servers.map(s => s.name),
-            false
-        );
-        const result = await dialog.open();
-        if (result) {
-            await this.saveServer(result);
-        }
+    protected openAddServerDialog(): Promise<void> {
+        return this.serverEditor.openAddServer();
     }
 
-    protected async openEditServerDialog(server: MCPServerDescription): Promise<void> {
-        let formData: MCPServerFormData;
-
-        if (isLocalMCPServerDescription(server)) {
-            formData = {
-                name: server.name,
-                serverType: 'local',
-                command: server.command,
-                args: server.args?.join(' ') ?? '',
-                env: server.env ? Object.entries(server.env).map(([k, v]) => `${k}=${v}`).join('\n') : '',
-                serverUrl: '',
-                serverAuthToken: '',
-                serverAuthTokenHeader: '',
-                headers: '',
-                autostart: server.autostart ?? true
-            };
-        } else if (isRemoteMCPServerDescription(server)) {
-            formData = {
-                name: server.name,
-                serverType: 'remote',
-                command: '',
-                args: '',
-                env: '',
-                serverUrl: server.serverUrl,
-                serverAuthToken: server.serverAuthToken ?? '',
-                serverAuthTokenHeader: server.serverAuthTokenHeader ?? '',
-                headers: server.headers
-                    ? Object.entries(server.headers).map(([k, v]) => `${k}=${v}`).join('\n')
-                    : '',
-                autostart: server.autostart ?? true
-            };
-        } else {
-            return;
-        }
-
-        const dialog = new MCPServerDialog(
-            { title: nls.localize('theia/ai/mcpConfiguration/editServerTitle', 'Edit MCP Server'), maxWidth: 500 },
-            formData,
-            this.servers.filter(s => s.name !== server.name).map(s => s.name),
-            true
-        );
-        const result = await dialog.open();
-        if (result) {
-            await this.saveServer(result);
-        }
-    }
-
-    protected parseKeyValuePairs(input: string): Record<string, string> | undefined {
-        if (!input.trim()) {
-            return undefined;
-        }
-        const result: Record<string, string> = {};
-        const lines = input.split('\n').filter(line => line.trim());
-        for (const line of lines) {
-            const eqIndex = line.indexOf('=');
-            if (eqIndex > 0) {
-                const key = line.substring(0, eqIndex).trim();
-                const value = line.substring(eqIndex + 1).trim();
-                if (key) {
-                    result[key] = value;
-                }
-            }
-        }
-        return Object.keys(result).length > 0 ? result : undefined;
-    }
-
-    protected async saveServer(formData: MCPServerFormData): Promise<void> {
-        const currentServers = this.preferenceService.get<Record<string, object>>(MCP_SERVERS_PREF, {});
-        const newServers = { ...currentServers };
-        const serverName = formData.name.trim();
-
-        if (formData.serverType === 'local') {
-            const serverConfig: Partial<LocalMCPServerDescription> = {
-                command: formData.command.trim(),
-                autostart: formData.autostart
-            };
-            if (formData.args.trim()) {
-                serverConfig.args = formData.args.trim().split(/\s+/);
-            }
-            const env = this.parseKeyValuePairs(formData.env);
-            if (env) {
-                serverConfig.env = env;
-            }
-            newServers[serverName] = serverConfig;
-        } else {
-            const serverConfig: Partial<RemoteMCPServerDescription> = {
-                serverUrl: formData.serverUrl.trim(),
-                autostart: formData.autostart
-            };
-            if (formData.serverAuthToken.trim()) {
-                serverConfig.serverAuthToken = formData.serverAuthToken.trim();
-            }
-            if (formData.serverAuthTokenHeader.trim()) {
-                serverConfig.serverAuthTokenHeader = formData.serverAuthTokenHeader.trim();
-            }
-            const headers = this.parseKeyValuePairs(formData.headers);
-            if (headers) {
-                serverConfig.headers = headers;
-            }
-            newServers[serverName] = serverConfig;
-        }
-
-        try {
-            await this.preferenceService.set(MCP_SERVERS_PREF, newServers, PreferenceScope.User);
-        } catch (error) {
-            this.messageService.error(nls.localize('theia/ai/mcpConfiguration/saveServerError', 'Failed to save MCP server configuration: {0}', String(error)));
-        }
+    protected openEditServerDialog(server: MCPServerDescription): Promise<void> {
+        return this.serverEditor.openEditServer(server, this.servers.map(s => s.name));
     }
 
     protected async handleDeleteServer(serverName: string): Promise<void> {
@@ -790,7 +463,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
         const shouldDelete = await dialog.open();
         if (shouldDelete) {
             try {
-                const currentServers = this.preferenceService.get<Record<string, object>>(MCP_SERVERS_PREF, {});
+                const currentServers = this.preferenceService.get<Record<string, object>>(MCP_SERVERS_PREF, {}) ?? {};
                 const newServers = { ...currentServers };
                 delete newServers[serverName];
                 await this.preferenceService.set(MCP_SERVERS_PREF, newServers, PreferenceScope.User);
@@ -798,6 +471,32 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                 this.messageService.error(nls.localize('theia/ai/mcpConfiguration/deleteServerError', 'Failed to delete MCP server: {0}', String(error)));
             }
         }
+    }
+
+    /**
+     * Inline "From registry" link next to the server name. Clicking it opens the
+     * Extensions view (focused on this server when the registry still knows about it,
+     * otherwise the Installed section where the warning + Remove action live).
+     * Hidden when the server is not linked to a registry entry, or when the registry
+     * package isn't installed so we can't drive the navigation.
+     */
+    protected renderRegistryAffordance(server: MCPServerDescription): React.ReactNode {
+        const registryId = server.registryServerId;
+        const bridge = this.registryBridge;
+        if (!registryId || !bridge) {
+            return undefined;
+        }
+        return (
+            <button
+                type="button"
+                className="mcp-server-registry-link"
+                onClick={() => bridge.openRegistry(registryId)}
+                title={nls.localize('theia/ai/mcpConfiguration/openInRegistry', 'Open in AI registry: {0}', registryId)}
+            >
+                <i className={`${codicon('link-external')} mcp-server-registry-link-icon`} />
+                {nls.localize('theia/ai/mcpConfiguration/fromRegistryLink', 'From registry')}
+            </button>
+        );
     }
 
     protected render(): React.ReactNode {
@@ -808,6 +507,15 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                         <i className={codicon('add')}></i>
                         {nls.localizeByDefault('Add MCP Server')}
                     </button>
+                    {this.registryBridge && (
+                        <button
+                            className="theia-button secondary"
+                            onClick={() => this.registryBridge?.openRegistry()}
+                        >
+                            <i className={codicon('search')}></i>
+                            {nls.localize('theia/ai/mcpConfiguration/searchInRegistry', 'Search in registry')}
+                        </button>
+                    )}
                 </div>
                 {this.servers.length === 0 ? (
                     <div className="mcp-no-servers">

--- a/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
+++ b/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
@@ -60,7 +60,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
     protected readonly serverEditor: MCPServerEditor;
 
     /**
-     * Registry integration is optional — `@theia/ai-registry` binds it. When absent
+     * Registry integration is optional - `@theia/ai-registry` binds it. When absent
      * (registry package not in the bundle), all registry-specific affordances are hidden.
      */
     @inject(MCPRegistryUiBridge) @optional()
@@ -481,7 +481,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
      * package isn't installed so we can't drive the navigation.
      */
     protected renderRegistryAffordance(server: MCPServerDescription): React.ReactNode {
-        const registryId = server.registryServerId;
+        const registryId = server.registryMetadata?.serverId;
         const bridge = this.registryBridge;
         if (!registryId || !bridge) {
             return undefined;
@@ -510,10 +510,14 @@ export class AIMCPConfigurationWidget extends ReactWidget {
                     {this.registryBridge && (
                         <button
                             className="theia-button secondary"
+                            title={nls.localize(
+                                'theia/ai/mcpConfiguration/browseAIRegistryTooltip',
+                                'Open the Extensions view to browse AI registry entries'
+                            )}
                             onClick={() => this.registryBridge?.openRegistry()}
                         >
-                            <i className={codicon('search')}></i>
-                            {nls.localize('theia/ai/mcpConfiguration/searchInRegistry', 'Search in registry')}
+                            <i className={codicon('link-external')}></i>
+                            {nls.localize('theia/ai/mcpConfiguration/browseAIRegistry', 'Browse AI registry')}
                         </button>
                     )}
                 </div>

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.spec.ts
@@ -17,7 +17,13 @@
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
-FrontendApplicationConfigProvider.set({});
+// Another spec in this package may have already set the configuration; mocha loads all
+// specs into one process and `set` throws if called twice, so guard it.
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
 
 import 'reflect-metadata';
 

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -28,57 +28,7 @@ import {
     WorkspaceRestriction
 } from '@theia/workspace/lib/browser/workspace-trust-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-
-interface BaseMCPServerPreferenceValue {
-    autostart?: boolean;
-}
-
-interface LocalMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
-    command: string;
-    args?: string[];
-    env?: { [key: string]: string };
-}
-
-interface RemoteMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
-    serverUrl: string;
-    serverAuthToken?: string;
-    serverAuthTokenHeader?: string;
-    headers?: { [key: string]: string };
-}
-
-type MCPServersPreferenceValue = LocalMCPServerPreferenceValue | RemoteMCPServerPreferenceValue;
-
-interface MCPServersPreference {
-    [name: string]: MCPServersPreferenceValue
-};
-
-namespace MCPServersPreference {
-    export function isValue(obj: unknown): obj is MCPServersPreferenceValue {
-        return !!obj && typeof obj === 'object' &&
-            ('command' in obj || 'serverUrl' in obj) &&
-            (!('command' in obj) || typeof obj.command === 'string') &&
-            (!('args' in obj) || Array.isArray(obj.args) && obj.args.every(arg => typeof arg === 'string')) &&
-            (!('env' in obj) || !!obj.env && typeof obj.env === 'object' && Object.values(obj.env).every(value => typeof value === 'string')) &&
-            (!('autostart' in obj) || typeof obj.autostart === 'boolean') &&
-            (!('serverUrl' in obj) || typeof obj.serverUrl === 'string') &&
-            (!('serverAuthToken' in obj) || typeof obj.serverAuthToken === 'string') &&
-            (!('serverAuthTokenHeader' in obj) || typeof obj.serverAuthTokenHeader === 'string') &&
-            (!('headers' in obj) || !!obj.headers && typeof obj.headers === 'object' && Object.values(obj.headers).every(value => typeof value === 'string'));
-    }
-}
-
-function filterValidValues(servers: unknown): MCPServersPreference {
-    const result: MCPServersPreference = {};
-    if (!servers || typeof servers !== 'object') {
-        return result;
-    }
-    for (const [name, value] of Object.entries(servers)) {
-        if (typeof name === 'string' && MCPServersPreference.isValue(value)) {
-            result[name] = value;
-        }
-    }
-    return result;
-}
+import { filterValidValues, MCPServersPreference } from '../common/mcp-servers-preference';
 
 @injectable()
 export class McpFrontendApplicationContribution implements FrontendApplicationContribution, WorkspaceRestrictionContribution {
@@ -289,6 +239,12 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
         Object.entries(servers).forEach(([name, description]) => {
             let filteredDescription: MCPServerDescription;
 
+            const { registryServerId, registryVersion, registryConfigHash } = description as {
+                registryServerId?: string;
+                registryVersion?: string;
+                registryConfigHash?: string;
+            };
+
             if ('serverUrl' in description) {
                 // Create RemoteMCPServerDescription by picking only remote-specific properties
                 const { serverUrl, serverAuthToken, serverAuthTokenHeader, headers, autostart } = description;
@@ -299,6 +255,9 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
                     ...(serverAuthTokenHeader && { serverAuthTokenHeader }),
                     ...(headers && { headers }),
                     autostart: autostart ?? true,
+                    ...(registryServerId && { registryServerId }),
+                    ...(registryVersion && { registryVersion }),
+                    ...(registryConfigHash && { registryConfigHash }),
                 };
             } else {
                 // Create LocalMCPServerDescription by picking only local-specific properties
@@ -309,6 +268,9 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
                     ...(args && { args }),
                     ...(env && { env }),
                     autostart: autostart ?? true,
+                    ...(registryServerId && { registryServerId }),
+                    ...(registryVersion && { registryVersion }),
+                    ...(registryConfigHash && { registryConfigHash }),
                 };
             }
 

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -239,11 +239,7 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
         Object.entries(servers).forEach(([name, description]) => {
             let filteredDescription: MCPServerDescription;
 
-            const { registryServerId, registryVersion, registryConfigHash } = description as {
-                registryServerId?: string;
-                registryVersion?: string;
-                registryConfigHash?: string;
-            };
+            const { registryMetadata } = description;
 
             if ('serverUrl' in description) {
                 // Create RemoteMCPServerDescription by picking only remote-specific properties
@@ -255,9 +251,7 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
                     ...(serverAuthTokenHeader && { serverAuthTokenHeader }),
                     ...(headers && { headers }),
                     autostart: autostart ?? true,
-                    ...(registryServerId && { registryServerId }),
-                    ...(registryVersion && { registryVersion }),
-                    ...(registryConfigHash && { registryConfigHash }),
+                    ...(registryMetadata && { registryMetadata }),
                 };
             } else {
                 // Create LocalMCPServerDescription by picking only local-specific properties
@@ -268,9 +262,7 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
                     ...(args && { args }),
                     ...(env && { env }),
                     autostart: autostart ?? true,
-                    ...(registryServerId && { registryServerId }),
-                    ...(registryVersion && { registryVersion }),
-                    ...(registryConfigHash && { registryConfigHash }),
+                    ...(registryMetadata && { registryMetadata }),
                 };
             }
 

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -28,57 +28,7 @@ import {
     WorkspaceRestriction
 } from '@theia/workspace/lib/browser/workspace-trust-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
-
-interface BaseMCPServerPreferenceValue {
-    autostart?: boolean;
-}
-
-interface LocalMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
-    command: string;
-    args?: string[];
-    env?: { [key: string]: string };
-}
-
-interface RemoteMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
-    serverUrl: string;
-    serverAuthToken?: string;
-    serverAuthTokenHeader?: string;
-    headers?: { [key: string]: string };
-}
-
-type MCPServersPreferenceValue = LocalMCPServerPreferenceValue | RemoteMCPServerPreferenceValue;
-
-interface MCPServersPreference {
-    [name: string]: MCPServersPreferenceValue
-};
-
-namespace MCPServersPreference {
-    export function isValue(obj: unknown): obj is MCPServersPreferenceValue {
-        return !!obj && typeof obj === 'object' &&
-            ('command' in obj || 'serverUrl' in obj) &&
-            (!('command' in obj) || typeof obj.command === 'string') &&
-            (!('args' in obj) || Array.isArray(obj.args) && obj.args.every(arg => typeof arg === 'string')) &&
-            (!('env' in obj) || !!obj.env && typeof obj.env === 'object' && Object.values(obj.env).every(value => typeof value === 'string')) &&
-            (!('autostart' in obj) || typeof obj.autostart === 'boolean') &&
-            (!('serverUrl' in obj) || typeof obj.serverUrl === 'string') &&
-            (!('serverAuthToken' in obj) || typeof obj.serverAuthToken === 'string') &&
-            (!('serverAuthTokenHeader' in obj) || typeof obj.serverAuthTokenHeader === 'string') &&
-            (!('headers' in obj) || !!obj.headers && typeof obj.headers === 'object' && Object.values(obj.headers).every(value => typeof value === 'string'));
-    }
-}
-
-function filterValidValues(servers: unknown): MCPServersPreference {
-    const result: MCPServersPreference = {};
-    if (!servers || typeof servers !== 'object') {
-        return result;
-    }
-    for (const [name, value] of Object.entries(servers)) {
-        if (typeof name === 'string' && MCPServersPreference.isValue(value)) {
-            result[name] = value;
-        }
-    }
-    return result;
-}
+import { filterValidValues, MCPServersPreference } from '../common/mcp-servers-preference';
 
 @injectable()
 export class McpFrontendApplicationContribution implements FrontendApplicationContribution, WorkspaceRestrictionContribution {
@@ -288,6 +238,12 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
         Object.entries(servers).forEach(([name, description]) => {
             let filteredDescription: MCPServerDescription;
 
+            const { registryServerId, registryVersion, registryConfigHash } = description as {
+                registryServerId?: string;
+                registryVersion?: string;
+                registryConfigHash?: string;
+            };
+
             if ('serverUrl' in description) {
                 // Create RemoteMCPServerDescription by picking only remote-specific properties
                 const { serverUrl, serverAuthToken, serverAuthTokenHeader, headers, autostart } = description;
@@ -298,6 +254,9 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
                     ...(serverAuthTokenHeader && { serverAuthTokenHeader }),
                     ...(headers && { headers }),
                     autostart: autostart ?? true,
+                    ...(registryServerId && { registryServerId }),
+                    ...(registryVersion && { registryVersion }),
+                    ...(registryConfigHash && { registryConfigHash }),
                 };
             } else {
                 // Create LocalMCPServerDescription by picking only local-specific properties
@@ -308,6 +267,9 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
                     ...(args && { args }),
                     ...(env && { env }),
                     autostart: autostart ?? true,
+                    ...(registryServerId && { registryServerId }),
+                    ...(registryVersion && { registryVersion }),
+                    ...(registryConfigHash && { registryConfigHash }),
                 };
             }
 

--- a/packages/ai-mcp/src/browser/mcp-frontend-module.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-module.ts
@@ -34,7 +34,9 @@ import { MCPServerManagerServer, MCPServerManagerServerClient, MCPServerManagerS
 import { WorkspaceRestrictionContribution } from '@theia/workspace/lib/browser/workspace-trust-service';
 import { GenericCapabilitiesContribution } from '@theia/ai-core';
 import { MCPGenericCapabilitiesContribution } from './mcp-generic-capabilities-contribution';
-import { MCPServerEditor } from './mcp-server-editor';
+import { MCPServerEditor, MCPServerEditorImpl, MCPServerEditDialogFactory, MCPServerEditDialogParameters } from './mcp-server-editor';
+import { MCPServerEditDialog, DEFAULT_MCP_SERVER_FORM_DATA } from './mcp-server-edit-dialog';
+import { MCPServerInstallDialog, MCPServerInstallDialogFactory, MCPServerInstallDialogOptions } from './mcp-server-install-dialog';
 import { AIMCPConfigurationWidget } from './mcp-configuration-widget';
 import { MCPConfigurationCommandContribution } from './mcp-configuration-command-contribution';
 import { MCPInstallUriConfiguration } from './mcp-install-uri-configuration';
@@ -47,7 +49,17 @@ export default new ContainerModule(bind => {
     bind(MCPFrontendService).to(MCPFrontendServiceImpl).inSingletonScope();
     bind(MCPFrontendNotificationService).to(MCPFrontendNotificationServiceImpl).inSingletonScope();
 
-    bind(MCPServerEditor).toSelf().inSingletonScope();
+    bind(MCPServerEditDialogFactory).toFactory(() =>
+        (parameters: MCPServerEditDialogParameters) => new MCPServerEditDialog(
+            parameters.props,
+            parameters.initialData ?? { ...DEFAULT_MCP_SERVER_FORM_DATA },
+            parameters.existingServerNames,
+            parameters.isEditing
+        ));
+    bind(MCPServerInstallDialogFactory).toFactory(() =>
+        (options: MCPServerInstallDialogOptions) => new MCPServerInstallDialog(options));
+    bind(MCPServerEditorImpl).toSelf().inSingletonScope();
+    bind(MCPServerEditor).toService(MCPServerEditorImpl);
 
     bind(AIMCPConfigurationWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(ctx => ({

--- a/packages/ai-mcp/src/browser/mcp-frontend-module.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-module.ts
@@ -14,8 +14,12 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import '../../src/browser/style/mcp-server-dialog.css';
+import '../../src/browser/style/mcp-configuration-widget.css';
+
+import { CommandContribution } from '@theia/core';
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { FrontendApplicationContribution, RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
+import { FrontendApplicationContribution, OpenHandler, RemoteConnectionProvider, ServiceConnectionProvider, WidgetFactory } from '@theia/core/lib/browser';
 import {
     MCPFrontendService,
     MCPServerManager,
@@ -30,6 +34,11 @@ import { MCPServerManagerServer, MCPServerManagerServerClient, MCPServerManagerS
 import { WorkspaceRestrictionContribution } from '@theia/workspace/lib/browser/workspace-trust-service';
 import { GenericCapabilitiesContribution } from '@theia/ai-core';
 import { MCPGenericCapabilitiesContribution } from './mcp-generic-capabilities-contribution';
+import { MCPServerEditor } from './mcp-server-editor';
+import { AIMCPConfigurationWidget } from './mcp-configuration-widget';
+import { MCPConfigurationCommandContribution } from './mcp-configuration-command-contribution';
+import { MCPInstallUriConfiguration } from './mcp-install-uri-configuration';
+import { InstallMcpUriHandler } from './install-mcp-uri-handler';
 
 export default new ContainerModule(bind => {
     bind(McpFrontendApplicationContribution).toSelf().inSingletonScope();
@@ -37,6 +46,20 @@ export default new ContainerModule(bind => {
     bind(WorkspaceRestrictionContribution).toService(McpFrontendApplicationContribution);
     bind(MCPFrontendService).to(MCPFrontendServiceImpl).inSingletonScope();
     bind(MCPFrontendNotificationService).to(MCPFrontendNotificationServiceImpl).inSingletonScope();
+
+    bind(MCPServerEditor).toSelf().inSingletonScope();
+
+    bind(AIMCPConfigurationWidget).toSelf();
+    bind(WidgetFactory).toDynamicValue(ctx => ({
+        id: AIMCPConfigurationWidget.ID,
+        createWidget: () => ctx.container.get(AIMCPConfigurationWidget)
+    })).inSingletonScope();
+    bind(MCPConfigurationCommandContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(MCPConfigurationCommandContribution);
+
+    bind(MCPInstallUriConfiguration).toSelf().inSingletonScope();
+    bind(InstallMcpUriHandler).toSelf().inSingletonScope();
+    bind(OpenHandler).toService(InstallMcpUriHandler);
 
     bind(MCPGenericCapabilitiesContribution).toSelf().inSingletonScope();
     bind(GenericCapabilitiesContribution).toService(MCPGenericCapabilitiesContribution);

--- a/packages/ai-mcp/src/browser/mcp-install-uri-configuration.ts
+++ b/packages/ai-mcp/src/browser/mcp-install-uri-configuration.ts
@@ -1,0 +1,44 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+
+/**
+ * Configuration for the `install-mcp` deep-link URL handler.
+ *
+ * Defaults to `<electron-uri-scheme>://install-mcp` — products override by rebinding
+ * this class in their frontend module. The same scheme/authority is used by the
+ * registry maintainer when generating per-entry install URLs in the registry JSON, so
+ * that a click on such a link is routed to Theia and dispatched to this package's
+ * `InstallMcpUriHandler`.
+ */
+@injectable()
+export class MCPInstallUriConfiguration {
+
+    /**
+     * Scheme of the install URL — must match the product's Electron protocol
+     * registration (see `theia.frontend.config.electron.uriScheme` in `package.json`).
+     */
+    getScheme(): string {
+        return FrontendApplicationConfigProvider.get().electron?.uriScheme ?? 'theia';
+    }
+
+    /** URL authority that identifies install-mcp links. */
+    getAuthority(): string {
+        return 'install-mcp';
+    }
+}

--- a/packages/ai-mcp/src/browser/mcp-install-uri-configuration.ts
+++ b/packages/ai-mcp/src/browser/mcp-install-uri-configuration.ts
@@ -20,7 +20,7 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 /**
  * Configuration for the `install-mcp` deep-link URL handler.
  *
- * Defaults to `<electron-uri-scheme>://install-mcp` — products override by rebinding
+ * Defaults to `<electron-uri-scheme>://install-mcp` - products override by rebinding
  * this class in their frontend module. The same scheme/authority is used by the
  * registry maintainer when generating per-entry install URLs in the registry JSON, so
  * that a click on such a link is routed to Theia and dispatched to this package's
@@ -30,7 +30,7 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 export class MCPInstallUriConfiguration {
 
     /**
-     * Scheme of the install URL — must match the product's Electron protocol
+     * Scheme of the install URL - must match the product's Electron protocol
      * registration (see `theia.frontend.config.electron.uriScheme` in `package.json`).
      */
     getScheme(): string {

--- a/packages/ai-mcp/src/browser/mcp-registry-ui-bridge.ts
+++ b/packages/ai-mcp/src/browser/mcp-registry-ui-bridge.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core/lib/common/event';
+import { MCPInstallEntry } from './mcp-server-editor';
+
+export const MCPRegistryUiBridge = Symbol('MCPRegistryUiBridge');
+
+/**
+ * Optional integration point exposed by `@theia/ai-registry` so that AI-related
+ * widgets (e.g. the MCP configuration view in `@theia/ai-ide`) can surface
+ * registry affordances without taking a hard dependency on the registry package.
+ *
+ * If no registry implementation is bound, consumers should treat this as absent
+ * and hide all registry-specific affordances.
+ */
+export interface MCPRegistryUiBridge {
+    /** Fires when the cached set of registry server IDs changes (e.g. after a refresh). */
+    readonly onDidChange: Event<void>;
+    /**
+     * Resolves once the bridge has completed its initial registry fetch.
+     * Consumers (e.g. the install-mcp URL handler) await this before relying on
+     * `hasServer` / `getInstallEntry` so cold-start clicks don't get a false miss.
+     */
+    ready(): Promise<void>;
+    /** Synchronous, cached lookup: is `serverId` currently approved in the registry? */
+    hasServer(serverId: string): boolean;
+    /**
+     * Resolve the registry entry for `serverId` into a self-contained install payload
+     * (slug, config, version, configHash, display metadata). Returns `undefined` when
+     * the registry has no approval for the given id. Used by the `install-mcp` URL
+     * handler to drive the install flow purely from the registry.
+     */
+    getInstallEntry(serverId: string): MCPInstallEntry | undefined;
+    /** Opens the registry browser. If `serverId` is provided, the view scrolls to / filters that entry. */
+    openRegistry(serverId?: string): Promise<void>;
+}

--- a/packages/ai-mcp/src/browser/mcp-registry-ui-bridge.ts
+++ b/packages/ai-mcp/src/browser/mcp-registry-ui-bridge.ts
@@ -40,7 +40,7 @@ export interface MCPRegistryUiBridge {
     hasServer(serverId: string): boolean;
     /**
      * Resolve the registry entry for `serverId` into a self-contained install payload
-     * (slug, config, version, configHash, display metadata). Returns `undefined` when
+     * (key, config, version, configHash, display metadata). Returns `undefined` when
      * the registry has no approval for the given id. Used by the `install-mcp` URL
      * handler to drive the install flow purely from the registry.
      */

--- a/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
@@ -20,7 +20,7 @@ import { DialogProps } from '@theia/core/lib/browser/dialogs';
 import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
 import { SelectComponent } from '@theia/core/lib/browser/widgets/select-component';
 
-/** Server type discriminator the dialog edits — stdio launch vs remote URL. */
+/** Server type discriminator the dialog edits - stdio launch vs remote URL. */
 export type MCPServerType = 'local' | 'remote';
 
 /** User-facing form fields collected by the Add/Edit MCP Server dialog. */
@@ -53,7 +53,7 @@ export const DEFAULT_MCP_SERVER_FORM_DATA: MCPServerFormData = {
 /**
  * Dialog for adding or editing an MCP server. Kept in a separate module from
  * `MCPServerEditor` so importing the editor doesn't pull in the DOM-touching
- * `ReactDialog` chain — important for unit tests that load the editor's types.
+ * `ReactDialog` chain - important for unit tests that load the editor's types.
  */
 export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefined> {
 

--- a/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
@@ -1,0 +1,247 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { DialogProps } from '@theia/core/lib/browser/dialogs';
+import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
+import { SelectComponent } from '@theia/core/lib/browser/widgets/select-component';
+
+/** Server type discriminator the dialog edits — stdio launch vs remote URL. */
+export type MCPServerType = 'local' | 'remote';
+
+/** User-facing form fields collected by the Add/Edit MCP Server dialog. */
+export interface MCPServerFormData {
+    name: string;
+    serverType: MCPServerType;
+    command: string;
+    args: string;
+    env: string;
+    serverUrl: string;
+    serverAuthToken: string;
+    serverAuthTokenHeader: string;
+    headers: string;
+    autostart: boolean;
+}
+
+export const DEFAULT_MCP_SERVER_FORM_DATA: MCPServerFormData = {
+    name: '',
+    serverType: 'local',
+    command: '',
+    args: '',
+    env: '',
+    serverUrl: '',
+    serverAuthToken: '',
+    serverAuthTokenHeader: '',
+    headers: '',
+    autostart: true
+};
+
+/**
+ * Dialog for adding or editing an MCP server. Kept in a separate module from
+ * `MCPServerEditor` so importing the editor doesn't pull in the DOM-touching
+ * `ReactDialog` chain — important for unit tests that load the editor's types.
+ */
+export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefined> {
+
+    protected formData: MCPServerFormData;
+    protected existingServerNames: string[];
+    protected isEditing: boolean;
+
+    constructor(
+        props: DialogProps,
+        initialData: MCPServerFormData,
+        existingServerNames: string[],
+        isEditing: boolean
+    ) {
+        super(props);
+        this.formData = { ...initialData };
+        this.existingServerNames = existingServerNames;
+        this.isEditing = isEditing;
+        this.appendCloseButton(nls.localizeByDefault('Cancel'));
+        this.appendAcceptButton(isEditing
+            ? nls.localize('theia/ai/mcpConfiguration/form/saveChanges', 'Save Changes')
+            : nls.localizeByDefault('Add Server'));
+    }
+
+    get value(): MCPServerFormData | undefined {
+        return this.formData;
+    }
+
+    protected override isValid(): string {
+        const errors: string[] = [];
+        if (!this.formData.name.trim()) {
+            errors.push(nls.localize('theia/ai/mcpConfiguration/form/nameRequired', 'Server name is required'));
+        } else if (!this.isEditing && this.existingServerNames.includes(this.formData.name.trim())) {
+            errors.push(nls.localize('theia/ai/mcpConfiguration/form/nameExists', 'A server with this name already exists'));
+        }
+        if (this.formData.serverType === 'local') {
+            if (!this.formData.command.trim()) {
+                errors.push(nls.localize('theia/ai/mcpConfiguration/form/commandRequired', 'Command is required for local servers'));
+            }
+        } else if (!this.formData.serverUrl.trim()) {
+            errors.push(nls.localize('theia/ai/mcpConfiguration/form/serverUrlRequired', 'Server URL is required for remote servers'));
+        }
+        return errors.join('. ');
+    }
+
+    protected handleFormChange = (field: keyof MCPServerFormData, value: string | boolean): void => {
+        this.formData = { ...this.formData, [field]: value };
+        this.update();
+    };
+
+    protected render(): React.ReactNode {
+        return (
+            <div className="mcp-dialog-form">
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/form/serverName', 'Server Name')}:</label>
+                    <input
+                        type="text"
+                        className="theia-input"
+                        value={this.formData.name}
+                        onChange={e => this.handleFormChange('name', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/serverNamePlaceholder', 'e.g., my-mcp-server')}
+                        disabled={this.isEditing}
+                        spellCheck={false}
+                    />
+                </div>
+
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/form/serverType', 'Server Type')}:</label>
+                    <SelectComponent
+                        className="theia-select"
+                        defaultValue={this.formData.serverType}
+                        options={[
+                            { value: 'local', label: nls.localize('theia/ai/mcpConfiguration/form/localServer', 'Local (Command)') },
+                            { value: 'remote', label: nls.localize('theia/ai/mcpConfiguration/form/remoteServer', 'Remote (URL)') }
+                        ]}
+                        onChange={option => this.handleFormChange('serverType', option.value as MCPServerType)}
+                    />
+                </div>
+
+                {this.formData.serverType === 'local' ? this.renderLocalServerFields() : this.renderRemoteServerFields()}
+
+                <div className="mcp-form-field mcp-form-checkbox">
+                    <label>
+                        <input
+                            type="checkbox"
+                            className='theia-input'
+                            checked={this.formData.autostart}
+                            onChange={e => this.handleFormChange('autostart', e.target.checked)}
+                        />
+                        {nls.localize('theia/ai/mcpConfiguration/form/autostart', 'Autostart')}
+                    </label>
+                </div>
+            </div>
+        );
+    }
+
+    protected renderLocalServerFields(): React.ReactNode {
+        return (
+            <>
+                <div className="mcp-form-field">
+                    <label>{nls.localizeByDefault('Command')}:</label>
+                    <input
+                        type="text"
+                        className="theia-input"
+                        value={this.formData.command}
+                        onChange={e => this.handleFormChange('command', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/commandPlaceholder', 'e.g., npx or uvx')}
+                        spellCheck={false}
+                    />
+                </div>
+
+                <div className="mcp-form-field">
+                    <label>{nls.localizeByDefault('Arguments')}:</label>
+                    <input
+                        type="text"
+                        className="theia-input"
+                        value={this.formData.args}
+                        onChange={e => this.handleFormChange('args', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/argsPlaceholder', 'Space-separated, e.g., -y @modelcontextprotocol/server-brave-search')}
+                        spellCheck={false}
+                    />
+                </div>
+
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/environmentVariables', 'Environment Variables')}:</label>
+                    <textarea
+                        className="theia-input"
+                        value={this.formData.env}
+                        onChange={e => this.handleFormChange('env', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/envPlaceholder', 'KEY=value (one per line)')}
+                        rows={3}
+                        spellCheck={false}
+                    />
+                </div>
+            </>
+        );
+    }
+
+    protected renderRemoteServerFields(): React.ReactNode {
+        return (
+            <>
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/serverUrl', 'Server URL')}:</label>
+                    <input
+                        type="text"
+                        className="theia-input"
+                        value={this.formData.serverUrl}
+                        onChange={e => this.handleFormChange('serverUrl', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/serverUrlPlaceholder', 'e.g., https://mcp.example.com')}
+                        spellCheck={false}
+                    />
+                </div>
+
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/serverAuthToken', 'Auth Token')}:</label>
+                    <input
+                        type="password"
+                        className="theia-input"
+                        value={this.formData.serverAuthToken}
+                        onChange={e => this.handleFormChange('serverAuthToken', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/authTokenPlaceholder', 'Optional authentication token')}
+                        spellCheck={false}
+                    />
+                </div>
+
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/serverAuthTokenHeader', 'Auth Header Name')}:</label>
+                    <input
+                        type="text"
+                        className="theia-input"
+                        value={this.formData.serverAuthTokenHeader}
+                        onChange={e => this.handleFormChange('serverAuthTokenHeader', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/authHeaderPlaceholder', 'Default: Authorization with Bearer')}
+                        spellCheck={false}
+                    />
+                </div>
+
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/headers', 'Headers')}:</label>
+                    <textarea
+                        className="theia-input"
+                        value={this.formData.headers}
+                        onChange={e => this.handleFormChange('headers', e.target.value)}
+                        placeholder={nls.localize('theia/ai/mcpConfiguration/form/headersPlaceholder', 'Header-Name=value (one per line)')}
+                        rows={3}
+                        spellCheck={false}
+                    />
+                </div>
+            </>
+        );
+    }
+}

--- a/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
@@ -1,0 +1,137 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { MessageService, PreferenceService } from '@theia/core';
+import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
+import { MCPFrontendService } from '../common/mcp-server-manager';
+import { MCPInstallEntry, MCPServerEditor } from './mcp-server-editor';
+
+class FakePreferenceService {
+    private readonly store = new Map<string, unknown>();
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return (this.store.has(key) ? this.store.get(key) : defaultValue) as T | undefined;
+    }
+    async set(key: string, value: unknown): Promise<void> {
+        this.store.set(key, value);
+    }
+    snapshot<T>(key: string): T | undefined {
+        return this.store.get(key) as T | undefined;
+    }
+}
+
+describe('MCPServerEditor.installFromEntry', () => {
+
+    let prefs: FakePreferenceService;
+    let editor: MCPServerEditor;
+
+    beforeEach(() => {
+        const container = new Container();
+        prefs = new FakePreferenceService();
+        container.bind(PreferenceService).toConstantValue(prefs as unknown as PreferenceService);
+        container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
+        container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
+        container.bind(MCPServerEditor).toSelf().inSingletonScope();
+        editor = container.get(MCPServerEditor);
+    });
+
+    it('writes the config blob under entry.localSlug and tags it with registry metadata', async () => {
+        const entry: MCPInstallEntry = {
+            localSlug: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] },
+            serverId: 'io.github.example/example-mcp',
+            version: '^1.0.0',
+            configHash: 'hash-v1'
+        };
+
+        await editor.installFromEntry(entry);
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+    });
+
+    it('omits registry metadata fields the entry does not carry — keeps the preference free of registry-link traces for URL-driven installs', async () => {
+        const entry: MCPInstallEntry = {
+            localSlug: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] }
+        };
+
+        await editor.installFromEntry(entry);
+
+        const stored = prefs.snapshot<Record<string, Record<string, unknown>>>(MCP_SERVERS_PREF)!.example;
+        expect(stored).to.not.have.property('registryServerId');
+        expect(stored).to.not.have.property('registryVersion');
+        expect(stored).to.not.have.property('registryConfigHash');
+    });
+
+    it('applies the autostart override the dialog collected', async () => {
+        const entry: MCPInstallEntry = {
+            localSlug: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] }
+        };
+
+        await editor.installFromEntry(entry, { autostart: false });
+
+        expect(prefs.snapshot<Record<string, { autostart?: boolean }>>(MCP_SERVERS_PREF)!.example.autostart).to.equal(false);
+    });
+
+    it('fills serverAuthToken when the entry config advertises the slot — even if the slot was empty', async () => {
+        const entry: MCPInstallEntry = {
+            localSlug: 'example',
+            config: { serverUrl: 'https://example.com/mcp', serverAuthToken: '' }
+        };
+
+        await editor.installFromEntry(entry, { serverAuthToken: 'secret-123' });
+
+        expect(prefs.snapshot<Record<string, { serverAuthToken?: string }>>(MCP_SERVERS_PREF)!.example.serverAuthToken).to.equal('secret-123');
+    });
+
+    it('ignores serverAuthToken when the entry config does not advertise the slot — avoids leaking it onto local entries', async () => {
+        const entry: MCPInstallEntry = {
+            localSlug: 'example',
+            // No `serverAuthToken` key — entry is local stdio.
+            config: { command: 'npx', args: ['-y', 'example-mcp'] }
+        };
+
+        await editor.installFromEntry(entry, { serverAuthToken: 'should-be-ignored' });
+
+        expect(prefs.snapshot<Record<string, Record<string, unknown>>>(MCP_SERVERS_PREF)!.example).to.not.have.property('serverAuthToken');
+    });
+
+    it('preserves unrelated servers already in the preference', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            other: { command: 'node', args: ['unrelated.js'] }
+        });
+        const entry: MCPInstallEntry = {
+            localSlug: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] }
+        };
+
+        await editor.installFromEntry(entry);
+
+        const all = prefs.snapshot<Record<string, unknown>>(MCP_SERVERS_PREF)!;
+        expect(Object.keys(all).sort()).to.deep.equal(['example', 'other']);
+        expect(all.other).to.deep.equal({ command: 'node', args: ['unrelated.js'] });
+    });
+});

--- a/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
@@ -19,7 +19,7 @@ import { Container } from '@theia/core/shared/inversify';
 import { MessageService, PreferenceService } from '@theia/core';
 import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
 import { MCPFrontendService } from '../common/mcp-server-manager';
-import { MCPInstallEntry, MCPServerEditor } from './mcp-server-editor';
+import { MCPInstallEntry, MCPServerEditDialogFactory, MCPServerEditorImpl } from './mcp-server-editor';
 
 class FakePreferenceService {
     private readonly store = new Map<string, unknown>();
@@ -37,7 +37,7 @@ class FakePreferenceService {
 describe('MCPServerEditor.installFromEntry', () => {
 
     let prefs: FakePreferenceService;
-    let editor: MCPServerEditor;
+    let editor: MCPServerEditorImpl;
 
     beforeEach(() => {
         const container = new Container();
@@ -45,13 +45,17 @@ describe('MCPServerEditor.installFromEntry', () => {
         container.bind(PreferenceService).toConstantValue(prefs as unknown as PreferenceService);
         container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
         container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
-        container.bind(MCPServerEditor).toSelf().inSingletonScope();
-        editor = container.get(MCPServerEditor);
+        // installFromEntry never opens a dialog; bind a factory that fails loudly if it is used.
+        container.bind(MCPServerEditDialogFactory).toConstantValue(() => {
+            throw new Error('MCPServerEditDialogFactory should not be invoked in these tests');
+        });
+        container.bind(MCPServerEditorImpl).toSelf().inSingletonScope();
+        editor = container.get(MCPServerEditorImpl);
     });
 
-    it('writes the config blob under entry.localSlug and tags it with registry metadata', async () => {
+    it('writes the config blob under entry.localName and tags it with registry metadata', async () => {
         const entry: MCPInstallEntry = {
-            localSlug: 'example',
+            localName: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] },
             serverId: 'io.github.example/example-mcp',
             version: '^1.0.0',
@@ -75,7 +79,7 @@ describe('MCPServerEditor.installFromEntry', () => {
 
     it('omits registryMetadata when the entry carries no serverId - keeps the preference free of registry-link traces for URL-driven installs', async () => {
         const entry: MCPInstallEntry = {
-            localSlug: 'example',
+            localName: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] }
         };
 
@@ -87,7 +91,7 @@ describe('MCPServerEditor.installFromEntry', () => {
 
     it('omits optional metadata fields the entry does not carry while keeping the required serverId', async () => {
         const entry: MCPInstallEntry = {
-            localSlug: 'example',
+            localName: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] },
             serverId: 'io.github.example/example-mcp'
         };
@@ -100,7 +104,7 @@ describe('MCPServerEditor.installFromEntry', () => {
 
     it('applies the autostart override the dialog collected', async () => {
         const entry: MCPInstallEntry = {
-            localSlug: 'example',
+            localName: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] }
         };
 
@@ -111,7 +115,7 @@ describe('MCPServerEditor.installFromEntry', () => {
 
     it('fills serverAuthToken when the entry config advertises the slot - even if the slot was empty', async () => {
         const entry: MCPInstallEntry = {
-            localSlug: 'example',
+            localName: 'example',
             config: { serverUrl: 'https://example.com/mcp', serverAuthToken: '' }
         };
 
@@ -122,7 +126,7 @@ describe('MCPServerEditor.installFromEntry', () => {
 
     it('ignores serverAuthToken when the entry config does not advertise the slot - avoids leaking it onto local entries', async () => {
         const entry: MCPInstallEntry = {
-            localSlug: 'example',
+            localName: 'example',
             // No `serverAuthToken` key - entry is local stdio.
             config: { command: 'npx', args: ['-y', 'example-mcp'] }
         };
@@ -137,7 +141,7 @@ describe('MCPServerEditor.installFromEntry', () => {
             other: { command: 'node', args: ['unrelated.js'] }
         });
         const entry: MCPInstallEntry = {
-            localSlug: 'example',
+            localName: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] }
         };
 

--- a/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
@@ -64,14 +64,16 @@ describe('MCPServerEditor.installFromEntry', () => {
             example: {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
     });
 
-    it('omits registry metadata fields the entry does not carry — keeps the preference free of registry-link traces for URL-driven installs', async () => {
+    it('omits registryMetadata when the entry carries no serverId - keeps the preference free of registry-link traces for URL-driven installs', async () => {
         const entry: MCPInstallEntry = {
             localSlug: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] }
@@ -80,9 +82,20 @@ describe('MCPServerEditor.installFromEntry', () => {
         await editor.installFromEntry(entry);
 
         const stored = prefs.snapshot<Record<string, Record<string, unknown>>>(MCP_SERVERS_PREF)!.example;
-        expect(stored).to.not.have.property('registryServerId');
-        expect(stored).to.not.have.property('registryVersion');
-        expect(stored).to.not.have.property('registryConfigHash');
+        expect(stored).to.not.have.property('registryMetadata');
+    });
+
+    it('omits optional metadata fields the entry does not carry while keeping the required serverId', async () => {
+        const entry: MCPInstallEntry = {
+            localSlug: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] },
+            serverId: 'io.github.example/example-mcp'
+        };
+
+        await editor.installFromEntry(entry);
+
+        const stored = prefs.snapshot<Record<string, { registryMetadata?: Record<string, unknown> }>>(MCP_SERVERS_PREF)!.example;
+        expect(stored.registryMetadata).to.deep.equal({ serverId: 'io.github.example/example-mcp' });
     });
 
     it('applies the autostart override the dialog collected', async () => {
@@ -96,7 +109,7 @@ describe('MCPServerEditor.installFromEntry', () => {
         expect(prefs.snapshot<Record<string, { autostart?: boolean }>>(MCP_SERVERS_PREF)!.example.autostart).to.equal(false);
     });
 
-    it('fills serverAuthToken when the entry config advertises the slot — even if the slot was empty', async () => {
+    it('fills serverAuthToken when the entry config advertises the slot - even if the slot was empty', async () => {
         const entry: MCPInstallEntry = {
             localSlug: 'example',
             config: { serverUrl: 'https://example.com/mcp', serverAuthToken: '' }
@@ -107,10 +120,10 @@ describe('MCPServerEditor.installFromEntry', () => {
         expect(prefs.snapshot<Record<string, { serverAuthToken?: string }>>(MCP_SERVERS_PREF)!.example.serverAuthToken).to.equal('secret-123');
     });
 
-    it('ignores serverAuthToken when the entry config does not advertise the slot — avoids leaking it onto local entries', async () => {
+    it('ignores serverAuthToken when the entry config does not advertise the slot - avoids leaking it onto local entries', async () => {
         const entry: MCPInstallEntry = {
             localSlug: 'example',
-            // No `serverAuthToken` key — entry is local stdio.
+            // No `serverAuthToken` key - entry is local stdio.
             config: { command: 'npx', args: ['-y', 'example-mcp'] }
         };
 

--- a/packages/ai-mcp/src/browser/mcp-server-editor.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.ts
@@ -27,19 +27,38 @@ import {
     RemoteMCPServerDescription
 } from '../common/mcp-server-manager';
 import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
-import type { MCPServerFormData } from './mcp-server-edit-dialog';
-
-export type { MCPInstallEntryConfig };
+import type { DialogProps } from '@theia/core/lib/browser/dialogs';
+import type { MCPServerEditDialog, MCPServerFormData } from './mcp-server-edit-dialog';
 
 /**
- * Self-contained install payload: the slug to use in the preference, the config blob
+ * Parameters consumed by {@link MCPServerEditDialogFactory}. `initialData` is omitted for
+ * the "add" flow, where the factory seeds the form with defaults.
+ */
+export interface MCPServerEditDialogParameters {
+    props: DialogProps;
+    initialData?: MCPServerFormData;
+    existingServerNames: string[];
+    isEditing: boolean;
+}
+
+/**
+ * Factory for the DOM-touching {@link MCPServerEditDialog}. Injected (rather than the
+ * dialog module being imported directly) so the editor stays free of the Lumino widget
+ * chain - keeping it loadable in Node-only unit tests - and so adopters can rebind the
+ * dialog if needed.
+ */
+export const MCPServerEditDialogFactory = Symbol('MCPServerEditDialogFactory');
+export type MCPServerEditDialogFactory = (parameters: MCPServerEditDialogParameters) => MCPServerEditDialog;
+
+/**
+ * Self-contained install payload: the local preference key, the config blob
  * to write, and optional registry-provenance metadata. When `serverId` is set the
  * fields are persisted as a single `registryMetadata` block on the stored entry.
  */
 export interface MCPInstallEntry {
     /** Local preference key. */
-    localSlug: string;
-    /** Config blob to write under `mcpServers[localSlug]`. */
+    localName: string;
+    /** Config blob to write under `mcpServers[localName]`. */
     config: MCPInstallEntryConfig;
     /** Registry server id - populates `registryMetadata.serverId` so updates stay tracked. */
     serverId?: string;
@@ -60,12 +79,24 @@ export interface MCPInstallOverrides {
  * Owns the persistence + dialog flows for MCP servers. Lives in `@theia/ai-mcp`
  * alongside the data model so both the configuration widget (in ai-ide) and the
  * registry/URL-driven install flows (in ai-registry / ai-mcp) can share it.
- *
- * The DOM-touching `MCPServerEditDialog` is imported lazily so test-time imports
- * of this service don't drag the Lumino widget chain into Node-only test runs.
+ */
+export const MCPServerEditor = Symbol('MCPServerEditor');
+export interface MCPServerEditor {
+    /** Opens the "Add MCP Server" dialog and persists the result. */
+    openAddServer(): Promise<void>;
+    /** Opens the "Edit MCP Server" dialog pre-filled from `server` and persists the result. */
+    openEditServer(server: MCPServerDescription, existingNames: string[]): Promise<void>;
+    /** Installs a self-contained entry, applying any user-supplied overrides. */
+    installFromEntry(entry: MCPInstallEntry, overrides?: MCPInstallOverrides): Promise<void>;
+}
+
+/**
+ * Default {@link MCPServerEditor} implementation. The DOM-touching `MCPServerEditDialog`
+ * is created through an injected {@link MCPServerEditDialogFactory} rather than imported
+ * directly, so this service stays loadable in Node-only unit tests.
  */
 @injectable()
-export class MCPServerEditor {
+export class MCPServerEditorImpl implements MCPServerEditor {
 
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
@@ -76,15 +107,16 @@ export class MCPServerEditor {
     @inject(MCPFrontendService)
     protected readonly mcpFrontendService: MCPFrontendService;
 
+    @inject(MCPServerEditDialogFactory)
+    protected readonly editDialogFactory: MCPServerEditDialogFactory;
+
     async openAddServer(): Promise<void> {
         const existing = (await this.mcpFrontendService.getServerNames()) ?? [];
-        const { MCPServerEditDialog, DEFAULT_MCP_SERVER_FORM_DATA } = await import('./mcp-server-edit-dialog');
-        const dialog = new MCPServerEditDialog(
-            { title: nls.localizeByDefault('Add MCP Server'), maxWidth: 500 },
-            { ...DEFAULT_MCP_SERVER_FORM_DATA },
-            existing,
-            false
-        );
+        const dialog = this.editDialogFactory({
+            props: { title: nls.localizeByDefault('Add MCP Server'), maxWidth: 500 },
+            existingServerNames: existing,
+            isEditing: false
+        });
         const result = await dialog.open();
         if (result) {
             await this.save(result);
@@ -96,13 +128,12 @@ export class MCPServerEditor {
         if (!formData) {
             return;
         }
-        const { MCPServerEditDialog } = await import('./mcp-server-edit-dialog');
-        const dialog = new MCPServerEditDialog(
-            { title: nls.localize('theia/ai/mcpConfiguration/editServerTitle', 'Edit MCP Server'), maxWidth: 500 },
-            formData,
-            existingNames.filter(n => n !== server.name),
-            true
-        );
+        const dialog = this.editDialogFactory({
+            props: { title: nls.localize('theia/ai/mcpConfiguration/editServerTitle', 'Edit MCP Server'), maxWidth: 500 },
+            initialData: formData,
+            existingServerNames: existingNames.filter(n => n !== server.name),
+            isEditing: true
+        });
         const result = await dialog.open();
         if (result) {
             await this.save(result);
@@ -110,8 +141,8 @@ export class MCPServerEditor {
     }
 
     /**
-     * Install an MCP server from a self-contained entry — used by registry install actions
-     * and the `install-mcp` URL handler. Writes the config blob to `mcpServers[localSlug]`
+     * Install an MCP server from a self-contained entry - used by registry install actions
+     * and the `install-mcp` URL handler. Writes the config blob to `mcpServers[localName]`
      * along with registry-provenance metadata, applying any user-supplied overrides
      * collected by the install dialog.
      */
@@ -128,7 +159,7 @@ export class MCPServerEditor {
         try {
             await this.preferenceService.set(
                 MCP_SERVERS_PREF,
-                { ...current, [entry.localSlug]: stored },
+                { ...current, [entry.localName]: stored },
                 PreferenceScope.User
             );
         } catch (error) {

--- a/packages/ai-mcp/src/browser/mcp-server-editor.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.ts
@@ -1,0 +1,286 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { MessageService, nls, PreferenceScope, PreferenceService } from '@theia/core';
+import {
+    isLocalMCPServerDescription,
+    isRemoteMCPServerDescription,
+    LocalMCPServerDescription,
+    MCPFrontendService,
+    MCPServerDescription,
+    RemoteMCPServerDescription
+} from '../common/mcp-server-manager';
+import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
+import type { MCPServerFormData } from './mcp-server-edit-dialog';
+
+/**
+ * Subset of an MCP server's persisted configuration that an install flow may carry:
+ * either set by a registry entry or hand-crafted in an install URL. Identical in shape
+ * to `RegistryMCPServerConfigEntry` from `@theia/ai-registry`; kept here so ai-mcp can
+ * own the install path without depending on the registry package.
+ */
+export interface MCPInstallEntryConfig {
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    serverUrl?: string;
+    serverAuthToken?: string;
+    serverAuthTokenHeader?: string;
+    headers?: Record<string, string>;
+}
+
+/**
+ * Self-contained install payload: the slug to use in the preference, the config blob
+ * to write, and optional registry-provenance metadata. `serverId` is used for the
+ * `registryServerId` link-back when present; `version` becomes `registryVersion`
+ * (display-only) and `configHash` becomes `registryConfigHash` (update detection).
+ */
+export interface MCPInstallEntry {
+    /** Local preference key. */
+    localSlug: string;
+    /** Config blob to write under `mcpServers[localSlug]`. */
+    config: MCPInstallEntryConfig;
+    /** Registry server id — populates `registryServerId` so updates stay tracked. */
+    serverId?: string;
+    /** Approved version published by the registry — populates `registryVersion` for display. */
+    version?: string;
+    /** Hash of the registry approval — populates `registryConfigHash` and drives update detection. */
+    configHash?: string;
+}
+
+/** User-supplied parameters collected by the install dialog before persisting. */
+export interface MCPInstallOverrides {
+    autostart?: boolean;
+    /** Filled into a remote server's `serverAuthToken` slot when supplied by the user. */
+    serverAuthToken?: string;
+}
+
+/**
+ * Owns the persistence + dialog flows for MCP servers. Lives in `@theia/ai-mcp`
+ * alongside the data model so both the configuration widget (in ai-ide) and the
+ * registry/URL-driven install flows (in ai-registry / ai-mcp) can share it.
+ *
+ * The DOM-touching `MCPServerEditDialog` is imported lazily so test-time imports
+ * of this service don't drag the Lumino widget chain into Node-only test runs.
+ */
+@injectable()
+export class MCPServerEditor {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(MCPFrontendService)
+    protected readonly mcpFrontendService: MCPFrontendService;
+
+    async openAddServer(): Promise<void> {
+        const existing = (await this.mcpFrontendService.getServerNames()) ?? [];
+        const { MCPServerEditDialog, DEFAULT_MCP_SERVER_FORM_DATA } = await import('./mcp-server-edit-dialog');
+        const dialog = new MCPServerEditDialog(
+            { title: nls.localizeByDefault('Add MCP Server'), maxWidth: 500 },
+            { ...DEFAULT_MCP_SERVER_FORM_DATA },
+            existing,
+            false
+        );
+        const result = await dialog.open();
+        if (result) {
+            await this.save(result);
+        }
+    }
+
+    async openEditServer(server: MCPServerDescription, existingNames: string[]): Promise<void> {
+        const formData = this.toFormData(server);
+        if (!formData) {
+            return;
+        }
+        const { MCPServerEditDialog } = await import('./mcp-server-edit-dialog');
+        const dialog = new MCPServerEditDialog(
+            { title: nls.localize('theia/ai/mcpConfiguration/editServerTitle', 'Edit MCP Server'), maxWidth: 500 },
+            formData,
+            existingNames.filter(n => n !== server.name),
+            true
+        );
+        const result = await dialog.open();
+        if (result) {
+            await this.save(result);
+        }
+    }
+
+    /**
+     * Install an MCP server from a self-contained entry — used by registry install actions
+     * and the `install-mcp` URL handler. Writes the config blob to `mcpServers[localSlug]`
+     * along with registry-provenance metadata, applying any user-supplied overrides
+     * collected by the install dialog.
+     */
+    async installFromEntry(entry: MCPInstallEntry, overrides?: MCPInstallOverrides): Promise<void> {
+        const current = this.readServers();
+        const stored: Record<string, unknown> = {
+            ...entry.config,
+            ...this.applyOverrides(entry.config, overrides)
+        };
+        if (entry.serverId !== undefined) {
+            stored.registryServerId = entry.serverId;
+        }
+        if (entry.version !== undefined) {
+            stored.registryVersion = entry.version;
+        }
+        if (entry.configHash !== undefined) {
+            stored.registryConfigHash = entry.configHash;
+        }
+        try {
+            await this.preferenceService.set(
+                MCP_SERVERS_PREF,
+                { ...current, [entry.localSlug]: stored },
+                PreferenceScope.User
+            );
+        } catch (error) {
+            this.messageService.error(nls.localize('theia/ai/mcpConfiguration/saveServerError', 'Failed to save MCP server configuration: {0}', String(error)));
+        }
+    }
+
+    protected readServers(): Record<string, unknown> {
+        return this.preferenceService.get<Record<string, unknown>>(MCP_SERVERS_PREF, {}) ?? {};
+    }
+
+    /** Merge user overrides into the config blob (only fields the dialog collects). */
+    protected applyOverrides(
+        config: MCPInstallEntryConfig,
+        overrides: MCPInstallOverrides | undefined
+    ): Partial<MCPInstallEntryConfig & { autostart: boolean }> {
+        if (!overrides) {
+            return {};
+        }
+        const merged: Partial<MCPInstallEntryConfig & { autostart: boolean }> = {};
+        if (overrides.autostart !== undefined) {
+            merged.autostart = overrides.autostart;
+        }
+        // Sanity-check: only persist a token when the config actually has the slot.
+        if (overrides.serverAuthToken !== undefined && 'serverAuthToken' in config) {
+            merged.serverAuthToken = overrides.serverAuthToken;
+        }
+        return merged;
+    }
+
+    /**
+     * Persist the form to the user preference. Preserves any extra fields on an existing entry
+     * (e.g. `registryServerId`) since the dialog only edits user-facing fields.
+     */
+    async save(formData: MCPServerFormData): Promise<void> {
+        const currentServers = this.preferenceService.get<Record<string, object>>(MCP_SERVERS_PREF, {}) ?? {};
+        const serverName = formData.name.trim();
+        const existing = (currentServers[serverName] ?? {}) as Record<string, unknown>;
+        const serverConfig = formData.serverType === 'local'
+            ? this.toLocalConfig(formData)
+            : this.toRemoteConfig(formData);
+        try {
+            await this.preferenceService.set(
+                MCP_SERVERS_PREF,
+                { ...currentServers, [serverName]: { ...existing, ...serverConfig } },
+                PreferenceScope.User
+            );
+        } catch (error) {
+            this.messageService.error(nls.localize('theia/ai/mcpConfiguration/saveServerError', 'Failed to save MCP server configuration: {0}', String(error)));
+        }
+    }
+
+    protected toFormData(server: MCPServerDescription): MCPServerFormData | undefined {
+        if (isLocalMCPServerDescription(server)) {
+            return {
+                name: server.name,
+                serverType: 'local',
+                command: server.command,
+                args: server.args?.join(' ') ?? '',
+                env: server.env ? Object.entries(server.env).map(([k, v]) => `${k}=${v}`).join('\n') : '',
+                serverUrl: '',
+                serverAuthToken: '',
+                serverAuthTokenHeader: '',
+                headers: '',
+                autostart: server.autostart ?? true
+            };
+        }
+        if (isRemoteMCPServerDescription(server)) {
+            return {
+                name: server.name,
+                serverType: 'remote',
+                command: '',
+                args: '',
+                env: '',
+                serverUrl: server.serverUrl,
+                serverAuthToken: server.serverAuthToken ?? '',
+                serverAuthTokenHeader: server.serverAuthTokenHeader ?? '',
+                headers: server.headers
+                    ? Object.entries(server.headers).map(([k, v]) => `${k}=${v}`).join('\n')
+                    : '',
+                autostart: server.autostart ?? true
+            };
+        }
+        return undefined;
+    }
+
+    protected toLocalConfig(formData: MCPServerFormData): Partial<LocalMCPServerDescription> {
+        const config: Partial<LocalMCPServerDescription> = {
+            command: formData.command.trim(),
+            autostart: formData.autostart
+        };
+        if (formData.args.trim()) {
+            config.args = formData.args.trim().split(/\s+/);
+        }
+        const env = parseKeyValuePairs(formData.env);
+        if (env) {
+            config.env = env;
+        }
+        return config;
+    }
+
+    protected toRemoteConfig(formData: MCPServerFormData): Partial<RemoteMCPServerDescription> {
+        const config: Partial<RemoteMCPServerDescription> = {
+            serverUrl: formData.serverUrl.trim(),
+            autostart: formData.autostart
+        };
+        if (formData.serverAuthToken.trim()) {
+            config.serverAuthToken = formData.serverAuthToken.trim();
+        }
+        if (formData.serverAuthTokenHeader.trim()) {
+            config.serverAuthTokenHeader = formData.serverAuthTokenHeader.trim();
+        }
+        const headers = parseKeyValuePairs(formData.headers);
+        if (headers) {
+            config.headers = headers;
+        }
+        return config;
+    }
+}
+
+function parseKeyValuePairs(input: string): Record<string, string> | undefined {
+    if (!input.trim()) {
+        return undefined;
+    }
+    const result: Record<string, string> = {};
+    for (const line of input.split('\n').filter(l => l.trim())) {
+        const eqIndex = line.indexOf('=');
+        if (eqIndex > 0) {
+            const key = line.substring(0, eqIndex).trim();
+            const value = line.substring(eqIndex + 1).trim();
+            if (key) {
+                result[key] = value;
+            }
+        }
+    }
+    return Object.keys(result).length > 0 ? result : undefined;
+}

--- a/packages/ai-mcp/src/browser/mcp-server-editor.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.ts
@@ -21,44 +21,31 @@ import {
     isRemoteMCPServerDescription,
     LocalMCPServerDescription,
     MCPFrontendService,
+    MCPInstallEntryConfig,
+    MCPRegistryMetadata,
     MCPServerDescription,
     RemoteMCPServerDescription
 } from '../common/mcp-server-manager';
 import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
 import type { MCPServerFormData } from './mcp-server-edit-dialog';
 
-/**
- * Subset of an MCP server's persisted configuration that an install flow may carry:
- * either set by a registry entry or hand-crafted in an install URL. Identical in shape
- * to `RegistryMCPServerConfigEntry` from `@theia/ai-registry`; kept here so ai-mcp can
- * own the install path without depending on the registry package.
- */
-export interface MCPInstallEntryConfig {
-    command?: string;
-    args?: string[];
-    env?: Record<string, string>;
-    serverUrl?: string;
-    serverAuthToken?: string;
-    serverAuthTokenHeader?: string;
-    headers?: Record<string, string>;
-}
+export type { MCPInstallEntryConfig };
 
 /**
  * Self-contained install payload: the slug to use in the preference, the config blob
- * to write, and optional registry-provenance metadata. `serverId` is used for the
- * `registryServerId` link-back when present; `version` becomes `registryVersion`
- * (display-only) and `configHash` becomes `registryConfigHash` (update detection).
+ * to write, and optional registry-provenance metadata. When `serverId` is set the
+ * fields are persisted as a single `registryMetadata` block on the stored entry.
  */
 export interface MCPInstallEntry {
     /** Local preference key. */
     localSlug: string;
     /** Config blob to write under `mcpServers[localSlug]`. */
     config: MCPInstallEntryConfig;
-    /** Registry server id — populates `registryServerId` so updates stay tracked. */
+    /** Registry server id - populates `registryMetadata.serverId` so updates stay tracked. */
     serverId?: string;
-    /** Approved version published by the registry — populates `registryVersion` for display. */
+    /** Approved version published by the registry - populates `registryMetadata.version` for display. */
     version?: string;
-    /** Hash of the registry approval — populates `registryConfigHash` and drives update detection. */
+    /** Hash of the registry approval - populates `registryMetadata.configHash` and drives update detection. */
     configHash?: string;
 }
 
@@ -134,14 +121,9 @@ export class MCPServerEditor {
             ...entry.config,
             ...this.applyOverrides(entry.config, overrides)
         };
-        if (entry.serverId !== undefined) {
-            stored.registryServerId = entry.serverId;
-        }
-        if (entry.version !== undefined) {
-            stored.registryVersion = entry.version;
-        }
-        if (entry.configHash !== undefined) {
-            stored.registryConfigHash = entry.configHash;
+        const metadata = this.buildMetadata(entry);
+        if (metadata) {
+            stored.registryMetadata = metadata;
         }
         try {
             await this.preferenceService.set(
@@ -156,6 +138,22 @@ export class MCPServerEditor {
 
     protected readServers(): Record<string, unknown> {
         return this.preferenceService.get<Record<string, unknown>>(MCP_SERVERS_PREF, {}) ?? {};
+    }
+
+    /**
+     * Build a `registryMetadata` block from an install entry's flat provenance fields,
+     * or return undefined when the entry carries no registry link (e.g. a hand-crafted
+     * `install-mcp` URL without an id).
+     */
+    protected buildMetadata(entry: MCPInstallEntry): MCPRegistryMetadata | undefined {
+        if (entry.serverId === undefined) {
+            return undefined;
+        }
+        return {
+            serverId: entry.serverId,
+            ...(entry.version !== undefined && { version: entry.version }),
+            ...(entry.configHash !== undefined && { configHash: entry.configHash })
+        };
     }
 
     /** Merge user overrides into the config blob (only fields the dialog collects). */
@@ -179,7 +177,7 @@ export class MCPServerEditor {
 
     /**
      * Persist the form to the user preference. Preserves any extra fields on an existing entry
-     * (e.g. `registryServerId`) since the dialog only edits user-facing fields.
+     * (e.g. `registryMetadata`) since the dialog only edits user-facing fields.
      */
     async save(formData: MCPServerFormData): Promise<void> {
         const currentServers = this.preferenceService.get<Record<string, object>>(MCP_SERVERS_PREF, {}) ?? {};

--- a/packages/ai-mcp/src/browser/mcp-server-install-dialog.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-install-dialog.spec.ts
@@ -1,0 +1,76 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+// Another spec in this package may have already set the configuration; mocha loads all
+// specs into one process and `set` throws if called twice, so guard it.
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { DialogError } from '@theia/core/lib/browser/dialogs';
+import { MCPServerInstallDialog, MCPServerInstallDialogOptions } from './mcp-server-install-dialog';
+
+// Balance the import-time enable; the suite re-enables JSDOM around its own tests so it
+// is robust to other specs in the package toggling the shared JSDOM globals.
+disableJSDOM();
+
+/** Exposes the protected validation hook and token field so we can assert on them directly. */
+class TestInstallDialog extends MCPServerInstallDialog {
+    setToken(token: string): void {
+        this.serverAuthToken = token;
+    }
+    runValidation(): DialogError {
+        return this.isValid(this.value, 'open') as DialogError;
+    }
+}
+
+function dialog(options: Partial<MCPServerInstallDialogOptions> = {}): TestInstallDialog {
+    return new TestInstallDialog({ name: 'example', ...options });
+}
+
+describe('MCPServerInstallDialog.isValid', () => {
+
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    it('accepts any input when the server does not require an auth token', () => {
+        const d = dialog({ requireAuthToken: false });
+        expect(d.runValidation()).to.equal('');
+    });
+
+    it('rejects an empty token when the server requires one', () => {
+        const d = dialog({ requireAuthToken: true });
+        expect(d.runValidation()).to.match(/auth token is required/i);
+    });
+
+    it('rejects a whitespace-only token when the server requires one', () => {
+        const d = dialog({ requireAuthToken: true });
+        d.setToken('   ');
+        expect(d.runValidation()).to.match(/auth token is required/i);
+    });
+
+    it('accepts a non-empty token when the server requires one', () => {
+        const d = dialog({ requireAuthToken: true });
+        d.setToken('real-token');
+        expect(d.runValidation()).to.equal('');
+    });
+});

--- a/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
@@ -15,7 +15,8 @@
 // *****************************************************************************
 
 import * as React from '@theia/core/shared/react';
-import { nls } from '@theia/core';
+import { MaybePromise, nls } from '@theia/core';
+import { DialogError, DialogMode } from '@theia/core/lib/browser/dialogs';
 import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
 
 export interface MCPServerInstallParameters {
@@ -29,9 +30,9 @@ export interface MCPServerInstallParameters {
  * Trust signal rendered as a banner at the top of the install dialog. Lets the user see
  * whether the install they're about to perform is approved by the configured AI registry.
  *
- * - `verified`     — registry is configured and lists this server
- * - `unverified`   — registry is configured but does NOT list this server
- * - `no-registry`  — no registry is configured, so trust can't be assessed
+ * - `verified`     - registry is configured and lists this server
+ * - `unverified`   - registry is configured but does NOT list this server
+ * - `no-registry`  - no registry is configured, so trust can't be assessed
  */
 export type MCPServerInstallTrust =
     | { readonly status: 'verified'; readonly serverId: string }
@@ -52,7 +53,7 @@ export interface MCPServerInstallDialogOptions {
 /**
  * Lightweight install confirmation dialog. Distinct from `MCPServerDialog` because the
  * user can't rename a server picked from the registry and the rest of the config comes
- * from the registry entry — we only need to collect the truly user-supplied parameters
+ * from the registry entry - we only need to collect the truly user-supplied parameters
  * (autostart and, when relevant, an auth token).
  */
 export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParameters | undefined> {
@@ -77,6 +78,22 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
                 ? { serverAuthToken: this.serverAuthToken.trim() }
                 : {})
         };
+    }
+
+    /**
+     * Guard the auth-token field: when the server requires a token, an empty value must
+     * block the install. Otherwise the registry-supplied placeholder (e.g.
+     * `<github-pat-or-app-token>`) would survive into settings.json and the server would
+     * fail later with an opaque error.
+     */
+    protected override isValid(_value: MCPServerInstallParameters | undefined, _mode: DialogMode): MaybePromise<DialogError> {
+        if (this.options.requireAuthToken && !this.serverAuthToken.trim()) {
+            return nls.localize(
+                'theia/ai-mcp/installDialog/authTokenRequired',
+                'An auth token is required to install this server.'
+            );
+        }
+        return '';
     }
 
     protected handleAutostartChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
@@ -128,7 +145,7 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
                         <span>
                             {nls.localize(
                                 'theia/ai-mcp/installDialog/trust/unknown',
-                                'No AI registry is configured — trust cannot be verified.'
+                                'No AI registry is configured - trust cannot be verified.'
                             )}
                         </span>
                     </div>

--- a/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
@@ -51,6 +51,14 @@ export interface MCPServerInstallDialogOptions {
 }
 
 /**
+ * Factory for the {@link MCPServerInstallDialog}. Injected so the registry install actions
+ * and the `install-mcp` URL handler construct the dialog through dependency injection
+ * rather than importing it directly, and so adopters can rebind the dialog if needed.
+ */
+export const MCPServerInstallDialogFactory = Symbol('MCPServerInstallDialogFactory');
+export type MCPServerInstallDialogFactory = (options: MCPServerInstallDialogOptions) => MCPServerInstallDialog;
+
+/**
  * Lightweight install confirmation dialog. Distinct from `MCPServerDialog` because the
  * user can't rename a server picked from the registry and the rest of the config comes
  * from the registry entry - we only need to collect the truly user-supplied parameters

--- a/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
@@ -1,0 +1,180 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
+
+export interface MCPServerInstallParameters {
+    /** Whether the server should autostart. Defaults to true if the dialog isn't shown. */
+    autostart: boolean;
+    /** Authentication token entered by the user; only collected for remote servers that need one. */
+    serverAuthToken?: string;
+}
+
+/**
+ * Trust signal rendered as a banner at the top of the install dialog. Lets the user see
+ * whether the install they're about to perform is approved by the configured AI registry.
+ *
+ * - `verified`     — registry is configured and lists this server
+ * - `unverified`   — registry is configured but does NOT list this server
+ * - `no-registry`  — no registry is configured, so trust can't be assessed
+ */
+export type MCPServerInstallTrust =
+    | { readonly status: 'verified'; readonly serverId: string }
+    | { readonly status: 'unverified'; readonly serverId: string }
+    | { readonly status: 'no-registry' };
+
+export interface MCPServerInstallDialogOptions {
+    /** Server name as it will be saved into the preference (read-only, shown to the user). */
+    readonly name: string;
+    /** Initial autostart value (typically `true`). */
+    readonly autostart?: boolean;
+    /** Whether to show the auth-token field; set when the entry advertises an auth token slot. */
+    readonly requireAuthToken?: boolean;
+    /** When set, renders a trust banner explaining the registry approval status. */
+    readonly trust?: MCPServerInstallTrust;
+}
+
+/**
+ * Lightweight install confirmation dialog. Distinct from `MCPServerDialog` because the
+ * user can't rename a server picked from the registry and the rest of the config comes
+ * from the registry entry — we only need to collect the truly user-supplied parameters
+ * (autostart and, when relevant, an auth token).
+ */
+export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParameters | undefined> {
+
+    protected autostart: boolean;
+    protected serverAuthToken: string = '';
+
+    constructor(protected readonly options: MCPServerInstallDialogOptions) {
+        super({
+            title: nls.localize('theia/ai-mcp/installDialog/title', 'Install MCP Server'),
+            maxWidth: 460
+        });
+        this.autostart = options.autostart ?? true;
+        this.appendCloseButton(nls.localizeByDefault('Cancel'));
+        this.appendAcceptButton(nls.localizeByDefault('Install'));
+    }
+
+    get value(): MCPServerInstallParameters | undefined {
+        return {
+            autostart: this.autostart,
+            ...(this.options.requireAuthToken && this.serverAuthToken.trim()
+                ? { serverAuthToken: this.serverAuthToken.trim() }
+                : {})
+        };
+    }
+
+    protected handleAutostartChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        this.autostart = e.target.checked;
+        this.update();
+    };
+
+    protected handleAuthTokenChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        this.serverAuthToken = e.target.value;
+        this.update();
+    };
+
+    protected renderTrustBanner(): React.ReactNode {
+        const trust = this.options.trust;
+        if (!trust) {
+            return undefined;
+        }
+        switch (trust.status) {
+            case 'verified':
+                return (
+                    <div className="mcp-install-trust-banner mcp-install-trust-banner--verified">
+                        <i className="codicon codicon-verified-filled" />
+                        <span>
+                            {nls.localize(
+                                'theia/ai-mcp/installDialog/trust/verified',
+                                'Approved by your AI registry ({0}).',
+                                trust.serverId
+                            )}
+                        </span>
+                    </div>
+                );
+            case 'unverified':
+                return (
+                    <div className="mcp-install-trust-banner mcp-install-trust-banner--unverified">
+                        <i className="codicon codicon-warning" />
+                        <span>
+                            {nls.localize(
+                                'theia/ai-mcp/installDialog/trust/unverified',
+                                'This server is not listed in your AI registry ({0}). Install at your own risk.',
+                                trust.serverId
+                            )}
+                        </span>
+                    </div>
+                );
+            case 'no-registry':
+                return (
+                    <div className="mcp-install-trust-banner mcp-install-trust-banner--unknown">
+                        <i className="codicon codicon-info" />
+                        <span>
+                            {nls.localize(
+                                'theia/ai-mcp/installDialog/trust/unknown',
+                                'No AI registry is configured — trust cannot be verified.'
+                            )}
+                        </span>
+                    </div>
+                );
+        }
+    }
+
+    protected render(): React.ReactNode {
+        return (
+            <div className="mcp-dialog-form">
+                {this.renderTrustBanner()}
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/form/serverName', 'Server Name')}:</label>
+                    <span className="mcp-form-static-value">{this.options.name}</span>
+                </div>
+
+                {this.options.requireAuthToken && (
+                    <div className="mcp-form-field">
+                        <label>{nls.localize('theia/ai/mcpConfiguration/serverAuthToken', 'Auth Token')}:</label>
+                        <input
+                            type="password"
+                            className="theia-input"
+                            value={this.serverAuthToken}
+                            onChange={this.handleAuthTokenChange}
+                            placeholder={nls.localize(
+                                'theia/ai-mcp/installDialog/authTokenPlaceholder',
+                                'Required by this server to connect'
+                            )}
+                            spellCheck={false}
+                            autoFocus
+                        />
+                    </div>
+                )}
+
+                <div className="mcp-form-field mcp-form-checkbox">
+                    <label>
+                        <input
+                            type="checkbox"
+                            className="theia-input"
+                            checked={this.autostart}
+                            onChange={this.handleAutostartChange}
+                        />
+                        {nls.localize('theia/ai/mcpConfiguration/form/autostart', 'Autostart')}
+                    </label>
+                </div>
+            </div>
+        );
+    }
+}

--- a/packages/ai-mcp/src/browser/style/mcp-configuration-widget.css
+++ b/packages/ai-mcp/src/browser/style/mcp-configuration-widget.css
@@ -51,6 +51,36 @@
   font-weight: 600;
   font-size: var(--theia-ui-font-size2);
   color: var(--theia-foreground);
+  display: flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding));
+}
+
+.mcp-server-registry-link {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding) / 2);
+  background: none;
+  border: none;
+  padding: 0 calc(var(--theia-ui-padding) / 2);
+  font-size: var(--theia-ui-font-size0);
+  font-weight: 400;
+  color: var(--theia-textLink-foreground);
+  cursor: pointer;
+}
+
+.mcp-server-registry-link:hover:not(:disabled) {
+  color: var(--theia-textLink-activeForeground);
+  text-decoration: underline;
+}
+
+.mcp-server-registry-link:disabled {
+  cursor: default;
+  opacity: 0.6;
+}
+
+.mcp-server-registry-link-icon {
+  font-size: var(--theia-ui-font-size1);
 }
 
 .mcp-server-header-controls {
@@ -264,6 +294,7 @@
 .mcp-header-actions {
   display: flex;
   justify-content: flex-end;
+  gap: var(--theia-ui-padding);
   margin-bottom: calc(var(--theia-ui-padding) * 2);
 }
 
@@ -280,41 +311,4 @@
 
 .mcp-server-header .mcp-action-button.mcp-delete-button:hover {
   background-color: var(--theia-errorBackground);
-}
-
-/* Dialog Form Styles */
-.mcp-dialog-form {
-  min-width: 400px;
-}
-
-.mcp-dialog-form .mcp-form-field {
-  margin-bottom: calc(var(--theia-ui-padding) * 1.5);
-}
-
-.mcp-dialog-form .mcp-form-field label {
-  display: block;
-  margin-bottom: calc(var(--theia-ui-padding) / 2);
-  font-weight: 500;
-  color: var(--theia-foreground);
-}
-
-.mcp-dialog-form .mcp-form-field .theia-input,
-.mcp-dialog-form .mcp-form-field .theia-select {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.mcp-dialog-form .mcp-form-field textarea.theia-input {
-  resize: vertical;
-  min-height: 60px;
-  font-family: var(--monaco-monospace-font);
-  font-size: var(--theia-ui-font-size1);
-}
-
-.mcp-dialog-form .mcp-form-checkbox label {
-  display: inline-flex;
-  align-items: center;
-  gap: calc(var(--theia-ui-padding) / 2);
-  cursor: pointer;
-  margin-bottom: 0;
 }

--- a/packages/ai-mcp/src/browser/style/mcp-server-dialog.css
+++ b/packages/ai-mcp/src/browser/style/mcp-server-dialog.css
@@ -1,0 +1,107 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource GmbH.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/* Shared styles for MCP Server dialogs (add/edit, install). Loaded by @theia/ai-mcp
+   so both the configuration view and the registry install flow render consistently. */
+
+.mcp-dialog-form {
+  min-width: 400px;
+}
+
+.mcp-dialog-form .mcp-form-field {
+  margin-bottom: calc(var(--theia-ui-padding) * 1.5);
+}
+
+.mcp-dialog-form .mcp-form-field label {
+  display: block;
+  margin-bottom: calc(var(--theia-ui-padding) / 2);
+  font-weight: 500;
+  color: var(--theia-foreground);
+}
+
+.mcp-dialog-form .mcp-form-field .theia-input,
+.mcp-dialog-form .mcp-form-field .theia-select {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.mcp-dialog-form .mcp-form-field textarea.theia-input {
+  resize: vertical;
+  min-height: 60px;
+  font-family: var(--monaco-monospace-font);
+  font-size: var(--theia-ui-font-size1);
+}
+
+.mcp-dialog-form .mcp-form-checkbox label {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding) / 2);
+  cursor: pointer;
+  margin-bottom: 0;
+}
+
+.mcp-dialog-form .mcp-form-static-value {
+  display: block;
+  padding: calc(var(--theia-ui-padding) / 2) calc(var(--theia-ui-padding));
+  background: var(--theia-editorWidget-background);
+  border: var(--theia-border-width) solid var(--theia-widget-border);
+  border-radius: 2px;
+  font-family: var(--monaco-monospace-font);
+  font-size: var(--theia-ui-font-size1);
+  color: var(--theia-descriptionForeground);
+}
+
+/* Trust banner rendered at the top of the install dialog when an MCPServerInstallTrust
+   is supplied. Three variants reflect the three registry states. */
+.mcp-install-trust-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: calc(var(--theia-ui-padding));
+  padding: calc(var(--theia-ui-padding)) calc(var(--theia-ui-padding) * 1.5);
+  border-radius: 3px;
+  margin-bottom: calc(var(--theia-ui-padding) * 1.5);
+  font-size: var(--theia-ui-font-size1);
+  line-height: 1.4;
+}
+
+.mcp-install-trust-banner .codicon {
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+.mcp-install-trust-banner--verified {
+  background-color: var(--theia-inputValidation-infoBackground);
+  color: var(--theia-inputValidation-infoForeground);
+}
+
+.mcp-install-trust-banner--verified .codicon {
+  color: var(--theia-extensionIcon-verifiedForeground, var(--theia-textLink-foreground));
+}
+
+.mcp-install-trust-banner--unverified {
+  background-color: var(--theia-inputValidation-warningBackground);
+  color: var(--theia-inputValidation-warningForeground);
+}
+
+.mcp-install-trust-banner--unverified .codicon {
+  color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+}
+
+.mcp-install-trust-banner--unknown {
+  background-color: var(--theia-editorWidget-background);
+  color: var(--theia-descriptionForeground);
+  border: var(--theia-border-width) solid var(--theia-widget-border);
+}

--- a/packages/ai-mcp/src/common/mcp-preferences.ts
+++ b/packages/ai-mcp/src/common/mcp-preferences.ts
@@ -109,6 +109,24 @@ Example configuration:\n\
                         title: nls.localize('theia/ai/mcp/servers/headers/title', 'Headers'),
                         markdownDescription: nls.localize('theia/ai/mcp/servers/headers/mdDescription',
                             'Optional additional headers included with each request to the server.'),
+                    },
+                    registryServerId: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/mcp/servers/registryServerId/title', 'Registry Server Id'),
+                        markdownDescription: nls.localize('theia/ai/mcp/servers/registryServerId/mdDescription',
+                            'Identifies the AI registry entry this server was installed from.'),
+                    },
+                    registryVersion: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/mcp/servers/registryVersion/title', 'Registry Version'),
+                        markdownDescription: nls.localize('theia/ai/mcp/servers/registryVersion/mdDescription',
+                            'The registry-published version recorded at the time of install.'),
+                    },
+                    registryConfigHash: {
+                        type: 'string',
+                        title: nls.localize('theia/ai/mcp/servers/registryConfigHash/title', 'Registry Config Hash'),
+                        markdownDescription: nls.localize('theia/ai/mcp/servers/registryConfigHash/mdDescription',
+                            'Content hash of the registry approval used to install this server.'),
                     }
                 },
                 required: []

--- a/packages/ai-mcp/src/common/mcp-preferences.ts
+++ b/packages/ai-mcp/src/common/mcp-preferences.ts
@@ -110,23 +110,32 @@ Example configuration:\n\
                         markdownDescription: nls.localize('theia/ai/mcp/servers/headers/mdDescription',
                             'Optional additional headers included with each request to the server.'),
                     },
-                    registryServerId: {
-                        type: 'string',
-                        title: nls.localize('theia/ai/mcp/servers/registryServerId/title', 'Registry Server Id'),
-                        markdownDescription: nls.localize('theia/ai/mcp/servers/registryServerId/mdDescription',
-                            'Identifies the AI registry entry this server was installed from.'),
-                    },
-                    registryVersion: {
-                        type: 'string',
-                        title: nls.localize('theia/ai/mcp/servers/registryVersion/title', 'Registry Version'),
-                        markdownDescription: nls.localize('theia/ai/mcp/servers/registryVersion/mdDescription',
-                            'The registry-published version recorded at the time of install.'),
-                    },
-                    registryConfigHash: {
-                        type: 'string',
-                        title: nls.localize('theia/ai/mcp/servers/registryConfigHash/title', 'Registry Config Hash'),
-                        markdownDescription: nls.localize('theia/ai/mcp/servers/registryConfigHash/mdDescription',
-                            'Content hash of the registry approval used to install this server.'),
+                    registryMetadata: {
+                        type: 'object',
+                        title: nls.localize('theia/ai/mcp/servers/registryMetadata/title', 'Registry Metadata'),
+                        markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/mdDescription',
+                            'Provenance metadata for a server installed from an AI registry. Written by `@theia/ai-registry`; not user-editable.'),
+                        properties: {
+                            serverId: {
+                                type: 'string',
+                                title: nls.localize('theia/ai/mcp/servers/registryMetadata/serverId/title', 'Registry Server Id'),
+                                markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/serverId/mdDescription',
+                                    'Identifies the AI registry entry this server was installed from.'),
+                            },
+                            version: {
+                                type: 'string',
+                                title: nls.localize('theia/ai/mcp/servers/registryMetadata/version/title', 'Registry Version'),
+                                markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/version/mdDescription',
+                                    'The registry-published version recorded at the time of install.'),
+                            },
+                            configHash: {
+                                type: 'string',
+                                title: nls.localize('theia/ai/mcp/servers/registryMetadata/configHash/title', 'Registry Config Hash'),
+                                markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/configHash/mdDescription',
+                                    'Content hash of the registry approval used to install this server.'),
+                            }
+                        },
+                        required: ['serverId']
                     }
                 },
                 required: []

--- a/packages/ai-mcp/src/common/mcp-preferences.ts
+++ b/packages/ai-mcp/src/common/mcp-preferences.ts
@@ -30,7 +30,8 @@ or remote with server URL, authentication token and optionally an authentication
 Each server is identified by a unique key, such as "brave-search" or "filesystem". \
 To start a server, use the "MCP: Start MCP Server" command, which enables you to select the desired server. \
 To stop a server, use the "MCP: Stop MCP Server" command. \
-Please note that autostart will only take effect after a restart, you need to start a server manually for the first time.\
+Please note that autostart will only take effect after a restart, you need to start a server manually for the first time. \
+Servers installed from an AI registry carry an additional `registryMetadata` block that is managed automatically and is not meant to be edited manually.\
 \n\
 Example configuration:\n\
 ```\

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -116,26 +116,52 @@ export interface BaseMCPServerDescription {
     resolve?: (description: MCPServerDescription) => Promise<MCPServerDescription>;
 
     /**
-     * If set, identifies the AI registry entry this server was installed from.
-     * Written by `@theia/ai-registry` on install / link / fix; not user-editable.
+     * If set, provenance metadata for a server installed from an AI registry.
+     * Written by `@theia/ai-registry` on install / link / fix / update; not user-editable.
      */
-    registryServerId?: string;
+    registryMetadata?: MCPRegistryMetadata;
+}
+
+/**
+ * Provenance metadata for an MCP server linked to an AI registry approval. Grouped
+ * under a single `registryMetadata` block in {@link BaseMCPServerDescription} and in
+ * the `ai-features.mcp.mcpServers` preference so registry-link data stays visually
+ * separated from the server configuration the user edits.
+ */
+export interface MCPRegistryMetadata {
+    /** Identifies the AI registry entry this server was installed from. */
+    serverId: string;
 
     /**
-     * If set, the registry's published version at the time of install / link / fix.
+     * Registry-published version recorded at install / link / fix / update time.
      * Kept purely for display in the UI; the registry may publish a different version
      * later, but we don't want to lose the version the user actually installed.
-     * Update detection uses {@link registryConfigHash} instead.
+     * Update detection uses {@link configHash} instead.
      */
-    registryVersion?: string;
+    version?: string;
 
     /**
-     * If set, a content hash of the registry approval that produced this entry.
-     * Written by `@theia/ai-registry` on install / link / fix / update and used to
-     * detect when the registry has published a new approval for this server.
-     * Do not use {@link registryVersion} for update checks — it is display-only.
+     * Content hash of the registry approval that produced this entry. Used to detect
+     * when the registry has published a new approval for this server. Do not use
+     * {@link version} for update checks - it is display-only.
      */
-    registryConfigHash?: string;
+    configHash?: string;
+}
+
+/**
+ * Subset of an MCP server's persisted configuration that an install flow may carry:
+ * either set by a registry entry or hand-crafted in an install URL. Lives in `common`
+ * so `@theia/ai-registry` (which resolves registry entries in `common`) can reference
+ * the same canonical shape the browser-side install path writes.
+ */
+export interface MCPInstallEntryConfig {
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    serverUrl?: string;
+    serverAuthToken?: string;
+    serverAuthTokenHeader?: string;
+    headers?: Record<string, string>;
 }
 
 export interface LocalMCPServerDescription extends BaseMCPServerDescription {

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -114,6 +114,28 @@ export interface BaseMCPServerDescription {
      * @returns A promise that resolves to the processed server description
      */
     resolve?: (description: MCPServerDescription) => Promise<MCPServerDescription>;
+
+    /**
+     * If set, identifies the AI registry entry this server was installed from.
+     * Written by `@theia/ai-registry` on install / link / fix; not user-editable.
+     */
+    registryServerId?: string;
+
+    /**
+     * If set, the registry's published version at the time of install / link / fix.
+     * Kept purely for display in the UI; the registry may publish a different version
+     * later, but we don't want to lose the version the user actually installed.
+     * Update detection uses {@link registryConfigHash} instead.
+     */
+    registryVersion?: string;
+
+    /**
+     * If set, a content hash of the registry approval that produced this entry.
+     * Written by `@theia/ai-registry` on install / link / fix / update and used to
+     * detect when the registry has published a new approval for this server.
+     * Do not use {@link registryVersion} for update checks — it is display-only.
+     */
+    registryConfigHash?: string;
 }
 
 export interface LocalMCPServerDescription extends BaseMCPServerDescription {

--- a/packages/ai-mcp/src/common/mcp-servers-preference.ts
+++ b/packages/ai-mcp/src/common/mcp-servers-preference.ts
@@ -14,6 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { MCPRegistryMetadata } from './mcp-server-manager';
+
 /**
  * Shape and value-guard for the `ai-features.mcp.mcpServers` preference. Lives in
  * `common` so any consumer (browser-side contribution, registry view, future Node-side
@@ -22,6 +24,8 @@
 
 export interface BaseMCPServerPreferenceValue {
     autostart?: boolean;
+    /** Provenance link to an AI registry entry; written by `@theia/ai-registry`. */
+    registryMetadata?: MCPRegistryMetadata;
 }
 
 export interface LocalMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
@@ -55,10 +59,15 @@ export namespace MCPServersPreference {
             (!('serverAuthToken' in obj) || typeof obj.serverAuthToken === 'string') &&
             (!('serverAuthTokenHeader' in obj) || typeof obj.serverAuthTokenHeader === 'string') &&
             (!('headers' in obj) || !!obj.headers && typeof obj.headers === 'object' && Object.values(obj.headers).every(value => typeof value === 'string')) &&
-            (!('registryServerId' in obj) || typeof obj.registryServerId === 'string') &&
-            (!('registryVersion' in obj) || typeof obj.registryVersion === 'string') &&
-            (!('registryConfigHash' in obj) || typeof obj.registryConfigHash === 'string');
+            (!('registryMetadata' in obj) || isRegistryMetadata(obj.registryMetadata));
     }
+}
+
+function isRegistryMetadata(obj: unknown): obj is MCPRegistryMetadata {
+    return !!obj && typeof obj === 'object'
+        && 'serverId' in obj && typeof obj.serverId === 'string'
+        && (!('version' in obj) || typeof obj.version === 'string')
+        && (!('configHash' in obj) || typeof obj.configHash === 'string');
 }
 
 export function filterValidValues(servers: unknown): MCPServersPreference {

--- a/packages/ai-mcp/src/common/mcp-servers-preference.ts
+++ b/packages/ai-mcp/src/common/mcp-servers-preference.ts
@@ -1,0 +1,75 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Shape and value-guard for the `ai-features.mcp.mcpServers` preference. Lives in
+ * `common` so any consumer (browser-side contribution, registry view, future Node-side
+ * tooling) can apply the same checks without pulling in DOM-touching modules.
+ */
+
+export interface BaseMCPServerPreferenceValue {
+    autostart?: boolean;
+}
+
+export interface LocalMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
+    command: string;
+    args?: string[];
+    env?: { [key: string]: string };
+}
+
+export interface RemoteMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
+    serverUrl: string;
+    serverAuthToken?: string;
+    serverAuthTokenHeader?: string;
+    headers?: { [key: string]: string };
+}
+
+export type MCPServersPreferenceValue = LocalMCPServerPreferenceValue | RemoteMCPServerPreferenceValue;
+
+export interface MCPServersPreference {
+    [name: string]: MCPServersPreferenceValue
+}
+
+export namespace MCPServersPreference {
+    export function isValue(obj: unknown): obj is MCPServersPreferenceValue {
+        return !!obj && typeof obj === 'object' &&
+            ('command' in obj || 'serverUrl' in obj) &&
+            (!('command' in obj) || typeof obj.command === 'string') &&
+            (!('args' in obj) || Array.isArray(obj.args) && obj.args.every(arg => typeof arg === 'string')) &&
+            (!('env' in obj) || !!obj.env && typeof obj.env === 'object' && Object.values(obj.env).every(value => typeof value === 'string')) &&
+            (!('autostart' in obj) || typeof obj.autostart === 'boolean') &&
+            (!('serverUrl' in obj) || typeof obj.serverUrl === 'string') &&
+            (!('serverAuthToken' in obj) || typeof obj.serverAuthToken === 'string') &&
+            (!('serverAuthTokenHeader' in obj) || typeof obj.serverAuthTokenHeader === 'string') &&
+            (!('headers' in obj) || !!obj.headers && typeof obj.headers === 'object' && Object.values(obj.headers).every(value => typeof value === 'string')) &&
+            (!('registryServerId' in obj) || typeof obj.registryServerId === 'string') &&
+            (!('registryVersion' in obj) || typeof obj.registryVersion === 'string') &&
+            (!('registryConfigHash' in obj) || typeof obj.registryConfigHash === 'string');
+    }
+}
+
+export function filterValidValues(servers: unknown): MCPServersPreference {
+    const result: MCPServersPreference = {};
+    if (!servers || typeof servers !== 'object') {
+        return result;
+    }
+    for (const [name, value] of Object.entries(servers)) {
+        if (typeof name === 'string' && MCPServersPreference.isValue(value)) {
+            result[name] = value;
+        }
+    }
+    return result;
+}

--- a/packages/ai-registry/.eslintrc.js
+++ b/packages/ai-registry/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/ai-registry/README.md
+++ b/packages/ai-registry/README.md
@@ -17,7 +17,7 @@ The AI Registry package integrates Theia with a remote AI artifact registry (suc
 ### Features
 
 - Contributes registry-approved MCP servers to the Extensions view alongside Open VSX extensions.
-- Detects whether a server is installed from the registry, manually with a matching slug, or has drifted from the registry config — and surfaces Install / Link / Update / Fix config / Uninstall accordingly.
+- Detects whether a server is installed from the registry, manually with a matching key, or has drifted from the registry config — and surfaces Install / Link / Update / Fix config / Uninstall accordingly.
 - Installs servers by writing the registry's published config snippet to the existing `ai-features.mcp.mcpServers` preference.
 
 ### Product configuration

--- a/packages/ai-registry/README.md
+++ b/packages/ai-registry/README.md
@@ -1,0 +1,40 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - AI REGISTRY EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The AI Registry package integrates Theia with a remote AI artifact registry (such as `ai-registry-core`). Users can browse approved MCP servers and install them with a single action.
+
+### Features
+
+- Contributes registry-approved MCP servers to the Extensions view alongside Open VSX extensions.
+- Detects whether a server is installed from the registry, manually with a matching slug, or has drifted from the registry config — and surfaces Install / Link / Update / Fix config / Uninstall accordingly.
+- Installs servers by writing the registry's published config snippet to the existing `ai-features.mcp.mcpServers` preference.
+
+### Product configuration
+
+Theia products override the default tool name (`all`) and registry base URL by rebinding `AIRegistryConfiguration` in their frontend module.
+
+## Additional Information
+
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+<https://www.eclipse.org/theia>

--- a/packages/ai-registry/package.json
+++ b/packages/ai-registry/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@theia/ai-registry",
+  "version": "1.72.0",
+  "description": "Theia - AI Registry Integration",
+  "dependencies": {
+    "@theia/ai-mcp": "1.72.0",
+    "@theia/core": "1.72.0",
+    "@theia/vsx-registry": "1.72.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/common",
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/ai-registry-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.72.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-registry/package.json
+++ b/packages/ai-registry/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@theia/ai-registry",
+  "version": "1.71.0",
+  "description": "Theia - AI Registry Integration",
+  "dependencies": {
+    "@theia/ai-mcp": "1.71.0",
+    "@theia/core": "1.71.0",
+    "@theia/vsx-registry": "1.71.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "lib/common",
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/ai-registry-frontend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.71.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -21,18 +21,21 @@ import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar
 import { ExtensionsSourceContribution } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
-import { MCPRegistryEntryResolver } from '../common/mcp/mcp-registry-entry-resolver';
-import { RegistryFetchService } from '../common/registry-fetch-service';
-import { MCPInstallService } from './mcp/mcp-install-service';
+import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../common/mcp/mcp-registry-entry-resolver';
+import { RegistryFetchService, RegistryFetchServiceImpl } from '../common/registry-fetch-service';
+import { MCPInstallService, MCPInstallServiceImpl } from './mcp/mcp-install-service';
 import { MCPExtensionsContribution } from './mcp/mcp-extensions-contribution';
 import { MCPRegistryUiBridgeImpl } from './mcp/mcp-registry-ui-bridge-impl';
 import { AIRegistryToolbarContribution } from './ai-registry-toolbar-contribution';
 
 export default new ContainerModule(bind => {
     bind(AIRegistryConfiguration).toSelf().inSingletonScope();
-    bind(MCPRegistryEntryResolver).toSelf().inSingletonScope();
-    bind(RegistryFetchService).toSelf().inSingletonScope();
-    bind(MCPInstallService).toSelf().inSingletonScope();
+    bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
+    bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
+    bind(RegistryFetchServiceImpl).toSelf().inSingletonScope();
+    bind(RegistryFetchService).toService(RegistryFetchServiceImpl);
+    bind(MCPInstallServiceImpl).toSelf().inSingletonScope();
+    bind(MCPInstallService).toService(MCPInstallServiceImpl);
 
     bind(MCPExtensionsContribution).toSelf().inSingletonScope();
     bind(ExtensionsSourceContribution).toService(MCPExtensionsContribution);

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -1,0 +1,45 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import '../../src/browser/style/mcp-entries.css';
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { ExtensionsContribution } from '@theia/vsx-registry/lib/browser/extensions-contribution';
+import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
+import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
+import { MCPRegistryEntryResolver } from '../common/mcp/mcp-registry-entry-resolver';
+import { RegistryFetchService } from '../common/registry-fetch-service';
+import { MCPInstallService } from './mcp/mcp-install-service';
+import { MCPExtensionsContribution } from './mcp/mcp-extensions-contribution';
+import { MCPRegistryUiBridgeImpl } from './mcp/mcp-registry-ui-bridge-impl';
+import { AIRegistryToolbarContribution } from './ai-registry-toolbar-contribution';
+
+export default new ContainerModule(bind => {
+    bind(AIRegistryConfiguration).toSelf().inSingletonScope();
+    bind(MCPRegistryEntryResolver).toSelf().inSingletonScope();
+    bind(RegistryFetchService).toSelf().inSingletonScope();
+    bind(MCPInstallService).toSelf().inSingletonScope();
+
+    bind(MCPExtensionsContribution).toSelf().inSingletonScope();
+    bind(ExtensionsContribution).toService(MCPExtensionsContribution);
+
+    bind(MCPRegistryUiBridgeImpl).toSelf().inSingletonScope();
+    bind(MCPRegistryUiBridge).toService(MCPRegistryUiBridgeImpl);
+
+    bind(AIRegistryToolbarContribution).toSelf().inSingletonScope();
+    bind(TabBarToolbarContribution).toService(AIRegistryToolbarContribution);
+});

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -18,7 +18,7 @@ import '../../src/browser/style/mcp-entries.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
-import { ExtensionsContribution } from '@theia/vsx-registry/lib/browser/extensions-contribution';
+import { ExtensionsSourceContribution } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
 import { MCPRegistryEntryResolver } from '../common/mcp/mcp-registry-entry-resolver';
@@ -35,7 +35,7 @@ export default new ContainerModule(bind => {
     bind(MCPInstallService).toSelf().inSingletonScope();
 
     bind(MCPExtensionsContribution).toSelf().inSingletonScope();
-    bind(ExtensionsContribution).toService(MCPExtensionsContribution);
+    bind(ExtensionsSourceContribution).toService(MCPExtensionsContribution);
 
     bind(MCPRegistryUiBridgeImpl).toSelf().inSingletonScope();
     bind(MCPRegistryUiBridge).toService(MCPRegistryUiBridgeImpl);

--- a/packages/ai-registry/src/browser/ai-registry-toolbar-contribution.ts
+++ b/packages/ai-registry/src/browser/ai-registry-toolbar-contribution.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { CommandRegistry, nls } from '@theia/core';
+import { CommandRegistry } from '@theia/core';
 import { Widget } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ADD_MCP_SERVER_COMMAND } from '@theia/ai-mcp/lib/browser/mcp-configuration-command-contribution';
@@ -32,7 +32,6 @@ export class AIRegistryToolbarContribution implements TabBarToolbarContribution 
         registry.registerItem({
             id: 'ai-registry.addMcpServerManually',
             command: ADD_MCP_SERVER_COMMAND.id,
-            text: nls.localize('theia/ai-registry/toolbar/addMcpServerManually', 'Manually add a MCP server'),
             group: 'other_1',
             // The view container's own in-container items use `widget === getTabBarDelegate()`,
             // which resolves to either the container itself (multi-part mode) or one of its

--- a/packages/ai-registry/src/browser/ai-registry-toolbar-contribution.ts
+++ b/packages/ai-registry/src/browser/ai-registry-toolbar-contribution.ts
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CommandRegistry, nls } from '@theia/core';
+import { Widget } from '@theia/core/lib/browser';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { ADD_MCP_SERVER_COMMAND } from '@theia/ai-mcp/lib/browser/mcp-configuration-command-contribution';
+import { VSXExtensionsViewContainer } from '@theia/vsx-registry/lib/browser/vsx-extensions-view-container';
+import { VSXExtensionsWidget } from '@theia/vsx-registry/lib/browser/vsx-extensions-widget';
+import { inject, injectable } from '@theia/core/shared/inversify';
+
+@injectable()
+export class AIRegistryToolbarContribution implements TabBarToolbarContribution {
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        registry.registerItem({
+            id: 'ai-registry.addMcpServerManually',
+            command: ADD_MCP_SERVER_COMMAND.id,
+            text: nls.localize('theia/ai-registry/toolbar/addMcpServerManually', 'Manually add a MCP server'),
+            group: 'other_1',
+            // The view container's own in-container items use `widget === getTabBarDelegate()`,
+            // which resolves to either the container itself (multi-part mode) or one of its
+            // child parts (single-part modes like Installed / Search). A separate toolbar
+            // contribution cannot reach the container instance, so we match both shapes by id
+            // and by the part-id prefix produced by `generateExtensionWidgetId`.
+            isVisible: (widget: Widget) =>
+                this.isVsxExtensionsWidget(widget)
+                && this.commandRegistry.getCommand(ADD_MCP_SERVER_COMMAND.id) !== undefined
+        });
+    }
+
+    protected isVsxExtensionsWidget(widget: Widget): boolean {
+        return widget.id === VSXExtensionsViewContainer.ID
+            || widget.id.startsWith(VSXExtensionsWidget.ID + ':');
+    }
+}

--- a/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
+++ b/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
@@ -1,0 +1,251 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { TypeBadge } from '@theia/vsx-registry/lib/browser/type-badge';
+import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+
+/**
+ * Per-entry action callbacks provided by the contribution. Entries close over
+ * these so their card render functions can dispatch user actions without
+ * pulling the install service through dependency injection at the React level.
+ */
+export interface MCPEntryHandlers {
+    install(entry: ResolvedRegistryEntry): Promise<void>;
+    uninstall(slug: string): Promise<void>;
+    update(entry: ResolvedRegistryEntry): Promise<void>;
+    link(entry: ResolvedRegistryEntry): Promise<void>;
+    fixConfig(entry: ResolvedRegistryEntry): Promise<void>;
+}
+
+/** An entry surfacing a locally installed MCP server in the Installed section. */
+export class MCPInstalledEntry implements TreeElement {
+
+    readonly id: string;
+
+    constructor(
+        readonly local: MCPServerDescription,
+        readonly matchedEntry: ResolvedRegistryEntry | undefined,
+        readonly state: ClassificationResult,
+        readonly handlers: MCPEntryHandlers
+    ) {
+        this.id = `mcp-installed-${local.name}`;
+    }
+
+    render(): React.ReactNode {
+        return (
+            <MCPCard
+                // When the registry knows this server we prefer its display name / description;
+                // otherwise fall back to whatever the user-edited local entry has.
+                title={this.matchedEntry?.name ?? this.local.name}
+                description={this.matchedEntry?.description}
+                // Show what the user has actually installed; fall back to the registry range
+                // for the unusual case where the local entry is missing a recorded version.
+                version={this.local.registryVersion ?? this.matchedEntry?.version}
+                identifier={this.matchedEntry?.serverId ?? this.local.registryServerId}
+                verified={this.matchedEntry?.mcpRegistryVerified}
+                actions={renderActions(this.state, this.matchedEntry, this.local.name, this.handlers, this.local.registryVersion)}
+            />
+        );
+    }
+}
+
+/** An entry surfacing a registry-resolved MCP server in the Search Results section. */
+export class MCPSearchResultEntry implements TreeElement {
+
+    readonly id: string;
+
+    constructor(
+        readonly entry: ResolvedRegistryEntry,
+        readonly state: ClassificationResult,
+        readonly handlers: MCPEntryHandlers
+    ) {
+        this.id = `mcp-search-${entry.serverId}`;
+    }
+
+    render(): React.ReactNode {
+        return (
+            <MCPCard
+                title={this.entry.name}
+                description={this.entry.description}
+                version={this.entry.version}
+                identifier={this.entry.serverId}
+                verified={this.entry.mcpRegistryVerified}
+                actions={renderActions(this.state, this.entry, this.entry.localSlug, this.handlers)}
+            />
+        );
+    }
+}
+
+interface MCPCardProps {
+    title: string;
+    description?: string;
+    version?: string;
+    /** Stable identifier shown in the publisher-row slot — typically the registry serverId. */
+    identifier?: string;
+    /** Drives the trust icon next to `identifier`: verified → filled check, unverified → question mark. */
+    verified?: boolean;
+    actions?: React.ReactNode;
+}
+
+/**
+ * MCP entry card. Reuses the VSX extension card's CSS classes so MCP entries
+ * sit visually alongside extensions in the unified Extensions view without
+ * duplicating styles. The MCP-specific bits are the codicon-based icon
+ * placeholder, the type badge and the publisher-row trust icon.
+ */
+const MCPCard: React.FC<MCPCardProps> = props => (
+    <div className="theia-vsx-extension noselect">
+        <div className="theia-vsx-extension-icon placeholder theia-mcp-extension-icon">
+            <i className="codicon codicon-mcp" />
+        </div>
+        <div className="theia-vsx-extension-content">
+            <div className="title">
+                <div className="noWrapInfo">
+                    <span className="name">{props.title}</span>&nbsp;
+                    {props.version && <><span className="version">{props.version}</span>&nbsp;</>}
+                    <TypeBadge
+                        icon={<i className="codicon codicon-mcp" />}
+                        label={nls.localizeByDefault('MCP')}
+                        variant="mcp"
+                    />
+                </div>
+            </div>
+            {props.description && (
+                <div className="noWrapInfo theia-vsx-extension-description">{props.description}</div>
+            )}
+            <div className="theia-vsx-extension-action-bar">
+                <div className="theia-vsx-extension-publisher-container">
+                    <i className={`codicon codicon-${props.verified === true ? 'verified-filled' : 'question'}`} />
+                    {props.identifier && (
+                        <span className="noWrapInfo theia-vsx-extension-publisher" title={props.identifier}>
+                            {props.identifier}
+                        </span>
+                    )}
+                </div>
+                <div className="theia-mcp-extension-actions">
+                    {props.actions}
+                </div>
+            </div>
+        </div>
+    </div>
+);
+
+/**
+ * Buttons are state-driven and identical in the Installed and Search sections, mirroring
+ * how VSX renders extension actions. State conveys itself through which buttons appear:
+ *
+ * - `not-installed`              → [Install]
+ * - `installed-from-registry`    → [Update?] [Uninstall]      (Update only when newer version is available)
+ * - `installed-manually`         → [Link to registry]         (no Uninstall — user wanted only the link affordance)
+ * - `fix-config`                 → ⚠︎ [Fix config] [Uninstall]
+ * - `installed-registry-revoked` → ⚠︎ "no longer in registry" [Remove]
+ * - `installed-user-added`       → filtered out before reaching this view
+ */
+function renderActions(
+    state: ClassificationResult,
+    registryEntry: ResolvedRegistryEntry | undefined,
+    localName: string,
+    handlers: MCPEntryHandlers,
+    localVersion?: string
+): React.ReactNode {
+    switch (state.kind) {
+        case 'not-installed':
+            return registryEntry && (
+                <button className="theia-button prominent action" onClick={() => handlers.install(registryEntry)}>
+                    {nls.localizeByDefault('Install')}
+                </button>
+            );
+        case 'installed-from-registry':
+            return (
+                <>
+                    {state.updateAvailable && registryEntry && (
+                        <button
+                            className="theia-button prominent action"
+                            title={
+                                registryEntry.version && registryEntry.version !== localVersion
+                                    ? nls.localize(
+                                        'theia/ai-registry/action/updateTooltip',
+                                        'Update from {0} to {1}',
+                                        localVersion ?? '?',
+                                        registryEntry.version
+                                    )
+                                    : nls.localizeByDefault('Update')
+                            }
+                            onClick={() => handlers.update(registryEntry)}
+                        >
+                            {nls.localizeByDefault('Update')}
+                        </button>
+                    )}
+                    <button className="theia-button action" onClick={() => handlers.uninstall(localName)}>
+                        {nls.localizeByDefault('Uninstall')}
+                    </button>
+                </>
+            );
+        case 'installed-manually':
+            // No Uninstall here by design — the only meaningful action is to link
+            // the existing local server to the registry so future updates are tracked.
+            return registryEntry && (
+                <button className="theia-button action" onClick={() => handlers.link(registryEntry)}>
+                    {nls.localize('theia/ai-registry/action/link', 'Link to registry')}
+                </button>
+            );
+        case 'fix-config':
+            return (
+                <>
+                    <i
+                        className="codicon codicon-warning theia-mcp-extension-warning"
+                        title={nls.localize(
+                            'theia/ai-registry/warning/fixConfig',
+                            "This server's configuration differs from the registry. Click 'Fix config' to restore it."
+                        )}
+                    />
+                    {registryEntry && (
+                        <button className="theia-button prominent action" onClick={() => handlers.fixConfig(registryEntry)}>
+                            {nls.localize('theia/ai-registry/action/fix', 'Fix config')}
+                        </button>
+                    )}
+                    <button className="theia-button action" onClick={() => handlers.uninstall(localName)}>
+                        {nls.localizeByDefault('Uninstall')}
+                    </button>
+                </>
+            );
+        case 'installed-registry-revoked':
+            return (
+                <>
+                    <span
+                        className="theia-mcp-extension-revoked-message"
+                        title={nls.localize(
+                            'theia/ai-registry/warning/revokedTitle',
+                            "This MCP server no longer exists in the registry. Click 'Remove' to uninstall."
+                        )}
+                    >
+                        <i className="codicon codicon-warning theia-mcp-extension-warning" />
+                        {nls.localize('theia/ai-registry/warning/revoked', 'No longer in registry')}
+                    </span>
+                    <button className="theia-button action theia-mcp-extension-remove" onClick={() => handlers.uninstall(localName)}>
+                        {nls.localizeByDefault('Remove')}
+                    </button>
+                </>
+            );
+        case 'installed-user-added':
+            // Filtered out of resolveInstalled and never returned from search; render nothing defensively.
+            return undefined;
+    }
+}

--- a/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
+++ b/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
@@ -31,8 +31,8 @@ import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mc
  */
 export interface MCPEntryHandlers {
     install(entry: ResolvedRegistryEntry): Promise<void>;
-    uninstall(slug: string): Promise<void>;
-    unlink(slug: string): Promise<void>;
+    uninstall(serverKey: string): Promise<void>;
+    unlink(serverKey: string): Promise<void>;
     update(entry: ResolvedRegistryEntry): Promise<void>;
     link(entry: ResolvedRegistryEntry): Promise<void>;
     fixConfig(entry: ResolvedRegistryEntry): Promise<void>;

--- a/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
+++ b/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
@@ -96,7 +96,7 @@ export class MCPSearchResultEntry implements TreeElement {
                 identifier={this.entry.serverId}
                 verified={this.entry.mcpRegistryVerified}
                 hoverService={this.hoverService}
-                actions={renderActions(this.state, this.entry, this.entry.localSlug, this.handlers)}
+                actions={renderActions(this.state, this.entry, this.entry.localName, this.handlers)}
             />
         );
     }
@@ -117,6 +117,9 @@ interface MCPCardProps {
 /** Build the markdown tooltip shown on hover, mirroring the depth of the VSX card's tooltip. */
 function buildHoverContent(props: MCPCardProps): MarkdownStringImpl {
     const lines = [`**${props.title}**`];
+    if (props.version) {
+        lines.push('', `_${props.version}_`);
+    }
     if (props.description) {
         lines.push('', props.description);
     }

--- a/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
+++ b/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
@@ -16,8 +16,11 @@
 
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { TypeBadge } from '@theia/vsx-registry/lib/browser/type-badge';
+import { ExtensionCard, ExtensionCardTrust } from '@theia/vsx-registry/lib/browser/extension-card';
 import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 
@@ -29,6 +32,7 @@ import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mc
 export interface MCPEntryHandlers {
     install(entry: ResolvedRegistryEntry): Promise<void>;
     uninstall(slug: string): Promise<void>;
+    unlink(slug: string): Promise<void>;
     update(entry: ResolvedRegistryEntry): Promise<void>;
     link(entry: ResolvedRegistryEntry): Promise<void>;
     fixConfig(entry: ResolvedRegistryEntry): Promise<void>;
@@ -43,12 +47,14 @@ export class MCPInstalledEntry implements TreeElement {
         readonly local: MCPServerDescription,
         readonly matchedEntry: ResolvedRegistryEntry | undefined,
         readonly state: ClassificationResult,
-        readonly handlers: MCPEntryHandlers
+        readonly handlers: MCPEntryHandlers,
+        readonly hoverService: HoverService
     ) {
         this.id = `mcp-installed-${local.name}`;
     }
 
     render(): React.ReactNode {
+        const localVersion = this.local.registryMetadata?.version;
         return (
             <MCPCard
                 // When the registry knows this server we prefer its display name / description;
@@ -57,10 +63,11 @@ export class MCPInstalledEntry implements TreeElement {
                 description={this.matchedEntry?.description}
                 // Show what the user has actually installed; fall back to the registry range
                 // for the unusual case where the local entry is missing a recorded version.
-                version={this.local.registryVersion ?? this.matchedEntry?.version}
-                identifier={this.matchedEntry?.serverId ?? this.local.registryServerId}
+                version={localVersion ?? this.matchedEntry?.version}
+                identifier={this.matchedEntry?.serverId ?? this.local.registryMetadata?.serverId}
                 verified={this.matchedEntry?.mcpRegistryVerified}
-                actions={renderActions(this.state, this.matchedEntry, this.local.name, this.handlers, this.local.registryVersion)}
+                hoverService={this.hoverService}
+                actions={renderActions(this.state, this.matchedEntry, this.local.name, this.handlers, localVersion)}
             />
         );
     }
@@ -74,7 +81,8 @@ export class MCPSearchResultEntry implements TreeElement {
     constructor(
         readonly entry: ResolvedRegistryEntry,
         readonly state: ClassificationResult,
-        readonly handlers: MCPEntryHandlers
+        readonly handlers: MCPEntryHandlers,
+        readonly hoverService: HoverService
     ) {
         this.id = `mcp-search-${entry.serverId}`;
     }
@@ -87,6 +95,7 @@ export class MCPSearchResultEntry implements TreeElement {
                 version={this.entry.version}
                 identifier={this.entry.serverId}
                 verified={this.entry.mcpRegistryVerified}
+                hoverService={this.hoverService}
                 actions={renderActions(this.state, this.entry, this.entry.localSlug, this.handlers)}
             />
         );
@@ -97,66 +106,78 @@ interface MCPCardProps {
     title: string;
     description?: string;
     version?: string;
-    /** Stable identifier shown in the publisher-row slot — typically the registry serverId. */
+    /** Stable identifier shown in the publisher-row slot - typically the registry serverId. */
     identifier?: string;
-    /** Drives the trust icon next to `identifier`: verified → filled check, unverified → question mark. */
+    /** Drives the trust icon next to `identifier`: verified -> filled check, otherwise question mark. */
     verified?: boolean;
+    hoverService: HoverService;
     actions?: React.ReactNode;
 }
 
+/** Build the markdown tooltip shown on hover, mirroring the depth of the VSX card's tooltip. */
+function buildHoverContent(props: MCPCardProps): MarkdownStringImpl {
+    const lines = [`**${props.title}**`];
+    if (props.description) {
+        lines.push('', props.description);
+    }
+    if (props.identifier) {
+        lines.push('', `_${props.identifier}_`);
+    }
+    return new MarkdownStringImpl(lines.join('\n'));
+}
+
 /**
- * MCP entry card. Reuses the VSX extension card's CSS classes so MCP entries
- * sit visually alongside extensions in the unified Extensions view without
- * duplicating styles. The MCP-specific bits are the codicon-based icon
- * placeholder, the type badge and the publisher-row trust icon.
+ * MCP entry card. Renders against the shared {@link ExtensionCard} shell so MCP entries
+ * sit visually alongside extensions in the unified Extensions view, sharing the layout,
+ * trust icon and hover tooltip. The MCP-specific bits are the codicon icon, the type
+ * badge, the derived trust state and the action set.
+ *
+ * The trailing invisible settings-gear element reserves the same layout space VSX cards
+ * use for their context-menu gear, so MCP and VSX action bars align across the view.
  */
-const MCPCard: React.FC<MCPCardProps> = props => (
-    <div className="theia-vsx-extension noselect">
-        <div className="theia-vsx-extension-icon placeholder theia-mcp-extension-icon">
-            <i className="codicon codicon-mcp" />
-        </div>
-        <div className="theia-vsx-extension-content">
-            <div className="title">
-                <div className="noWrapInfo">
-                    <span className="name">{props.title}</span>&nbsp;
-                    {props.version && <><span className="version">{props.version}</span>&nbsp;</>}
-                    <TypeBadge
-                        icon={<i className="codicon codicon-mcp" />}
-                        label={nls.localizeByDefault('MCP')}
-                        variant="mcp"
-                    />
-                </div>
-            </div>
-            {props.description && (
-                <div className="noWrapInfo theia-vsx-extension-description">{props.description}</div>
-            )}
-            <div className="theia-vsx-extension-action-bar">
-                <div className="theia-vsx-extension-publisher-container">
-                    <i className={`codicon codicon-${props.verified === true ? 'verified-filled' : 'question'}`} />
-                    {props.identifier && (
-                        <span className="noWrapInfo theia-vsx-extension-publisher" title={props.identifier}>
-                            {props.identifier}
-                        </span>
-                    )}
-                </div>
+const MCPCard: React.FC<MCPCardProps> = props => {
+    const trust: ExtensionCardTrust = props.verified === true ? 'verified' : 'unknown';
+    return (
+        <ExtensionCard
+            title={props.title}
+            version={props.version}
+            description={props.description}
+            icon={<i className="codicon codicon-mcp" />}
+            iconClassName="theia-mcp-extension-icon"
+            typeBadge={
+                <TypeBadge
+                    icon={<i className="codicon codicon-mcp" />}
+                    label={nls.localizeByDefault('MCP')}
+                    variant="mcp"
+                />
+            }
+            publisher={props.identifier}
+            publisherTitle={props.identifier}
+            trust={trust}
+            hover={{ content: buildHoverContent(props), hoverService: props.hoverService }}
+            actions={
                 <div className="theia-mcp-extension-actions">
                     {props.actions}
+                    <div
+                        className="codicon codicon-settings-gear action theia-mcp-extension-gear-placeholder"
+                        aria-hidden="true"
+                    />
                 </div>
-            </div>
-        </div>
-    </div>
-);
+            }
+        />
+    );
+};
 
 /**
  * Buttons are state-driven and identical in the Installed and Search sections, mirroring
  * how VSX renders extension actions. State conveys itself through which buttons appear:
  *
- * - `not-installed`              → [Install]
- * - `installed-from-registry`    → [Update?] [Uninstall]      (Update only when newer version is available)
- * - `installed-manually`         → [Link to registry]         (no Uninstall — user wanted only the link affordance)
- * - `fix-config`                 → ⚠︎ [Fix config] [Uninstall]
- * - `installed-registry-revoked` → ⚠︎ "no longer in registry" [Remove]
- * - `installed-user-added`       → filtered out before reaching this view
+ * - `not-installed`              -> [Install]
+ * - `installed-from-registry`    -> [Update?] [Uninstall]      (Update only when newer version is available)
+ * - `installed-manually`         -> [Link to registry]         (no Uninstall - user wanted only the link affordance)
+ * - `fix-config`                 -> warning [Fix config] [Uninstall]
+ * - `installed-link-stale`       -> warning "Not in registry" [Unlink] [Uninstall]
+ * - `installed-user-added`       -> filtered out before reaching this view
  */
 function renderActions(
     state: ClassificationResult,
@@ -199,7 +220,7 @@ function renderActions(
                 </>
             );
         case 'installed-manually':
-            // No Uninstall here by design — the only meaningful action is to link
+            // No Uninstall here by design - the only meaningful action is to link
             // the existing local server to the registry so future updates are tracked.
             return registryEntry && (
                 <button className="theia-button action" onClick={() => handlers.link(registryEntry)}>
@@ -226,24 +247,37 @@ function renderActions(
                     </button>
                 </>
             );
-        case 'installed-registry-revoked':
+        case 'installed-link-stale': {
+            // The registry no longer lists the linked serverId. The server itself may
+            // still work, so we offer Unlink (drop the registry link, keep the config)
+            // as the soft option and keep Uninstall available for users who want the
+            // server gone. Wording stays cautious - we don't assert the server works,
+            // we let the user decide.
+            const tooltip = nls.localize(
+                'theia/ai-registry/warning/linkStale',
+                'This server was installed from the registry, but the registry no longer lists it. '
+                + 'If you are sure you want to keep it and it still works for you, click Unlink to drop '
+                + 'the registry link. Otherwise click Uninstall to remove the server.'
+            );
             return (
                 <>
-                    <span
-                        className="theia-mcp-extension-revoked-message"
-                        title={nls.localize(
-                            'theia/ai-registry/warning/revokedTitle',
-                            "This MCP server no longer exists in the registry. Click 'Remove' to uninstall."
-                        )}
-                    >
+                    <span className="theia-mcp-extension-link-stale-message" title={tooltip}>
                         <i className="codicon codicon-warning theia-mcp-extension-warning" />
-                        {nls.localize('theia/ai-registry/warning/revoked', 'No longer in registry')}
+                        {nls.localize('theia/ai-registry/warning/notInRegistry', 'Not in registry')}
                     </span>
-                    <button className="theia-button action theia-mcp-extension-remove" onClick={() => handlers.uninstall(localName)}>
-                        {nls.localizeByDefault('Remove')}
+                    <button
+                        className="theia-button action"
+                        title={tooltip}
+                        onClick={() => handlers.unlink(localName)}
+                    >
+                        {nls.localize('theia/ai-registry/action/unlink', 'Unlink')}
+                    </button>
+                    <button className="theia-button action" onClick={() => handlers.uninstall(localName)}>
+                        {nls.localizeByDefault('Uninstall')}
                     </button>
                 </>
             );
+        }
         case 'installed-user-added':
             // Filtered out of resolveInstalled and never returned from search; render nothing defensively.
             return undefined;

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -154,9 +154,9 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
         expect(entries[0].state).to.deep.equal({ kind: 'installed-link-stale' });
     });
 
-    it('shows installed-link-stale (Unlink + Uninstall) when the local is linked to a missing id, even if the slug still matches a registry entry', async () => {
+    it('shows installed-link-stale (Unlink + Uninstall) when the local is linked to a missing id, even if the key still matches a registry entry', async () => {
         // PR scenario: user installs from the registry, then manually rewrites
-        // `registryMetadata.serverId` to a value that no longer exists. The local slug
+        // `registryMetadata.serverId` to a value that no longer exists. The local key
         // still matches a registry `localName`, but the broken id linkage must take
         // precedence - the entry has to surface as link-stale so the user sees the
         // Unlink + Uninstall affordances and the warning, not Link (which would suggest
@@ -250,7 +250,7 @@ describe('MCPExtensionsContribution.resolveSearchResults', () => {
         expect(githubResult.searchableText).to.contain(githubEntry.description);
     });
 
-    it('classifies a registry entry as installed-link-stale when the matching-slug local is linked to a server id missing from the registry', async () => {
+    it('classifies a registry entry as installed-link-stale when the matching-key local is linked to a server id missing from the registry', async () => {
         // PR scenario: user installed `example` from the registry, then manually pointed
         // its `registryMetadata.serverId` at an id not in the registry. In Search results
         // the matching registry entry must show the **Unlink / Uninstall** affordances -

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -14,9 +14,21 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// Entries render against the shared ExtensionCard, which pulls in browser-side modules,
+// so a DOM is required at import time.
+const disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
 import { Emitter, MessageService, PreferenceService } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
@@ -26,6 +38,8 @@ import { MCPRegistryEntryResolver } from '../../common/mcp/mcp-registry-entry-re
 import { MCPInstallService } from './mcp-install-service';
 import { MCPExtensionsContribution } from './mcp-extensions-contribution';
 import { MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
+
+after(() => disableJSDOM());
 
 class FakePreferenceService {
     private readonly store = new Map<string, unknown>();
@@ -63,6 +77,7 @@ function buildContainer(prefs: FakePreferenceService, fetch: StubRegistryFetchSe
     // MCPInstallService now injects MCPServerEditor so we stub its required services.
     container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
     container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
+    container.bind(HoverService).toConstantValue({ requestHover: () => undefined } as unknown as HoverService);
     container.bind(MCPServerEditor).toSelf().inSingletonScope();
     container.bind(MCPInstallService).toSelf().inSingletonScope();
     container.bind(MCPExtensionsContribution).toSelf().inSingletonScope();
@@ -89,9 +104,11 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
             example: {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
-                registryServerId: exampleRegistryEntry.serverId,
-                registryVersion: exampleRegistryEntry.version,
-                registryConfigHash: exampleRegistryEntry.configHash
+                registryMetadata: {
+                    serverId: exampleRegistryEntry.serverId,
+                    version: exampleRegistryEntry.version,
+                    configHash: exampleRegistryEntry.configHash
+                }
             },
             // User-added: no registry counterpart at all.
             standalone: { command: 'node', args: ['srv.js'] }
@@ -105,14 +122,16 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
         expect(entries[0].state).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
     });
 
-    it('surfaces installed-registry-revoked entries so the view can render the warning + Remove action', async () => {
+    it('surfaces installed-link-stale entries so the view can render the warning + Unlink/Uninstall actions', async () => {
         const prefs = new FakePreferenceService();
         await prefs.set(MCP_SERVERS_PREF, {
-            revoked: {
+            stale: {
                 command: 'npx',
                 args: ['-y', 'gone-mcp'],
-                registryServerId: 'io.github.example/gone-server',
-                registryVersion: '^1.0.0'
+                registryMetadata: {
+                    serverId: 'io.github.example/gone-server',
+                    version: '^1.0.0'
+                }
             }
         });
         const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
@@ -120,24 +139,27 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
 
         const entries = [...await contribution.resolveInstalled()] as MCPInstalledEntry[];
 
-        expect(entries.map(e => e.local.name)).to.deep.equal(['revoked']);
-        expect(entries[0].state).to.deep.equal({ kind: 'installed-registry-revoked' });
+        expect(entries.map(e => e.local.name)).to.deep.equal(['stale']);
+        expect(entries[0].state).to.deep.equal({ kind: 'installed-link-stale' });
     });
 
-    it('shows installed-registry-revoked (Remove) when the local is linked to a missing id, even if the slug still matches a registry entry', async () => {
+    it('shows installed-link-stale (Unlink + Uninstall) when the local is linked to a missing id, even if the slug still matches a registry entry', async () => {
         // PR scenario: user installs from the registry, then manually rewrites
-        // `registryServerId` to a value that no longer exists. The local slug still
-        // matches a registry `localSlug`, but the broken id linkage must take precedence
-        // — the entry has to surface as revoked so the user sees Remove + warning, not
-        // Link (which would suggest the entry is merely unlinked).
+        // `registryMetadata.serverId` to a value that no longer exists. The local slug
+        // still matches a registry `localSlug`, but the broken id linkage must take
+        // precedence - the entry has to surface as link-stale so the user sees the
+        // Unlink + Uninstall affordances and the warning, not Link (which would suggest
+        // the entry is merely unlinked).
         const prefs = new FakePreferenceService();
         await prefs.set(MCP_SERVERS_PREF, {
             example: {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
-                registryServerId: 'io.example/gone',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.example/gone',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
         const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
@@ -146,7 +168,7 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
         const entries = [...await contribution.resolveInstalled()] as MCPInstalledEntry[];
 
         expect(entries).to.have.length(1);
-        expect(entries[0].state).to.deep.equal({ kind: 'installed-registry-revoked' });
+        expect(entries[0].state).to.deep.equal({ kind: 'installed-link-stale' });
     });
 
     it('skips malformed stored entries whose `command` is not a string — mere key presence is not enough', async () => {
@@ -158,9 +180,11 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
             example: {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
-                registryServerId: exampleRegistryEntry.serverId,
-                registryVersion: exampleRegistryEntry.version,
-                registryConfigHash: exampleRegistryEntry.configHash
+                registryMetadata: {
+                    serverId: exampleRegistryEntry.serverId,
+                    version: exampleRegistryEntry.version,
+                    configHash: exampleRegistryEntry.configHash
+                }
             }
         });
         const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
@@ -215,20 +239,22 @@ describe('MCPExtensionsContribution.resolveSearchResults', () => {
         expect(githubResult.searchableText).to.contain(githubEntry.description);
     });
 
-    it('classifies a registry entry as installed-registry-revoked when the matching-slug local is linked to a server id missing from the registry', async () => {
+    it('classifies a registry entry as installed-link-stale when the matching-slug local is linked to a server id missing from the registry', async () => {
         // PR scenario: user installed `example` from the registry, then manually pointed
-        // its `registryServerId` at an id not in the registry. In Search results the
-        // matching registry entry must show the **Remove** affordance — mirroring what
-        // the Installed view shows — instead of **Link** (which would imply the local is
-        // merely unlinked rather than revoked).
+        // its `registryMetadata.serverId` at an id not in the registry. In Search results
+        // the matching registry entry must show the **Unlink / Uninstall** affordances -
+        // mirroring what the Installed view shows - instead of **Link** (which would
+        // imply the local is merely unlinked rather than stale-linked).
         const prefs = new FakePreferenceService();
         await prefs.set(MCP_SERVERS_PREF, {
             example: {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
-                registryServerId: 'io.example/gone',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.example/gone',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
         const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
@@ -238,7 +264,7 @@ describe('MCPExtensionsContribution.resolveSearchResults', () => {
         const exampleResult = results.find(r => (r.element as MCPSearchResultEntry).entry.serverId === exampleRegistryEntry.serverId);
 
         expect(exampleResult, 'registry entry must surface in search results').to.not.be.undefined;
-        expect((exampleResult!.element as MCPSearchResultEntry).state).to.deep.equal({ kind: 'installed-registry-revoked' });
+        expect((exampleResult!.element as MCPSearchResultEntry).state).to.deep.equal({ kind: 'installed-link-stale' });
     });
 
     it('omits unverified entries when verifiedOnly is true and keeps verified ones', async () => {

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -31,11 +31,12 @@ import { Emitter, MessageService, PreferenceService } from '@theia/core';
 import { HoverService } from '@theia/core/lib/browser';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager';
-import { MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { MCPServerEditor, MCPServerEditorImpl, MCPServerEditDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { MCPServerInstallDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-install-dialog';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
-import { MCPRegistryEntryResolver } from '../../common/mcp/mcp-registry-entry-resolver';
-import { MCPInstallService } from './mcp-install-service';
+import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../../common/mcp/mcp-registry-entry-resolver';
+import { MCPInstallService, MCPInstallServiceImpl } from './mcp-install-service';
 import { MCPExtensionsContribution } from './mcp-extensions-contribution';
 import { MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
 
@@ -72,14 +73,24 @@ function buildContainer(prefs: FakePreferenceService, fetch: StubRegistryFetchSe
     const container = new Container();
     container.bind(PreferenceService).toConstantValue(prefs);
     container.bind(RegistryFetchService).toConstantValue(fetch as unknown as RegistryFetchService);
-    container.bind(MCPRegistryEntryResolver).toSelf().inSingletonScope();
+    container.bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
+    container.bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
     // Editor dependencies — the contribution doesn't invoke the install path here, but
     // MCPInstallService now injects MCPServerEditor so we stub its required services.
     container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
     container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
     container.bind(HoverService).toConstantValue({ requestHover: () => undefined } as unknown as HoverService);
-    container.bind(MCPServerEditor).toSelf().inSingletonScope();
-    container.bind(MCPInstallService).toSelf().inSingletonScope();
+    // The contribution doesn't open dialogs in these tests; bind factories that fail loudly if used.
+    container.bind(MCPServerEditDialogFactory).toConstantValue(() => {
+        throw new Error('MCPServerEditDialogFactory should not be invoked in these tests');
+    });
+    container.bind(MCPServerInstallDialogFactory).toConstantValue(() => {
+        throw new Error('MCPServerInstallDialogFactory should not be invoked in these tests');
+    });
+    container.bind(MCPServerEditorImpl).toSelf().inSingletonScope();
+    container.bind(MCPServerEditor).toService(MCPServerEditorImpl);
+    container.bind(MCPInstallServiceImpl).toSelf().inSingletonScope();
+    container.bind(MCPInstallService).toService(MCPInstallServiceImpl);
     container.bind(MCPExtensionsContribution).toSelf().inSingletonScope();
     return container;
 }
@@ -88,7 +99,7 @@ const exampleRegistryEntry: ResolvedRegistryEntry = {
     serverId: 'io.github.example/example-mcp',
     name: 'Example',
     description: 'Example MCP server',
-    localSlug: 'example',
+    localName: 'example',
     config: { command: 'npx', args: ['-y', 'example-mcp'] },
     version: '^1.0.0',
     configHash: 'hash-v1',
@@ -146,7 +157,7 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
     it('shows installed-link-stale (Unlink + Uninstall) when the local is linked to a missing id, even if the slug still matches a registry entry', async () => {
         // PR scenario: user installs from the registry, then manually rewrites
         // `registryMetadata.serverId` to a value that no longer exists. The local slug
-        // still matches a registry `localSlug`, but the broken id linkage must take
+        // still matches a registry `localName`, but the broken id linkage must take
         // precedence - the entry has to surface as link-stale so the user sees the
         // Unlink + Uninstall affordances and the warning, not Link (which would suggest
         // the entry is merely unlinked).
@@ -202,7 +213,7 @@ describe('MCPExtensionsContribution.resolveSearchResults', () => {
         serverId: 'io.github.github/github-mcp-server',
         name: 'GitHub',
         description: 'Connect AI assistants to GitHub repositories',
-        localSlug: 'github',
+        localName: 'github',
         config: { command: 'docker', args: ['run', '-i', '--rm'] },
         version: '^1.0.0',
         configHash: 'hash-github',

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -1,0 +1,257 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { Emitter, MessageService, PreferenceService } from '@theia/core';
+import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { MCPRegistryEntryResolver } from '../../common/mcp/mcp-registry-entry-resolver';
+import { MCPInstallService } from './mcp-install-service';
+import { MCPExtensionsContribution } from './mcp-extensions-contribution';
+import { MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
+
+class FakePreferenceService {
+    private readonly store = new Map<string, unknown>();
+    private readonly listeners: ((change: { preferenceName: string }) => void)[] = [];
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return (this.store.has(key) ? this.store.get(key) : defaultValue) as T | undefined;
+    }
+    async set(key: string, value: unknown): Promise<void> {
+        this.store.set(key, value);
+        for (const l of this.listeners) {
+            l({ preferenceName: key });
+        }
+    }
+    onPreferenceChanged(listener: (change: { preferenceName: string }) => void): { dispose(): void } {
+        this.listeners.push(listener);
+        return { dispose: () => { /* no-op for tests */ } };
+    }
+}
+
+class StubRegistryFetchService {
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+    constructor(public entries: ResolvedRegistryEntry[] = []) { }
+    async getEntries(): Promise<ResolvedRegistryEntry[]> {
+        return this.entries;
+    }
+}
+
+function buildContainer(prefs: FakePreferenceService, fetch: StubRegistryFetchService): Container {
+    const container = new Container();
+    container.bind(PreferenceService).toConstantValue(prefs);
+    container.bind(RegistryFetchService).toConstantValue(fetch as unknown as RegistryFetchService);
+    container.bind(MCPRegistryEntryResolver).toSelf().inSingletonScope();
+    // Editor dependencies — the contribution doesn't invoke the install path here, but
+    // MCPInstallService now injects MCPServerEditor so we stub its required services.
+    container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
+    container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
+    container.bind(MCPServerEditor).toSelf().inSingletonScope();
+    container.bind(MCPInstallService).toSelf().inSingletonScope();
+    container.bind(MCPExtensionsContribution).toSelf().inSingletonScope();
+    return container;
+}
+
+const exampleRegistryEntry: ResolvedRegistryEntry = {
+    serverId: 'io.github.example/example-mcp',
+    name: 'Example',
+    description: 'Example MCP server',
+    localSlug: 'example',
+    config: { command: 'npx', args: ['-y', 'example-mcp'] },
+    version: '^1.0.0',
+    configHash: 'hash-v1',
+    mcpRegistryVerified: true
+};
+
+describe('MCPExtensionsContribution.resolveInstalled', () => {
+
+    it('only surfaces servers tied to a registry entry; user-added entries are filtered out', async () => {
+        const prefs = new FakePreferenceService();
+        await prefs.set(MCP_SERVERS_PREF, {
+            // Linked: matches a registry entry by serverId.
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryServerId: exampleRegistryEntry.serverId,
+                registryVersion: exampleRegistryEntry.version,
+                registryConfigHash: exampleRegistryEntry.configHash
+            },
+            // User-added: no registry counterpart at all.
+            standalone: { command: 'node', args: ['srv.js'] }
+        });
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const entries = [...await contribution.resolveInstalled()] as MCPInstalledEntry[];
+
+        expect(entries.map(e => e.local.name)).to.deep.equal(['example']);
+        expect(entries[0].state).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('surfaces installed-registry-revoked entries so the view can render the warning + Remove action', async () => {
+        const prefs = new FakePreferenceService();
+        await prefs.set(MCP_SERVERS_PREF, {
+            revoked: {
+                command: 'npx',
+                args: ['-y', 'gone-mcp'],
+                registryServerId: 'io.github.example/gone-server',
+                registryVersion: '^1.0.0'
+            }
+        });
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const entries = [...await contribution.resolveInstalled()] as MCPInstalledEntry[];
+
+        expect(entries.map(e => e.local.name)).to.deep.equal(['revoked']);
+        expect(entries[0].state).to.deep.equal({ kind: 'installed-registry-revoked' });
+    });
+
+    it('shows installed-registry-revoked (Remove) when the local is linked to a missing id, even if the slug still matches a registry entry', async () => {
+        // PR scenario: user installs from the registry, then manually rewrites
+        // `registryServerId` to a value that no longer exists. The local slug still
+        // matches a registry `localSlug`, but the broken id linkage must take precedence
+        // — the entry has to surface as revoked so the user sees Remove + warning, not
+        // Link (which would suggest the entry is merely unlinked).
+        const prefs = new FakePreferenceService();
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryServerId: 'io.example/gone',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const entries = [...await contribution.resolveInstalled()] as MCPInstalledEntry[];
+
+        expect(entries).to.have.length(1);
+        expect(entries[0].state).to.deep.equal({ kind: 'installed-registry-revoked' });
+    });
+
+    it('skips malformed stored entries whose `command` is not a string — mere key presence is not enough', async () => {
+        const prefs = new FakePreferenceService();
+        await prefs.set(MCP_SERVERS_PREF, {
+            // `command` is present but typed wrong; the shared MCPServersPreference.isValue
+            // guard must reject this so it doesn't get cast to MCPServerDescription.
+            broken: { command: 42, args: ['-y', 'whatever'] },
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryServerId: exampleRegistryEntry.serverId,
+                registryVersion: exampleRegistryEntry.version,
+                registryConfigHash: exampleRegistryEntry.configHash
+            }
+        });
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const entries = [...await contribution.resolveInstalled()] as MCPInstalledEntry[];
+
+        expect(entries.map(e => e.local.name)).to.deep.equal(['example']);
+    });
+});
+
+describe('MCPExtensionsContribution.resolveSearchResults', () => {
+
+    const githubEntry: ResolvedRegistryEntry = {
+        serverId: 'io.github.github/github-mcp-server',
+        name: 'GitHub',
+        description: 'Connect AI assistants to GitHub repositories',
+        localSlug: 'github',
+        config: { command: 'docker', args: ['run', '-i', '--rm'] },
+        version: '^1.0.0',
+        configHash: 'hash-github',
+        mcpRegistryVerified: true
+    };
+
+    it('returns nothing for an empty or whitespace-only query', async () => {
+        const prefs = new FakePreferenceService();
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry, githubEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const empty = [...await contribution.resolveSearchResults('', { verifiedOnly: false })];
+        const whitespace = [...await contribution.resolveSearchResults('   ', { verifiedOnly: false })];
+
+        expect(empty).to.be.empty;
+        expect(whitespace).to.be.empty;
+    });
+
+    it('returns all entries with searchableText covering name, serverId and description so the global fuzzy ranker can match any of them', async () => {
+        const prefs = new FakePreferenceService();
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry, githubEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        // The contribution intentionally does not filter by the query string: that's the
+        // view's job (`VSXExtensionsSource.collectSearchResults` runs `FuzzySearch.filter`
+        // across results from every contribution). The contribution's only responsibility
+        // is to supply candidates with rich `searchableText`.
+        const results = [...await contribution.resolveSearchResults('REPOSITORIES', { verifiedOnly: false })];
+
+        expect(results).to.have.length(2);
+        const githubResult = results.find(r => (r.element as MCPSearchResultEntry).entry.serverId === githubEntry.serverId)!;
+        expect(githubResult.searchableText).to.contain(githubEntry.name);
+        expect(githubResult.searchableText).to.contain(githubEntry.serverId);
+        expect(githubResult.searchableText).to.contain(githubEntry.description);
+    });
+
+    it('classifies a registry entry as installed-registry-revoked when the matching-slug local is linked to a server id missing from the registry', async () => {
+        // PR scenario: user installed `example` from the registry, then manually pointed
+        // its `registryServerId` at an id not in the registry. In Search results the
+        // matching registry entry must show the **Remove** affordance — mirroring what
+        // the Installed view shows — instead of **Link** (which would imply the local is
+        // merely unlinked rather than revoked).
+        const prefs = new FakePreferenceService();
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryServerId: 'io.example/gone',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const results = [...await contribution.resolveSearchResults('example', { verifiedOnly: false })];
+        const exampleResult = results.find(r => (r.element as MCPSearchResultEntry).entry.serverId === exampleRegistryEntry.serverId);
+
+        expect(exampleResult, 'registry entry must surface in search results').to.not.be.undefined;
+        expect((exampleResult!.element as MCPSearchResultEntry).state).to.deep.equal({ kind: 'installed-registry-revoked' });
+    });
+
+    it('omits unverified entries when verifiedOnly is true and keeps verified ones', async () => {
+        const unverified: ResolvedRegistryEntry = { ...exampleRegistryEntry, mcpRegistryVerified: false };
+        const prefs = new FakePreferenceService();
+        const fetch = new StubRegistryFetchService([unverified, githubEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const all = [...await contribution.resolveSearchResults('example', { verifiedOnly: false })];
+        const verifiedOnly = [...await contribution.resolveSearchResults('example', { verifiedOnly: true })];
+
+        expect(all).to.have.length(2);
+        expect(verifiedOnly).to.have.length(1);
+        expect((verifiedOnly[0].element as MCPSearchResultEntry).entry.serverId).to.equal(githubEntry.serverId);
+    });
+});

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -22,6 +22,7 @@ import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@thei
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCPServersPreference, MCPServersPreferenceValue } from '@theia/ai-mcp/lib/common/mcp-servers-preference';
+import { MCPServerInstallDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-install-dialog';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { MCPInstallService } from './mcp-install-service';
@@ -47,6 +48,9 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
 
     @inject(HoverService)
     protected readonly hoverService: HoverService;
+
+    @inject(MCPServerInstallDialogFactory)
+    protected readonly installDialogFactory: MCPServerInstallDialogFactory;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
@@ -81,7 +85,7 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
         const stored = this.readStoredServers();
         const registryEntries = await this.safeGetRegistryEntries();
         const byServerId = new Map(registryEntries.map(e => [e.serverId, e]));
-        const bySlug = new Map(registryEntries.map(e => [e.localSlug, e]));
+        const byName = new Map(registryEntries.map(e => [e.localName, e]));
         const result: TreeElement[] = [];
         for (const [name, config] of Object.entries(stored)) {
             const local = this.toServerDescription(name, config);
@@ -96,7 +100,7 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
                 continue;
             }
             const linkedId = local.registryMetadata?.serverId;
-            const matchedEntry = (linkedId && byServerId.get(linkedId)) || bySlug.get(local.name);
+            const matchedEntry = (linkedId && byServerId.get(linkedId)) || byName.get(local.name);
             result.push(new MCPInstalledEntry(local, matchedEntry, state, this.handlers, this.hoverService));
         }
         return result;
@@ -175,13 +179,12 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
     /**
      * Prompts the user for parameters the registry can't decide for them (autostart,
      * auth token) before writing the entry. Cancelling the dialog aborts the install.
-     * The dialog module is imported lazily to keep the DOM-touching `ReactDialog`
-     * chain out of the test-time module graph.
+     * The dialog is created through an injected factory so this contribution doesn't
+     * import the DOM-touching `ReactDialog` chain directly.
      */
     protected async confirmAndInstall(entry: ResolvedRegistryEntry): Promise<void> {
-        const { MCPServerInstallDialog } = await import('@theia/ai-mcp/lib/browser/mcp-server-install-dialog');
-        const dialog = new MCPServerInstallDialog({
-            name: entry.localSlug,
+        const dialog = this.installDialogFactory({
+            name: entry.localName,
             autostart: true,
             // The registry sets `serverAuthToken` to mark auth as part of the connection
             // contract, even with no default value — so we check key presence, not value.

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -16,8 +16,9 @@
 
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { Disposable, DisposableCollection, Emitter, Event, nls, PreferenceChange, PreferenceService } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
-import { ExtensionsContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-contribution';
+import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCPServersPreference, MCPServersPreferenceValue } from '@theia/ai-mcp/lib/common/mcp-servers-preference';
@@ -26,14 +27,10 @@ import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { MCPInstallService } from './mcp-install-service';
 import { MCPEntryHandlers, MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
 
-type StoredServer = MCPServersPreferenceValue & {
-    registryServerId?: string;
-    registryVersion?: string;
-    registryConfigHash?: string;
-};
+type StoredServer = MCPServersPreferenceValue;
 
 @injectable()
-export class MCPExtensionsContribution implements ExtensionsContribution, Disposable {
+export class MCPExtensionsContribution implements ExtensionsSourceContribution, Disposable {
 
     readonly type = 'mcp-server';
     readonly displayName = nls.localizeByDefault('MCP Servers');
@@ -48,6 +45,9 @@ export class MCPExtensionsContribution implements ExtensionsContribution, Dispos
     @inject(RegistryFetchService)
     protected readonly fetchService: RegistryFetchService;
 
+    @inject(HoverService)
+    protected readonly hoverService: HoverService;
+
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
 
@@ -60,6 +60,7 @@ export class MCPExtensionsContribution implements ExtensionsContribution, Dispos
         this.handlers = {
             install: entry => this.confirmAndInstall(entry),
             uninstall: slug => this.installService.uninstall(slug),
+            unlink: slug => this.installService.unlink(slug),
             update: entry => this.installService.update(entry),
             link: entry => this.installService.link(entry),
             fixConfig: entry => this.installService.fixConfig(entry)
@@ -89,13 +90,14 @@ export class MCPExtensionsContribution implements ExtensionsContribution, Dispos
             }
             const state = this.installService.classifyLocalServer(local, registryEntries);
             // Hand-added local servers belong to the MCP configuration widget, not this view.
-            // Revoked entries (registryServerId set but registry no longer lists it) do belong
-            // here so we can surface the warning and offer a one-click Remove.
+            // Stale-linked entries (registryMetadata.serverId set but registry no longer lists
+            // it) do belong here so we can surface the warning and offer Unlink / Uninstall.
             if (state.kind === 'installed-user-added') {
                 continue;
             }
-            const matchedEntry = (local.registryServerId && byServerId.get(local.registryServerId)) || bySlug.get(local.name);
-            result.push(new MCPInstalledEntry(local, matchedEntry, state, this.handlers));
+            const linkedId = local.registryMetadata?.serverId;
+            const matchedEntry = (linkedId && byServerId.get(linkedId)) || bySlug.get(local.name);
+            result.push(new MCPInstalledEntry(local, matchedEntry, state, this.handlers, this.hoverService));
         }
         return result;
     }
@@ -127,7 +129,7 @@ export class MCPExtensionsContribution implements ExtensionsContribution, Dispos
             const searchableText = `${entry.name} ${entry.serverId} ${entry.description}`;
             const state = this.installService.classifyRegistryEntry(entry, localDescriptions, registryEntries);
             result.push({
-                element: new MCPSearchResultEntry(entry, state, this.handlers),
+                element: new MCPSearchResultEntry(entry, state, this.handlers, this.hoverService),
                 searchableText
             });
         }

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -63,8 +63,8 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
     protected init(): void {
         this.handlers = {
             install: entry => this.confirmAndInstall(entry),
-            uninstall: slug => this.installService.uninstall(slug),
-            unlink: slug => this.installService.unlink(slug),
+            uninstall: serverKey => this.installService.uninstall(serverKey),
+            unlink: serverKey => this.installService.unlink(serverKey),
             update: entry => this.installService.update(entry),
             link: entry => this.installService.link(entry),
             fixConfig: entry => this.installService.fixConfig(entry)

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -1,0 +1,194 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { Disposable, DisposableCollection, Emitter, Event, nls, PreferenceChange, PreferenceService } from '@theia/core';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { ExtensionsContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-contribution';
+import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { MCPServersPreference, MCPServersPreferenceValue } from '@theia/ai-mcp/lib/common/mcp-servers-preference';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { MCPInstallService } from './mcp-install-service';
+import { MCPEntryHandlers, MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
+
+type StoredServer = MCPServersPreferenceValue & {
+    registryServerId?: string;
+    registryVersion?: string;
+    registryConfigHash?: string;
+};
+
+@injectable()
+export class MCPExtensionsContribution implements ExtensionsContribution, Disposable {
+
+    readonly type = 'mcp-server';
+    readonly displayName = nls.localizeByDefault('MCP Servers');
+    readonly priority = 100;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(MCPInstallService)
+    protected readonly installService: MCPInstallService;
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection(this.onDidChangeEmitter);
+
+    protected handlers: MCPEntryHandlers;
+
+    @postConstruct()
+    protected init(): void {
+        this.handlers = {
+            install: entry => this.confirmAndInstall(entry),
+            uninstall: slug => this.installService.uninstall(slug),
+            update: entry => this.installService.update(entry),
+            link: entry => this.installService.link(entry),
+            fixConfig: entry => this.installService.fixConfig(entry)
+        };
+        this.toDispose.push(this.preferenceService.onPreferenceChanged((change: PreferenceChange) => {
+            if (change.preferenceName === MCP_SERVERS_PREF) {
+                this.onDidChangeEmitter.fire();
+            }
+        }));
+        this.toDispose.push(this.fetchService.onDidChange(() => this.onDidChangeEmitter.fire()));
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    async resolveInstalled(): Promise<Iterable<TreeElement>> {
+        const stored = this.readStoredServers();
+        const registryEntries = await this.safeGetRegistryEntries();
+        const byServerId = new Map(registryEntries.map(e => [e.serverId, e]));
+        const bySlug = new Map(registryEntries.map(e => [e.localSlug, e]));
+        const result: TreeElement[] = [];
+        for (const [name, config] of Object.entries(stored)) {
+            const local = this.toServerDescription(name, config);
+            if (!local) {
+                continue;
+            }
+            const state = this.installService.classifyLocalServer(local, registryEntries);
+            // Hand-added local servers belong to the MCP configuration widget, not this view.
+            // Revoked entries (registryServerId set but registry no longer lists it) do belong
+            // here so we can surface the warning and offer a one-click Remove.
+            if (state.kind === 'installed-user-added') {
+                continue;
+            }
+            const matchedEntry = (local.registryServerId && byServerId.get(local.registryServerId)) || bySlug.get(local.name);
+            result.push(new MCPInstalledEntry(local, matchedEntry, state, this.handlers));
+        }
+        return result;
+    }
+
+    async resolveSearchResults(query: string, context: SearchContext): Promise<Iterable<SearchResult>> {
+        if (!query.trim()) {
+            return [];
+        }
+        const registryEntries = await this.safeGetRegistryEntries();
+        const localDescriptions: MCPServerDescription[] = [];
+        for (const [name, cfg] of Object.entries(this.readStoredServers())) {
+            const local = this.toServerDescription(name, cfg);
+            if (local) {
+                localDescriptions.push(local);
+            }
+        }
+        const result: SearchResult[] = [];
+        for (const entry of registryEntries) {
+            // `verifiedOnly` comes from the OVSX-named `extensions.onlyShowVerifiedExtensions`
+            // preference. In this contribution "verified" maps to `mcpRegistryVerified`
+            // (i.e. approved in the AI registry), piggy-backing on the same toggle.
+            if (context.verifiedOnly && !entry.mcpRegistryVerified) {
+                continue;
+            }
+            // Hand all candidates to the view's global fuzzy ranker (`FuzzySearch.filter`
+            // in `VSXExtensionsSource.collectSearchResults`). It already discards entries
+            // that don't match the query, and a substring pre-filter would drop legitimate
+            // fuzzy matches such as "ChroDevTo" → "Chrome DevTools".
+            const searchableText = `${entry.name} ${entry.serverId} ${entry.description}`;
+            const state = this.installService.classifyRegistryEntry(entry, localDescriptions, registryEntries);
+            result.push({
+                element: new MCPSearchResultEntry(entry, state, this.handlers),
+                searchableText
+            });
+        }
+        return result;
+    }
+
+    async refresh(): Promise<void> {
+        await this.fetchService.getEntries(true);
+    }
+
+    /**
+     * Returns the raw (untyped) servers preference; per-entry validation happens in
+     * `toServerDescription`, which uses the shared `MCPServersPreference.isValue` guard
+     * so this view and `McpFrontendApplicationContribution` apply the same value checks.
+     */
+    protected readStoredServers(): Record<string, unknown> {
+        return this.preferenceService.get<Record<string, unknown>>(MCP_SERVERS_PREF, {}) ?? {};
+    }
+
+    protected async safeGetRegistryEntries(): Promise<ResolvedRegistryEntry[]> {
+        try {
+            return await this.fetchService.getEntries();
+        } catch (error) {
+            // Without entries, locally-installed servers classify as user-added and the
+            // MCP section shows nothing; users can still manage servers from the AI
+            // configuration widget directly.
+            console.warn('AI registry fetch failed; MCP entries unavailable.', error);
+            return [];
+        }
+    }
+
+    protected toServerDescription(name: string, stored: unknown): MCPServerDescription | undefined {
+        // Reuse the same value guard the MCP frontend contribution applies to the
+        // preference, so a `command: 42` (or any non-string) entry is rejected here too
+        // instead of being cast straight to `MCPServerDescription`.
+        if (!MCPServersPreference.isValue(stored)) {
+            console.warn(`Ignoring malformed MCP server "${name}": value does not match the MCP servers preference schema.`);
+            return undefined;
+        }
+        return { name, ...(stored as StoredServer) } as MCPServerDescription;
+    }
+
+    /**
+     * Prompts the user for parameters the registry can't decide for them (autostart,
+     * auth token) before writing the entry. Cancelling the dialog aborts the install.
+     * The dialog module is imported lazily to keep the DOM-touching `ReactDialog`
+     * chain out of the test-time module graph.
+     */
+    protected async confirmAndInstall(entry: ResolvedRegistryEntry): Promise<void> {
+        const { MCPServerInstallDialog } = await import('@theia/ai-mcp/lib/browser/mcp-server-install-dialog');
+        const dialog = new MCPServerInstallDialog({
+            name: entry.localSlug,
+            autostart: true,
+            // The registry sets `serverAuthToken` to mark auth as part of the connection
+            // contract, even with no default value — so we check key presence, not value.
+            requireAuthToken: 'serverAuthToken' in entry.config
+        });
+        const result = await dialog.open();
+        if (!result) {
+            return;
+        }
+        await this.installService.install(entry, result);
+    }
+}

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
@@ -19,9 +19,9 @@ import { Container } from '@theia/core/shared/inversify';
 import { MessageService, PreferenceService } from '@theia/core';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager';
-import { MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { MCPServerEditor, MCPServerEditorImpl, MCPServerEditDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
-import { MCPInstallService } from './mcp-install-service';
+import { MCPInstallService, MCPInstallServiceImpl } from './mcp-install-service';
 
 class FakePreferenceService {
     private readonly store = new Map<string, unknown>();
@@ -42,7 +42,7 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
         serverId: 'io.github.example/example-mcp',
         name: 'Example',
         description: 'Example MCP server',
-        localSlug: 'example',
+        localName: 'example',
         config: { command: 'npx', args: ['-y', 'example-mcp'] },
         version: '^1.0.0',
         configHash: 'hash-v1',
@@ -52,7 +52,7 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
     let service: MCPInstallService;
 
     beforeEach(() => {
-        service = new MCPInstallService();
+        service = new MCPInstallServiceImpl();
     });
 
     it('returns not-installed when no local server matches the registry slug', () => {
@@ -131,7 +131,7 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
             serverId: 'io.github.example/remote-mcp',
             name: 'Remote Example',
             description: 'Remote MCP server',
-            localSlug: 'remote-example',
+            localName: 'remote-example',
             config: { serverUrl: 'https://example.com/mcp' },
             version: '^1.0.0',
             configHash: 'hash-remote',
@@ -174,7 +174,7 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
         const otherEntry: ResolvedRegistryEntry = {
             ...entry,
             serverId: 'io.github.example/other-mcp',
-            localSlug: 'other'
+            localName: 'other'
         };
         const locals = [{
             name: 'example',
@@ -246,7 +246,7 @@ describe('MCPInstallService.classifyLocalServer', () => {
         serverId: 'io.github.example/example-mcp',
         name: 'Example',
         description: 'Example MCP server',
-        localSlug: 'example',
+        localName: 'example',
         config: { command: 'npx', args: ['-y', 'example-mcp'] },
         version: '^1.0.0',
         configHash: 'hash-v1',
@@ -256,7 +256,7 @@ describe('MCPInstallService.classifyLocalServer', () => {
     let service: MCPInstallService;
 
     beforeEach(() => {
-        service = new MCPInstallService();
+        service = new MCPInstallServiceImpl();
     });
 
     it('returns installed-user-added when the local server has no registryMetadata and no registry entry matches its slug', () => {
@@ -345,7 +345,7 @@ describe('MCPInstallService actions', () => {
         serverId: 'io.github.example/example-mcp',
         name: 'Example',
         description: 'Example MCP server',
-        localSlug: 'example',
+        localName: 'example',
         config: { command: 'npx', args: ['-y', 'example-mcp'] },
         version: '^1.0.0',
         configHash: 'hash-v1',
@@ -364,8 +364,14 @@ describe('MCPInstallService actions', () => {
         // editor methods that the install path doesn't touch.
         container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
         container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
-        container.bind(MCPServerEditor).toSelf().inSingletonScope();
-        container.bind(MCPInstallService).toSelf().inSingletonScope();
+        // The install path here only writes preferences; bind a dialog factory that fails loudly if used.
+        container.bind(MCPServerEditDialogFactory).toConstantValue(() => {
+            throw new Error('MCPServerEditDialogFactory should not be invoked in these tests');
+        });
+        container.bind(MCPServerEditorImpl).toSelf().inSingletonScope();
+        container.bind(MCPServerEditor).toService(MCPServerEditorImpl);
+        container.bind(MCPInstallServiceImpl).toSelf().inSingletonScope();
+        container.bind(MCPInstallService).toService(MCPInstallServiceImpl);
         service = container.get(MCPInstallService);
     });
 

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
@@ -59,57 +59,65 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
         expect(service.classifyRegistryEntry(entry, [], [entry])).to.deep.equal({ kind: 'not-installed' });
     });
 
-    it('returns installed-from-registry with no update when registryServerId and registryConfigHash match', () => {
+    it('returns installed-from-registry with no update when the linked serverId matches and configHash matches', () => {
         const locals = [{
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: entry.serverId,
-            registryVersion: entry.version,
-            registryConfigHash: entry.configHash
+            registryMetadata: {
+                serverId: entry.serverId,
+                version: entry.version,
+                configHash: entry.configHash
+            }
         }];
         expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
     });
 
-    it('returns installed-from-registry with update available when registryConfigHash differs from the entry configHash', () => {
+    it('returns installed-from-registry with update available when the linked configHash differs from the entry configHash', () => {
         const locals = [{
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: entry.serverId,
-            // Display version still matches — update detection must rely on the hash alone.
-            registryVersion: entry.version,
-            registryConfigHash: 'hash-v0'
+            registryMetadata: {
+                serverId: entry.serverId,
+                // Display version still matches - update detection must rely on the hash alone.
+                version: entry.version,
+                configHash: 'hash-v0'
+            }
         }];
         expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
     });
 
-    it('does not offer an update when registryVersion drifts but the configHash still matches — version is display-only', () => {
+    it('does not offer an update when the linked version drifts but the configHash still matches - version is display-only', () => {
         const locals = [{
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: entry.serverId,
-            // Local version is stale, but the underlying approval hasn't changed.
-            registryVersion: '^0.9.0',
-            registryConfigHash: entry.configHash
+            registryMetadata: {
+                serverId: entry.serverId,
+                // Local version is stale, but the underlying approval hasn't changed.
+                version: '^0.9.0',
+                configHash: entry.configHash
+            }
         }];
         expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
     });
 
-    it('does not offer an update when the registry entry has no configHash — keeps older payloads quiet', () => {
+    it('does not offer an update when the registry entry has no configHash - keeps older payloads quiet', () => {
         const noHashEntry: ResolvedRegistryEntry = { ...entry, configHash: undefined };
         const locals = [{
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: entry.serverId,
-            registryVersion: entry.version
+            registryMetadata: {
+                serverId: entry.serverId,
+                version: entry.version
+            }
         }];
         expect(service.classifyRegistryEntry(noHashEntry, locals, [noHashEntry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
     });
 
-    it('returns installed-manually when a local stdio server matches name + command + args but has no registryServerId', () => {
+    it('returns installed-manually when a local stdio server matches name + command + args but has no registryMetadata', () => {
         const locals = [{
             name: 'example',
             command: 'npx',
@@ -118,7 +126,7 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
         expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-manually' });
     });
 
-    it('returns installed-manually for a remote entry when a local server matches name + serverUrl but has no registryServerId', () => {
+    it('returns installed-manually for a remote entry when a local server matches name + serverUrl but has no registryMetadata', () => {
         const remoteEntry: ResolvedRegistryEntry = {
             serverId: 'io.github.example/remote-mcp',
             name: 'Remote Example',
@@ -136,7 +144,7 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
         expect(service.classifyRegistryEntry(remoteEntry, locals, [remoteEntry])).to.deep.equal({ kind: 'installed-manually' });
     });
 
-    it('returns installed-manually for an unlinked local server matching the slug even if the config differs — drift only matters once linked', () => {
+    it('returns installed-manually for an unlinked local server matching the slug even if the config differs - drift only matters once linked', () => {
         const locals = [{
             name: 'example',
             command: 'node',
@@ -145,22 +153,24 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
         expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-manually' });
     });
 
-    it('returns installed-registry-revoked when the slug-matching local is linked to a server id that is absent from the registry', () => {
+    it('returns installed-link-stale when the slug-matching local is linked to a server id that is absent from the registry', () => {
         const locals = [{
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: 'io.example/gone',
-            registryVersion: '^1.0.0',
-            registryConfigHash: 'hash-v1'
+            registryMetadata: {
+                serverId: 'io.example/gone',
+                version: '^1.0.0',
+                configHash: 'hash-v1'
+            }
         }];
         // The registry still publishes `entry` (slug `example`) but no longer publishes
-        // `io.example/gone`. The local must surface as revoked so the Search view mirrors
-        // what the Installed view shows (Remove instead of Link).
-        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-registry-revoked' });
+        // `io.example/gone`. The local must surface as link-stale so the Search view
+        // mirrors what the Installed view shows (Unlink + Uninstall instead of Link).
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-link-stale' });
     });
 
-    it('returns installed-manually (not revoked) when the slug-matching local is linked to a different but valid registry id', () => {
+    it('returns installed-manually (not link-stale) when the slug-matching local is linked to a different but valid registry id', () => {
         const otherEntry: ResolvedRegistryEntry = {
             ...entry,
             serverId: 'io.github.example/other-mcp',
@@ -170,9 +180,9 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            // The id is real — just bound to a different registry entry. The user can still
-            // re-link this local to `entry` from Search, so we surface Link, not Remove.
-            registryServerId: otherEntry.serverId
+            // The id is real - just bound to a different registry entry. The user can still
+            // re-link this local to `entry` from Search, so we surface Link, not Unlink.
+            registryMetadata: { serverId: otherEntry.serverId }
         }];
         expect(service.classifyRegistryEntry(entry, locals, [entry, otherEntry])).to.deep.equal({ kind: 'installed-manually' });
     });
@@ -182,9 +192,11 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
             name: 'example',
             command: 'node',
             args: ['-y', 'example-mcp'],
-            registryServerId: entry.serverId,
-            registryVersion: entry.version,
-            registryConfigHash: entry.configHash
+            registryMetadata: {
+                serverId: entry.serverId,
+                version: entry.version,
+                configHash: entry.configHash
+            }
         }];
         expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'fix-config' });
     });
@@ -199,9 +211,11 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
             command: 'npx',
             args: ['-y', 'example-mcp'],
             env: { LOG_LEVEL: 'info', USER_TOKEN: 'secret' },
-            registryServerId: entry.serverId,
-            registryVersion: entry.version,
-            registryConfigHash: entry.configHash
+            registryMetadata: {
+                serverId: entry.serverId,
+                version: entry.version,
+                configHash: entry.configHash
+            }
         }];
         expect(service.classifyRegistryEntry(entryWithEnv, locals, [entryWithEnv])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
     });
@@ -216,9 +230,11 @@ describe('MCPInstallService.classifyRegistryEntry', () => {
             command: 'npx',
             args: ['-y', 'example-mcp'],
             env: { LOG_LEVEL: 'debug' },
-            registryServerId: entry.serverId,
-            registryVersion: entry.version,
-            registryConfigHash: entry.configHash
+            registryMetadata: {
+                serverId: entry.serverId,
+                version: entry.version,
+                configHash: entry.configHash
+            }
         }];
         expect(service.classifyRegistryEntry(entryWithEnv, locals, [entryWithEnv])).to.deep.equal({ kind: 'fix-config' });
     });
@@ -243,48 +259,54 @@ describe('MCPInstallService.classifyLocalServer', () => {
         service = new MCPInstallService();
     });
 
-    it('returns installed-user-added when the local server has no registryServerId and no registry entry matches its slug', () => {
+    it('returns installed-user-added when the local server has no registryMetadata and no registry entry matches its slug', () => {
         const local = { name: 'unrelated', command: 'node', args: ['my-script.js'] };
         expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-user-added' });
     });
 
-    it('returns installed-from-registry with no update when registryServerId and registryConfigHash match', () => {
+    it('returns installed-from-registry with no update when the linked serverId matches and configHash matches', () => {
         const local = {
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: exampleEntry.serverId,
-            registryVersion: exampleEntry.version,
-            registryConfigHash: exampleEntry.configHash
+            registryMetadata: {
+                serverId: exampleEntry.serverId,
+                version: exampleEntry.version,
+                configHash: exampleEntry.configHash
+            }
         };
         expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
     });
 
-    it('returns installed-from-registry with update available when registryConfigHash differs from the matched entry configHash', () => {
+    it('returns installed-from-registry with update available when the linked configHash differs from the matched entry configHash', () => {
         const local = {
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: exampleEntry.serverId,
-            registryVersion: exampleEntry.version,
-            registryConfigHash: 'hash-v0'
+            registryMetadata: {
+                serverId: exampleEntry.serverId,
+                version: exampleEntry.version,
+                configHash: 'hash-v0'
+            }
         };
         expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
     });
 
-    it('returns installed-registry-revoked when registryServerId points to a serverId no longer in the registry', () => {
+    it('returns installed-link-stale when the linked serverId points to a serverId no longer in the registry', () => {
         const local = {
             name: 'example',
             command: 'npx',
             args: ['-y', 'example-mcp'],
-            registryServerId: 'io.github.example/removed-mcp',
-            registryVersion: '^1.0.0',
-            registryConfigHash: 'hash-removed'
+            registryMetadata: {
+                serverId: 'io.github.example/removed-mcp',
+                version: '^1.0.0',
+                configHash: 'hash-removed'
+            }
         };
-        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-registry-revoked' });
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-link-stale' });
     });
 
-    it('returns installed-manually when the local server has no registryServerId but its slug matches a registry entry', () => {
+    it('returns installed-manually when the local server has no registryMetadata but its slug matches a registry entry', () => {
         const local = {
             name: 'example',
             command: 'npx',
@@ -293,7 +315,7 @@ describe('MCPInstallService.classifyLocalServer', () => {
         expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-manually' });
     });
 
-    it('returns installed-manually when an unlinked local server has a diverging command — Link must be offered before drift is actioned', () => {
+    it('returns installed-manually when an unlinked local server has a diverging command - Link must be offered before drift is actioned', () => {
         const local = {
             name: 'example',
             command: 'node',
@@ -307,9 +329,11 @@ describe('MCPInstallService.classifyLocalServer', () => {
             name: 'example',
             command: 'node',
             args: ['-y', 'example-mcp'],
-            registryServerId: exampleEntry.serverId,
-            registryVersion: exampleEntry.version,
-            registryConfigHash: exampleEntry.configHash
+            registryMetadata: {
+                serverId: exampleEntry.serverId,
+                version: exampleEntry.version,
+                configHash: exampleEntry.configHash
+            }
         };
         expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'fix-config' });
     });
@@ -335,7 +359,7 @@ describe('MCPInstallService actions', () => {
         const container = new Container();
         prefs = new FakePreferenceService();
         container.bind(PreferenceService).toConstantValue(prefs);
-        // Stubs for the editor's deps — we only exercise installFromEntry which uses
+        // Stubs for the editor's deps - we only exercise installFromEntry which uses
         // PreferenceService; MessageService and MCPFrontendService are referenced by other
         // editor methods that the install path doesn't touch.
         container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
@@ -362,29 +386,35 @@ describe('MCPInstallService actions', () => {
         expect(prefs.snapshot<Record<string, { serverAuthToken?: string }>>(MCP_SERVERS_PREF)!.example.serverAuthToken).to.equal('secret-123');
     });
 
-    it('install ignores a token override when the registry entry has no serverAuthToken slot — keeps local entries from accidentally storing one', async () => {
+    it('install ignores a token override when the registry entry has no serverAuthToken slot - keeps local entries from accidentally storing one', async () => {
         await service.install(entry, { serverAuthToken: 'ignored' });
 
         expect(prefs.snapshot<Record<string, Record<string, unknown>>>(MCP_SERVERS_PREF)!.example).to.not.have.property('serverAuthToken');
     });
 
-    it('install writes a new entry with the registry config and registry metadata (including configHash) to the preference', async () => {
+    it('install writes a new entry with the registry config and a registryMetadata block (including configHash) to the preference', async () => {
         await service.install(entry);
 
         expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
             example: {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
     });
 
     it('uninstall removes the entry by slug and leaves unrelated servers intact', async () => {
         await prefs.set(MCP_SERVERS_PREF, {
-            example: { command: 'npx', args: ['-y', 'example-mcp'], registryServerId: 'io.github.example/example-mcp' },
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryMetadata: { serverId: 'io.github.example/example-mcp' }
+            },
             other: { command: 'node', args: ['unrelated.js'] }
         });
 
@@ -395,7 +425,46 @@ describe('MCPInstallService actions', () => {
         });
     });
 
-    it('fixConfig overwrites the local config with the registry config and sets registry metadata', async () => {
+    it('unlink removes the registryMetadata block while leaving the server config intact', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                env: { USER_TOKEN: 'secret' },
+                autostart: true,
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
+            }
+        });
+
+        await service.unlink('example');
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                env: { USER_TOKEN: 'secret' },
+                autostart: true
+            }
+        });
+    });
+
+    it('unlink is a no-op on entries that have no registryMetadata block', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: { command: 'npx', args: ['-y', 'example-mcp'] }
+        });
+
+        await service.unlink('example');
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: { command: 'npx', args: ['-y', 'example-mcp'] }
+        });
+    });
+
+    it('fixConfig overwrites the local config with the registry config and sets the registryMetadata block', async () => {
         await prefs.set(MCP_SERVERS_PREF, {
             example: {
                 command: 'node',
@@ -409,14 +478,16 @@ describe('MCPInstallService actions', () => {
             example: {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
     });
 
-    it('fixConfig preserves the existing autostart preference — the registry has no opinion on it', async () => {
+    it('fixConfig preserves the existing autostart preference - the registry has no opinion on it', async () => {
         await prefs.set(MCP_SERVERS_PREF, {
             example: {
                 command: 'node',
@@ -430,7 +501,7 @@ describe('MCPInstallService actions', () => {
         expect(prefs.snapshot<Record<string, { autostart?: boolean }>>(MCP_SERVERS_PREF)!.example.autostart).to.equal(false);
     });
 
-    it('link sets registryServerId, registryVersion and registryConfigHash on the existing entry, leaving its config untouched', async () => {
+    it('link sets the registryMetadata block on the existing entry, leaving its config untouched', async () => {
         await prefs.set(MCP_SERVERS_PREF, {
             example: {
                 command: 'npx',
@@ -448,9 +519,11 @@ describe('MCPInstallService actions', () => {
                 args: ['-y', 'example-mcp'],
                 env: { USER_TOKEN: 'secret' },
                 autostart: true,
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
     });
@@ -465,9 +538,11 @@ describe('MCPInstallService actions', () => {
             example: {
                 serverUrl: 'https://example.com/mcp',
                 serverAuthToken: 'user-secret',
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
 
@@ -488,9 +563,11 @@ describe('MCPInstallService actions', () => {
                 args: ['-y', 'example-mcp'],
                 env: { LOG_LEVEL: 'debug' },
                 autostart: true,
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
 
@@ -500,9 +577,11 @@ describe('MCPInstallService actions', () => {
             example: {
                 serverUrl: 'https://example.com/mcp',
                 autostart: true,
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v2'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v2'
+                }
             }
         });
     });
@@ -520,9 +599,11 @@ describe('MCPInstallService actions', () => {
                 serverAuthTokenHeader: 'X-Token',
                 headers: { 'X-Custom': 'value' },
                 autostart: true,
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
 
@@ -533,14 +614,16 @@ describe('MCPInstallService actions', () => {
                 command: 'npx',
                 args: ['-y', 'example-mcp'],
                 autostart: true,
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v2'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v2'
+                }
             }
         });
     });
 
-    it('update overwrites registry-set fields, preserves user-added env keys and autostart, and bumps registryVersion + registryConfigHash', async () => {
+    it('update overwrites registry-set fields, preserves user-added env keys and autostart, and bumps the registryMetadata block', async () => {
         const newEntry: ResolvedRegistryEntry = {
             ...entry,
             config: {
@@ -557,9 +640,11 @@ describe('MCPInstallService actions', () => {
                 args: ['-y', 'example-mcp@0.9.0'],
                 env: { LOG_LEVEL: 'debug', USER_TOKEN: 'secret' },
                 autostart: false,
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^0.9.0',
-                registryConfigHash: 'hash-v1'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^0.9.0',
+                    configHash: 'hash-v1'
+                }
             }
         });
 
@@ -571,9 +656,11 @@ describe('MCPInstallService actions', () => {
                 args: ['-y', 'example-mcp@1.0.0'],
                 env: { LOG_LEVEL: 'info', USER_TOKEN: 'secret' },
                 autostart: false,
-                registryServerId: 'io.github.example/example-mcp',
-                registryVersion: '^1.0.0',
-                registryConfigHash: 'hash-v2'
+                registryMetadata: {
+                    serverId: 'io.github.example/example-mcp',
+                    version: '^1.0.0',
+                    configHash: 'hash-v2'
+                }
             }
         });
     });

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
@@ -1,0 +1,580 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { MessageService, PreferenceService } from '@theia/core';
+import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { MCPInstallService } from './mcp-install-service';
+
+class FakePreferenceService {
+    private readonly store = new Map<string, unknown>();
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return (this.store.has(key) ? this.store.get(key) : defaultValue) as T | undefined;
+    }
+    async set(key: string, value: unknown): Promise<void> {
+        this.store.set(key, value);
+    }
+    snapshot<T>(key: string): T | undefined {
+        return this.store.get(key) as T | undefined;
+    }
+}
+
+describe('MCPInstallService.classifyRegistryEntry', () => {
+
+    const entry: ResolvedRegistryEntry = {
+        serverId: 'io.github.example/example-mcp',
+        name: 'Example',
+        description: 'Example MCP server',
+        localSlug: 'example',
+        config: { command: 'npx', args: ['-y', 'example-mcp'] },
+        version: '^1.0.0',
+        configHash: 'hash-v1',
+        mcpRegistryVerified: true
+    };
+
+    let service: MCPInstallService;
+
+    beforeEach(() => {
+        service = new MCPInstallService();
+    });
+
+    it('returns not-installed when no local server matches the registry slug', () => {
+        expect(service.classifyRegistryEntry(entry, [], [entry])).to.deep.equal({ kind: 'not-installed' });
+    });
+
+    it('returns installed-from-registry with no update when registryServerId and registryConfigHash match', () => {
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: entry.serverId,
+            registryVersion: entry.version,
+            registryConfigHash: entry.configHash
+        }];
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('returns installed-from-registry with update available when registryConfigHash differs from the entry configHash', () => {
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: entry.serverId,
+            // Display version still matches — update detection must rely on the hash alone.
+            registryVersion: entry.version,
+            registryConfigHash: 'hash-v0'
+        }];
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('does not offer an update when registryVersion drifts but the configHash still matches — version is display-only', () => {
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: entry.serverId,
+            // Local version is stale, but the underlying approval hasn't changed.
+            registryVersion: '^0.9.0',
+            registryConfigHash: entry.configHash
+        }];
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('does not offer an update when the registry entry has no configHash — keeps older payloads quiet', () => {
+        const noHashEntry: ResolvedRegistryEntry = { ...entry, configHash: undefined };
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: entry.serverId,
+            registryVersion: entry.version
+        }];
+        expect(service.classifyRegistryEntry(noHashEntry, locals, [noHashEntry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('returns installed-manually when a local stdio server matches name + command + args but has no registryServerId', () => {
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp']
+        }];
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns installed-manually for a remote entry when a local server matches name + serverUrl but has no registryServerId', () => {
+        const remoteEntry: ResolvedRegistryEntry = {
+            serverId: 'io.github.example/remote-mcp',
+            name: 'Remote Example',
+            description: 'Remote MCP server',
+            localSlug: 'remote-example',
+            config: { serverUrl: 'https://example.com/mcp' },
+            version: '^1.0.0',
+            configHash: 'hash-remote',
+            mcpRegistryVerified: true
+        };
+        const locals = [{
+            name: 'remote-example',
+            serverUrl: 'https://example.com/mcp'
+        }];
+        expect(service.classifyRegistryEntry(remoteEntry, locals, [remoteEntry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns installed-manually for an unlinked local server matching the slug even if the config differs — drift only matters once linked', () => {
+        const locals = [{
+            name: 'example',
+            command: 'node',
+            args: ['-y', 'example-mcp']
+        }];
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns installed-registry-revoked when the slug-matching local is linked to a server id that is absent from the registry', () => {
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: 'io.example/gone',
+            registryVersion: '^1.0.0',
+            registryConfigHash: 'hash-v1'
+        }];
+        // The registry still publishes `entry` (slug `example`) but no longer publishes
+        // `io.example/gone`. The local must surface as revoked so the Search view mirrors
+        // what the Installed view shows (Remove instead of Link).
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'installed-registry-revoked' });
+    });
+
+    it('returns installed-manually (not revoked) when the slug-matching local is linked to a different but valid registry id', () => {
+        const otherEntry: ResolvedRegistryEntry = {
+            ...entry,
+            serverId: 'io.github.example/other-mcp',
+            localSlug: 'other'
+        };
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            // The id is real — just bound to a different registry entry. The user can still
+            // re-link this local to `entry` from Search, so we surface Link, not Remove.
+            registryServerId: otherEntry.serverId
+        }];
+        expect(service.classifyRegistryEntry(entry, locals, [entry, otherEntry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns fix-config only when the local server is already linked to this serverId but its registry-set fields diverge', () => {
+        const locals = [{
+            name: 'example',
+            command: 'node',
+            args: ['-y', 'example-mcp'],
+            registryServerId: entry.serverId,
+            registryVersion: entry.version,
+            registryConfigHash: entry.configHash
+        }];
+        expect(service.classifyRegistryEntry(entry, locals, [entry])).to.deep.equal({ kind: 'fix-config' });
+    });
+
+    it('treats user-added env keys absent from the registry config as non-drift (installed-from-registry) for linked servers', () => {
+        const entryWithEnv: ResolvedRegistryEntry = {
+            ...entry,
+            config: { command: 'npx', args: ['-y', 'example-mcp'], env: { LOG_LEVEL: 'info' } }
+        };
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            env: { LOG_LEVEL: 'info', USER_TOKEN: 'secret' },
+            registryServerId: entry.serverId,
+            registryVersion: entry.version,
+            registryConfigHash: entry.configHash
+        }];
+        expect(service.classifyRegistryEntry(entryWithEnv, locals, [entryWithEnv])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('returns fix-config when a linked server has a registry-set env value differing from the local one', () => {
+        const entryWithEnv: ResolvedRegistryEntry = {
+            ...entry,
+            config: { command: 'npx', args: ['-y', 'example-mcp'], env: { LOG_LEVEL: 'info' } }
+        };
+        const locals = [{
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            env: { LOG_LEVEL: 'debug' },
+            registryServerId: entry.serverId,
+            registryVersion: entry.version,
+            registryConfigHash: entry.configHash
+        }];
+        expect(service.classifyRegistryEntry(entryWithEnv, locals, [entryWithEnv])).to.deep.equal({ kind: 'fix-config' });
+    });
+});
+
+describe('MCPInstallService.classifyLocalServer', () => {
+
+    const exampleEntry: ResolvedRegistryEntry = {
+        serverId: 'io.github.example/example-mcp',
+        name: 'Example',
+        description: 'Example MCP server',
+        localSlug: 'example',
+        config: { command: 'npx', args: ['-y', 'example-mcp'] },
+        version: '^1.0.0',
+        configHash: 'hash-v1',
+        mcpRegistryVerified: true
+    };
+
+    let service: MCPInstallService;
+
+    beforeEach(() => {
+        service = new MCPInstallService();
+    });
+
+    it('returns installed-user-added when the local server has no registryServerId and no registry entry matches its slug', () => {
+        const local = { name: 'unrelated', command: 'node', args: ['my-script.js'] };
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-user-added' });
+    });
+
+    it('returns installed-from-registry with no update when registryServerId and registryConfigHash match', () => {
+        const local = {
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: exampleEntry.serverId,
+            registryVersion: exampleEntry.version,
+            registryConfigHash: exampleEntry.configHash
+        };
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('returns installed-from-registry with update available when registryConfigHash differs from the matched entry configHash', () => {
+        const local = {
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: exampleEntry.serverId,
+            registryVersion: exampleEntry.version,
+            registryConfigHash: 'hash-v0'
+        };
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('returns installed-registry-revoked when registryServerId points to a serverId no longer in the registry', () => {
+        const local = {
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp'],
+            registryServerId: 'io.github.example/removed-mcp',
+            registryVersion: '^1.0.0',
+            registryConfigHash: 'hash-removed'
+        };
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-registry-revoked' });
+    });
+
+    it('returns installed-manually when the local server has no registryServerId but its slug matches a registry entry', () => {
+        const local = {
+            name: 'example',
+            command: 'npx',
+            args: ['-y', 'example-mcp']
+        };
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns installed-manually when an unlinked local server has a diverging command — Link must be offered before drift is actioned', () => {
+        const local = {
+            name: 'example',
+            command: 'node',
+            args: ['-y', 'example-mcp']
+        };
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns fix-config when a linked local server has drifted away from the registry config', () => {
+        const local = {
+            name: 'example',
+            command: 'node',
+            args: ['-y', 'example-mcp'],
+            registryServerId: exampleEntry.serverId,
+            registryVersion: exampleEntry.version,
+            registryConfigHash: exampleEntry.configHash
+        };
+        expect(service.classifyLocalServer(local, [exampleEntry])).to.deep.equal({ kind: 'fix-config' });
+    });
+});
+
+describe('MCPInstallService actions', () => {
+
+    const entry: ResolvedRegistryEntry = {
+        serverId: 'io.github.example/example-mcp',
+        name: 'Example',
+        description: 'Example MCP server',
+        localSlug: 'example',
+        config: { command: 'npx', args: ['-y', 'example-mcp'] },
+        version: '^1.0.0',
+        configHash: 'hash-v1',
+        mcpRegistryVerified: true
+    };
+
+    let prefs: FakePreferenceService;
+    let service: MCPInstallService;
+
+    beforeEach(() => {
+        const container = new Container();
+        prefs = new FakePreferenceService();
+        container.bind(PreferenceService).toConstantValue(prefs);
+        // Stubs for the editor's deps — we only exercise installFromEntry which uses
+        // PreferenceService; MessageService and MCPFrontendService are referenced by other
+        // editor methods that the install path doesn't touch.
+        container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
+        container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
+        container.bind(MCPServerEditor).toSelf().inSingletonScope();
+        container.bind(MCPInstallService).toSelf().inSingletonScope();
+        service = container.get(MCPInstallService);
+    });
+
+    it('install with override autostart=false persists the user choice instead of leaving the registry default', async () => {
+        await service.install(entry, { autostart: false });
+
+        expect(prefs.snapshot<Record<string, { autostart?: boolean }>>(MCP_SERVERS_PREF)!.example.autostart).to.equal(false);
+    });
+
+    it('install with auth token override fills it into a remote entry that advertises a serverAuthToken slot', async () => {
+        const remoteEntry: ResolvedRegistryEntry = {
+            ...entry,
+            config: { serverUrl: 'https://example.com', serverAuthToken: '' }
+        };
+
+        await service.install(remoteEntry, { serverAuthToken: 'secret-123' });
+
+        expect(prefs.snapshot<Record<string, { serverAuthToken?: string }>>(MCP_SERVERS_PREF)!.example.serverAuthToken).to.equal('secret-123');
+    });
+
+    it('install ignores a token override when the registry entry has no serverAuthToken slot — keeps local entries from accidentally storing one', async () => {
+        await service.install(entry, { serverAuthToken: 'ignored' });
+
+        expect(prefs.snapshot<Record<string, Record<string, unknown>>>(MCP_SERVERS_PREF)!.example).to.not.have.property('serverAuthToken');
+    });
+
+    it('install writes a new entry with the registry config and registry metadata (including configHash) to the preference', async () => {
+        await service.install(entry);
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+    });
+
+    it('uninstall removes the entry by slug and leaves unrelated servers intact', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: { command: 'npx', args: ['-y', 'example-mcp'], registryServerId: 'io.github.example/example-mcp' },
+            other: { command: 'node', args: ['unrelated.js'] }
+        });
+
+        await service.uninstall('example');
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            other: { command: 'node', args: ['unrelated.js'] }
+        });
+    });
+
+    it('fixConfig overwrites the local config with the registry config and sets registry metadata', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'node',
+                args: ['drifted-args']
+            }
+        });
+
+        await service.fixConfig(entry);
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+    });
+
+    it('fixConfig preserves the existing autostart preference — the registry has no opinion on it', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'node',
+                args: ['drifted-args'],
+                autostart: false
+            }
+        });
+
+        await service.fixConfig(entry);
+
+        expect(prefs.snapshot<Record<string, { autostart?: boolean }>>(MCP_SERVERS_PREF)!.example.autostart).to.equal(false);
+    });
+
+    it('link sets registryServerId, registryVersion and registryConfigHash on the existing entry, leaving its config untouched', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                env: { USER_TOKEN: 'secret' },
+                autostart: true
+            }
+        });
+
+        await service.link(entry);
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                env: { USER_TOKEN: 'secret' },
+                autostart: true,
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+    });
+
+    it('update preserves a user-supplied serverAuthToken when the registry approval ships an empty slot', async () => {
+        const remoteEntry: ResolvedRegistryEntry = {
+            ...entry,
+            config: { serverUrl: 'https://example.com/mcp', serverAuthToken: '' },
+            configHash: 'hash-v2'
+        };
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                serverUrl: 'https://example.com/mcp',
+                serverAuthToken: 'user-secret',
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+
+        await service.update(remoteEntry);
+
+        expect(prefs.snapshot<Record<string, { serverAuthToken?: string }>>(MCP_SERVERS_PREF)!.example.serverAuthToken).to.equal('user-secret');
+    });
+
+    it('update strips stale local fields when the registry switches a remote entry from command/args to serverUrl', async () => {
+        const remoteEntry: ResolvedRegistryEntry = {
+            ...entry,
+            config: { serverUrl: 'https://example.com/mcp' },
+            configHash: 'hash-v2'
+        };
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                env: { LOG_LEVEL: 'debug' },
+                autostart: true,
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+
+        await service.update(remoteEntry);
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                serverUrl: 'https://example.com/mcp',
+                autostart: true,
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v2'
+            }
+        });
+    });
+
+    it('update strips stale remote fields when the registry switches an entry from serverUrl to command/args', async () => {
+        const localEntry: ResolvedRegistryEntry = {
+            ...entry,
+            config: { command: 'npx', args: ['-y', 'example-mcp'] },
+            configHash: 'hash-v2'
+        };
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                serverUrl: 'https://example.com/mcp',
+                serverAuthToken: 'user-secret',
+                serverAuthTokenHeader: 'X-Token',
+                headers: { 'X-Custom': 'value' },
+                autostart: true,
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+
+        await service.update(localEntry);
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                autostart: true,
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v2'
+            }
+        });
+    });
+
+    it('update overwrites registry-set fields, preserves user-added env keys and autostart, and bumps registryVersion + registryConfigHash', async () => {
+        const newEntry: ResolvedRegistryEntry = {
+            ...entry,
+            config: {
+                command: 'npx',
+                args: ['-y', 'example-mcp@1.0.0'],
+                env: { LOG_LEVEL: 'info' }
+            },
+            version: '^1.0.0',
+            configHash: 'hash-v2'
+        };
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp@0.9.0'],
+                env: { LOG_LEVEL: 'debug', USER_TOKEN: 'secret' },
+                autostart: false,
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^0.9.0',
+                registryConfigHash: 'hash-v1'
+            }
+        });
+
+        await service.update(newEntry);
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp@1.0.0'],
+                env: { LOG_LEVEL: 'info', USER_TOKEN: 'secret' },
+                autostart: false,
+                registryServerId: 'io.github.example/example-mcp',
+                registryVersion: '^1.0.0',
+                registryConfigHash: 'hash-v2'
+            }
+        });
+    });
+});

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
@@ -19,11 +19,12 @@ import { PreferenceScope, PreferenceService } from '@theia/core';
 import {
     isLocalMCPServerDescription,
     isRemoteMCPServerDescription,
+    MCPInstallEntryConfig,
     MCPRegistryMetadata,
     MCPServerDescription
 } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
-import { MCPInstallEntryConfig, MCPInstallOverrides, MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { MCPInstallOverrides, MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
 import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 
 export { MCPInstallOverrides };
@@ -35,8 +36,28 @@ type StoredEntry = MCPInstallEntryConfig & {
 
 type StoredServers = Record<string, StoredEntry>;
 
+export const MCPInstallService = Symbol('MCPInstallService');
+export interface MCPInstallService {
+    /** Installs a registry entry, applying any user-supplied overrides collected by the install dialog. */
+    install(entry: ResolvedRegistryEntry, overrides?: MCPInstallOverrides): Promise<void>;
+    /** Restores a drifted entry's registry-owned config fields while preserving user-owned ones. */
+    fixConfig(entry: ResolvedRegistryEntry): Promise<void>;
+    /** Applies a newer registry approval to an installed entry, preserving user-supplied additions. */
+    update(entry: ResolvedRegistryEntry): Promise<void>;
+    /** Links an existing local server to a registry entry by stamping its registry metadata. */
+    link(entry: ResolvedRegistryEntry): Promise<void>;
+    /** Drops the registry link from a local server while keeping its config intact. */
+    unlink(name: string): Promise<void>;
+    /** Removes an installed server entry by its local preference key. */
+    uninstall(name: string): Promise<void>;
+    /** Classifies a locally stored server against the registry (for the Installed view). */
+    classifyLocalServer(local: MCPServerDescription, registryEntries: ResolvedRegistryEntry[]): ClassificationResult;
+    /** Classifies a registry entry against the locally stored servers (for the Search view). */
+    classifyRegistryEntry(entry: ResolvedRegistryEntry, locals: MCPServerDescription[], registryEntries: ResolvedRegistryEntry[]): ClassificationResult;
+}
+
 @injectable()
-export class MCPInstallService {
+export class MCPInstallServiceImpl implements MCPInstallService {
 
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
@@ -54,7 +75,7 @@ export class MCPInstallService {
         // (today: autostart). The registry has no opinion on `autostart`, so wiping it on
         // fix-config would silently discard a user preference. Once the registry grows a
         // formal notion of "user-configurable parameters", extend the forwarded set here.
-        const existing = this.readServers()[entry.localSlug];
+        const existing = this.readServers()[entry.localName];
         const overrides: MCPInstallOverrides = {};
         if (existing?.autostart !== undefined) {
             overrides.autostart = existing.autostart;
@@ -64,7 +85,7 @@ export class MCPInstallService {
 
     async update(entry: ResolvedRegistryEntry): Promise<void> {
         const current = this.readServers();
-        const existing = current[entry.localSlug];
+        const existing = current[entry.localName];
         if (!existing) {
             return;
         }
@@ -107,18 +128,18 @@ export class MCPInstallService {
             ...(mergedEnv && { env: mergedEnv }),
             registryMetadata: this.metadata(entry)
         };
-        await this.writeServers({ ...current, [entry.localSlug]: updated });
+        await this.writeServers({ ...current, [entry.localName]: updated });
     }
 
     async link(entry: ResolvedRegistryEntry): Promise<void> {
         const current = this.readServers();
-        const existing = current[entry.localSlug];
+        const existing = current[entry.localName];
         if (!existing) {
             return;
         }
         await this.writeServers({
             ...current,
-            [entry.localSlug]: { ...existing, registryMetadata: this.metadata(entry) }
+            [entry.localName]: { ...existing, registryMetadata: this.metadata(entry) }
         });
     }
 
@@ -127,24 +148,24 @@ export class MCPInstallService {
      * Used to convert a stale-linked entry (registry no longer lists the serverId)
      * into a plain user-added entry without losing the user's running server config.
      */
-    async unlink(slug: string): Promise<void> {
+    async unlink(name: string): Promise<void> {
         const current = this.readServers();
-        const existing = current[slug];
+        const existing = current[name];
         if (!existing || existing.registryMetadata === undefined) {
             return;
         }
         const next: StoredEntry = { ...existing };
         delete next.registryMetadata;
-        await this.writeServers({ ...current, [slug]: next });
+        await this.writeServers({ ...current, [name]: next });
     }
 
-    async uninstall(slug: string): Promise<void> {
+    async uninstall(name: string): Promise<void> {
         const current = this.readServers();
-        if (!(slug in current)) {
+        if (!(name in current)) {
             return;
         }
         const next: StoredServers = { ...current };
-        delete next[slug];
+        delete next[name];
         await this.writeServers(next);
     }
 
@@ -174,7 +195,7 @@ export class MCPInstallService {
             }
             return this.classifyLinked(byServerId, local);
         }
-        const matchingEntry = registryEntries.find(e => e.localSlug === local.name);
+        const matchingEntry = registryEntries.find(e => e.localName === local.name);
         if (!matchingEntry) {
             return { kind: 'installed-user-added' };
         }
@@ -188,7 +209,7 @@ export class MCPInstallService {
         locals: MCPServerDescription[],
         registryEntries: ResolvedRegistryEntry[]
     ): ClassificationResult {
-        const local = locals.find(l => l.name === entry.localSlug);
+        const local = locals.find(l => l.name === entry.localName);
         if (!local) {
             return { kind: 'not-installed' };
         }

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
@@ -1,0 +1,254 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PreferenceScope, PreferenceService } from '@theia/core';
+import { isLocalMCPServerDescription, isRemoteMCPServerDescription, MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { MCPInstallOverrides, MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { ClassificationResult, ResolvedRegistryEntry, RegistryMCPServerConfigEntry } from '../../common/mcp/mcp-registry-types';
+
+export { MCPInstallOverrides };
+
+type StoredEntry = RegistryMCPServerConfigEntry & {
+    autostart?: boolean;
+    registryServerId?: string;
+    registryVersion?: string;
+    registryConfigHash?: string;
+};
+
+type StoredServers = Record<string, StoredEntry>;
+
+@injectable()
+export class MCPInstallService {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(MCPServerEditor)
+    protected readonly editor: MCPServerEditor;
+
+    /** Delegates to the generic editor so both registry installs and `install-mcp` URL handlers go through the same code path. */
+    async install(entry: ResolvedRegistryEntry, overrides?: MCPInstallOverrides): Promise<void> {
+        await this.editor.installFromEntry(entry, overrides);
+    }
+
+    async fixConfig(entry: ResolvedRegistryEntry): Promise<void> {
+        // Overwrite the registry-owned config fields, but carry forward user-owned ones
+        // (today: autostart). The registry has no opinion on `autostart`, so wiping it on
+        // fix-config would silently discard a user preference. Once the registry grows a
+        // formal notion of "user-configurable parameters", extend the forwarded set here.
+        const existing = this.readServers()[entry.localSlug];
+        const overrides: MCPInstallOverrides = {};
+        if (existing?.autostart !== undefined) {
+            overrides.autostart = existing.autostart;
+        }
+        await this.install(entry, overrides);
+    }
+
+    async update(entry: ResolvedRegistryEntry): Promise<void> {
+        const current = this.readServers();
+        const existing = current[entry.localSlug];
+        if (!existing) {
+            return;
+        }
+        // If the registry switched the entry's transport (e.g. local stdio → remote URL),
+        // drop the previous side's fields so settings.json doesn't end up carrying both.
+        const sanitized: StoredEntry = { ...existing };
+        if (entry.config.serverUrl !== undefined) {
+            delete sanitized.command;
+            delete sanitized.args;
+            delete sanitized.env;
+        } else if (entry.config.command !== undefined) {
+            delete sanitized.serverUrl;
+            delete sanitized.serverAuthToken;
+            delete sanitized.serverAuthTokenHeader;
+            delete sanitized.headers;
+        }
+        // Preserve user-added env keys; registry values win for keys the registry sets.
+        // Asymmetry: keys the registry previously set and has since dropped are also
+        // preserved here, because we cannot distinguish them from user-added keys without
+        // tracking provenance. A registry approval that published e.g. `LOG_LEVEL` in v1
+        // and removes it in v2 will leave the stale key in the local entry. This will be
+        // addressed alongside the planned "user-configurable parameters" work, which
+        // introduces an explicit registry-set vs. user-set distinction.
+        const mergedEnv = (entry.config.env || sanitized.env)
+            ? { ...sanitized.env, ...(entry.config.env ?? {}) }
+            : undefined;
+        // Preserve user-supplied additions across updates. Today we only carry the auth
+        // token forward — registries should not ship secrets, so the new approval will
+        // either omit `serverAuthToken` entirely or carry it as an empty slot, both of
+        // which would otherwise wipe a token the user previously entered in the install
+        // dialog. A broader policy for user-additions belongs with the planned parameter
+        // configuration work.
+        const userAdditions = sanitized.serverAuthToken !== undefined
+            ? { serverAuthToken: sanitized.serverAuthToken }
+            : {};
+        const updated: StoredEntry = {
+            ...sanitized,
+            ...entry.config,
+            ...userAdditions,
+            ...(mergedEnv && { env: mergedEnv }),
+            ...this.metadata(entry)
+        };
+        await this.writeServers({ ...current, [entry.localSlug]: updated });
+    }
+
+    async link(entry: ResolvedRegistryEntry): Promise<void> {
+        const current = this.readServers();
+        const existing = current[entry.localSlug];
+        if (!existing) {
+            return;
+        }
+        await this.writeServers({ ...current, [entry.localSlug]: { ...existing, ...this.metadata(entry) } });
+    }
+
+    async uninstall(slug: string): Promise<void> {
+        const current = this.readServers();
+        if (!(slug in current)) {
+            return;
+        }
+        const next: StoredServers = { ...current };
+        delete next[slug];
+        await this.writeServers(next);
+    }
+
+    protected readServers(): StoredServers {
+        return this.preferenceService.get<StoredServers>(MCP_SERVERS_PREF, {}) ?? {};
+    }
+
+    protected async writeServers(next: StoredServers): Promise<void> {
+        await this.preferenceService.set(MCP_SERVERS_PREF, next, PreferenceScope.User);
+    }
+
+    /** Registry-managed fields written onto every linked server entry. */
+    protected metadata(entry: ResolvedRegistryEntry): Pick<StoredEntry, 'registryServerId' | 'registryVersion' | 'registryConfigHash'> {
+        return {
+            registryServerId: entry.serverId,
+            ...(entry.version !== undefined && { registryVersion: entry.version }),
+            ...(entry.configHash !== undefined && { registryConfigHash: entry.configHash })
+        };
+    }
+
+    classifyLocalServer(local: MCPServerDescription, registryEntries: ResolvedRegistryEntry[]): ClassificationResult {
+        if (local.registryServerId) {
+            const byServerId = registryEntries.find(e => e.serverId === local.registryServerId);
+            if (!byServerId) {
+                return { kind: 'installed-registry-revoked' };
+            }
+            return this.classifyLinked(byServerId, local);
+        }
+        const matchingEntry = registryEntries.find(e => e.localSlug === local.name);
+        if (!matchingEntry) {
+            return { kind: 'installed-user-added' };
+        }
+        // Unlinked + same slug: always offer Link, regardless of config drift. Drift is only
+        // considered actionable (fix-config) once the user has opted in by linking.
+        return { kind: 'installed-manually' };
+    }
+
+    classifyRegistryEntry(
+        entry: ResolvedRegistryEntry,
+        locals: MCPServerDescription[],
+        registryEntries: ResolvedRegistryEntry[]
+    ): ClassificationResult {
+        const local = locals.find(l => l.name === entry.localSlug);
+        if (!local) {
+            return { kind: 'not-installed' };
+        }
+        if (local.registryServerId === entry.serverId) {
+            return this.classifyLinked(entry, local);
+        }
+        // Local links to a registry id that doesn't exist in the registry — the local is
+        // revoked. Surface the same state Installed shows so the user sees the Remove
+        // affordance in both views instead of a misleading Link button.
+        if (local.registryServerId && !registryEntries.some(e => e.serverId === local.registryServerId)) {
+            return { kind: 'installed-registry-revoked' };
+        }
+        // Same slug but not linked (no registryServerId, or pointing to a different valid
+        // id): offer Link before surfacing any drift — drift handling is a post-link concern.
+        return { kind: 'installed-manually' };
+    }
+
+    /**
+     * Classify a local server that is already linked to a registry entry. Either the
+     * registry config matches (eligible for Update when the registry has published a new
+     * approval — detected via `configHash`) or it has drifted away (`fix-config`).
+     *
+     * Update detection uses `registryConfigHash` exclusively. `registryVersion` is kept
+     * on the local entry for display only; the registry may publish a new version
+     * without changing the install config, in which case we still want to offer Update.
+     */
+    protected classifyLinked(entry: ResolvedRegistryEntry, local: MCPServerDescription): ClassificationResult {
+        if (!this.matchesByConfig(entry, local)) {
+            return { kind: 'fix-config' };
+        }
+        const updateAvailable = this.isUpdateAvailable(entry, local);
+        return { kind: 'installed-from-registry', updateAvailable };
+    }
+
+    /**
+     * True when the registry's `configHash` differs from the locally stored
+     * `registryConfigHash`. Returns false when the registry has no `configHash` to
+     * compare against (older payloads) — without a hash we cannot make a confident
+     * "update available" decision and prefer not to nag the user.
+     */
+    protected isUpdateAvailable(entry: ResolvedRegistryEntry, local: MCPServerDescription): boolean {
+        if (entry.configHash === undefined) {
+            return false;
+        }
+        return local.registryConfigHash !== entry.configHash;
+    }
+
+    protected matchesByConfig(entry: ResolvedRegistryEntry, local: MCPServerDescription): boolean {
+        if (entry.config.command !== undefined) {
+            if (!isLocalMCPServerDescription(local)) {
+                return false;
+            }
+            if (local.command !== entry.config.command) {
+                return false;
+            }
+            const entryArgs = entry.config.args ?? [];
+            const localArgs = local.args ?? [];
+            if (entryArgs.length !== localArgs.length) {
+                return false;
+            }
+            if (!entryArgs.every((value, index) => value === localArgs[index])) {
+                return false;
+            }
+            return this.envMatches(entry.config.env, local.env);
+        }
+        if (entry.config.serverUrl !== undefined) {
+            if (!isRemoteMCPServerDescription(local)) {
+                return false;
+            }
+            return local.serverUrl === entry.config.serverUrl;
+        }
+        return false;
+    }
+
+    protected envMatches(registryEnv: Record<string, string> | undefined, localEnv: Record<string, string> | undefined): boolean {
+        if (!registryEnv) {
+            return true;
+        }
+        for (const key of Object.keys(registryEnv)) {
+            if (localEnv?.[key] !== registryEnv[key]) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
@@ -199,7 +199,7 @@ export class MCPInstallServiceImpl implements MCPInstallService {
         if (!matchingEntry) {
             return { kind: 'installed-user-added' };
         }
-        // Unlinked + same slug: always offer Link, regardless of config drift. Drift is only
+        // Unlinked + same key: always offer Link, regardless of config drift. Drift is only
         // considered actionable (fix-config) once the user has opted in by linking.
         return { kind: 'installed-manually' };
     }
@@ -223,7 +223,7 @@ export class MCPInstallServiceImpl implements MCPInstallService {
         if (linkedId && !registryEntries.some(e => e.serverId === linkedId)) {
             return { kind: 'installed-link-stale' };
         }
-        // Same slug but not linked (no registryMetadata, or pointing to a different valid
+        // Same key but not linked (no registryMetadata, or pointing to a different valid
         // id): offer Link before surfacing any drift - drift handling is a post-link concern.
         return { kind: 'installed-manually' };
     }

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
@@ -16,18 +16,21 @@
 
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { PreferenceScope, PreferenceService } from '@theia/core';
-import { isLocalMCPServerDescription, isRemoteMCPServerDescription, MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import {
+    isLocalMCPServerDescription,
+    isRemoteMCPServerDescription,
+    MCPRegistryMetadata,
+    MCPServerDescription
+} from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
-import { MCPInstallOverrides, MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
-import { ClassificationResult, ResolvedRegistryEntry, RegistryMCPServerConfigEntry } from '../../common/mcp/mcp-registry-types';
+import { MCPInstallEntryConfig, MCPInstallOverrides, MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 
 export { MCPInstallOverrides };
 
-type StoredEntry = RegistryMCPServerConfigEntry & {
+type StoredEntry = MCPInstallEntryConfig & {
     autostart?: boolean;
-    registryServerId?: string;
-    registryVersion?: string;
-    registryConfigHash?: string;
+    registryMetadata?: MCPRegistryMetadata;
 };
 
 type StoredServers = Record<string, StoredEntry>;
@@ -65,7 +68,7 @@ export class MCPInstallService {
         if (!existing) {
             return;
         }
-        // If the registry switched the entry's transport (e.g. local stdio → remote URL),
+        // If the registry switched the entry's transport (e.g. local stdio -> remote URL),
         // drop the previous side's fields so settings.json doesn't end up carrying both.
         const sanitized: StoredEntry = { ...existing };
         if (entry.config.serverUrl !== undefined) {
@@ -89,7 +92,7 @@ export class MCPInstallService {
             ? { ...sanitized.env, ...(entry.config.env ?? {}) }
             : undefined;
         // Preserve user-supplied additions across updates. Today we only carry the auth
-        // token forward — registries should not ship secrets, so the new approval will
+        // token forward - registries should not ship secrets, so the new approval will
         // either omit `serverAuthToken` entirely or carry it as an empty slot, both of
         // which would otherwise wipe a token the user previously entered in the install
         // dialog. A broader policy for user-additions belongs with the planned parameter
@@ -102,7 +105,7 @@ export class MCPInstallService {
             ...entry.config,
             ...userAdditions,
             ...(mergedEnv && { env: mergedEnv }),
-            ...this.metadata(entry)
+            registryMetadata: this.metadata(entry)
         };
         await this.writeServers({ ...current, [entry.localSlug]: updated });
     }
@@ -113,7 +116,26 @@ export class MCPInstallService {
         if (!existing) {
             return;
         }
-        await this.writeServers({ ...current, [entry.localSlug]: { ...existing, ...this.metadata(entry) } });
+        await this.writeServers({
+            ...current,
+            [entry.localSlug]: { ...existing, registryMetadata: this.metadata(entry) }
+        });
+    }
+
+    /**
+     * Drop the registry link from a local server while keeping its config intact.
+     * Used to convert a stale-linked entry (registry no longer lists the serverId)
+     * into a plain user-added entry without losing the user's running server config.
+     */
+    async unlink(slug: string): Promise<void> {
+        const current = this.readServers();
+        const existing = current[slug];
+        if (!existing || existing.registryMetadata === undefined) {
+            return;
+        }
+        const next: StoredEntry = { ...existing };
+        delete next.registryMetadata;
+        await this.writeServers({ ...current, [slug]: next });
     }
 
     async uninstall(slug: string): Promise<void> {
@@ -134,20 +156,21 @@ export class MCPInstallService {
         await this.preferenceService.set(MCP_SERVERS_PREF, next, PreferenceScope.User);
     }
 
-    /** Registry-managed fields written onto every linked server entry. */
-    protected metadata(entry: ResolvedRegistryEntry): Pick<StoredEntry, 'registryServerId' | 'registryVersion' | 'registryConfigHash'> {
+    /** Registry-managed metadata block written onto every linked server entry. */
+    protected metadata(entry: ResolvedRegistryEntry): MCPRegistryMetadata {
         return {
-            registryServerId: entry.serverId,
-            ...(entry.version !== undefined && { registryVersion: entry.version }),
-            ...(entry.configHash !== undefined && { registryConfigHash: entry.configHash })
+            serverId: entry.serverId,
+            ...(entry.version !== undefined && { version: entry.version }),
+            ...(entry.configHash !== undefined && { configHash: entry.configHash })
         };
     }
 
     classifyLocalServer(local: MCPServerDescription, registryEntries: ResolvedRegistryEntry[]): ClassificationResult {
-        if (local.registryServerId) {
-            const byServerId = registryEntries.find(e => e.serverId === local.registryServerId);
+        const linkedId = local.registryMetadata?.serverId;
+        if (linkedId) {
+            const byServerId = registryEntries.find(e => e.serverId === linkedId);
             if (!byServerId) {
-                return { kind: 'installed-registry-revoked' };
+                return { kind: 'installed-link-stale' };
             }
             return this.classifyLinked(byServerId, local);
         }
@@ -169,28 +192,30 @@ export class MCPInstallService {
         if (!local) {
             return { kind: 'not-installed' };
         }
-        if (local.registryServerId === entry.serverId) {
+        const linkedId = local.registryMetadata?.serverId;
+        if (linkedId === entry.serverId) {
             return this.classifyLinked(entry, local);
         }
-        // Local links to a registry id that doesn't exist in the registry — the local is
-        // revoked. Surface the same state Installed shows so the user sees the Remove
-        // affordance in both views instead of a misleading Link button.
-        if (local.registryServerId && !registryEntries.some(e => e.serverId === local.registryServerId)) {
-            return { kind: 'installed-registry-revoked' };
+        // Local links to a registry id that doesn't exist in the registry - the link is
+        // stale. Surface the same state Installed shows so the user sees the Unlink and
+        // Uninstall affordances in both views instead of a misleading Link button.
+        if (linkedId && !registryEntries.some(e => e.serverId === linkedId)) {
+            return { kind: 'installed-link-stale' };
         }
-        // Same slug but not linked (no registryServerId, or pointing to a different valid
-        // id): offer Link before surfacing any drift — drift handling is a post-link concern.
+        // Same slug but not linked (no registryMetadata, or pointing to a different valid
+        // id): offer Link before surfacing any drift - drift handling is a post-link concern.
         return { kind: 'installed-manually' };
     }
 
     /**
      * Classify a local server that is already linked to a registry entry. Either the
      * registry config matches (eligible for Update when the registry has published a new
-     * approval — detected via `configHash`) or it has drifted away (`fix-config`).
+     * approval - detected via `configHash`) or it has drifted away (`fix-config`).
      *
-     * Update detection uses `registryConfigHash` exclusively. `registryVersion` is kept
-     * on the local entry for display only; the registry may publish a new version
-     * without changing the install config, in which case we still want to offer Update.
+     * Update detection uses `registryMetadata.configHash` exclusively.
+     * `registryMetadata.version` is kept on the local entry for display only; the
+     * registry may publish a new version without changing the install config, in which
+     * case we still want to offer Update.
      */
     protected classifyLinked(entry: ResolvedRegistryEntry, local: MCPServerDescription): ClassificationResult {
         if (!this.matchesByConfig(entry, local)) {
@@ -202,15 +227,15 @@ export class MCPInstallService {
 
     /**
      * True when the registry's `configHash` differs from the locally stored
-     * `registryConfigHash`. Returns false when the registry has no `configHash` to
-     * compare against (older payloads) — without a hash we cannot make a confident
+     * `registryMetadata.configHash`. Returns false when the registry has no `configHash`
+     * to compare against (older payloads) - without a hash we cannot make a confident
      * "update available" decision and prefer not to nag the user.
      */
     protected isUpdateAvailable(entry: ResolvedRegistryEntry, local: MCPServerDescription): boolean {
         if (entry.configHash === undefined) {
             return false;
         }
-        return local.registryConfigHash !== entry.configHash;
+        return local.registryMetadata?.configHash !== entry.configHash;
     }
 
     protected matchesByConfig(entry: ResolvedRegistryEntry, local: MCPServerDescription): boolean {

--- a/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
@@ -1,0 +1,130 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, Event } from '@theia/core';
+import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
+import { MCPInstallEntry } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { VSXExtensionsViewContainer } from '@theia/vsx-registry/lib/browser/vsx-extensions-view-container';
+import { VSXExtensionsSearchModel } from '@theia/vsx-registry/lib/browser/vsx-extensions-search-model';
+import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+
+@injectable()
+export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    @inject(WidgetManager)
+    protected readonly widgetManager: WidgetManager;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(VSXExtensionsSearchModel)
+    protected readonly searchModel: VSXExtensionsSearchModel;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    protected knownServerIds = new Set<string>();
+    protected entriesByServerId = new Map<string, ResolvedRegistryEntry>();
+
+    /** Resolves after `refreshCache` has run for the first time, success or failure. */
+    protected readonly readyDeferred = new Deferred<void>();
+
+    @postConstruct()
+    protected init(): void {
+        // Re-sync our id cache whenever the registry data changes (initial load, refresh).
+        this.fetchService.onDidChange(() => this.refreshCache());
+        // Prime the cache eagerly so the very first `hasServer` check after the UI mounts
+        // returns the right answer instead of erring on the side of "still unknown".
+        this.refreshCache();
+    }
+
+    ready(): Promise<void> {
+        return this.readyDeferred.promise;
+    }
+
+    hasServer(serverId: string): boolean {
+        return this.knownServerIds.has(serverId);
+    }
+
+    getInstallEntry(serverId: string): MCPInstallEntry | undefined {
+        const entry = this.entriesByServerId.get(serverId);
+        if (!entry) {
+            return undefined;
+        }
+        return {
+            localSlug: entry.localSlug,
+            config: { ...entry.config },
+            serverId: entry.serverId,
+            ...(entry.version !== undefined && { version: entry.version }),
+            ...(entry.configHash !== undefined && { configHash: entry.configHash })
+        };
+    }
+
+    async openRegistry(serverId?: string): Promise<void> {
+        // Pre-populate the search only for known-good ids so the entry is in focus when
+        // the view opens. For revoked ids the server appears in the Installed section
+        // (with a warning + Remove); jumping to an empty search hides it, so we just
+        // show the view and let the user see the warning in Installed.
+        if (serverId && this.hasServer(serverId)) {
+            this.searchModel.query = serverId;
+        }
+        // Reveal-and-activate rather than toggle: a second click on "Search in registry"
+        // must keep the view visible, not collapse it again.
+        const widget = await this.widgetManager.getOrCreateWidget(VSXExtensionsViewContainer.ID);
+        await this.shell.revealWidget(widget.id);
+        await this.shell.activateWidget(widget.id);
+    }
+
+    protected async refreshCache(): Promise<void> {
+        try {
+            const entries = await this.fetchService.getEntries();
+            const next = new Set(entries.map(entry => entry.serverId));
+            // Refresh the per-id lookup table regardless of whether the id set itself
+            // changed — the *contents* of an entry (config, configHash) may have moved
+            // even when the id list is unchanged, and `getInstallEntry` callers expect
+            // the latest values.
+            this.entriesByServerId = new Map(entries.map(entry => [entry.serverId, entry]));
+            if (!setsEqual(next, this.knownServerIds)) {
+                this.knownServerIds = next;
+                this.onDidChangeEmitter.fire();
+            }
+        } catch {
+            // Leave the cache as-is on failure; surfaced errors are the fetch service's job.
+        } finally {
+            // Signal readiness regardless of outcome — failed fetch is still a "we tried".
+            this.readyDeferred.resolve();
+        }
+    }
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+    if (a.size !== b.size) {
+        return false;
+    }
+    for (const value of a) {
+        if (!b.has(value)) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
@@ -72,7 +72,7 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
             return undefined;
         }
         return {
-            localSlug: entry.localSlug,
+            localName: entry.localName,
             config: { ...entry.config },
             serverId: entry.serverId,
             ...(entry.version !== undefined && { version: entry.version }),
@@ -83,12 +83,12 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
     async openRegistry(serverId?: string): Promise<void> {
         // Pre-populate the search only for known-good ids so the entry is in focus when
         // the view opens. For revoked ids the server appears in the Installed section
-        // (with a warning + Remove); jumping to an empty search hides it, so we just
-        // show the view and let the user see the warning in Installed.
+        // (with a warning + Unlink / Uninstall); jumping to an empty search hides it, so
+        // we just show the view and let the user see the warning in Installed.
         if (serverId && this.hasServer(serverId)) {
             this.searchModel.query = serverId;
         }
-        // Reveal-and-activate rather than toggle: a second click on "Search in registry"
+        // Reveal-and-activate rather than toggle: a second click on "Browse AI registry"
         // must keep the view visible, not collapse it again.
         const widget = await this.widgetManager.getOrCreateWidget(VSXExtensionsViewContainer.ID);
         await this.shell.revealWidget(widget.id);
@@ -104,7 +104,7 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
             // even when the id list is unchanged, and `getInstallEntry` callers expect
             // the latest values.
             this.entriesByServerId = new Map(entries.map(entry => [entry.serverId, entry]));
-            if (!setsEqual(next, this.knownServerIds)) {
+            if (!areSetsEqual(next, this.knownServerIds)) {
                 this.knownServerIds = next;
                 this.onDidChangeEmitter.fire();
             }
@@ -117,7 +117,7 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
     }
 }
 
-function setsEqual(a: Set<string>, b: Set<string>): boolean {
+function areSetsEqual(a: Set<string>, b: Set<string>): boolean {
     if (a.size !== b.size) {
         return false;
     }

--- a/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
@@ -100,7 +100,7 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
             const entries = await this.fetchService.getEntries();
             const next = new Set(entries.map(entry => entry.serverId));
             // Refresh the per-id lookup table regardless of whether the id set itself
-            // changed — the *contents* of an entry (config, configHash) may have moved
+            // changed - the *contents* of an entry (config, configHash) may have moved
             // even when the id list is unchanged, and `getInstallEntry` callers expect
             // the latest values.
             this.entriesByServerId = new Map(entries.map(entry => [entry.serverId, entry]));
@@ -111,7 +111,7 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
         } catch {
             // Leave the cache as-is on failure; surfaced errors are the fetch service's job.
         } finally {
-            // Signal readiness regardless of outcome — failed fetch is still a "we tried".
+            // Signal readiness regardless of outcome - failed fetch is still a "we tried".
             this.readyDeferred.resolve();
         }
     }

--- a/packages/ai-registry/src/browser/style/mcp-entries.css
+++ b/packages/ai-registry/src/browser/style/mcp-entries.css
@@ -1,0 +1,57 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource GmbH.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/** MCP-specific tweaks layered on top of the shared `.theia-vsx-extension` card. */
+
+.theia-vsx-extension-icon.theia-mcp-extension-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image: none;
+}
+
+.theia-vsx-extension-icon.theia-mcp-extension-icon .codicon {
+    font-size: calc(var(--theia-vsx-extension-icon-size) * 0.65);
+    color: var(--theia-descriptionForeground);
+}
+
+.theia-mcp-extension-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--theia-ui-padding);
+}
+
+.theia-mcp-extension-warning {
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+    font-size: 14px;
+}
+
+.theia-mcp-extension-revoked-message {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) / 2);
+    font-size: 90%;
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+}
+
+.theia-mcp-extension-actions .theia-button.action.theia-mcp-extension-remove {
+    color: var(--theia-button-foreground);
+    background-color: var(--theia-errorForeground);
+}
+
+.theia-mcp-extension-actions .theia-button.action.theia-mcp-extension-remove:hover {
+    filter: brightness(1.1);
+}

--- a/packages/ai-registry/src/browser/style/mcp-entries.css
+++ b/packages/ai-registry/src/browser/style/mcp-entries.css
@@ -32,6 +32,15 @@
     display: flex;
     align-items: center;
     gap: var(--theia-ui-padding);
+    /* Keep the action controls at full width when a long publisher string competes for space. */
+    flex-shrink: 0;
+}
+
+/* Invisible spacer reserving the same width VSX cards use for their context-menu gear,
+   so MCP and VSX action bars line up across the unified Extensions view. */
+.theia-mcp-extension-gear-placeholder {
+    visibility: hidden;
+    pointer-events: none;
 }
 
 .theia-mcp-extension-warning {
@@ -39,19 +48,10 @@
     font-size: 14px;
 }
 
-.theia-mcp-extension-revoked-message {
+.theia-mcp-extension-link-stale-message {
     display: inline-flex;
     align-items: center;
     gap: calc(var(--theia-ui-padding) / 2);
     font-size: 90%;
     color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
-}
-
-.theia-mcp-extension-actions .theia-button.action.theia-mcp-extension-remove {
-    color: var(--theia-button-foreground);
-    background-color: var(--theia-errorForeground);
-}
-
-.theia-mcp-extension-actions .theia-button.action.theia-mcp-extension-remove:hover {
-    filter: brightness(1.1);
 }

--- a/packages/ai-registry/src/browser/style/mcp-entries.css
+++ b/packages/ai-registry/src/browser/style/mcp-entries.css
@@ -31,7 +31,6 @@
 .theia-mcp-extension-actions {
     display: flex;
     align-items: center;
-    gap: var(--theia-ui-padding);
     /* Keep the action controls at full width when a long publisher string competes for space. */
     flex-shrink: 0;
 }

--- a/packages/ai-registry/src/common/ai-registry-configuration.ts
+++ b/packages/ai-registry/src/common/ai-registry-configuration.ts
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+
+/**
+ * Endpoint and tool identity for the AI registry integration.
+ *
+ * Defaults to the public Eclipse-hosted AI registry with tool name `'all'`. Products
+ * that want a different registry or a tool-specific filter rebind this class in their
+ * frontend module:
+ *
+ * ```ts
+ * rebind(AIRegistryConfiguration).toConstantValue(new (class extends AIRegistryConfiguration {
+ *     override getToolName(): string { return 'my-product'; }
+ *     override getBaseUrl(): string { return 'https://internal.example/registry/'; }
+ * })());
+ * ```
+ *
+ * Values are intentionally not exposed as user preferences — a user must not be able
+ * to redirect the IDE to a different registry URL or change the tool identity (both
+ * are trust-relevant decisions).
+ */
+@injectable()
+export class AIRegistryConfiguration {
+
+    /**
+     * Tool identifier used to scope which approvals apply. `'all'` is the safe default
+     * for any Theia-based product; rebind this in product code to filter the registry
+     * down to a tool-specific approval set.
+     */
+    getToolName(): string {
+        return 'all';
+    }
+
+    getBaseUrl(): string {
+        return 'https://eclipsefdn-ai-registry.github.io/ai-registry-core/api/v1/';
+    }
+}

--- a/packages/ai-registry/src/common/ai-registry-configuration.ts
+++ b/packages/ai-registry/src/common/ai-registry-configuration.ts
@@ -30,7 +30,7 @@ import { injectable } from '@theia/core/shared/inversify';
  * })());
  * ```
  *
- * Values are intentionally not exposed as user preferences — a user must not be able
+ * Values are intentionally not exposed as user preferences - a user must not be able
  * to redirect the IDE to a different registry URL or change the tool identity (both
  * are trust-relevant decisions).
  */

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
@@ -1,0 +1,248 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { AIRegistryConfiguration } from '../ai-registry-configuration';
+import { MCPRegistryEntryResolver } from './mcp-registry-entry-resolver';
+import { RegistryMCPServer } from './mcp-registry-types';
+
+function createResolver(toolName: string = 'theia-ide'): MCPRegistryEntryResolver {
+    const resolver = new MCPRegistryEntryResolver();
+    const configuration: AIRegistryConfiguration = Object.assign(new AIRegistryConfiguration(), {
+        getToolName(): string {
+            return toolName;
+        }
+    });
+    Object.assign(resolver, { configuration });
+    return resolver;
+}
+
+describe('MCPRegistryEntryResolver.resolve', () => {
+
+    let resolver: MCPRegistryEntryResolver;
+
+    beforeEach(() => {
+        resolver = createResolver();
+    });
+
+    it('normalises a server with a single approval, install config and inner server, propagating configHash', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/example-mcp',
+            name: 'Example',
+            description: 'Example MCP server',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                configHash: 'hash-v1',
+                installConfigs: [{
+                    tool: 'theia-ide',
+                    config: { servers: { example: { command: 'npx', args: ['-y', 'example-mcp'] } } }
+                }]
+            }]
+        };
+
+        expect(resolver.resolve(raw)).to.deep.equal({
+            serverId: 'io.github.example/example-mcp',
+            name: 'Example',
+            description: 'Example MCP server',
+            localSlug: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] },
+            version: '^1.0.0',
+            configHash: 'hash-v1',
+            mcpRegistryVerified: true
+        });
+    });
+
+    it('omits configHash when the approval has none — supports payloads pre-dating the field', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/legacy-mcp',
+            name: 'Legacy',
+            description: 'Legacy MCP server with no configHash',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                installConfigs: [{
+                    tool: 'theia-ide',
+                    config: { servers: { legacy: { command: 'npx', args: ['-y', 'legacy-mcp'] } } }
+                }]
+            }]
+        };
+
+        const resolved = resolver.resolve(raw);
+        expect(resolved).to.not.have.property('configHash');
+        expect(resolved?.version).to.equal('^1.0.0');
+    });
+
+    it('picks the most recent approval when multiple organisations approved the same server', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/example-mcp',
+            name: 'Example',
+            description: 'Example MCP server',
+            mcpRegistryVerified: true,
+            approvals: [
+                {
+                    organizationId: 'older-org',
+                    date: '2025-01-01',
+                    version: '^0.5.0',
+                    installConfigs: [{
+                        tool: 'theia-ide',
+                        config: { servers: { example: { command: 'old-cmd' } } }
+                    }]
+                },
+                {
+                    organizationId: 'newer-org',
+                    date: '2026-04-01',
+                    version: '^1.0.0',
+                    installConfigs: [{
+                        tool: 'theia-ide',
+                        config: { servers: { example: { command: 'new-cmd' } } }
+                    }]
+                }
+            ]
+        };
+
+        const resolved = resolver.resolve(raw);
+        expect(resolved?.version).to.equal('^1.0.0');
+        expect(resolved?.config).to.deep.equal({ command: 'new-cmd' });
+    });
+
+    it('returns undefined when the server has no approvals', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/orphan',
+            name: 'Orphan',
+            description: 'No approvals',
+            mcpRegistryVerified: false,
+            approvals: []
+        };
+        expect(resolver.resolve(raw)).to.be.undefined;
+    });
+
+    it('returns undefined when the picked approval has no usable install config', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/empty',
+            name: 'Empty',
+            description: 'Approval with no usable config',
+            mcpRegistryVerified: false,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                installConfigs: [{ tool: 'theia-ide' }]
+            }]
+        };
+        expect(resolver.resolve(raw)).to.be.undefined;
+    });
+
+    it('picks the install config matching the configured tool name when multiple are present', () => {
+        const productResolver = createResolver('my-product');
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/multi-tool',
+            name: 'Multi Tool',
+            description: 'Approval carrying configs for several tools',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                installConfigs: [
+                    { tool: 'theia-ide', config: { servers: { example: { command: 'theia-cmd' } } } },
+                    { tool: 'my-product', config: { servers: { example: { command: 'product-cmd' } } } }
+                ]
+            }]
+        };
+
+        expect(productResolver.resolve(raw)?.config).to.deep.equal({ command: 'product-cmd' });
+    });
+
+    it('accepts an untagged install config as a fallback when no tool-specific config matches', () => {
+        const productResolver = createResolver('my-product');
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/untagged',
+            name: 'Untagged',
+            description: 'Approval whose install config has no tool tag',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                installConfigs: [
+                    { config: { servers: { example: { command: 'untagged-cmd' } } } }
+                ]
+            }]
+        };
+
+        expect(productResolver.resolve(raw)?.config).to.deep.equal({ command: 'untagged-cmd' });
+    });
+
+    it("accepts every install config when the configured tool name is 'all'", () => {
+        const allResolver = createResolver('all');
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/all',
+            name: 'Any tool',
+            description: 'Approval whose install config is tagged for a different tool',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                installConfigs: [
+                    { tool: 'other-tool', config: { servers: { example: { command: 'other-cmd' } } } }
+                ]
+            }]
+        };
+
+        expect(allResolver.resolve(raw)?.config).to.deep.equal({ command: 'other-cmd' });
+    });
+
+    it('warns and picks the first slug deterministically when the install config exposes multiple servers', () => {
+        const raw: RegistryMCPServer = {
+            serverId: 'io.github.example/multi-server',
+            name: 'Multi Server',
+            description: 'Approval whose install config exposes multiple servers',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                installConfigs: [{
+                    tool: 'theia-ide',
+                    config: {
+                        servers: {
+                            primary: { command: 'first-cmd' },
+                            secondary: { command: 'second-cmd' }
+                        }
+                    }
+                }]
+            }]
+        };
+
+        const warnings: string[] = [];
+        const originalWarn = console.warn;
+        console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
+        try {
+            const resolved = resolver.resolve(raw);
+            expect(resolved?.localSlug).to.equal('primary');
+            expect(resolved?.config).to.deep.equal({ command: 'first-cmd' });
+            expect(warnings.some(w => w.includes('multiple servers'))).to.equal(true);
+        } finally {
+            console.warn = originalWarn;
+        }
+    });
+});

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
@@ -211,7 +211,7 @@ describe('MCPRegistryEntryResolver.resolve', () => {
         expect(allResolver.resolve(raw)?.config).to.deep.equal({ command: 'other-cmd' });
     });
 
-    it('warns and picks the first slug deterministically when the install config exposes multiple servers', () => {
+    it('warns and picks the first key deterministically when the install config exposes multiple servers', () => {
         const raw: RegistryMCPServer = {
             serverId: 'io.github.example/multi-server',
             name: 'Multi Server',

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
@@ -16,11 +16,11 @@
 
 import { expect } from 'chai';
 import { AIRegistryConfiguration } from '../ai-registry-configuration';
-import { MCPRegistryEntryResolver } from './mcp-registry-entry-resolver';
+import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from './mcp-registry-entry-resolver';
 import { RegistryMCPServer } from './mcp-registry-types';
 
 function createResolver(toolName: string = 'theia-ide'): MCPRegistryEntryResolver {
-    const resolver = new MCPRegistryEntryResolver();
+    const resolver = new MCPRegistryEntryResolverImpl();
     const configuration: AIRegistryConfiguration = Object.assign(new AIRegistryConfiguration(), {
         getToolName(): string {
             return toolName;
@@ -60,7 +60,7 @@ describe('MCPRegistryEntryResolver.resolve', () => {
             serverId: 'io.github.example/example-mcp',
             name: 'Example',
             description: 'Example MCP server',
-            localSlug: 'example',
+            localName: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] },
             version: '^1.0.0',
             configHash: 'hash-v1',
@@ -238,7 +238,7 @@ describe('MCPRegistryEntryResolver.resolve', () => {
         console.warn = (...args: unknown[]) => { warnings.push(args.map(String).join(' ')); };
         try {
             const resolved = resolver.resolve(raw);
-            expect(resolved?.localSlug).to.equal('primary');
+            expect(resolved?.localName).to.equal('primary');
             expect(resolved?.config).to.deep.equal({ command: 'first-cmd' });
             expect(warnings.some(w => w.includes('multiple servers'))).to.equal(true);
         } finally {

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.spec.ts
@@ -68,7 +68,7 @@ describe('MCPRegistryEntryResolver.resolve', () => {
         });
     });
 
-    it('omits configHash when the approval has none — supports payloads pre-dating the field', () => {
+    it('omits configHash when the approval has none - supports payloads pre-dating the field', () => {
         const raw: RegistryMCPServer = {
             serverId: 'io.github.example/legacy-mcp',
             name: 'Legacy',

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
@@ -18,8 +18,14 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { AIRegistryConfiguration } from '../ai-registry-configuration';
 import { RegistryMCPServer, ResolvedRegistryEntry } from './mcp-registry-types';
 
+export const MCPRegistryEntryResolver = Symbol('MCPRegistryEntryResolver');
+export interface MCPRegistryEntryResolver {
+    /** Normalises a raw registry server entry into the single (slug, config, version) tuple the install path uses. */
+    resolve(raw: RegistryMCPServer): ResolvedRegistryEntry | undefined;
+}
+
 @injectable()
-export class MCPRegistryEntryResolver {
+export class MCPRegistryEntryResolverImpl implements MCPRegistryEntryResolver {
 
     @inject(AIRegistryConfiguration)
     protected readonly configuration: AIRegistryConfiguration;
@@ -47,13 +53,13 @@ export class MCPRegistryEntryResolver {
             // exposed more than we use, and pick the first slug deterministically.
             console.warn(`AI registry entry ${raw.serverId} has multiple servers in its install config; using ${slugs[0]}.`);
         }
-        const localSlug = slugs[0];
+        const localName = slugs[0];
         return {
             serverId: raw.serverId,
             name: raw.name,
             description: raw.description,
-            localSlug,
-            config: servers[localSlug],
+            localName,
+            config: servers[localName],
             version: approval.version,
             ...(approval.configHash !== undefined && { configHash: approval.configHash }),
             mcpRegistryVerified: raw.mcpRegistryVerified

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
@@ -42,7 +42,7 @@ export class MCPRegistryEntryResolver {
             return undefined;
         }
         if (slugs.length > 1) {
-            // Multi-server install configs aren't a Theia concept — we install one server
+            // Multi-server install configs aren't a Theia concept - we install one server
             // per registry entry. Warn so the registry maintainer is aware their payload
             // exposed more than we use, and pick the first slug deterministically.
             console.warn(`AI registry entry ${raw.serverId} has multiple servers in its install config; using ${slugs[0]}.`);

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { AIRegistryConfiguration } from '../ai-registry-configuration';
+import { RegistryMCPServer, ResolvedRegistryEntry } from './mcp-registry-types';
+
+@injectable()
+export class MCPRegistryEntryResolver {
+
+    @inject(AIRegistryConfiguration)
+    protected readonly configuration: AIRegistryConfiguration;
+
+    resolve(raw: RegistryMCPServer): ResolvedRegistryEntry | undefined {
+        const approval = [...raw.approvals].sort((a, b) => b.date.localeCompare(a.date))[0];
+        if (!approval) {
+            return undefined;
+        }
+        // Per-tool endpoints should already pre-filter install configs, but a registry
+        // may still emit several. Pick the one tagged for our configured tool name
+        // (or untagged, which we treat as "applies to all tools"); fall back to the
+        // first config so a registry that hasn't tagged its entries still works.
+        const toolName = this.configuration.getToolName();
+        const installConfig = approval.installConfigs.find(c => !c.tool || c.tool === toolName || toolName === 'all')
+            ?? approval.installConfigs[0];
+        const servers = installConfig?.config?.servers ?? {};
+        const slugs = Object.keys(servers);
+        if (slugs.length === 0) {
+            return undefined;
+        }
+        if (slugs.length > 1) {
+            // Multi-server install configs aren't a Theia concept — we install one server
+            // per registry entry. Warn so the registry maintainer is aware their payload
+            // exposed more than we use, and pick the first slug deterministically.
+            console.warn(`AI registry entry ${raw.serverId} has multiple servers in its install config; using ${slugs[0]}.`);
+        }
+        const localSlug = slugs[0];
+        return {
+            serverId: raw.serverId,
+            name: raw.name,
+            description: raw.description,
+            localSlug,
+            config: servers[localSlug],
+            version: approval.version,
+            ...(approval.configHash !== undefined && { configHash: approval.configHash }),
+            mcpRegistryVerified: raw.mcpRegistryVerified
+        };
+    }
+}

--- a/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-entry-resolver.ts
@@ -43,17 +43,17 @@ export class MCPRegistryEntryResolverImpl implements MCPRegistryEntryResolver {
         const installConfig = approval.installConfigs.find(c => !c.tool || c.tool === toolName || toolName === 'all')
             ?? approval.installConfigs[0];
         const servers = installConfig?.config?.servers ?? {};
-        const slugs = Object.keys(servers);
-        if (slugs.length === 0) {
+        const serverKeys = Object.keys(servers);
+        if (serverKeys.length === 0) {
             return undefined;
         }
-        if (slugs.length > 1) {
+        if (serverKeys.length > 1) {
             // Multi-server install configs aren't a Theia concept - we install one server
             // per registry entry. Warn so the registry maintainer is aware their payload
             // exposed more than we use, and pick the first slug deterministically.
-            console.warn(`AI registry entry ${raw.serverId} has multiple servers in its install config; using ${slugs[0]}.`);
+            console.warn(`AI registry entry ${raw.serverId} has multiple servers in its install config; using ${serverKeys[0]}.`);
         }
-        const localName = slugs[0];
+        const localName = serverKeys[0];
         return {
             serverId: raw.serverId,
             name: raw.name,

--- a/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
@@ -1,0 +1,130 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * Shape of a single MCP server config entry inside `installConfigs[].config.servers[name]`.
+ * Mirrors the registry's "ready to paste" snippet — intentionally permissive because the
+ * registry maintainer publishes whatever the target tool understands.
+ */
+export interface RegistryMCPServerConfigEntry {
+    command?: string;
+    args?: string[];
+    env?: Record<string, string>;
+    serverUrl?: string;
+    serverAuthToken?: string;
+    serverAuthTokenHeader?: string;
+    headers?: Record<string, string>;
+}
+
+/**
+ * Shape of `installConfigs[].config` for Theia: a `servers` map keyed by the local
+ * MCP server slug chosen by the registry maintainer.
+ */
+export interface RegistryMCPInstallConfigBlob {
+    servers: Record<string, RegistryMCPServerConfigEntry>;
+}
+
+/**
+ * A single install config inside an approval. Already filtered per-tool by the registry
+ * for the per-tool view (`<baseUrl>/<toolName>.json`).
+ */
+export interface RegistryInstallConfig {
+    tool?: string;
+    installUrl?: string;
+    openVsxUrl?: string;
+    config?: RegistryMCPInstallConfigBlob;
+    instructions?: string;
+}
+
+/**
+ * One organization's approval of an MCP server entry, with the install configs for the
+ * tools that organization approved.
+ */
+export interface RegistryApproval {
+    organizationId: string;
+    date: string;
+    /** Pinned server version (per the AI-registry approval schema). Omitted means "use the latest from the Anthropic MCP registry". */
+    version?: string;
+    /**
+     * Content hash of the approval produced by the registry's consolidation pipeline.
+     * Drives update detection on the client — when the hash differs from the locally
+     * stored `registryConfigHash`, the registry has published a new approval and Theia
+     * offers an Update action. Optional for backwards compatibility with older payloads
+     * that pre-date the field.
+     */
+    configHash?: string;
+    installConfigs: RegistryInstallConfig[];
+}
+
+/**
+ * Top-level MCP server entry as returned by the registry's per-tool JSON endpoint.
+ */
+export interface RegistryMCPServer {
+    serverId: string;
+    name: string;
+    description: string;
+    mcpRegistryVerified: boolean;
+    approvals: RegistryApproval[];
+}
+
+/**
+ * A registry MCP entry after resolving the (potentially multiple) approvals and install configs
+ * down to the single (slug, config, version) tuple the install service operates on.
+ *
+ * Resolution lives in the fetch layer; the install service expects this normalised shape.
+ */
+export interface ResolvedRegistryEntry {
+    serverId: string;
+    name: string;
+    description: string;
+    /** The local preference key the registry maintainer chose (inner config.servers key). */
+    localSlug: string;
+    /** The config blob to write into `ai-features.mcp.mcpServers[localSlug]`. */
+    config: RegistryMCPServerConfigEntry;
+    /** Registry-published version. Stored alongside installed entries for display only — update detection uses {@link configHash}. */
+    version?: string;
+    /**
+     * Content hash of the chosen approval — compared against the local
+     * `registryConfigHash` to decide whether an Update is available. Optional for
+     * backwards compatibility with older registry payloads — when absent the client
+     * does not offer Update, since "no hash" is not evidence of a new version.
+     */
+    configHash?: string;
+    /** True if the entry is verified against the Anthropic MCP registry — drives the "verified only" search filter. */
+    mcpRegistryVerified: boolean;
+}
+
+/**
+ * Outcome of classifying an entry against the opposite side (registry → local prefs
+ * for search/list views, or local prefs → registry for the Installed view).
+ *
+ * Not every state is producible in both directions:
+ *
+ * - `not-installed` is only produced by `classifyRegistryEntry`.
+ * - `installed-user-added` is only produced by `classifyLocalServer`.
+ * - `installed-registry-revoked` is produced by both classifiers — `classifyLocalServer`
+ *   when a linked local points to an unknown id, and `classifyRegistryEntry` when the
+ *   slug-matching local does so. The Installed and Search views show the same Remove
+ *   affordance in either case.
+ * - `installed-from-registry`, `installed-manually`, and `fix-config` are common.
+ */
+export type ClassificationResult =
+    | { kind: 'installed-from-registry'; updateAvailable: boolean }
+    | { kind: 'installed-manually' }
+    | { kind: 'fix-config' }
+    | { kind: 'not-installed' }
+    | { kind: 'installed-registry-revoked' }
+    | { kind: 'installed-user-added' };

--- a/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
@@ -18,7 +18,7 @@ import { MCPInstallEntryConfig } from '@theia/ai-mcp/lib/common/mcp-server-manag
 
 /**
  * Shape of `installConfigs[].config` for Theia: a `servers` map keyed by the local
- * MCP server slug chosen by the registry maintainer. Server entries use the canonical
+ * MCP server key chosen by the registry maintainer. Server entries use the canonical
  * {@link MCPInstallEntryConfig} type from `@theia/ai-mcp` so the registry and the
  * install path can never drift in shape.
  */
@@ -71,7 +71,7 @@ export interface RegistryMCPServer {
 
 /**
  * A registry MCP entry after resolving the (potentially multiple) approvals and install configs
- * down to the single (slug, config, version) tuple the install service operates on.
+ * down to the single (key, config, version) tuple the install service operates on.
  *
  * Resolution lives in the fetch layer; the install service expects this normalised shape.
  */
@@ -106,7 +106,7 @@ export interface ResolvedRegistryEntry {
  * - `installed-user-added` is only produced by `classifyLocalServer`.
  * - `installed-link-stale` is produced by both classifiers - `classifyLocalServer`
  *   when a linked local points to an unknown id, and `classifyRegistryEntry` when the
- *   slug-matching local does so. The Installed and Search views show the same Unlink
+ *   key-matching local does so. The Installed and Search views show the same Unlink
  *   and Uninstall affordances in either case.
  * - `installed-from-registry`, `installed-manually`, and `fix-config` are common.
  */

--- a/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
@@ -14,27 +14,16 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-/**
- * Shape of a single MCP server config entry inside `installConfigs[].config.servers[name]`.
- * Mirrors the registry's "ready to paste" snippet — intentionally permissive because the
- * registry maintainer publishes whatever the target tool understands.
- */
-export interface RegistryMCPServerConfigEntry {
-    command?: string;
-    args?: string[];
-    env?: Record<string, string>;
-    serverUrl?: string;
-    serverAuthToken?: string;
-    serverAuthTokenHeader?: string;
-    headers?: Record<string, string>;
-}
+import { MCPInstallEntryConfig } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 
 /**
  * Shape of `installConfigs[].config` for Theia: a `servers` map keyed by the local
- * MCP server slug chosen by the registry maintainer.
+ * MCP server slug chosen by the registry maintainer. Server entries use the canonical
+ * {@link MCPInstallEntryConfig} type from `@theia/ai-mcp` so the registry and the
+ * install path can never drift in shape.
  */
 export interface RegistryMCPInstallConfigBlob {
-    servers: Record<string, RegistryMCPServerConfigEntry>;
+    servers: Record<string, MCPInstallEntryConfig>;
 }
 
 /**
@@ -60,10 +49,10 @@ export interface RegistryApproval {
     version?: string;
     /**
      * Content hash of the approval produced by the registry's consolidation pipeline.
-     * Drives update detection on the client — when the hash differs from the locally
-     * stored `registryConfigHash`, the registry has published a new approval and Theia
-     * offers an Update action. Optional for backwards compatibility with older payloads
-     * that pre-date the field.
+     * Drives update detection on the client - when the hash differs from the locally
+     * stored `registryMetadata.configHash`, the registry has published a new approval
+     * and Theia offers an Update action. Optional for backwards compatibility with
+     * older payloads that pre-date the field.
      */
     configHash?: string;
     installConfigs: RegistryInstallConfig[];
@@ -93,32 +82,32 @@ export interface ResolvedRegistryEntry {
     /** The local preference key the registry maintainer chose (inner config.servers key). */
     localSlug: string;
     /** The config blob to write into `ai-features.mcp.mcpServers[localSlug]`. */
-    config: RegistryMCPServerConfigEntry;
-    /** Registry-published version. Stored alongside installed entries for display only — update detection uses {@link configHash}. */
+    config: MCPInstallEntryConfig;
+    /** Registry-published version. Stored alongside installed entries for display only - update detection uses {@link configHash}. */
     version?: string;
     /**
-     * Content hash of the chosen approval — compared against the local
-     * `registryConfigHash` to decide whether an Update is available. Optional for
-     * backwards compatibility with older registry payloads — when absent the client
+     * Content hash of the chosen approval - compared against the local
+     * `registryMetadata.configHash` to decide whether an Update is available. Optional
+     * for backwards compatibility with older registry payloads - when absent the client
      * does not offer Update, since "no hash" is not evidence of a new version.
      */
     configHash?: string;
-    /** True if the entry is verified against the Anthropic MCP registry — drives the "verified only" search filter. */
+    /** True if the entry is verified against the Anthropic MCP registry - drives the "verified only" search filter. */
     mcpRegistryVerified: boolean;
 }
 
 /**
- * Outcome of classifying an entry against the opposite side (registry → local prefs
- * for search/list views, or local prefs → registry for the Installed view).
+ * Outcome of classifying an entry against the opposite side (registry -> local prefs
+ * for search/list views, or local prefs -> registry for the Installed view).
  *
  * Not every state is producible in both directions:
  *
  * - `not-installed` is only produced by `classifyRegistryEntry`.
  * - `installed-user-added` is only produced by `classifyLocalServer`.
- * - `installed-registry-revoked` is produced by both classifiers — `classifyLocalServer`
+ * - `installed-link-stale` is produced by both classifiers - `classifyLocalServer`
  *   when a linked local points to an unknown id, and `classifyRegistryEntry` when the
- *   slug-matching local does so. The Installed and Search views show the same Remove
- *   affordance in either case.
+ *   slug-matching local does so. The Installed and Search views show the same Unlink
+ *   and Uninstall affordances in either case.
  * - `installed-from-registry`, `installed-manually`, and `fix-config` are common.
  */
 export type ClassificationResult =
@@ -126,5 +115,5 @@ export type ClassificationResult =
     | { kind: 'installed-manually' }
     | { kind: 'fix-config' }
     | { kind: 'not-installed' }
-    | { kind: 'installed-registry-revoked' }
+    | { kind: 'installed-link-stale' }
     | { kind: 'installed-user-added' };

--- a/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
@@ -80,8 +80,8 @@ export interface ResolvedRegistryEntry {
     name: string;
     description: string;
     /** The local preference key the registry maintainer chose (inner config.servers key). */
-    localSlug: string;
-    /** The config blob to write into `ai-features.mcp.mcpServers[localSlug]`. */
+    localName: string;
+    /** The config blob to write into `ai-features.mcp.mcpServers[localName]`. */
     config: MCPInstallEntryConfig;
     /** Registry-published version. Stored alongside installed entries for display only - update detection uses {@link configHash}. */
     version?: string;

--- a/packages/ai-registry/src/common/registry-fetch-service.spec.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.spec.ts
@@ -18,8 +18,8 @@ import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
 import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
 import { AIRegistryConfiguration } from './ai-registry-configuration';
-import { MCPRegistryEntryResolver } from './mcp/mcp-registry-entry-resolver';
-import { RegistryFetchService } from './registry-fetch-service';
+import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from './mcp/mcp-registry-entry-resolver';
+import { RegistryFetchService, RegistryFetchServiceImpl } from './registry-fetch-service';
 
 class FakeRequestService implements RequestService {
     public lastUrl: string | undefined;
@@ -73,15 +73,17 @@ describe('RegistryFetchService', () => {
         const container = new Container();
         container.bind(RequestService).toConstantValue(requestService);
         container.bind(AIRegistryConfiguration).toConstantValue(config);
-        container.bind(MCPRegistryEntryResolver).toSelf().inSingletonScope();
-        container.bind(RegistryFetchService).toSelf().inSingletonScope();
+        container.bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
+        container.bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
+        container.bind(RegistryFetchServiceImpl).toSelf().inSingletonScope();
+        container.bind(RegistryFetchService).toService(RegistryFetchServiceImpl);
         return container;
     }
 
     it('fetches the per-tool JSON from <baseUrl>/<toolName>.json and returns resolved entries', async () => {
         const request = new FakeRequestService(payload());
         const config = new FakeConfiguration('theia-ide', 'https://example.test/api/v1/');
-        const service = buildContainer(request, config).get(RegistryFetchService);
+        const service = buildContainer(request, config).get<RegistryFetchService>(RegistryFetchService);
 
         const entries = await service.getEntries();
 
@@ -91,7 +93,7 @@ describe('RegistryFetchService', () => {
             serverId: 'io.github.example/example-mcp',
             name: 'Example',
             description: 'Example MCP server',
-            localSlug: 'example',
+            localName: 'example',
             config: { command: 'npx', args: ['-y', 'example-mcp'] },
             version: '^1.0.0',
             configHash: 'hash-v1',
@@ -101,7 +103,7 @@ describe('RegistryFetchService', () => {
 
     it('serves cached entries on a second call without issuing a new request', async () => {
         const request = new FakeRequestService(payload());
-        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get(RegistryFetchService);
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get<RegistryFetchService>(RegistryFetchService);
 
         await service.getEntries();
         await service.getEntries();
@@ -111,7 +113,7 @@ describe('RegistryFetchService', () => {
 
     it('refetches when forceRefresh is true', async () => {
         const request = new FakeRequestService(payload());
-        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get(RegistryFetchService);
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get<RegistryFetchService>(RegistryFetchService);
 
         await service.getEntries();
         await service.getEntries(true);
@@ -121,7 +123,7 @@ describe('RegistryFetchService', () => {
 
     it('throws a descriptive error when the server returns a non-success status', async () => {
         const request = new FakeRequestService('', 404);
-        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get(RegistryFetchService);
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get<RegistryFetchService>(RegistryFetchService);
 
         let caught: Error | undefined;
         try {

--- a/packages/ai-registry/src/common/registry-fetch-service.spec.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.spec.ts
@@ -1,0 +1,134 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
+import { AIRegistryConfiguration } from './ai-registry-configuration';
+import { MCPRegistryEntryResolver } from './mcp/mcp-registry-entry-resolver';
+import { RegistryFetchService } from './registry-fetch-service';
+
+class FakeRequestService implements RequestService {
+    public lastUrl: string | undefined;
+    public callCount = 0;
+    constructor(private readonly responseBody: string, private readonly statusCode = 200) { }
+    async configure(): Promise<void> { /* no-op */ }
+    async resolveProxy(): Promise<string | undefined> { return undefined; }
+    async request(options: RequestOptions): Promise<RequestContext> {
+        this.lastUrl = options.url;
+        this.callCount += 1;
+        return {
+            url: options.url,
+            res: { headers: {}, statusCode: this.statusCode },
+            buffer: new TextEncoder().encode(this.responseBody)
+        };
+    }
+}
+
+class FakeConfiguration extends AIRegistryConfiguration {
+    constructor(private readonly toolName: string, private readonly baseUrl: string) { super(); }
+    override getToolName(): string { return this.toolName; }
+    override getBaseUrl(): string { return this.baseUrl; }
+}
+
+function payload(): string {
+    return JSON.stringify({
+        organizations: [],
+        tools: [],
+        mcp: [{
+            serverId: 'io.github.example/example-mcp',
+            name: 'Example',
+            description: 'Example MCP server',
+            mcpRegistryVerified: true,
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                version: '^1.0.0',
+                configHash: 'hash-v1',
+                installConfigs: [{
+                    tool: 'theia-ide',
+                    config: { servers: { example: { command: 'npx', args: ['-y', 'example-mcp'] } } }
+                }]
+            }]
+        }]
+    });
+}
+
+describe('RegistryFetchService', () => {
+
+    function buildContainer(requestService: RequestService, config: AIRegistryConfiguration): Container {
+        const container = new Container();
+        container.bind(RequestService).toConstantValue(requestService);
+        container.bind(AIRegistryConfiguration).toConstantValue(config);
+        container.bind(MCPRegistryEntryResolver).toSelf().inSingletonScope();
+        container.bind(RegistryFetchService).toSelf().inSingletonScope();
+        return container;
+    }
+
+    it('fetches the per-tool JSON from <baseUrl>/<toolName>.json and returns resolved entries', async () => {
+        const request = new FakeRequestService(payload());
+        const config = new FakeConfiguration('theia-ide', 'https://example.test/api/v1/');
+        const service = buildContainer(request, config).get(RegistryFetchService);
+
+        const entries = await service.getEntries();
+
+        expect(request.lastUrl).to.equal('https://example.test/api/v1/theia-ide.json');
+        expect(entries).to.have.length(1);
+        expect(entries[0]).to.deep.equal({
+            serverId: 'io.github.example/example-mcp',
+            name: 'Example',
+            description: 'Example MCP server',
+            localSlug: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] },
+            version: '^1.0.0',
+            configHash: 'hash-v1',
+            mcpRegistryVerified: true
+        });
+    });
+
+    it('serves cached entries on a second call without issuing a new request', async () => {
+        const request = new FakeRequestService(payload());
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get(RegistryFetchService);
+
+        await service.getEntries();
+        await service.getEntries();
+
+        expect(request.callCount).to.equal(1);
+    });
+
+    it('refetches when forceRefresh is true', async () => {
+        const request = new FakeRequestService(payload());
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get(RegistryFetchService);
+
+        await service.getEntries();
+        await service.getEntries(true);
+
+        expect(request.callCount).to.equal(2);
+    });
+
+    it('throws a descriptive error when the server returns a non-success status', async () => {
+        const request = new FakeRequestService('', 404);
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get(RegistryFetchService);
+
+        let caught: Error | undefined;
+        try {
+            await service.getEntries();
+        } catch (error) {
+            caught = error as Error;
+        }
+        expect(caught?.message).to.match(/HTTP 404/);
+    });
+});

--- a/packages/ai-registry/src/common/registry-fetch-service.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.ts
@@ -25,8 +25,16 @@ interface RegistryResponse {
     mcp?: RegistryMCPServer[];
 }
 
+export const RegistryFetchService = Symbol('RegistryFetchService');
+export interface RegistryFetchService {
+    /** Fires whenever the cached set of resolved entries changes (initial load, manual refresh). */
+    readonly onDidChange: Event<void>;
+    /** Returns the resolved registry entries, fetching (and caching) them on first use or when `forceRefresh` is set. */
+    getEntries(forceRefresh?: boolean): Promise<ResolvedRegistryEntry[]>;
+}
+
 @injectable()
-export class RegistryFetchService {
+export class RegistryFetchServiceImpl implements RegistryFetchService {
 
     @inject(RequestService)
     protected readonly requestService: RequestService;

--- a/packages/ai-registry/src/common/registry-fetch-service.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.ts
@@ -1,0 +1,70 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, Event } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { RequestContext, RequestService } from '@theia/core/shared/@theia/request';
+import { AIRegistryConfiguration } from './ai-registry-configuration';
+import { MCPRegistryEntryResolver } from './mcp/mcp-registry-entry-resolver';
+import { RegistryMCPServer, ResolvedRegistryEntry } from './mcp/mcp-registry-types';
+
+interface RegistryResponse {
+    mcp?: RegistryMCPServer[];
+}
+
+@injectable()
+export class RegistryFetchService {
+
+    @inject(RequestService)
+    protected readonly requestService: RequestService;
+
+    @inject(AIRegistryConfiguration)
+    protected readonly configuration: AIRegistryConfiguration;
+
+    @inject(MCPRegistryEntryResolver)
+    protected readonly resolver: MCPRegistryEntryResolver;
+
+    protected cached: ResolvedRegistryEntry[] | undefined;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    /** Fires whenever the cached set of resolved entries changes (initial load, manual refresh). */
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    async getEntries(forceRefresh: boolean = false): Promise<ResolvedRegistryEntry[]> {
+        if (this.cached && !forceRefresh) {
+            return this.cached;
+        }
+        const url = this.buildEndpointUrl();
+        const context = await this.requestService.request({ url });
+        if (!RequestContext.isSuccess(context)) {
+            throw new Error(`Failed to fetch AI registry from ${url}: HTTP ${context.res.statusCode ?? 'unknown'}`);
+        }
+        const data = RequestContext.asJson<RegistryResponse>(context);
+        const entries = (data.mcp ?? [])
+            .map(server => this.resolver.resolve(server))
+            .filter((entry): entry is ResolvedRegistryEntry => entry !== undefined);
+        this.cached = entries;
+        this.onDidChangeEmitter.fire();
+        return entries;
+    }
+
+    protected buildEndpointUrl(): string {
+        const base = this.configuration.getBaseUrl();
+        const tool = this.configuration.getToolName();
+        const separator = base.endsWith('/') ? '' : '/';
+        return `${base}${separator}${tool}.json`;
+    }
+}

--- a/packages/ai-registry/src/package.spec.ts
+++ b/packages/ai-registry/src/package.spec.ts
@@ -1,0 +1,28 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* note: this bogus test file is required so that
+   we are able to run mocha unit tests on this
+   package, without having any actual unit tests in it.
+   This way a coverage report will be generated,
+   showing 0% coverage, instead of no report.
+   This file can be removed once we have real unit
+   tests in place. */
+
+describe('ai-registry package', () => {
+
+    it('support code coverage statistics', () => true);
+});

--- a/packages/ai-registry/tsconfig.json
+++ b/packages/ai-registry/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../ai-mcp"
+    },
+    {
+      "path": "../core"
+    },
+    {
+      "path": "../vsx-registry"
+    }
+  ]
+}

--- a/packages/vsx-registry/src/browser/extension-card.tsx
+++ b/packages/vsx-registry/src/browser/extension-card.tsx
@@ -1,0 +1,142 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { codicon, HoverPosition, HoverService } from '@theia/core/lib/browser';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+
+/**
+ * Trust state for the publisher-row icon. Both the OVSX and MCP entry types map their
+ * own notion of "verified" onto these three states:
+ *
+ * - `verified`   -> filled check (namespace-verified / registry-approved)
+ * - `unverified` -> outline check (known but not verified)
+ * - `unknown`    -> question mark (no trust information)
+ */
+export type ExtensionCardTrust = 'verified' | 'unverified' | 'unknown';
+
+/** Markdown (or plain text) tooltip shown when hovering the card. */
+export interface ExtensionCardHover {
+    readonly content: string | MarkdownString;
+    readonly hoverService: HoverService;
+    /** Defaults to `'right'`. */
+    readonly position?: HoverPosition;
+}
+
+export interface ExtensionCardProps {
+    readonly title: string;
+    readonly version?: string;
+    readonly description?: string;
+
+    /** Custom icon content (e.g. a codicon). Ignored when {@link iconUrl} is set. */
+    readonly icon?: React.ReactNode;
+    /** When set, the icon is rendered as an `<img>` from this URL. */
+    readonly iconUrl?: string;
+    /** Extra class on the icon element (e.g. `theia-mcp-extension-icon`). */
+    readonly iconClassName?: string;
+
+    /** Pill rendered next to the version indicating which contribution produced the entry. */
+    readonly typeBadge: React.ReactNode;
+    /** Extra inline labels after the type badge (e.g. `(disabled)`, `(Restricted Mode)`). */
+    readonly titleLabels?: React.ReactNode;
+    /** Right-aligned stat block in the title row (e.g. download count + rating). */
+    readonly stat?: React.ReactNode;
+
+    readonly publisher?: string;
+    /** Tooltip on the publisher row (typically the full identifier). */
+    readonly publisherTitle?: string;
+    readonly trust: ExtensionCardTrust;
+
+    /** Per-type action controls rendered at the end of the action bar. */
+    readonly actions: React.ReactNode;
+
+    /** Extra class on the card root (e.g. `theia-vsx-extension-disabled-by-trust`). */
+    readonly extraClassName?: string;
+    readonly hover?: ExtensionCardHover;
+    readonly onContextMenu?: (event: React.MouseEvent<HTMLElement>) => void;
+}
+
+function trustIconClass(trust: ExtensionCardTrust): string {
+    switch (trust) {
+        case 'verified':
+            return codicon('verified-filled');
+        case 'unverified':
+            return codicon('verified');
+        case 'unknown':
+            return codicon('question');
+    }
+}
+
+/**
+ * Visual shell shared by the OVSX extension card and the MCP server card in the unified
+ * Extensions view. Owns the layout, the icon slot, the title row (name + version + type
+ * badge), the description, the publisher row with its trust icon, and the hover tooltip.
+ *
+ * State and actions stay per-type: callers pass their own `actions` node and map their
+ * domain trust signal onto {@link ExtensionCardTrust}. This keeps both card types
+ * visually consistent (and makes adding future artifact types straightforward) without
+ * coupling their behaviour.
+ */
+export const ExtensionCard: React.FC<ExtensionCardProps> = props => {
+    const className = `theia-vsx-extension noselect${props.extraClassName ? ' ' + props.extraClassName : ''}`;
+    const onMouseEnter = props.hover
+        ? (event: React.MouseEvent<HTMLElement>) => props.hover!.hoverService.requestHover({
+            content: props.hover!.content,
+            target: event.currentTarget,
+            position: props.hover!.position ?? 'right'
+        })
+        : undefined;
+    return (
+        <div
+            className={className}
+            onMouseEnter={onMouseEnter}
+            onContextMenu={props.onContextMenu}
+        >
+            {props.iconUrl
+                ? <img className="theia-vsx-extension-icon" src={props.iconUrl} />
+                : (
+                    <div className={`theia-vsx-extension-icon placeholder${props.iconClassName ? ' ' + props.iconClassName : ''}`}>
+                        {props.icon}
+                    </div>
+                )}
+            <div className="theia-vsx-extension-content">
+                <div className="title">
+                    <div className="noWrapInfo">
+                        <span className="name">{props.title}</span>&nbsp;
+                        {props.version && <><span className="version">{props.version}</span>&nbsp;</>}
+                        {props.typeBadge}
+                        {props.titleLabels}
+                    </div>
+                    {props.stat && <div className="stat">{props.stat}</div>}
+                </div>
+                {props.description !== undefined && (
+                    <div className="noWrapInfo theia-vsx-extension-description">{props.description}</div>
+                )}
+                <div className="theia-vsx-extension-action-bar">
+                    <div className="theia-vsx-extension-publisher-container">
+                        <i className={trustIconClass(props.trust)} title={props.publisherTitle} />
+                        {props.publisher && (
+                            <span className="noWrapInfo theia-vsx-extension-publisher" title={props.publisherTitle}>
+                                {props.publisher}
+                            </span>
+                        )}
+                    </div>
+                    {props.actions}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/packages/vsx-registry/src/browser/extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/extensions-contribution.ts
@@ -1,0 +1,108 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core/lib/common/event';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+
+export const ExtensionsContribution = Symbol('ExtensionsContribution');
+
+/**
+ * Context passed to `resolveSearchResults` so contributions can honour the search
+ * bar's "only show verified" toggle (and any future filters added there).
+ */
+export interface SearchContext {
+    /**
+     * Toggled by the `extensions.onlyShowVerifiedExtensions` preference. The preference
+     * was introduced to filter the OVSX result set down to namespace-verified publishers,
+     * but the same flag also drives "verified" filters in other contributions — each one
+     * decides what "verified" means in its domain (e.g. `@theia/ai-registry` reads it as
+     * "approved in the AI registry"). Document this domain mapping next to any consumer.
+     */
+    readonly verifiedOnly: boolean;
+}
+
+/**
+ * A search hit produced by a contribution. The view collects these from all
+ * contributions and orders them globally by fuzzy-match against the current
+ * query, so the most relevant hits surface first regardless of which
+ * contribution produced them.
+ */
+export interface SearchResult {
+    readonly element: TreeElement;
+    /**
+     * Text the global fuzzy matcher should consider when ranking this entry —
+     * typically a concatenation of the entry's most distinctive fields
+     * (name, identifier, description, etc.). Contributions are encouraged to
+     * include anything the user might plausibly have searched for.
+     */
+    readonly searchableText: string;
+}
+
+/**
+ * Contribution point for the Extensions view. Each contribution represents one
+ * artifact type (e.g. `extension`, `mcp-server`, future `skill`) and supplies
+ * entries to the relevant sections of the view.
+ *
+ * Contributions implement only the modes they participate in. A contribution
+ * that has no concept of "built-in", for example, simply omits `resolveBuiltIn`.
+ *
+ * Each returned `TreeElement` carries its own `render(host)` — the contribution
+ * controls how its entries look. The view groups results by contribution type
+ * (using `displayName` as the group header) when more than one contribution
+ * yields entries for a section.
+ */
+export interface ExtensionsContribution {
+    /** Stable, machine-readable identifier for the artifact type. */
+    readonly type: string;
+
+    /** Human-readable label used as the group header in the view. */
+    readonly displayName: string;
+
+    /** Ordering hint when multiple contributions yield entries for the same section. Lower numbers come first. Defaults to 0. */
+    readonly priority?: number;
+
+    /** Fired when the contribution's entries change (e.g. after install, refresh, or preference update). */
+    readonly onDidChange: Event<void>;
+
+    /** Entries for the "Installed" section. Omit if this type has no installed concept. */
+    resolveInstalled?(): Iterable<TreeElement> | Promise<Iterable<TreeElement>>;
+
+    /**
+     * Entries matching a user search. Each result carries its own `searchableText`
+     * so the view can rank hits from all contributions against a single query.
+     * Omit if this type does not participate in search.
+     *
+     * Contributions may ignore `query` when their internal state already reflects the
+     * current query (e.g. the VSX adapter, whose model is kept in sync with the search
+     * bar via the singleton `VSXExtensionsSearchModel`). In that case the contribution
+     * is expected to yield its current result set and let the view's cross-contribution
+     * fuzzy ranker handle the actual ordering.
+     */
+    resolveSearchResults?(query: string, context: SearchContext): Iterable<SearchResult> | Promise<Iterable<SearchResult>>;
+
+    /** Entries for the "Recommended" section. Omit if this type has no recommendations. */
+    resolveRecommended?(): Iterable<TreeElement> | Promise<Iterable<TreeElement>>;
+
+    /** Entries for the "Built-in" section. Omit if this type has no built-ins. */
+    resolveBuiltIn?(): Iterable<TreeElement> | Promise<Iterable<TreeElement>>;
+
+    /**
+     * Called when the user triggers a refresh on the view toolbar. Contributions
+     * should re-fetch any remote state and fire `onDidChange` once new data is
+     * available. Optional — contributions without remote data can omit this.
+     */
+    refresh?(): Promise<void>;
+}

--- a/packages/vsx-registry/src/browser/extensions-source-contribution.ts
+++ b/packages/vsx-registry/src/browser/extensions-source-contribution.ts
@@ -17,7 +17,7 @@
 import { Event } from '@theia/core/lib/common/event';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 
-export const ExtensionsContribution = Symbol('ExtensionsContribution');
+export const ExtensionsSourceContribution = Symbol('ExtensionsSourceContribution');
 
 /**
  * Context passed to `resolveSearchResults` so contributions can honour the search
@@ -27,7 +27,7 @@ export interface SearchContext {
     /**
      * Toggled by the `extensions.onlyShowVerifiedExtensions` preference. The preference
      * was introduced to filter the OVSX result set down to namespace-verified publishers,
-     * but the same flag also drives "verified" filters in other contributions — each one
+     * but the same flag also drives "verified" filters in other contributions - each one
      * decides what "verified" means in its domain (e.g. `@theia/ai-registry` reads it as
      * "approved in the AI registry"). Document this domain mapping next to any consumer.
      */
@@ -43,7 +43,7 @@ export interface SearchContext {
 export interface SearchResult {
     readonly element: TreeElement;
     /**
-     * Text the global fuzzy matcher should consider when ranking this entry —
+     * Text the global fuzzy matcher should consider when ranking this entry -
      * typically a concatenation of the entry's most distinctive fields
      * (name, identifier, description, etc.). Contributions are encouraged to
      * include anything the user might plausibly have searched for.
@@ -59,12 +59,12 @@ export interface SearchResult {
  * Contributions implement only the modes they participate in. A contribution
  * that has no concept of "built-in", for example, simply omits `resolveBuiltIn`.
  *
- * Each returned `TreeElement` carries its own `render(host)` — the contribution
+ * Each returned `TreeElement` carries its own `render(host)` - the contribution
  * controls how its entries look. The view groups results by contribution type
  * (using `displayName` as the group header) when more than one contribution
  * yields entries for a section.
  */
-export interface ExtensionsContribution {
+export interface ExtensionsSourceContribution {
     /** Stable, machine-readable identifier for the artifact type. */
     readonly type: string;
 
@@ -102,7 +102,7 @@ export interface ExtensionsContribution {
     /**
      * Called when the user triggers a refresh on the view toolbar. Contributions
      * should re-fetch any remote state and fire `onDidChange` once new data is
-     * available. Optional — contributions without remote data can omit this.
+     * available. Optional - contributions without remote data can omit this.
      */
     refresh?(): Promise<void>;
 }

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -447,3 +447,52 @@
 .theia-vsx-extension-action-bar .action.prominent:hover {
   background-color: var(--theia-extensionButton-prominentHoverBackground);
 }
+
+/** Type badge — pill shown next to the version on each entry to indicate which contribution it came from. */
+
+.theia-extensions-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--theia-ui-font-size0);
+  padding: 0 calc(var(--theia-ui-padding) * 4 / 3);
+  border-radius: 8px;
+  background-color: var(--theia-badge-background);
+  color: var(--theia-badge-foreground);
+  white-space: nowrap;
+  vertical-align: middle;
+  line-height: 1.4;
+}
+
+.theia-extensions-type-badge .codicon {
+  font-size: 12px;
+}
+
+.theia-extensions-type-badge-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.theia-extensions-type-badge-icon--extension {
+  background-image: url("defaultIcon.png");
+}
+
+.theia-extensions-type-badge-label {
+  text-transform: uppercase;
+  font-size: 90%;
+  letter-spacing: 0.02em;
+}
+
+.theia-extensions-type-badge--extension {
+  background-color: var(--theia-extensionBadge-remoteBackground, var(--theia-badge-background));
+  color: var(--theia-extensionBadge-remoteForeground, var(--theia-badge-foreground));
+}
+
+.theia-extensions-type-badge--mcp {
+  background-color: var(--theia-inputValidation-infoBackground, var(--theia-badge-background));
+  color: var(--theia-inputValidation-infoForeground, var(--theia-badge-foreground));
+}

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -214,6 +214,9 @@
 
 .theia-vsx-extension-publisher-container {
   display: flex;
+  /* Allow the publisher text to shrink and ellipsis instead of pushing the actions out of view. */
+  min-width: 0;
+  overflow: hidden;
 }
 
 .theia-vsx-extension-action-bar .action {
@@ -448,12 +451,12 @@
   background-color: var(--theia-extensionButton-prominentHoverBackground);
 }
 
-/** Type badge — pill shown next to the version on each entry to indicate which contribution it came from. */
+/** Type badge - pill shown next to the version on each entry to indicate which contribution it came from. */
 
 .theia-extensions-type-badge {
   display: inline-flex;
   align-items: center;
-  gap: 4px;
+  gap: calc(var(--theia-ui-padding) / 2);
   font-size: var(--theia-ui-font-size0);
   padding: 0 calc(var(--theia-ui-padding) * 4 / 3);
   border-radius: 8px;
@@ -465,7 +468,7 @@
 }
 
 .theia-extensions-type-badge .codicon {
-  font-size: 12px;
+  font-size: var(--theia-ui-font-size0);
 }
 
 .theia-extensions-type-badge-icon {
@@ -482,7 +485,6 @@
 }
 
 .theia-extensions-type-badge-label {
-  text-transform: uppercase;
   font-size: 90%;
   letter-spacing: 0.02em;
 }

--- a/packages/vsx-registry/src/browser/style/index.css
+++ b/packages/vsx-registry/src/browser/style/index.css
@@ -446,3 +446,52 @@
 .theia-vsx-extension-action-bar .action.prominent:hover {
   background-color: var(--theia-extensionButton-prominentHoverBackground);
 }
+
+/** Type badge — pill shown next to the version on each entry to indicate which contribution it came from. */
+
+.theia-extensions-type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: var(--theia-ui-font-size0);
+  padding: 0 calc(var(--theia-ui-padding) * 4 / 3);
+  border-radius: 8px;
+  background-color: var(--theia-badge-background);
+  color: var(--theia-badge-foreground);
+  white-space: nowrap;
+  vertical-align: middle;
+  line-height: 1.4;
+}
+
+.theia-extensions-type-badge .codicon {
+  font-size: 12px;
+}
+
+.theia-extensions-type-badge-icon {
+  display: inline-block;
+  width: 12px;
+  height: 12px;
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: contain;
+}
+
+.theia-extensions-type-badge-icon--extension {
+  background-image: url("defaultIcon.png");
+}
+
+.theia-extensions-type-badge-label {
+  text-transform: uppercase;
+  font-size: 90%;
+  letter-spacing: 0.02em;
+}
+
+.theia-extensions-type-badge--extension {
+  background-color: var(--theia-extensionBadge-remoteBackground, var(--theia-badge-background));
+  color: var(--theia-extensionBadge-remoteForeground, var(--theia-badge-foreground));
+}
+
+.theia-extensions-type-badge--mcp {
+  background-color: var(--theia-inputValidation-infoBackground, var(--theia-badge-background));
+  color: var(--theia-inputValidation-infoForeground, var(--theia-badge-foreground));
+}

--- a/packages/vsx-registry/src/browser/type-badge.tsx
+++ b/packages/vsx-registry/src/browser/type-badge.tsx
@@ -20,7 +20,7 @@ export interface TypeBadgeProps {
     /**
      * Icon shown to the left of the label. Either pass a codicon `<i>` (e.g.
      * `<i className="codicon codicon-mcp" />`) or an image `<i>` whose CSS class
-     * sets a background-image — anything that renders as a small inline glyph.
+     * sets a background-image - anything that renders as a small inline glyph.
      */
     readonly icon: React.ReactNode;
     /** Visible label, e.g. "Extension" or "MCP". */

--- a/packages/vsx-registry/src/browser/type-badge.tsx
+++ b/packages/vsx-registry/src/browser/type-badge.tsx
@@ -1,0 +1,45 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+
+export interface TypeBadgeProps {
+    /**
+     * Icon shown to the left of the label. Either pass a codicon `<i>` (e.g.
+     * `<i className="codicon codicon-mcp" />`) or an image `<i>` whose CSS class
+     * sets a background-image — anything that renders as a small inline glyph.
+     */
+    readonly icon: React.ReactNode;
+    /** Visible label, e.g. "Extension" or "MCP". */
+    readonly label: string;
+    /**
+     * Variant key used as a CSS modifier (`theia-extensions-type-badge--{variant}`).
+     * Distinguishes badges visually (background tint) per contribution type.
+     */
+    readonly variant: string;
+    readonly title?: string;
+}
+
+/**
+ * Pill-style badge with an icon and a text label, used in the Extensions view to
+ * indicate which contribution type an entry came from (e.g. extension vs MCP server).
+ */
+export const TypeBadge: React.FC<TypeBadgeProps> = ({ icon, label, variant, title }) => (
+    <span className={`theia-extensions-type-badge theia-extensions-type-badge--${variant}`} title={title ?? label}>
+        {icon}
+        <span className="theia-extensions-type-badge-label">{label}</span>
+    </span>
+);

--- a/packages/vsx-registry/src/browser/vsx-extension-commands.ts
+++ b/packages/vsx-registry/src/browser/vsx-extension-commands.ts
@@ -73,4 +73,10 @@ export namespace VSXExtensionsCommands {
         label: 'Show Recommended Extensions',
         category: EXTENSIONS_CATEGORY,
     });
+    export const REFRESH = Command.toDefaultLocalizedCommand({
+        id: 'vsxExtension.refresh',
+        label: 'Refresh',
+        category: EXTENSIONS_CATEGORY,
+        iconClass: codicon('refresh')
+    });
 }

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -29,6 +29,7 @@ import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import { TypeBadge } from './type-badge';
+import { ExtensionCard, ExtensionCardTrust } from './extension-card';
 import { CommandRegistry, MenuPath, nls } from '@theia/core/lib/common';
 import { codicon, ConfirmDialog, ContextMenuRenderer, HoverService, TreeWidget } from '@theia/core/lib/browser';
 import { VSXExtensionNamespaceAccess, VSXUser } from '@theia/ovsx-client/lib/ovsx-types';
@@ -586,61 +587,42 @@ export class VSXExtensionComponent<Props extends VSXExtensionComponent.Props = V
             averageRating, tooltip, verified, disabled, disabledByTrust, installed
         } = this.props.extension;
 
-        return <div
-            className={`theia-vsx-extension noselect${disabledByTrust ? ' theia-vsx-extension-disabled-by-trust' : ''}`}
-            onMouseEnter={event => {
-                this.props.hoverService.requestHover({
-                    content: new MarkdownStringImpl(tooltip),
-                    target: event.currentTarget,
-                    position: 'right'
-                });
-            }}
-            onMouseUp={event => {
-                if (event.button === 2) {
-                    this.manage(event);
-                }
-            }}
-        >
-            {iconUrl ?
-                <img className='theia-vsx-extension-icon' src={iconUrl} /> :
-                <div className='theia-vsx-extension-icon placeholder' />}
-            <div className='theia-vsx-extension-content'>
-                <div className='title'>
-                    <div className='noWrapInfo'>
-                        <span className='name'>{displayName}</span>&nbsp;
-                        <span className='version'>{VSXExtension.formatVersion(version)}</span>&nbsp;
-                        <TypeBadge
-                            icon={<i className='theia-extensions-type-badge-icon theia-extensions-type-badge-icon--extension' />}
-                            label={nls.localizeByDefault('Extension')}
-                            variant='extension'
-                        />
-                        {disabled && installed && <span className='disabled'>&nbsp;({nls.localizeByDefault('disabled')})</span>}
-                        {disabledByTrust && <span className='disabled' title={nls.localizeByDefault('Disabled in Restricted Mode')}>
-                            ({nls.localizeByDefault('Restricted Mode')})
-                        </span>}
-                    </div>
-                    <div className='stat'>
-                        {!!downloadCount && <span className='download-count'><i className={codicon('cloud-download')} />{downloadCompactFormatter.format(downloadCount)}</span>}
-                        {!!averageRating && <span className='average-rating'><i className={codicon('star-full')} />{averageRatingFormatter(averageRating)}</span>}
-                    </div>
-                </div>
-                <div className='noWrapInfo theia-vsx-extension-description'>{description}</div>
+        const trust: ExtensionCardTrust = verified === true ? 'verified' : verified === false ? 'unverified' : 'unknown';
 
-                <div className='theia-vsx-extension-action-bar'>
-                    <div className='theia-vsx-extension-publisher-container'>
-                        {verified === true ? (
-                            <i className={codicon('verified-filled')} />
-                        ) : verified === false ? (
-                            <i className={codicon('verified')} />
-                        ) : (
-                            <i className={codicon('question')} />
-                        )}
-                        <span className='noWrapInfo theia-vsx-extension-publisher'>{publisher}</span>
-                    </div>
-                    {this.renderAction(this.props.host)}
-                </div>
-            </div>
-        </div >;
+        return <ExtensionCard
+            title={displayName ?? ''}
+            version={VSXExtension.formatVersion(version)}
+            // Preserve the previous behaviour of always rendering the description row.
+            description={description ?? ''}
+            iconUrl={iconUrl}
+            typeBadge={
+                <TypeBadge
+                    icon={<i className='theia-extensions-type-badge-icon theia-extensions-type-badge-icon--extension' />}
+                    label={nls.localizeByDefault('Extension')}
+                    variant='extension'
+                />
+            }
+            titleLabels={
+                <>
+                    {disabled && installed && <span className='disabled'>&nbsp;({nls.localizeByDefault('disabled')})</span>}
+                    {disabledByTrust && <span className='disabled' title={nls.localizeByDefault('Disabled in Restricted Mode')}>
+                        ({nls.localizeByDefault('Restricted Mode')})
+                    </span>}
+                </>
+            }
+            stat={
+                <>
+                    {!!downloadCount && <span className='download-count'><i className={codicon('cloud-download')} />{downloadCompactFormatter.format(downloadCount)}</span>}
+                    {!!averageRating && <span className='average-rating'><i className={codicon('star-full')} />{averageRatingFormatter(averageRating)}</span>}
+                </>
+            }
+            publisher={publisher}
+            trust={trust}
+            actions={this.renderAction(this.props.host)}
+            extraClassName={disabledByTrust ? 'theia-vsx-extension-disabled-by-trust' : undefined}
+            hover={{ content: new MarkdownStringImpl(tooltip), hoverService: this.props.hoverService }}
+            onContextMenu={event => this.manage(event)}
+        />;
     }
 }
 

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -28,6 +28,7 @@ import { ProgressService } from '@theia/core/lib/common/progress-service';
 import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
+import { TypeBadge } from './type-badge';
 import { CommandRegistry, MenuPath, nls } from '@theia/core/lib/common';
 import { codicon, ConfirmDialog, ContextMenuRenderer, HoverService, TreeWidget } from '@theia/core/lib/browser';
 import { VSXExtensionNamespaceAccess, VSXUser } from '@theia/ovsx-client/lib/ovsx-types';
@@ -607,8 +608,13 @@ export class VSXExtensionComponent<Props extends VSXExtensionComponent.Props = V
                 <div className='title'>
                     <div className='noWrapInfo'>
                         <span className='name'>{displayName}</span>&nbsp;
-                        <span className='version'>{VSXExtension.formatVersion(version)}&nbsp;
-                        </span>{disabled && installed && <span className='disabled'>({nls.localizeByDefault('disabled')})</span>}
+                        <span className='version'>{VSXExtension.formatVersion(version)}</span>&nbsp;
+                        <TypeBadge
+                            icon={<i className='theia-extensions-type-badge-icon theia-extensions-type-badge-icon--extension' />}
+                            label={nls.localizeByDefault('Extension')}
+                            variant='extension'
+                        />
+                        {disabled && installed && <span className='disabled'>&nbsp;({nls.localizeByDefault('disabled')})</span>}
                         {disabledByTrust && <span className='disabled' title={nls.localizeByDefault('Disabled in Restricted Mode')}>
                             ({nls.localizeByDefault('Restricted Mode')})
                         </span>}

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -28,6 +28,7 @@ import { ProgressService } from '@theia/core/lib/common/progress-service';
 import { Endpoint } from '@theia/core/lib/browser/endpoint';
 import { VSXEnvironment } from '../common/vsx-environment';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
+import { TypeBadge } from './type-badge';
 import { CommandRegistry, MenuPath, nls } from '@theia/core/lib/common';
 import { codicon, ConfirmDialog, ContextMenuRenderer, HoverService, TreeWidget } from '@theia/core/lib/browser';
 import { VSXExtensionNamespaceAccess, VSXUser } from '@theia/ovsx-client/lib/ovsx-types';
@@ -591,8 +592,13 @@ export class VSXExtensionComponent<Props extends VSXExtensionComponent.Props = V
                 <div className='title'>
                     <div className='noWrapInfo'>
                         <span className='name'>{displayName}</span>&nbsp;
-                        <span className='version'>{VSXExtension.formatVersion(version)}&nbsp;
-                        </span>{disabled && installed && <span className='disabled'>({nls.localizeByDefault('disabled')})</span>}
+                        <span className='version'>{VSXExtension.formatVersion(version)}</span>&nbsp;
+                        <TypeBadge
+                            icon={<i className='theia-extensions-type-badge-icon theia-extensions-type-badge-icon--extension' />}
+                            label={nls.localizeByDefault('Extension')}
+                            variant='extension'
+                        />
+                        {disabled && installed && <span className='disabled'>&nbsp;({nls.localizeByDefault('disabled')})</span>}
                         {disabledByTrust && <span className='disabled' title={nls.localizeByDefault('Disabled in Restricted Mode')}>
                             ({nls.localizeByDefault('Restricted Mode')})
                         </span>}

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.spec.ts
@@ -33,7 +33,7 @@ import { Emitter } from '@theia/core';
 import { VSXExtension } from './vsx-extension';
 import { VSXExtensionsModel } from './vsx-extensions-model';
 import { VSXExtensionsContributionAdapter } from './vsx-extensions-contribution-adapter';
-import { SearchResult } from './extensions-contribution';
+import { SearchResult } from './extensions-source-contribution';
 
 after(() => disableJSDOM());
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.spec.ts
@@ -1,0 +1,182 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+// xterm.js (pulled in transitively via plugin-ext from VSXExtensionsModel) calls
+// HTMLCanvasElement.prototype.getContext at module-load time. JSDOM's default impl
+// throws 'Not implemented' without the optional `canvas` package; replace it with a
+// no-op so the module graph evaluates. The tests below never render xterm itself.
+const canvasProto = (globalThis as { HTMLCanvasElement?: { prototype: { getContext?: unknown } } }).HTMLCanvasElement?.prototype;
+if (canvasProto) {
+    canvasProto.getContext = () => undefined;
+}
+try { FrontendApplicationConfigProvider.set({}); } catch { /* already set by a sibling spec */ }
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { Emitter } from '@theia/core';
+import { VSXExtension } from './vsx-extension';
+import { VSXExtensionsModel } from './vsx-extensions-model';
+import { VSXExtensionsContributionAdapter } from './vsx-extensions-contribution-adapter';
+import { SearchResult } from './extensions-contribution';
+
+after(() => disableJSDOM());
+
+interface StubExtensionShape {
+    id: string;
+    displayName?: string;
+    publisher?: string;
+    description?: string;
+    builtin?: boolean;
+}
+
+class StubModel {
+    readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+    private readonly extensions = new Map<string, StubExtensionShape>();
+    private _installed: string[] = [];
+    private _recommended: string[] = [];
+    private _searchResult: string[] = [];
+
+    setExtensions(extensions: StubExtensionShape[]): void {
+        for (const ext of extensions) {
+            this.extensions.set(ext.id, ext);
+        }
+    }
+    setInstalled(versioned: string[]): void { this._installed = versioned; }
+    setRecommended(ids: string[]): void { this._recommended = ids; }
+    setSearchResult(ids: string[]): void { this._searchResult = ids; }
+
+    get installed(): IterableIterator<string> { return this._installed.values(); }
+    get recommended(): IterableIterator<string> { return this._recommended.values(); }
+    get searchResult(): IterableIterator<string> { return this._searchResult.values(); }
+
+    isInstalled(id: string): boolean { return this._installed.some(v => v.startsWith(`${id}@`) || v === id); }
+    getExtension(id: string): VSXExtension | undefined {
+        return this.extensions.get(id) as unknown as VSXExtension | undefined;
+    }
+}
+
+function buildAdapter(model: StubModel): VSXExtensionsContributionAdapter {
+    const container = new Container();
+    container.bind(VSXExtensionsModel).toConstantValue(model as unknown as VSXExtensionsModel);
+    container.bind(VSXExtensionsContributionAdapter).toSelf().inSingletonScope();
+    return container.get(VSXExtensionsContributionAdapter);
+}
+
+describe('VSXExtensionsContributionAdapter.resolveInstalled', () => {
+
+    it('yields installed user extensions and filters out built-ins', () => {
+        const model = new StubModel();
+        model.setExtensions([
+            { id: 'pub.userext', displayName: 'User Ext', builtin: false },
+            { id: 'pub.builtinext', displayName: 'Builtin Ext', builtin: true }
+        ]);
+        model.setInstalled(['pub.userext@1.0.0', 'pub.builtinext@1.0.0']);
+        const adapter = buildAdapter(model);
+
+        const ids = [...adapter.resolveInstalled()].map(e => (e as unknown as StubExtensionShape).id);
+
+        expect(ids).to.deep.equal(['pub.userext']);
+    });
+
+    it('skips versioned ids whose extension is unknown to the model (entries deployed but not yet resolved)', () => {
+        const model = new StubModel();
+        model.setExtensions([{ id: 'pub.known', displayName: 'Known', builtin: false }]);
+        model.setInstalled(['pub.known@1.0.0', 'pub.unknown@1.0.0']);
+        const adapter = buildAdapter(model);
+
+        const ids = [...adapter.resolveInstalled()].map(e => (e as unknown as StubExtensionShape).id);
+
+        expect(ids).to.deep.equal(['pub.known']);
+    });
+});
+
+describe('VSXExtensionsContributionAdapter.resolveBuiltIn', () => {
+
+    it('mirrors resolveInstalled but yields only built-ins', () => {
+        const model = new StubModel();
+        model.setExtensions([
+            { id: 'pub.userext', displayName: 'User Ext', builtin: false },
+            { id: 'pub.builtinext', displayName: 'Builtin Ext', builtin: true }
+        ]);
+        model.setInstalled(['pub.userext@1.0.0', 'pub.builtinext@1.0.0']);
+        const adapter = buildAdapter(model);
+
+        const ids = [...adapter.resolveBuiltIn()].map(e => (e as unknown as StubExtensionShape).id);
+
+        expect(ids).to.deep.equal(['pub.builtinext']);
+    });
+});
+
+describe('VSXExtensionsContributionAdapter.resolveRecommended', () => {
+
+    it('yields recommendations the user does not yet have installed and that are not built-ins', () => {
+        const model = new StubModel();
+        model.setExtensions([
+            { id: 'pub.alreadyinstalled', displayName: 'Already', builtin: false },
+            { id: 'pub.builtinrec', displayName: 'Builtin Rec', builtin: true },
+            { id: 'pub.newrec', displayName: 'New Rec', builtin: false }
+        ]);
+        model.setInstalled(['pub.alreadyinstalled@1.0.0']);
+        model.setRecommended(['pub.alreadyinstalled', 'pub.builtinrec', 'pub.newrec']);
+        const adapter = buildAdapter(model);
+
+        const ids = [...adapter.resolveRecommended()].map(e => (e as unknown as StubExtensionShape).id);
+
+        // Already installed → filtered; built-in → filtered (recommendations are user-facing
+        // opt-ins, not built-ins); fresh recommendation → kept.
+        expect(ids).to.deep.equal(['pub.newrec']);
+    });
+});
+
+describe('VSXExtensionsContributionAdapter.resolveSearchResults', () => {
+
+    it("yields the model's current search result and concatenates the user-visible fields into searchableText for the global ranker", () => {
+        const model = new StubModel();
+        model.setExtensions([
+            { id: 'pub.match', displayName: 'Match', publisher: 'pub', description: 'Some description', builtin: false }
+        ]);
+        model.setSearchResult(['pub.match']);
+        const adapter = buildAdapter(model);
+
+        const results = [...adapter.resolveSearchResults()] as SearchResult[];
+
+        expect(results).to.have.length(1);
+        // The id-derived element is whatever the model returns; we only assert searchableText
+        // contains the distinctive fields used by the cross-contribution fuzzy ranker.
+        expect(results[0].searchableText).to.contain('Match');
+        expect(results[0].searchableText).to.contain('pub.match');
+        expect(results[0].searchableText).to.contain('pub');
+        expect(results[0].searchableText).to.contain('Some description');
+    });
+
+    it('omits built-ins from search results so the user can never reinstall something they already have shipped', () => {
+        const model = new StubModel();
+        model.setExtensions([
+            { id: 'pub.userext', displayName: 'User', builtin: false },
+            { id: 'pub.builtinext', displayName: 'Builtin', builtin: true }
+        ]);
+        model.setSearchResult(['pub.userext', 'pub.builtinext']);
+        const adapter = buildAdapter(model);
+
+        const ids = [...adapter.resolveSearchResults()].map(r => (r.element as unknown as StubExtensionShape).id);
+
+        expect(ids).to.deep.equal(['pub.userext']);
+    });
+});

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.ts
@@ -1,0 +1,100 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Event, nls } from '@theia/core';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { PluginIdentifiers } from '@theia/plugin-ext';
+import { ExtensionsContribution, SearchResult } from './extensions-contribution';
+import { VSXExtension } from './vsx-extension';
+import { VSXExtensionsModel } from './vsx-extensions-model';
+
+/**
+ * Adapter that exposes the VSX extensions model as a generic `ExtensionsContribution`.
+ *
+ * The model continues to own all VSX-specific state (OVSX search, plugin server
+ * lifecycle, recommendations). This adapter is a thin translation layer that lets
+ * the Extensions view query VSX entries through the same contribution mechanism
+ * as MCP servers and future artifact types.
+ */
+@injectable()
+export class VSXExtensionsContributionAdapter implements ExtensionsContribution {
+
+    readonly type = 'extension';
+    readonly displayName = nls.localizeByDefault('Extensions');
+    readonly priority = 0;
+
+    @inject(VSXExtensionsModel)
+    protected readonly model: VSXExtensionsModel;
+
+    get onDidChange(): Event<void> {
+        return this.model.onDidChange;
+    }
+
+    *resolveInstalled(): Iterable<TreeElement> {
+        yield* this.installedExtensions(false);
+    }
+
+    *resolveBuiltIn(): Iterable<TreeElement> {
+        yield* this.installedExtensions(true);
+    }
+
+    *resolveRecommended(): Iterable<TreeElement> {
+        for (const id of this.model.recommended) {
+            if (this.model.isInstalled(id)) {
+                continue;
+            }
+            const extension = this.model.getExtension(id);
+            if (extension && !extension.builtin) {
+                yield extension;
+            }
+        }
+    }
+
+    *resolveSearchResults(): Iterable<SearchResult> {
+        // VSX's search results are driven by the search bar's query into the model
+        // (the model subscribes to `VSXExtensionsSearchModel.onDidChangeQuery`). The
+        // contribution interface's `query` argument is therefore not consumed here —
+        // the model already maintains the result set in step with the query.
+        for (const id of this.model.searchResult) {
+            const extension = this.model.getExtension(id);
+            if (extension && !extension.builtin) {
+                yield { element: extension, searchableText: searchableTextFor(extension) };
+            }
+        }
+    }
+
+    protected *installedExtensions(builtIn: boolean): Iterable<VSXExtension> {
+        for (const versioned of this.model.installed) {
+            const id = PluginIdentifiers.toUnversioned(versioned as PluginIdentifiers.VersionedId);
+            const extension = this.model.getExtension(id);
+            if (!extension) {
+                continue;
+            }
+            if (Boolean(extension.builtin) === builtIn) {
+                yield extension;
+            }
+        }
+    }
+}
+
+function searchableTextFor(extension: VSXExtension): string {
+    // Concatenate the most distinctive user-visible fields so the global fuzzy
+    // matcher considers the same things the user typically searches for.
+    return [extension.displayName, extension.id, extension.publisher, extension.description]
+        .filter((s): s is string => !!s)
+        .join(' ');
+}

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.ts
@@ -18,12 +18,12 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { Event, nls } from '@theia/core';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { PluginIdentifiers } from '@theia/plugin-ext';
-import { ExtensionsContribution, SearchResult } from './extensions-contribution';
+import { ExtensionsSourceContribution, SearchResult } from './extensions-source-contribution';
 import { VSXExtension } from './vsx-extension';
 import { VSXExtensionsModel } from './vsx-extensions-model';
 
 /**
- * Adapter that exposes the VSX extensions model as a generic `ExtensionsContribution`.
+ * Adapter that exposes the VSX extensions model as a generic `ExtensionsSourceContribution`.
  *
  * The model continues to own all VSX-specific state (OVSX search, plugin server
  * lifecycle, recommendations). This adapter is a thin translation layer that lets
@@ -31,7 +31,7 @@ import { VSXExtensionsModel } from './vsx-extensions-model';
  * as MCP servers and future artifact types.
  */
 @injectable()
-export class VSXExtensionsContributionAdapter implements ExtensionsContribution {
+export class VSXExtensionsContributionAdapter implements ExtensionsSourceContribution {
 
     readonly type = 'extension';
     readonly displayName = nls.localizeByDefault('Extensions');
@@ -67,7 +67,7 @@ export class VSXExtensionsContributionAdapter implements ExtensionsContribution 
     *resolveSearchResults(): Iterable<SearchResult> {
         // VSX's search results are driven by the search bar's query into the model
         // (the model subscribes to `VSXExtensionsSearchModel.onDidChangeQuery`). The
-        // contribution interface's `query` argument is therefore not consumed here —
+        // contribution interface's `query` argument is therefore not consumed here -
         // the model already maintains the result set in step with the query.
         for (const id of this.model.searchResult) {
             const extension = this.model.getExtension(id);

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -28,7 +28,7 @@ import { Color } from '@theia/core/lib/common/color';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import URI from '@theia/core/lib/common/uri';
 import { UriAwareCommandHandler } from '@theia/core/lib/common/uri-command-handler';
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { FileDialogService, OpenFileDialogProps } from '@theia/filesystem/lib/browser';
 import { NAVIGATOR_CONTEXT_MENU } from '@theia/navigator/lib/browser/navigator-contribution';
 import { OVSXApiFilterProvider, VSXExtensionRaw } from '@theia/ovsx-client';
@@ -42,6 +42,8 @@ import { VSXExtensionsModel } from './vsx-extensions-model';
 import { BUILTIN_QUERY, INSTALLED_QUERY, RECOMMENDED_QUERY } from './vsx-extensions-search-model';
 import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
 import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { ExtensionsContribution } from './extensions-contribution';
 import debounce = require('@theia/core/shared/lodash.debounce');
 
 export namespace VSXCommands {
@@ -65,6 +67,8 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
     @inject(ApplicationServer) protected applicationServer: ApplicationServer;
     @inject(QuickInputService) protected quickInput: QuickInputService;
     @inject(SelectionService) protected readonly selectionService: SelectionService;
+    @inject(ContributionProvider) @named(ExtensionsContribution)
+    protected readonly extensionsContributions: ContributionProvider<ExtensionsContribution>;
 
     constructor() {
         super({
@@ -147,6 +151,24 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         commands.registerCommand(VSXExtensionsCommands.SHOW_RECOMMENDATIONS, {
             execute: () => this.showRecommendedExtensions()
         });
+
+        commands.registerCommand(VSXExtensionsCommands.REFRESH, {
+            execute: () => this.refresh()
+        });
+    }
+
+    /** Refreshes every contribution that opts in — e.g. MCP re-fetches its registry JSON. */
+    protected async refresh(): Promise<void> {
+        const failures = await Promise.allSettled(
+            this.extensionsContributions.getContributions()
+                .filter(c => !!c.refresh)
+                .map(c => c.refresh!())
+        );
+        for (const result of failures) {
+            if (result.status === 'rejected') {
+                console.warn('Extensions view refresh failed for one contribution:', result.reason);
+            }
+        }
     }
 
     override registerMenus(menus: MenuModelRegistry): void {

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -43,7 +43,7 @@ import { BUILTIN_QUERY, INSTALLED_QUERY, RECOMMENDED_QUERY } from './vsx-extensi
 import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
 import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
-import { ExtensionsContribution } from './extensions-contribution';
+import { ExtensionsSourceContribution } from './extensions-source-contribution';
 import debounce = require('@theia/core/shared/lodash.debounce');
 
 export namespace VSXCommands {
@@ -67,8 +67,8 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
     @inject(ApplicationServer) protected applicationServer: ApplicationServer;
     @inject(QuickInputService) protected quickInput: QuickInputService;
     @inject(SelectionService) protected readonly selectionService: SelectionService;
-    @inject(ContributionProvider) @named(ExtensionsContribution)
-    protected readonly extensionsContributions: ContributionProvider<ExtensionsContribution>;
+    @inject(ContributionProvider) @named(ExtensionsSourceContribution)
+    protected readonly extensionsContributions: ContributionProvider<ExtensionsSourceContribution>;
 
     constructor() {
         super({
@@ -157,7 +157,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         });
     }
 
-    /** Refreshes every contribution that opts in — e.g. MCP re-fetches its registry JSON. */
+    /** Refreshes every contribution that opts in - e.g. MCP re-fetches its registry JSON. */
     protected async refresh(): Promise<void> {
         const failures = await Promise.allSettled(
             this.extensionsContributions.getContributions()

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
@@ -37,7 +37,7 @@ import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsModel } from './vsx-extensions-model';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
-import { ExtensionsContribution, SearchResult } from './extensions-contribution';
+import { ExtensionsSourceContribution, SearchResult } from './extensions-source-contribution';
 
 after(() => disableJSDOM());
 
@@ -45,7 +45,7 @@ after(() => disableJSDOM());
  * Minimal contribution stub: yields a fixed set of search results. The element is
  * tagged with `id` so we can assert ordering after the fuzzy ranker has run.
  */
-class StubContribution implements ExtensionsContribution {
+class StubContribution implements ExtensionsSourceContribution {
     readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange = this.onDidChangeEmitter.event;
     constructor(
@@ -82,14 +82,14 @@ class StubPreferenceService {
     }
 }
 
-function buildSource(contributions: ExtensionsContribution[], query: string): VSXExtensionsSource {
+function buildSource(contributions: ExtensionsSourceContribution[], query: string): VSXExtensionsSource {
     const container = new Container();
     container.bind(VSXExtensionsSourceOptions).toConstantValue({ id: VSXExtensionsSourceOptions.SEARCH_RESULT });
     container.bind(VSXExtensionsModel).toConstantValue({
         onDidChange: new Emitter<void>().event
     } as unknown as VSXExtensionsModel);
-    const provider: ContributionProvider<ExtensionsContribution> = { getContributions: () => contributions };
-    container.bind(ContributionProvider).toConstantValue(provider).whenTargetNamed(ExtensionsContribution);
+    const provider: ContributionProvider<ExtensionsSourceContribution> = { getContributions: () => contributions };
+    container.bind(ContributionProvider).toConstantValue(provider).whenTargetNamed(ExtensionsSourceContribution);
     const searchModel = new StubSearchModel();
     searchModel.query = query;
     container.bind(VSXExtensionsSearchModel).toConstantValue(searchModel as unknown as VSXExtensionsSearchModel);

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
@@ -1,0 +1,155 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+// xterm.js (pulled in transitively via plugin-ext from VSXExtensionsModel) calls
+// HTMLCanvasElement.prototype.getContext at module-load time. JSDOM's default impl
+// throws 'Not implemented' without the optional `canvas` package; replace it with a
+// no-op so the module graph evaluates. The tests below never render xterm itself.
+const canvasProto = (globalThis as { HTMLCanvasElement?: { prototype: { getContext?: unknown } } }).HTMLCanvasElement?.prototype;
+if (canvasProto) {
+    canvasProto.getContext = () => undefined;
+}
+try { FrontendApplicationConfigProvider.set({}); } catch { /* already set by a sibling spec */ }
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { Emitter } from '@theia/core';
+import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
+import { FuzzySearch } from '@theia/core/lib/common/fuzzy-search';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { VSXExtensionsModel } from './vsx-extensions-model';
+import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
+import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
+import { ExtensionsContribution, SearchResult } from './extensions-contribution';
+
+after(() => disableJSDOM());
+
+/**
+ * Minimal contribution stub: yields a fixed set of search results. The element is
+ * tagged with `id` so we can assert ordering after the fuzzy ranker has run.
+ */
+class StubContribution implements ExtensionsContribution {
+    readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+    constructor(
+        readonly type: string,
+        readonly displayName: string,
+        private readonly results: SearchResult[],
+        readonly priority = 0
+    ) { }
+    resolveSearchResults(): Iterable<SearchResult> {
+        return this.results;
+    }
+}
+
+interface TaggedElement extends TreeElement {
+    readonly id: string;
+}
+
+function makeResult(id: string, searchableText: string): SearchResult {
+    const element: TaggedElement = { id, render: () => undefined };
+    return { element, searchableText };
+}
+
+class StubSearchModel {
+    query: string = '';
+}
+
+class StubPreferenceService {
+    public verifiedOnly: boolean = false;
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        if (key === 'extensions.onlyShowVerifiedExtensions') {
+            return this.verifiedOnly as unknown as T;
+        }
+        return defaultValue;
+    }
+}
+
+function buildSource(contributions: ExtensionsContribution[], query: string): VSXExtensionsSource {
+    const container = new Container();
+    container.bind(VSXExtensionsSourceOptions).toConstantValue({ id: VSXExtensionsSourceOptions.SEARCH_RESULT });
+    container.bind(VSXExtensionsModel).toConstantValue({
+        onDidChange: new Emitter<void>().event
+    } as unknown as VSXExtensionsModel);
+    const provider: ContributionProvider<ExtensionsContribution> = { getContributions: () => contributions };
+    container.bind(ContributionProvider).toConstantValue(provider).whenTargetNamed(ExtensionsContribution);
+    const searchModel = new StubSearchModel();
+    searchModel.query = query;
+    container.bind(VSXExtensionsSearchModel).toConstantValue(searchModel as unknown as VSXExtensionsSearchModel);
+    container.bind(PreferenceService).toConstantValue(new StubPreferenceService() as unknown as PreferenceService);
+    container.bind(FuzzySearch).toSelf().inSingletonScope();
+    container.bind(VSXExtensionsSource).toSelf().inSingletonScope();
+    return container.get(VSXExtensionsSource);
+}
+
+describe('VSXExtensionsSource.collectSearchResults', () => {
+
+    it('passes hits through unranked when the query is empty', async () => {
+        const contribution = new StubContribution('extension', 'Extensions', [
+            makeResult('a', 'alpha'),
+            makeResult('b', 'beta')
+        ]);
+        const source = buildSource([contribution], '');
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id)).to.deep.equal(['a', 'b']);
+    });
+
+    it('passes hits through unranked when there is only one result, regardless of query', async () => {
+        const contribution = new StubContribution('extension', 'Extensions', [
+            makeResult('only', 'unrelated text')
+        ]);
+        const source = buildSource([contribution], 'something');
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id)).to.deep.equal(['only']);
+    });
+
+    it('re-ranks hits from multiple contributions globally so the best match for the query surfaces first', async () => {
+        // First contribution exposes a weak match for "git"; second contribution exposes
+        // a much better match. Without global ranking the weak match would win simply
+        // because it came from the earlier contribution.
+        const weak = new StubContribution('extension', 'Extensions', [
+            makeResult('weakly-related', 'configuration tool that integrates with git pipelines')
+        ]);
+        const strong = new StubContribution('mcp-server', 'MCP Servers', [
+            makeResult('strong-match', 'git')
+        ], 100);
+        const source = buildSource([weak, strong], 'git');
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements[0].id).to.equal('strong-match');
+    });
+
+    it('drops hits whose searchableText does not match the query at all', async () => {
+        const contribution = new StubContribution('extension', 'Extensions', [
+            makeResult('matches', 'git client'),
+            makeResult('nope', 'totally unrelated content')
+        ]);
+        const source = buildSource([contribution], 'git');
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id)).to.deep.equal(['matches']);
+    });
+});

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -20,7 +20,7 @@ import { ContributionProvider } from '@theia/core/lib/common/contribution-provid
 import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
 import { FuzzySearch } from '@theia/core/lib/common/fuzzy-search';
 import { VSXExtensionsModel } from './vsx-extensions-model';
-import { ExtensionsContribution, SearchContext } from './extensions-contribution';
+import { ExtensionsSourceContribution, SearchContext } from './extensions-source-contribution';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import debounce = require('@theia/core/shared/lodash.debounce');
 
@@ -42,8 +42,8 @@ export class VSXExtensionsSource extends TreeSource {
     @inject(VSXExtensionsModel)
     protected readonly model: VSXExtensionsModel;
 
-    @inject(ContributionProvider) @named(ExtensionsContribution)
-    protected readonly contributions: ContributionProvider<ExtensionsContribution>;
+    @inject(ContributionProvider) @named(ExtensionsSourceContribution)
+    protected readonly contributions: ContributionProvider<ExtensionsSourceContribution>;
 
     @inject(VSXExtensionsSearchModel)
     protected readonly searchModel: VSXExtensionsSearchModel;
@@ -93,7 +93,7 @@ export class VSXExtensionsSource extends TreeSource {
      * Sort the combined hits globally by fuzzy match so the best results surface first
      * regardless of which contribution produced them.
      */
-    protected async collectSearchResults(contributions: ExtensionsContribution[]): Promise<IterableIterator<TreeElement>> {
+    protected async collectSearchResults(contributions: ExtensionsSourceContribution[]): Promise<IterableIterator<TreeElement>> {
         const query = this.searchModel.query;
         const ctx: SearchContext = {
             verifiedOnly: this.preferenceService.get<boolean>('extensions.onlyShowVerifiedExtensions', false)
@@ -112,7 +112,7 @@ export class VSXExtensionsSource extends TreeSource {
         return matches.map(m => m.item.element).values();
     }
 
-    protected async resolveForSection(contribution: ExtensionsContribution): Promise<Iterable<TreeElement> | undefined> {
+    protected async resolveForSection(contribution: ExtensionsSourceContribution): Promise<Iterable<TreeElement> | undefined> {
         switch (this.options.id) {
             case VSXExtensionsSourceOptions.INSTALLED:
                 return contribution.resolveInstalled?.();

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -14,11 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
-import { TreeSource, TreeElement } from '@theia/core/lib/browser/source-tree';
+import { injectable, inject, postConstruct, named } from '@theia/core/shared/inversify';
+import { TreeElement, TreeSource } from '@theia/core/lib/browser/source-tree';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
+import { FuzzySearch } from '@theia/core/lib/common/fuzzy-search';
 import { VSXExtensionsModel } from './vsx-extensions-model';
+import { ExtensionsContribution, SearchContext } from './extensions-contribution';
+import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import debounce = require('@theia/core/shared/lodash.debounce');
-import { PluginIdentifiers } from '@theia/plugin-ext';
 
 @injectable()
 export class VSXExtensionsSourceOptions {
@@ -38,10 +42,24 @@ export class VSXExtensionsSource extends TreeSource {
     @inject(VSXExtensionsModel)
     protected readonly model: VSXExtensionsModel;
 
+    @inject(ContributionProvider) @named(ExtensionsContribution)
+    protected readonly contributions: ContributionProvider<ExtensionsContribution>;
+
+    @inject(VSXExtensionsSearchModel)
+    protected readonly searchModel: VSXExtensionsSearchModel;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(FuzzySearch)
+    protected readonly fuzzySearch: FuzzySearch;
+
     @postConstruct()
     protected init(): void {
         this.fireDidChange();
-        this.toDispose.push(this.model.onDidChange(() => this.scheduleFireDidChange()));
+        for (const contribution of this.contributions.getContributions()) {
+            this.toDispose.push(contribution.onDidChange(() => this.scheduleFireDidChange()));
+        }
     }
 
     protected scheduleFireDidChange = debounce(() => this.fireDidChange(), 100, { leading: false, trailing: true });
@@ -50,40 +68,59 @@ export class VSXExtensionsSource extends TreeSource {
         return this.model;
     }
 
-    *getElements(): IterableIterator<TreeElement> {
-        for (const id of this.doGetElements()) {
-            const extension = this.model.getExtension(id);
-            if (!extension) {
+    async getElements(): Promise<IterableIterator<TreeElement>> {
+        const ordered = [...this.contributions.getContributions()]
+            .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+
+        if (this.options.id === VSXExtensionsSourceOptions.SEARCH_RESULT) {
+            return this.collectSearchResults(ordered);
+        }
+
+        const entries: TreeElement[] = [];
+        for (const contribution of ordered) {
+            const iter = await this.resolveForSection(contribution);
+            if (!iter) {
                 continue;
             }
-            if (this.options.id === VSXExtensionsSourceOptions.RECOMMENDED) {
-                if (this.model.isInstalled(id)) {
-                    continue;
-                }
-            }
-            if (this.options.id === VSXExtensionsSourceOptions.BUILT_IN) {
-                if (extension.builtin) {
-                    yield extension;
-                }
-            } else if (!extension.builtin) {
-                yield extension;
+            for (const entry of iter) {
+                entries.push(entry);
             }
         }
+        return entries.values();
     }
 
-    protected doGetElements(): IterableIterator<string> {
-        if (this.options.id === VSXExtensionsSourceOptions.SEARCH_RESULT) {
-            return this.model.searchResult;
-        }
-        if (this.options.id === VSXExtensionsSourceOptions.RECOMMENDED) {
-            return this.model.recommended;
-        }
-        return this.mapInstalled();
-    }
-
-    protected *mapInstalled(): IterableIterator<string> {
-        for (const installed of this.model.installed) {
-            yield PluginIdentifiers.toUnversioned(installed as PluginIdentifiers.VersionedId);
+    /**
+     * Sort the combined hits globally by fuzzy match so the best results surface first
+     * regardless of which contribution produced them.
+     */
+    protected async collectSearchResults(contributions: ExtensionsContribution[]): Promise<IterableIterator<TreeElement>> {
+        const query = this.searchModel.query;
+        const ctx: SearchContext = {
+            verifiedOnly: this.preferenceService.get<boolean>('extensions.onlyShowVerifiedExtensions', false)
         };
+        const results = await Promise.all(contributions.map(c => c.resolveSearchResults?.(query, ctx) ?? []));
+        const all = results.flatMap(r => [...r]);
+        const trimmed = query.trim();
+        if (!trimmed || all.length <= 1) {
+            return all.map(r => r.element).values();
+        }
+        const matches = await this.fuzzySearch.filter({
+            pattern: trimmed,
+            items: all,
+            transform: r => r.searchableText
+        });
+        return matches.map(m => m.item.element).values();
+    }
+
+    protected async resolveForSection(contribution: ExtensionsContribution): Promise<Iterable<TreeElement> | undefined> {
+        switch (this.options.id) {
+            case VSXExtensionsSourceOptions.INSTALLED:
+                return contribution.resolveInstalled?.();
+            case VSXExtensionsSourceOptions.RECOMMENDED:
+                return contribution.resolveRecommended?.();
+            case VSXExtensionsSourceOptions.BUILT_IN:
+                return contribution.resolveBuiltIn?.();
+        }
+        return undefined;
     }
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-view-container.ts
@@ -177,6 +177,14 @@ export class VSXExtensionsViewContainer extends ViewContainer {
             onDidChange: this.model.onDidChange,
             isVisible: (widget: Widget) => widget === this.getTabBarDelegate()
         }));
+
+        this.toDisposeOnUpdateTitle.push(this.toolbarRegistry.registerItem({
+            id: VSXExtensionsCommands.REFRESH.id,
+            command: VSXExtensionsCommands.REFRESH.id,
+            tooltip: VSXExtensionsCommands.REFRESH.label,
+            priority: 2,
+            isVisible: (widget: Widget) => widget === this.getTabBarDelegate()
+        }));
     }
 
     protected override getToggleVisibilityGroupLabel(): string {

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -27,6 +27,10 @@ import { VSXExtensionsContribution } from './vsx-extensions-contribution';
 import { VSXExtensionsSearchBar } from './vsx-extensions-search-bar';
 import { VSXExtensionsModel } from './vsx-extensions-model';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
+import { bindRootContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { FuzzySearch } from '@theia/core/lib/common/fuzzy-search';
+import { ExtensionsContribution } from './extensions-contribution';
+import { VSXExtensionsContributionAdapter } from './vsx-extensions-contribution-adapter';
 import { VSXExtensionsWidget, VSXExtensionsWidgetOptions } from './vsx-extensions-widget';
 import { VSXExtensionFactory, VSXExtension, VSXExtensionOptions } from './vsx-extension';
 import { VSXExtensionEditor } from './vsx-extension-editor';
@@ -108,6 +112,17 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bindViewContribution(bind, VSXExtensionsContribution);
     bind(FrontendApplicationContribution).toService(VSXExtensionsContribution);
     bind(ColorContribution).toService(VSXExtensionsContribution);
+
+    // Extensions view contribution provider: any package can bind an `ExtensionsContribution`
+    // to surface its artifact type (extensions, MCP servers, future skills, ...) in this view.
+    bindRootContributionProvider(bind, ExtensionsContribution);
+    bind(VSXExtensionsContributionAdapter).toSelf().inSingletonScope();
+    bind(ExtensionsContribution).toService(VSXExtensionsContributionAdapter);
+    // FuzzySearch is not bound globally by core — bind it here so the extensions
+    // source can use it to merge search results across contributions.
+    if (!isBound(FuzzySearch)) {
+        bind(FuzzySearch).toSelf().inSingletonScope();
+    }
 
     bindExtensionPreferences(bind);
     bindPreferenceProviderOverrides(bind, unbind);

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -29,7 +29,7 @@ import { VSXExtensionsModel } from './vsx-extensions-model';
 import { ColorContribution } from '@theia/core/lib/browser/color-application-contribution';
 import { bindRootContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { FuzzySearch } from '@theia/core/lib/common/fuzzy-search';
-import { ExtensionsContribution } from './extensions-contribution';
+import { ExtensionsSourceContribution } from './extensions-source-contribution';
 import { VSXExtensionsContributionAdapter } from './vsx-extensions-contribution-adapter';
 import { VSXExtensionsWidget, VSXExtensionsWidgetOptions } from './vsx-extensions-widget';
 import { VSXExtensionFactory, VSXExtension, VSXExtensionOptions } from './vsx-extension';
@@ -113,12 +113,12 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     bind(FrontendApplicationContribution).toService(VSXExtensionsContribution);
     bind(ColorContribution).toService(VSXExtensionsContribution);
 
-    // Extensions view contribution provider: any package can bind an `ExtensionsContribution`
+    // Extensions view contribution provider: any package can bind an `ExtensionsSourceContribution`
     // to surface its artifact type (extensions, MCP servers, future skills, ...) in this view.
-    bindRootContributionProvider(bind, ExtensionsContribution);
+    bindRootContributionProvider(bind, ExtensionsSourceContribution);
     bind(VSXExtensionsContributionAdapter).toSelf().inSingletonScope();
-    bind(ExtensionsContribution).toService(VSXExtensionsContributionAdapter);
-    // FuzzySearch is not bound globally by core — bind it here so the extensions
+    bind(ExtensionsSourceContribution).toService(VSXExtensionsContributionAdapter);
+    // FuzzySearch is not bound globally by core - bind it here so the extensions
     // source can use it to merge search results across contributions.
     if (!isBound(FuzzySearch)) {
         bind(FuzzySearch).toSelf().inSingletonScope();


### PR DESCRIPTION
#### What it does

Adds support for surfacing and installing approved MCP servers from the [AI Registry](https://eclipsefdn-ai-registry.github.io/ai-registry-core/) - a vendor-neutral, federated trust registry for AI artifacts hosted at the Eclipse Foundation - into Theia's existing Extensions view, alongside Open VSX extensions.

Technical highlights:

- **New `@theia/ai-registry` package.** Opt-in per product: enable it by including the package and rebinding `AIRegistryConfiguration` to point at the registry URL and tool name.
- **Generalised `ExtensionsContribution` API in `@theia/vsx-registry`.** The view aggregates entries from multiple contribution sources and ranks search hits with cross-source fuzzy matching. The existing OVSX behaviour is preserved by an adapter contribution; new artifact types (e.g. future skills) plug in by implementing `ExtensionsContribution`.
- **Server-state classification against the AI Registry.** `registryServerId`, `registryVersion` and `registryConfigHash` are stored on the local `ai-features.mcp.mcpServers` entry and drive the per-entry Install / Update / Link / Fix config / Uninstall / Remove actions.
- **New `install-mcp` deep-link handler in `@theia/ai-mcp`.** `theia://install-mcp?id=<serverId>` opens an install dialog populated from the registry. The URL carries only the id; config, version, display name and trust banner are resolved at install time. The scheme follows the product's `electron.uriScheme`, so derived products (e.g. `theia-next://install-mcp?…`) work without extra wiring.
- **MCP configuration widget moved from `@theia/ai-ide` into `@theia/ai-mcp`** and is reusable via `MCPServerEditor` (shared by the widget, the URL handler and the registry install flow). It gained registry-aware affordances (origin row, stale-link warning, "Open registry" link) through an optional `MCPRegistryUiBridge`.
- **"Manually add a MCP server"** now lives on the Extensions view toolbar (contributed by `@theia/ai-registry`) in addition to the AI Configuration MCP tab.

#### How to test

**1 - Browse and install from the registry**

1. Open the Extensions view. Confirm "MCP Servers" entries appear (Chrome DevTools MCP, GitHub, Context7…).
2. Search "github" - confirm MCP results appear interleaved with VSX results, ranked by fuzzy match.
3. Click **Install** on *Chrome DevTools MCP*. The install dialog shows the slug, autostart toggle and (for entries advertising an auth token) the token field.
4. Confirm. Open `Preferences: Open Settings (JSON)` and verify `ai-features.mcp.mcpServers.chrome-devtools` has been written with `command`, `args`, `registryServerId`, `registryVersion`, `registryConfigHash`.

**2 - Walk every button state by editing settings.json**

With the entry from step 1 installed, edit `ai-features.mcp.mcpServers.chrome-devtools` in `settings.json` and observe how the Extensions view buttons change after each save:

| Change | Visible buttons |
| --- | --- |
| (baseline, fresh install) | **Uninstall** |
| Change `registryMetadata.configHash` to any other value| **Update** + **Uninstall** |
| Remove `registryMetadata entirely | **Link** |
| Set `registryMetadata.serverId` to a value not in the registry | **Unlink + Uninstall** (with a warning banner - entry surfaces in Installed only) |
| Restore `registryMetadata.serverId`, then change `args`| **Fix config** + **Uninstall** |
| Uninstall the entry from settings (delete the key) | **Install** (back in search results) |

After clicking **Fix config**, confirm `args` snaps back to the registry's value and `registryConfigHash` is rewritten.

**3 - Manually-added MCP server is hidden from the Extensions view**

1. Use the toolbar overflow → "Add local MCP config..." to add a new local server (e.g. `my-local`, command `echo`).
2. Confirm `my-local` does **not** appear under MCP Servers in the Extensions view (it belongs to the AI configuration widget). Open AI Configuration → MCP and confirm it is listed there.

**4 - AI Configuration · MCP tab**

Open *AI Configuration* (Command Palette → "AI Configuration: Open AI Configuration"), select the **MCP** tab. With the entry from step 1 installed (Chrome DevTools MCP) and the manual server from step 3 (`my-local`):

1. The card for *Chrome DevTools MCP* shows a **From registry** link next to the server name. Click it - the Extensions view opens with the search pre-populated and the registry entry in focus.
2. The card for `my-local` does **not** show the **From registry** link (it has no `registryServerId`).
3. Click the header's **Browse AI registry** button - the Extensions view opens with the MCP section scrolled into view. (The button only appears when `@theia/ai-registry` is in the bundle - it would be hidden in a product without the registry.)
4. In `settings.json` set `registryServerId` on the Chrome DevTools entry to `"io.example/gone"` (an id not in the registry). Reopen the MCP tab and click **From registry** - the Extensions view opens on the Installed section so the user can see the revoked-entry warning + **Remove** action. Restore the original `registryServerId` afterwards.
5. Click **Add MCP Server** in the header - confirm the add-server dialog still works after the widget's move from `@theia/ai-ide` to `@theia/ai-mcp`. Cancel.

**5 - Deep-link install (`install-mcp` URL handler)**

> **Caveat:** browser-to-app routing of `theia://…` links requires OS-level protocol registration, which only happens when the app is **packaged and installed** (macOS `Info.plist`, Linux `.desktop`, Windows `setAsDefaultProtocolClient`). Neither the `npm run start:electron` dev launcher nor the `--open-url` CLI flag dispatches into a running Theia in dev mode, so reviewers cannot click a `theia://` link to test the handler.
>
> The handler itself runs in-process. The cleanest dev-mode path is to dispatch a URI directly through Theia's `OpenerService` from the renderer's DevTools console - exactly what a real protocol-routed click would trigger.

1. Start the electron app: `npm run start:electron`.
2. Open DevTools (Help → Toggle Developer Tools) → Console.
3. Paste:

   ```js
   const { default: URI } = window.theia['@theia/core/lib/common/uri'];
   const { OpenerService } = window.theia['@theia/core/lib/browser/opener-service'];
   const open = async id => {
       const uri = new URI(`theia://install-mcp?id=${encodeURIComponent(id)}`);
       const opener = await window.theia.container.get(OpenerService).getOpener(uri);
       return opener.open(uri);
   };
   ```

4. Test the **happy path** - install dialog opens populated from the registry entry:
   ```js
   open('io.github.ChromeDevTools/chrome-devtools-mcp')
   ```
5. Test the **unknown-id error path** - Theia surfaces "MCP server … is not listed in your AI registry":
   ```js
   open('com.example/unknown-mcp')
   ```
6. Test the **auth-token entry** - install dialog shows the auth-token field (the registry entry advertises `serverAuthToken`):
   ```js
   open('io.github.github/github-mcp-server')
   ```
7. Test the **already-installed prompt** - with *Chrome DevTools MCP* installed, run `open('io.github.ChromeDevTools/chrome-devtools-mcp')` again. Theia must prompt to overwrite before proceeding.

#### Follow-ups

- **Wire up `AIRegistryConfiguration` in the Theia IDE and Theia IDE Next product extensions.** Each channel should rebind the class in its frontend module to point at the registry URL it should consume (and override `getToolName()` if the channel publishes under a different tool id). The `install-mcp` URL handler already works out of the box on both channels: `MCPInstallUriConfiguration.getScheme()` reads the product's `electron.uriScheme`, so `theia://install-mcp?…` and `theia-next://install-mcp?…` are routed automatically without any product-side changes.
- **Refine which user-supplied fields are preserved across updates.** Today `MCPInstallService.update` only carries the `serverAuthToken` forward (plus any user-added env keys the registry doesn't set); everything else is overwritten by the new approval. This is intentionally narrow because the registry has no concept of "user-configurable parameters" yet. Once the registry grows a parameter mechanism (declaring which slots a user fills in vs. which the registry owns), the install service should preserve exactly those slots on update - and the install dialog should drive them too.
- **Centralise `FuzzySearch` binding in `@theia/core` browser module**
- **Surface registry-known MCP servers' friendly name consistently across UI surfaces (configuration widget, AI Configuration tab, error messages)**

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
