### PR TITLE
fix(ffmpeg): tolerate missing electron dist/version

### DIFF
--- a/dev-packages/ffmpeg/src/replace-ffmpeg.ts
+++ b/dev-packages/ffmpeg/src/replace-ffmpeg.ts
@@ -75,6 +75,12 @@ export async function replaceFfmpeg(options: ffmpeg.FfmpegOptions = {}): Promise
 
 export async function readElectronVersion(electronDist: string): Promise<string> {
     const electronVersionFilePath = path.resolve(electronDist, 'version');
-    const version = await fs.readFile(electronVersionFilePath, 'utf8');
-    return version.trim();
+    try {
+        const version = await fs.readFile(electronVersionFilePath, 'utf8');
+        return version.trim();
+    } catch {
+        // `dist/version` is part of the Electron binary archive and can be absent after a
+        // partial postinstall extraction on CI. Fall back to the npm package's version.
+        return require('electron/package.json').version;
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Fall back to `electron/package.json` version when `node_modules/electron/dist/version` cannot be read.
- The `dist/version` file is part of the Electron binary archive and may be absent after a partial postinstall extraction, which has been seen sporadically on CI after a successful `electron-rebuild`.
- Avoids ENOENT during `theia build` for the electron target, which calls `prepareElectron` -> `replaceFfmpeg` -> `readElectronVersion` before the bundle step.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
