### PR TITLE
fix(ffmpeg): fall back to package.json when electron dist/version is missing

### DIFF
--- a/dev-packages/ffmpeg/src/replace-ffmpeg.ts
+++ b/dev-packages/ffmpeg/src/replace-ffmpeg.ts
@@ -75,6 +75,16 @@ export async function replaceFfmpeg(options: ffmpeg.FfmpegOptions = {}): Promise
 
 export async function readElectronVersion(electronDist: string): Promise<string> {
     const electronVersionFilePath = path.resolve(electronDist, 'version');
-    const version = await fs.readFile(electronVersionFilePath, 'utf8');
-    return version.trim();
+    try {
+        const version = await fs.readFile(electronVersionFilePath, 'utf8');
+        return version.trim();
+    } catch (error) {
+        // `dist/version` is part of the Electron binary archive and can be absent after a
+        // sporadically-failing postinstall extraction (observed on Node.js 24 CI runners with the
+        // unmaintained `extract-zip@2.0.1` used by electron's installer). Fall back to the version
+        // string from `electron/package.json`; the two files always hold the same value.
+        const electronPackageJson = await fs.readJson(require.resolve('electron/package.json'));
+        console.warn(`Could not read ${electronVersionFilePath}; falling back to electron/package.json version (${electronPackageJson.version}).`, error);
+        return electronPackageJson.version;
+    }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes the intermittent `ENOENT: ... node_modules/electron/dist/version` failure during `theia build` on Node.js 24 CI runners (Windows and Linux). Downstream Theia-based products are affected too.

When `dist/version` cannot be read, `readElectronVersion` now falls back to the version string in `electron/package.json` (both files always hold the same value) instead of letting the build abort. Uses `require.resolve` so `import/no-extraneous-dependencies` stays clean.

This is a defensive workaround. The root cause is the unmaintained `extract-zip@2.0.1` that Electron's postinstall still uses, exposed by Node.js 24's stream-cleanup changes. Re-running Electron's installer does not help (the same race can drop the same file on the re-extract), and upgrading Electron alone does not either (verified against `42.x` and `43` alphas, which still depend on `extract-zip ^2.0.1`). The fallback reads the version into memory only and does not rewrite `dist/version` to disk, which is fine for the typical packagers (`@electron/packager`, `electron-builder`) that read the version from `electron/package.json` anyway.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Run CI checks a couple of times, with no sporadic failures of the windows/ubuntu runners on node 24.

Local reproduction of the failing state and recovery:

```bash
# Sanity check the file exists.
ls node_modules/electron/dist/version

# Simulate the broken postinstall state.
rm node_modules/electron/dist/version

# Run the build path that previously failed.
cd examples/electron
npm run bundle
```

Expected: build completes successfully and logs a warning. Without this change, the same sequence fails with `ENOENT: ... dist/version`.

Happy-path verification (no recovery should fire): a normal `npm run build:electron` should not log the warning when the install is healthy.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- #17570

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
