### PR TITLE
fix(core): tolerate ESRCH when terminating a unix process tree

### DIFF
--- a/packages/core/src/node/process-utils.spec.ts
+++ b/packages/core/src/node/process-utils.spec.ts
@@ -45,4 +45,52 @@ describe('ProcessUtils', () => {
         const pids = coreProcessManager['unixGetChildrenRecursive'](2);
         expect(Array.from(pids)).members([40, 5, 6, 7]);
     });
+
+    describe('#unixTerminateProcessTree', () => {
+        let originalKill: typeof process.kill;
+        let originalConsoleError: typeof console.error;
+        let loggedErrors: unknown[];
+
+        function throwingKill(code: string): typeof process.kill {
+            return (() => {
+                const error = new Error(`kill ${code}`) as NodeJS.ErrnoException;
+                error.code = code;
+                throw error;
+            }) as typeof process.kill;
+        }
+
+        beforeEach(() => {
+            originalKill = process.kill;
+            originalConsoleError = console.error;
+            loggedErrors = [];
+            console.error = (...args: unknown[]) => { loggedErrors.push(args); };
+            // One child plus the parent; report the parent as its own group leader so the `kill(-ppid)` branch runs too.
+            coreProcessManager['unixGetChildrenRecursive'] = () => new Set([424242]);
+            coreProcessManager['unixGetPGID'] = (pid: number) => pid;
+        });
+
+        afterEach(() => {
+            process.kill = originalKill;
+            console.error = originalConsoleError;
+        });
+
+        it('does not throw or log when processes in the tree are already gone (ESRCH)', () => {
+            process.kill = throwingKill('ESRCH');
+            expect(() => coreProcessManager['unixTerminateProcessTree'](424243)).to.not.throw();
+            expect(loggedErrors).to.be.empty;
+        });
+
+        it('logs unexpected kill errors (e.g. EPERM) without throwing', () => {
+            process.kill = throwingKill('EPERM');
+            expect(() => coreProcessManager['unixTerminateProcessTree'](424243)).to.not.throw();
+            expect(loggedErrors).to.not.be.empty;
+        });
+
+        it('does not throw when a kill rejects with a value that has no code (e.g. undefined)', () => {
+            const thrown: unknown = undefined;
+            process.kill = (() => { throw thrown; }) as typeof process.kill;
+            expect(() => coreProcessManager['unixTerminateProcessTree'](424243)).to.not.throw();
+            expect(loggedErrors).to.not.be.empty;
+        });
+    });
 });

--- a/packages/core/src/node/process-utils.ts
+++ b/packages/core/src/node/process-utils.ts
@@ -47,21 +47,28 @@ export class ProcessUtils {
         for (const pid of this.unixGetChildrenRecursive(ppid)) {
             // Prevent killing the current process:
             if (pid !== process.pid) {
-                // Don't stop if a process fails to be killed (keep on killing the others):
-                try {
-                    process.kill(pid);
-                } catch (error) {
-                    console.error(error);
-                }
+                this.unixKill(pid);
             }
         }
         if (ppid === this.unixGetPGID(ppid)) {
             // When a process pgid === pid this means the the process is a group leader.
             // We can then kill every process part of its group by doing `kill(-pgid)`.
             // This can catch leaked processes under `init` that are still part of the group.
-            process.kill(-ppid);
+            this.unixKill(-ppid);
         }
-        process.kill(ppid);
+        this.unixKill(ppid);
+    }
+
+    protected unixKill(pid: number): void {
+        try {
+            process.kill(pid);
+        } catch (error) {
+            // ESRCH means the process is already gone, which is the goal here. Log
+            // anything else but keep going so the rest of the tree is still killed.
+            if ((error as NodeJS.ErrnoException | undefined)?.code !== 'ESRCH') {
+                console.error(`[${pid}] failed to kill`, error);
+            }
+        }
     }
 
     protected unixGetPGID(pid: number): number {

--- a/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
+++ b/packages/plugin-ext/src/hosted/node/hosted-plugin-process.ts
@@ -140,17 +140,6 @@ export class HostedPluginProcess implements ServerPluginRunner {
         this.processUtils.terminateProcessTree(parentPid);
     }
 
-    protected killProcess(pid: number): void {
-        try {
-            process.kill(pid);
-        } catch (e) {
-            if (e && 'code' in e && e.code === 'ESRCH') {
-                return;
-            }
-            this.logger.error(`[${pid}] failed to kill`, e);
-        }
-    }
-
     public runPluginServer(serverName?: string): void {
         if (this.childProcess) {
             this.terminatePluginServer();


### PR DESCRIPTION
#### What it does

- Route every kill in unixTerminateProcessTree through a unixKill helper that swallows ESRCH, the expected outcome when a process has already exited during shutdown
- Guard the previously-unguarded kill(-ppid) and kill(ppid) calls so a racing self-exit no longer throws an uncaught error
- Log only unexpected failures; narrow on error code with optional chaining so a thrown undefined no longer crashes the handler
- Drop the dead HostedPluginProcess.killProcess method, orphaned since tree-walking moved into ProcessUtils

Fixes #17562

#### How to test

1. Run a browser backend with FRONTEND_CONNECTION_TIMEOUT=0 (closes connections immediately on disconnect).
2. Open and close a frontend a few times, or run an e2e suite that opens and closes pages.
3. Do not observe root ERROR Error: kill ESRCH lines in the backend log on each teardown.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
