### PR TITLE
Use OutputChannelManager's state when available

### DIFF
--- a/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
+++ b/examples/api-samples/src/browser/output/sample-output-channel-with-severity.ts
@@ -13,15 +13,33 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { ApplicationShell, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common';
 import { inject, injectable, interfaces } from '@theia/core/shared/inversify';
 import { OutputChannelManager, OutputChannelSeverity } from '@theia/output/lib/browser/output-channel';
+import { OutputCommands } from '@theia/output/lib/browser/output-commands';
+import { OutputWidget } from '@theia/output/lib/browser/output-widget';
+
+const API_SAMPLES_CATEGORY = 'API Samples';
+
+const ShowSecondOutputChannelCommand: Command = {
+    id: 'sample-output:show-second-channel',
+    label: 'Show Second Output Channel (After Closing Widget)',
+    category: API_SAMPLES_CATEGORY,
+};
 
 @injectable()
 export class SampleOutputChannelWithSeverity
-    implements FrontendApplicationContribution {
+    implements FrontendApplicationContribution, CommandContribution {
     @inject(OutputChannelManager)
     protected readonly outputChannelManager: OutputChannelManager;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
     public onStart(): void {
         const channel = this.outputChannelManager.getChannel('API Sample: my test channel');
         channel.appendLine('hello info1'); // showed without color
@@ -41,10 +59,46 @@ export class SampleOutputChannelWithSeverity
         channel.appendLine('\x1b[4m\x1b[36mANSI underlined cyan\x1b[0m');
         channel.appendLine('Mixed: \x1b[31mANSI error\x1b[0m and \x1b[32mANSI success\x1b[0m in one line');
         channel.appendLine('\x1b[41m\x1b[37mANSI white on red background\x1b[0m');
+
+        // Create a second channel for the demo command
+        const channelB = this.outputChannelManager.getChannel('API Sample: second channel');
+        channelB.appendLine('This is the second channel.');
+        channelB.appendLine('If the dropdown selector shows this channel, the fix works.');
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(ShowSecondOutputChannelCommand, {
+            execute: async () => {
+                // Step 1: Show Channel A so it becomes the selected channel
+                await this.commandRegistry.executeCommand(OutputCommands.SHOW.id, {
+                    name: 'API Sample: my test channel',
+                    options: { preserveFocus: false }
+                });
+
+                // Step 2: Close the Output widget after a short delay
+                await new Promise(resolve => setTimeout(resolve, 500));
+                const widget = this.shell.getWidgets('bottom').find(w => w.id === OutputWidget.ID);
+                if (widget) {
+                    widget.close();
+                    widget.dispose();
+                }
+
+                // Step 3: After another delay, show Channel B.
+                // This is the race: channel.show() sets selectedChannel on the manager,
+                // which triggers widget creation. The widget should show Channel B
+                // in both the editor content AND the dropdown selector.
+                await new Promise(resolve => setTimeout(resolve, 500));
+                await this.commandRegistry.executeCommand(OutputCommands.SHOW.id, {
+                    name: 'API Sample: second channel',
+                    options: { preserveFocus: false }
+                });
+            }
+        });
     }
 }
+
 export const bindSampleOutputChannelWithSeverity = (bind: interfaces.Bind) => {
-    bind(FrontendApplicationContribution)
-        .to(SampleOutputChannelWithSeverity)
-        .inSingletonScope();
+    bind(SampleOutputChannelWithSeverity).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(SampleOutputChannelWithSeverity);
+    bind(CommandContribution).toService(SampleOutputChannelWithSeverity);
 };

--- a/packages/output/src/browser/output-channel.ts
+++ b/packages/output/src/browser/output-channel.ts
@@ -78,9 +78,6 @@ export class OutputChannelManager implements Disposable, ResourceResolver {
         const channel = this.createChannel(resource);
         this.channels.set(name, channel);
         this.toDisposeOnChannelDeletion.set(name, this.registerListeners(channel));
-        if (!this.selectedChannel) {
-            this.selectedChannel = channel;
-        }
         this.channelAddedEmitter.fire(channel);
         return channel;
     }

--- a/packages/output/src/browser/output-toolbar-contribution.tsx
+++ b/packages/output/src/browser/output-toolbar-contribution.tsx
@@ -19,9 +19,9 @@ import { inject, injectable, postConstruct } from '@theia/core/shared/inversify'
 import { Emitter } from '@theia/core/lib/common/event';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { SelectComponent, SelectOption } from '@theia/core/lib/browser/widgets/select-component';
+import { WidgetManager } from '@theia/core/lib/browser/widget-manager';
 import { OutputWidget } from './output-widget';
 import { OutputCommands } from './output-commands';
-import { OutputContribution } from './output-contribution';
 import { OutputChannelManager } from './output-channel';
 import { nls } from '@theia/core/lib/common/nls';
 
@@ -31,8 +31,8 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
     @inject(OutputChannelManager)
     protected readonly outputChannelManager: OutputChannelManager;
 
-    @inject(OutputContribution)
-    protected readonly outputContribution: OutputContribution;
+    @inject(WidgetManager)
+    protected readonly widgetManager: WidgetManager;
 
     protected readonly onOutputWidgetStateChangedEmitter = new Emitter<void>();
     protected readonly onOutputWidgetStateChanged = this.onOutputWidgetStateChangedEmitter.event;
@@ -42,8 +42,10 @@ export class OutputToolbarContribution implements TabBarToolbarContribution {
 
     @postConstruct()
     protected init(): void {
-        this.outputContribution.widget.then(widget => {
-            widget.onStateChanged(() => this.onOutputWidgetStateChangedEmitter.fire());
+        this.widgetManager.onDidCreateWidget(({ factoryId, widget }) => {
+            if (factoryId === OutputWidget.ID && widget instanceof OutputWidget) {
+                widget.onStateChanged(() =>  this.onOutputWidgetStateChangedEmitter.fire());
+            }
         });
         const fireChannelsChanged = () => this.onChannelsChangedEmitter.fire();
         this.outputChannelManager.onSelectedChannelChanged(fireChannelsChanged);

--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -91,27 +91,32 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
     }
 
     /**
-     * Restore the selected channel from storage (used when widget is reopened).
-     * State restoration has higher priority, so this only applies if state restoration hasn't already
-     * set a selectedChannelName or pendingSelectedChannelName.
+     * Restore the selected channel from storage. This handles the case where the
+     * Output widget was closed before the application shut down, so the widget was
+     * not in the layout and `storeState`/`restoreState` never ran.
+     *
+     * Only applies if the manager doesn't already have a selected channel — if it
+     * does, something (e.g. a `channel.show()` call) already set the selection
+     * before this widget was created, and we should not override it.
      */
     protected async restoreSelectedChannelFromStorage(): Promise<void> {
         const storedChannelName = await this.storageService.getData<string>(OutputWidget.SELECTED_CHANNEL_STORAGE_KEY);
-        // Only apply storage restoration if state restoration hasn't provided a channel
-        if (storedChannelName && !this._state.selectedChannelName && !this._state.pendingSelectedChannelName) {
+        if (storedChannelName
+            && !this._state.selectedChannelName
+            && !this._state.pendingSelectedChannelName
+            && !this.outputChannelManager.selectedChannel
+        ) {
             const channel = this.outputChannelManager.getVisibleChannels().find(ch => ch.name === storedChannelName);
             if (channel) {
                 this.outputChannelManager.selectedChannel = channel;
                 this.refreshEditorWidget();
             } else {
-                // Channel not yet available, store as pending
                 this._state = { ...this._state, pendingSelectedChannelName: storedChannelName };
             }
         }
     }
 
     override dispose(): void {
-        // Save the selected channel to storage before disposing
         const channelName = this.selectedChannel?.name;
         if (channelName) {
             this.storageService.setData(OutputWidget.SELECTED_CHANNEL_STORAGE_KEY, channelName);

--- a/packages/output/src/browser/output-widget.ts
+++ b/packages/output/src/browser/output-widget.ts
@@ -114,6 +114,9 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
                 this._state = { ...this._state, pendingSelectedChannelName: storedChannelName };
             }
         }
+        // If no restoration occurred and nothing else has set a selection,
+        // fall back to the first visible channel so the widget isn't empty.
+        this.ensureChannelSelected();
     }
 
     override dispose(): void {
@@ -294,6 +297,19 @@ export class OutputWidget extends BaseWidget implements StatefulWidget {
                 const lineNumber = model.getLineCount();
                 const column = model.getLineMaxColumn(lineNumber);
                 editor.getControl().revealPosition({ lineNumber, column }, monaco.editor.ScrollType.Smooth);
+            }
+        }
+    }
+
+    /**
+     * If no channel is currently selected, select the first visible channel
+     * as a default so the widget shows content rather than an empty view.
+     */
+    protected ensureChannelSelected(): void {
+        if (!this.outputChannelManager.selectedChannel) {
+            const firstVisible = this.outputChannelManager.getVisibleChannels()[0];
+            if (firstVisible) {
+                this.outputChannelManager.selectedChannel = firstVisible;
             }
         }
     }


### PR DESCRIPTION
#### What it does

Fixes https://github.com/eclipse-theia/theia/issues/17549.

#16851 added `StorageService`-based persistence of the selected channel to handle the case where the Output widget is closed before the application shuts down (so `storeState`/`restoreState` never run). This introduced a race condition where the storage restoration in `restoreSelectedChannelFromStorage()` is can override a channel selection that was already set on the `OutputChannelManager` by `channel.show()` before the widget was created.

This PR adds a guard to `restoreSelectedChannelFromStorage()` that skips restoration if the manager already has a `selectedChannel`. If the manager already has a selection, it was set explicitly (e.g. by `channel.show()`) before the widget was created, and should not be overridden. The storage path only applies on a fresh application start when the manager has no opinion yet.

#### How to test

**Using the demo command:**
1. Open the command palette and run **"API Samples: Show Second Output Channel (After Closing Widget)"**
2. This will: show Channel A → close the Output widget → show Channel B
3. When the Output widget reopens, both the editor content **and** the dropdown selector should show "API Sample: second channel"

**Manual test (the original bug scenario):**
1. Open the Output view and note which channel is selected (e.g. "Channel A")
2. Close the Output view tab (not just collapse — actually close it via the X button)
3. Programmatically show a different channel (e.g. via an extension calling `outputChannel.show()`)
4. The Output view should reopen with the new channel selected in both the editor and the dropdown

**Verify storage restoration still works (the #11923 scenario):**
1. Open the Output view and select a specific channel
2. Close the Output view tab
3. Close and restart the application
4. Reopen the Output view — the previously selected channel should be restored

**Verify state restoration still works:**
1. Open the Output view and select a specific channel
2. Reload the application (without closing the Output tab first)
3. The same channel should be selected after reload

#### Follow-ups

The broader issue is that Theia's `StatefulWidget` mechanism only persists state for widgets that are in the shell layout at serialization time. This means any widget that is closed before app shutdown loses its state unless it implements its own persistence (as the Output widget does with `StorageService`). A framework-level solution for this pattern could benefit other widgets with similar needs.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)