### PR TITLE
fix(preferences): dispose preference storage and its provider

### DIFF
--- a/packages/preferences/src/common/abstract-resource-preference-provider.spec.ts
+++ b/packages/preferences/src/common/abstract-resource-preference-provider.spec.ts
@@ -41,7 +41,10 @@ class MockPreferenceStorage implements PreferenceStorage {
     writeValue(key: string, path: string[], value: JSONValue): Promise<boolean> {
         throw new Error('Method not implemented.');
     }
-    dispose(): void { }
+    disposed = false;
+    dispose(): void {
+        this.disposed = true;
+    }
     releaseContent = new Deferred();
     async read(): Promise<string> {
         await this.releaseContent.promise;
@@ -90,5 +93,11 @@ describe('AbstractResourcePreferenceProvider', () => {
         preferenceStorage.releaseContent.resolve();
         await provider.ready;
         expect(provider.get('editor.fontSize')).to.equal(20); // The value provided by the mock FileService implementation.
+    });
+
+    it('disposes its preference storage when the provider is disposed', () => {
+        expect(preferenceStorage.disposed).to.be.false;
+        provider.dispose();
+        expect(preferenceStorage.disposed).to.be.true;
     });
 });

--- a/packages/preferences/src/common/abstract-resource-preference-provider.ts
+++ b/packages/preferences/src/common/abstract-resource-preference-provider.ts
@@ -98,6 +98,7 @@ export abstract class AbstractResourcePreferenceProvider extends PreferenceProvi
         this.toDispose.push(Disposable.create(() => this.loading.reject(new Error(`Preference provider for '${uri}' was disposed.`))));
 
         this.preferenceStorage = this.preferenceStorageFactory(uri, this.getScope());
+        this.toDispose.push(this.preferenceStorage);
         this.preferenceStorage.onDidChangeFileContent(async ({ content, fileOK }) => {
             this.fileExists = fileOK;
             this.readPreferencesFromContent(content);

--- a/packages/preferences/src/node/backend-preference-storage.spec.ts
+++ b/packages/preferences/src/node/backend-preference-storage.spec.ts
@@ -1,0 +1,51 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { Event } from '@theia/core/lib/common/event';
+import { FileChange } from '@theia/filesystem/lib/common/files';
+import { DiskFileSystemProvider } from '@theia/filesystem/lib/node/disk-file-system-provider';
+import { EncodingService } from '@theia/core/lib/common/encoding-service';
+import { JSONCEditor } from '../common/jsonc-editor';
+import { BackendPreferenceStorage } from './backend-preference-storage';
+
+class MockDiskFileSystemProvider {
+    disposed = false;
+    watch(): Disposable {
+        return Disposable.NULL;
+    }
+    onDidChangeFile: Event<readonly FileChange[]> = Event.None;
+    dispose(): void {
+        this.disposed = true;
+    }
+}
+
+describe('BackendPreferenceStorage', () => {
+    it('disposes its file system provider when disposed', () => {
+        const provider = new MockDiskFileSystemProvider();
+        const storage = new BackendPreferenceStorage(
+            provider as unknown as DiskFileSystemProvider,
+            new URI('file:///settings.json'),
+            undefined as unknown as EncodingService,
+            undefined as unknown as JSONCEditor
+        );
+        expect(provider.disposed).to.be.false;
+        storage.dispose();
+        expect(provider.disposed).to.be.true;
+    });
+});

--- a/packages/preferences/src/node/backend-preference-storage.ts
+++ b/packages/preferences/src/node/backend-preference-storage.ts
@@ -112,6 +112,8 @@ export class BackendPreferenceStorage implements PreferenceStorage {
     }
 
     dispose(): void {
+        // Safe to dispose because the provider is bound transient and created solely for this storage.
+        this.fileSystem.dispose();
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Register the preference storage in AbstractResourcePreferenceProvider toDispose so it is released when the provider is disposed
- Dispose the owned DiskFileSystemProvider in BackendPreferenceStorage, releasing the file watch, watcher-client subscription and emitter that were leaking for the backend's lifetime

Fixes #17564

#### How to test

1. Open and close folders in a multi-root workspace (or reconnect frontends) to make preference providers come and go.
2. Watch the number of live DiskFileSystemProvider instances / file watches.
3. Note they DO NOT keep growing and as they are released.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
