### PR TITLE
fix(bundle-plugin): align webpack ripgrep resolution with esbuild

### DIFF
--- a/dev-packages/bundle-plugin/src/webpack-plugin.ts
+++ b/dev-packages/bundle-plugin/src/webpack-plugin.ts
@@ -17,6 +17,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import resolvePackagePath = require('resolve-package-path');
 
 import type { Compiler } from 'webpack';
 
@@ -101,7 +102,7 @@ export class NativeWebpackPlugin {
     protected async copyRipgrep(issuer: string, compiler: Compiler): Promise<void> {
         const fileName = process.platform === 'win32' ? 'rg.exe' : 'rg';
         const platformPkg = `@vscode/ripgrep-${process.platform}-${process.arch}`;
-        const sourceFile = require.resolve(`${platformPkg}/bin/${fileName}`, { paths: [issuer] });
+        const sourceFile = path.join(resolveModulePath(platformPkg, issuer), 'bin', fileName);
         const targetFile = path.join(compiler.outputPath, this.options.out, fileName);
         await this.copyExecutable(sourceFile, targetFile);
     }
@@ -152,6 +153,14 @@ export class NativeWebpackPlugin {
         await fs.promises.copyFile(source, target);
         await fs.promises.chmod(target, 0o777);
     }
+}
+
+function resolveModulePath(module: string, issuer: string): string {
+    const modulePath = resolvePackagePath(module, issuer);
+    if (!modulePath) {
+        throw new Error('Could not resolve path of module: ' + module);
+    }
+    return path.resolve(modulePath, '..');
 }
 
 function findNativeWatcherFile(issuer: string): string {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolve `@vscode/ripgrep-<platform>-<arch>` via `resolve-package-path` and append `bin/<rg>` manually, mirroring the esbuild bundle plugin.

Related to GH-17554

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Webpack-bundled apps should keep working unchanged.

1. Force the webpack bundler in the browser example by removing `examples/browser/esbuild.mjs` or renaming it temporarily
2. `rm -f examples/browser/lib/backend/native/rg`
3. `npm run build:browser`
4. Confirm `examples/browser/lib/backend/native/rg` exists and `./rg --version` works
5. `npm run start:browser`, then do a search in workspace (Ctrl+Shift+F) and/or a quick file open (Ctrl+P)
6. Restore the file afterwards: `git restore examples/browser/esbuild.mjs`

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

A backport of #17483 plus this hardening to `release/1.71.x` will be opened separately to address #17554 on the published 1.71.x line

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
