### PR TITLE
[1.71.x backport] fix(native-webpack-plugin): support @vscode/ripgrep >= 1.18.0

### DIFF
--- a/dev-packages/native-webpack-plugin/package.json
+++ b/dev-packages/native-webpack-plugin/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "detect-libc": "^2.1.2",
+    "resolve-package-path": "^4.0.3",
     "tslib": "^2.6.2",
     "webpack": "^5.105.4"
   },

--- a/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
+++ b/dev-packages/native-webpack-plugin/src/native-webpack-plugin.ts
@@ -17,6 +17,7 @@
 import * as path from 'path';
 import * as fs from 'fs';
 import * as os from 'os';
+import resolvePackagePath = require('resolve-package-path');
 
 import type { Compiler } from 'webpack';
 
@@ -99,9 +100,10 @@ export class NativeWebpackPlugin {
     }
 
     protected async copyRipgrep(issuer: string, compiler: Compiler): Promise<void> {
-        const suffix = process.platform === 'win32' ? '.exe' : '';
-        const sourceFile = require.resolve(`@vscode/ripgrep/bin/rg${suffix}`, { paths: [issuer] });
-        const targetFile = path.join(compiler.outputPath, this.options.out, `rg${suffix}`);
+        const fileName = process.platform === 'win32' ? 'rg.exe' : 'rg';
+        const platformPkg = `@vscode/ripgrep-${process.platform}-${process.arch}`;
+        const sourceFile = path.join(resolveModulePath(platformPkg, issuer), 'bin', fileName);
+        const targetFile = path.join(compiler.outputPath, this.options.out, fileName);
         await this.copyExecutable(sourceFile, targetFile);
     }
 
@@ -153,6 +155,14 @@ export class NativeWebpackPlugin {
     }
 }
 
+function resolveModulePath(module: string, issuer: string): string {
+    const modulePath = resolvePackagePath(module, issuer);
+    if (!modulePath) {
+        throw new Error('Could not resolve path of module: ' + module);
+    }
+    return path.resolve(modulePath, '..');
+}
+
 function findNativeWatcherFile(issuer: string): string {
     let name = `@parcel/watcher-${process.platform}-${process.arch}`;
     if (process.platform === 'linux') {
@@ -188,9 +198,7 @@ async function buildFile(root: string, name: string, content: string): Promise<s
 }
 
 const ripgrepReplacement = (nativePath: string = '.'): string => `
-const path = require('path');
-
-exports.rgPath = path.join(__dirname, \`./${nativePath}/rg\${process.platform === 'win32' ? '.exe' : ''}\`);
+export const rgPath = require('path').join(__dirname, \`./${nativePath}/rg\${process.platform === 'win32' ? '.exe' : ''}\`);
 `;
 
 const bindingsReplacement = (issuer: string, entries: [string, string][]): string => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -242,6 +242,7 @@
     "dev-packages/ffmpeg": {
       "name": "@theia/ffmpeg",
       "version": "1.71.1",
+      "hasInstallScript": true,
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@electron/get": "^2.0.3",
@@ -7950,44 +7951,180 @@
       }
     },
     "node_modules/@vscode/ripgrep": {
-      "version": "1.17.1",
-      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.17.1.tgz",
-      "integrity": "sha512-xTs7DGyAO3IsJYOCTBP8LnTvPiYVKEuyv8s0xyJDBXfs8rhBfqnZPvb6xDT+RnwWzcXqW27xLS/aGrkjX7lNWw==",
-      "hasInstallScript": true,
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
       "license": "MIT",
-      "dependencies": {
-        "https-proxy-agent": "^7.0.2",
-        "proxy-from-env": "^1.1.0",
-        "yauzl": "^2.9.2"
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
       }
     },
-    "node_modules/@vscode/ripgrep/node_modules/agent-base": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
       "license": "MIT",
-      "engines": {
-        "node": ">= 14"
-      }
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
-    "node_modules/@vscode/ripgrep/node_modules/https-proxy-agent": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
       "license": "MIT",
-      "dependencies": {
-        "agent-base": "^7.1.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
     },
-    "node_modules/@vscode/ripgrep/node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vscode/vsce": {
       "version": "2.32.0",
@@ -30438,7 +30575,7 @@
         "@theia/filesystem": "1.71.1",
         "@theia/process": "1.71.1",
         "@theia/workspace": "1.71.1",
-        "@vscode/ripgrep": "^1.17.1",
+        "@vscode/ripgrep": "^1.18.0",
         "tslib": "^2.6.2"
       },
       "devDependencies": {
@@ -31096,7 +31233,7 @@
         "@theia/navigator": "1.71.1",
         "@theia/process": "1.71.1",
         "@theia/workspace": "1.71.1",
-        "@vscode/ripgrep": "^1.17.1",
+        "@vscode/ripgrep": "^1.18.0",
         "minimatch": "^10.2.5",
         "react-textarea-autosize": "^8.5.9",
         "tslib": "^2.6.2"

--- a/packages/file-search/package.json
+++ b/packages/file-search/package.json
@@ -8,7 +8,7 @@
     "@theia/filesystem": "1.71.1",
     "@theia/process": "1.71.1",
     "@theia/workspace": "1.71.1",
-    "@vscode/ripgrep": "^1.17.1",
+    "@vscode/ripgrep": "^1.18.0",
     "tslib": "^2.6.2"
   },
   "publishConfig": {

--- a/packages/search-in-workspace/package.json
+++ b/packages/search-in-workspace/package.json
@@ -9,7 +9,7 @@
     "@theia/navigator": "1.71.1",
     "@theia/process": "1.71.1",
     "@theia/workspace": "1.71.1",
-    "@vscode/ripgrep": "^1.17.1",
+    "@vscode/ripgrep": "^1.18.0",
     "minimatch": "^10.2.5",
     "react-textarea-autosize": "^8.5.9",
     "tslib": "^2.6.2"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Resolve ripgrep via the new platform-specific subpackages `@vscode/ripgrep-<platform>-<arch>` and update the ripgrep shim to ESM-style export to match the `1.18.0` package layout.
- Resolve the platform package root via `resolve-package-path` and append `bin/<rg>` manually instead of `require.resolve` on a subpath, so a future restrictive `exports` map on the subpackages does not break the build.
- Bump `@vscode/ripgrep` minimum to `^1.18.0` in `@theia/file-search` and `@theia/search-in-workspace`.

Backport of #17483 plus hardening from the master follow-up (#17560).

Resolves GH-17554

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Tested locally with the `examples/browser` app. Just updating to ripgrep 1.18.0 without the changes from this PR caused the same error as reported in the linked issue.

1. `npm install && npm run compile`
2. `rm -f examples/browser/lib/backend/native/rg`
3. `npm run build:browser` should succeed without `ERR_PACKAGE_PATH_NOT_EXPORTED`.
4. Confirm the binary is back: `ls -la examples/browser/lib/backend/native/rg` and `examples/browser/lib/backend/native/rg --version`.
5. (Optional) `npm run start:browser`, open a folder, then do a search in workspace (Ctrl+Shift+F) and/or a quick file open (Ctrl+P).

Note: I additionally validated against a downstream consumer by linking this patched 1.71.x checkout and confirming the bundled app builds, runs, and search works.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

Note: raises the minimum `@vscode/ripgrep` to `^1.18.0`. This is not treated as a breaking change since `1.17.x` was already broken on fresh installs (the bug this PR fixes), and `^1.17.1` already resolved to `1.18.0` via semver. Consumers pinning `1.17.x` via `resolutions`/`overrides` will need to update. This will be called out in the 1.71.2 GitHub release notes.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
