### PR TITLE
Revert "fix(filesystem): show git decorations on every file when changes exceed the plugin-ext event cap (#17508)"

### DIFF
--- a/packages/core/src/browser/decorations-service.ts
+++ b/packages/core/src/browser/decorations-service.ts
@@ -148,10 +148,6 @@ class DecorationProviderWrapper {
             const request = new DecorationDataRequest(source, Promise.resolve(dataOrThenable).then(data => {
                 if (this.data.get(uri) === request) {
                     this.keepItem(uri, data);
-                    // Notify subscribers that a lazily-fetched decoration is now
-                    // available so renderers can re-query. Without this, decorations
-                    // dropped by event truncation never reach the UI.
-                    this.onDidChangeDecorationsEmitter.fire(this.decorations);
                 }
             }).catch(err => {
                 if (!(err instanceof Error && err.name === 'Canceled' && err.message === 'Canceled') && this.data.get(uri) === request) {

--- a/packages/filesystem/src/browser/file-tree/file-tree-decorator-adapter.ts
+++ b/packages/filesystem/src/browser/file-tree/file-tree-decorator-adapter.ts
@@ -40,7 +40,10 @@ export class FileTreeDecoratorAdapter implements TreeDecorator {
 
     @postConstruct()
     protected init(): void {
-        this.decorationsService.onDidChangeDecorations(() => this.fireDidChangeDecorations());
+        this.decorationsService.onDidChangeDecorations(newDecorations => {
+            this.updateDecorations(this.decorationsByUri.keys(), newDecorations.keys());
+            this.fireDidChangeDecorations();
+        });
     }
 
     decorations(tree: Tree): MaybePromise<Map<string, TreeDecoration.Data>> {
@@ -48,36 +51,19 @@ export class FileTreeDecoratorAdapter implements TreeDecorator {
     }
 
     protected collectDecorations(tree: Tree): Map<string, TreeDecoration.Data> {
-        const decorations = new Map<string, TreeDecoration.Data>();
-        if (!tree.root) {
-            return decorations;
-        }
-        this.decorationsByUri = new Map<string, TreeDecoration.Data>();
-        this.parentDecorations = new Map<string, TreeDecoration.Data>();
-        // Query the decorations service per visible URI so that decorations dropped
-        // by event truncation (see plugin-ext maxEventSize) are fetched on demand.
-        for (const node of new TopDownTreeIterator(tree.root)) {
-            const rawUri = this.getUriForNode(node);
-            if (!rawUri || this.decorationsByUri.has(rawUri)) {
-                continue;
-            }
-            const uri = new URI(rawUri);
-            const fetched = this.decorationsService.getDecoration(uri, false);
-            if (fetched.length) {
-                this.decorationsByUri.set(rawUri, this.toTheiaDecoration(fetched, false));
-                this.propagateDecorationsByUri(uri, fetched);
-            }
-        }
-        for (const node of new TopDownTreeIterator(tree.root)) {
-            const rawUri = this.getUriForNode(node);
-            if (!rawUri) {
-                continue;
-            }
-            const ownDecoration = this.decorationsByUri.get(rawUri);
-            const bubbledDecoration = this.parentDecorations.get(rawUri);
-            const combined = this.mergeDecorations(ownDecoration, bubbledDecoration);
-            if (combined) {
-                decorations.set(node.id, combined);
+        const decorations = new Map();
+        if (tree.root) {
+            for (const node of new TopDownTreeIterator(tree.root)) {
+                const uri = this.getUriForNode(node);
+                if (uri) {
+                    const stringified = uri.toString();
+                    const ownDecoration = this.decorationsByUri.get(stringified);
+                    const bubbledDecoration = this.parentDecorations.get(stringified);
+                    const combined = this.mergeDecorations(ownDecoration, bubbledDecoration);
+                    if (combined) {
+                        decorations.set(node.id, combined);
+                    }
+                }
             }
         }
         return decorations;
@@ -95,6 +81,28 @@ export class FileTreeDecoratorAdapter implements TreeDecorator {
                 tailDecorations
             };
         }
+    }
+
+    protected updateDecorations(oldKeys: IterableIterator<string>, newKeys: IterableIterator<string>): void {
+        this.parentDecorations.clear();
+        const newDecorations = new Map<string, TreeDecoration.Data>();
+        const handleUri = (rawUri: string) => {
+            if (!newDecorations.has(rawUri)) {
+                const uri = new URI(rawUri);
+                const decorations = this.decorationsService.getDecoration(uri, false);
+                if (decorations.length) {
+                    newDecorations.set(rawUri, this.toTheiaDecoration(decorations, false));
+                    this.propagateDecorationsByUri(uri, decorations);
+                }
+            }
+        };
+        for (const rawUri of oldKeys) {
+            handleUri(rawUri);
+        }
+        for (const rawUri of newKeys) {
+            handleUri(rawUri);
+        }
+        this.decorationsByUri = newDecorations;
     }
 
     protected toTheiaDecoration(decorations: Decoration[], bubble?: boolean): TreeDecoration.Data {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

This reverts commit 09b8c28d8bbd5390971b63262fd95153f6b6b5c8.

- Introduced noticeable UI lag and spurious "workspace too large for file watching" warnings on larger workspaces
- Root cause: per-URI emitter in decorations-service combined with full-tree re-collection in file-tree-decorator-adapter created a feedback loop of repeated TopDownTreeIterator walks and re-renders

Reverting until the original issue can be addressed without re-walking the entire tree on every async decoration resolution.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

  1. Open a reasonably large workspace (e.g. the Theia repo itself) on master.
  2. Observe UI lag when hovering editor tabs and the "workspace too large for file watching" warning.
  3. Check out this branch, rebuild (`npm run build:browser`), and verify both issues are gone.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

Reopen https://github.com/eclipse-theia/theia/issues/17507

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
