### PR TITLE
[vscode] API bump and nls update to 1.121.0

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,7 +18,7 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.116.0';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.121.0';
 
 /**
  * The default supported monaco editor version the framework supports.

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -504,7 +504,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
         if (confirm) {
             const confirmed = await new ConfirmDialog({
                 title: nls.localize('theia/ai/chat-ui/deleteChat', 'Delete Chat'),
-                msg: nls.localize('theia/ai/chat-ui/confirmDeleteChatMsg', 'Are you sure you want to delete this chat?')
+                msg: nls.localizeByDefault('Are you sure you want to delete this chat?')
             }).open();
             if (!confirmed) {
                 return;

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -2524,9 +2524,9 @@ const reasoningLevelLabel = (level: ReasoningLevel): string => {
     switch (level) {
         case 'off': return nls.localizeByDefault('Off');
         case 'minimal': return nls.localize('theia/ai/chat-ui/reasoning/minimal', 'Minimal');
-        case 'low': return nls.localize('theia/ai/chat-ui/reasoning/low', 'Low');
-        case 'medium': return nls.localize('theia/ai/chat-ui/reasoning/medium', 'Medium');
-        case 'high': return nls.localize('theia/ai/chat-ui/reasoning/high', 'High');
+        case 'low': return nls.localizeByDefault('Low');
+        case 'medium': return nls.localizeByDefault('Medium');
+        case 'high': return nls.localizeByDefault('High');
         case 'auto': return nls.localizeByDefault('Auto');
     }
 };

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/code-part-renderer.tsx
@@ -178,7 +178,7 @@ const CopyToClipboardButton = (props: { code: string, clipboardService: Clipboar
     }, [code, clipboardService]);
 
     const iconClass = copied ? 'codicon-check' : 'codicon-copy';
-    const title = copied ? nls.localize('theia/ai/chat-ui/code-part-renderer/copied', 'Copied') : nls.localizeByDefault('Copy');
+    const title = copied ? nls.localizeByDefault('Copied') : nls.localizeByDefault('Copy');
     return <div className={`button codicon ${iconClass}`} title={title} role='button' onClick={copyCodeToClipboard}></div>;
 };
 

--- a/packages/ai-claude-code/src/browser/renderers/multiedit-tool-renderer.tsx
+++ b/packages/ai-claude-code/src/browser/renderers/multiedit-tool-renderer.tsx
@@ -170,7 +170,7 @@ const MultiEditToolComponent: React.FC<{
             {input.edits.map((edit, index) => (
                 <div key={index} className="claude-code-tool edit-preview">
                     <div className="claude-code-tool edit-preview-header">
-                        <span className="claude-code-tool edit-preview-title">{nls.localizeByDefault('Edit {0}', index + 1)}</span>
+                        <span className="claude-code-tool edit-preview-title">{nls.localize('theia/ai/claude-code/edit', 'Edit {0}', index + 1)}</span>
                         {edit.replace_all && (
                             <span className="claude-code-tool edit-preview-badge">
                                 {nls.localizeByDefault('Replace All')}

--- a/packages/ai-history/src/browser/ai-history-exchange-card.tsx
+++ b/packages/ai-history/src/browser/ai-history-exchange-card.tsx
@@ -196,7 +196,7 @@ const RequestCard: React.FC<RequestCardProps> = ({ request, index, totalRequests
         <div className={`request-card ${isFromDifferentAgent ? 'different-agent-opacity' : ''}`}>
             <div className='request-header'>
                 {totalRequests > 1 && (
-                    <h3>{nls.localize('theia/ai/history/request-card/title', 'Request')} {index + 1}</h3>
+                    <h3>{nls.localizeByDefault('Request')} {index + 1}</h3>
                 )}
                 <div className='request-info'>
                     <span className='request-id'>ID: {request.id}</span>
@@ -224,7 +224,7 @@ const RequestCard: React.FC<RequestCardProps> = ({ request, index, totalRequests
             <div className='request-content-container'>
                 <details>
                     <summary>
-                        {nls.localize('theia/ai/history/request-card/request', 'Request')}
+                        {nls.localizeByDefault('Request')}
                     </summary>
                     <div className='request-content'>
                         {getRequestContent()}

--- a/packages/ai-ide/src/browser/architect-agent.ts
+++ b/packages/ai-ide/src/browser/architect-agent.ts
@@ -52,7 +52,7 @@ export class ArchitectAgent extends AbstractModeAwareChatAgent {
     protected readonly modeDefinitions: Omit<ChatMode, 'isDefault'>[] = [
         {
             id: ARCHITECT_PLANNING_PROMPT_ID,
-            name: nls.localize('theia/ai/ide/architectAgent/mode/plan', 'Plan Mode')
+            name: nls.localizeByDefault('Plan Mode')
         },
         {
             id: ARCHITECT_SIMPLE_PROMPT_ID,

--- a/packages/ai-vercel-ai/src/common/vercel-ai-preferences.ts
+++ b/packages/ai-vercel-ai/src/common/vercel-ai-preferences.ts
@@ -73,7 +73,7 @@ export const VercelAiPreferencesSchema: PreferenceSchema = {
                     provider: {
                         type: 'string',
                         enum: ['openai', 'anthropic'],
-                        title: nls.localizeByDefault('Provider')
+                        title: nls.localize('theia/ai/vercelai/models/model/provider', 'Provider')
                     }
                 },
                 required: ['id', 'model', 'provider']
@@ -116,7 +116,7 @@ export const VercelAiPreferencesSchema: PreferenceSchema = {
                     provider: {
                         type: 'string',
                         enum: ['openai', 'anthropic'],
-                        title: nls.localizeByDefault('Provider')
+                        title: nls.localize('theia/ai/vercelai/models/model/provider', 'Provider')
                     },
                     apiKey: {
                         type: ['string', 'boolean'],

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -379,6 +379,18 @@
 			"action.inlineSuggest.cancelSnooze",
 			"action.inlineSuggest.snooze",
 			"inlineCompletions.snoozed",
+			"snooze.10minutes",
+			"snooze.15minutes",
+			"snooze.1minute",
+			"snooze.30minutes",
+			"snooze.5minutes",
+			"snooze.60minutes",
+			"snooze.custom",
+			"snooze.customPlaceholder",
+			"snooze.customPrompt",
+			"snooze.invalidInput",
+			"snooze.lastCustom",
+			"snooze.lastUsed",
 			"snooze.placeholder"
 		],
 		"vs/editor/browser/widget/codeEditor/codeEditorWidget": [
@@ -2249,6 +2261,7 @@
 		"vs/editor/contrib/snippet/browser/snippetController2": [
 			"hasNextTabstop",
 			"hasPrevTabstop",
+			"inSnippetChoice",
 			"inSnippetMode",
 			"next"
 		],
@@ -2593,6 +2606,7 @@
 			"actionList.filter.ariaLabel",
 			"actionList.filter.placeholder",
 			"actionList.remove",
+			"actionList.submenuHint",
 			{
 				"key": "customQuickFixWidget",
 				"comment": [
@@ -2632,65 +2646,256 @@
 			"selectPrevCodeAction.title",
 			"toggleSectionCodeAction.title"
 		],
+		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
+			"agentHost.config.customizations.description",
+			"agentHost.config.customizations.descriptionField",
+			"agentHost.config.customizations.displayName",
+			"agentHost.config.customizations.itemTitle",
+			"agentHost.config.customizations.title",
+			"agentHost.config.customizations.uri",
+			"agentHost.config.defaultShell.description",
+			"agentHost.config.defaultShell.title",
+			"agentHost.config.disableCustomTerminalTool.description",
+			"agentHost.config.disableCustomTerminalTool.title"
+		],
+		"vs/platform/agentHost/common/agentHostSchema": [
+			"agentHost.config.telemetryLevel.description",
+			"agentHost.config.telemetryLevel.title",
+			"agentHost.sessionConfig.autoApprove",
+			"agentHost.sessionConfig.autoApprove.autopilot",
+			"agentHost.sessionConfig.autoApprove.autopilotDescription",
+			"agentHost.sessionConfig.autoApprove.bypass",
+			"agentHost.sessionConfig.autoApprove.bypassDescription",
+			"agentHost.sessionConfig.autoApprove.default",
+			"agentHost.sessionConfig.autoApprove.defaultDescription",
+			"agentHost.sessionConfig.autoApproveDescription",
+			"agentHost.sessionConfig.mode",
+			"agentHost.sessionConfig.mode.interactive",
+			"agentHost.sessionConfig.mode.interactiveDescription",
+			"agentHost.sessionConfig.mode.plan",
+			"agentHost.sessionConfig.mode.planDescription",
+			"agentHost.sessionConfig.modeDescription",
+			"agentHost.sessionConfig.permissions",
+			"agentHost.sessionConfig.permissions.allow",
+			"agentHost.sessionConfig.permissions.deny",
+			"agentHost.sessionConfig.permissions.toolName",
+			"agentHost.sessionConfig.permissionsDescription"
+		],
+		"vs/platform/agentHost/common/claudeModelConfig": [
+			"claude.modelThinkingLevel.description",
+			"claude.modelThinkingLevel.high",
+			"claude.modelThinkingLevel.low",
+			"claude.modelThinkingLevel.max",
+			"claude.modelThinkingLevel.medium",
+			"claude.modelThinkingLevel.title",
+			"claude.modelThinkingLevel.xhigh"
+		],
+		"vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl": [
+			"sshKbiDefaultPrompt"
+		],
 		"vs/platform/agentHost/node/agentHostMain": [
 			"agentHost"
 		],
+		"vs/platform/agentHost/node/claude/claudeAgent": [
+			"claude.sessionConfig.permissionMode",
+			"claude.sessionConfig.permissionMode.acceptEdits",
+			"claude.sessionConfig.permissionMode.acceptEditsDescription",
+			"claude.sessionConfig.permissionMode.auto",
+			"claude.sessionConfig.permissionMode.autoDescription",
+			"claude.sessionConfig.permissionMode.bypassPermissions",
+			"claude.sessionConfig.permissionMode.bypassPermissionsDescription",
+			"claude.sessionConfig.permissionMode.default",
+			"claude.sessionConfig.permissionMode.defaultDescription",
+			"claude.sessionConfig.permissionMode.dontAsk",
+			"claude.sessionConfig.permissionMode.dontAskDescription",
+			"claude.sessionConfig.permissionMode.plan",
+			"claude.sessionConfig.permissionMode.planDescription",
+			"claude.sessionConfig.permissionModeDescription",
+			"claudeAgent.description",
+			"claudeAgent.displayName"
+		],
+		"vs/platform/agentHost/node/claude/claudeInteractiveTools": [
+			"claude.exitPlanMode.approve",
+			"claude.exitPlanMode.deny",
+			"claude.exitPlanMode.title"
+		],
+		"vs/platform/agentHost/node/claude/claudeToolDisplay": [
+			"claude.permission.default.title",
+			"claude.permission.mcp.title",
+			"claude.permission.read.title",
+			"claude.permission.shell.title",
+			"claude.permission.url.title",
+			"claude.permission.write.title",
+			"claude.tool.askUserQuestion",
+			"claude.tool.bash",
+			"claude.tool.bashOutput",
+			"claude.tool.edit",
+			"claude.tool.exitPlanMode",
+			"claude.tool.glob",
+			"claude.tool.grep",
+			"claude.tool.killBash",
+			"claude.tool.ls",
+			"claude.tool.mcp",
+			"claude.tool.multiEdit",
+			"claude.tool.notebookEdit",
+			"claude.tool.notebookRead",
+			"claude.tool.read",
+			"claude.tool.task",
+			"claude.tool.todoWrite",
+			"claude.tool.webFetch",
+			"claude.tool.write"
+		],
+		"vs/platform/agentHost/node/copilot/copilotAgent": [
+			"agentHost.sessionConfig.branch",
+			"agentHost.sessionConfig.branchDescription",
+			"agentHost.sessionConfig.isolation",
+			"agentHost.sessionConfig.isolation.folder",
+			"agentHost.sessionConfig.isolation.folderDescription",
+			"agentHost.sessionConfig.isolation.worktree",
+			"agentHost.sessionConfig.isolation.worktreeDescription",
+			"agentHost.sessionConfig.isolationDescription",
+			"copilot.modelThinkingLevel.description",
+			"copilot.modelThinkingLevel.high",
+			"copilot.modelThinkingLevel.low",
+			"copilot.modelThinkingLevel.medium",
+			"copilot.modelThinkingLevel.title",
+			"copilot.modelThinkingLevel.xhigh",
+			"copilotAgent.pluginParseError",
+			"copilotAgent.worktreeCreated"
+		],
 		"vs/platform/agentHost/node/copilot/copilotAgentSession": [
+			"agentHost.planReview.autopilot.description",
+			"agentHost.planReview.autopilot.label",
+			"agentHost.planReview.autopilotFleet.description",
+			"agentHost.planReview.autopilotFleet.label",
+			"agentHost.planReview.exitOnly.description",
+			"agentHost.planReview.exitOnly.label",
+			"agentHost.planReview.fallbackSummary",
+			"agentHost.planReview.interactive.description",
+			"agentHost.planReview.interactive.label",
+			"agentHost.planReview.questionMessage",
+			"agentHost.planReview.title",
+			"agentHost.planReview.viewPlanLink"
+		],
+		"vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider": [
+			"copilotSlashCommand.compact.description",
+			"copilotSlashCommand.plan.description"
+		],
+		"vs/platform/agentHost/node/copilot/copilotToolDisplay": [
 			"copilot.permission.default.message",
 			"copilot.permission.default.title",
 			"copilot.permission.mcp.defaultTool",
-			"copilot.permission.read.message",
+			"copilot.permission.mcp.title",
 			"copilot.permission.read.title",
-			"copilot.permission.shell.message",
 			"copilot.permission.shell.title",
-			"copilot.permission.write.message",
-			"copilot.permission.write.messageGeneric",
-			"copilot.permission.write.title"
-		],
-		"vs/platform/agentHost/node/copilot/copilotToolDisplay": [
+			"copilot.permission.url.message",
+			"copilot.permission.url.title",
+			"copilot.permission.write.title",
+			"toolComplete.create",
+			"toolComplete.createFile",
 			"toolComplete.edit",
 			"toolComplete.editFile",
+			"toolComplete.exitPlanMode",
 			"toolComplete.failed",
 			"toolComplete.generic",
 			"toolComplete.glob",
 			"toolComplete.globPattern",
 			"toolComplete.grep",
 			"toolComplete.grepPattern",
+			"toolComplete.patch",
+			"toolComplete.patchFile",
+			"toolComplete.patchFiles",
+			"toolComplete.readTerminal",
 			"toolComplete.shell",
 			"toolComplete.shellCmd",
+			"toolComplete.skill",
+			"toolComplete.skillName",
+			"toolComplete.sql",
 			"toolComplete.view",
 			"toolComplete.viewFile",
-			"toolComplete.write",
-			"toolComplete.writeFile",
+			"toolComplete.viewFileFromLine",
+			"toolComplete.viewFileLine",
+			"toolComplete.viewFileRange",
+			"toolComplete.writeShell",
+			"toolComplete.writeShellCmd",
+			"toolInvoke.create",
+			"toolInvoke.createFile",
 			"toolInvoke.edit",
 			"toolInvoke.editFile",
+			"toolInvoke.exitPlanMode",
 			"toolInvoke.generic",
 			"toolInvoke.glob",
 			"toolInvoke.globPattern",
 			"toolInvoke.grep",
 			"toolInvoke.grepPattern",
+			"toolInvoke.patch",
+			"toolInvoke.patchFile",
+			"toolInvoke.patchFiles",
+			"toolInvoke.readTerminal",
 			"toolInvoke.shell",
 			"toolInvoke.shellCmd",
+			"toolInvoke.skill",
+			"toolInvoke.skillName",
+			"toolInvoke.sql",
 			"toolInvoke.view",
 			"toolInvoke.viewFile",
-			"toolInvoke.write",
-			"toolInvoke.writeFile",
+			"toolInvoke.viewFileFromLine",
+			"toolInvoke.viewFileLine",
+			"toolInvoke.viewFileRange",
+			"toolInvoke.writeShell",
+			"toolInvoke.writeShellCmd",
+			"toolName.applyPatch",
 			"toolName.askUser",
-			"toolName.bash",
-			"toolName.bashShutdown",
+			"toolName.codeqlChecker",
+			"toolName.codeReview",
+			"toolName.create",
+			"toolName.createPullRequest",
 			"toolName.edit",
-			"toolName.glob",
-			"toolName.grep",
-			"toolName.listShells",
+			"toolName.exitPlanModeFull",
+			"toolName.fetchCopilotCliDocumentation",
+			"toolName.fetchWebContent",
+			"toolName.ghAdvisoryDatabase",
+			"toolName.invokeSkill",
+			"toolName.listAgents",
+			"toolName.listShellSessions",
+			"toolName.lsp",
+			"toolName.mcpReload",
+			"toolName.mcpValidate",
+			"toolName.parallelValidation",
 			"toolName.patch",
-			"toolName.powershell",
-			"toolName.readShell",
-			"toolName.view",
+			"toolName.proposeWork",
+			"toolName.read",
+			"toolName.readAgent",
+			"toolName.readTerminal",
+			"toolName.replyToComment",
+			"toolName.reportIntent",
+			"toolName.reportProgress",
+			"toolName.search",
+			"toolName.searchCode",
+			"toolName.shell",
+			"toolName.showFile",
+			"toolName.skill",
+			"toolName.sql",
+			"toolName.stopShell",
+			"toolName.storeMemory",
+			"toolName.task",
+			"toolName.taskComplete",
+			"toolName.think",
+			"toolName.toolSearchToolRegex",
+			"toolName.updateTodo",
 			"toolName.webSearch",
-			"toolName.write",
-			"toolName.writeShell"
+			"toolName.writeAgent",
+			"toolName.writeBash",
+			"toolName.writePowerShell"
+		],
+		"vs/platform/agentHost/node/sessionPermissions": [
+			"sessionPermissions.allowOnce",
+			"sessionPermissions.allowSession",
+			"sessionPermissions.skip"
 		],
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
+			"ssh.failedToReadPrivateKey",
+			"ssh.keyFileAuthRequiresPath",
 			"sshProgressCheckingAgent",
 			"sshProgressConnecting",
 			"sshProgressDownloadingCLI",
@@ -2698,11 +2903,15 @@
 			"sshProgressInstallingCLI",
 			"sshProgressStartingAgent"
 		],
+		"vs/platform/agentHost/node/tunnelHostMainService": [
+			"tunnelHost.log"
+		],
 		"vs/platform/browserView/common/browserView": [
 			"browserZoomAccessibilityLabel",
 			"browserZoomPercent"
 		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
+			"browser.contextMenu.addElementToChat",
 			"browser.contextMenu.back",
 			"browser.contextMenu.copyImage",
 			"browser.contextMenu.copyImageUrl",
@@ -3471,6 +3680,9 @@
 			"terminalLoggerName"
 		],
 		"vs/platform/terminal/common/terminalPlatformConfiguration": [
+			"terminal.integrated.agentHostProfile.linux",
+			"terminal.integrated.agentHostProfile.osx",
+			"terminal.integrated.agentHostProfile.windows",
 			"terminal.integrated.automationProfile.linux",
 			"terminal.integrated.automationProfile.osx",
 			"terminal.integrated.automationProfile.windows",
@@ -3533,6 +3745,7 @@
 			"foreground",
 			"iconForeground",
 			"selectionBackground",
+			"strongForeground",
 			"textBlockQuoteBackground",
 			"textBlockQuoteBorder",
 			"textCodeBlockBackground",
@@ -3786,6 +3999,7 @@
 			"quickInput.list.focusBackground deprecation",
 			"quickInput.listFocusBackground",
 			"quickInput.listFocusForeground",
+			"quickInput.listFocusHighlightForeground",
 			"quickInput.listFocusIconForeground"
 		],
 		"vs/platform/theme/common/colors/searchColors": [
@@ -3968,7 +4182,11 @@
 			"showReleaseNotes",
 			"start",
 			"updateConfigurationTitle",
-			"updateMode"
+			"updateMode",
+			"updateTitleBar"
+		],
+		"vs/platform/update/electron-main/notAvailableUpdateDialog": [
+			"noUpdatesAvailable"
 		],
 		"vs/platform/userDataProfile/common/userDataProfile": [
 			"defaultProfile"
@@ -4113,91 +4331,7 @@
 			"workspaceOpenedDetail",
 			"workspaceOpenedMessage"
 		],
-		"vs/sessions/browser/layoutActions": [
-			"agentPanelCloseIcon",
-			"agentSidebarToggleClosedIcon",
-			"agentSidebarToggleOpenIcon",
-			"openAndCloseSecondarySidebar",
-			"openAndCloseSidebar",
-			"secondarySidebarHidden",
-			"secondarySidebarVisible",
-			"sidebarHidden",
-			"sidebarVisible",
-			"togglePanel",
-			"toggleSecondarySidebar",
-			"toggleSidebar",
-			"toggleWindowAlwaysOnTop"
-		],
-		"vs/sessions/browser/parts/auxiliaryBarPart": [
-			"auxiliaryBarAriaLabel"
-		],
-		"vs/sessions/browser/parts/sessionCompositeBar": [
-			"deleteChat",
-			"renameChat",
-			"renameChat.prompt"
-		],
-		"vs/sessions/common/categories": [
-			"agents"
-		],
-		"vs/sessions/common/contextkeys": [
-			"activeChatBar",
-			"activeSessionHasGitRepository",
-			"activeSessionProviderId",
-			"activeSessionType",
-			"chatBarFocus",
-			"chatBarVisible",
-			"chatSessionProviderId",
-			"isActiveSessionArchived",
-			"isActiveSessionBackgroundProvider",
-			"sessionsWelcomeVisible"
-		],
-		"vs/sessions/common/theme": [
-			"agentFeedbackInputWidget.border",
-			"chatBarTitle.background",
-			"chatBarTitle.foreground",
-			"sessionsAuxiliaryBar.background",
-			"sessionsChatBar.background",
-			"sessionsPanel.background",
-			"sessionsSidebar.background",
-			"sessionsSidebarHeader.background",
-			"sessionsSidebarHeader.foreground",
-			"sessionsUpdateButton.downloadedBackground",
-			"sessionsUpdateButton.downloadingBackground"
-		],
-		"vs/sessions/contrib/accountMenu/browser/account.contribution": [
-			"accountMenuHeaderFallback",
-			{
-				"key": "agenticSignOutButton",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"agenticSignOutDetail",
-			"agenticSignOutMessage",
-			"agentsAccountStatusTitleBar",
-			"agentsUpdateTitleBar",
-			"loadingAccountHeader",
-			"sessionsTitleBarDownloading",
-			"sessionsTitleBarDownloadingAria",
-			"sessionsTitleBarInstalling",
-			"sessionsTitleBarInstallingAria",
-			"sessionsTitleBarInstallUpdate",
-			"sessionsTitleBarInstallUpdateAria",
-			"sessionsTitleBarRestartToUpdate",
-			"sessionsTitleBarRestartToUpdateAria",
-			"sessionsTitleBarUpdate",
-			"sessionsTitleBarUpdateAria",
-			"sessionsTitleBarUpdateAvailable",
-			"sessionsTitleBarUpdateAvailableAria",
-			"sessionsUpdateFromVSCode.detail",
-			"sessionsUpdateFromVSCode.open",
-			"sessionsUpdateFromVSCode.title",
-			"settings",
-			"signedInAsHeader",
-			"signIn",
-			"signOut"
-		],
-		"vs/sessions/contrib/accountMenu/browser/accountTitleBarState": [
+		"vs/sessions/browser/accountTitleBarState": [
 			"accountSignedInAria",
 			"accountSignedInAriaNameOnly",
 			"agentsSignedOut",
@@ -4216,22 +4350,234 @@
 			"signInAria",
 			"signInLabel"
 		],
-		"vs/sessions/contrib/accountMenu/browser/updateHoverWidget": [
-			"compactAgeDays",
-			"compactAgeHours",
-			"compactAgeMinutes",
-			"compactAgeMonths",
-			"compactAgeNow",
-			"compactAgeWeeks",
-			"downloadAvailable",
-			"downloadingUpdate",
-			"installingUpdate",
-			"unknownVersion",
-			"updateHoverCurrentVersionLabel",
-			"updateHoverNewVersionLabel",
-			"updateReady",
-			"updating",
-			"updatingApp"
+		"vs/sessions/browser/layoutActions": [
+			"agentPanelCloseIcon",
+			"agentSidebarToggleClosedIcon",
+			"agentSidebarToggleOpenIcon",
+			"openAndCloseSecondarySidebar",
+			"openAndCloseSidebar",
+			"secondarySidebarHidden",
+			"secondarySidebarVisible",
+			"sidebarHidden",
+			"sidebarVisible",
+			"togglePanel",
+			"toggleSecondarySidebar",
+			"toggleSidebar",
+			"toggleWindowAlwaysOnTop"
+		],
+		"vs/sessions/browser/parts/auxiliaryBarPart": [
+			"auxiliaryBarAriaLabel"
+		],
+		"vs/sessions/browser/parts/chatCompositeBar": [
+			"closeChat",
+			"renameChat",
+			"renameChat.prompt"
+		],
+		"vs/sessions/browser/parts/menubar.contribution": [
+			{
+				"key": "mEdit",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mFile",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mGo",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mHelp",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mPreferences",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mTerminal",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mView",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileChangesView": [
+			"changesView.back",
+			"changesView.backLabel",
+			"changesView.changeAdded",
+			"changesView.changeDeleted",
+			"changesView.changeModified",
+			"changesView.empty",
+			"changesView.rowAria",
+			"changesView.subtitleFilePlural",
+			"changesView.subtitleFileSingular",
+			"changesView.title"
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileDiffColors": [
+			"agentsMobileDiff.addedForeground",
+			"agentsMobileDiff.deletedForeground",
+			"agentsMobileDiff.modifiedForeground"
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileDiffView": [
+			"diffView.back",
+			"diffView.backLabel",
+			"diffView.loading",
+			"diffView.nextFile",
+			"diffView.noChanges",
+			"diffView.position",
+			"diffView.prevFile"
+		],
+		"vs/sessions/browser/parts/mobile/mobilePickerSheet": [
+			"mobilePickerSheet.done",
+			"mobilePickerSheet.doneAriaLabel",
+			"mobilePickerSheet.noResults",
+			"mobilePickerSheet.searching"
+		],
+		"vs/sessions/browser/parts/mobile/mobileSessionFilterChips": [
+			"chipCompleted",
+			"chipFailed",
+			"chipInProgress",
+			"filterChipsLabel",
+			"findAriaLabel",
+			"sortGroup",
+			"sortGroupAriaLabel"
+		],
+		"vs/sessions/browser/parts/mobile/mobileSortGroupSheet": [
+			"sortGroupSheet.close"
+		],
+		"vs/sessions/browser/parts/mobile/mobileTitlebarPart": [
+			"mobileAccount.close",
+			"mobileAccount.loading",
+			"mobileAccount.signedOut",
+			"mobileAccount.title",
+			"mobileTopBar.account",
+			"mobileTopBar.changes",
+			"mobileTopBar.changesTooltip",
+			"mobileTopBar.closeSessions",
+			"mobileTopBar.newSession",
+			"mobileTopBar.newSessionAria",
+			"mobileTopBar.openSessions"
+		],
+		"vs/sessions/browser/sessionsSetUpService": [
+			"loading",
+			"sessions.aiDisabled.detail",
+			"sessions.aiDisabled.enable",
+			"sessions.signIn",
+			"sessions.signingIn",
+			"sessions.signingIn.detail",
+			"sessions.welcome.detail",
+			"sessions.welcome.getStarted",
+			"sessions.welcome.title",
+			"walkthrough.productName",
+			{
+				"key": "welcomeFooter",
+				"comment": [
+					"{Locked=\"[\"}",
+					"{Locked=\"]({1})\"}",
+					"{Locked=\"]({2})\"}",
+					"{Locked=\"]({4})\"}",
+					"{Locked=\"]({5})\"}"
+				]
+			}
+		],
+		"vs/sessions/browser/widget/openInVSCodeWidget": [
+			"openInVSCodeHover"
+		],
+		"vs/sessions/common/categories": [
+			"agents"
+		],
+		"vs/sessions/common/contextkeys": [
+			"activeChatBar",
+			"activeSessionHasGitRepository",
+			"activeSessionHasGitSyncActionRunning",
+			"activeSessionProviderId",
+			"activeSessionType",
+			"activeSessionWorkspaceIsVirtual",
+			"chatBarFocus",
+			"chatBarVisible",
+			"chatSessionProviderId",
+			"editorMaximized",
+			"isActiveSessionArchived",
+			"isNewChatInSession",
+			"sessionsAquariumActive",
+			"sessionsCanGoBack",
+			"sessionsCanGoForward",
+			"sessionsIsPhoneLayout",
+			"sessionsKeyboardVisible",
+			"sessionsWelcomeVisible",
+			"sessionWorkspacePickerGroup"
+		],
+		"vs/sessions/common/sizes": [
+			"agents.fontSize.body1",
+			"agents.fontSize.body2",
+			"agents.fontSize.heading1",
+			"agents.fontSize.heading2",
+			"agents.fontSize.heading3",
+			"agents.fontSize.label1",
+			"agents.fontSize.label2",
+			"agents.fontSize.label3",
+			"agents.fontSize.label4",
+			"agents.fontWeight.medium",
+			"agents.fontWeight.regular",
+			"agents.fontWeight.semiBold"
+		],
+		"vs/sessions/common/theme": [
+			"agentFeedbackInputWidget.border",
+			"agents.background",
+			"agentsBadge.background",
+			"agentsBadge.foreground",
+			"agentsChatInput.background",
+			"agentsChatInput.border",
+			"agentsChatInput.focusBorder",
+			"agentsChatInput.foreground",
+			"agentsChatInput.placeholderForeground",
+			"agentsGradient.tintColor",
+			"agentsNewSessionButton.background",
+			"agentsNewSessionButton.border",
+			"agentsNewSessionButton.foreground",
+			"agentsNewSessionButton.hoverBackground",
+			"agentsPanel.background",
+			"agentsPanel.border",
+			"agentsPanel.foreground",
+			"agentsUnreadBadge.background",
+			"agentsUnreadBadge.foreground",
+			"agentsUpdateButton.downloadedBackground",
+			"agentsUpdateButton.downloadingBackground"
+		],
+		"vs/sessions/contrib/accountMenu/browser/account.contribution": [
+			"accountAvatarAlt",
+			"accountAvatarAltFallback",
+			"accountMenuHeaderFallback",
+			{
+				"key": "agenticSignOutButton",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"agenticSignOutDetail",
+			"agenticSignOutMessage",
+			"agentsAccountStatusTitleBar",
+			"loadingAccountHeader",
+			"sessionsAccountSubscriptionSectionLabel",
+			"settings",
+			"signIn",
+			"signOut"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution": [
 			"agentFeedback.submitFeedbackCount"
@@ -4319,7 +4665,6 @@
 			"instructions",
 			"mcpServers",
 			"pluginsWithCount",
-			"prompts",
 			"skills",
 			"userWithCount",
 			"workspaceWithCount"
@@ -4334,37 +4679,45 @@
 			"applyChangesToParentRepo",
 			"openInVSCode"
 		],
+		"vs/sessions/contrib/aquarium/browser/aquarium.contribution": [
+			"sessions.developerJoy.enabled"
+		],
+		"vs/sessions/contrib/aquarium/browser/aquariumOverlay": [
+			"aquarium.hide",
+			"aquarium.show"
+		],
+		"vs/sessions/contrib/changes/browser/changes.contribution": [
+			"changes",
+			"changesViewIcon",
+			{
+				"key": "miChanges",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
+		],
 		"vs/sessions/contrib/changes/browser/changesTitleBarWidget": [
-			"changesSummary",
+			"agentSecondarySidebarToggleClosedIcon",
+			"agentSecondarySidebarToggleOpenIcon",
+			"hideChanges",
 			"showChanges",
-			"toggleChanges"
+			"toggleSecondarySidebarTooltip"
 		],
 		"vs/sessions/contrib/changes/browser/changesView": [
 			"changes",
+			"changesView.diffStats.label",
 			"changesView.noChanges",
+			"changesView.viewChanges",
 			"changesViewTree",
-			"chatEditing.versionsAllChanges",
-			"chatEditing.versionsAllChanges.description",
-			"chatEditing.versionsBranchChanges",
-			"chatEditing.versionsLastTurnChanges",
-			"chatEditing.versionsLastTurnChanges.description",
 			"chatEditing.versionsPicker",
-			"sessionsChanges.versionsAllChanges",
-			"sessionsChanges.versionsBranchChanges",
-			"sessionsChanges.versionsLastTurn",
+			"sessions.changes.title",
 			"setListViewMode",
 			"setTreeViewMode"
 		],
-		"vs/sessions/contrib/changes/browser/changesView.contribution": [
-			"changes",
-			"changesViewIcon"
-		],
 		"vs/sessions/contrib/changes/browser/changesViewActions": [
-			"chatEditing.viewAllSessionChanges",
-			"focusChangesFileView",
-			"focusChangesView",
-			"focusChangesView.noChanges",
+			"openChanges",
 			"openChangesView",
+			"openFile",
 			"openPullRequest"
 		],
 		"vs/sessions/contrib/changes/browser/checksActions": [
@@ -4372,7 +4725,7 @@
 			"ci.pendingState",
 			"ci.runningState",
 			"ci.successfulState",
-			"fixCIChecks"
+			"fixChecks"
 		],
 		"vs/sessions/contrib/changes/browser/checksWidget": [
 			"ci.checkAriaLabel",
@@ -4403,8 +4756,18 @@
 			"chat.newEdits.label",
 			"chat.viewContainer.label",
 			"chatViewIcon",
-			"openInVSCode",
-			"sessions.newChat.view"
+			"sessions.newChat.view",
+			"sessions.newChatInSession.view"
+		],
+		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
+			"mobileSessionTypePicker.title"
+		],
+		"vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet": [
+			"mobileWorkspacePicker.caption",
+			"mobileWorkspacePicker.foldersSection",
+			"mobileWorkspacePicker.noFolders",
+			"mobileWorkspacePicker.searchFolders",
+			"mobileWorkspacePicker.title"
 		],
 		"vs/sessions/contrib/chat/browser/newChatContextAttachments": [
 			"attachAsContext",
@@ -4415,38 +4778,46 @@
 			"removeAttachment",
 			"selectFilesOrFolders"
 		],
-		"vs/sessions/contrib/chat/browser/newChatPermissionPicker": [
-			"permissionPicker.ariaLabel",
-			"permissions.autoApprove",
-			"permissions.autoApprove.label",
-			"permissions.autoApprove.subtext",
-			"permissions.autoApprove.warning.cancel",
-			"permissions.autoApprove.warning.confirm",
-			"permissions.autoApprove.warning.detail",
-			"permissions.autoApprove.warning.title",
-			"permissions.autopilot",
-			"permissions.autopilot.label",
-			"permissions.autopilot.subtext",
-			"permissions.autopilot.warning.cancel",
-			"permissions.autopilot.warning.confirm",
-			"permissions.autopilot.warning.detail",
-			"permissions.autopilot.warning.title",
-			"permissions.default",
-			"permissions.default.label",
-			"permissions.default.subtext",
-			"permissions.learnMore"
-		],
-		"vs/sessions/contrib/chat/browser/newChatViewPane": [
+		"vs/sessions/contrib/chat/browser/newChatInput": [
 			"addContext",
 			"chatInput",
 			"chatInput.accessibilityHelp",
 			"chatInput.accessibilityHelpNoKb",
-			"chatPlaceholder",
 			"loading",
+			"send",
+			"sessionsChatInput.placeholder.describeTheOutcome",
+			"sessionsChatInput.placeholder.describeWhatYouWantToBuild",
+			"sessionsChatInput.placeholder.describeYourMission",
+			"sessionsChatInput.placeholder.pitchYourIdea",
+			"sessionsChatInput.placeholder.whatAreYouBuilding",
+			"sessionsChatInput.placeholder.whatAreYouTryingToAchieve",
+			"sessionsChatInput.placeholder.whatFeatureAreYouDreamingUp",
+			"sessionsChatInput.placeholder.whatProblemAreYouSolving",
+			"sessionsChatInput.placeholder.whatsNextOnYourRoadmap",
+			"sessionsChatInput.placeholder.whatsTheGoal",
+			"sessionsChatInput.placeholder.whatsYourNextMilestone",
+			"sessionsChatInput.placeholder.whatWillYouCreate",
+			"sessionsChatInput.placeholder.whatWillYouLaunch",
+			"sessionsChatInput.placeholder.whatWillYouShipToday",
+			"sessionsChatInput.placeholder.whatWouldYouLikeToAutomate"
+		],
+		"vs/sessions/contrib/chat/browser/newChatInSessionViewPane": [
+			"newChatInSessionPlaceholder",
+			"subSessionTip.ariaLabel",
+			"subSessionTip.dismiss",
+			"subSessionTip.message"
+		],
+		"vs/sessions/contrib/chat/browser/newChatViewPane": [
 			"newSessionChooseWorkspace",
 			"newSessionIn",
-			"send",
+			"newSessionWith",
 			"trustFolderMessage"
+		],
+		"vs/sessions/contrib/chat/browser/noAgentHostEmptyState": [
+			"noAgentHost.aria",
+			"noAgentHost.description",
+			"noAgentHost.learnMore",
+			"noAgentHost.title"
 		],
 		"vs/sessions/contrib/chat/browser/runScriptAction": [
 			"addActionTooltip",
@@ -4455,9 +4826,13 @@
 			"addActionWidgetTitle",
 			"addExistingActionWidgetDescription",
 			"addExistingActionWidgetTitle",
+			"browserActionsCategory",
 			"closeQuickWidget",
 			"configureActionWidgetDescription",
 			"configureActionWidgetTitle",
+			"configureBrowserUrl",
+			"configureBrowserUrlPrompt",
+			"configureBrowserUrlTitle",
 			"configureDefaultRunAction",
 			"configureDefaultRunAction",
 			"configureTask",
@@ -4472,7 +4847,12 @@
 			"generateRunAction",
 			"generateRunActionTooltip",
 			"npmTaskCommandPreview",
+			"openBrowserAction",
+			"openBrowserActionTooltip",
+			"openBrowserActionTooltipUnconfigured",
 			"pickRunAction",
+			"pinBrowser",
+			"pinBrowserTooltip",
 			"pinTask",
 			"pinTaskTooltip",
 			"removeTask",
@@ -4484,6 +4864,8 @@
 			"runPrimaryTaskTooltip",
 			"runScriptNotAvailableTooltip",
 			"tasksActionsCategory",
+			"unpinBrowser",
+			"unpinBrowserTooltip",
 			"unpinTask",
 			"unpinTaskTooltip",
 			"workspaceStorageUnavailableTooltip",
@@ -4518,53 +4900,38 @@
 			"sessionsChat.filesView",
 			"sessionsChat.history",
 			"sessionsChat.input",
+			"sessionsChat.mobileConfig",
 			"sessionsChat.overview",
 			"sessionsChat.sessionsView",
 			"sessionsChat.workspace"
 		],
 		"vs/sessions/contrib/chat/browser/sessionTypePicker": [
-			"sessionTypePicker.ariaLabel"
+			"sessionTypePicker.ariaLabel",
+			"sessionTypePicker.triggerAriaLabel"
 		],
 		"vs/sessions/contrib/chat/browser/sessionWorkspacePicker": [
+			"pickLocalProvider",
 			"pickWorkspace",
 			"workspacePicker.ariaLabel",
-			"workspacePicker.browseAction",
-			"workspacePicker.browseSelect",
 			"workspacePicker.browseSelectAction",
-			"workspacePicker.copyAddress",
+			"workspacePicker.browseSelectLocal",
+			"workspacePicker.experimental",
 			"workspacePicker.filter",
-			"workspacePicker.hoverConnected",
-			"workspacePicker.hoverConnectedAddr",
-			"workspacePicker.hoverConnecting",
-			"workspacePicker.hoverConnectingAddr",
-			"workspacePicker.hoverDisconnected",
-			"workspacePicker.hoverDisconnectedAddr",
-			"workspacePicker.offline",
-			"workspacePicker.offlineSingle",
-			"workspacePicker.openSettings",
 			"workspacePicker.pickAriaLabel",
-			"workspacePicker.providerOffline",
-			"workspacePicker.reconnect",
-			"workspacePicker.remoteOptions",
-			"workspacePicker.remoteOptionsTitle",
-			"workspacePicker.removeRemote",
-			"workspacePicker.selectedAriaLabel",
-			"workspacePicker.showOutput",
-			"workspacePicker.statusConnecting",
-			"workspacePicker.statusOffline",
-			"workspacePicker.statusOnline",
-			"workspacePicker.tunnels"
+			"workspacePicker.selectedAriaLabel"
 		],
 		"vs/sessions/contrib/chat/browser/slashCommands": [
 			"slashCommand.agents",
 			"slashCommand.hooks",
 			"slashCommand.instructions",
-			"slashCommand.prompts",
 			"slashCommand.skills"
 		],
 		"vs/sessions/contrib/chat/browser/variableCompletions": [
 			"activeFile",
 			"fileEntryDescription"
+		],
+		"vs/sessions/contrib/chat/browser/webWorkspacePicker": [
+			"scopedWorkspacePicker.selectFolder"
 		],
 		"vs/sessions/contrib/chatDebug/browser/chatDebug.contribution": [
 			"chatDebug",
@@ -4583,97 +4950,269 @@
 			"sessions.runCodeReview.tooltip.oneUnresolved",
 			"sessions.runCodeReview.tooltip.runAgain"
 		],
-		"vs/sessions/contrib/copilotChatSessions/browser/branchPicker": [
-			"branchPicker.ariaLabel",
-			"branchPicker.filter",
-			"branchPicker.select"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution": [
-			"sessions.github.copilot.multiChatSessions"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions": [
-			"branchPicker",
-			"cloudModelPicker",
-			"isolationPicker",
-			"localModelPicker",
-			"modePicker",
-			"permissionPicker"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider": [
-			"copilotChatSessionsProvider",
-			"folders",
-			"new chat",
-			"new session",
-			"repositories"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/isolationPicker": [
-			"isolationMode.folder",
-			"isolationMode.worktree",
-			"isolationPicker.ariaLabel"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/modelPicker": [
-			"modelPicker.ariaLabel",
-			"modelPicker.auto",
-			"modelPicker.filter"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/modePicker": [
-			"configureCustomAgents",
-			"modePicker.ariaLabel",
-			"sessions.modePicker.ariaLabel"
+		"vs/sessions/contrib/editor/browser/editor.contribution": [
+			"closeMainEditorPart",
+			"maximizeMainEditorPart",
+			"openEditorInModal",
+			"openModalEditorInEditor",
+			"restoreMainEditorPart"
 		],
 		"vs/sessions/contrib/files/browser/files.contribution": [
 			"collapseExplorerFolders",
+			"explore",
 			"files",
-			"sessionsFilesViewIcon"
+			{
+				"key": "miFiles",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"sessionsFilesViewIcon",
+			"syncChanges"
 		],
 		"vs/sessions/contrib/files/browser/filesView": [
 			"filesView.noFiles"
 		],
-		"vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider": [
-			"cannotChangeExistingSessionType",
-			"folders",
-			"localAgentHostDescription",
-			"localAgentHostLabel",
-			"localAgentHostSessionType",
-			"localAgentHostSessionTypeLocation",
-			"noAgents",
-			"selectLocalFolder",
-			"unknownSessionType"
-		],
-		"vs/sessions/contrib/logs/browser/logs.contribution": [
-			"logs",
-			"sessionsLogsViewIcon"
-		],
 		"vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked": [
+			"accountGate.approvedOrgs",
+			"accountGate.aria",
+			"accountGate.contactAdmin",
+			"accountGate.descriptionNoAccount",
+			"accountGate.descriptionWithAccount",
+			"accountGate.learnMore",
+			"accountGate.signIn",
+			"accountGate.title",
+			"loading.aria",
 			"policyBlocked.aria",
 			"policyBlocked.description",
 			"policyBlocked.learnMore",
 			"policyBlocked.openVSCode",
 			"policyBlocked.title"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution": [
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker": [
+			"agentHostClaudePermissionModePicker.ariaLabel",
+			"agentHostClaudePermissionModePicker.triggerAriaLabel",
+			"permissions.learnMore"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker": [
+			"agentHostModelPicker"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
+			"agentHostModePicker.ariaLabel",
+			"agentHostModePicker.triggerAriaLabel"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
+			"copySessionBranchName"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker": [
+			"agentHostAutoApprove.autopilot.warning.detail",
+			"agentHostAutoApprove.autopilot.warning.title",
+			"agentHostAutoApprove.bypass.warning.detail",
+			"agentHostAutoApprove.bypass.warning.title",
+			"agentHostAutoApprove.warning.cancel",
+			"agentHostAutoApprove.warning.confirm",
+			"agentHostAutoApprove.warning.detailWithDefaultSetting",
+			"agentHostNewSessionApprovePicker",
+			"agentHostNewSessionModePicker",
+			"agentHostRunningSessionConfigPicker",
+			"agentHostRunningSessionModePicker",
+			"agentHostRunningSessionPermissionModePicker",
+			"agentHostSessionConfig.ariaLabel",
+			"agentHostSessionConfig.filter",
+			"agentHostSessionConfig.triggerAria",
+			"agentHostSessionConfig.triggerAriaReadOnly",
+			"agentHostSessionConfigPicker",
+			"mobileAgentHostSessionConfig.repoSheet.branchSearchAria",
+			"mobileAgentHostSessionConfig.repoSheet.branchSearchEmpty",
+			"mobileAgentHostSessionConfig.repoSheet.branchSearchPlaceholder",
+			"mobileAgentHostSessionConfig.repoSheet.branchSection",
+			"mobileAgentHostSessionConfig.repoSheet.isolationSection",
+			"mobileAgentHostSessionConfig.repoSheet.title",
+			"selected"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSettings.contribution": [
+			"agentHostSettings.label",
+			"openHostSettings"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSettingsFileSystemProvider": [
+			"agentHostSettings.header",
+			"agentHostSettings.notObject",
+			"agentHostSettings.parseError",
+			"agentHostSettings.saveHint"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSkillButtons": [
+			"agentSessions.runSkill.createDraftPR",
+			"agentSessions.runSkill.createPR",
+			"agentSessions.runSkill.merge",
+			"agentSessions.runSkill.updatePR"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentSessionSettings.contribution": [
+			"agentSessionSettings.label",
+			"openSessionSettings"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentSessionSettingsFileSystemProvider": [
+			"agentSessionSettings.header",
+			"agentSessionSettings.notObject",
+			"agentSessionSettings.parseError",
+			"agentSessionSettings.saveHint"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider": [
+			"copilotCLI",
+			"noAgents",
+			"notConnectedSend"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
+			"exportAgentHostDebugLogs"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider": [
+			"localAgentHostLabel",
+			"localAgentHostSessionTypeLocation"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
+			"openSessionEventsFile"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker": [
+			"branchPicker.ariaLabel",
+			"branchPicker.filter",
+			"branchPicker.select",
+			"branchPicker.triggerAriaLabel"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker": [
+			"claude.permissionMode.acceptEdits",
+			"claude.permissionMode.acceptEdits.description",
+			"claude.permissionMode.auto",
+			"claude.permissionMode.auto.description",
+			"claude.permissionMode.default",
+			"claude.permissionMode.default.description",
+			"claude.permissionMode.plan",
+			"claude.permissionMode.plan.description",
+			"claudePermissionModePicker.ariaLabel",
+			"claudePermissionModePicker.triggerAriaLabel"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution": [
+			"sessions.chat.claudeAgent.enabled",
+			"sessions.chat.localAgent.enabled",
+			"sessions.github.copilot.multiChatSessions"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
+			"branchPicker",
+			"claudePermissionModePicker",
+			"cloudModelPicker",
+			"deleteSession",
+			"isolationPicker",
+			"localModelPicker",
+			"modePicker",
+			"permissionPicker"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsChangesets": [
+			"allChanges",
+			"allChangesDescription",
+			"branchChanges",
+			"changesCategory",
+			"checkpointsCategory",
+			"lastTurnChanges",
+			"lastTurnChangesDescription",
+			"uncommittedChanges",
+			"uncommittedChangesDescription"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider": [
+			"claudeCode",
+			"copilotChatSessionsProvider",
+			"copilotCloud",
+			"deleteChat.confirm",
+			"deleteChat.delete",
+			"deleteChat.detail",
+			"deleteSession.confirm",
+			"deleteSession.delete",
+			"deleteSession.detail",
+			"deleteSession.detailMultiple",
+			"localSession",
+			"new chat",
+			"new session",
+			"repositories",
+			"sessionWorkspaceGroup.github"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker": [
+			"isolationMode.folder",
+			"isolationMode.worktree",
+			"isolationPicker.ariaLabel",
+			"isolationPicker.triggerAriaLabel"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/mobilePermissionPicker": [
+			"permissionPicker.title",
+			"permissions.autoApprove",
+			"permissions.autoApprove.subtext",
+			"permissions.autopilot",
+			"permissions.autopilot.subtext",
+			"permissions.default",
+			"permissions.default.subtext",
+			"permissions.learnMore"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/modelPicker": [
+			"modelPicker.ariaLabel",
+			"modelPicker.auto",
+			"modelPicker.filter",
+			"modelPicker.triggerAriaLabel"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker": [
+			"configureCustomAgents",
+			"modePicker.ariaLabel",
+			"modePicker.triggerAriaLabel"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/permissionPicker": [
+			"permissionPicker.ariaLabel",
+			"permissionPicker.triggerAriaLabel",
+			"permissions.autoApprove",
+			"permissions.autoApprove.label",
+			"permissions.autoApprove.subtext",
+			"permissions.autopilot",
+			"permissions.autopilot.label",
+			"permissions.autopilot.subtext",
+			"permissions.default",
+			"permissions.default.label",
+			"permissions.default.subtext",
+			"permissions.learnMore"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/manageRemoteAgentHosts": [
+			"manageHosts.actionsHeader",
+			"manageHosts.placeholder",
+			"manageHosts.remoteHostsHeader",
+			"manageHosts.removeTooltip",
+			"manageHosts.title",
+			"manageRemoteAgentHosts"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution": [
+			"chat.agentHost.forwardSSHAgent",
+			"chat.agentHost.localFilePermissions",
+			"chat.agentHost.localFilePermissions.read",
+			"chat.agentHost.localFilePermissions.readWrite",
 			"chat.remoteAgentHosts",
 			"chat.remoteAgentHosts.address",
+			"chat.remoteAgentHosts.autoConnect",
 			"chat.remoteAgentHosts.connectionToken",
 			"chat.remoteAgentHosts.enabled",
 			"chat.remoteAgentHosts.name",
-			"chat.remoteAgentHosts.sshConfigHost",
 			"chat.remoteAgentTunnels",
 			"chat.sshRemoteAgentHostCommand"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions": [
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions": [
+			"addNewSSHHost",
 			"addRemoteAgentHost",
 			"addRemoteFailed",
 			"addRemotePrompt",
 			"addRemoteTitle",
 			"addRemoteValidationEmpty",
 			"addRemoteValidationInvalid",
+			"configureSSHHosts",
 			"connectViaSSH",
+			"connectViaSSHShort",
 			"connectViaTunnel",
+			"connectViaTunnelShort",
 			"nameRemotePlaceholder",
 			"nameRemotePrompt",
 			"nameRemoteTitle",
 			"nameRemoteValidationEmpty",
+			"sshAddNewHost",
 			"sshAuthAgent",
 			"sshAuthAgentDesc",
 			"sshAuthKey",
@@ -4682,19 +5221,23 @@
 			"sshAuthPasswordDesc",
 			"sshAuthPlaceholder",
 			"sshAuthTitle",
+			"sshConfigCreateFailed",
+			"sshConfigListFailed",
+			"sshConfigOpenFailed",
+			"sshConfigPickPlaceholder",
+			"sshConfigPickTitle",
+			"sshConfigureHosts",
 			"sshConnectFailed",
 			"sshConnecting",
-			"sshEnterManually",
-			"sshEnterManuallyDesc",
 			"sshHostEmpty",
+			"sshHostInvalid",
 			"sshHostInvalidPort",
 			"sshHostMissingAfterAt",
-			"sshHostPrompt",
+			"sshHostPickerPlaceholder",
 			"sshHostTitle",
 			"sshKeyEmpty",
 			"sshKeyPrompt",
 			"sshKeyTitle",
-			"sshManualHostTitle",
 			"sshNameEmpty",
 			"sshNamePlaceholder",
 			"sshNamePrompt",
@@ -4702,19 +5245,12 @@
 			"sshPasswordEmpty",
 			"sshPasswordPrompt",
 			"sshPasswordTitle",
-			"sshPickHostPlaceholder",
 			"sshResolveConfigFailed",
 			"sshUsernameEmpty",
 			"sshUsernameMissingInHost",
 			"sshUsernamePrompt",
 			"sshUsernameTitle",
 			"tunnelAuthFailed",
-			"tunnelAuthGitHub",
-			"tunnelAuthGitHubDesc",
-			"tunnelAuthMicrosoft",
-			"tunnelAuthMicrosoftDesc",
-			"tunnelAuthPlaceholder",
-			"tunnelAuthTitle",
 			"tunnelConnectFailed",
 			"tunnelConnecting",
 			"tunnelListFailed",
@@ -4722,18 +5258,70 @@
 			"tunnelPickPlaceholder",
 			"tunnelPickTitle"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider": [
-			"cannotChangeExistingSessionType",
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostCustomizationHarness": [
+			"remoteAgentHost.addPlugin",
+			"remoteAgentHost.addPluginTooltip",
+			"remoteAgentHost.pluginAlreadyConfigured",
+			"remoteAgentHost.removeConfiguredPlugin",
+			"remoteAgentHost.selectPluginFolder"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider": [
+			"connectFailed",
 			"folders",
 			"noAgents",
 			"notConnected",
 			"notConnectedSend",
 			"notConnectedSession",
-			"selectRemoteFolder",
-			"unknownSessionType"
+			"selectRemoteFolder"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution": [
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.contribution": [
+			"agentHostTerminal.channelRemote"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteHostOptions": [
+			"agentHostIncompatibleNotification",
+			"agentHostIncompatibleShowOptions",
+			"agentHostIncompatibleUpdate",
+			"workspacePicker.copyAddress",
+			"workspacePicker.hoverConnected",
+			"workspacePicker.hoverConnectedAddr",
+			"workspacePicker.hoverConnecting",
+			"workspacePicker.hoverConnectingAddr",
+			"workspacePicker.hoverDisconnected",
+			"workspacePicker.hoverDisconnectedAddr",
+			"workspacePicker.hoverIncompatible",
+			"workspacePicker.hoverIncompatibleAddr",
+			"workspacePicker.incompatibleValidationClient",
+			"workspacePicker.incompatibleValidationServer",
+			"workspacePicker.openSettings",
+			"workspacePicker.reconnect",
+			"workspacePicker.remoteOptionsTitle",
+			"workspacePicker.removeRemote",
+			"workspacePicker.showOutput",
+			"workspacePicker.statusConnecting",
+			"workspacePicker.statusIncompatible",
+			"workspacePicker.statusOffline",
+			"workspacePicker.statusOnline",
+			"workspacePicker.updateServer",
+			"workspacePicker.upgradeCountdown",
+			"workspacePicker.upgradeFailed",
+			"workspacePicker.upgradeFailedWithReason",
+			"workspacePicker.upgradeNotNeeded",
+			"workspacePicker.upgradeNotStarted",
+			"workspacePicker.upgradeReconnecting",
+			"workspacePicker.upgradingServer"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution": [
 			"tunnelConnecting"
+		],
+		"vs/sessions/contrib/search/browser/search.contribution": [
+			"findInFolder",
+			{
+				"key": "miSearch",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"openSearch"
 		],
 		"vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget": [
 			"customizations"
@@ -4745,17 +5333,44 @@
 			"instructions",
 			"mcpServers",
 			"plugins",
-			"prompts",
+			"sessions.customizations.sidebarMode",
+			"sessions.customizations.sidebarMode.section",
+			"sessions.customizations.sidebarMode.single",
+			"sessions.customizations.sidebarMode.welcome",
 			"skills"
+		],
+		"vs/sessions/contrib/sessions/browser/mobile/mobileOverlayContribution": [
+			"mobileOpenFileDiff",
+			"mobileOpenSessionChanges"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"agentSessions.view.label",
-			"agentSessionsViewIcon"
+			"agentSessionsViewIcon",
+			{
+				"key": "miSessions",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			}
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsActions": [
+			{
+				"key": "miSessionsBack",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "miSessionsForward",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
 			"newSession",
 			"recentSessions",
 			"searchSessions",
+			"sessionsGoBack",
+			"sessionsGoForward",
 			"showSessionsPicker",
 			"untitledSession"
 		],
@@ -4763,9 +5378,7 @@
 			"agentSessions.newSession",
 			"agentSessionsControl",
 			"agentSessionsShowSessions",
-			"showSessions",
-			"toggleSidebarA11y",
-			"toggleSidebarUnread"
+			"showSessions"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
 			"allowAction",
@@ -4775,11 +5388,18 @@
 			"lastSevenDays",
 			"needsInput",
 			"older",
+			"pinned",
 			"secondsDuration",
 			"sessionItemAria",
 			"sessionsList",
+			"showLessAria",
+			"showLessCompact",
+			"showLessWorkspacesAria",
+			"showLessWorkspacesCompact",
 			"showMoreAria",
 			"showMoreCompact",
+			"showMoreWorkspacesAria",
+			"showMoreWorkspacesCompact",
 			"today",
 			"unknown",
 			"working",
@@ -4788,6 +5408,8 @@
 		"vs/sessions/contrib/sessions/browser/views/sessionsView": [
 			"filterArchived",
 			"filterRead",
+			"groupByTime",
+			"groupByWorkspace",
 			"newCompact",
 			"newSessionButtonAriaLabel",
 			"newSessionButtonAriaLabelWithoutKeybinding",
@@ -4795,6 +5417,11 @@
 			"newSessionButtonTitleWithoutKeybinding",
 			"resetFilters",
 			"sessionsHeader",
+			"sortByCreated",
+			"sortByUpdated",
+			"sortGroupSheet.group",
+			"sortGroupSheet.sort",
+			"sortGroupSheet.title",
 			"statusCompleted",
 			"statusFailed",
 			"statusInProgress",
@@ -4802,8 +5429,8 @@
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
 			"addChat",
-			"addChat.placeholder",
-			"addChat.prompt",
+			"archivePinnedSectionSessions.confirm",
+			"archivePinnedSectionSessions.confirmSingle",
 			"archiveSection",
 			"archiveSectionSessions.archive",
 			"archiveSectionSessions.confirm",
@@ -4811,6 +5438,7 @@
 			"archiveSectionSessions.detail",
 			"archiveSession",
 			"closeSession",
+			"collapseAllGroups",
 			"doNotAskAgain",
 			"doNotAskAgain2",
 			"filter",
@@ -4829,6 +5457,7 @@
 			"renameSession",
 			"renameSession.empty",
 			"renameSession.prompt",
+			"restore",
 			"showAllSessions",
 			"showRecentSessions",
 			"sortByCreated",
@@ -4845,43 +5474,44 @@
 			"openInTerminal",
 			"showAllTerminals"
 		],
-		"vs/sessions/contrib/welcome/browser/sessionsWalkthrough": [
-			"walkthrough.aria",
-			"walkthrough.canceledError",
-			"walkthrough.disclaimer.end",
-			"walkthrough.disclaimer.final",
-			"walkthrough.disclaimer.middle",
-			"walkthrough.disclaimer.prefix",
-			"walkthrough.disclaimer.privacy",
-			"walkthrough.disclaimer.publicCode",
-			"walkthrough.disclaimer.settings",
-			"walkthrough.disclaimer.suffix",
-			"walkthrough.disclaimer.terms",
-			"walkthrough.finishingSubtitle",
-			"walkthrough.poweredBy",
-			"walkthrough.restart",
-			"walkthrough.settingUp",
-			"walkthrough.signin.apple",
-			"walkthrough.signin.enterprise",
-			"walkthrough.signin.github",
-			"walkthrough.signin.google",
-			"walkthrough.signInError",
-			"walkthrough.signingIn",
-			"walkthrough.step1.subtitle",
-			"walkthrough.step1.title"
+		"vs/sessions/contrib/tunnelHost/electron-browser/toggleRemoteConnectionsActionViewItem": [
+			"tunnelHost.hover.connecting",
+			"tunnelHost.hover.enabled",
+			"tunnelHost.hover.idle",
+			"tunnelHost.hover.sharing",
+			"tunnelHost.hover.showOutput",
+			"tunnelHost.toast"
 		],
-		"vs/sessions/contrib/welcome/browser/welcome.contribution": [
-			"resetSessionsWelcome"
+		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution": [
+			"showTunnelHostOutput",
+			"toggleSharing",
+			"tunnelHost.category",
+			"tunnelHost.enableMicrosoftAuth",
+			"tunnelHost.error"
+		],
+		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHostService": [
+			"tunnelHost.noAuth",
+			"tunnelHost.outputChannel"
+		],
+		"vs/sessions/electron-browser/actions/vscodeActions": [
+			"openInVSCode",
+			"openVSCodeWindow"
+		],
+		"vs/sessions/electron-browser/parts/titlebarPart": [
+			"agentsWindowTitle"
 		],
 		"vs/sessions/electron-browser/sessions.main": [
 			"join.closeStorage"
 		],
 		"vs/sessions/services/sessions/common/session": [
-			"copilotCLI",
-			"copilotCloud"
+			"sessionWorkspaceGroup.local",
+			"sessionWorkspaceGroup.remote"
 		],
 		"vs/sessions/services/sessions/common/sessionsManagement": [
 			"activeSessionSupportsMultiChat"
+		],
+		"vs/sessions/services/workspace/browser/workspaceContextService": [
+			"agentsWindow"
 		],
 		"vs/workbench/api/browser/mainThreadAuthentication": [
 			"addClientRegistrationDetails",
@@ -5139,6 +5769,7 @@
 		"vs/workbench/api/common/configurationExtensionPoint": [
 			"accessibility",
 			"advanced",
+			"config.property.agentsWindow.proposed",
 			"config.property.defaultConfiguration.warning",
 			"config.property.duplicate",
 			"config.property.preventDefaultConfiguration.warning",
@@ -5152,6 +5783,9 @@
 			"invalid.title",
 			"language",
 			"preview",
+			"scope.agentsWindow",
+			"scope.agentsWindow.default",
+			"scope.agentsWindow.readOnly",
 			"scope.application.description",
 			"scope.deprecationMessage",
 			"scope.description",
@@ -5320,6 +5954,9 @@
 			"stopTrackDisposables",
 			"storageLogDialogDetails",
 			"storageLogDialogMessage",
+			"syncAccountPolicy",
+			"syncAccountPolicy.error",
+			"syncAccountPolicy.success",
 			"toggle screencast mode",
 			"user",
 			"workspace"
@@ -5468,12 +6105,6 @@
 					"&& denotes a mnemonic"
 				]
 			},
-			{
-				"key": "miToggleZenMode",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
 			"move second sidebar left",
 			"move second sidebar right",
 			"move side bar right",
@@ -5569,7 +6200,6 @@
 			"toggleSidebarPosition",
 			"toggleStatusbar",
 			"toggleVisibility",
-			"toggleZenMode",
 			"top",
 			"zenMode",
 			"zenModeIcon"
@@ -6273,6 +6903,7 @@
 			"pin",
 			"pinEditor",
 			"previousChangeIcon",
+			"reopenAsText",
 			"reopenWith",
 			"reopenWith",
 			"share",
@@ -6511,6 +7142,7 @@
 			"unlockEditorGroup"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
+			"editor.diffEditorAssociations",
 			"editor.editorAssociations",
 			"editorLargeFileSizeConfirmation",
 			"interactiveWindow",
@@ -6651,6 +7283,7 @@
 		],
 		"vs/workbench/browser/parts/editor/editorTabsControl": [
 			"ariaLabelEditorActions",
+			"ariaLabelEditorActionsLayout",
 			"draggedEditorGroup"
 		],
 		"vs/workbench/browser/parts/editor/modalEditorPart": [
@@ -6888,37 +7521,13 @@
 			"title2",
 			"title3"
 		],
-		"vs/workbench/browser/parts/titlebar/menubarControl": [
-			{
-				"key": "checkForUpdates",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"checkingForUpdates",
-			{
-				"key": "download now",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
-			"DownloadingUpdate",
-			"focusMenu",
-			"goToSetting",
-			"installingUpdate",
-			{
-				"key": "installUpdate...",
-				"comment": [
-					"&& denotes a mnemonic"
-				]
-			},
+		"vs/workbench/browser/parts/titlebar/menubar.contribution": [
 			{
 				"key": "mEdit",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
 			},
-			"menubar.customTitlebarAccessibilityNotification",
 			{
 				"key": "mFile",
 				"comment": [
@@ -6960,7 +7569,33 @@
 				"comment": [
 					"&& denotes a mnemonic"
 				]
+			}
+		],
+		"vs/workbench/browser/parts/titlebar/menubarControl": [
+			{
+				"key": "checkForUpdates",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
 			},
+			"checkingForUpdates",
+			{
+				"key": "download now",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"DownloadingUpdate",
+			"focusMenu",
+			"goToSetting",
+			"installingUpdate",
+			{
+				"key": "installUpdate...",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"menubar.customTitlebarAccessibilityNotification",
 			{
 				"key": "restartToUpdate",
 				"comment": [
@@ -7458,7 +8093,17 @@
 					"{0}, {1} will be a setting name rendered as a link"
 				],
 				"key": "wrapTabs"
+			}
+		],
+		"vs/workbench/browser/workbench.zenMode.contribution": [
+			{
+				"key": "miToggleZenMode",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
 			},
+			"tabBar",
+			"toggleZenMode",
 			"zenMode.centerLayout",
 			"zenMode.fullScreen",
 			"zenMode.hideActivityBar",
@@ -7487,6 +8132,8 @@
 		"vs/workbench/common/contextkeys": [
 			"activeAuxiliary",
 			"activeCompareEditorCanSwap",
+			"activeCustomEditorDiffCanToggleLayout",
+			"activeCustomEditorTextDiff",
 			"activeEditor",
 			"activeEditorAvailableEditorIds",
 			"activeEditorCanRevert",
@@ -7529,6 +8176,7 @@
 			"isFullscreen",
 			"isMainEditorCenteredLayout",
 			"isSessionsWindow",
+			"isTopRightEditorGroup",
 			"isWindowAlwaysOnTop",
 			"mainEditorAreaVisible",
 			"multipleEditorGroups",
@@ -7890,6 +8538,7 @@
 			"speechLanguage.auto",
 			"terminal.integrated.accessibleView.closeOnKeyPress",
 			"verbosity.chat.description",
+			"verbosity.chatQuestionCarousel",
 			"verbosity.comments",
 			"verbosity.debug",
 			"verbosity.diffEditor.description",
@@ -8172,7 +8821,6 @@
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures": [
 			"browser.addConsoleLogsToChatAction",
 			"browser.addElementToChatAction",
-			"browser.addFocusedElementToChat",
 			"browser.agentSharingContentWarning.detail",
 			"browser.agentSharingContentWarning.dontShowAgain",
 			"browser.agentSharingContentWarning.message",
@@ -8183,7 +8831,8 @@
 			"browser.sharingWithAgent",
 			"browser.unshareWithAgent",
 			"browserCategory",
-			"consoleLogs"
+			"consoleLogs",
+			"workbench.browser.agentHostChatToolsEnabled"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorFindFeature": [
 			"browser.findNextAction",
@@ -8213,15 +8862,21 @@
 			"browser.zoomOutAction"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures": [
+			"browser.backgroundGroup",
 			"browser.closeAll",
 			"browser.closeAllInGroup",
 			"browser.closeAllInGroupShort",
 			"browser.closeAllTabs",
 			"browser.closeTab",
 			"browser.editorOpen",
+			"browser.linkOpenedHint.ariaLabel",
+			"browser.linkOpenedHint.detail",
+			"browser.linkOpenedHint.dismiss",
+			"browser.linkOpenedHint.label",
+			"browser.linkOpenedHint.openSettings",
 			"browser.newTabAction",
 			"browser.openAction",
-			"browser.openFromViewMenuAction",
+			"browser.openFileAction",
 			{
 				"comment": [
 					"This is the description for a setting."
@@ -8229,6 +8884,7 @@
 				"key": "browser.openLocalhostLinks"
 			},
 			"browser.openNewTab",
+			"browser.openOrListAction",
 			"browser.quickOpenAction",
 			"browser.quickOpenPlaceholder",
 			{
@@ -8329,8 +8985,28 @@
 			"browser.open.confirmMessage",
 			"browser.open.confirmTitle",
 			"browser.open.invocation",
+			"browser.open.newPageOption",
+			{
+				"key": "browser.open.noPagesOption",
+				"comment": [
+					"{Locked=\" - \"}"
+				]
+			},
 			"browser.open.past",
+			"browser.open.prompt.invocation",
+			"browser.open.prompt.past",
 			"browser.open.result",
+			"browser.open.sharedResult",
+			{
+				"key": "browser.open.shareExistingOption",
+				"comment": [
+					"{Locked=\" - \"}",
+					"{0} is the editor title",
+					"{1} is the truncated URL"
+				]
+			},
+			"browser.open.shareQuestion.message",
+			"browser.open.shareQuestion.title",
 			"openBrowserTool.displayName",
 			"openBrowserTool.userDescription"
 		],
@@ -8574,7 +9250,8 @@
 			"workbench.action.chat.nextUserPrompt",
 			"workbench.action.chat.previousUserPrompt",
 			"workbench.action.chat.restoreLastCheckpoint",
-			"workbench.action.chat.undoEdits"
+			"workbench.action.chat.undoEdits",
+			"workbench.action.openAgentsWindow"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatActions": [
 			"actions.interactiveSession.focus",
@@ -8614,6 +9291,7 @@
 			"interactiveSession.clearHistory.label",
 			"interactiveSession.focusInput.label",
 			"interactiveSession.focusQuestionCarousel.label",
+			"interactiveSession.focusQuestionCarouselTerminal.label",
 			"interactiveSession.focusTip.label",
 			"interactiveSession.focusTodosView.label",
 			"interactiveSession.newChatWindow",
@@ -8690,14 +9368,19 @@
 			"chat.copyKatexMathSource.label",
 			"interactive.copyAll.label",
 			"interactive.copyFinalResponse.label",
-			"interactive.copyItem.label"
+			"interactive.copyItem.ariaLabel",
+			"interactive.copyItem.copied",
+			"interactive.copyItem.copiedAriaLabel",
+			"interactive.copyItem.label",
+			"interactive.copyItem.status"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatDeveloperActions": [
 			"workbench.action.chat.clearRecentlyUsedLanguageModels.label",
 			"workbench.action.chat.inspectChatModel.label",
 			"workbench.action.chat.inspectChatModelReferences.label",
 			"workbench.action.chat.logChatIndex.label",
-			"workbench.action.chat.logInputHistory.label"
+			"workbench.action.chat.logInputHistory.label",
+			"workbench.action.chat.resetPermissionWarningDialogs.label"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatElicitationActions": [
 			"chat.acceptElicitation"
@@ -8730,6 +9413,7 @@
 			"interactive.submit.label",
 			"interactive.submitWithoutDispatch.label",
 			"interactive.switchToNextModel.label",
+			"interactive.switchToNextPinnedModel.label",
 			"interactive.toggleAgent.label",
 			"selectWorkspace",
 			"sendToAgent",
@@ -8818,6 +9502,7 @@
 			"interactive.previousUserPrompt.label"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatQueueActions": [
+			"chat.editPendingRequest",
 			"chat.queueMessage",
 			"chat.queueMessage.tooltip",
 			"chat.queueSubmenu",
@@ -8914,6 +9599,20 @@
 			"showAll",
 			"skills"
 		],
+		"vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction": [
+			"exportAgentHostDebugLogs",
+			"exportDebugLogs.folderDialogTitle",
+			"exportDebugLogs.noFiles.activeSession",
+			"exportDebugLogs.noFiles.currentWindow",
+			"exportDebugLogs.saveError"
+		],
+		"vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction": [
+			"openSessionEventsFile",
+			"openSessionEventsFile.noHome",
+			"openSessionEventsFile.noSession",
+			"openSessionEventsFile.notConnected",
+			"openSessionEventsFile.unsupported"
+		],
 		"vs/workbench/contrib/chat/browser/agentPluginActions": [
 			"disable",
 			"disableForWorkspace",
@@ -8953,13 +9652,54 @@
 			"noAgentPlugins",
 			"update"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution": [
+			"agentHost.displayName",
+			"agentHostHarnessLabel.local"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
+			"agentHostChatInputPicker.ariaLabel",
+			"agentHostChatInputPicker.filter",
+			"agentHostChatInputPicker.learnMorePermissions",
+			"agentHostChatInputPicker.triggerAria",
+			"agentHostChatInputPicker.triggerAriaReadOnly",
+			"selected"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution": [
+			"agentHost.autoApprovePicker",
+			"agentHost.branchPicker",
+			"agentHost.isolationPicker",
+			"agentHost.modePicker",
+			"agentHost.permissionModePicker"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostEditingSession": [
 			"multiDiffEditorInput.name"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution": [
+			"agentHost.permission.allow",
+			"agentHost.permission.allowAlways",
+			"agentHost.permission.deny",
+			"agentHost.permission.morePending",
+			"agentHost.permission.oneMorePending",
+			"agentHost.permission.read",
+			"agentHost.permission.write"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler": [
 			"agentHost.authRequired",
+			"agentHost.elicit.url.cancel",
+			"agentHost.elicit.url.instruction",
+			"agentHost.elicit.url.open",
+			"agentHost.elicit.url.title",
+			"agentHost.responseDetails.credit",
+			"agentHost.responseDetails.credits",
 			"chat.forked.fallbackTitle",
 			"chat.forked.title"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
+			"agentHostTerminal.channelLocal",
+			"agentHostTerminal.local"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter": [
+			"ahp.running"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionHoverWidget": [
 			"agentSessionCompleted",
@@ -9043,6 +9783,9 @@
 			"unarchiveSectionSessions.unarchive",
 			"unpin"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner": [
+			"agentsBanner.tryAgentsAppLabel"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl": [
 			"agentSessions.noFilterResults",
 			"agentSessions.resetFilter"
@@ -9051,6 +9794,8 @@
 			"agentSessions.filter.archived",
 			"agentSessions.filter.read",
 			"agentSessions.filter.reset",
+			"agentSessions.filter.sortByCreated",
+			"agentSessions.filter.sortByUpdated",
 			"agentSessionStatus.completed",
 			"agentSessionStatus.failed",
 			"agentSessionStatus.inProgress",
@@ -9138,7 +9883,6 @@
 			"askAnythingPlaceholder",
 			"askTooltip",
 			"askTooltip2",
-			"chatQuotaExceededButton",
 			"enterAgentSessionProjection",
 			"enterAgentSessionProjectionTooltip",
 			"enterAgentSessionProjectionTooltipNoKey",
@@ -9153,7 +9897,6 @@
 			"openQuickOpenTooltip",
 			"openQuickOpenTooltip2",
 			"review",
-			"signInToChatSetup",
 			"toggleChat",
 			"unreadSessionsTooltip",
 			"unreadSessionsTooltip1"
@@ -9200,15 +9943,16 @@
 			"aiCustomizationViewIcon",
 			"aiCustomizationWorkspaceIcon"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource": [
+			"hookUnset",
+			"uiIntegrationBadge"
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget": [
 			"agent",
 			"agentInstructionsGroup",
 			"agentInstructionsGroupDescription",
+			"agents",
 			"agentsDescription",
-			"agentsGroup",
-			"agentsGroupDescription",
-			"alwaysAdded",
-			"alwaysAddedTooltip",
 			"builtinGroup",
 			"builtinGroupDescription",
 			"builtinSource",
@@ -9219,6 +9963,36 @@
 			"contextInstructionsGroupDescription",
 			"copyFullPath",
 			"copyRelativePath",
+			"countAgents",
+			"countAgentsNone",
+			"countAgentsNoResults",
+			"countAgentsOne",
+			"countAgentsOneResult",
+			"countAgentsResults",
+			"countHooks",
+			"countHooksNone",
+			"countHooksNoResults",
+			"countHooksOne",
+			"countHooksOneResult",
+			"countHooksResults",
+			"countInstructions",
+			"countInstructionsNone",
+			"countInstructionsNoResults",
+			"countInstructionsOne",
+			"countInstructionsOneResult",
+			"countInstructionsResults",
+			"countPrompts",
+			"countPromptsNone",
+			"countPromptsNoResults",
+			"countPromptsOne",
+			"countPromptsOneResult",
+			"countPromptsResults",
+			"countSkills",
+			"countSkillsNone",
+			"countSkillsNoResults",
+			"countSkillsOne",
+			"countSkillsOneResult",
+			"countSkillsResults",
 			"createFirstAgent",
 			"createFirstHook",
 			"createFirstInstructions",
@@ -9231,8 +10005,8 @@
 			"fromPlugin",
 			"groupAriaLabel",
 			"hook",
+			"hooks",
 			"hooksDescription",
-			"hookUnset",
 			"instructions",
 			"instructionsDescription",
 			"itemAriaLabel",
@@ -9243,28 +10017,26 @@
 			"learnMorePrompts",
 			"learnMoreSkills",
 			"listAriaLabel",
-			"localGroup",
-			"localGroupDescription",
 			"noAgents",
 			"noHooks",
 			"noInstructions",
 			"noMatchingItems",
 			"noPrompts",
 			"noSkills",
-			"onContextTooltip",
 			"onDemandInstructionsGroup",
 			"onDemandInstructionsGroupDescription",
 			"pluginGroup",
 			"pluginGroupDescription",
 			"prompt",
+			"prompts",
 			"promptsDescription",
+			"remoteClientGroupShort",
+			"remoteHostGroupShort",
 			"searchPlaceholder",
 			"skill",
+			"skills",
 			"skillsDescription",
-			"syncItem",
 			"tryDifferentSearch",
-			"uiIntegrationBadge",
-			"unsyncItem",
 			"userGroup",
 			"userGroupDescription",
 			"workspaceGroup",
@@ -9299,6 +10071,8 @@
 			"enable",
 			"enable",
 			"generateDebugReport",
+			"Install Chat Customization Extension",
+			"installChatCustomizationExtension",
 			"open",
 			"open",
 			"openAICustomizations",
@@ -9323,10 +10097,19 @@
 			"backToListTooltip",
 			"backToMcpList",
 			"backToMcpListTooltip",
+			"backToOverview",
+			"backToOverviewTooltip",
 			"backToPluginList",
 			"backToPluginListTooltip",
 			"cancelSaveTarget",
+			"customizationPreviewAriaLabel",
 			"editorActionButtonFailed",
+			"editorEditRawButtonLabel",
+			"editorEditRawButtonTooltip",
+			"editorPreviewButtonLabel",
+			"editorPreviewButtonTooltip",
+			"editorViewRawButtonLabel",
+			"editorViewRawButtonTooltip",
 			"homeButton",
 			"homeButtonTooltip",
 			"hooks",
@@ -9342,6 +10125,12 @@
 			"overview",
 			"plugins",
 			"pluginsDesc",
+			"previewFieldHelpAriaLabel",
+			"previewHeaderIssuesDescription",
+			"previewHeaderIssuesTitle",
+			"previewNoBody",
+			"previewNoFrontMatter",
+			"previewUnknownFieldDescription",
 			"prompts",
 			"promptsDesc",
 			"saveBuiltinCopyAndChooseLocation",
@@ -9351,6 +10140,7 @@
 			"saveBuiltinCopyPlaceholder",
 			"saveCustomizationOnExitFailed",
 			"saved",
+			"sectionAriaLabelWithCount",
 			"sectionsAriaLabel",
 			"selectHarness",
 			"selectTargetDirectory",
@@ -9362,30 +10152,11 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput": [
 			"aiCustomizationManagementEditorName"
 		],
-		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic": [
-			"agents",
-			"agentsDesc",
-			"browse",
-			"generateWithAI",
-			"gettingStartedDesc",
-			"gettingStartedTitle",
-			"hooks",
-			"hooksDesc",
-			"instructions",
-			"instructionsDesc",
-			"mcpServers",
-			"mcpServersDesc",
-			"plugins",
-			"pluginsDesc",
-			"skills",
-			"skillsDesc",
-			"welcomeHeading",
-			"welcomeSubtitle"
-		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers": [
 			"agents",
 			"agentsDesc",
 			"browse",
+			"browseCategoryAriaLabel",
 			"gettingStartedDesc",
 			"gettingStartedTitle",
 			"hooks",
@@ -9395,6 +10166,7 @@
 			"mcpServers",
 			"mcpServersDesc",
 			"new",
+			"newCategoryAriaLabel",
 			"plugins",
 			"pluginsDesc",
 			"sentToChat",
@@ -9413,14 +10185,22 @@
 			"nameRequired",
 			"selectTargetDirectory"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail": [
+			"pluginDetailEmpty",
+			"pluginSourceInstalled",
+			"pluginSourceLocal",
+			"pluginSourceMarketplace",
+			"pluginSourceMarketplaceUnknown"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail": [
+			"mcpDetailEmpty",
+			"mcpScopeUser",
+			"mcpScopeWorkspace"
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget": [
 			"addMcpServer",
 			"addServer",
 			"addServerTooltip",
-			"backToInstalled",
-			"backToInstalledAriaLabel",
-			"bridged",
-			"bridgedHover",
 			"browseMarketplace",
 			"builtInGroup",
 			"builtInGroupDescription",
@@ -9440,7 +10220,12 @@
 			"installing",
 			"learnMoreMcp",
 			"loadingGallery",
+			"mcpAccessDisabledByPolicy",
+			"mcpAccessDisabledBySettingPrefix",
+			"mcpAccessDisabledSettingLink",
+			"mcpAccessDisabledTitle",
 			"mcpGroupAriaLabel",
+			"mcpServers",
 			"mcpServersDescription",
 			"mcpServersListAriaLabel",
 			"noGalleryResults",
@@ -9464,42 +10249,63 @@
 			"workspaceGroupDescription"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget": [
-			"backToInstalledPlugins",
-			"backToInstalledPluginsAriaLabel",
+			"addPlugin",
+			"addRemotePlugins",
 			"browseMarketplace",
+			"browseMarketplaceUnsupportedWeb",
 			"browseToAdd",
 			"byPublisher",
 			"collapsed",
 			"createPlugin",
-			"createPluginTooltip",
-			"disabled",
 			"disabledGroup",
 			"disabledGroupDescription",
+			"disablePlugin",
 			"emptyMarketplace",
-			"enabled",
 			"enabledGroup",
 			"enabledGroupDescription",
+			"enablePlugin",
 			"expanded",
 			"install",
 			"installed",
 			"installFromSource",
-			"installFromSourceTooltip",
 			"installing",
 			"learnMorePlugins",
 			"loadingMarketplace",
 			"marketplaceError",
+			"morePluginAddActions",
 			"noMarketplaceResults",
 			"noMatchingPlugins",
 			"noPlugins",
+			"noRemotePlugins",
 			"pluginGroupAriaLabel",
+			"pluginInstalledItemAriaLabelDisabled",
+			"pluginInstalledItemAriaLabelEnabled",
+			"pluginItemAriaLabel",
+			"plugins",
 			"pluginsDescription",
+			"pluginsDisabledByPolicy",
+			"pluginsDisabledBySettingPrefix",
+			"pluginsDisabledSettingLink",
+			"pluginsDisabledTitle",
 			"pluginsListAriaLabel",
+			"remoteHostGroup",
+			"remoteHostGroupDescription",
+			"remotePluginDegraded",
+			"remotePluginDisabled",
+			"remotePluginError",
+			"remotePluginLoaded",
+			"remotePluginLoading",
 			"searchMarketplacePlaceholder",
 			"searchPluginsPlaceholder",
-			"syncPlugin",
 			"tryAgainLater",
-			"tryDifferentSearch",
-			"unsyncPlugin"
+			"tryDifferentSearch"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider": [
+			"alwaysAdded",
+			"alwaysAddedTooltip",
+			"hookUnset",
+			"onContextTooltip",
+			"uiIntegrationBadge"
 		],
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentResolveService": [
 			"imageTooLarge",
@@ -9509,6 +10315,13 @@
 			"chat.attachment",
 			"chat.attachment.clearButton",
 			"chat.attachment.withDeleteHint",
+			"chat.browserToolsDisabled",
+			"chat.browserToolsDisabled.aria",
+			"chat.browserViewAttachment.aria",
+			"chat.browserViewClosed",
+			"chat.browserViewClosed.aria",
+			"chat.browserViewNotShared",
+			"chat.browserViewNotShared.aria",
 			"chat.clickToViewContents",
 			"chat.elementAttachment",
 			"chat.elementHover.attributes",
@@ -9521,12 +10334,14 @@
 			"chat.fileAttachment",
 			"chat.fileAttachmentHover",
 			"chat.fileAttachmentWithRange",
+			"chat.folderImageLimitExceededHover",
 			"chat.imageAttachment",
 			"chat.imageAttachmentHover",
 			"chat.imageAttachmentPreviewFeaturesDisabled",
 			"chat.imageAttachmentWarning",
 			"chat.imageLimitExceededAttachment",
 			"chat.imageLimitExceededHover",
+			"chat.imageLimitExceededHoverUnknownLimit",
 			"chat.instructionsAttachment",
 			"chat.NotebookImageAttachment",
 			"chat.omittedFileAttachment",
@@ -9552,6 +10367,7 @@
 		"vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment": [
 			"addToContext",
 			"cell.lowercase",
+			"chat.implicitBrowserContext",
 			"chat.implicitFileContext",
 			"chat.implicitFileContextWithRange",
 			"chat.implicitStringContext",
@@ -9565,26 +10381,7 @@
 			"openFile",
 			"pinSelection"
 		],
-		"vs/workbench/contrib/chat/browser/attachments/simpleBrowserEditorOverlay": [
-			"cancelSelection",
-			"cancelSelectionLabel",
-			"chat.configureElements",
-			"chat.expandOverlay",
-			"chat.hideOverlay",
-			"chat.nextSelection",
-			"connectingWebviewElement",
-			"continuousSelectionDropdown",
-			"elementCancelMessage",
-			"elementSelectionComplete",
-			"elementSelectionInProgress",
-			"elementSelectionMessage",
-			"finishSelectionLabel",
-			"reopenErrorWebviewElement",
-			"selectAnElement",
-			"selectElementDropdown",
-			"startSelection"
-		],
-		"vs/workbench/contrib/chat/browser/chat.contribution": [
+		"vs/workbench/contrib/chat/browser/chat.shared.contribution": [
 			"agentPlugin",
 			"agentSandbox.allowedNetworkDomains.deprecated",
 			"agentSandbox.allowedNetworkDomains2.deprecated",
@@ -9610,8 +10407,18 @@
 			"chat.agent.thinkingMode.collapsedPreview",
 			"chat.agent.thinkingMode.fixedScrolling",
 			"chat.agent.thinkingStyle",
+			"chat.agentHost.ahpJsonlLogging",
+			"chat.agentHost.claudeAgent.path",
+			"chat.agentHost.clientTools",
+			"chat.agentHost.customTerminalTool.enabled",
 			"chat.agentHost.enabled",
 			"chat.agentHost.ipcLogging",
+			"chat.agentHost.otel.captureContent",
+			"chat.agentHost.otel.dbSpanExporter.enabled",
+			"chat.agentHost.otel.enabled",
+			"chat.agentHost.otel.exporterType",
+			"chat.agentHost.otel.otlpEndpoint",
+			"chat.agentHost.otel.outfile",
 			"chat.agentLocations.invalidPath",
 			"chat.agents.config.locations.description",
 			"chat.agents.config.locations.title",
@@ -9624,6 +10431,8 @@
 			"chat.agentSkillsLocations.invalidPath",
 			"chat.agentSkillsLocations.title",
 			"chat.allowAnonymousAccess",
+			"chat.approvedAccountOrganizations",
+			"chat.approvedAccountOrganizations.policy.description",
 			"chat.artifacts.enabled",
 			"chat.artifacts.rules.byFilePath",
 			"chat.artifacts.rules.byFilePath.groupName",
@@ -9641,9 +10450,8 @@
 			"chat.codeBlock.showProgressAnimation.description",
 			"chat.contextUsage.enabled",
 			"chat.customizations.harnessSelector.enabled",
-			"chat.customizations.welcomePageVariant",
-			"chat.customizations.welcomePageVariant.classic",
-			"chat.customizations.welcomePageVariant.promptLaunchers",
+			"chat.customizations.structuredPreview.enabled",
+			"chat.customizations.useChatSessionCustomizationsForCustomAgents",
 			"chat.detectParticipant.enabled",
 			"chat.disableAIFeatures",
 			"chat.editing.autoAcceptDelay",
@@ -9657,6 +10465,19 @@
 			"chat.exitAfterDelegation",
 			"chat.experimental.detectParticipant.enabled",
 			"chat.experimental.detectParticipant.enabled.deprecated",
+			"chat.experimental.incrementalRendering.animationStyle",
+			"chat.experimental.incrementalRendering.animationStyle.blur",
+			"chat.experimental.incrementalRendering.animationStyle.fade",
+			"chat.experimental.incrementalRendering.animationStyle.none",
+			"chat.experimental.incrementalRendering.animationStyle.reveal",
+			"chat.experimental.incrementalRendering.animationStyle.rise",
+			"chat.experimental.incrementalRendering.animationStyle.scale",
+			"chat.experimental.incrementalRendering.animationStyle.slide",
+			"chat.experimental.incrementalRendering.buffering",
+			"chat.experimental.incrementalRendering.buffering.off",
+			"chat.experimental.incrementalRendering.buffering.paragraph",
+			"chat.experimental.incrementalRendering.buffering.word",
+			"chat.experimental.incrementalRendering.enabled",
 			"chat.experimentalSessionsWindowOverride",
 			"chat.exploreAgent.defaultModel.description",
 			"chat.extensionToolsEnabled",
@@ -9694,6 +10515,9 @@
 			"chat.mcp.autostart.never",
 			"chat.mcp.autostart.newAndOutdated",
 			"chat.mcp.autostart.onlyNew",
+			"chat.mcp.collisionBehavior",
+			"chat.mcp.collisionBehavior.disable",
+			"chat.mcp.collisionBehavior.suffix",
 			"chat.mcp.gallery.enabled",
 			"chat.mcp.serverSampling",
 			"chat.mcp.serverSampling.allowedDuringChat",
@@ -9712,10 +10536,21 @@
 			"chat.notifyWindowOnResponseReceived.always",
 			"chat.notifyWindowOnResponseReceived.off",
 			"chat.notifyWindowOnResponseReceived.windowNotFocused",
+			"chat.offlineByok",
+			"chat.permissions.default.autoApprove.description",
+			"chat.permissions.default.autoApprove.label",
+			"chat.permissions.default.autopilot.description",
+			"chat.permissions.default.autopilot.label",
+			"chat.permissions.default.default.description",
+			"chat.permissions.default.default.label",
+			"chat.permissions.default.settingDescription",
+			"chat.persistentProgress.enabled",
 			"chat.planAgent.defaultModel.description",
+			"chat.planReview.inlineEditor.enabled",
 			"chat.pluginLocations",
 			"chat.plugins.enabled",
 			"chat.plugins.marketplaces",
+			"chat.progressBorder.enabled",
 			"chat.promptFileLocations.invalidPath",
 			"chat.promptFilesRecommendations.description",
 			"chat.promptFilesRecommendations.title",
@@ -9725,24 +10560,25 @@
 			"chat.restoreLastPanelSession",
 			"chat.reusablePrompts.config.locations.description",
 			"chat.reusablePrompts.config.locations.title",
-			"chat.sendElementsToChat.attachCSS",
 			"chat.sendElementsToChat.attachImages",
-			"chat.sendElementsToChat.enabled",
-			"chat.signInTitleBar",
+			"chat.sessionSync.enabled",
+			"chat.sessionSync.enabled.policy",
+			"chat.sessionSync.excludeRepositories",
 			"chat.subagents.allowInvocationsFromSubagents",
 			"chat.subagents.allowInvocationsFromSubagents.md",
-			"chat.subagentTool.customAgents",
 			"chat.tips.enabled",
+			"chat.titleBar.signIn.enabled",
 			"chat.toolReferenceName.description",
 			"chat.tools.autoApprove.edits",
 			"chat.tools.autoExpandFailures",
+			"chat.tools.compressOutput.enabled",
 			"chat.tools.confirmationCarousel",
 			"chat.tools.eligibleForAutoApproval",
 			"chat.tools.fetchPage.approvedUrls",
-			"chat.tools.renameTool.enabled",
+			"chat.tools.riskAssessment.enabled",
+			"chat.tools.riskAssessment.model",
 			"chat.tools.terminal.simpleCollapsible",
 			"chat.tools.todos.showWidget",
-			"chat.tools.usagesTool.enabled",
 			"chat.undoRequests.restoreInput",
 			"chat.unifiedAgentsBar.enabled",
 			"chat.upvoteAnimation",
@@ -9759,8 +10595,6 @@
 			"chat.useClaudeHooks.title",
 			"chat.useClaudeMd.description",
 			"chat.useClaudeMd.title",
-			"chat.useCustomAgentHooks.description",
-			"chat.useCustomAgentHooks.title",
 			"chat.useCustomizationsInParentRepos.description",
 			"chat.useCustomizationsInParentRepos.title",
 			"chat.useHooks.description",
@@ -9769,6 +10603,8 @@
 			"chat.useNestedAgentMd.title",
 			"chat.useSkillAdherencePrompt.description",
 			"chat.useSkillAdherencePrompt.title",
+			"chat.utilityModel.description",
+			"chat.utilitySmallModel.description",
 			"chat.viewProgressBadge.enabled",
 			"chat.viewSessions.enabled",
 			"chat.viewSessions.orientation",
@@ -9819,6 +10655,111 @@
 			"chatDebug.totalFiles",
 			"chatDebug.unknown"
 		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView": [
+			"chatDebug.cache.allComponentsIdentical",
+			"chatDebug.cache.badge.contentDrift",
+			"chatDebug.cache.badge.identical",
+			"chatDebug.cache.badge.lengthChange",
+			"chatDebug.cache.badge.onlyA",
+			"chatDebug.cache.badge.onlyB",
+			"chatDebug.cache.breakAt",
+			"chatDebug.cache.breakLineTooltip",
+			"chatDebug.cache.cachedTok",
+			"chatDebug.cache.cacheHit",
+			"chatDebug.cache.charsTotal",
+			"chatDebug.cache.componentsHeading",
+			"chatDebug.cache.componentSizes",
+			"chatDebug.cache.continuationComponentsNote",
+			"chatDebug.cache.continuationDeltaAlsoChanged",
+			"chatDebug.cache.continuationDeltaBreak",
+			"chatDebug.cache.continuationNoDeltaBreak",
+			"chatDebug.cache.diffSideA",
+			"chatDebug.cache.diffSideB",
+			"chatDebug.cache.diffSummary",
+			"chatDebug.cache.driftLegend",
+			"chatDebug.cache.duration",
+			"chatDebug.cache.endTime",
+			"chatDebug.cache.expirationHeadline",
+			"chatDebug.cache.expirationNote",
+			"chatDebug.cache.firstMessage",
+			"chatDebug.cache.firstRequest",
+			"chatDebug.cache.firstRequestNote",
+			"chatDebug.cache.hitChip",
+			"chatDebug.cache.hitHeadline",
+			"chatDebug.cache.inputTok",
+			"chatDebug.cache.kind.added",
+			"chatDebug.cache.kind.addedNoSize",
+			"chatDebug.cache.kind.contentDrift",
+			"chatDebug.cache.kind.contentDriftNoSize",
+			"chatDebug.cache.kind.dropped",
+			"chatDebug.cache.kind.lengthChange",
+			"chatDebug.cache.kind.lengthChangeNoSize",
+			"chatDebug.cache.laneCurrent",
+			"chatDebug.cache.lanePrevious",
+			"chatDebug.cache.legend.tools",
+			"chatDebug.cache.legend.toolSearch",
+			"chatDebug.cache.lossLine",
+			"chatDebug.cache.model",
+			"chatDebug.cache.modelTurn",
+			"chatDebug.cache.msChip",
+			"chatDebug.cache.noBreak",
+			"chatDebug.cache.notPresent",
+			"chatDebug.cache.noTurns",
+			"chatDebug.cache.optionsBanner",
+			"chatDebug.cache.optionsBroke",
+			"chatDebug.cache.optionsCurr",
+			"chatDebug.cache.optionsKey",
+			"chatDebug.cache.optionsPrev",
+			"chatDebug.cache.performance",
+			"chatDebug.cache.previousRequest",
+			"chatDebug.cache.requestId",
+			"chatDebug.cache.requestIdTooltip",
+			"chatDebug.cache.requestOptionsHeading",
+			"chatDebug.cache.requestShape",
+			"chatDebug.cache.requestShape.continuation",
+			"chatDebug.cache.requestShape.continuationDescription",
+			"chatDebug.cache.requestShape.fullInput",
+			"chatDebug.cache.requestShape.toolOutput",
+			"chatDebug.cache.requestShape.toolOutputDescription",
+			"chatDebug.cache.requestShape.toolOutputRequest",
+			"chatDebug.cache.requestShape.toolSearch",
+			"chatDebug.cache.requestShape.toolSearchDescription",
+			"chatDebug.cache.requestShape.toolSearchRequest",
+			"chatDebug.cache.requestShape.toolSearchRequestDescription",
+			"chatDebug.cache.requestTitle",
+			"chatDebug.cache.signatureHeading",
+			"chatDebug.cache.signatureSummaryBreakComponent",
+			"chatDebug.cache.signatureSummaryClean",
+			"chatDebug.cache.startTime",
+			"chatDebug.cache.summaryAdded",
+			"chatDebug.cache.summaryChanged",
+			"chatDebug.cache.summaryDropped",
+			"chatDebug.cache.summaryIdentical",
+			"chatDebug.cache.systemBroke",
+			"chatDebug.cache.systemComponent",
+			"chatDebug.cache.toggleGroup",
+			"chatDebug.cache.tokensReused",
+			"chatDebug.cache.toolsBroke",
+			"chatDebug.cache.toolsComponent",
+			"chatDebug.cache.truncatedBoth",
+			"chatDebug.cache.truncatedOne",
+			"chatDebug.cache.truncatedSideCurr",
+			"chatDebug.cache.truncatedSidePrev",
+			"chatDebug.cache.ttft",
+			"chatDebug.cache.turnAria",
+			"chatDebug.cache.turnHelp",
+			"chatDebug.cache.uncachedLine",
+			"chatDebug.cache.unknownPrompt",
+			"chatDebug.cache.visibleSignatureHeading",
+			"chatDebug.cache.visibleSignatureNote",
+			"chatDebug.cache.visibleSignatureSummaryBreak",
+			"chatDebug.cache.visibleSignatureSummaryClean",
+			"chatDebug.cache.visibleWireInput",
+			"chatDebug.cache.whereBroke",
+			"chatDebug.cacheExplorer",
+			"chatDebug.cacheExplorer.title",
+			"chatDebug.title"
+		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugDetailPanel": [
 			"chatDebug.closeDetail",
 			"chatDebug.copyToClipboard",
@@ -9831,6 +10772,7 @@
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventDetailRenderer": [
 			"chatDebug.detail.agent",
 			"chatDebug.detail.agentResponse",
+			"chatDebug.detail.cachedTokens",
 			"chatDebug.detail.callId",
 			"chatDebug.detail.description",
 			"chatDebug.detail.durationMs",
@@ -9882,6 +10824,7 @@
 			"tokenCount",
 			"toolCallLabel",
 			"toolCallsCount",
+			"tooltipCachedTokens",
 			"tooltipDuration",
 			"tooltipInput",
 			"tooltipInputTokens",
@@ -9926,6 +10869,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView": [
 			"chatDebug.aria.agentResponse",
+			"chatDebug.aria.cachedTokens",
 			"chatDebug.aria.model",
 			"chatDebug.aria.modelTurn",
 			"chatDebug.aria.subagent",
@@ -9988,6 +10932,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView": [
 			"chatDebug.agentFlowChart",
+			"chatDebug.cacheExplorer",
 			"chatDebug.detail.created",
 			"chatDebug.detail.lastActivity",
 			"chatDebug.detail.location",
@@ -9998,10 +10943,13 @@
 			"chatDebug.location.editor",
 			"chatDebug.location.notebook",
 			"chatDebug.location.terminal",
+			"chatDebug.metric.copilotUsage",
 			"chatDebug.metric.errors",
 			"chatDebug.metric.modelTurns",
 			"chatDebug.metric.toolCalls",
-			"chatDebug.metric.totalEvents",
+			"chatDebug.metric.totalCachedInputTokens",
+			"chatDebug.metric.totalInputTokens",
+			"chatDebug.metric.totalOutputTokens",
 			"chatDebug.metric.totalTokens",
 			"chatDebug.revealChatSession",
 			"chatDebug.sessionDetails",
@@ -10150,6 +11098,8 @@
 			"chatImageCarousel.allImages"
 		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution": [
+			"enableChatForByok",
+			"enableChatForByokReason",
 			"languageModelsOpenSettings",
 			"models.clearResults",
 			"modelsManagementEditor",
@@ -10160,11 +11110,9 @@
 			"modelsManagementEditorInputName",
 			"modelsManagementEditorLabelIcon"
 		],
-		"vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel": [
-			"hidden",
-			"visible"
-		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget": [
+			"cacheCost.ariaLabel.plural",
+			"cacheCost.ariaLabel.singular",
 			"capabilities",
 			"capability.agent",
 			"capability.tools",
@@ -10173,51 +11121,55 @@
 			"collapse",
 			"collapseAll",
 			"cost",
+			"cost.cache",
+			"cost.cacheHover.plural",
+			"cost.cacheHover.singular",
+			"cost.input",
+			"cost.inputHover.plural",
+			"cost.inputHover.singular",
+			"cost.output",
+			"cost.outputHover.plural",
+			"cost.outputHover.singular",
 			"expand",
 			"filter",
-			"filter.hidden",
-			"filter.visible",
 			"filterByCapability",
 			"filterByProvider",
-			"filterByVisible",
-			"groupBy",
-			"groupBy.provider",
-			"groupBy.visibility",
-			"groupByTooltip",
 			"hidden.ariaLabel",
+			"inputCost.ariaLabel.plural",
+			"inputCost.ariaLabel.singular",
 			"model.capabilities",
 			"model.contextSize.totalTokens",
-			"model.hidden",
 			"model.name",
-			"model.visible",
 			"modelName",
 			"models.agentMode",
+			"models.cacheCost.plural",
+			"models.cacheCost.singular",
 			"models.capabilities",
 			"models.configure",
 			"models.configureContextMenu",
 			"models.configureModel",
 			"models.contextSize",
-			"models.cost",
 			"models.deleteAction",
 			"models.deleteConfirmation",
 			"models.enableModelProvider",
-			"models.hidden",
-			"models.hide",
-			"models.hideAll",
-			"models.hideSelected",
+			"models.inputCost.plural",
+			"models.inputCost.singular",
 			"models.managedByOrganization",
 			"models.manageProvider",
-			"models.show",
-			"models.showAll",
-			"models.showSelected",
+			"models.outputCost.plural",
+			"models.outputCost.singular",
+			"models.pinModel",
+			"models.pricing",
 			"models.toolCalling",
 			"models.tools",
-			"models.userSelectable",
-			"models.visible",
+			"models.unpinModel",
 			"models.vision",
 			"modelsTable.ariaLabel",
-			"multiplier.tooltip",
-			"provider",
+			"outputCost.ariaLabel.plural",
+			"outputCost.ariaLabel.singular",
+			"pricing",
+			"pricing.ariaLabel",
+			"pricing.tooltip",
 			"Search.FullTextSearchPlaceholder",
 			"status.ariaLabel",
 			"tokenLimits",
@@ -10225,6 +11177,7 @@
 			"visible.ariaLabel"
 		],
 		"vs/workbench/contrib/chat/browser/chatOutputItemRenderer": [
+			"chatOutputRenderer.codeBlockLanguageIdentifiers",
 			"chatOutputRenderer.mimeTypes",
 			"chatOutputRenderer.viewType",
 			"vscode.extension.contributes.chatOutputRenderer"
@@ -10332,7 +11285,7 @@
 			"fix",
 			"forceSignIn",
 			"hideChatSetup",
-			"manageOverages",
+			"manageAdditionalSpend",
 			"managePlan",
 			"restartExtensionHost.reason.disable",
 			"restartExtensionHost.reason.enable",
@@ -10340,6 +11293,8 @@
 			"review",
 			"setupErrorDialog",
 			"signInIndicatorTitleBarAction",
+			"toggle.chatSignIn",
+			"toggle.chatSignInDescription",
 			"triggerChatSetup",
 			"triggerChatSetupFromAccounts"
 		],
@@ -10416,6 +11371,7 @@
 			"agents",
 			"autoApprove",
 			"autopilot",
+			"chatSessionOption.slashCommand.detail",
 			"clear",
 			"debug",
 			"disableAutoApprove",
@@ -10441,15 +11397,7 @@
 					"{Locked=\"]({3})\"}"
 				]
 			},
-			"additionalUsageApprovedLine1",
-			"additionalUsageApprovedLine2",
-			"additionalUsageDisabled",
-			"anonymousTitle",
 			"cancelSnooze",
-			"chat.session.inProgress.background",
-			"chat.session.inProgress.cloud",
-			"chat.session.inProgress.local",
-			"chatAgentSessionsTitle",
 			"chatsLabel",
 			"completions.plus5min",
 			"completions.remainingTime",
@@ -10458,50 +11406,53 @@
 			"completions.snoozeAdditional5minutes",
 			"completions.snoozeTimeDescription",
 			"completionsLabel",
-			"currentModel.description",
-			"currentOption.description",
-			"enableAdditionalUsage",
+			"creditsLabel",
 			"enableAIFeatures",
 			"enableCopilotButton",
 			"enableDescription",
 			"enableMoreAIFeatures",
 			"enableMoreDescription",
-			"gaugeBackground",
-			"gaugeBorder",
-			"gaugeErrorBackground",
-			"gaugeErrorForeground",
-			"gaugeForeground",
-			"gaugeWarningBackground",
-			"gaugeWarningForeground",
 			"includedPremiumChatsLabel",
-			"inlineSuggestions",
-			"inProgressChatSession",
+			"includedTitle",
+			"includedTitleTBB",
+			"inlineSuggestionsDisabled",
+			"inlineSuggestionsEnabled",
+			"inlineSuggestionsTab",
 			"learnMore",
-			"limitQuota",
+			"manageBudget",
 			"modelLabel",
 			"premiumChatsLabel",
+			"premiumIncluded",
+			"premiumIncludedCompact",
+			"premiumLimitReached",
+			"premiumLimitReachedCompact",
+			"quotaAdditionalUsageActive",
+			"quotaAdditionalUsageApproaching",
+			"quotaBudgetActive",
+			"quotaBudgetApproaching",
+			"quotaCreditsDisplay",
 			"quotaDisplay",
-			"quotaDisplayWithOverage",
 			"quotaLabel",
+			"quotaLabelUsed",
 			"quotaLimited",
+			"quotaPaused",
+			"quotaPausedEnterprise",
+			"quotaResets",
+			"quotaResetsAt",
 			"quotaTooltip",
-			"quotaUnlimited",
+			"quotaUsed",
+			"quotaWarning",
+			"quotaWarningEnterprise",
 			"selectModel",
-			"selectModelFor",
 			"selectOption",
-			"selectProviderOptionFor",
 			"settings.codeCompletions.allFiles",
 			"settings.codeCompletions.language",
 			"settings.nextEditSuggestions",
+			"settings.overridden",
 			"settings.snooze",
-			"settingsLabel",
-			"settingsTooltip",
 			"signInDescription",
 			"signInToUseAIFeatures",
-			"upgradeToCopilotPro",
-			"usageTitleWithPlan",
-			"viewChatSessionsLabel",
-			"viewChatSessionsTooltip"
+			"upgrade"
 		],
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry": [
 			"chatAndCompletionsQuotaExceededStatus",
@@ -10514,8 +11465,6 @@
 			"completionsQuotaExceededStatus",
 			"completionsSnoozedStatus",
 			"copilotDisabledStatus",
-			"finishSetup",
-			"notSignedIn",
 			"signIn"
 		],
 		"vs/workbench/contrib/chat/browser/chatTipCatalog": [
@@ -10527,11 +11476,11 @@
 			"tip.createAgent",
 			"tip.createPrompt",
 			"tip.createSkill",
+			"tip.defaultPermissions",
 			"tip.forkConversation",
 			"tip.init",
 			"tip.mermaid",
 			"tip.messageQueueing",
-			"tip.openAgentsWindow",
 			"tip.planMode",
 			"tip.subagents",
 			"tip.switchToAuto",
@@ -10564,7 +11513,8 @@
 		],
 		"vs/workbench/contrib/chat/browser/defaultModelContribution": [
 			"defaultModel",
-			"defaultModelDescription"
+			"defaultModelDescription",
+			"modelLabelWithVendor"
 		],
 		"vs/workbench/contrib/chat/browser/enablementActions": [
 			"disable",
@@ -10581,8 +11531,24 @@
 		"vs/workbench/contrib/chat/browser/languageModelsConfigurationService": [
 			"settings.perModelConfig"
 		],
+		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions": [
+			"planReviewFeedback.clear",
+			"planReviewFeedback.clearAllTooltip",
+			"planReviewFeedback.navStatus.label",
+			"planReviewFeedback.next",
+			"planReviewFeedback.previous"
+		],
+		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution": [
+			"planReviewFeedback.add",
+			"planReviewFeedback.addFeedback",
+			"planReviewFeedback.enter",
+			"planReviewFeedback.navStatus.nOfM",
+			"planReviewFeedback.navStatus.zero"
+		],
 		"vs/workbench/contrib/chat/browser/pluginGitCommandService": [
-			"pluginsNotSupported"
+			"pluginsBrowserGitHubAccessRequired",
+			"pluginsBrowserGitHubSignInRequired",
+			"pluginsBrowserUnsupportedHost"
 		],
 		"vs/workbench/contrib/chat/browser/pluginInstallService": [
 			"cloneFailed",
@@ -10696,6 +11662,7 @@
 			"agentHooks",
 			"commands.addNewHook.label",
 			"commands.createNewHookFile.label",
+			"commands.hook.defaultFolder",
 			"commands.hook.filename.invalidChars",
 			"commands.hook.filename.placeholder",
 			"commands.hook.filename.prompt",
@@ -10760,12 +11727,12 @@
 			"commands.instructions.create.ask-folder.empty.placeholder",
 			"commands.prompts.create.ask-folder.empty.docs-label",
 			"commands.prompts.create.ask-folder.empty.placeholder",
-			"commands.prompts.create.source-folder.current-workspace",
 			"commands.skill.create.ask-folder.empty.docs-label",
 			"commands.skill.create.ask-folder.empty.placeholder",
 			"current.folder",
 			"instructions.copy.location.placeholder",
 			"instructions.move.location.placeholder",
+			"pathWithDefault",
 			"prompt.copy.location.placeholder",
 			"prompt.move.location.placeholder",
 			"skill.copy.location.placeholder",
@@ -10855,6 +11822,11 @@
 			"configure-skills",
 			"configure-skills.short"
 		],
+		"vs/workbench/contrib/chat/browser/tools/chatToolRiskAssessmentService": [
+			"riskDefaultGreen",
+			"riskDefaultOrange",
+			"riskDefaultRed"
+		],
 		"vs/workbench/contrib/chat/browser/tools/languageModelToolsConfirmationService": [
 			"allowCombinationGlobally",
 			"allowCombinationGloballyTooltip",
@@ -10934,8 +11906,7 @@
 			"tool.rename.edits",
 			"tool.rename.invocationMessage",
 			"tool.rename.oneEdit",
-			"tool.rename.userDescription",
-			"tool.rename.userDescriptionWithLanguages"
+			"tool.rename.userDescription"
 		],
 		"vs/workbench/contrib/chat/browser/tools/toolSetsContribution": [
 			"bad_name1",
@@ -10958,8 +11929,11 @@
 			"tool.usages.noResults",
 			"tool.usages.oneResult",
 			"tool.usages.results",
-			"tool.usages.userDescription",
-			"tool.usages.userDescriptionWithLanguages"
+			"tool.usages.userDescription"
+		],
+		"vs/workbench/contrib/chat/browser/utilityModelContribution": [
+			"chat.utilityModel.defaultEntry.description",
+			"chat.utilityModel.defaultEntry.label"
 		],
 		"vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler": [
 			"chatViewsWelcome.content",
@@ -11005,7 +11979,8 @@
 			"dismiss"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatConfirmationWidget": [
-			"chat.confirmationWidget.ariaLabel"
+			"chat.confirmationWidget.ariaLabel",
+			"chat.confirmationWidget.ariaLabelWithBannerTitleMessageBanner"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDisabledClaudeHooksContentPart": [
 			"chat.disabledClaudeHooks.enableLink",
@@ -11065,6 +12040,9 @@
 			"chat.codeblock.generating",
 			"chat.codeblock.insertions",
 			"chat.codeblock.insertions.one",
+			"chat.codeBlockOutputError",
+			"chat.codeBlockOutputRendering",
+			"chat.renderedCodeBlockLabel",
 			"summary"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersInteractionContentPart": [
@@ -11084,16 +12062,52 @@
 			"chatMultiDiff.openAllChanges",
 			"chatMultiDiffList"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart": [
+			"chat.planReview.ariaLabel",
+			"chat.planReview.autopilot.cancel",
+			"chat.planReview.autopilot.confirm",
+			"chat.planReview.autopilot.detail",
+			"chat.planReview.autopilot.title",
+			"chat.planReview.cancelButtonLabel",
+			"chat.planReview.cancelTooltip",
+			"chat.planReview.clearAll",
+			"chat.planReview.clearAllConfirm",
+			"chat.planReview.clearAllConfirmPrimary",
+			"chat.planReview.clearAllDetail",
+			"chat.planReview.close",
+			"chat.planReview.collapse",
+			"chat.planReview.commentRowAriaLabel",
+			"chat.planReview.commentRowLine",
+			"chat.planReview.expand",
+			"chat.planReview.expandSize",
+			"chat.planReview.feedbackLabel",
+			"chat.planReview.feedbackPlaceholder",
+			"chat.planReview.inlineCommentLocation",
+			"chat.planReview.inlineCommentLocationLine",
+			"chat.planReview.inlineCommentsHeading",
+			"chat.planReview.inlineCommentsHeadingNoFile",
+			"chat.planReview.openButtonLabel",
+			"chat.planReview.openTooltip",
+			"chat.planReview.reject",
+			"chat.planReview.removeComment",
+			"chat.planReview.restoreSize",
+			"chat.planReview.reviewButtonLabel",
+			"chat.planReview.reviewTooltip",
+			"chat.planReview.submitFeedback",
+			"chat.planReview.submitFeedbackWithCount"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatProgressContentPart": [
-			"toolCallUnresponsive",
-			"workingMessage"
+			"toolCallUnresponsive"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart": [
 			"chat.questionCarousel.collapseTitle",
+			"chat.questionCarousel.combinedFocusTerminalHint",
+			"chat.questionCarousel.combinedFocusTerminalHintNoKb",
 			"chat.questionCarousel.deferredToTerminal",
 			"chat.questionCarousel.enterCustomAnswer",
 			"chat.questionCarousel.enterText",
 			"chat.questionCarousel.expandTitle",
+			"chat.questionCarousel.focusTerminalAriaLabel",
 			"chat.questionCarousel.focusTerminalTitle",
 			"chat.questionCarousel.label",
 			"chat.questionCarousel.labelWithKeybinding",
@@ -11129,6 +12143,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart": [
 			"clickToContinue",
+			"configureBudget",
 			"enableAdditionalUsage",
 			"upgradeToCopilotPro",
 			"waitWarning"
@@ -11204,12 +12219,18 @@
 			"chat.thinking.thinking.3",
 			"chat.thinking.thinking.4",
 			"chat.thinking.thinking.5",
+			"chat.thinking.thinking.6",
 			"chat.thinking.titleWithDiff",
 			"chat.thinking.tool.1",
 			"chat.thinking.tool.2",
 			"chat.thinking.tool.3",
 			"chat.thinking.tool.4",
-			"chat.thinking.tool.5"
+			"chat.thinking.tool.5",
+			"chat.working.fun.1",
+			"chat.working.fun.2",
+			"chat.working.fun.3",
+			"chat.working.fun.minecraft.1",
+			"chat.working.fun.ms.1"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart": [
 			"chatTip",
@@ -11299,6 +12320,8 @@
 			"autoApprove.markdown",
 			"autoApprove.markdown2",
 			"autoApprove.title",
+			"chat.terminal.detail.approvalNeeded",
+			"chat.terminal.detail.sandboxInsufficient",
 			"chat.terminal.unsandboxedExecution.defaultReason",
 			"newRule.session",
 			"newRule.session.plural",
@@ -11314,13 +12337,20 @@
 			"tool.skip"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart": [
+			"chat.terminal.backgroundSuffix",
 			"chat.terminal.ran.plain",
 			"chat.terminal.ran.prefix",
 			"chat.terminal.ranInSandbox.prefix",
 			"chat.terminal.running.plain",
 			"chat.terminal.running.prefix",
+			"chat.terminal.runningInBackground.plain",
 			"chat.terminal.runningInSandbox.prefix",
+			"chat.terminal.sandbox.backgroundSuffix",
 			"chat.terminal.sandbox.suffix",
+			"chat.terminal.showTerminal",
+			"chat.terminal.skipped.plain",
+			"chat.terminal.skipped.prefix",
+			"chat.terminal.skippedInSandbox.prefix",
 			"chat.terminalOutputCommandMissing",
 			"chat.terminalOutputEmpty",
 			"chat.terminalOutputTerminalMissing",
@@ -11338,15 +12368,13 @@
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationCarouselPart": [
 			"allow",
 			"allowAll",
-			"collapse",
-			"confirmTool",
-			"confirmTools",
-			"expand",
 			"expandConfirmationUp",
 			"next",
 			"previous",
 			"restoreConfirmationSize",
 			"scrollToSubagent",
+			"skip",
+			"skipAll",
 			"toolConfirmationCarousel"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart": [
@@ -11378,6 +12406,12 @@
 			"noResults",
 			"skip.post"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/toolRiskBadgeWidget": [
+			"toolRisk.aiGenerated",
+			"toolRisk.assessing",
+			"toolRisk.assessingHover",
+			"toolRisk.detailsIconLabel"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatDragAndDrop": [
 			"attacAsContext",
 			"dragAndDroppedImageName",
@@ -11391,6 +12425,12 @@
 			"url"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatListRenderer": [
+			"chat.planReview.approved",
+			"chat.planReview.autopilot",
+			"chat.planReview.feedback",
+			"chat.planReview.feedbackInline",
+			"chat.planReview.rejected",
+			"chat.planReview.required",
 			"chat.questionCarouselAlertMany",
 			"chat.questionCarouselAlertOne",
 			"chat.questionCarouselNeedsInputSR",
@@ -11410,6 +12450,8 @@
 			"requestMarkdownPartTitle",
 			"steeringDivider",
 			"steeringDividerTooltip",
+			"systemNotificationDivider",
+			"systemNotificationDividerTooltip",
 			"usedAgent",
 			"usedAgentSlashCommand",
 			"working"
@@ -11440,6 +12482,9 @@
 		"vs/workbench/contrib/chat/browser/widget/input/chatFollowups": [
 			"followUpAriaLabel"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget": [
+			"dismissNotification"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputPart": [
 			"actions.chat.accessibiltyHelp",
 			"chatEditingSession.ariaLabelWithCounts",
@@ -11455,6 +12500,8 @@
 			"chatInput.model"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatModelPicker": [
+			"chat.effort.costHint",
+			"chat.effort.header",
 			"chat.manageModels",
 			"chat.manageModels.tooltip",
 			"chat.modelPicker.adminDescription",
@@ -11464,14 +12511,42 @@
 			"chat.modelPicker.auto",
 			"chat.modelPicker.checkUpdateHover",
 			"chat.modelPicker.downloadUpdateHover",
+			"chat.modelPicker.effortAriaLabel",
+			"chat.modelPicker.effortTooltip",
 			"chat.modelPicker.otherModels",
+			"chat.modelPicker.pin",
+			"chat.modelPicker.pinned",
 			"chat.modelPicker.restartUpdateHover",
 			"chat.modelPicker.search",
+			"chat.modelPicker.tokensAriaLabel",
+			"chat.modelPicker.tokensTooltip",
+			"chat.modelPicker.unpin",
 			"chat.modelPicker.updateDescription",
 			"chat.modelPicker.upgradeHover",
+			"chat.modelPicker.upgradeHoverProPlus",
 			"chat.modelPicker.upgradeLink",
+			"chat.priceCategory.high",
+			"chat.priceCategory.low",
+			"chat.priceCategory.medium",
+			"chat.priceCategory.veryHigh",
+			"chat.tokens.costHint",
+			"chat.tokens.header",
+			"models.cacheCostLabel",
+			"models.configurable",
 			"models.contextSize",
-			"multiplier.tooltip"
+			"models.cost",
+			"models.costValuePlural",
+			"models.costValueSingular",
+			"models.effortDefault",
+			"models.inputCostLabel",
+			"models.outputCostLabel",
+			"models.priceCategoryTitle",
+			"models.priceTitle",
+			"models.tokensDefault"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter": [
+			"chatPhoneInput.autoLabel",
+			"chatPhoneInput.triggerAriaLabel"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem": [
 			"chat.queueMessage",
@@ -11481,14 +12556,6 @@
 			"chat.sendImmediately.hover",
 			"chat.steerWithMessage",
 			"chat.steerWithMessage.hover"
-		],
-		"vs/workbench/contrib/chat/browser/widget/input/chatStatusWidget": [
-			"chat.anonymousRateLimited.message",
-			"chat.anonymousRateLimited.signIn",
-			"chat.anonymousRateLimited.signIn.ariaLabel",
-			"chat.freeQuotaExceeded.message",
-			"chat.freeQuotaExceeded.upgrade",
-			"chat.freeQuotaExceeded.upgrade.ariaLabel"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem": [
 			"chat.learnMoreAgentHandOff",
@@ -11524,7 +12591,7 @@
 			"pastedImageName",
 			"pastedSymbolReference"
 		],
-		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem2": [
+		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem": [
 			"chat.modelPicker.label"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem": [
@@ -11535,30 +12602,24 @@
 			"viewModeConfiguration"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem": [
+			"permissions.ariaLabel",
 			"permissions.autoApprove",
 			"permissions.autoApprove.description",
 			"permissions.autoApprove.label",
 			"permissions.autoApprove.policyDescription",
 			"permissions.autoApprove.policyDisabled",
 			"permissions.autoApprove.subtext",
-			"permissions.autoApprove.warning.cancel",
-			"permissions.autoApprove.warning.confirm",
-			"permissions.autoApprove.warning.detail",
-			"permissions.autoApprove.warning.title",
 			"permissions.autopilot",
 			"permissions.autopilot.description",
 			"permissions.autopilot.label",
 			"permissions.autopilot.policyDescription",
 			"permissions.autopilot.policyDisabled",
 			"permissions.autopilot.subtext",
-			"permissions.autopilot.warning.cancel",
-			"permissions.autopilot.warning.confirm",
-			"permissions.autopilot.warning.detail",
-			"permissions.autopilot.warning.title",
 			"permissions.default",
 			"permissions.default.description",
 			"permissions.default.label",
 			"permissions.default.subtext",
+			"permissions.ext.locked",
 			"permissions.learnMore"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem": [
@@ -11656,10 +12717,12 @@
 			"chatModelsAreUserSelectable",
 			"chatModeName",
 			"chatNewChatButtonExperimentIcon",
+			"chatNonCopilotModelsAreUserSelectable",
 			"chatPanelExtensionParticipantRegistered",
 			"chatPanelLocation",
 			"chatParticipantRegistered",
 			"chatPermissionLevel",
+			"chatQuestionCarouselHasTerminal",
 			"chatRemoteJobCreating",
 			"chatRequest",
 			"chatRequestIsPending",
@@ -11720,6 +12783,17 @@
 			"chatDescription",
 			"editsDescription"
 		],
+		"vs/workbench/contrib/chat/common/chatPermissionWarnings": [
+			"permissions.autoApprove.warning.cancel",
+			"permissions.autoApprove.warning.confirm",
+			"permissions.autoApprove.warning.detail",
+			"permissions.autoApprove.warning.title",
+			"permissions.autopilot.warning.cancel",
+			"permissions.autopilot.warning.confirm",
+			"permissions.autopilot.warning.detail",
+			"permissions.autopilot.warning.title",
+			"permissions.warning.dontShowAgain"
+		],
 		"vs/workbench/contrib/chat/common/chatService/chatServiceImpl": [
 			"agentDebugLog.troubleshootDisabled",
 			"emptyResponse",
@@ -11735,14 +12809,12 @@
 			"chatMultidiff.autoGenerated"
 		],
 		"vs/workbench/contrib/chat/common/languageModels": [
-			"booleanRequired",
 			"configureLanguageModelGroup",
 			"enterName",
 			"enterValue",
 			"languageModelGroupName",
 			"models.enumDefault",
 			"nameExists",
-			"numberRequired",
 			"selectValue",
 			"valueRequired",
 			"vscode.extension.contributes.languageModelChatProviders",
@@ -11769,7 +12841,8 @@
 			"editsSummary",
 			"filteredContentRetry",
 			"waitingAnswer",
-			"waitingForPostApproval"
+			"waitingForPostApproval",
+			"waitingPlanReview"
 		],
 		"vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation": [
 			"toolDeniedMessage"
@@ -11788,6 +12861,9 @@
 			"chatPlugins.schema.description",
 			"chatPluginsPath",
 			"chatPluginsWhen",
+			"copilotCliPlugin.remove.confirm",
+			"copilotCliPlugin.remove.detail",
+			"copilotCliPlugin.remove.primary",
 			"extension.plugin.invalid.path",
 			"extension.plugin.invalid.when",
 			"extension.plugin.missing.path",
@@ -11801,6 +12877,7 @@
 			"chatContribution.property.name.deprecated",
 			"chatContribution.property.path",
 			"chatContribution.property.path.skills",
+			"chatContribution.property.sessionTypes",
 			"chatContribution.property.when",
 			"chatContribution.schema.description",
 			"chatFilesDescription",
@@ -11821,8 +12898,9 @@
 			"debugDetail.noMatch",
 			"debugDetail.noPattern",
 			"debugDetail.skillDebugDisabled",
+			"debugDetail.skillNoDescription",
 			"debugDetail.skillNotModelInvocable",
-			"debugDetail.skillWhenClause",
+			"debugDetail.skillSessionType",
 			"instruction.file.description.agentsmd.folder",
 			"instruction.file.description.agentsmd.root",
 			"instruction.file.reason.allFiles",
@@ -11949,6 +13027,8 @@
 			"promptHeader.prompt.tools",
 			"promptHeader.skill.argumentHint",
 			"promptHeader.skill.compatibility",
+			"promptHeader.skill.context",
+			"promptHeader.skill.context.fork",
 			"promptHeader.skill.description",
 			"promptHeader.skill.disableModelInvocation",
 			"promptHeader.skill.license",
@@ -12062,7 +13142,6 @@
 			"promptValidator.agentNotFound",
 			"promptValidator.agentsMustBeArray",
 			"promptValidator.agentsRequiresAgentTool",
-			"promptValidator.agentsRequiresConfig",
 			"promptValidator.applyToMustBeString",
 			"promptValidator.applyToMustBeValidGlob",
 			"promptValidator.argumentHintMustBeString",
@@ -12073,6 +13152,7 @@
 			"promptValidator.chatModesRenamedToAgentsNoMove",
 			"promptValidator.claude.attributeMustBeString",
 			"promptValidator.claude.attributeNotFound",
+			"promptValidator.contextForkNotSupported",
 			"promptValidator.deprecatedVariableReference",
 			"promptValidator.deprecatedVariableReferenceMultipleNames",
 			"promptValidator.descriptionMustBeString",
@@ -12109,7 +13189,6 @@
 			"promptValidator.hookValueMustBeArray",
 			"promptValidator.ignoredAttribute.vscode-agent",
 			"promptValidator.inferDeprecated",
-			"promptValidator.inferRequiresConfig",
 			"promptValidator.invalidFileReference",
 			"promptValidator.invalidPermissionValue",
 			"promptValidator.missingHandoffProperties",
@@ -12131,9 +13210,11 @@
 			"promptValidator.permissionsMustBeMap",
 			"promptValidator.permissionValueMustBeString",
 			"promptValidator.skillDescriptionMissing",
+			"promptValidator.skillModelInvocationRequiresDescription",
 			"promptValidator.skillNameFolderMismatch",
 			"promptValidator.skillNameInvalidChars",
 			"promptValidator.skillNameMissing",
+			"promptValidator.skillUserInvocableRequiresDescription",
 			"promptValidator.targetInvalidValue",
 			"promptValidator.targetMustBeNonEmpty",
 			"promptValidator.targetMustBeString",
@@ -12156,6 +13237,18 @@
 			"promptValidator.unknownPermissionScope",
 			"promptValidator.unknownVariableReference",
 			"promptValidator.userInvocableMustBeBoolean"
+		],
+		"vs/workbench/contrib/chat/common/promptSyntax/promptTypes": [
+			"source.agentsPersonal",
+			"source.agentsWorkspace",
+			"source.claudePersonal",
+			"source.claudeWorkspace",
+			"source.claudeWorkspaceLocal",
+			"source.configPersonal",
+			"source.configWorkspace",
+			"source.copilotPersonal",
+			"source.githubWorkspace",
+			"source.userData"
 		],
 		"vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl": [
 			"extension.with.id",
@@ -12219,6 +13312,14 @@
 			"tool.manageTodoList.displayName",
 			"tool.manageTodoList.userDescription"
 		],
+		"vs/workbench/contrib/chat/common/tools/builtinTools/reviewPlanTool": [
+			"reviewPlanTool.defaultTitle",
+			"reviewPlanTool.invocation",
+			"reviewPlanTool.invocation.past",
+			"reviewPlanTool.noActions",
+			"tool.reviewPlan.displayName",
+			"tool.reviewPlan.userDescription"
+		],
 		"vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool": [
 			"tool.runSubagent.displayName",
 			"tool.runSubagent.userDescription"
@@ -12276,6 +13377,9 @@
 			"chat.avatarBackground",
 			"chat.avatarForeground",
 			"chat.editedFileForeground",
+			"chat.inputWorkingBorderColor1",
+			"chat.inputWorkingBorderColor2",
+			"chat.inputWorkingBorderColor3",
 			"chat.linesAddedForeground",
 			"chat.linesRemovedForeground",
 			"chat.requestBackground",
@@ -12288,9 +13392,6 @@
 			"chat.thinkingShimmer",
 			"chatCheckpointSeparator"
 		],
-		"vs/workbench/contrib/chat/common/widget/input/modelPickerWidget": [
-			"chat.modelPicker.other"
-		],
 		"vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions": [
 			"workbench.action.chat.openStorageFolder.label"
 		],
@@ -12298,6 +13399,19 @@
 			"chat.exportAsZip.label",
 			"chatExportZip.error",
 			"chatExportZip.noRepoData"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/debugAgentHostAction": [
+			"debugAgentHost.noInspectPort",
+			"debugAgentHostInDevTools"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService": [
+			"exportDebugLogs.saveDialogTitle",
+			"exportDebugLogs.zipFilter"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/exportAgentTracesDb": [
+			"exportAgentTracesDB.error",
+			"exportAgentTracesDB.label",
+			"exportAgentTracesDB.notFound"
 		],
 		"vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions": [
 			"keywordActivation.status.active",
@@ -12325,7 +13439,9 @@
 			"workbench.action.speech.stopReadAloud"
 		],
 		"vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions": [
-			"openAgentsWindow"
+			"openAgentsWindow",
+			"openInAgentsHover",
+			"openWorkspaceInAgentsWindow"
 		],
 		"vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool": [
 			"fetchWebPage.binaryNotSupported",
@@ -12984,6 +14100,11 @@
 			"hasCommentingProvider",
 			"hasCommentingRange"
 		],
+		"vs/workbench/contrib/customEditor/browser/customEditorDiffInput": [
+			"customEditorDiffLabel",
+			"customEditorDiffTitle",
+			"customEditorSideBySideDiffTitle"
+		],
 		"vs/workbench/contrib/customEditor/browser/customEditorInput": [
 			"editorCannotMove",
 			"editorUnsupportedInWindow",
@@ -13003,6 +14124,9 @@
 			"contributes.displayName",
 			"contributes.priority",
 			"contributes.priority.default",
+			"contributes.priority.diff",
+			"contributes.priority.editor",
+			"contributes.priority.merge",
 			"contributes.priority.option",
 			"contributes.selector",
 			"contributes.selector.filenamePattern",
@@ -14615,6 +15739,7 @@
 			"extensions.autoUpdate.false",
 			"extensions.autoUpdate.true",
 			"extensions.gallery.serviceUrl",
+			"extensions.supportAgentsWindow",
 			"extensions.supportUntrustedWorkspaces",
 			"extensions.supportUntrustedWorkspaces.false",
 			"extensions.supportUntrustedWorkspaces.limited",
@@ -16089,12 +17214,6 @@
 			"read.title",
 			"stop.title"
 		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution": [
-			"cancel",
-			"cancelShort",
-			"send.edit",
-			"send.generate"
-		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
 			"askInChat",
 			"cancel",
@@ -16106,39 +17225,22 @@
 			"editCodeShort",
 			"fix",
 			"focus",
-			"hideInput",
 			"Keep",
-			"placeholderAskInChat",
-			"placeholderNoSelection",
-			"placeholderWithSelection",
-			"queueInChat",
 			"rephrase",
 			"run",
 			"runShort",
-			"startInlineChat",
-			"submitInput",
-			"undo"
+			"startInlineChat"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
 			"fix1",
 			"fixN",
 			"loading",
 			"placeholder",
-			"placeholderNoSelectionHover",
-			"placeholderWithSelection",
-			"placeholderWithSelectionHover"
+			"placeholderWithSelection"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel": [
 			"inlineChatConfigurationTitle",
 			"inlineChatDefaultModelDescription"
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget": [
-			"done",
-			"done1",
-			"doneN",
-			"error",
-			"needsApproval",
-			"working"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl": [
 			"name",
@@ -16170,16 +17272,12 @@
 			"editorMinimap.inlineChatInserted",
 			"editorOverviewRuler.inlineChatInserted",
 			"editorOverviewRuler.inlineChatRemoved",
-			"enableV2",
-			"finishOnType",
 			"fixDiagnostics",
 			"inlineChat.background",
 			"inlineChat.border",
 			"inlineChat.foreground",
 			"inlineChat.shadow",
 			"inlineChatAffordanceVisible",
-			"inlineChatChangeHasDiff",
-			"inlineChatChangeShowsDiff",
 			"inlineChatDiff.inserted",
 			"inlineChatDiff.removed",
 			"inlineChatEditing",
@@ -16190,26 +17288,16 @@
 			"inlineChatHasNotebookAgent",
 			"inlineChatHasNotebookInline",
 			"inlineChatHasPossible",
-			"inlineChatHasStashedSession",
-			"inlineChatInnerCursorFirst",
-			"inlineChatInnerCursorLast",
 			"inlineChatInput.background",
 			"inlineChatInput.border",
 			"inlineChatInput.focusBorder",
 			"inlineChatInput.placeholderForeground",
-			"inlineChatInputHasText",
-			"inlineChatInputWidgetFocused",
 			"inlineChatOuterCursorPosition",
-			"inlineChatPendingConfirmation",
 			"inlineChatRequestInProgress",
 			"inlineChatResponseFocused",
-			"inlineChatResponseTypes",
 			"inlineChatTerminated",
 			"inlineChatVisible",
-			"notebookAgent",
-			"renderMode",
-			"renderMode.hover",
-			"renderMode.zone"
+			"notebookAgent"
 		],
 		"vs/workbench/contrib/inlineCompletions/browser/inlineCompletionLanguageStatusBarContribution": [
 			"inlineCompletionAvailable",
@@ -16278,6 +17366,7 @@
 			"show",
 			"similarIssues",
 			"stepsToReproduce",
+			"submittingIssue",
 			"undefinedPlaceholder",
 			"unknown",
 			"vscode",
@@ -16788,6 +17877,7 @@
 			"mcp.disabled",
 			"mcp.disconnect",
 			"mcp.editStoredInput",
+			"mcp.enableWorkspace",
 			"mcp.err.md.multi",
 			"mcp.err.md.single",
 			"mcp.installFromManifest",
@@ -16930,6 +18020,7 @@
 			"mcp.start",
 			"mcp.stop",
 			"mcp.variableNotFound",
+			"server.disabled",
 			"server.error",
 			"server.promptcount",
 			"server.running",
@@ -17010,6 +18101,8 @@
 			"configurationtooltip",
 			"details",
 			"detailstooltip",
+			"envFile",
+			"environment",
 			"environmentVariables",
 			"headers",
 			"id",
@@ -18580,6 +19673,9 @@
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"advancedLabel",
+			"agentsWindowReadOnlyAccessible",
+			"agentsWindowReadOnlyDescription",
+			"agentsWindowReadOnlyLabelText",
 			"alsoConfiguredElsewhere",
 			"alsoConfiguredIn",
 			"alsoModifiedInScopes",
@@ -18944,6 +20040,8 @@
 					"&& denotes a mnemonic"
 				]
 			},
+			"arm32ServerDeprecation.banner",
+			"arm32ServerDeprecationBannerLearnMore",
 			{
 				"key": "learnMore",
 				"comment": [
@@ -18951,6 +20049,7 @@
 				]
 			},
 			"remember",
+			"remoteBannerDoNotShowAgainThisVersion",
 			"unsupportedGlibcBannerLearnMore",
 			"unsupportedGlibcWarning",
 			"unsupportedGlibcWarning.banner"
@@ -19295,6 +20394,30 @@
 		"vs/workbench/contrib/scm/browser/menus": [
 			"miShare"
 		],
+		"vs/workbench/contrib/scm/browser/quickDiff.contribution": [
+			"diffDecorations",
+			"diffDecorationsIgnoreTrimWhitespace",
+			"diffGutterPattern",
+			"diffGutterPatternAdded",
+			"diffGutterPatternModifed",
+			"diffGutterWidth",
+			"quickDiffDecoration",
+			"scm.diffDecorations.all",
+			"scm.diffDecorations.gutter",
+			"scm.diffDecorations.minimap",
+			"scm.diffDecorations.none",
+			"scm.diffDecorations.overviewRuler",
+			"scm.diffDecorationsGutterAction",
+			"scm.diffDecorationsGutterAction.diff",
+			"scm.diffDecorationsGutterAction.none",
+			"scm.diffDecorationsGutterVisibility",
+			"scm.diffDecorationsGutterVisibility.always",
+			"scm.diffDecorationsGutterVisibility.hover",
+			"scm.diffDecorationsIgnoreTrimWhitespace.false",
+			"scm.diffDecorationsIgnoreTrimWhitespace.inherit",
+			"scm.diffDecorationsIgnoreTrimWhitespace.true",
+			"scmConfigurationTitle"
+		],
 		"vs/workbench/contrib/scm/browser/quickDiffDecorator": [
 			"diffAdded",
 			"diffDeleted",
@@ -19352,7 +20475,6 @@
 			"open in external terminal",
 			"open in integrated terminal",
 			"providersVisible",
-			"quickDiffDecoration",
 			"repositoriesSortOrder",
 			"scm accept",
 			"scm view next commit",
@@ -19603,9 +20725,11 @@
 			"fileReplaceChanges",
 			"searchReplace.source"
 		],
+		"vs/workbench/contrib/search/browser/search.common.contribution": [
+			"search.searchOnType",
+			"search.searchOnTypeDebouncePeriod"
+		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
-			"anythingQuickAccess",
-			"anythingQuickAccessPlaceholder",
 			"exclude",
 			"exclude.boolean",
 			{
@@ -19636,6 +20760,7 @@
 			"search.decorations.colors",
 			"search.defaultViewMode",
 			"search.experimental.closedNotebookResults",
+			"search.experimental.useIgnoreFilesInFindFiles",
 			"search.followSymlinks",
 			"search.globalFindClipboard",
 			"search.location",
@@ -19650,23 +20775,6 @@
 			"search.quickOpen.includeHistory",
 			"search.quickOpen.includeSymbols",
 			"search.ripgrep.maxThreads",
-			"search.searchEditor.defaultNumberOfContextLines",
-			"search.searchEditor.doubleClickBehaviour",
-			"search.searchEditor.doubleClickBehaviour.goToLocation",
-			"search.searchEditor.doubleClickBehaviour.openLocationToSide",
-			"search.searchEditor.doubleClickBehaviour.selectWord",
-			"search.searchEditor.focusResultsOnSearch",
-			{
-				"key": "search.searchEditor.reusePriorSearchConfiguration",
-				"comment": [
-					"\"Search Editor\" is a type of editor that can display search results. \"includes, excludes, and flags\" refers to the \"files to include\" and \"files to exclude\" input boxes, and the flags that control whether a query is case-sensitive or a regex."
-				]
-			},
-			"search.searchEditor.singleClickBehaviour",
-			"search.searchEditor.singleClickBehaviour.default",
-			"search.searchEditor.singleClickBehaviour.peekDefinition",
-			"search.searchOnType",
-			"search.searchOnTypeDebouncePeriod",
 			"search.searchView.keywordSuggestions",
 			"search.searchView.semanticSearchBehavior",
 			"search.searchView.semanticSearchBehavior.auto",
@@ -19679,15 +20787,12 @@
 			"search.sortOrder",
 			"search.usePCRE2",
 			"search.useReplacePreview",
-			"searchConfigurationTitle",
 			"searchSortOrder.countAscending",
 			"searchSortOrder.countDescending",
 			"searchSortOrder.default",
 			"searchSortOrder.filesOnly",
 			"searchSortOrder.modified",
 			"searchSortOrder.type",
-			"symbolsQuickAccess",
-			"symbolsQuickAccessPlaceholder",
 			"textSearchPickerHelp",
 			"textSearchPickerPlaceholder",
 			"useGlobalIgnoreFiles",
@@ -19866,6 +20971,12 @@
 			"unable to open",
 			"unable to open trust"
 		],
+		"vs/workbench/contrib/search/browser/searchQuickAccess.contribution": [
+			"anythingQuickAccess",
+			"anythingQuickAccessPlaceholder",
+			"symbolsQuickAccess",
+			"symbolsQuickAccessPlaceholder"
+		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"fileMatchAriaLabel",
 			"folderMatchAriaLabel",
@@ -19968,6 +21079,9 @@
 			"openToBottom",
 			"openToSide"
 		],
+		"vs/workbench/contrib/search/common/search": [
+			"searchConfigurationTitle"
+		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
 			"label.excludes",
 			"label.includes",
@@ -19991,6 +21105,21 @@
 			"search.openResultsInEditor",
 			"search.openSearchEditor",
 			"search.rerunSearchInEditor",
+			"search.searchEditor.defaultNumberOfContextLines",
+			"search.searchEditor.doubleClickBehaviour",
+			"search.searchEditor.doubleClickBehaviour.goToLocation",
+			"search.searchEditor.doubleClickBehaviour.openLocationToSide",
+			"search.searchEditor.doubleClickBehaviour.selectWord",
+			"search.searchEditor.focusResultsOnSearch",
+			{
+				"key": "search.searchEditor.reusePriorSearchConfiguration",
+				"comment": [
+					"\"Search Editor\" is a type of editor that can display search results. \"includes, excludes, and flags\" refers to the \"files to include\" and \"files to exclude\" input boxes, and the flags that control whether a query is case-sensitive or a regex."
+				]
+			},
+			"search.searchEditor.singleClickBehaviour",
+			"search.searchEditor.singleClickBehaviour.default",
+			"search.searchEditor.singleClickBehaviour.peekDefinition",
 			"searchEditor",
 			"searchEditor.action.decreaseSearchEditorContextLines",
 			"searchEditor.action.increaseSearchEditorContextLines",
@@ -20681,6 +21810,7 @@
 		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
 			"TaskDefinition.description",
 			"TaskDefinition.properties",
+			"TaskDefinition.required",
 			"TaskDefinition.when",
 			"TaskDefinitionExtPoint",
 			"TaskTypeConfiguration.noType"
@@ -20725,16 +21855,11 @@
 		"vs/workbench/contrib/telemetry/browser/telemetry.contribution": [
 			"showTelemetry"
 		],
-		"vs/workbench/contrib/terminal/browser/agentHostTerminalContribution": [
-			"agentHostTerminal.channelLocal",
-			"agentHostTerminal.channelRemote",
-			"agentHostTerminal.local",
-			"agentHostTerminal.pick",
-			"agentHostTerminal.pickHost",
-			"agentHostTerminal.profileName"
-		],
 		"vs/workbench/contrib/terminal/browser/agentHostTerminalService": [
 			"agentHostTerminal.default",
+			"agentHostTerminal.pick",
+			"agentHostTerminal.pickHost",
+			"agentHostTerminal.profileName",
 			"agentHostTerminal.tool"
 		],
 		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
@@ -21211,6 +22336,7 @@
 			"terminal.integrated.splitCwd.inherited",
 			"terminal.integrated.splitCwd.initial",
 			"terminal.integrated.splitCwd.workspaceRoot",
+			"terminal.integrated.tabs.allowAgentCliTitle",
 			"terminal.integrated.tabs.defaultColor",
 			"terminal.integrated.tabs.defaultIcon",
 			"terminal.integrated.tabs.enableAnimation",
@@ -21459,10 +22585,10 @@
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool": [
 			"allow",
-			"backgroundTaskCompleted",
-			"backgroundTaskNeedsInput",
 			"runInTerminal",
 			"runInTerminal.confirmationMessage",
+			"runInTerminal.defaultExplanation",
+			"runInTerminal.defaultGoal",
 			"runInTerminal.inDirectory",
 			"runInTerminal.invocation",
 			"runInTerminal.invocation.sandbox",
@@ -21477,14 +22603,25 @@
 			"runInTerminal.presentationOverride.inDirectory",
 			"runInTerminal.presentationOverride.inDirectory.withoutLanguage",
 			"runInTerminal.presentationOverride.withoutLanguage",
+			"runInTerminal.sensitiveInput.autoCancelMessage",
+			"runInTerminal.sensitiveInput.autoCancelTitle",
+			"runInTerminal.sensitiveInput.cancel",
+			"runInTerminal.sensitiveInput.dismiss",
+			"runInTerminal.sensitiveInput.focus",
+			"runInTerminal.sensitiveInput.message",
+			"runInTerminal.sensitiveInput.title",
 			"runInTerminal.streaming",
 			"runInTerminal.streaming.default",
 			"runInTerminal.unsandboxed",
+			"runInTerminal.unsandboxed.autoRetry",
 			"runInTerminal.unsandboxed.autoRetry.confirmationMessage",
+			"runInTerminal.unsandboxed.autoRetry.domain",
 			"runInTerminal.unsandboxed.autoRetry.invocation",
 			"runInTerminal.unsandboxed.autoRetry.reason",
 			"runInTerminal.unsandboxed.confirmationMessage",
 			"runInTerminal.unsandboxed.confirmationMessage.defaultReason",
+			"runInTerminal.unsandboxed.disabled.invocation",
+			"runInTerminal.unsandboxed.disabled.result",
 			"runInTerminal.unsandboxed.domain",
 			"runInTerminal.unsandboxed.domain.reason.denied.multi",
 			"runInTerminal.unsandboxed.domain.reason.denied.single",
@@ -21496,7 +22633,10 @@
 			"runInTerminalTool.altBufferMessage",
 			"runInTerminalTool.displayName",
 			"runInTerminalTool.userDescription",
-			"skip"
+			"skip",
+			"terminalAssessingOutput",
+			"terminalCommandCompleted",
+			"terminalProcessExited"
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool": [
 			"focusTerminal",
@@ -21552,17 +22692,23 @@
 			"copilotChat.taskFailedWithExitCode"
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration": [
+			"agentSandbox.allowAutoApprove",
+			"agentSandbox.allowUnsandboxedCommands",
+			"agentSandbox.autoApproveUnsandboxedCommands",
 			"agentSandbox.enabled.deprecated",
 			"agentSandbox.enabledSetting",
+			"agentSandbox.enabledSetting.allowNetworkDescription",
 			"agentSandbox.enabledSetting.offDescription",
 			"agentSandbox.enabledSetting.onDescription",
 			"agentSandbox.fileSystemLinux.deprecated",
 			"agentSandbox.fileSystemMac.deprecated",
 			"agentSandbox.linuxFileSystemSetting",
+			"agentSandbox.linuxFileSystemSetting.allowRead",
 			"agentSandbox.linuxFileSystemSetting.allowWrite",
 			"agentSandbox.linuxFileSystemSetting.denyRead",
 			"agentSandbox.linuxFileSystemSetting.denyWrite",
 			"agentSandbox.macFileSystemSetting",
+			"agentSandbox.macFileSystemSetting.allowRead",
 			"agentSandbox.macFileSystemSetting.allowWrite",
 			"agentSandbox.macFileSystemSetting.denyRead",
 			"agentSandbox.macFileSystemSetting.denyWrite",
@@ -21603,7 +22749,9 @@
 			"detachBackgroundProcesses.description",
 			"enforceTimeoutFromModel.description",
 			"idlePollInterval.description",
+			"idleSilenceTimeoutMs.description",
 			"ignoreDefaultAutoApproveRules.description",
+			"outputDeltas.description",
 			"outputLocation.chat",
 			"outputLocation.description",
 			"outputLocation.terminal",
@@ -21769,7 +22917,7 @@
 		],
 		"vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration": [
 			"terminal.integrated.initialHint",
-			"terminal.integrated.initialHint.copilotCli"
+			"terminal.integrated.initialHintCopilotCli"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
 			"workbench.action.terminal.openDetectedLink",
@@ -22431,7 +23579,11 @@
 			"runTestTool.invoke.progress",
 			"runTestTool.noRunStarted",
 			"runTestTool.noTests",
-			"runTestTool.userDescription"
+			"runTestTool.userDescription",
+			"testFailureTool.displayName",
+			"testFailureTool.invocation",
+			"testFailureTool.pastTense",
+			"testFailureTool.userDescription"
 		],
 		"vs/workbench/contrib/testing/common/testingContentProvider": [
 			"runNoOutout"
@@ -22601,6 +23753,11 @@
 			"supertypes",
 			"tree.aria"
 		],
+		"vs/workbench/contrib/update/browser/postUpdateWidget": [
+			"postUpdate.close",
+			"postUpdate.releaseNotes",
+			"postUpdate.title"
+		],
 		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
 			"releaseNotesInputName",
 			"showOnUpdate",
@@ -22615,7 +23772,6 @@
 			"DownloadingUpdate",
 			"installingUpdate",
 			"installUpdate...",
-			"noUpdatesAvailable",
 			"read the release notes",
 			"relaunchDetailInsiders",
 			"relaunchDetailStable",
@@ -22713,9 +23869,6 @@
 			"updateTooltip.initializingMessage",
 			"updateTooltip.initializingTitle",
 			"updateTooltip.installButton",
-			"updateTooltip.installedDefaultMessage",
-			"updateTooltip.installedDefaultTitle",
-			"updateTooltip.installedTitle",
 			"updateTooltip.installingPleaseWait",
 			"updateTooltip.installingUpdateTitle",
 			"updateTooltip.latestVersionLabel",
@@ -23558,16 +24711,13 @@
 			"onboarding.a.aria",
 			"onboarding.aiPref.hint",
 			"onboarding.aiPref.label",
+			"onboarding.aiPref.selected.alert",
 			"onboarding.back",
+			"onboarding.close",
 			"onboarding.continueWithoutSignIn",
-			"onboarding.ext.install",
-			"onboarding.ext.installed",
-			"onboarding.ext.installError",
-			"onboarding.ext.installing",
-			"onboarding.ext.listLabel",
-			"onboarding.ext.row.aria",
 			"onboarding.getStarted",
 			"onboarding.keymap.installError",
+			"onboarding.keymap.selected.alert",
 			"onboarding.next",
 			"onboarding.personalize.keymap",
 			"onboarding.personalize.keymapHint",
@@ -23585,20 +24735,18 @@
 			"onboarding.personalize.tip.prefix",
 			"onboarding.personalize.tip.shift",
 			"onboarding.personalize.tip.suffix",
+			"onboarding.sessions.agentMode",
+			"onboarding.sessions.agentMode.desc",
 			"onboarding.sessions.agentsTutorial",
-			"onboarding.sessions.cloud",
-			"onboarding.sessions.cloud.desc",
-			"onboarding.sessions.inline",
-			"onboarding.sessions.inline.desc1",
-			"onboarding.sessions.inline.desc2",
-			"onboarding.sessions.inline.desc3",
-			"onboarding.sessions.inline.esc",
-			"onboarding.sessions.inline.tab",
-			"onboarding.sessions.local",
-			"onboarding.sessions.local.desc",
+			"onboarding.sessions.customize",
+			"onboarding.sessions.customize.desc",
+			"onboarding.sessions.group.chat",
+			"onboarding.sessions.group.more",
+			"onboarding.sessions.planMode",
+			"onboarding.sessions.planMode.desc",
+			"onboarding.sessions.runAnywhere",
+			"onboarding.sessions.runAnywhere.desc",
 			"onboarding.sessions.signInNudge",
-			"onboarding.sessions.worktree",
-			"onboarding.sessions.worktree.desc",
 			"onboarding.signIn.apple",
 			"onboarding.signIn.disclaimer.copilotPrefix",
 			"onboarding.signIn.disclaimer.improveSuffix",
@@ -23623,11 +24771,10 @@
 			"onboarding.signIn.google",
 			"onboarding.signIn.heroSubtitle",
 			"onboarding.signIn.heroTitle",
-			"onboarding.skip",
-			"onboarding.step.agentSessions.subtitle.after",
 			"onboarding.step.agentSessions.subtitle.before",
 			"onboarding.step.aria",
-			"onboarding.stepOf"
+			"onboarding.stepOf",
+			"onboarding.theme.selected.alert"
 		],
 		"vs/workbench/contrib/welcomeOnboarding/browser/welcomeOnboarding.contribution": [
 			"welcomeOnboarding2026"
@@ -23643,8 +24790,6 @@
 			"onboarding.step.agentSessions.subtitle",
 			"onboarding.step.aiPreference",
 			"onboarding.step.aiPreference.subtitle",
-			"onboarding.step.extensions",
-			"onboarding.step.extensions.subtitle",
 			"onboarding.step.personalize",
 			"onboarding.step.personalize.subtitle",
 			"onboarding.step.signIn",
@@ -23762,6 +24907,8 @@
 			"restrictedModeBannerMessageFolder",
 			"restrictedModeBannerMessageWindow",
 			"restrictedModeBannerMessageWorkspace",
+			"sessionsWindowFolderTrustNote",
+			"sessionsWindowWorkspaceTrustNote",
 			"startupTrustRequestLearnMore",
 			"status.ariaUntrustedFolder",
 			"status.ariaUntrustedWindow",
@@ -23992,6 +25139,7 @@
 				]
 			},
 			"quickSwitchWindow",
+			"switchToMainWindow",
 			"switchWindow",
 			"switchWindowPlaceHolder",
 			"toggleWindowAlwaysOnTop",
@@ -24181,14 +25329,16 @@
 			"issue.reporter",
 			"keyboard shortcuts",
 			"menuContexts",
+			"menus.agentsChangeInline",
+			"menus.agentsChangesPrimaryActionSubMenu",
+			"menus.agentsChangesToolbar",
 			"menus.artifactContext",
 			"menus.artifactGroupContext",
 			"menus.changeTitle",
 			"menus.chatContextUsageActions",
 			"menus.chatCustomizationsCreate",
-			"menus.chatEditingSessionApplySubmenu",
+			"menus.chatCustomizationsItem",
 			"menus.chatEditingSessionChangesToolbar",
-			"menus.chatEditingSessionChangeToolbar",
 			"menus.chatEditingSessionTitleToolbar",
 			"menus.chatEditorInlineGutter",
 			"menus.chatMultiDiffContext",
@@ -24420,6 +25570,7 @@
 			"plan.eduName",
 			"plan.enterpriseName",
 			"plan.freeName",
+			"plan.maxName",
 			"plan.proName",
 			"plan.proPlusName",
 			"retry",
@@ -24597,6 +25748,7 @@
 			"promptOpenWith.updateDefaultPlaceHolder"
 		],
 		"vs/workbench/services/editor/common/editorResolverService": [
+			"editor.diffEditorAssociations",
 			"editor.editorAssociations"
 		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
@@ -25095,6 +26247,17 @@
 		],
 		"vs/workbench/services/notification/common/notificationService": [
 			"neverShowAgain"
+		],
+		"vs/workbench/services/policies/browser/accountPolicyGateContribution": [
+			"accountPolicy.notification.learnMore",
+			"accountPolicy.notification.orgWithAccount",
+			"accountPolicy.notification.orgWithAccountNoList",
+			"accountPolicy.notification.signin",
+			"accountPolicy.notification.signin.action",
+			"accountPolicy.notification.signinWithOrgs"
+		],
+		"vs/workbench/services/policies/common/accountPolicyService": [
+			"chatAccountPolicyGateActive"
 		],
 		"vs/workbench/services/preferences/browser/keybindingsEditorInput": [
 			"keybindingsEditorLabelIcon",
@@ -26176,6 +27339,18 @@
 			"Cancel Snooze Inline Suggestions",
 			"Snooze Inline Suggestions",
 			"Whether inline completions are currently snoozed",
+			"10 minutes",
+			"15 minutes",
+			"1 minute",
+			"30 minutes",
+			"5 minutes",
+			"60 minutes",
+			"Custom...",
+			"Duration in minutes (e.g. 90)",
+			"Enter snooze duration in minutes",
+			"Please enter a positive number",
+			"{0} minutes (Last used)",
+			"Last used custom duration",
 			"Select snooze duration for Inline Suggestions"
 		],
 		"vs/editor/browser/widget/codeEditor/codeEditorWidget": [
@@ -27752,6 +28927,7 @@
 		"vs/editor/contrib/snippet/browser/snippetController2": [
 			"Whether there is a next tab stop when in snippet mode",
 			"Whether there is a previous tab stop when in snippet mode",
+			"Whether the current snippet tab stop is a choice",
 			"Whether the editor in current in snippet mode",
 			"Go to next placeholder..."
 		],
@@ -28055,6 +29231,7 @@
 			"Filter items",
 			"Search...",
 			"Remove",
+			"{0}, use right arrow to access options",
 			"Action Widget",
 			"{0}, Disabled Reason: {1}",
 			"{0} to Apply",
@@ -28074,65 +29251,256 @@
 			"Select previous action",
 			"Toggle section"
 		],
+		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
+			"Plugins configured on this agent host and available to remote sessions.",
+			"Description",
+			"Name",
+			"Plugin",
+			"Plugins",
+			"Plugin URI",
+			"Absolute path to the shell executable used by host-managed terminals. Normally pushed by the connected VS Code client from `terminal.integrated.agentHostProfile.<os>` (falling back to `terminal.integrated.defaultProfile.<os>`); when unset, the agent host falls back to the system shell. Only the path is supported; `args` and `env` from the workbench profile are not piped through yet. The workbench only pushes this for the local agent host — remote agent host operators should set this directly in the remote machine's `agent-host-config.json`.",
+			"Default Shell",
+			"When enabled, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override.",
+			"Use SDK Terminal Tool"
+		],
+		"vs/platform/agentHost/common/agentHostSchema": [
+			"Most restrictive telemetry level requested by connected clients.",
+			"Telemetry Level",
+			"Approvals",
+			"Autopilot (Preview)",
+			"Autonomously iterates from start to finish",
+			"Bypass Approvals",
+			"All tool calls are auto-approved",
+			"Default Approvals",
+			"Copilot uses your configured settings",
+			"Tool approval behavior for this session",
+			"Agent Mode",
+			"Interactive",
+			"Ask for input and approval for each action",
+			"Plan",
+			"Generate a plan first, then choose how to execute it",
+			"How the agent should approach this turn",
+			"Permissions",
+			"Allowed tools",
+			"Denied tools",
+			"Tool name",
+			"Per-tool session permissions. Updated automatically when approving a tool \"in this Session\"."
+		],
+		"vs/platform/agentHost/common/claudeModelConfig": [
+			"Controls how much reasoning effort Claude uses.",
+			"High",
+			"Low",
+			"Max",
+			"Medium",
+			"Thinking Level",
+			"Extra High"
+		],
+		"vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl": [
+			"Authentication required for {0}@{1}"
+		],
 		"vs/platform/agentHost/node/agentHostMain": [
 			"Agent Host"
 		],
-		"vs/platform/agentHost/node/copilot/copilotAgentSession": [
-			"Permission request",
-			"Permission request",
-			"MCP Tool",
-			"Read file",
-			"Read file",
-			"Run command",
-			"Run in terminal",
-			"Edit {0}",
+		"vs/platform/agentHost/node/claude/claudeAgent": [
+			"Approvals",
+			"Auto-Approve Edits",
+			"Auto-approve file edits; prompt for shell and other tools.",
+			"Auto",
+			"Let the model classifier choose between approve and prompt per call.",
+			"Bypass Approvals",
+			"Auto-approve every tool call.",
+			"Ask Each Time",
+			"Prompt for every tool call.",
+			"Don't Ask",
+			"Auto-approve every tool call without prompting.",
+			"Plan Only (Read-Only)",
+			"Read-only research mode; no tool calls executed.",
+			"How Claude handles tool approvals.",
+			"Claude agent backed by the Anthropic Claude Agent SDK",
+			"Claude"
+		],
+		"vs/platform/agentHost/node/claude/claudeInteractiveTools": [
+			"Approve",
+			"Deny",
+			"Ready to code?"
+		],
+		"vs/platform/agentHost/node/claude/claudeToolDisplay": [
+			"Allow tool call?",
+			"Allow tool from {0}?",
+			"Read file?",
+			"Run in terminal?",
+			"Fetch URL?",
+			"Edit file?",
+			"Ask user a question",
+			"Run shell command",
+			"Read shell output",
 			"Edit file",
+			"Ready to code?",
+			"Find files",
+			"Search files",
+			"Kill shell command",
+			"List directory",
+			"Run MCP tool {0}",
+			"Edit file",
+			"Edit notebook",
+			"Read notebook",
+			"Read file",
+			"Run subagent task",
+			"Update todo list",
+			"Fetch URL",
 			"Write file"
 		],
+		"vs/platform/agentHost/node/copilot/copilotAgent": [
+			"Branch",
+			"Base branch to work from",
+			"Isolation",
+			"Folder",
+			"Work directly in the folder",
+			"Worktree",
+			"Create a Git worktree for isolation",
+			"Where the agent should make changes",
+			"Controls how much reasoning effort the model uses.",
+			"High",
+			"Low",
+			"Medium",
+			"Thinking Level",
+			"Extra High",
+			"Error parsing plugin.",
+			"Created isolated worktree for branch {0}"
+		],
+		"vs/platform/agentHost/node/copilot/copilotAgentSession": [
+			"Auto-approve all tool calls and continue until done.",
+			"Implement with Autopilot",
+			"Auto-approve all tool calls, including fleet management actions, and continue until done.",
+			"Implement with Autopilot Fleet",
+			"Approve the plan without executing it. I will implement it myself.",
+			"Approve Plan Only",
+			"A plan is ready for review.",
+			"Implement the plan, asking for input and approval for each action.",
+			"Implement Plan",
+			"How would you like to proceed?",
+			"Review Plan",
+			"View full plan"
+		],
+		"vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider": [
+			"Free up context by compacting the conversation history",
+			"Create an implementation plan before coding"
+		],
 		"vs/platform/agentHost/node/copilot/copilotToolDisplay": [
+			"Allow the model to call {0}?",
+			"Allow tool call?",
+			"MCP Tool",
+			"Allow tool from {0}?",
+			"Read file?",
+			"Run in terminal?",
+			"Allow fetching web content?",
+			"Fetch URL?",
+			"Write file?",
+			"Created file",
+			"Created {0}",
 			"Edited file",
 			"Edited {0}",
+			"Exited plan mode",
 			"\"{0}\" failed",
 			"Used \"{0}\"",
 			"Found files",
-			"Found files matching `{0}`",
+			"Found files matching {0}",
 			"Searched files",
-			"Searched for `{0}`",
+			"Searched for {0}",
+			"Edited files",
+			"Edited {0}",
+			"Edited {0}",
+			"Read Terminal",
 			"Ran {0} command",
-			"Ran `{0}`",
+			"Ran {0}",
+			"Read skill {0}",
+			"Read skill {0}",
+			"Executed SQL query",
 			"Read file",
 			"Read {0}",
-			"Wrote file",
-			"Wrote to {0}",
+			"Read {0}, line {1} to the end",
+			"Read {0}, line {1}",
+			"Read {0}, lines {1} to {2}",
+			"Sent input to shell",
+			"Sent {0} to shell",
+			"Creating file",
+			"Creating {0}",
 			"Editing file",
 			"Editing {0}",
+			"Presenting plan",
 			"Using \"{0}\"",
 			"Finding files",
-			"Finding files matching `{0}`",
+			"Finding files matching {0}",
 			"Searching files",
-			"Searching for `{0}`",
+			"Searching for {0}",
+			"Editing files",
+			"Editing {0}",
+			"Editing {0}",
+			"Reading Terminal",
 			"Running {0} command",
-			"Running `{0}`",
+			"Running {0}",
+			"Reading skill {0}",
+			"Reading skill {0}",
+			"Executing SQL query",
 			"Reading file",
 			"Reading {0}",
-			"Writing file",
-			"Writing to {0}",
+			"Reading {0}, line {1} to the end",
+			"Reading {0}, line {1}",
+			"Reading {0}, lines {1} to {2}",
+			"Sending input to shell",
+			"Sending {0} to shell",
+			"Apply Patch",
 			"Ask User",
-			"Bash",
-			"Stop Shell",
+			"CodeQL Security Scan",
+			"Code Review",
+			"Create File",
+			"Create Pull Request",
 			"Edit File",
-			"Find Files",
-			"Search",
-			"List Shells",
+			"Exit Plan Mode",
+			"Fetch Documentation",
+			"Fetch Web Content",
+			"Check Dependencies",
+			"Invoke Skill",
+			"List Agents",
+			"List Shell Sessions",
+			"Language Server",
+			"Reload MCP Config",
+			"Validate MCP Config",
+			"Validate Changes",
 			"Patch",
-			"PowerShell",
-			"Read Shell Output",
-			"View File",
+			"Propose Work",
+			"Read",
+			"Read Agent",
+			"Read Terminal",
+			"Reply to Comment",
+			"Report Intent",
+			"Progress update",
+			"Search",
+			"Search Code",
+			"Run Shell Command",
+			"Show File",
+			"Read Skill",
+			"Execute SQL",
+			"Stop Terminal Session",
+			"Store Memory",
+			"Delegate Task",
+			"Task Complete",
+			"Thinking",
+			"Search Tools",
+			"Update Todo",
 			"Web Search",
-			"Write File",
-			"Write Shell Input"
+			"Write to Agent",
+			"Write to Bash",
+			"Write to PowerShell"
+		],
+		"vs/platform/agentHost/node/sessionPermissions": [
+			"Allow Once",
+			"Allow in this Session",
+			"Skip"
 		],
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
+			"Failed to read private key file: {0}",
+			"Key file authentication requires a private key path.",
 			"Checking for existing agent host...",
 			"Establishing SSH connection...",
 			"Installing VS Code CLI on remote...",
@@ -28140,11 +29508,15 @@
 			"Checking remote CLI installation...",
 			"Starting remote agent host..."
 		],
+		"vs/platform/agentHost/node/tunnelHostMainService": [
+			"Remote Connections"
+		],
 		"vs/platform/browserView/common/browserView": [
 			"Page Zoom: {0}%",
 			"{0}%"
 		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
+			"Add Element to Chat",
 			"Back",
 			"Copy Image",
 			"Copy Image URL",
@@ -28766,6 +30138,9 @@
 			"Terminal"
 		],
 		"vs/platform/terminal/common/terminalPlatformConfiguration": [
+			"The terminal profile to use on Linux for agent host terminals, including shells launched by AI agent tools. Accepts either a profile name from {0} or an inline profile object. When unset, falls back to {1}. Currently applies to the local agent host. Only the executable `path` is honored today; `args` and `env` from the profile are ignored. Remote agent hosts need remote-side shell configuration because local resolved paths may be invalid on the remote.",
+			"The terminal profile to use on macOS for agent host terminals, including shells launched by AI agent tools. Accepts either a profile name from {0} or an inline profile object. When unset, falls back to {1}. Currently applies to the local agent host. Only the executable `path` is honored today; `args` and `env` from the profile are ignored. Remote agent hosts need remote-side shell configuration because local resolved paths may be invalid on the remote.",
+			"The terminal profile to use on Windows for agent host terminals, including shells launched by AI agent tools. Accepts either a profile name from {0} or an inline profile object. When unset, falls back to {1}. Currently applies to the local agent host. Only the executable `path` is honored today; `args` and `env` from the profile are ignored. Remote agent hosts need remote-side shell configuration because local resolved paths may be invalid on the remote.",
 			"The terminal profile to use on Linux for automation-related terminal usage like tasks and debug.",
 			"The terminal profile to use on macOS for automation-related terminal usage like tasks and debug.",
 			"The terminal profile to use for automation-related terminal usage like tasks and debug. This setting will currently be ignored if {0} (now deprecated) is set.",
@@ -28823,6 +30198,7 @@
 			"Overall foreground color. This color is only used if not overridden by a component.",
 			"The default color for icons in the workbench.",
 			"The background color of text selections in the workbench (e.g. for input fields or text areas). Note that this does not apply to selections within the editor.",
+			"Highest-contrast foreground color, intended for text or icons that need maximum legibility across various backgrounds. This color is only used if not overridden by a component.",
 			"Background color for block quotes in text.",
 			"Border color for block quotes in text.",
 			"Background color for code blocks in text.",
@@ -29076,6 +30452,7 @@
 			"Please use quickInputList.focusBackground instead",
 			"Quick picker background color for the focused item.",
 			"Quick picker foreground color for the focused item.",
+			"Quick picker foreground color of the match highlights on the focused item.",
 			"Quick picker icon foreground color for the focused item."
 		],
 		"vs/platform/theme/common/colors/searchColors": [
@@ -29179,11 +30556,15 @@
 			"Enable Background Updates",
 			"Disable automatic background update checks. Updates will be available if you manually check for updates.",
 			"Disable updates.",
-			"Show update information tooltip in the title bar after a new version is installed.",
+			"Show a post-install update tooltip in the title bar instead of opening the release notes editor.",
 			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service.",
 			"Check for updates only on startup. Disable automatic background update checks.",
 			"Update",
-			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service."
+			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"Show the update indicator in the title bar."
+		],
+		"vs/platform/update/electron-main/notAvailableUpdateDialog": [
+			"There are currently no updates available."
 		],
 		"vs/platform/userDataProfile/common/userDataProfile": [
 			"Default"
@@ -29268,86 +30649,7 @@
 			"The workspace is already opened in another window. Please close that window first and then try again.",
 			"Unable to save workspace '{0}'"
 		],
-		"vs/sessions/browser/layoutActions": [
-			"Icon to close the panel.",
-			"Icon for the sessions sidebar when closed.",
-			"Icon for the sessions sidebar when open.",
-			"Open/Show and Close/Hide Secondary Side Bar",
-			"Open/Show and Close/Hide Sidebar",
-			"Secondary Side Bar hidden",
-			"Secondary Side Bar shown",
-			"Primary Side Bar hidden",
-			"Primary Side Bar shown",
-			"Toggle Panel Visibility",
-			"Toggle Secondary Side Bar Visibility",
-			"Toggle Primary Side Bar Visibility",
-			"Toggle Always on Top"
-		],
-		"vs/sessions/browser/parts/auxiliaryBarPart": [
-			"Session Details"
-		],
-		"vs/sessions/browser/parts/sessionCompositeBar": [
-			"Delete",
-			"Rename",
-			"Rename Chat"
-		],
-		"vs/sessions/common/categories": [
-			"Agents"
-		],
-		"vs/sessions/common/contextkeys": [
-			"The identifier of the active chat bar panel",
-			"Whether the active session has an associated git repository",
-			"The provider ID of the active session",
-			"The session type of the active session",
-			"Whether the chat bar has keyboard focus",
-			"Whether the chat bar is visible",
-			"The provider ID of a session in context menu overlays",
-			"Whether the active session is archived (marked as done)",
-			"Whether the active session uses the background agent provider",
-			"Whether the sessions welcome overlay is visible"
-		],
-		"vs/sessions/common/theme": [
-			"Border color of the agent feedback input widget shown in the editor.",
-			"Background color of the chat bar title area in the agent sessions window.",
-			"Foreground color of the chat bar title area in the agent sessions window.",
-			"Background color of the auxiliary bar in the agent sessions window.",
-			"Background color of the chat bar in the agent sessions window.",
-			"Background color of the panel in the agent sessions window.",
-			"Background color of the sidebar view in the agent sessions window.",
-			"Background color of the sidebar header area in the agent sessions window.",
-			"Foreground color of the sidebar header area in the agent sessions window.",
-			"Background color of the update button when download is complete in the agent sessions window.",
-			"Background color of the update button to show download progress in the agent sessions window."
-		],
-		"vs/sessions/contrib/accountMenu/browser/account.contribution": [
-			"Account",
-			"&&Sign Out",
-			"This will sign out '{0}' from the Agents app.",
-			"Sign out of the Agents app?",
-			"Agents Account and Status",
-			"Agents Update",
-			"Loading Account...",
-			"Downloading...",
-			"Update download in progress",
-			"Installing...",
-			"Update install in progress",
-			"Install Update",
-			"Install downloaded update",
-			"Restart to Update",
-			"Restart to apply update",
-			"Update",
-			"Update",
-			"Update Available",
-			"Update available",
-			"This will close the Agents app and open VS Code so you can install the update.\n\nLaunch Agents again after the update is complete.",
-			"Close and Open VS Code",
-			"Update from VS Code",
-			"Settings",
-			"Signed in as {0}",
-			"Sign In",
-			"Sign Out"
-		],
-		"vs/sessions/contrib/accountMenu/browser/accountTitleBarState": [
+		"vs/sessions/browser/accountTitleBarState": [
 			"Signed in as {0} with {1}",
 			"Signed in as {0}",
 			"Agents Signed Out",
@@ -29366,22 +30668,185 @@
 			"Sign in to your account",
 			"Sign In"
 		],
-		"vs/sessions/contrib/accountMenu/browser/updateHoverWidget": [
-			"{0}d ago",
-			"{0}h ago",
-			"{0}m ago",
-			"{0}mo ago",
-			"now",
-			"{0}w ago",
-			"{0} Update Available",
-			"Downloading {0}",
-			"Installing {0}",
-			"Unknown",
-			"Current",
-			"New",
-			"{0} Update Ready",
-			"Updating {0}",
-			"Updating {0}"
+		"vs/sessions/browser/layoutActions": [
+			"Icon to close the panel.",
+			"Icon for the sessions sidebar when closed.",
+			"Icon for the sessions sidebar when open.",
+			"Open/Show and Close/Hide Secondary Side Bar",
+			"Open/Show and Close/Hide Sidebar",
+			"Secondary Side Bar hidden",
+			"Secondary Side Bar shown",
+			"Primary Side Bar hidden",
+			"Primary Side Bar shown",
+			"Toggle Panel Visibility",
+			"Toggle Secondary Side Bar Visibility",
+			"Toggle Primary Side Bar Visibility",
+			"Toggle Always on Top"
+		],
+		"vs/sessions/browser/parts/auxiliaryBarPart": [
+			"Session Details"
+		],
+		"vs/sessions/browser/parts/chatCompositeBar": [
+			"Close",
+			"Rename",
+			"Rename Chat"
+		],
+		"vs/sessions/browser/parts/menubar.contribution": [
+			"&&Edit",
+			"&&File",
+			"&&Go",
+			"&&Help",
+			"&&Preferences",
+			"&&Terminal",
+			"&&View"
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileChangesView": [
+			"Back",
+			"Back",
+			"added",
+			"deleted",
+			"modified",
+			"No changes in this session yet.",
+			"{0}, {1}, +{2} -{3}",
+			"{0} files",
+			"1 file",
+			"Session Changes"
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileDiffColors": [
+			"Foreground color used for added files / lines in the mobile changes-list and diff overlay in the agent sessions window.",
+			"Foreground color used for deleted files / removed lines in the mobile changes-list and diff overlay in the agent sessions window.",
+			"Foreground color used for modified files in the mobile changes-list in the agent sessions window."
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileDiffView": [
+			"Back",
+			"Back",
+			"Loading…",
+			"Next file",
+			"No changes in this file.",
+			"{0} / {1}",
+			"Previous file"
+		],
+		"vs/sessions/browser/parts/mobile/mobilePickerSheet": [
+			"Done",
+			"Close {0}",
+			"No results",
+			"Searching…"
+		],
+		"vs/sessions/browser/parts/mobile/mobileSessionFilterChips": [
+			"Completed",
+			"Failed",
+			"In Progress",
+			"Session status filters",
+			"Find session",
+			"Sort",
+			"Sort and group options"
+		],
+		"vs/sessions/browser/parts/mobile/mobileSortGroupSheet": [
+			"Close"
+		],
+		"vs/sessions/browser/parts/mobile/mobileTitlebarPart": [
+			"Close",
+			"Loading...",
+			"Not signed in",
+			"Account",
+			"Account",
+			"View changes",
+			"{0} files changed (+{1} -{2})",
+			"Close sessions",
+			"New Session",
+			"New session",
+			"Open sessions"
+		],
+		"vs/sessions/browser/sessionsSetUpService": [
+			"Loading",
+			"Enable AI features to continue using Agents.",
+			"Enable AI Features",
+			"Sign in to use Agents",
+			"Signing in…",
+			"Please complete sign-in in the browser.",
+			"Your AI-powered coding experience where agents explore, build, and iterate with you.",
+			"Get Started",
+			"Welcome to {0}",
+			"{0} - Agents",
+			"By continuing, you agree to {0}'s [Terms]({1}) and [Privacy Statement]({2}). {3} Copilot may show [public code]({4}) suggestions and use your data to improve the product. You can change these [settings]({5}) anytime."
+		],
+		"vs/sessions/browser/widget/openInVSCodeWidget": [
+			"Open in VS Code Editor Window"
+		],
+		"vs/sessions/common/categories": [
+			"Agents"
+		],
+		"vs/sessions/common/contextkeys": [
+			"The identifier of the active chat bar panel",
+			"Whether the active session has an associated git repository",
+			"Whether the active session has a git sync action currently running",
+			"The provider ID of the active session",
+			"The session type of the active session",
+			"Whether the active session's workspace is virtual",
+			"Whether the chat bar has keyboard focus",
+			"Whether the chat bar is visible",
+			"The provider ID of a session in context menu overlays",
+			"Whether the editor area is maximized",
+			"Whether the active session is archived (marked as done)",
+			"Whether the user is composing a new chat within the active session",
+			"Whether the sessions aquarium overlay is active",
+			"Whether there is a previous session in the navigation history",
+			"Whether there is a next session in the navigation history",
+			"Whether the current layout is the phone layout",
+			"Whether the virtual keyboard is visible",
+			"Whether the sessions welcome overlay is visible",
+			"The currently active group tab in the session workspace picker"
+		],
+		"vs/sessions/common/sizes": [
+			"Primary body font size for the agents window.",
+			"Secondary body font size for the agents window.",
+			"Heading 1 font size for the agents window (welcome screen title).",
+			"Heading 2 font size for the agents window (title).",
+			"Heading 3 font size for the agents window (subtitle).",
+			"Label 1 font size for the agents window (interactive tabs).",
+			"Label 2 font size for the agents window (metadata emphasis).",
+			"Label 3 font size for the agents window (metadata primary).",
+			"Label 4 font size for the agents window (badge).",
+			"Medium font weight (500) for the agents window.",
+			"Regular font weight (400) for the agents window.",
+			"SemiBold font weight (600) for the agents window."
+		],
+		"vs/sessions/common/theme": [
+			"Border color of the agent feedback input widget shown in the editor.",
+			"Background color of the agent sessions window shell and gradient base.",
+			"Background color of badges in the agent sessions window.",
+			"Foreground color of badges in the agent sessions window.",
+			"Background color of the chat input field in the agent sessions window.",
+			"Border color of the chat input field in the agent sessions window.",
+			"Border color of the chat input field when focused in the agent sessions window.",
+			"Foreground color of the chat input field in the agent sessions window.",
+			"Placeholder text color in the chat input field in the agent sessions window.",
+			"Tint color used in the background gradient of the agent sessions window shell.",
+			"Background color of the New Session button in the agent sessions sidebar.",
+			"Border color of the New Session button in the agent sessions sidebar.",
+			"Foreground color of the New Session button in the agent sessions sidebar.",
+			"Background color of the New Session button when hovered in the agent sessions sidebar.",
+			"Background color of the card panels (chat, files, terminal) in the agent sessions window.",
+			"Border color of the card panels (chat, files, terminal) in the agent sessions window.",
+			"Foreground color of the card panels (chat, files, terminal) in the agent sessions window.",
+			"Background color of the unread sessions count badge on the sidebar toggle.",
+			"Foreground color of the unread sessions count badge on the sidebar toggle.",
+			"Background color of the update button when download is complete in the agent sessions window.",
+			"Background color of the update button to show download progress in the agent sessions window."
+		],
+		"vs/sessions/contrib/accountMenu/browser/account.contribution": [
+			"GitHub profile image for {0}",
+			"Account profile image",
+			"Account",
+			"&&Sign Out",
+			"This will sign out '{0}' from the Agents window.",
+			"Sign out of the Agents window?",
+			"Agents Account and Status",
+			"Loading Account...",
+			"Subscription",
+			"Settings",
+			"Sign In",
+			"Sign Out"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution": [
 			"Submit Feedback ({0})"
@@ -29469,7 +30934,6 @@
 			"Instructions",
 			"MCP Servers",
 			"Plugins ({0})",
-			"Prompts",
 			"Skills",
 			"User ({0})",
 			"Workspace ({0})"
@@ -29484,37 +30948,40 @@
 			"Apply Changes to Parent Repository",
 			"Open in VS Code"
 		],
+		"vs/sessions/contrib/aquarium/browser/aquarium.contribution": [
+			"Adds an easter egg to the Agents window."
+		],
+		"vs/sessions/contrib/aquarium/browser/aquariumOverlay": [
+			"Hide Aquarium",
+			"Show Aquarium"
+		],
+		"vs/sessions/contrib/changes/browser/changes.contribution": [
+			"Changes",
+			"View icon for the Changes view.",
+			"Chan&&ges"
+		],
 		"vs/sessions/contrib/changes/browser/changesTitleBarWidget": [
-			"{0} file(s) changed, {1} insertion(s), {2} deletion(s)",
+			"Icon for the sessions secondary sidebar when closed.",
+			"Icon for the sessions secondary sidebar when open.",
+			"Hide Changes",
 			"Show Changes",
-			"Toggle Changes"
+			"Toggle Secondary Side Bar Visibility"
 		],
 		"vs/sessions/contrib/changes/browser/changesView": [
 			"Changes",
+			"{0} files, {1} additions, {2} deletions",
 			"Changed files and other session artifacts will appear here.",
+			"View All Changes",
 			"Changes Tree",
-			"All Changes",
-			"Show all changes made in this session",
-			"Branch Changes",
-			"Last Turn's Changes",
-			"Show only changes from the last turn",
 			"Versions",
-			"All Changes",
-			"Branch Changes",
-			"Last Turn's Changes",
+			"Session Changes",
 			"View as List",
 			"View as Tree"
 		],
-		"vs/sessions/contrib/changes/browser/changesView.contribution": [
-			"Changes",
-			"View icon for the Changes view."
-		],
 		"vs/sessions/contrib/changes/browser/changesViewActions": [
-			"View All Changes",
-			"Focus Files Explorer View",
-			"Focus Changes View",
-			"There are no changes.",
+			"Open Changes",
 			"Changes",
+			"Open File",
 			"Open Pull Request"
 		],
 		"vs/sessions/contrib/changes/browser/checksActions": [
@@ -29522,7 +30989,7 @@
 			"pending",
 			"running",
 			"successful",
-			"Fix CI Checks"
+			"Fix Checks"
 		],
 		"vs/sessions/contrib/changes/browser/checksWidget": [
 			"{0}, {1}",
@@ -29553,8 +31020,18 @@
 			"New Chat",
 			"Chat",
 			"View icon of the chat view.",
-			"Open in VS Code",
-			"New Session"
+			"New Session",
+			"New Chat"
+		],
+		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
+			"Session Type"
+		],
+		"vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet": [
+			"Search to browse folders on the host",
+			"Folders",
+			"No folders match",
+			"Search folders…",
+			"Choose Workspace"
 		],
 		"vs/sessions/contrib/chat/browser/newChatContextAttachments": [
 			"Attach as Context",
@@ -29565,38 +31042,46 @@
 			"Remove",
 			"Select Files or Folders"
 		],
-		"vs/sessions/contrib/chat/browser/newChatPermissionPicker": [
-			"Permission Picker",
-			"Bypass Approvals",
-			"Bypass Approvals",
-			"All tool calls are auto-approved",
-			"Cancel",
-			"Enable",
-			"Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.",
-			"Enable Bypass Approvals?",
-			"Autopilot (Preview)",
-			"Autopilot (Preview)",
-			"Autonomously iterates from start to finish",
-			"Cancel",
-			"Enable",
-			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.",
-			"Enable Autopilot?",
-			"Default Approvals",
-			"Default Approvals",
-			"Copilot uses your configured settings",
-			"Learn more about permissions"
-		],
-		"vs/sessions/contrib/chat/browser/newChatViewPane": [
+		"vs/sessions/contrib/chat/browser/newChatInput": [
 			"Add Context...",
 			"Chat input",
 			"Chat input. Press Enter to send out the request. Use {0} for Chat Accessibility Help.",
 			"Chat input. Press Enter to send out the request. Use the Chat Accessibility Help command for more information.",
-			"Run tasks in the background, type '#' for adding context",
 			"Loading...",
+			"Send",
+			"Describe the outcome you want",
+			"Describe what you want to build",
+			"Describe your mission",
+			"Pitch your idea",
+			"What are you building?",
+			"What are you trying to achieve?",
+			"What feature are you dreaming up?",
+			"What problem are you solving?",
+			"What's next on your roadmap?",
+			"What's the goal?",
+			"What's your next milestone?",
+			"What will you create?",
+			"What will you launch?",
+			"What will you ship today?",
+			"What would you like to automate?"
+		],
+		"vs/sessions/contrib/chat/browser/newChatInSessionViewPane": [
+			"Ask a follow-up question or start a new topic within this session...",
+			"Sub-session tip",
+			"Dismiss tip",
+			"This is a sub-session, a new chat in the same workspace. Use it to ask questions, run tasks, or explore ideas with fresh context."
+		],
+		"vs/sessions/contrib/chat/browser/newChatViewPane": [
 			"Start by picking a",
 			"New session in",
-			"Send",
+			"with",
 			"An agent session will be able to read files, run commands, and make changes in this folder."
+		],
+		"vs/sessions/contrib/chat/browser/noAgentHostEmptyState": [
+			"No agent hosts available",
+			"Run ``{0}`` from any device, then return here to run agent tasks on it.",
+			"Learn more",
+			"Connect a host to get started"
 		],
 		"vs/sessions/contrib/chat/browser/runScriptAction": [
 			"Add a new task",
@@ -29605,9 +31090,13 @@
 			"Add Task",
 			"Enable an existing task for sessions and configure when it should run.",
 			"Add Existing Task",
+			"Browser",
 			"Close",
 			"Update how this task is named, saved, and run.",
 			"Configure Task",
+			"Configure URL",
+			"Enter the URL to open in the integrated browser. Leave empty to clear.",
+			"Configure Browser URL",
 			"Add Task...",
 			"Add Task...",
 			"Configure",
@@ -29622,7 +31111,12 @@
 			"Generate New Task...",
 			"Generate a new workspace task",
 			"npm run {0}",
+			"Open Browser",
+			"Open '{0}' in the integrated browser",
+			"Open the integrated browser",
 			"Select or create a task",
+			"Pin",
+			"Pin",
 			"Pin",
 			"Pin",
 			"Remove",
@@ -29634,6 +31128,8 @@
 			"Run Primary Task",
 			"Run Task is not available for this session type",
 			"Tasks",
+			"Unpin",
+			"Unpin",
 			"Unpin",
 			"Unpin",
 			"Workspace storage is unavailable for this session",
@@ -29668,53 +31164,38 @@
 			"Focus the Files Explorer view{0}.",
 			"Use up and down arrows to navigate your request history in the input box.",
 			"You are in the chat input. Type a message and press Enter to send it.",
-			"You are in the Agents app. The Agents app is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options.",
+			"On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection.",
+			"You are in the Agents window. The Agents window is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options.",
 			"Focus the Chat Sessions view{0}.",
 			"Shift+Tab to navigate to the workspace picker and choose a workspace for your session."
 		],
 		"vs/sessions/contrib/chat/browser/sessionTypePicker": [
-			"Session Type"
+			"Session Type",
+			"Pick Session Type, {0}"
 		],
 		"vs/sessions/contrib/chat/browser/sessionWorkspacePicker": [
+			"Select a provider",
 			"workspace",
 			"Workspace Picker",
-			"{0}...",
 			"Select...",
-			"Select {0}...",
-			"Copy Address",
+			"Select...",
+			"Experimental",
 			"Search Workspaces...",
-			"Remote agent host is connected and ready.",
-			"Remote agent host is connected and ready.\n\nAddress: {0}",
-			"Attempting to connect to remote agent host...",
-			"Attempting to connect to remote agent host...\n\nAddress: {0}",
-			"Remote agent host is disconnected. Click the gear icon for options.",
-			"Remote agent host is disconnected. Click the gear icon for options.\n\nAddress: {0}",
-			"Offline",
-			"Offline",
-			"Open Settings",
 			"Start by picking a workspace",
-			"{0} (Offline)",
-			"Reconnect",
-			"Options",
-			"Options for {0}",
-			"Remove Remote",
-			"New session in {0}",
-			"Show Output",
-			"Connecting",
-			"Offline",
-			"Online",
-			"Tunnels..."
+			"New session in {0}"
 		],
 		"vs/sessions/contrib/chat/browser/slashCommands": [
 			"View and manage custom agents",
 			"View and manage hooks",
 			"View and manage instructions",
-			"View and manage prompt files",
 			"View and manage skills"
 		],
 		"vs/sessions/contrib/chat/browser/variableCompletions": [
 			"Active file",
 			"{0} ({1})"
+		],
+		"vs/sessions/contrib/chat/browser/webWorkspacePicker": [
+			"Select Folder..."
 		],
 		"vs/sessions/contrib/chatDebug/browser/chatDebug.contribution": [
 			"Chat Debug",
@@ -29733,97 +31214,264 @@
 			"1 review comment unresolved.",
 			"Run another code review."
 		],
-		"vs/sessions/contrib/copilotChatSessions/browser/branchPicker": [
-			"Branch Picker",
-			"Filter branches...",
-			"Branch"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessions.contribution": [
-			"Whether to enable multiple chats within a single session in the Copilot Chat sessions provider."
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsActions": [
-			"Branch",
-			"Model",
-			"Isolation Mode",
-			"Model",
-			"Mode",
-			"Permissions"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/copilotChatSessionsProvider": [
-			"Copilot Chat",
-			"Folders",
-			"New Chat",
-			"New Session",
-			"Repositories"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/isolationPicker": [
-			"Folder",
-			"Worktree",
-			"Isolation Mode"
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/modelPicker": [
-			"Model Picker",
-			"Auto",
-			"Filter models..."
-		],
-		"vs/sessions/contrib/copilotChatSessions/browser/modePicker": [
-			"Configure Custom Agents...",
-			"Mode Picker",
-			"Select chat mode"
+		"vs/sessions/contrib/editor/browser/editor.contribution": [
+			"Close Editor Area",
+			"Maximize Editor Area",
+			"Open in Modal Editor",
+			"Open in Editor Area",
+			"Restore Editor Area"
 		],
 		"vs/sessions/contrib/files/browser/files.contribution": [
 			"Collapse Folders in Explorer",
+			"Explorer",
 			"Files",
-			"View icon of the files view in the sessions window."
+			"Fil&&es",
+			"View icon of the files view in the sessions window.",
+			"Sync Changes"
 		],
 		"vs/sessions/contrib/files/browser/filesView": [
 			"Folders and files will appear here."
 		],
-		"vs/sessions/contrib/localAgentHost/browser/localAgentHostSessionsProvider": [
-			"Cannot change session type on an existing local agent host session.",
-			"Folders",
-			"Local",
-			"Local Agent Host",
-			"{0} [{1}]",
-			"Local",
-			"Local agent host has not advertised any agents yet.",
-			"Select Folder",
-			"Session type '{0}' is not available on local agent host."
-		],
-		"vs/sessions/contrib/logs/browser/logs.contribution": [
-			"Logs",
-			"View icon of the logs view in the sessions window."
-		],
 		"vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked": [
+			"Allowed organizations:",
+			"Sign-in required by your administrator",
+			"Contact your administrator for more information.",
+			"Your administrator restricts Agents to members of the organizations below.",
+			"The account \"{0}\" is not a member of an organization that your administrator allows for Agents.",
+			"Learn more",
+			"Sign In",
+			"Sign-In Required",
+			"Loading",
 			"Agents disabled by organization policy",
 			"Your organization has disabled Agents via policy.",
 			"Learn more",
 			"Open VS Code",
 			"Agents Disabled"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHost.contribution": [
-			"A list of remote agent host addresses to connect to (e.g. \"localhost:3000\").",
-			"The address of the remote agent host (e.g. \"localhost:3000\").",
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker": [
+			"Approvals Picker",
+			"Pick Approvals, {0}",
+			"Learn more about permissions"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker": [
+			"Model"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
+			"Agent Mode Picker",
+			"Pick Agent Mode, {0}"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
+			"Copy Session Branch Name"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker": [
+			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.",
+			"Enable Autopilot?",
+			"Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.",
+			"Enable Bypass Approvals?",
+			"Cancel",
+			"Enable",
+			"{0}\n\nTo make this the starting permission level for new chat sessions, change the [{1}](command:workbench.action.openSettings?%5B%22{1}%22%5D) setting.",
+			"Session Approvals",
+			"Agent Mode",
+			"Session Approvals",
+			"Agent Mode",
+			"Approvals",
+			"{0} Picker",
+			"Filter options...",
+			"{0}: {1}",
+			"{0}: {1}, Read-Only",
+			"Session Configuration",
+			"Search base branches",
+			"No matching branches.",
+			"Search branches",
+			"Base Branch",
+			"Isolation",
+			"Worktree",
+			"(Selected)"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSettings.contribution": [
+			"Host Settings",
+			"Open Host Settings"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSettingsFileSystemProvider": [
+			"Agent host settings.",
+			"Agent host settings must be a JSON object.",
+			"Failed to parse agent host settings as JSON.",
+			"Edit values below and save to apply. Unknown properties are ignored."
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSkillButtons": [
+			"Create Draft Pull Request",
+			"Create Pull Request",
+			"Merge Changes",
+			"Sync Pull Request"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentSessionSettings.contribution": [
+			"Session Settings",
+			"Open Session Settings"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentSessionSettingsFileSystemProvider": [
+			"Session settings for this agent host session.",
+			"Agent session settings must be a JSON object.",
+			"Failed to parse agent session settings as JSON.",
+			"Edit values below and save to apply. Unknown or non-mutable properties are ignored."
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider": [
+			"Copilot CLI",
+			"Agent host has not advertised any agents yet.",
+			"Cannot send request: not connected to agent host."
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
+			"Export Agent Host Debug Logs..."
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider": [
+			"Local Agent Host",
+			"Local"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
+			"Open Copilot CLI State File"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker": [
+			"Branch Picker",
+			"Filter branches...",
+			"Branch",
+			"Pick Branch, {0}"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker": [
+			"Edit Automatically",
+			"Claude edits files without asking",
+			"Auto",
+			"A model classifier approves or denies tool operations automatically",
+			"Ask Before Edits",
+			"Claude asks for approval before making changes",
+			"Plan Mode",
+			"Claude creates a plan before making changes",
+			"Permission Mode",
+			"Pick Permission Mode, {0}"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution": [
+			"Enable Claude Agent sessions in the Agents window. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly. Uses your existing Copilot subscription.",
+			"Enable Local VS Code chat sessions in the Agents Window.",
+			"Whether to enable multiple chats within a single session in the Copilot Chat sessions provider."
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
+			"Branch",
+			"Permission Mode",
+			"Model",
+			"Delete...",
+			"Isolation Mode",
+			"Model",
+			"Mode",
+			"Permissions"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsChangesets": [
+			"All Changes",
+			"Show all changes made in this session",
+			"Branch Changes",
+			"Changes",
+			"Checkpoints",
+			"Last Turn Changes",
+			"Show only changes made in the last turn",
+			"Uncommitted Changes",
+			"Show uncommitted changes in this session"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider": [
+			"Claude",
+			"Copilot Chat",
+			"Cloud",
+			"Are you sure you want to delete this chat?",
+			"Delete",
+			"This action cannot be undone.",
+			"Are you sure you want to delete this session?",
+			"Delete",
+			"This action cannot be undone.",
+			"This will delete all {0} chats in this session. This action cannot be undone.",
+			"Local",
+			"New Chat",
+			"New Session",
+			"Repositories",
+			"GitHub"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker": [
+			"Folder",
+			"Worktree",
+			"Isolation Mode",
+			"Pick Isolation Mode, {0}"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/mobilePermissionPicker": [
+			"Approvals",
+			"Bypass Approvals",
+			"All tool calls are auto-approved",
+			"Autopilot (Preview)",
+			"Autonomously iterates from start to finish",
+			"Default Approvals",
+			"Copilot uses your configured settings",
+			"Learn more about permissions"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/modelPicker": [
+			"Model Picker",
+			"Auto",
+			"Filter models...",
+			"Pick Model, {0}"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker": [
+			"Configure Custom Agents...",
+			"Mode Picker",
+			"Pick Mode, {0}"
+		],
+		"vs/sessions/contrib/providers/copilotChatSessions/browser/permissionPicker": [
+			"Permission Picker",
+			"Pick Permission Level, {0}",
+			"Bypass Approvals",
+			"Bypass Approvals",
+			"All tool calls are auto-approved",
+			"Autopilot (Preview)",
+			"Autopilot (Preview)",
+			"Autonomously iterates from start to finish",
+			"Default Approvals",
+			"Default Approvals",
+			"Copilot uses your configured settings",
+			"Learn more about permissions"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/manageRemoteAgentHosts": [
+			"Add or Manage",
+			"Select a remote to manage or pick an action",
+			"Remote Agent Hosts",
+			"Remove",
+			"Manage Remote Agent Hosts",
+			"Manage Remote Agent Hosts..."
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution": [
+			"When enabled, forwards the local SSH agent to the remote machine during SSH agent host connections to hosts whose SSH config has `ForwardAgent yes`. Only enable this for trusted hosts. The remote agent host process must be restarted for this setting to take effect.",
+			"Per-host filesystem grants for remote agent hosts. Maps a remote agent host address to URI strings and the access mode the host has been granted (`r` for read, `rw` for read and write). Hosts cannot read or write any files outside the granted URIs without prompting; a URI grant covers descendants. This setting is normally maintained by the agent-host permission prompts and rarely edited by hand.",
+			"Read-only access.",
+			"Read and write access.",
+			"A list of WebSocket remote agent host addresses to connect to (e.g. \"localhost:3000\"). SSH remote agent host details are managed by VS Code.",
+			"The WebSocket address of the remote agent host (e.g. \"localhost:3000\").",
+			"Automatically connect to online dev tunnel and SSH-configured remote agent hosts on startup. When disabled, cached sessions are still shown but connections are established only on demand.",
 			"An optional connection token for authenticating with the remote agent host.",
 			"Enable connecting to remote agent hosts.",
 			"A display name for this remote agent host.",
-			"SSH config host alias for automatic reconnection via SSH tunnel.",
 			"Additional dev tunnel names to look for when connecting to remote agent hosts. These are looked up in addition to tunnels automatically enumerated from your account.",
 			"For development: Override the command used to start the remote agent host over SSH. When set, skips automatic CLI installation and runs this command instead. The command must print a WebSocket URL matching ws://127.0.0.1:PORT (optionally with ?tkn=TOKEN) to stdout or stderr./"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostActions": [
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions": [
+			"Add New SSH Host...",
 			"Add Remote Agent Host...",
 			"Failed to connect to remote agent host {0}.",
 			"Paste a host, host:port, or WebSocket URL. Example: {0}",
 			"Add Remote Agent Host",
 			"Enter a remote agent host address.",
 			"Enter a valid host, host:port, or WebSocket URL.",
+			"Configure SSH Hosts...",
 			"Connect to Remote Agent Host via SSH",
+			"SSH...",
 			"Connect to Remote Agent Host via Dev Tunnel",
+			"Tunnels...",
 			"My Remote",
 			"Enter a display name for this remote agent host.",
 			"Name Remote Agent Host",
 			"Enter a name for this remote agent host.",
+			"Add New SSH Host...",
 			"SSH Agent",
 			"Use the running SSH agent for authentication",
 			"Private Key File",
@@ -29832,19 +31480,23 @@
 			"Authenticate with a password",
 			"Choose how to authenticate with {0}",
 			"Authentication Method",
+			"Failed to create SSH config file: {0}",
+			"Failed to list SSH config files: {0}",
+			"Failed to open SSH config file: {0}",
+			"Select an SSH configuration file",
+			"Select SSH configuration file to edit",
+			"Configure SSH Hosts...",
 			"Failed to connect via SSH to {0}: {1}",
 			"Connecting to {0} via SSH...",
-			"Enter Manually...",
-			"Type in host, username, and port",
 			"Enter an SSH host.",
+			"Invalid SSH host.",
 			"Enter a valid port number.",
 			"Enter a host name after '@'.",
-			"Enter the SSH host (e.g. user@hostname or user@hostname:port).",
+			"Select configured SSH host or enter user@host",
 			"Connect via SSH",
 			"Enter a key file path.",
 			"Enter the path to your SSH private key.",
 			"Private Key Path",
-			"Connect via SSH",
 			"Enter a name.",
 			"My Remote",
 			"Enter a display name for this SSH remote.",
@@ -29852,19 +31504,12 @@
 			"Enter a password.",
 			"Enter the password for {0}@{1}.",
 			"SSH Password",
-			"Select an SSH host or enter manually",
 			"Failed to resolve SSH config for {0}: {1}",
 			"Enter a username.",
 			"Enter a username before '@'.",
 			"Enter the username for {0}.",
 			"SSH Username",
 			"Authentication failed. Please try again.",
-			"GitHub",
-			"Sign in with your GitHub account",
-			"Microsoft Account",
-			"Sign in with your Microsoft account",
-			"Choose an authentication provider",
-			"Sign In for Dev Tunnels",
 			"Failed to connect to tunnel '{0}': {1}",
 			"Connecting to tunnel '{0}'...",
 			"Failed to list dev tunnels: {0}",
@@ -29872,18 +31517,65 @@
 			"Select a dev tunnel to connect to",
 			"Connect via Dev Tunnel"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/remoteAgentHostSessionsProvider": [
-			"Cannot change session type on an existing remote agent host session.",
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostCustomizationHarness": [
+			"Add Remote Plugin",
+			"Add a plugin folder that already exists on this remote agent host.",
+			"'{0}' is already configured on {1}.",
+			"Remove from Remote Host",
+			"Select Plugin Folder on {0}"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider": [
+			"Failed to connect to remote agent host '{0}': {1}",
 			"Folders",
 			"Remote agent host '{0}' has not advertised any agents yet.",
 			"Unable to connect to remote agent host '{0}'.",
 			"Cannot send request: not connected to remote agent host '{0}'.",
 			"Cannot create session: not connected to remote agent host '{0}'.",
-			"Select Folder on {0}",
-			"Session type '{0}' is not available on remote agent host '{1}'."
+			"Select Folder on {0}"
 		],
-		"vs/sessions/contrib/remoteAgentHost/browser/tunnelAgentHost.contribution": [
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.contribution": [
+			"Agent Host Terminal ({0})"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteHostOptions": [
+			"Cannot connect to {0}: {1}",
+			"Show Options",
+			"Update Server",
+			"Copy Address",
+			"Remote agent host is connected and ready.",
+			"Remote agent host is connected and ready.\n\nAddress: {0}",
+			"Attempting to connect to remote agent host...",
+			"Attempting to connect to remote agent host...\n\nAddress: {0}",
+			"Remote agent host is disconnected.",
+			"Remote agent host is disconnected.\n\nAddress: {0}",
+			"Cannot connect to remote agent host: {0}\n\nThis client speaks protocol version {1}.",
+			"Cannot connect to remote agent host: {0}\n\nThis client speaks protocol version {1}.\n\nAddress: {2}",
+			"Incompatible protocol version. We speak {0}. Error from {1}: {2}\n\n Ensure {3} and {1} are both up to date.",
+			"Incompatible protocol version. We speak {0}, but {1} speaks {2}. Ensure {3} and {1} are both up to date.",
+			"Open Settings",
+			"Reconnect",
+			"Options for {0}",
+			"Remove Remote",
+			"Show Output",
+			"Connecting",
+			"Incompatible",
+			"Offline",
+			"Online",
+			"Update Server",
+			"Restarting in {0}s...",
+			"Failed to update {0}: {1}",
+			"Failed to update {0}: {1}",
+			"{0} is already on the latest version.",
+			"{0} did not start an update.",
+			"Reconnecting...",
+			"Updating {0}..."
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution": [
 			"Connecting to tunnel '{0}'..."
+		],
+		"vs/sessions/contrib/search/browser/search.contribution": [
+			"Find in Folder...",
+			"&&Search",
+			"Search"
 		],
 		"vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget": [
 			"Customizations"
@@ -29895,17 +31587,29 @@
 			"Instructions",
 			"MCP Servers",
 			"Plugins",
-			"Prompts",
+			"Controls how the Customizations section in the Agents sidebar is presented and what happens when an entry is clicked.",
+			"Show one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor.",
+			"Show a single \"Customizations\" entry instead of one item per category. Clicking it opens the Customizations welcome page.",
+			"Show one item per customization category. Clicking a category opens the Customizations welcome page.",
 			"Skills"
+		],
+		"vs/sessions/contrib/sessions/browser/mobile/mobileOverlayContribution": [
+			"Open File Diff",
+			"Open Session Changes"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"Sessions",
-			"Icon for Agent Sessions View"
+			"Icon for Agent Sessions View",
+			"&&Sessions"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsActions": [
+			"&&Back",
+			"&&Forward",
 			"New Session",
 			"Recent Sessions",
 			"Search sessions by name",
+			"Go Back",
+			"Go Forward",
 			"Show Sessions Picker",
 			"New Session"
 		],
@@ -29913,9 +31617,7 @@
 			"New Session",
 			"Agent Sessions",
 			"Show Sessions",
-			"Show Sessions",
-			"Toggle Primary Side Bar",
-			"{0}, {1} unread session(s)"
+			"Show Sessions"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
 			"Allow",
@@ -29925,11 +31627,18 @@
 			"Last 7 Days",
 			"Input needed",
 			"Older",
+			"Pinned",
 			"now",
 			"{0}, created {1}",
 			"Sessions",
+			"Show fewer sessions",
+			"Show less",
+			"Show fewer workspaces",
+			"Show fewer workspaces",
 			"Show {0} more sessions",
 			"+{0} more",
+			"Show {0} more workspaces",
+			"+{0} more workspaces",
 			"Today",
 			"Unknown",
 			"Working...",
@@ -29938,6 +31647,8 @@
 		"vs/sessions/contrib/sessions/browser/views/sessionsView": [
 			"Done",
 			"Read",
+			"Group by Time",
+			"Group by Workspace",
 			"New",
 			"New Session ({0})",
 			"New Session",
@@ -29945,15 +31656,20 @@
 			"New Session",
 			"Reset",
 			"Sessions",
+			"Sort by Created",
+			"Sort by Updated",
+			"Group",
+			"Sort",
+			"Sort",
 			"Completed",
 			"Failed",
 			"In Progress",
 			"Input Needed"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
-			"Add Chat",
-			"Enter a prompt for the new chat",
-			"Add a new chat to the active session",
+			"New Sub-Session",
+			"Are you sure you want to mark {0} pinned sessions as done?",
+			"Are you sure you want to mark 1 pinned session as done?",
 			"Mark All as Done",
 			"Mark All as Done",
 			"Are you sure you want to mark {0} sessions from '{1}' as done?",
@@ -29961,6 +31677,7 @@
 			"You can restore sessions later if needed from the sessions view.",
 			"Mark as Done",
 			"Close Session",
+			"Collapse All Groups",
 			"Do not ask me again",
 			"Do not ask me again",
 			"Filter",
@@ -29979,6 +31696,7 @@
 			"Rename...",
 			"Title cannot be empty",
 			"New agent session title",
+			"Restore",
 			"Show All Sessions",
 			"Show Recent Sessions",
 			"Sort by Created",
@@ -29995,43 +31713,44 @@
 			"Open Terminal",
 			"Show All Terminals"
 		],
-		"vs/sessions/contrib/welcome/browser/sessionsWalkthrough": [
-			"Agents onboarding walkthrough",
-			"Sign-in was canceled. Please try again.",
-			" anytime.",
-			" suggestions and use your data to improve the product. You can change these ",
-			" and ",
-			"By continuing, you agree to GitHub's ",
-			"Privacy Statement",
-			"public code",
-			"settings",
-			". GitHub Copilot may show ",
-			"Terms",
-			"Getting everything ready for you.",
-			"Complete authorization in your browser.",
-			"Completing Agents setup",
-			"Signing in…",
-			"Continue with Apple",
-			"Continue with {0}",
-			"Continue with GitHub",
-			"Continue with Google",
-			"Something went wrong. Please try again.",
-			"Finishing setup…",
-			"Sign in to continue with agent-powered development.",
-			"Welcome to Agents"
+		"vs/sessions/contrib/tunnelHost/electron-browser/toggleRemoteConnectionsActionViewItem": [
+			"Establishing tunnel connection...",
+			"Remote session access is enabled",
+			"Allow remote session access",
+			"Remote session access enabled via tunnel '{0}'",
+			"Show Output",
+			"Remote session access is now enabled"
 		],
-		"vs/sessions/contrib/welcome/browser/welcome.contribution": [
-			"Reset Agents Welcome"
+		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution": [
+			"Show Remote Connections Output",
+			"Allow Remote Connections",
+			"Remote Connections",
+			"Enable Microsoft account authentication for agent host tunnels. When disabled, only GitHub authentication is used.",
+			"Failed to toggle remote connections: {0}"
+		],
+		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHostService": [
+			"No authentication token available. Please sign in and try again.",
+			"Remote Connections"
+		],
+		"vs/sessions/electron-browser/actions/vscodeActions": [
+			"Open in Editor",
+			"Open VS Code Window"
+		],
+		"vs/sessions/electron-browser/parts/titlebarPart": [
+			"Agents"
 		],
 		"vs/sessions/electron-browser/sessions.main": [
 			"Saving UI state"
 		],
 		"vs/sessions/services/sessions/common/session": [
-			"Copilot CLI",
-			"Cloud"
+			"Local",
+			"Remote"
 		],
 		"vs/sessions/services/sessions/common/sessionsManagement": [
-			"Whether the active session's provider supports multiple chats per session"
+			"Whether the active session supports multiple chats"
+		],
+		"vs/sessions/services/workspace/browser/workspaceContextService": [
+			"Agents Window"
 		],
 		"vs/workbench/api/browser/mainThreadAuthentication": [
 			"Add Client Registration Details",
@@ -30234,6 +31953,7 @@
 		"vs/workbench/api/common/configurationExtensionPoint": [
 			"Accessibility settings",
 			"Advanced settings are hidden by default in the Settings editor unless the user chooses to show advanced settings.",
+			"Extension '{0}' CANNOT use 'agentsWindow' property on configuration '{1}' without enabling the 'agentsWindowConfiguration' API proposal.",
 			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
 			"Cannot register '{0}'. This property is already registered.",
 			"Cannot register configuration defaults for '{0}'. This setting does not allow contributing configuration defaults.",
@@ -30247,6 +31967,9 @@
 			"'configuration.title' must be a string",
 			"Languages",
 			"Preview settings can be used to try out new features before they are finalized.",
+			"Configuration overrides for the Agents window. Allows specifying a different default value and read-only behavior for this setting when running in the Agents window.\n\n**Note**: This is a proposed API. To use it, extensions must include `agentsWindowConfiguration` in their `enabledApiProposals`.",
+			"The default value for this setting in the Agents window.",
+			"When true, this setting cannot be changed by the user in the Agents window.",
 			"Configuration that can be configured only in the user settings.",
 			"If set, the property is marked as deprecated and the given message is shown as an explanation.",
 			"Scope in which the configuration is applicable. Available scopes are `application`, `machine`, `window`, `resource`, and `machine-overridable`.",
@@ -30395,6 +32118,9 @@
 			"Stop Tracking Disposables",
 			"Open developer tools from the menu and select the Console tab.",
 			"The storage database contents have been logged to the developer tools.",
+			"Sync Account Policy",
+			"Failed to sync account policy.",
+			"Account policy has been synced.",
 			"Toggle Screencast Mode",
 			"User",
 			"Workspace"
@@ -30468,7 +32194,6 @@
 			"Show &&Editor Area",
 			"S&&tatus Bar",
 			"&&Centered Layout",
-			"Zen Mode",
 			"Move Secondary Side Bar Left",
 			"Move Secondary Side Bar Right",
 			"Move Primary Side Bar Right",
@@ -30549,7 +32274,6 @@
 			"Toggle Primary Side Bar Position",
 			"Toggle Status Bar Visibility",
 			"Visibility",
-			"Toggle Zen Mode",
 			"Top",
 			"Zen Mode",
 			"Represents zen mode"
@@ -30933,6 +32657,7 @@
 			"Pin",
 			"Pin Editor",
 			"Icon for the previous change action in the diff editor.",
+			"Reopen as Text",
 			"Reopen Editor With...",
 			"Reopen Editor With...",
 			"Share",
@@ -31126,6 +32851,7 @@
 			"Unlock Editor Group"
 		],
 		"vs/workbench/browser/parts/editor/editorConfiguration": [
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for diff views (for example `\"*.md\": \"vscode.markdown.preview.editor\"`). These override `workbench.editorAssociations` for diffs.",
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
 			"Controls the minimum size of a file in MB before asking for confirmation when opening in the editor. Note that this setting may not apply to all editor types and environments.",
 			"Interactive Window",
@@ -31251,6 +32977,7 @@
 		],
 		"vs/workbench/browser/parts/editor/editorTabsControl": [
 			"Editor actions",
+			"Editor layout actions",
 			"{0} (+{1})"
 		],
 		"vs/workbench/browser/parts/editor/modalEditorPart": [
@@ -31463,6 +33190,16 @@
 			"Search {0} — {1}",
 			"Command Center"
 		],
+		"vs/workbench/browser/parts/titlebar/menubar.contribution": [
+			"&&Edit",
+			"&&File",
+			"&&Go",
+			"&&Help",
+			"&&Preferences",
+			"&&Selection",
+			"&&Terminal",
+			"&&View"
+		],
 		"vs/workbench/browser/parts/titlebar/menubarControl": [
 			"Check for &&Updates...",
 			"Checking for Updates...",
@@ -31472,15 +33209,7 @@
 			"Open Settings",
 			"Installing Update...",
 			"Install &&Update...",
-			"&&Edit",
 			"Accessibility support is enabled for you. For the most accessible experience, we recommend the custom menu style.",
-			"&&File",
-			"&&Go",
-			"&&Help",
-			"Preferences",
-			"&&Selection",
-			"&&Terminal",
-			"&&View",
 			"Restart to &&Update"
 		],
 		"vs/workbench/browser/parts/titlebar/titlebarActions": [
@@ -31813,7 +33542,12 @@
 			"The secondary side bar is visible by default.",
 			"The secondary side bar is visible by default if a workspace is opened.",
 			"If an extension requests a hidden view to be shown, display a clickable status bar indicator instead.",
-			"Controls whether tabs should be wrapped over multiple lines when exceeding available space or whether a scrollbar should appear instead. This value is ignored when {0} is not set to '{1}'.",
+			"Controls whether tabs should be wrapped over multiple lines when exceeding available space or whether a scrollbar should appear instead. This value is ignored when {0} is not set to '{1}'."
+		],
+		"vs/workbench/browser/workbench.zenMode.contribution": [
+			"Zen Mode",
+			"Tab Bar",
+			"Toggle Zen Mode",
 			"Controls whether turning on Zen Mode also centers the layout.",
 			"Controls whether turning on Zen Mode also puts the workbench into full screen mode.",
 			"Controls whether turning on Zen Mode also hides the activity bar either at the left or right of the workbench.",
@@ -31842,6 +33576,8 @@
 		"vs/workbench/common/contextkeys": [
 			"The identifier of the active auxiliary panel",
 			"Whether the active compare editor can swap sides",
+			"Whether the active custom editor diff can toggle between inline and side by side layout",
+			"Whether the active custom editor diff is backed by text documents",
 			"The identifier of the active editor",
 			"The available editor identifiers that are usable for the active editor",
 			"Whether the active editor can revert",
@@ -31884,6 +33620,7 @@
 			"Whether the main window is in fullscreen mode",
 			"Whether centered layout is enabled for the main editor",
 			"Whether the current window is a agent sessions window.",
+			"Whether the editor group is the top right editor group in the editor part",
 			"Whether the window is always on top",
 			"Whether the editor area in the main window is visible",
 			"Whether there are multiple editor groups opened",
@@ -32245,6 +33982,7 @@
 			"Auto (Use Display Language)",
 			"On keypress, close the Accessible View and focus the element from which it was invoked.",
 			"Provide information about how to access the chat help menu when the chat input is focused.",
+			"Provide information about how to navigate and interact with the chat question carousel, including how to focus the terminal when applicable.",
 			"Provide information about actions that can be taken in the comment widget or in a file which contains comments.",
 			"Provide information about how to access the debug console accessibility help dialog when the debug console or run and debug viewlet is focused. Note that a reload of the window is required for this to take effect.",
 			"Provide information about how to navigate changes in the diff editor when it is focused.",
@@ -32259,7 +33997,7 @@
 			"Provide information about how to open the notification in an Accessible View.",
 			"Provide information about how to access the REPL editor accessibility help menu when the REPL editor is focused.",
 			"Provide information about how to access the source control accessibility help menu when the input is focused.",
-			"Provide information about how to access the Agents app accessibility help menu when the chat input is focused.",
+			"Provide information about how to access the Agents window accessibility help menu when the chat input is focused.",
 			"Provide information about how to access the terminal accessibility help menu when the terminal is focused.",
 			"Provide information about how to open the chat terminal output in the Accessible View.",
 			"Provide information about how to open the walkthrough in an Accessible View.",
@@ -32492,7 +34230,6 @@
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures": [
 			"Add Console Logs to Chat",
 			"Add Element to Chat",
-			"Add Focused Element to Chat",
 			"Pages may contain hidden prompts that can influence agent behavior. Double-check the attached contents before sending.",
 			"Don't show again",
 			"Use caution when attaching content from untrusted sources.",
@@ -32503,7 +34240,8 @@
 			"Sharing with Agent",
 			"Stop Sharing with Agent",
 			"Browser",
-			"Console Logs"
+			"Console Logs",
+			"When enabled, integrated browser tools are exposed as client-provided tools to agent host sessions in the Sessions window. Requires {0} and {1}."
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorFindFeature": [
 			"Find Next",
@@ -32523,19 +34261,26 @@
 			"Zoom Out"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures": [
+			"Background",
 			"Close All Browser Tabs",
 			"Close All Browser Tabs in Group",
 			"Close All Browser Tabs",
 			"Close All",
 			"Close",
 			"Whether any browser editor is currently open",
+			"This link opened in the integrated browser",
+			"**Integrated Browser**\n\nLocalhost links automatically open in the integrated browser.",
+			"Don't Show Again",
+			"Link opened here",
+			"Open Settings",
 			"New Tab",
 			"Open Integrated Browser",
-			"Browser",
-			"When enabled, localhost links from the terminal, chat, and other sources will open in the Integrated Browser instead of the system browser.",
+			"Open in Integrated Browser",
+			"When enabled, localhost links (`localhost`, `127.0.0.1`, `[::1]`) and all-interfaces links (`0.0.0.0`, `[0:0:0:0:0:0:0:0]`, `[::]`) from the terminal, chat, and other sources will open in the Integrated Browser instead of the system browser.",
 			"New Integrated Browser Tab",
+			"Browser",
 			"Quick Open Browser Tab...",
-			"Select a browser tab or enter a URL",
+			"Select a browser tab",
 			"Controls whether the Integrated Browser button is shown in the title bar.",
 			"The button is never shown in the title bar.",
 			"The button is always shown in the title bar.",
@@ -32609,8 +34354,16 @@
 			"This will open {0} in the integrated browser. The agent will be able to read and interact with its contents.",
 			"Open Browser Page?",
 			"Opening browser page at {0}",
+			"No, open a new page at {0}",
+			"No - Do not share any tabs with the agent",
 			"Opened browser page at {0}",
+			"Prompting user to share a browser tab",
+			"Prompted user to share a browser tab",
 			"Opened {0}",
+			"User shared {0}",
+			"Yes, share \"{0}\" - {1}",
+			"Share an existing browser tab?",
+			"Share Browser Tab",
 			"Open Browser Page",
 			"Open a URL in the integrated browser"
 		],
@@ -32849,7 +34602,8 @@
 			"To navigate to the next user prompt in the conversation, invoke the Next User Prompt command{0}.",
 			"To navigate to the previous user prompt in the conversation, invoke the Previous User Prompt command{0}.",
 			"- Restore to Last Checkpoint{0}.",
-			"- Undo Edits{0}."
+			"- Undo Edits{0}.",
+			"To open the Agents Window, invoke the Open Agents Window command{0}. In screen reader mode, this keybinding includes Alt to avoid conflicts with screen reader shortcuts."
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatActions": [
 			"Focus Chat List",
@@ -32889,6 +34643,7 @@
 			"Clear Input History",
 			"Focus Chat Input",
 			"Chat: Toggle Focus Between Question and Input",
+			"Chat: Focus Terminal from Question Carousel",
 			"Chat: Toggle Focus Between Tip and Input",
 			"Toggle Focus Between TODOs and Input",
 			"New Chat Window",
@@ -32897,7 +34652,7 @@
 			"New Chat Editor to the Side",
 			"Chat: Previous Question",
 			"Show Context Window Usage",
-			"Manage Chat",
+			"Manage Copilot Settings",
 			"Open Chat",
 			"Open Customizations",
 			"Chat Settings",
@@ -32965,14 +34720,19 @@
 			"Copy Math Source",
 			"Copy All",
 			"Copy Final Response",
-			"Copy"
+			"Copy",
+			"Copied",
+			"Copied",
+			"Copy",
+			"Copied to clipboard"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatDeveloperActions": [
 			"Clear Recently Used Language Models",
 			"Inspect Chat Model",
 			"Inspect Chat Model References",
 			"Log Chat Index",
-			"Log Chat Input History"
+			"Log Chat Input History",
+			"Reset Permission Warning Dialogs (Autopilot, Bypass Approvals)"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatElicitationActions": [
 			"Accept Request"
@@ -33005,6 +34765,7 @@
 			"Send",
 			"Send",
 			"Switch to Next Model",
+			"Switch to Next Pinned Model",
 			"Switch to Next Agent",
 			"Select Target Workspace",
 			"Send to Agent",
@@ -33093,6 +34854,7 @@
 			"Previous User Prompt"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatQueueActions": [
+			"Edit",
 			"Add to Queue",
 			"Queue this message to send after the current request completes",
 			"Queue",
@@ -33189,6 +34951,20 @@
 			"Show Built-in, Extension, and Plugin Resources",
 			"Skills"
 		],
+		"vs/workbench/contrib/chat/browser/actions/exportAgentHostDebugLogsAction": [
+			"Export Agent Host Debug Logs...",
+			"Select Folder for Agent Host Debug Logs",
+			"No log files were found for the active Agent Host session.",
+			"No Agent Host log files were found for the current window.",
+			"Failed to save debug logs: {0}"
+		],
+		"vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction": [
+			"Open Copilot CLI State File",
+			"Remote agent host '{0}' did not report a home directory.",
+			"No Copilot CLI session is active.",
+			"No active connection found for remote agent host '{0}'.",
+			"The active chat session is not a Copilot CLI session."
+		],
 		"vs/workbench/contrib/chat/browser/agentPluginActions": [
 			"Disable",
 			"Disable (Workspace)",
@@ -33228,13 +35004,54 @@
 			"No agent plugins found.",
 			"Update"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution": [
+			"{0} - Agent Host",
+			"{0} [Local]"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
+			"{0} Picker",
+			"Filter...",
+			"Learn more about permissions",
+			"{0}: {1}",
+			"{0}: {1}, Read-Only",
+			"(Selected)"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution": [
+			"Auto-Approve",
+			"Branch",
+			"Isolation",
+			"Agent Mode",
+			"Approvals"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostEditingSession": [
 			"Suggested Edits"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution": [
+			"Allow",
+			"Always Allow",
+			"Deny",
+			"+{0} more requests waiting",
+			"+1 more request waiting",
+			"Remote agent host \"{0}\" wants to read {1}",
+			"Remote agent host \"{0}\" wants to write {1}"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler": [
 			"Authentication is required to start a session. Please sign in and try again.",
+			"Cancel",
+			"Open this URL?",
+			"Open {0}",
+			"Authorization Required",
+			"{0} credit",
+			"{0} credits",
 			"Forked Session",
 			"Forked: {0}"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
+			"Agent Host Terminal (Local)",
+			"Local"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter": [
+			"Running {0}..."
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionHoverWidget": [
 			"Completed",
@@ -33318,6 +35135,9 @@
 			"Unarchive All",
 			"Unpin"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner": [
+			"Try out the new Agents window"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsControl": [
 			"No matching sessions",
 			"Reset Filter"
@@ -33326,6 +35146,8 @@
 			"Archived",
 			"Read",
 			"Reset",
+			"Sort by Created",
+			"Sort by Updated",
 			"Completed",
 			"Failed",
 			"In Progress",
@@ -33413,7 +35235,6 @@
 			"Ask anything or describe what to build",
 			"Open Quick Access ({0})",
 			"Open Quick Access",
-			"GitHub Copilot Free plan chat messages quota reached. Click for details.",
 			"Enter Agent Session Projection",
 			"Review Changes ({0})",
 			"Review Changes",
@@ -33428,7 +35249,6 @@
 			"Go to File ({0})",
 			"Go to File",
 			"Review",
-			"Sign in to use AI features...",
 			"Toggle Chat",
 			"{0} unread sessions",
 			"{0} unread session"
@@ -33475,15 +35295,16 @@
 			"Icon for the Agent Customization view.",
 			"Icon for workspace items."
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationItemSource": [
+			"(unset)",
+			"UI Integration"
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationListWidget": [
 			"Agent",
 			"Agent Instructions",
 			"Instruction files automatically loaded for all agent interactions (e.g. AGENTS.md, CLAUDE.md, copilot-instructions.md).",
-			"Configure the AI to adopt different personas tailored to specific development tasks. Each agent has its own instructions, tools, and behavior.",
 			"Agents",
-			"Hooks defined in agent files.",
-			"always added",
-			"This instruction is automatically included in every interaction.",
+			"Configure the AI to adopt different personas tailored to specific development tasks. Each agent has its own instructions, tools, and behavior.",
 			"Built-in",
 			"Built-in customizations shipped with the application.",
 			"Built-in",
@@ -33494,6 +35315,36 @@
 			"Instructions automatically loaded when matching files are part of the context.",
 			"Copy Full Path",
 			"Copy Relative Path",
+			"{0} agents",
+			"No agents",
+			"No agents found",
+			"1 agent",
+			"1 agent found",
+			"{0} agents found",
+			"{0} hooks",
+			"No hooks",
+			"No hooks found",
+			"1 hook",
+			"1 hook found",
+			"{0} hooks found",
+			"{0} instruction files",
+			"No instructions",
+			"No instructions found",
+			"1 instruction file",
+			"1 instruction file found",
+			"{0} instruction files found",
+			"{0} prompts",
+			"No prompts",
+			"No prompts found",
+			"1 prompt",
+			"1 prompt found",
+			"{0} prompts found",
+			"{0} skills",
+			"No skills",
+			"No skills found",
+			"1 skill",
+			"1 skill found",
+			"{0} skills found",
 			"Create your first custom agent to get started",
 			"Create hooks to execute commands at agent lifecycle events",
 			"Add instructions to teach Copilot about your codebase",
@@ -33506,11 +35357,11 @@
 			"Plugin: {0}",
 			"{0}, {1} items, {2}",
 			"Hook",
+			"Hooks",
 			"Prompts executed at specific points during an agentic lifecycle.",
-			"(unset)",
 			"Instructions",
 			"Define common guidelines and rules that automatically influence how AI generates code and handles development tasks.",
-			"{0}, {1}",
+			"{0}. {1}",
 			"{0}, disabled",
 			"Learn more about custom agents",
 			"Learn more about hooks",
@@ -33518,28 +35369,26 @@
 			"Learn more about prompt files",
 			"Learn more about agent skills",
 			"Agent Customizations",
-			"Local",
-			"Local customizations available to sync to the remote agent.",
 			"No agents yet",
 			"No hooks yet",
 			"No instructions yet",
 			"No items match '{0}'",
 			"No prompts yet",
 			"No skills yet",
-			"This instruction is automatically included when files matching '{0}' are in context.",
 			"Loaded on Demand",
 			"Instructions loaded only when explicitly referenced.",
 			"Plugins",
 			"Read-only customizations provided by installed plugins.",
 			"Prompt",
+			"Prompts",
 			"Reusable prompts for common development tasks like generating code, performing reviews, or scaffolding components.",
+			"Local",
+			"Remote",
 			"Type to search...",
 			"Skill",
+			"Skills",
 			"Folders of instructions, scripts, and resources that Copilot loads when relevant to perform specialized tasks.",
-			"Add {0} to sync",
 			"Try a different search term",
-			"UI Integration",
-			"Remove {0} from sync",
 			"User",
 			"Customizations stored locally on your machine in a central location. Private to you and available across all projects.",
 			"Workspace",
@@ -33574,6 +35423,8 @@
 			"Enable",
 			"Enable",
 			"Generate Customization Debug Report",
+			"Install Chat Customization Extension",
+			"Install Chat Customization Extension",
 			"Open",
 			"Open",
 			"Open Customizations",
@@ -33598,10 +35449,19 @@
 			"Back to list",
 			"Back to MCP servers",
 			"Back to MCP servers",
+			"Back to overview",
+			"Back to overview",
 			"Back to plugins",
 			"Back to plugins",
 			"Cancel",
+			"Customization preview",
 			"Failed to finish the prompt action.",
+			"Edit",
+			"Edit the raw markdown file",
+			"Preview",
+			"Show structured preview",
+			"View Raw",
+			"Show the raw markdown file",
 			"Overview",
 			"Back to overview",
 			"Hooks",
@@ -33617,6 +35477,12 @@
 			"Overview",
 			"Plugins",
 			"Install and manage agent plugins that add additional tools, skills, and integrations.",
+			"Show help for '{0}'",
+			"Switch to raw view to fix invalid or unsupported metadata entries.",
+			"Header issues detected",
+			"No markdown body found in this file.",
+			"No metadata found in this file.",
+			"Custom metadata field `{0}`.",
 			"Prompts",
 			"Reusable prompt templates that can be invoked as slash commands.",
 			"Save override",
@@ -33626,6 +35492,7 @@
 			"Select Workspace, User, or Cancel",
 			"Could not save changes to {0}.",
 			"Saved",
+			"{0}, {1} items",
 			"Agent Customization Sections",
 			"Select customization target",
 			"Select a directory for the new customization file",
@@ -33637,30 +35504,11 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput": [
 			"Agent Customizations"
 		],
-		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePageClassic": [
-			"Agents",
-			"Define custom agents with specialized personas, tool access, and instructions for specific tasks.",
-			"Browse",
-			"Generate with AI",
-			"Describe your project and coding patterns. Copilot will generate agents, skills, and instructions tailored to your workflow.",
-			"Configure Your AI",
-			"Hooks",
-			"Configure automated actions triggered by events like saving files or running tasks.",
-			"Instructions",
-			"Set always-on instructions that guide AI behavior across your workspace or user profile.",
-			"MCP Servers",
-			"Connect external tool servers that extend AI capabilities with custom tools and data sources.",
-			"Plugins",
-			"Install and manage agent plugins that add additional tools, skills, and integrations.",
-			"Skills",
-			"Create reusable skill files that provide domain-specific knowledge and workflows.",
-			"Chat Customizations",
-			"Tailor how agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects."
-		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers": [
 			"Agents",
 			"Define custom agents with specialized personas, tool access, and instructions for specific tasks.",
 			"Browse...",
+			"Browse {0}...",
 			"Describe your preferences and conventions to draft agents, skills, and instructions.",
 			"Customize Your Agent",
 			"Hooks",
@@ -33670,6 +35518,7 @@
 			"MCP Servers",
 			"Connect external tool servers that extend AI capabilities with custom tools and data sources.",
 			"New...",
+			"New {0}...",
 			"Plugins",
 			"Install and manage agent plugins that add additional tools, skills, and integrations.",
 			"Sent to chat ✓",
@@ -33688,14 +35537,22 @@
 			"Name is required",
 			"Select a directory for the new customization file"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail": [
+			"No plugin selected.",
+			"Installed from {0}",
+			"Installed plugin",
+			"From {0}",
+			"Marketplace plugin"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail": [
+			"No MCP server selected.",
+			"User",
+			"Workspace"
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget": [
 			"Add an MCP server configuration to get started",
 			"Add Server",
 			"Add Server",
-			"Back to installed servers",
-			"Back to installed servers",
-			"Bridged",
-			"This server is managed by VS Code and forwarded to all compatible agent sessions.",
 			"Browse Marketplace",
 			"Built-in",
 			"MCP servers built into VS Code. These are available automatically.",
@@ -33715,7 +35572,12 @@
 			"Installing...",
 			"Learn more about MCP servers",
 			"Loading marketplace...",
+			"Access to MCP servers is disabled by your organization. Contact your organization administrator for more information.",
+			"MCP servers are disabled in settings. ",
+			"Configure in settings.",
+			"MCP servers are disabled",
 			"{0}, {1} items, {2}",
+			"MCP Servers",
 			"An open standard that lets AI use external tools and services. MCP servers provide tools for file operations, databases, APIs, and more.",
 			"MCP Servers",
 			"No servers match '{0}'",
@@ -33739,42 +35601,63 @@
 			"MCP servers configured in your workspace settings, shared with your team via version control."
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget": [
-			"Back to installed plugins",
-			"Back to installed plugins",
+			"Add Plugin",
+			"Use the toolbar to add remote plugins or install plugins from a source.",
 			"Browse Marketplace",
+			"Browse Marketplace is not available in VS Code for the Web.",
 			"Browse the marketplace to discover and install plugins",
 			"by {0}",
 			"collapsed",
 			"Create Plugin",
-			"Create Plugin",
-			"Disabled",
-			"Disabled",
-			"Plugins that are installed but currently disabled. Enable them to use their capabilities.",
+			"Disabled Locally",
+			"Plugins installed in this client but currently disabled.",
+			"Disable {0} from sync",
 			"No plugins available",
-			"Enabled",
-			"Enabled",
-			"Plugins that are currently active and providing commands, skills, agents, and other capabilities.",
+			"Enabled Locally",
+			"Plugins installed in this client and available for syncing to the remote session.",
+			"Enable {0} for sync",
 			"expanded",
 			"Install",
 			"Installed",
-			"Install Plugin from Source",
 			"Install Plugin from Source",
 			"Installing...",
 			"Learn more about agent plugins",
 			"Loading marketplace...",
 			"Unable to load marketplace",
+			"More Plugin Add Actions...",
 			"No plugins match '{0}'",
 			"No plugins match '{0}'",
 			"No plugins installed",
+			"No plugins configured",
 			"{0}, {1} items, {2}",
-			"Extend your AI agent with plugins that add commands, skills, agents, hooks, and MCP servers from reusable packages.",
+			"{0}. Disabled",
+			"{0}. Enabled",
+			"{0}. {1}",
 			"Plugins",
+			"Extend your AI agent with plugins that add commands, skills, agents, hooks, and MCP servers from reusable packages.",
+			"Plugin integration in chat is disabled by your organization. Contact your organization administrator for more information.",
+			"Plugins are disabled in settings. ",
+			"Configure in settings.",
+			"Plugins are disabled",
+			"Plugins",
+			"Remote",
+			"Plugins configured directly on the remote agent host and available without local sync.",
+			"Warning",
+			"Disabled",
+			"Error",
+			"Loaded",
+			"Loading",
 			"Search plugin marketplace...",
 			"Type to search...",
-			"Add {0} to sync",
 			"Check your connection and try again",
-			"Try a different search term",
-			"Remove {0} from sync"
+			"Try a different search term"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider": [
+			"always added",
+			"This instruction is automatically included in every interaction.",
+			"(unset)",
+			"This instruction is automatically included when files matching '{0}' are in context.",
+			"UI Integration"
 		],
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentResolveService": [
 			"Image is too large",
@@ -33784,6 +35667,13 @@
 			"Attached context, {0}",
 			"Remove from context",
 			"{0} (Delete)",
+			"Browser tools are not enabled.",
+			"Browser tools are not enabled, {0}",
+			"Attached browser page, {0}",
+			"This browser page is no longer open.",
+			"Browser page unavailable, {0}",
+			"This browser page is not shared with the agent.",
+			"Browser page not shared with agent, {0}",
 			"Click to view the contents of: {0}",
 			"Attached element, {0}",
 			"ATTRIBUTES",
@@ -33796,12 +35686,14 @@
 			"Attached file, {0}",
 			"{0} does not support this file type.",
 			"Attached file, {0}, line {1} to line {2}",
+			"This folder contains {0} images, which exceeds the maximum of {1} images per request. Older images will not be sent.",
 			"Attached image, {0}",
 			"{0} does not support images.",
 			"Vision is disabled by your organization.",
 			"This GIF was partially omitted - current frame will be sent.",
 			"Image not sent due to limit: {0}",
 			"This image was not sent because the maximum of {0} images per request was exceeded.",
+			"This image was not sent because this model's image limit was exceeded.",
 			"Instructions attachment, {0}",
 			"Attached Notebook output, {0}",
 			"Omitted this file: {0}",
@@ -33827,6 +35719,7 @@
 		"vs/workbench/contrib/chat/browser/attachments/implicitContextAttachment": [
 			"Add {0} to context",
 			"cell",
+			"Suggested browser context, {0}",
 			"Suggested context, {0}, {1}",
 			"Suggested context, {0}, {1}, line {2} to line {3}",
 			"Suggested context, {0}",
@@ -33840,26 +35733,7 @@
 			"Current file context",
 			"Pin selection"
 		],
-		"vs/workbench/contrib/chat/browser/attachments/simpleBrowserEditorOverlay": [
-			"Click to cancel selection.",
-			"Cancel",
-			"Configure Attachments Sent",
-			"Expand Overlay",
-			"Collapse Overlay",
-			"Select Again",
-			"Connecting to webview...",
-			"Continuous Selection",
-			"Selection canceled",
-			"Element added to chat",
-			"Selecting element...",
-			"Add element to chat",
-			"Done",
-			"Please reopen the preview.",
-			"Click to select an element.",
-			"Select an Element",
-			"Start"
-		],
-		"vs/workbench/contrib/chat/browser/chat.contribution": [
+		"vs/workbench/contrib/chat/browser/chat.shared.contribution": [
 			"Agent Plugin",
 			"Use {0} instead",
 			"Use {0} instead",
@@ -33867,11 +35741,11 @@
 			"Use {0} instead",
 			"Global auto approve also known as \"YOLO mode\" disables manual approval completely for all tools in all workspaces, allowing the agent to act fully autonomously. This is extremely dangerous and is *never* recommended, even containerized environments like Codespaces and Dev Containers have user keys forwarded into the container that could be compromised.\n\nThis feature disables critical security protections and makes it much easier for an attacker to compromise the machine.\n\nNote: This setting only controls tool approval and does not prevent the agent from asking questions. To automatically answer agent questions, use the `#chat.autoReply#` setting.",
 			"Chat",
-			"Allowed domains for network access by agent tools (fetch tool, integrated browser). Only takes effect when {0} is enabled. When {1} is enabled, these also apply to the terminal sandbox. Supports wildcards like {2}. When both allowed and denied lists are empty, all domains are blocked. Denied domains (see {3}) take precedence.",
-			"Denied domains for network access by agent tools (fetch tool, integrated browser). Only takes effect when {0} is enabled. When {1} is enabled, these also apply to the terminal sandbox. Takes precedence over {2}. Supports wildcards like {3}.",
+			"Allowed domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. When {1} is set to {2}, all domains are allowed. Supports wildcards like {3}. When both allowed and denied lists are empty, all domains are blocked. Denied domains (see {4}) take precedence.",
+			"Denied domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. This does not apply when {1} is set to {2}. Takes precedence over {3}. Supports wildcards like {4}.",
 			"When enabled, agent mode can be activated from chat and tools in agentic contexts with side effects can be used.",
 			"The maximum number of requests to allow per-turn when using an agent. When the limit is reached, will ask to confirm to continue.",
-			"When enabled, network access by agent tools (fetch tool, integrated browser) is restricted according to {0} and {1}. When disabled, no network filtering is applied.",
+			"When enabled, network access by agent tools (fetch tool, integrated browser) is restricted according to {0} and {1}. Domain filtering is also applied to those tools when {2} is enabled.",
 			"Controls how tool calls are displayed in relation to thinking sections.",
 			"Tool calls are always collapsed, even without thinking.",
 			"Tool calls are shown separately, not collapsed into thinking.",
@@ -33885,8 +35759,18 @@
 			"Thinking parts will be expanded first, then collapse once we reach a part that is not thinking.",
 			"Show thinking in a fixed-height streaming panel that auto-scrolls; click header to expand to full height.",
 			"Controls how thinking is rendered.",
+			"When enabled, logs all AHP transport messages for agent host connections to JSONL files under the window's log directory.",
+			"Experimental, for local testing only. Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package. When set, the Claude agent provider is registered inside the agent host and the SDK is loaded from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect. This setting will be removed once the SDK is delivered through the Extension Marketplace.",
+			"Tool reference names to expose as client-provided tools in agent host sessions.",
+			"When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior.",
 			"When enabled, some agents run in a separate agent host process.",
 			"When enabled, logs all IPC traffic for each agent host to a dedicated output channel.",
+			"When enabled, includes prompt and response content in OTel span attributes. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks.",
+			"When enabled, the agent host persists every emitted OTel span to a local SQLite database. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink.",
+			"When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally.",
+			"Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime.",
+			"OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process.",
+			"Output path for span JSON lines when exporter type is `file`. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
 			"Specify location(s) of custom agent files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
 			"Agent File Locations",
@@ -33899,6 +35783,8 @@
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
 			"Agent Skills Locations",
 			"Controls whether anonymous access is allowed in chat.",
+			"List of GitHub organization logins whose members are permitted to use AI features. When set to a non-empty list, AI features are disabled until the user signs into a GitHub account that belongs to one of the specified organizations and account-level policy data has been resolved. Set to '*' to allow any authenticated GitHub or GitHub Enterprise account.",
+			"Setting this policy to a non-empty list activates the Approved Account gate: all AI features are disabled until the user signs into a GitHub account whose organizations intersect this list AND the account-side policy data has resolved. Comparison is case-insensitive. Use '*' as a wildcard to accept any signed-in GitHub or GHE account (use this for GHE deployments where the organization list is not surfaced).",
 			"Controls whether the artifacts view is available in chat.",
 			"Rules for extracting artifacts from written files by file path pattern. Maps glob patterns to group configuration.",
 			"Display name for the artifact group.",
@@ -33916,9 +35802,8 @@
 			"When applying edits, show a progress animation in the code block pill. If disabled, shows the progress percentage instead.",
 			"Show the context window usage indicator in the chat input.",
 			"Controls whether the harness selector is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering.",
-			"Controls which welcome page implementation is shown in Agent Customizations.",
-			"Uses the original welcome page layout from the baseline implementation.",
-			"Uses the experimental welcome page with grouped command prompt launchers.",
+			"Controls whether the Chat Customizations editor shows a structured preview for markdown customization files (agents, skills, instructions, prompts). When disabled, the editor always opens the raw markdown in the embedded code editor.",
+			"When enabled, custom agents shown in the chat mode picker are sourced from the customization harness service (scoped per session type) instead of the prompts service.",
 			"Enables chat participant autodetection for panel chat.",
 			"Disable and hide built-in AI features provided by GitHub Copilot, including chat and inline suggestions.",
 			"Delay after which changes made by chat are automatically accepted. Values are in seconds, `0` means disabled and `100` seconds is the maximum.",
@@ -33932,6 +35817,19 @@
 			"Controls whether the chat panel automatically exits after delegating a request to another session.",
 			"Enables chat participant autodetection for panel chat.",
 			"This setting is deprecated. Please use `chat.detectParticipant.enabled` instead.",
+			"Controls the animation style for incremental rendering.",
+			"Content fades in from a blurred state.",
+			"Simple opacity fade from 0 to 1.",
+			"No animation. Content appears instantly.",
+			"Content reveals top-to-bottom with a soft gradient edge.",
+			"Content fades in while rising upward.",
+			"Content scales up from slightly smaller.",
+			"Content slides in from the left.",
+			"Controls how content is buffered before rendering during incremental rendering. Lower buffering levels render faster but may show incomplete sentences or partially formed markdown.",
+			"Renders content immediately as tokens arrive.",
+			"Buffers content until a paragraph break before rendering.",
+			"Reveals content word by word.",
+			"Enables incremental rendering with optional block-level animation when streaming chat responses.",
 			"When true, enables sessions-window-specific behavior for extensions.",
 			"Select the default language model to use for the Explore subagent from the available providers.",
 			"Enable using tools contributed by third-party extensions.",
@@ -33969,9 +35867,12 @@
 			"Never automatically start MCP servers.",
 			"Automatically start new and outdated MCP servers that are not yet running.",
 			"Only automatically start new MCP servers that have never been run.",
+			"Controls behavior when multiple MCP servers are discovered with the same name. 'disable' disables lower-priority duplicates. 'suffix' appends numeric suffixes to disambiguate.",
+			"Disable lower-priority servers with duplicate names.",
+			"Append numeric suffixes to servers with duplicate names.",
 			"Enables the default Marketplace for Model Context Protocol (MCP) servers.",
 			"Configures which models are exposed to MCP servers for sampling (making model requests in the background). This setting can be edited in a graphical way under the `{0}` command.",
-			"Whether this server is make sampling requests during its tool calls in a chat session.",
+			"Whether this server is allowed to make sampling requests during its tool calls in a chat session.",
 			"Whether this server is allowed to make sampling requests outside of a chat session.",
 			"A model the MCP server has access to.",
 			"Controls whether MCP servers can provide custom UI for tool invocations.",
@@ -33987,10 +35888,21 @@
 			"Always show OS notifications for responses, even when the window is focused.",
 			"Never show OS notifications for responses.",
 			"Show OS notifications for responses when the window is not focused.",
+			"Experimental: enable BYOK chat features without GitHub sign-in.",
+			"Start new chat sessions in Bypass Approvals mode.",
+			"Bypass Approvals",
+			"Start new chat sessions in Autopilot mode.",
+			"Autopilot (Preview)",
+			"Start new chat sessions with Default Approvals.",
+			"Default Approvals",
+			"Controls the default permissions picker mode for new chat sessions. You can still change the permission mode per session, and each session remembers the permission mode that was used. If enterprise policy disables auto approval, new sessions use Default Approvals.",
+			"Always show progress in chat.",
 			"Select the default language model to use for the Plan agent from the available providers.",
+			"When enabled, the plan review widget mounts an editor inline, as opposed to in a separate editor tab.",
 			"Plugin directories to discover. Each key is a path that points directly to a plugin folder, and the value enables (`true`) or disables (`false`) it. Paths can be absolute, relative to the workspace root, or start with `~/` for the user's home directory.",
 			"Enable agent plugin integration in chat.",
 			"Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated.",
+			"Show an animated gradient border around the chat input while the agent is working or thinking. When enabled and reduced motion is not enabled, this overrides {0} to be off. Has no effect when reduced motion is enabled.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported. Glob patterns are deprecated and will be removed in future versions.",
 			"Configure which prompt files to recommend in the chat welcome view. Each key is a prompt file name, and the value can be `true` to always recommend, `false` to never recommend, or a [when clause](https://aka.ms/vscode-when-clause) expression like `resourceExtname == .js` or `resourceLangId == markdown`.",
 			"Prompt File Recommendations",
@@ -34000,24 +35912,25 @@
 			"Controls whether the last session is restored in panel after restart.",
 			"Specify location(s) of reusable prompt files (`*{0}`) that can be run in Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
 			"Prompt File Locations",
-			"Controls whether CSS of the selected element will be added to the chat. {0} must be enabled.",
-			"Controls whether a screenshot of the selected element will be added to the chat. {0} must be enabled.",
-			"Controls whether elements can be sent to chat from the Simple Browser.",
-			"Controls whether to show a sign-in button in the title bar for users who are not signed in.",
+			"Controls whether a screenshot of the selected element will be added to the chat.",
+			"Enable session sync to GitHub.com. When enabled, Copilot session data is synced to your GitHub account for cross-device access and richer insights. Requires `#github.copilot.chat.localIndex.enabled#` to also be enabled.",
+			"Enable session sync to GitHub.com for cross-device Copilot session history. When disabled by organization policy, session data is kept local only.",
+			"Repository patterns to exclude from session sync. Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repositories will only be stored locally.",
 			"Allow subagents to invoke subagents.",
 			"Controls whether subagents can invoke other subagents. When enabled, nesting is limited to a maximum depth of 5.",
-			"Whether the runSubagent tool is able to use custom agents. When enabled, the tool can take the name of a custom agent, but it must be given the exact name of the agent.",
 			"Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features.",
+			"Controls whether the Copilot Sign In button is shown in the title bar when signed out. When disabled, the Sign In affordance falls back to the status bar.",
 			"{0} - {1}",
 			"Controls whether edits made by the agent are automatically approved. The default is to approve all edits except those made to certain files which have the potential to cause immediate unintended side-effects, such as `**/.vscode/*.json`.\n\nSet to `true` to automatically approve edits to matching files, `false` to always require explicit approval. The last pattern matching a given file will determine whether the edit is automatically approved.",
 			"When enabled, tool failures are automatically expanded in the chat UI to show error details.",
+			"Post-process tool output (for example `git diff`, `ls -l`, or `npm install`) to reduce token usage before it is sent to the model.",
 			"When enabled, multiple tool confirmations are batched into a carousel above the input.",
 			"Controls which tools are eligible for automatic approval. Tools set to 'false' will always present a confirmation and will never offer the option to auto-approve. The default behavior (or setting a tool to 'true') may result in the tool offering auto-approval options.",
 			"Controls which URLs are automatically approved when requested by chat tools. Keys are URL patterns and values can be `true` to approve both requests and responses, `false` to deny, or an object with `approveRequest` and `approveResponse` properties for granular control.\n\nExamples:\n- `\"https://example.com\": true` - Approve all requests to example.com\n- `\"https://*.example.com\": true` - Approve all requests to any subdomain of example.com\n- `\"https://example.com/api/*\": { \"approveRequest\": true, \"approveResponse\": false }` - Approve requests but not responses for example.com/api paths",
-			"Controls whether the rename tool is available for renaming code symbols across the workspace.",
+			"When enabled, terminal tool confirmations show an LLM-generated risk level (Safe / Caution / Review carefully) and a short explanation.",
+			"The language model id used to generate tool risk assessments. Should be a small, fast model.",
 			"When enabled, terminal tool calls are always displayed in a collapsible container with a simplified view.",
 			"Controls whether to show the todo list widget above the chat input. When enabled, the widget displays todo items created by the agent and updates as progress is made.",
-			"Controls whether the usages tool is available for finding references, definitions, and implementations of code symbols.",
 			"Controls whether the input of the chat should be restored when an undo request is made. The input will be filled with the text of the request that was restored.",
 			"Replaces the command center search box with a unified chat and search widget.",
 			"Controls whether an animation is shown when clicking the thumbs up button on a chat response.",
@@ -34034,8 +35947,6 @@
 			"Use Claude Hooks",
 			"Controls whether instructions from `CLAUDE.md` file found in workspace roots, .claude and ~/.claude folder are attached to all chat requests.",
 			"Use CLAUDE.md file",
-			"Controls whether hooks defined in custom agent frontmatter are parsed and executed. When disabled, hooks from agent files are ignored.",
-			"Use Custom Agent Hooks",
 			"Controls whether to use chat customization files in parent repositories.",
 			"Use Customizations in Parent Repositories",
 			"Controls whether chat hooks are executed at strategic points during an agent's workflow. Hooks are loaded from the files configured in `#chat.hookFilesLocations#`.",
@@ -34044,6 +35955,8 @@
 			"Use nested AGENTS.md files",
 			"Controls whether a stronger skill adherence prompt is used that encourages the model to immediately invoke skills when relevant rather than just announcing them.",
 			"Use Skill Adherence Prompt",
+			"Override the language model used by built-in utility flows (titles, summaries, fallback responses, etc.). Leave empty to use the default model.",
+			"Override the language model used by built-in small/fast utility flows (commit messages, intent detection, inline-chat progress, etc.). A fast and inexpensive model is recommended. Leave empty to use the default model.",
 			"Show a progress badge on the chat view when an agent session is in progress that is opened in that view.",
 			"Show chat agent sessions when chat is empty or to the side when chat view is wide enough.",
 			"Controls the orientation of the chat agent sessions view when it is shown alongside the chat.",
@@ -34094,6 +36007,111 @@
 			"Total files: {0}",
 			"unknown"
 		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView": [
+			"All components are identical between A and B.",
+			"content drift",
+			"identical",
+			"length change",
+			"only in A",
+			"only in B",
+			"At {0} — {1}",
+			"Cache break at messages[{0}]",
+			"cached tok",
+			"cache hit",
+			"{0} chars",
+			"Components",
+			"{0} → {1} chars",
+			"This request uses previous_response_id, so input messages are not positionally diffed against the previous request. Components below show cache-key shape changes; the current continuation delta is shown separately.",
+			"The visible wire delta also changed at {0}. That is expected when comparing consecutive continuation requests of different kinds, such as tool_search_output followed by a new user input.",
+			"The captured wire delta changed at {0} — {1}. This is a delta-to-delta comparison between consecutive Responses API requests, not the full reconstructed prompt prefix.",
+			"No divergence detected in the captured wire delta. The full reconstructed prompt prefix is provider-side for this continuation request.",
+			"Previous · {0} chars",
+			"Current · {0} chars",
+			"Diff summary",
+			"drift",
+			"duration",
+			"endTime",
+			"{0}% cache hit — likely cache expiration",
+			"The prompt prefix matches but the model still treated this as a fresh request. Most likely the cached entry expired between requests.",
+			"the first message",
+			"First request in session",
+			"OTel-reported cache hit. Nothing earlier in this session to diff against — the system prompt and tools may still match a previous session's cache.",
+			"[cache {0}%]",
+			"{0}% cache hit",
+			"input tok",
+			"added {0} message ({1} chars)",
+			"added {0} message",
+			"{0} message body changed ({1} chars)",
+			"{0} message body changed",
+			"previous {0} message dropped",
+			"{0} message resized to {1} chars",
+			"{0} message size changed",
+			"Current",
+			"Previous",
+			"tools (catalog)",
+			"tool search",
+			"Lost: {0} tokens ({1}% of this request)",
+			"model",
+			"Model Turn",
+			"[{0}ms]",
+			"No prefix divergence detected.",
+			"(not present)",
+			"No model turns recorded for this session yet.",
+			"Options changed: {0}",
+			"Request options changed — the cache was invalidated even though the message prefix matches.",
+			"Current",
+			"Option",
+			"Previous",
+			"Cache performance",
+			"Previous request",
+			"requestId",
+			"Request id: {0}",
+			"Request Options",
+			"shape",
+			"Responses API continuation",
+			"Responses API continuation: the displayed input is only the delta sent over the wire. The provider reconstructs prior context from the previous response id.",
+			"full input request",
+			"tool output continuation",
+			"Responses API continuation: the displayed input is only the tool-output delta sent over the wire. The provider reconstructs prior context from the previous response id.",
+			"tool output request",
+			"tool_search_output continuation",
+			"Responses API continuation: the displayed input is only the tool-search delta sent over the wire. The provider reconstructs prior context from the previous response id.",
+			"tool_search_output request",
+			"This request contains a Responses API tool_search_output item. No previous-response continuation marker was captured, so the displayed input may be a full or history-sliced request rather than only a continuation delta.",
+			"Request",
+			"Prompt Signature",
+			"{0} of {1} chars reused · break at {2}",
+			"{0} of {1} chars reused · no divergence detected",
+			"startTime",
+			"{0} added in this request",
+			"{0} in-place changed",
+			"{0} dropped from previous",
+			"{0} identical",
+			"System instructions changed — the cache was invalidated even though the message prefix matches.",
+			"system",
+			"Toggle group",
+			"{0} of {1} input tokens reused",
+			"Tool definitions changed — the catalog of available tools differs between requests, which invalidates the cache even though the message prefix matches.",
+			"tools catalog",
+			"Both sides truncated by the OTel attribute cap (originals were {0} and {1} chars) — diff may be partial.",
+			"{0} side truncated by the OTel attribute cap (original was {1} chars) — diff may be partial.",
+			"Current",
+			"Previous",
+			"timeToFirstToken",
+			"Turn {0}: {1}",
+			"Click to compare this request against the previous one",
+			"Uncached in this request: {0} tokens ({1}% of this request)",
+			"(no prompt captured)",
+			"Visible Request Signature",
+			"For Responses API continuations, this shows the captured request inputs: system instructions, tools sent on this request, and the visible input delta. Earlier conversation state is referenced by previous response id and is not expanded here.",
+			"{0} of {1} captured request chars match before first captured drift: {2}",
+			"{0} of {1} captured request chars match · no captured divergence detected",
+			"Visible wire input",
+			"Where the cache broke",
+			"Cache Explorer",
+			"Cache Explorer — Prefix Diff",
+			"Agent Debug Logs"
+		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugDetailPanel": [
 			"Close",
 			"Copy",
@@ -34106,6 +36124,7 @@
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventDetailRenderer": [
 			"Agent: {0}",
 			"Agent Response: {0}",
+			"Cached tokens: {0}",
 			"Call ID: {0}",
 			"Description: {0}",
 			"Duration: {0}ms",
@@ -34157,6 +36176,7 @@
 			"{0} tokens",
 			"Tool Call",
 			"{0} calls",
+			"Cached tokens: {0}",
 			"Duration: {0}",
 			"Input: {0}",
 			"Input tokens: {0}",
@@ -34201,8 +36221,9 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugLogsView": [
 			"Agent response: {0}",
+			" {0} cached",
 			"model",
-			"Model turn: {0}{1}",
+			"Model turn: {0}{1}{2}",
 			"Subagent: {0}{1}",
 			" {0} tokens",
 			"Tool call: {0}{1}",
@@ -34263,6 +36284,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView": [
 			"Agent Flow Chart",
+			"Cache Explorer",
 			"Created",
 			"Last Activity",
 			"Location",
@@ -34273,10 +36295,13 @@
 			"Editor Inline",
 			"Notebook",
 			"Terminal",
+			"Copilot Usage (AIC)",
 			"Errors",
 			"Model Turns",
 			"Tool Calls",
-			"Total Events",
+			"Total Cached Input Tokens",
+			"Total Input Tokens",
+			"Total Output Tokens",
 			"Total Tokens",
 			"Reveal Chat Session",
 			"Session Details",
@@ -34425,6 +36450,8 @@
 			"Conversation Images"
 		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution": [
+			"Enabling AI features…",
+			"Enabling AI features",
 			"Icon for open language models settings commands.",
 			"Clear Models Search Results",
 			"Models Management Editor",
@@ -34435,11 +36462,9 @@
 			"Language Models",
 			"Icon of the Models Management editor label."
 		],
-		"vs/workbench/contrib/chat/browser/chatManagement/chatModelsViewModel": [
-			"Hidden",
-			"Visible"
-		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget": [
+			"Cache cost: {0} credits per 1M tokens",
+			"Cache cost: {0} credit per 1M tokens",
 			"Capabilities",
 			"Agent Mode",
 			"Tools",
@@ -34447,52 +36472,56 @@
 			"Clear Search",
 			"Collapse",
 			"Collapse All",
-			"Request Multiplier",
+			"Cost (Credits per 1M Tokens)",
+			"Cache: {0}",
+			"Cache: {0} credits per 1M tokens",
+			"Cache: {0} credit per 1M tokens",
+			"In: {0}",
+			"Input: {0} credits per 1M tokens",
+			"Input: {0} credit per 1M tokens",
+			"Out: {0}",
+			"Output: {0} credits per 1M tokens",
+			"Output: {0} credit per 1M tokens",
 			"Expand",
 			"Filter",
-			"Hidden in Chat Model Picker",
-			"Visible in Chat Model Picker",
 			"Filter by {0}",
 			"Filter by {0}",
-			"Filter by {0}",
-			"Group By",
-			"Provider",
-			"Visibility (Chat Model Picker)",
-			"Group by {0}",
 			"Hidden Models",
+			"Input cost: {0} credits per 1M tokens",
+			"Input cost: {0} credit per 1M tokens",
 			"Capabilities: {0}",
 			"Context size: {0} tokens",
-			"This model is hidden in the chat model picker",
 			"{0} from {1}",
-			"This model is visible in the chat model picker",
 			"Name",
 			"Agent Mode",
+			"Cache Cost: {0} credits per 1M tokens",
+			"Cache Cost: {0} credit per 1M tokens",
 			"Capabilities",
 			"Configure...",
 			"Configure",
 			"Configure...",
 			"Context Size",
-			"Multiplier",
 			"Delete",
 			"Would you like to delete {0}?",
 			"Add Models...",
-			"Show in the chat model picker",
-			"Hide",
-			"Hide in the Chat Model Picker",
-			"Hide in the Chat Model Picker",
+			"Input Cost: {0} credits per 1M tokens",
+			"Input Cost: {0} credit per 1M tokens",
 			"Adding models is managed by your organization",
 			"Manage {0}...",
-			"Show",
-			"Show in the Chat Model Picker",
-			"Show in the Chat Model Picker",
+			"Output Cost: {0} credits per 1M tokens",
+			"Output Cost: {0} credit per 1M tokens",
+			"Pin Model",
+			"Pricing",
 			"Tools",
 			"Tools",
-			"This model is hidden in the chat model picker",
-			"Hide in the chat model picker",
+			"Unpin Model",
 			"Vision",
 			"Language Models",
-			"Every chat message counts {0} towards your premium model request quota",
-			"Provider",
+			"Output cost: {0} credits per 1M tokens",
+			"Output cost: {0} credit per 1M tokens",
+			"Pricing",
+			"Pricing: {0}",
+			"Pricing: {0}",
 			"Type to search...",
 			"Status: {0}",
 			"Context Size",
@@ -34500,9 +36529,10 @@
 			"Visible Models"
 		],
 		"vs/workbench/contrib/chat/browser/chatOutputItemRenderer": [
+			"Code block language identifiers that this renderer can handle",
 			"MIME types that this renderer can handle",
 			"Unique identifier for the renderer.",
-			"Contributes a renderer for specific MIME types in chat outputs"
+			"Contributes a renderer for specific MIME types and code block language identifiers in chat outputs"
 		],
 		"vs/workbench/contrib/chat/browser/chatParticipant.contribution": [
 			"Chat",
@@ -34602,7 +36632,7 @@
 			"Fix",
 			"Sign in to use AI features",
 			"Learn How to Hide AI Features",
-			"Manage GitHub Copilot Overages",
+			"Manage GitHub Copilot Budget",
 			"Upgrade to GitHub Copilot Pro",
 			"Disabling AI features",
 			"Enabling AI features",
@@ -34610,6 +36640,8 @@
 			"Code Review",
 			"Chat setup failed. Would you like to try again?",
 			"Sign In",
+			"Copilot Sign In",
+			"Toggle visibility of the Copilot Sign In button in title bar",
 			"Use AI Features with Copilot for free...",
 			"Sign in to use AI features..."
 		],
@@ -34670,6 +36702,7 @@
 			"Configure custom agents",
 			"Set permissions to bypass approvals",
 			"Set permissions to autopilot mode",
+			"Switch to '{0}'",
 			"Start a new chat and archive the current one",
 			"Show Chat Debug View",
 			"Set permissions back to default",
@@ -34689,15 +36722,7 @@
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard": [
 			"Set up Copilot to use AI features.",
 			"By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})",
-			"Additional premium requests approved.",
-			"You can continue after the included premium requests limit reaches 100%.",
-			"Additional paid premium requests disabled.",
-			"Copilot Usage",
 			"Cancel Snooze",
-			"Background Agent",
-			"Cloud Agent",
-			"Local Agent",
-			"Agent Sessions",
 			"Chat messages",
 			"+5 min",
 			"remaining",
@@ -34706,50 +36731,53 @@
 			"Snooze additional 5 min",
 			"Inline suggestions are hidden for the remaining duration",
 			"Inline Suggestions",
-			"Currently selected",
-			"Currently selected",
-			"Manage paid premium requests",
+			"Credits",
 			"Use AI Features",
 			"Enable AI Features",
 			"Enable Copilot to use AI features.",
 			"Enable more AI Features",
 			"Sign in to enable more Copilot AI features.",
-			"Gauge background color.",
-			"Gauge border color.",
-			"Gauge error background color.",
-			"Gauge error foreground color.",
-			"Gauge foreground color.",
-			"Gauge warning background color.",
-			"Gauge warning foreground color.",
 			"Included premium requests",
+			"Premium Requests",
+			"Credits",
+			"Disabled",
+			"Enabled",
 			"Inline Suggestions",
-			"{0} in progress",
 			"Learn More",
-			"Allowance resets {0}.",
+			"Manage Budget",
 			"Model",
 			"Premium requests",
+			"Included with your organization's plan.",
+			"{0} included with your organization's plan.",
+			"Organization limit reached.",
+			"{0} limit reached.",
+			"Additional budget is configured. Usage will continue until limits reset.",
+			"Once the limit is reached, additional budget will be used.",
+			"Premium request budget is configured. Usage will continue until limits reset.",
+			"Once the limit is reached, premium request budget will be used.",
+			"{0} / {1}",
 			"{0}%",
-			"+{0} requests",
-			"Manage Chat",
+			"Manage Copilot Settings",
+			"{0} used",
 			"Limited",
-			"Manage Chat",
-			"Included",
+			"Copilot is paused until the limit resets.",
+			"Copilot is paused until the limit resets. Contact your administrator for more information.",
+			"Resets {0}",
+			"Resets {0} at {1}",
+			"Manage Copilot Settings",
+			"used",
+			"Copilot will pause when the limit is reached.",
+			"Copilot will pause when the limit is reached. Contact your administrator for more information.",
 			"Select Model",
-			"Select a model for {0}",
 			"Select {0}",
-			"Select {0}",
-			"All files",
-			"{0}",
+			"Ghost text suggestions",
+			"Ghost text suggestions for {0}",
 			"Next edit suggestions",
+			"(overridden)",
 			"Snooze",
-			"Settings",
-			"Open Settings",
 			"Sign in to use Copilot AI features.",
 			"Sign in to use AI Features",
-			"Upgrade to GitHub Copilot Pro",
-			"{0} Usage",
-			"View Agent Sessions",
-			"View Agent Sessions"
+			"Upgrade"
 		],
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry": [
 			"Quota reached",
@@ -34762,8 +36790,6 @@
 			"Inline suggestions quota reached",
 			"Inline suggestions snoozed",
 			"Copilot disabled",
-			"Finish Setup",
-			"Signed out",
 			"Sign In"
 		],
 		"vs/workbench/contrib/chat/browser/chatTipCatalog": [
@@ -34775,11 +36801,11 @@
 			"Use [{0}](command:{1} \"Run /create-agent\"){2} to scaffold a custom agent for your workflow.",
 			"Use [{0}](command:{1} \"Run /create-prompt\"){2} to generate a reusable prompt file with the agent.",
 			"Use [{0}](command:{1} \"Run /create-skill\"){2} to create a skill the agent can load when relevant.",
+			"Configure [{0}](command:workbench.action.openSettings?%5B%22{1}%22%5D \"Open Settings\") to start new sessions in Bypass Approvals or Autopilot mode.",
 			"Use [{0}](command:{1} \"Run /fork\"){2} to branch the conversation. Explore a different approach without losing the original context.",
 			"Use [{0}](command:{1} \"Run /init\"){2} to generate or update a workspace instructions file for AI coding agents.",
 			"Ask the agent to draw an architectural diagram or flow chart. It can render Mermaid diagrams directly in chat.",
 			"Steer the agent mid-task by sending follow-up messages. They queue and apply in order.",
-			"Try the [Agents Application](command:workbench.action.openAgentsWindow \"Open Agents Application\") to run multiple agents simultaneously and manage your coding sessions.",
 			"Try the [{0}](command:workbench.action.chat.openPlan \"Start Plan Mode\"){1} to research and plan before implementing changes.",
 			"Have another task to work on? Start a new session to run multiple agents at once.",
 			"Using GPT-4.1? Try switching to [Auto](command:workbench.action.chat.openModelPicker \"Open Model Picker\") in the model picker for better coding performance.",
@@ -34812,7 +36838,8 @@
 		],
 		"vs/workbench/contrib/chat/browser/defaultModelContribution": [
 			"Auto (Vendor Default)",
-			"Use the vendor's default model"
+			"Use the vendor's default model",
+			"{0} ({1})"
 		],
 		"vs/workbench/contrib/chat/browser/enablementActions": [
 			"Disable",
@@ -34829,8 +36856,24 @@
 		"vs/workbench/contrib/chat/browser/languageModelsConfigurationService": [
 			"Per-model settings"
 		],
+		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions": [
+			"Clear",
+			"Clear All Feedback",
+			"Navigation Status",
+			"Go to Next Feedback Comment",
+			"Go to Previous Feedback Comment"
+		],
+		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution": [
+			"Add Feedback (Enter)",
+			"Add Feedback",
+			"Enter",
+			"{0}/{1}",
+			"0/0"
+		],
 		"vs/workbench/contrib/chat/browser/pluginGitCommandService": [
-			"Agent plugins are not available in this environment"
+			"GitHub authentication is required to install '{0}'. Sign in with an account that has access to this repository, then try again.",
+			"Sign in to GitHub with an account that has access to '{0}' to install this plugin.",
+			"Agent plugins in the browser can only be installed from GitHub HTTPS URLs. To install '{0}', use the desktop application or connect to a remote agent host."
 		],
 		"vs/workbench/contrib/chat/browser/pluginInstallService": [
 			"Failed to clone plugin source '{0}'.",
@@ -34924,6 +36967,7 @@
 			"Agent: {0}",
 			"Add new hook...",
 			"Create new hook config file...",
+			"{0} (default)",
 			"File name contains invalid characters",
 			"e.g., hooks, diagnostics, security",
 			"Enter hook file name",
@@ -34988,12 +37032,12 @@
 			"No instruction source folders found.",
 			"Learn how to configure reusable prompts",
 			"No prompt source folders found.",
-			"Current Workspace",
 			"Learn how to configure skills",
 			"No skill source folders found.",
 			"Current Location",
 			"Select a location to copy the instructions file to",
 			"Select a location to move the instructions file to",
+			"{0} (default)",
 			"Select a location to copy the prompt file to",
 			"Select a location to move the prompt file to",
 			"Select a location to copy the skill to",
@@ -35078,6 +37122,11 @@
 			"Configure Skills...",
 			"Skills"
 		],
+		"vs/workbench/contrib/chat/browser/tools/chatToolRiskAssessmentService": [
+			"{0} appears to have no observable side effects.",
+			"{0} may modify your workspace or send data over the network.",
+			"{0} performs an action that is hard to undo."
+		],
 		"vs/workbench/contrib/chat/browser/tools/languageModelToolsConfirmationService": [
 			"Always {0}",
 			"Always allow this particular combination of tool and arguments without confirmation.",
@@ -35148,8 +37197,7 @@
 			"Renamed `{0}` to `{1}` - {2} edits across {3} files.",
 			"Renaming `{0}` to `{1}`",
 			"Renamed `{0}` to `{1}` - 1 edit in {2} file.",
-			"Rename a symbol across the workspace",
-			"Rename a symbol across the workspace ({0})"
+			"Rename a symbol across the workspace"
 		],
 		"vs/workbench/contrib/chat/browser/tools/toolSetsContribution": [
 			"Invalid file name",
@@ -35172,8 +37220,11 @@
 			"Analyzed usages of `{0}`, no results",
 			"Analyzed usages of `{0}`, 1 result",
 			"Analyzed usages of `{0}`, {1} results",
-			"Find references, definitions, and implementations of a symbol",
-			"Find references, definitions, and implementations of a symbol ({0})"
+			"Find references, definitions, and implementations of a symbol"
+		],
+		"vs/workbench/contrib/chat/browser/utilityModelContribution": [
+			"Use the built-in default utility model",
+			"Default"
 		],
 		"vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler": [
 			"The content of the welcome message. The first command link will be rendered as a button.",
@@ -35219,7 +37270,8 @@
 			"Dismiss"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatConfirmationWidget": [
-			"Chat Confirmation Dialog {0} {1}"
+			"Chat Confirmation Dialog {0} {1}",
+			"Chat Confirmation Dialog {0} {1} {2}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatDisabledClaudeHooksContentPart": [
 			"Enable",
@@ -35259,6 +37311,9 @@
 			"Generating edits...",
 			"{0} insertions",
 			"1 insertion",
+			"Error rendering the code block",
+			"Rendering code block...",
+			"Rendered code block {0}",
 			"Edited {0}, {1}, {2}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersInteractionContentPart": [
@@ -35278,16 +37333,52 @@
 			"Open Changes",
 			"File Changes"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatPlanReviewPart": [
+			"Plan review: {0}",
+			"Cancel",
+			"Enable",
+			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.",
+			"Enable Autopilot?",
+			"Cancel",
+			"Exit feedback mode",
+			"Clear All",
+			"Clear {0} inline comment(s)?",
+			"Clear All",
+			"These comments will be removed from the plan file and not sent to the agent.",
+			"Close",
+			"Collapse",
+			"Line {0}: {1}",
+			"Line {0}",
+			"Expand",
+			"Expand",
+			"Feedback",
+			"Add an overall comment for the agent...",
+			"Line {0}, Column {1}",
+			"Line {0}",
+			"Inline comments on `{0}`:",
+			"Inline comments:",
+			"Open Plan",
+			"Open {0}",
+			"Reject",
+			"Remove comment on line {0}",
+			"Restore Size",
+			"Edit or Provide Feedback",
+			"Review {0}",
+			"Submit Feedback",
+			"Submit Feedback ({0})"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatProgressContentPart": [
-			"Waiting for tool '{0}' to respond...",
-			"Working"
+			"Waiting for tool '{0}' to respond..."
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart": [
 			"Collapse Questions",
+			"{0} Use {1} to focus the terminal.",
+			"{0} Use the Focus Terminal from Question Carousel command to focus the terminal.",
 			"Deferring to user's input in the terminal",
 			"Enter custom answer",
 			"Enter your answer",
 			"Expand Questions",
+			"Focus Terminal ({0})",
 			"Focus Terminal",
 			"Chat question",
 			"{0} ({1})",
@@ -35323,7 +37414,8 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart": [
 			"Click to Retry",
-			"Manage Paid Premium Requests",
+			"Configure Budget",
+			"Configure Budget",
 			"Upgrade to GitHub Copilot Pro",
 			"Changes may take a few minutes to take effect."
 		],
@@ -35398,12 +37490,18 @@
 			"Considering",
 			"Analyzing",
 			"Evaluating",
+			"Working",
 			"{0}, {1}, {2}",
 			"Processing",
 			"Preparing",
 			"Loading",
 			"Analyzing",
-			"Evaluating"
+			"Evaluating",
+			"Bribing the hamster",
+			"Reticulating splines",
+			"Untangling the spaghetti",
+			"Mining diamonds",
+			"Summoning Clippy"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTipContentPart": [
 			"Chat tip",
@@ -35493,6 +37591,8 @@
 			"This will enable a configurable subset of commands to run in the terminal autonomously. It provides *best effort protections* and assumes the agent is not acting maliciously.",
 			"Learn more about the potential risks and how to avoid them.",
 			"Enable terminal auto approve?",
+			"Approval needed:",
+			"Sandbox insufficient:",
 			"The model did not provide a reason for requesting unsandboxed execution.",
 			"Session auto approve rule {0} added",
 			"Session auto approve rules {0} added",
@@ -35508,13 +37608,20 @@
 			"Skip"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolProgressPart": [
+			" in background",
 			"Ran {0}",
 			"Ran ",
 			"Ran ",
 			"Running {0}",
 			"Running ",
+			"Running {0} in background",
 			"Running ",
+			" in sandbox (background)",
 			" in sandbox",
+			"Show",
+			"Skipped {0}",
+			"Skipped ",
+			"Skipped ",
 			"Command information is not available.",
 			"No output was produced by the command.",
 			"Terminal is no longer available.",
@@ -35532,15 +37639,13 @@
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationCarouselPart": [
 			"Allow",
 			"Allow All",
-			"Collapse",
-			"Confirm tool?",
-			"Confirm {0} tools?",
-			"Expand",
 			"Expand Confirmation Up",
 			"Next",
 			"Previous",
 			"Restore Confirmation Size",
 			"Scroll to {0}",
+			"Skip",
+			"Skip All",
 			"Tool confirmation carousel"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationSubPart": [
@@ -35572,6 +37677,12 @@
 			"No results to display",
 			"Skip Results"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/toolRiskBadgeWidget": [
+			"Risk assessments are AI-generated and may be inaccurate.",
+			"Assessing risk…",
+			"Generating a risk assessment for this tool call.",
+			"Risk assessment details"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatDragAndDrop": [
 			"Attach {0} as Context",
 			"Image from URL",
@@ -35585,6 +37696,12 @@
 			"URL"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatListRenderer": [
+			"Approved plan",
+			"Started implementation with Autopilot",
+			"Provided feedback",
+			"{0}: {1}",
+			"Rejected plan",
+			"Plan review required",
 			"Chat input required ({0} questions): {1}",
 			"Chat input required (1 question): {0}",
 			"Chat input required.",
@@ -35604,6 +37721,8 @@
 			"Click to Edit",
 			"Steering",
 			"Steering message will be sent after the next tool call happens",
+			"System Notification",
+			"System notification will be sent after the next tool call happens",
 			"[[(rerun without)]]",
 			"used {0} [[(rerun without)]]",
 			"Working"
@@ -35628,6 +37747,9 @@
 		"vs/workbench/contrib/chat/browser/widget/input/chatFollowups": [
 			"Follow up question: {0}"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget": [
+			"Dismiss notification"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputPart": [
 			"Chat Input {0}{1} Press Enter to send out the request. Use {2} for Chat Accessibility Help.",
 			"{0}, {1} lines added, {2} lines removed",
@@ -35643,6 +37765,8 @@
 			", {0}. "
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatModelPicker": [
+			"Higher levels of thinking may increase costs",
+			"Thinking Effort",
 			"Manage Models...",
 			"Manage Language Models",
 			"Contact your admin",
@@ -35652,14 +37776,42 @@
 			"Auto",
 			"This model requires a newer version of VS Code. [Update VS Code](command:update.checkForUpdate) to access it.",
 			"This model requires a newer version of VS Code. [Download Update](command:update.downloadUpdate) to access it.",
+			"Thinking Effort: {0}",
+			"Set Thinking Effort",
 			"Other Models",
+			"Pin Model",
+			"Pinned",
 			"This model requires a newer version of VS Code. [Restart to Update](command:update.restartToUpdate) to access it.",
 			"Search models",
+			"Context Size: {0}",
+			"Set Context Size",
+			"Unpin Model",
 			"Update VS Code",
 			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
+			"[Upgrade to GitHub Copilot Pro+](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
 			"[Upgrade](command:workbench.action.chat.upgradePlan \" \")",
+			"High cost",
+			"Low cost",
+			"Medium cost",
+			"Very high cost",
+			"Larger size may increase cost in longer sessions",
 			"Context Size",
-			"Each chat message counts {0} toward your premium request quota"
+			"Cached input",
+			"Configurable:",
+			"Max context",
+			"Cost: {0}",
+			"{0} credits",
+			"{0} credit",
+			"{0} (default)",
+			"Input",
+			"Output",
+			"Cost",
+			"Cost (per 1M tokens)",
+			"{0} (default)"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter": [
+			"Auto",
+			"Pick Mode and Model, {0}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem": [
 			"Add to Queue",
@@ -35669,14 +37821,6 @@
 			"Cancel the current request and send this message immediately.",
 			"Steer with Message",
 			"Send this message at the next opportunity, signaling the current request to yield. The current response will stop and the new message will be sent immediately."
-		],
-		"vs/workbench/contrib/chat/browser/widget/input/chatStatusWidget": [
-			"You've reached the limit for chat messages. Sign in to use Copilot Free.",
-			"Sign In",
-			"{0} {1}",
-			"You've reached the limit for chat messages.",
-			"Upgrade",
-			"{0} {1}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/delegationSessionPickerActionItem": [
 			"Learn about agent handoff...",
@@ -35712,7 +37856,7 @@
 			"Pasted Image",
 			"Pasted Symbol Reference"
 		],
-		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem2": [
+		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem": [
 			"Pick Model"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem": [
@@ -35723,30 +37867,24 @@
 			"View {0} agent"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem": [
+			"Permission picker, {0}",
 			"Bypass Approvals",
 			"Auto-approve all tool calls and retry on errors",
 			"Bypass Approvals",
 			"Disabled by enterprise policy",
 			"Disabled by enterprise policy",
 			"All tool calls are auto-approved",
-			"Cancel",
-			"Enable",
-			"Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.",
-			"Enable Bypass Approvals?",
 			"Autopilot (Preview)",
 			"Auto-approve all tool calls and continue until the task is done",
 			"Autopilot (Preview)",
 			"Disabled by enterprise policy",
 			"Disabled by enterprise policy",
 			"Autonomously iterates from start to finish",
-			"Cancel",
-			"Enable",
-			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.",
-			"Enable Autopilot?",
 			"Default Approvals",
 			"Use configured approval settings",
 			"Default Approvals",
 			"Copilot uses your configured settings",
+			"This option is locked",
 			"Learn more about permissions"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem": [
@@ -35838,10 +37976,12 @@
 			"True when the chat model can be selected manually by the user.",
 			"The name of the current chat mode (e.g. 'Plan' for custom modes).",
 			"The icon variant for the new chat button, controlled by experiment. Values: 'copilot', 'new-session', 'comment', or empty for default.",
+			"True when a user-selectable chat model from a non-Copilot vendor is available.",
 			"True when a default chat participant is registered for the panel from an extension.",
 			"The location of the chat panel.",
 			"True when a default chat participant is registered for the panel.",
 			"The current permission level for tool auto-approval.",
+			"True when the chat question carousel was triggered by a terminal and has a terminal to focus.",
 			"True when a remote coding agent job is being created.",
 			"The chat item is a request",
 			"True when the chat request item is pending in the queue.",
@@ -35902,6 +38042,17 @@
 			"Explore and understand your code",
 			"Edit or refactor selected code"
 		],
+		"vs/workbench/contrib/chat/common/chatPermissionWarnings": [
+			"Cancel",
+			"Enable",
+			"Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.\n\nTo make this the starting permission level for new chat sessions, change the [{0}](command:workbench.action.openSettings?%5B%22{0}%22%5D) setting.",
+			"Enable Bypass Approvals?",
+			"Cancel",
+			"Enable",
+			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.\n\nTo make this the starting permission level for new chat sessions, change the [{0}](command:workbench.action.openSettings?%5B%22{0}%22%5D) setting.",
+			"Enable Autopilot?",
+			"Don't show again"
+		],
 		"vs/workbench/contrib/chat/common/chatService/chatServiceImpl": [
 			"The `{0}` skill requires `{1}` to be enabled. After enabling, reload the window to apply. [Enable in Settings](command:workbench.action.openSettings?{2})",
 			"Provider returned null response",
@@ -35917,14 +38068,12 @@
 			"Changes to {0} files"
 		],
 		"vs/workbench/contrib/chat/common/languageModels": [
-			"Please enter true or false",
 			"Group Name",
 			"Please enter a name",
 			"Enter value for {0}",
 			"Enter a name for the group",
 			"{0} (default)",
 			"A language models group with this name already exists",
-			"Please enter a number",
 			"Select value for {0}",
 			"Value is required",
 			"Contribute language model chat providers of a specific vendor.",
@@ -35951,7 +38100,8 @@
 			"Made changes.",
 			"Response cleared due to content safety filters, retrying with modified prompt.",
 			"Answer questions to continue...",
-			"Approve tool result?"
+			"Approve tool result?",
+			"Review the plan to continue..."
 		],
 		"vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation": [
 			"Tool \"{0}\" was denied"
@@ -35970,6 +38120,9 @@
 			"Contributes agent plugins for chat.",
 			"Path",
 			"When",
+			"This plugin was installed by the Copilot CLI. Remove it from disk?",
+			"The plugin directory '{0}' will be moved to the trash. You can reinstall it later via the Copilot CLI.",
+			"Remove",
 			"Extension '{0}' chatPlugins entry '{1}' resolves outside the extension.",
 			"Extension '{0}' chatPlugins entry '{1}' has an invalid when clause: '{2}'.",
 			"Extension '{0}' cannot register a chatPlugins entry without a path.",
@@ -35983,6 +38136,7 @@
 			"Specify \"name\" in the prompt file itself instead.",
 			"Path to the file relative to the extension root.",
 			"Path to the SKILL.md file relative to the extension root. The folder name must match the \"name\" property in SKILL.md.",
+			"(Optional) The chat session types where this entry should be offered.",
 			"(Optional) A condition which must be true to enable this entry.",
 			"Contributes {0} for chat prompts.",
 			"Description",
@@ -36003,8 +38157,9 @@
 			"applyTo '{0}' did not match any attached files",
 			"no applyTo pattern",
 			"debug logging disabled",
+			"no description for model invocation",
 			"model invocation disabled",
-			"when clause not satisfied",
+			"session type not matched",
 			"Instructions for folder '{0}'",
 			"Instructions for the workspace",
 			"automatically attached as pattern is **",
@@ -36131,6 +38286,8 @@
 			"The tools to use in this prompt.",
 			"Hint shown during autocomplete to indicate expected arguments. Example: [issue-number] or [filename] [format]",
 			"Compatibility metadata for environments or runtimes.",
+			"Controls how the skill is loaded. Set to 'fork' to spawn a subagent with the skill instructions instead of returning them inline.",
+			"Spawn a subagent with the skill instructions injected as system context.",
 			"The description of the skill. The description is added to every request and will be used by the agent to decide when to load the skill.",
 			"Set to true to prevent the agent from automatically loading this skill. Use for workflows you want to trigger manually with /name. Default: false.",
 			"License information for the skill.",
@@ -36244,7 +38401,6 @@
 			"Unknown agent '{0}'. Available agents: {1}.",
 			"The 'agents' attribute must be an array.",
 			"When 'agents' and 'tools' are specified, the 'agent' tool must be included in the 'tools' attribute.",
-			"For agents to be used as subagent you also need to enable the 'chat.customAgentInSubagent.enabled' setting.",
 			"The 'applyTo' attribute must be a string.",
 			"The 'applyTo' attribute must be a valid glob pattern.",
 			"The 'argument-hint' attribute must be a string.",
@@ -36255,6 +38411,7 @@
 			"Chat modes have been renamed to agents. Please move the file to {0}",
 			"The '{0}' attribute must be a string.",
 			"Unknown value '{0}', valid: {1}.",
+			"The 'context: fork' attribute requires the skill tool to be enabled (github.copilot.chat.skillTool.enabled).",
 			"Tool or toolset '{0}' has been renamed, use '{1}' instead.",
 			"Tool or toolset '{0}' has been renamed, use the following tools instead: {1}",
 			"The 'description' attribute must be a string.",
@@ -36291,7 +38448,6 @@
 			"Hook event '{0}' must have an array of command objects as its value.",
 			"Attribute '{0}' is ignored when running locally in VS Code.",
 			"The 'infer' attribute is deprecated in favour of 'user-invocable' and 'disable-model-invocation'.",
-			"For agents to be used as subagent you also need to enable the 'chat.customAgentInSubagent.enabled' setting.",
 			"Invalid file reference '{0}'.",
 			"Invalid permission value '{0}' for scope '{1}'. Allowed values: {2}.",
 			"Missing required properties {0} in handoff object.",
@@ -36312,10 +38468,12 @@
 			"The 'paths' attribute must be an array of glob patterns.",
 			"The 'permissions' property must be an object.",
 			"The permission value for '{0}' must be a string.",
-			"Skill must provide a description.",
+			"Skill should provide a description.",
+			"A description is required when model invocation is enabled, because the model needs a description to decide when to load the skill.",
 			"The skill name '{0}' should match the folder name '{1}'.",
 			"Skill name may only contain lowercase letters, numbers, and hyphens.",
-			"Skill must provide a name.",
+			"Skill should provide a name.",
+			"A description is required when user-invocable is false, because the model needs a description to decide when to load the skill.",
 			"The 'target' attribute must be one of: {0}.",
 			"The 'target' attribute must be a non-empty string.",
 			"The 'target' attribute must be a string.",
@@ -36338,6 +38496,18 @@
 			"Unknown permission scope '{0}'. Valid scopes: {1}.",
 			"Unknown tool or toolset '{0}'.",
 			"The 'user-invocable' attribute must be 'true' or 'false'."
+		],
+		"vs/workbench/contrib/chat/common/promptSyntax/promptTypes": [
+			"Global",
+			"Workspace",
+			"Global (only used by Claude agents)",
+			"Workspace (only used by Claude agents)",
+			"Workspace (only used by Claude agents, usually git-ignored)",
+			"Global (contributed from settings)",
+			"Workspace (contributed from settings)",
+			"Global (only used by Copilot agents)",
+			"Workspace (only used by Copilot agents)",
+			"Global (roams with Settings Sync, only used by VS Code)"
 		],
 		"vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl": [
 			"Extension: {0}",
@@ -36401,6 +38571,14 @@
 			"Manage and track todo items for task planning",
 			"Manage and track todo items for task planning"
 		],
+		"vs/workbench/contrib/chat/common/tools/builtinTools/reviewPlanTool": [
+			"Review plan",
+			"Asking you to review the plan",
+			"Asked you to review the plan",
+			"At least one approval action must be provided.",
+			"Review Plan",
+			"Ask the user to review and approve a plan before proceeding."
+		],
 		"vs/workbench/contrib/chat/common/tools/builtinTools/runSubagentTool": [
 			"Run Subagent",
 			"Run a task within an isolated subagent context to enable efficient organization of tasks and context window management."
@@ -36458,6 +38636,9 @@
 			"The background color of a chat avatar.",
 			"The foreground color of a chat avatar.",
 			"The foreground color of a chat edited file in the edited file list.",
+			"First color stop of the animated chat input border shown while a request is in flight.",
+			"Secondary accent color used by other animated chat input affordances. Not used by the in-flight chat input border.",
+			"Tertiary accent color used by other animated chat input affordances. Not used by the in-flight chat input border.",
 			"Foreground color of lines added in chat code block pill.",
 			"Foreground color of lines removed in chat code block pill.",
 			"The background color of a chat request.",
@@ -36470,9 +38651,6 @@
 			"Shimmer highlight for thinking/working labels.",
 			"Chat checkpoint separator color."
 		],
-		"vs/workbench/contrib/chat/common/widget/input/modelPickerWidget": [
-			"Other Models"
-		],
 		"vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions": [
 			"Open Chat Storage Folder"
 		],
@@ -36480,6 +38658,19 @@
 			"Export Chat as Zip...",
 			"Failed to export chat as zip: {0}",
 			"Exported chat without repository context. No Git repository was detected."
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/debugAgentHostAction": [
+			"Could not enable the Node.js inspector for the agent host process.",
+			"Debug Local Agent Host Process In Dev Tools"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/exportAgentHostDebugLogsService": [
+			"Export Agent Host Debug Logs",
+			"Zip Archive"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/exportAgentTracesDb": [
+			"Failed to export agent host traces database: {0}",
+			"Export Agent Host Traces Database...",
+			"No agent host trace database found yet. Run an agent session with `#chat.agentHost.otel.dbSpanExporter.enabled#` turned on to populate it."
 		],
 		"vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions": [
 			"Listening to 'Hey Code'...",
@@ -36507,7 +38698,9 @@
 			"Stop Reading Aloud"
 		],
 		"vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions": [
-			"Open Agents Application"
+			"Open Agents Window",
+			"Open in Agents Window",
+			"Open in Agents"
 		],
 		"vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool": [
 			"Binary files are not supported at the moment.",
@@ -37065,6 +39258,11 @@
 			"Whether the open workspace has either comments or commenting ranges.",
 			"Whether the position at the active cursor has a commenting range"
 		],
+		"vs/workbench/contrib/customEditor/browser/customEditorDiffInput": [
+			"{0} - {1}",
+			"{0} ({1})",
+			"{0} ({1})"
+		],
 		"vs/workbench/contrib/customEditor/browser/customEditorInput": [
 			"Unable to move '{0}': The editor contains changes that can only be saved in its current window.",
 			"Unable to open the editor in this window, it contains modifications that can only be saved in the original window.",
@@ -37082,8 +39280,11 @@
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"Contributed custom editors.",
 			"Human readable name of the custom editor. This is displayed to users when selecting which editor to use.",
-			"Controls if the custom editor is enabled automatically when the user opens a file. This may be overridden by users using the `workbench.editorAssociations` setting.",
+			"Controls if the custom editor is enabled automatically when the user opens a file, diff, or merge editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting.",
 			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
+			"Controls if the custom editor is enabled automatically when the user opens a diff. When not specified, the value of `editor` is used.",
+			"Controls if the custom editor is enabled automatically when the user opens a file.",
+			"Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified, the value of `editor` is used.",
 			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.",
 			"Set of globs that the custom editor is enabled for.",
 			"Glob that the custom editor is enabled for.",
@@ -38236,6 +40437,7 @@
 			"Extensions are not automatically updated.",
 			"Download and install updates automatically for all extensions.",
 			"Configure the Marketplace service URL to connect to",
+			"Override the Agents window support of an extension. Extensions using `true` will be enabled in the Agents window even when they would otherwise be disabled.",
 			"Override the untrusted workspace support of an extension. Extensions using `true` will always be enabled. Extensions using `limited` will always be enabled, and the extension will hide functionality that requires trust. Extensions using `false` will only be enabled only when the workspace is trusted.",
 			"Extension will only be enabled only when the workspace is trusted.",
 			"Extension will always be enabled, and the extension will hide functionality requiring trust.",
@@ -39360,12 +41562,6 @@
 			"Read Line with Inlay Hints",
 			"Stop Inlay Hints Reading"
 		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChat.contribution": [
-			"Cancel Request",
-			"Cancel",
-			"Edit Code",
-			"Generate"
-		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatActions": [
 			"Ask in Chat",
 			"Cancel",
@@ -39377,39 +41573,22 @@
 			"Ask for Edits",
 			"Fix",
 			"Focus Input",
-			"Hide Input",
 			"Keep",
-			"Describe how to proceed in Chat",
-			"Describe what to generate",
-			"Describe how to change this",
-			"Queue in Chat",
 			"Rephrase",
 			"Open Inline Chat",
 			"Inline Chat",
-			"Icon which spawns the inline chat from the editor toolbar.",
-			"Send",
-			"Undo"
+			"Icon which spawns the inline chat from the editor toolbar."
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatController": [
 			"Fix the attached problem",
 			"Fix the attached problems",
 			"Working...",
 			"Generate code",
-			"Describe what to generate",
-			"Modify selected code",
-			"Describe how to change this"
+			"Modify selected code"
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatDefaultModel": [
 			"Inline Chat",
 			"Select the default language model to use for inline chat from the available providers. Model names may include the provider in parentheses, for example 'Claude Haiku 4.5 (copilot)'."
-		],
-		"vs/workbench/contrib/inlineChat/browser/inlineChatOverlayWidget": [
-			"Done",
-			"Done, 1 change",
-			"Done, {0} changes",
-			"Sorry, your request failed",
-			"Sorry, but an unexpected error happened",
-			"Working..."
 		],
 		"vs/workbench/contrib/inlineChat/browser/inlineChatSessionServiceImpl": [
 			"Inline Chat to Panel Chat",
@@ -39435,46 +41614,32 @@
 			"Minimap marker color for inline chat inserted content.",
 			"Overview ruler marker color for inline chat inserted content.",
 			"Overview ruler marker color for inline chat removed content.",
-			"Whether to use the next version of inline chat.",
-			"Whether to finish an inline chat session when typing outside of changed regions.",
 			"Controls whether the Fix action is shown for diagnostics in the editor.",
 			"Background color of the interactive editor widget",
 			"Border color of the interactive editor widget",
 			"Foreground color of the interactive editor widget",
 			"Shadow color of the interactive editor widget",
 			"Whether an inline chat affordance widget is visible",
-			"Whether the current change supports showing a diff",
-			"Whether the current change showing a diff",
 			"Background color of inserted text in the interactive editor input",
 			"Background color of removed text in the interactive editor input",
 			"Whether the user is currently editing or generating code in the inline chat",
 			"Whether the interactive editor input is empty",
 			"Whether the current file belongs to a chat editing session",
 			"Whether the interactive editor input is focused",
-			"Whether an agent for inline for interactive editors exists",
+			"Whether an agent for inline chat in interactive editors exists",
 			"Whether an agent for notebook cells exists",
 			"Whether an agent for notebook cells exists",
 			"Whether a provider for inline chat exists and whether an editor for inline chat is open",
-			"Whether interactive editor has kept a session for quick restore",
-			"Whether the cursor of the iteractive editor input is on the first line",
-			"Whether the cursor of the iteractive editor input is on the last line",
 			"Background color of the interactive editor input",
 			"Border color of the interactive editor input",
 			"Border color of the interactive editor input when focused",
 			"Foreground color of the interactive editor input placeholder",
-			"Whether the inline chat input widget has text",
-			"Whether the inline chat input widget editor is focused",
 			"Whether the cursor of the outer editor is above or below the interactive editor input",
-			"Whether an inline chat request is pending user confirmation",
 			"Whether an inline chat request is currently in progress",
 			"Whether the interactive widget's response is focused",
-			"What type was the responses have been receieved, nothing yet, just messages, or messaged and local edits",
 			"Whether the current inline chat session is terminated",
 			"Whether the interactive editor input is visible",
-			"Enable agent-like behavior for inline chat widget in notebooks.",
-			"Controls how inline chat is rendered.",
-			"Render inline chat as a hover overlay.",
-			"Render inline chat as a zone widget below the current line."
+			"Enable agent-like behavior for inline chat widget in notebooks."
 		],
 		"vs/workbench/contrib/inlineCompletions/browser/inlineCompletionLanguageStatusBarContribution": [
 			"Inline completion available",
@@ -39543,6 +41708,7 @@
 			"show",
 			"Similar issues",
 			"Steps to Reproduce",
+			"Submitting...",
 			"Please enter a title",
 			"Don't know",
 			"Visual Studio Code",
@@ -39996,6 +42162,7 @@
 			"Disabled",
 			"Disconnect Account",
 			"Edit Stored Input",
+			"Enable Server (Workspace)",
 			"Multiple MCP servers were unable to start successfully:\n\n{0}",
 			"MCP server {0} was unable to start successfully.",
 			"Install Server from Manifest...",
@@ -40133,6 +42300,7 @@
 			"Start",
 			"Stop",
 			"Variable `{0}` not found, did you mean ${{1}}?",
+			"Disabled",
 			"Error",
 			"{0} prompts",
 			"Running",
@@ -40213,6 +42381,8 @@
 			"Server configuration details",
 			"Details",
 			"Extension details, rendered from the extension's 'README.md' file",
+			"Environment File:",
+			"Environment:",
 			"Environment Variables:",
 			"Headers:",
 			"Identifier",
@@ -41630,6 +43800,9 @@
 		],
 		"vs/workbench/contrib/preferences/browser/settingsEditorSettingIndicators": [
 			"Advanced",
+			"Cannot be changed in Agents window",
+			"This setting cannot be changed in the Agents window.",
+			"Cannot be changed in Agents window",
 			"Also modified elsewhere",
 			"Also modified in",
 			"The setting has also been modified in the following scopes:",
@@ -41939,8 +44112,11 @@
 		],
 		"vs/workbench/contrib/remote/browser/remoteConnectionHealth": [
 			"&&Allow",
+			"Support for 32-bit ARM remote servers is deprecated and will be removed in a future release of {0}.",
+			"Learn More",
 			"&&Learn More",
 			"Do not show again",
+			"Do not show again in v{0}",
 			"Learn More",
 			"You are about to connect to an OS version that is unsupported by {0}.",
 			"You are connected to an OS version that is unsupported by {0}."
@@ -42210,6 +44386,30 @@
 		"vs/workbench/contrib/scm/browser/menus": [
 			"Share"
 		],
+		"vs/workbench/contrib/scm/browser/quickDiff.contribution": [
+			"Controls diff decorations in the editor.",
+			"Controls whether leading and trailing whitespace is ignored in Source Control diff gutter decorations.",
+			"Controls whether a pattern is used for the diff decorations in gutter.",
+			"Use pattern for the diff decorations in gutter for added lines.",
+			"Use pattern for the diff decorations in gutter for modified lines.",
+			"Controls the width(px) of diff decorations in gutter (added & modified).",
+			"Diff Decorations",
+			"Show the diff decorations in all available locations.",
+			"Show the diff decorations only in the editor gutter.",
+			"Show the diff decorations only in the minimap.",
+			"Do not show the diff decorations.",
+			"Show the diff decorations only in the overview ruler.",
+			"Controls the behavior of Source Control diff gutter decorations.",
+			"Show the inline diff Peek view on click.",
+			"Do nothing.",
+			"Controls the visibility of the Source Control diff decorator in the gutter.",
+			"Show the diff decorator in the gutter at all times.",
+			"Show the diff decorator in the gutter only on hover.",
+			"Do not ignore leading and trailing whitespace.",
+			"Inherit from `diffEditor.ignoreTrimWhitespace`.",
+			"Ignore leading and trailing whitespace.",
+			"Source Control"
+		],
 		"vs/workbench/contrib/scm/browser/quickDiffDecorator": [
 			"Added lines",
 			"Removed lines",
@@ -42252,7 +44452,6 @@
 			"Open in External Terminal",
 			"Open in Integrated Terminal",
 			"Controls how many repositories are visible in the Source Control Repositories section. Set to 0, to be able to manually resize the view.",
-			"Diff Decorations",
 			"Controls the sort order of the repositories in the source control repositories view.",
 			"Source Control: Accept Input",
 			"Source Control: View Next Commit",
@@ -42483,9 +44682,11 @@
 			"{0} ↔ {1} (Replace Preview)",
 			"Search and Replace"
 		],
+		"vs/workbench/contrib/search/browser/search.common.contribution": [
+			"Search all files as you type.",
+			"When {0} is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when {0} is disabled."
+		],
 		"vs/workbench/contrib/search/browser/search.contribution": [
-			"Go to File",
-			"Search files by name (append {0} to go to line or {1} to go to symbol)",
 			"Configure [glob patterns](https://code.visualstudio.com/docs/editor/codebasics#_advanced-search-options) for excluding files and folders in fulltext searches and file search in quick open. To exclude files from the recently opened list in quick open, patterns must be absolute (for example `**/node_modules/**`). Inherits all glob patterns from the `#files.exclude#` setting.",
 			"The glob pattern to match file paths against. Set to true or false to enable or disable the pattern.",
 			"Additional check on the siblings of a matching file. Use \\$(basename) as variable for the matching file name.",
@@ -42506,6 +44707,7 @@
 			"Controls whether search file decorations should use colors.",
 			"Controls the default search result view mode.",
 			"Show notebook editor rich content results for closed notebooks. Please refresh your search results after changing this setting.",
+			"When enabled, the legacy `findFiles` extension API honors the user's `#search.useIgnoreFiles#` setting instead of always ignoring `.gitignore`. Extensions that explicitly pass `null` as the `exclude` argument still get unfiltered results. Telemetry is emitted regardless of this setting to help decide future defaults.",
 			"Controls whether to follow symlinks while searching.",
 			"Controls whether the Search view should read or modify the shared find clipboard on macOS.",
 			"Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.",
@@ -42520,18 +44722,6 @@
 			"Whether to include results from recently opened files in the file results for Quick Open.",
 			"Whether to include results from a global symbol search in the file results for Quick Open.",
 			"Number of threads to use for searching. When set to 0, the engine automatically determines this value.",
-			"The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.",
-			"Configure effect of double-clicking a result in a search editor.",
-			"Double-clicking opens the result in the active editor group.",
-			"Double-clicking opens the result in the editor group to the side, creating one if it does not yet exist.",
-			"Double-clicking selects the word under the cursor.",
-			"When a search is triggered, focus the Search Editor results instead of the Search Editor input.",
-			"When enabled, new Search Editors will reuse the includes, excludes, and flags of the previously opened Search Editor.",
-			"Configure effect of single-clicking a result in a search editor.",
-			"Single-clicking does nothing.",
-			"Single-clicking opens a Peek Definition window.",
-			"Search all files as you type.",
-			"When {0} is enabled, controls the timeout in milliseconds between a character being typed and the search starting. Has no effect when {0} is disabled.",
 			"Enable keyword suggestions in the Search view.",
 			"Controls the behavior of the semantic search results displayed in the Search view.",
 			"Request semantic results automatically with every search.",
@@ -42544,15 +44734,12 @@
 			"Controls sorting order of search results.",
 			"Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.",
 			"Controls whether to open Replace Preview when selecting or replacing a match.",
-			"Search",
 			"Results are sorted by count per file, in ascending order.",
 			"Results are sorted by count per file, in descending order.",
 			"Results are sorted by folder and file names, in alphabetical order.",
 			"Results are sorted by file names ignoring folder order, in alphabetical order.",
 			"Results are sorted by file last modified date, in descending order.",
 			"Results are sorted by file extensions, in alphabetical order.",
-			"Go to Symbol in Workspace",
-			"Type the name of a symbol to open.",
 			"Search for Text",
 			"Search for text in your workspace files.",
 			"Controls whether to use your global gitignore file (for example, from `$HOME/.config/git/ignore`) when searching for files. Requires {0} to be enabled.",
@@ -42721,6 +44908,12 @@
 			"Unable to open unknown link: {0}",
 			"Unable to open command link from untrusted source: {0}"
 		],
+		"vs/workbench/contrib/search/browser/searchQuickAccess.contribution": [
+			"Go to File",
+			"Search files by name (append {0} to go to line or {1} to go to symbol)",
+			"Go to Symbol in Workspace",
+			"Type the name of a symbol to open."
+		],
 		"vs/workbench/contrib/search/browser/searchResultsView": [
 			"{0} matches in file {1} of folder {2}, Search result",
 			"{0} matches in folder root {1}, Search result",
@@ -42813,6 +45006,9 @@
 			"Open to the Bottom",
 			"Open to the Side"
 		],
+		"vs/workbench/contrib/search/common/search": [
+			"Search"
+		],
 		"vs/workbench/contrib/searchEditor/browser/searchEditor": [
 			"Search Exclude Patterns",
 			"Search Include Patterns",
@@ -42836,6 +45032,16 @@
 			"Open Results in Editor",
 			"Open Search Editor",
 			"Search Again",
+			"The default number of surrounding context lines to use when creating new Search Editors. If using `#search.searchEditor.reusePriorSearchConfiguration#`, this can be set to `null` (empty) to use the prior Search Editor's configuration.",
+			"Configure effect of double-clicking a result in a search editor.",
+			"Double-clicking opens the result in the active editor group.",
+			"Double-clicking opens the result in the editor group to the side, creating one if it does not yet exist.",
+			"Double-clicking selects the word under the cursor.",
+			"When a search is triggered, focus the Search Editor results instead of the Search Editor input.",
+			"When enabled, new Search Editors will reuse the includes, excludes, and flags of the previously opened Search Editor.",
+			"Configure effect of single-clicking a result in a search editor.",
+			"Single-clicking does nothing.",
+			"Single-clicking opens a Peek Definition window.",
 			"Search Editor",
 			"Decrease Context Lines",
 			"Increase Context Lines",
@@ -43445,6 +45651,7 @@
 		"vs/workbench/contrib/tasks/common/taskDefinitionRegistry": [
 			"The actual task type. Please note that types starting with a '$' are reserved for internal usage.",
 			"Additional properties of the task type",
+			"The names of the properties from the `properties` object that must be provided for a task of this type to be considered a match. Used by VS Code to associate a `tasks.json` entry with a registered task provider.",
 			"Condition which must be true to enable this type of task. Consider using `shellExecutionSupported`, `processExecutionSupported`, and `customExecutionSupported` as appropriate for this task definition. See the [API documentation](https://code.visualstudio.com/api/extension-guides/task-provider#when-clause) for more information.",
 			"Contributes task kinds",
 			"The task type configuration is missing the required 'taskType' property"
@@ -43479,16 +45686,11 @@
 		"vs/workbench/contrib/telemetry/browser/telemetry.contribution": [
 			"Show Telemetry"
 		],
-		"vs/workbench/contrib/terminal/browser/agentHostTerminalContribution": [
-			"Agent Host Terminal (Local)",
-			"Agent Host Terminal ({0})",
-			"Local",
-			"Agent Host…",
-			"Select an agent host to open a terminal on",
-			"Agent Host ({0})"
-		],
 		"vs/workbench/contrib/terminal/browser/agentHostTerminalService": [
 			"Agent Host Terminal",
+			"Agent Host…",
+			"Select an agent host to open a terminal on",
+			"Agent Host ({0})",
 			"Agent Host Terminal"
 		],
 		"vs/workbench/contrib/terminal/browser/baseTerminalBackend": [
@@ -43906,6 +46108,7 @@
 			"On macOS and Linux, a new split terminal will use the working directory of the parent terminal. On Windows, this behaves the same as initial.",
 			"A new split terminal will use the working directory that the parent terminal started with.",
 			"A new split terminal will use the workspace root as the working directory. In a multi-root workspace a choice for which root folder to use is offered.",
+			"Controls whether agentic CLIs (such as Claude Code, Codex, GitHub Copilot CLI, and Gemini CLI) are allowed to set the terminal tab title via escape sequences. When disabled, the configured tab title template is used instead.",
 			"A theme color ID to associate with terminal icons by default.",
 			"A codicon ID to associate with terminal icons by default.",
 			"Controls whether terminal tab statuses support animation (eg. in progress tasks).",
@@ -43936,7 +46139,7 @@
 			"Controls what version of Unicode to use when evaluating the width of characters in the terminal. If you experience emoji or other wide characters not taking up the right amount of space or backspace either deleting too much or too little then you may want to try tweaking this setting.",
 			"Version 11 of Unicode. This version provides better support on modern systems that use modern versions of Unicode.",
 			"Version 6 of Unicode. This is an older version which should work better on older systems.",
-			"Whether to use the experimental conpty.dll (v1.25.260303002) shipped with VS Code, instead of the one bundled with Windows.",
+			"Whether to use the conpty.dll (v1.25.260303002) shipped with VS Code, instead of the one bundled with Windows.",
 			"A string containing all characters to be considered word separators when double-clicking to select word and in the fallback 'word' link detection. Since this is used for link detection, including characters such as `:` that are used when detecting links will cause the line and column part of links like `file:10:5` to be ignored.",
 			"Controls the terminal description, which appears to the right of the title. Variables are substituted based on the context:",
 			"Integrated Terminal",
@@ -44154,10 +46357,10 @@
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool": [
 			"Allow",
-			"Background task `{0}` completed",
-			"Background task `{0}` needs input",
 			"Run `{0}` command?",
 			"Explanation: {0}\n\nGoal: {1}",
+			"No explanation provided",
+			"No goal provided",
 			"Run `{0}` command within `{1}`?",
 			"Running `{0}`",
 			"Running `{0}` in sandbox",
@@ -44172,14 +46375,25 @@
 			"Run `{0}` command in `{1}` within `{2}`?",
 			"Run command in `{0}` within `{1}`?",
 			"Run command in `{0}`?",
+			"The terminal command was prompting for a password or other secret. Auto-approve / autopilot mode cannot safely supply secrets, so the command was cancelled. Run the command interactively if you want to provide the secret.",
+			"Terminal command cancelled — sensitive input required",
+			"Cancel Command",
+			"Dismiss",
+			"Focus Terminal",
+			"The terminal command appears to be prompting for a password or other sensitive value. Focus the terminal to type it directly — secrets must not be sent through chat.",
+			"Terminal is waiting for sensitive input",
 			"Running `{0}`",
 			"Running command",
 			"Run `{0}` command outside the [sandbox]({1})?",
+			"Run `{0}` command outside the sandbox?",
 			"`{0}`",
+			"Run `{0}` command outside the sandbox to access {1}?",
 			"Running `{0}` outside the sandbox",
 			"The sandboxed execution output indicated the sandbox blocked the command.",
 			"Explanation: {0}\n\nGoal: {1}\n\nReason for leaving the sandbox: {2}",
 			"The model indicated that this command needs unsandboxed access.",
+			"Not running `{0}` because unsandboxed execution is disabled",
+			"The command was not executed because it requested to run outside the terminal sandbox, but running commands outside the sandbox is disabled by chat.agent.sandbox.allowUnsandboxedCommands. Run the command in the sandbox instead, or enable the setting to allow unsandboxed execution.",
 			"Run `{0}` command outside the [sandbox]({1}) to access {2}?",
 			"This command accesses {0} and {1} more domains that are blocked by chat.agent.deniedNetworkDomains.",
 			"This command accesses {0}, which is blocked by chat.agent.deniedNetworkDomains.",
@@ -44191,7 +46405,10 @@
 			"The command opened the alternate buffer.",
 			"Run in Terminal",
 			"Run commands in the terminal",
-			"Skip"
+			"Skip",
+			"`{0}` may need input",
+			"`{0}` completed",
+			"`{0}` terminal exited"
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool": [
 			"Focus Terminal",
@@ -44247,18 +46464,24 @@
 			"Task `{0}` failed with exit code {1}."
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration": [
+			"Controls whether agent mode terminal commands that run inside the sandbox are auto-approved. When disabled, the run in terminal tool uses the existing approval flow. This applies only when {0} is enabled.",
+			"Controls whether agent mode terminal commands can run outside the sandbox after user confirmation when a sandboxed command fails or when sandbox restrictions would block the command. This applies only when {0} is enabled.",
+			"Controls whether agent mode terminal commands that run outside the sandbox are auto-approved. This applies only when both {0} and {1} are enabled.",
 			"Use {0} instead",
 			"Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system.",
+			"Enable sandboxing for agent mode tools and allow all network domains.",
 			"Disable sandboxing for agent mode tools.",
 			"Enable sandboxing for agent mode tools.",
 			"Use {0} instead",
 			"Use {0} instead",
 			"Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on Linux. Paths do not support glob patterns, only literal paths (ex: ./src/, ~/.ssh, .env). **bubblewrap** and **socat** should be installed for this setting to work.",
-			"Array of paths to allow write access. Leave empty to disallow all writes.",
+			"Array of paths to re-allow read access within denied regions. Takes precedence over denyRead.",
+			"Array of additional paths to allow write access. Leave empty to disallow writes outside the workspace folders, workspace storage folder, and sandbox temp directory.",
 			"Array of paths to deny read access. Leave empty to allow reading all paths.",
 			"Array of paths to deny write access within allowed paths (takes precedence over allowWrite).",
 			"Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on macOS. Paths also support git-style glob patterns(ex: *.ts, ./src, ./src/**/*.ts, file?.txt).",
-			"Array of paths to allow write access. Leave empty to disallow all writes.",
+			"Array of paths to re-allow read access within denied regions. Takes precedence over denyRead.",
+			"Array of additional paths to allow write access. Leave empty to disallow writes outside the workspace folders, workspace storage folder, and sandbox temp directory.",
 			"Array of paths to deny read access. Leave empty to allow reading all paths.",
 			"Array of paths to deny write access within allowed paths (takes precedence over allowWrite).",
 			"Note: this setting is applicable only when {0} is enabled. Key/value pairs are passed through to the root of the sandbox runtime configuration.",
@@ -44298,7 +46521,9 @@
 			"Whether to detach persistent terminal processes so they survive when VS Code exits. When enabled, commands started with `mode: \"async\"` (legacy: `isBackground: true`) are wrapped with `nohup` (POSIX) or `Start-Process` (Windows) so the process continues running after the terminal is disposed.",
 			"Whether to enforce the timeout value provided by the model in the run in terminal tool. When enabled, if the model provides a timeout parameter, the tool will stop tracking the command after that duration and return the output collected so far.",
 			"Configures the idle poll interval in milliseconds used by the run in terminal tool to detect when commands have finished executing. Lower values make command detection faster but may cause false positives on slow systems. This primarily affects terminals without shell integration where idle detection is used instead of shell integration events.",
+			"Number of milliseconds the run in terminal tool will wait for new output from a synchronous command before moving it to a background terminal and returning what was collected so far. The process is not killed — the tool returns the terminal ID so the model can poll, send input, or kill it. Set to {0} to disable.",
 			"Whether to ignore the built-in default auto-approve rules used by the run in terminal tool as defined in {0}. When this setting is enabled, the run in terminal tool will ignore any rule that comes from the default set but still follow rules defined in the user, remote and workspace settings. Use this setting at your own risk; the default auto-approve rules are designed to protect you against running dangerous commands.",
+			"When enabled, repeated get terminal output tool calls return only output added since the previous poll for the same terminal execution, or a short unchanged-output message when there is no new output.",
 			"Reveal the terminal output within chat only.",
 			"Where to show the output from the run in terminal tool.",
 			"Reveal the terminal in the panel or editor in addition to chat.",
@@ -45071,7 +47296,11 @@
 			"Starting test run...",
 			"No test run was started. This may be an issue with your test runner or extension.",
 			"No tests found in the files",
-			"Run unit tests (optionally with coverage)"
+			"Run unit tests (optionally with coverage)",
+			"Test failures",
+			"Finding test failures",
+			"Found test failures",
+			"Include test failure information"
 		],
 		"vs/workbench/contrib/testing/common/testingContentProvider": [
 			"The test run did not record any output."
@@ -45101,7 +47330,7 @@
 			"Whether the message shown in a peek view has a stack trace",
 			"Type of the item in the output peek view. Either a \"test\", \"message\", \"task\", or \"result\".",
 			"Type of menu where the configure testing profile submenu exists. Either \"run\", \"debug\", or \"coverage\"",
-			"Indicates whether continous test running is supported",
+			"Indicates whether continuous test running is supported",
 			"ID of the current test item, set when creating or opening menus on test items",
 			"Boolean indicating whether the test item has a URI defined",
 			"Boolean indicating whether the test item is hidden",
@@ -45231,6 +47460,11 @@
 			"supertypes of {0}",
 			"Type Hierarchy"
 		],
+		"vs/workbench/contrib/update/browser/postUpdateWidget": [
+			"Close",
+			"Release Notes",
+			"New in {0}"
+		],
 		"vs/workbench/contrib/update/browser/releaseNotesEditor": [
 			"Release Notes: {0}",
 			"Show release notes after an update",
@@ -45245,7 +47479,6 @@
 			"Downloading Update...",
 			"Installing Update...",
 			"Install Update... (1)",
-			"There are currently no updates available.",
 			"Welcome to {0} v{1}! Would you like to read the Release Notes?",
 			"Press the reload button to switch to the Insiders version of VS Code.",
 			"Press the reload button to switch to the Stable version of VS Code.",
@@ -45278,7 +47511,7 @@
 			"Show Release Notes",
 			"Open Current File as Release Notes",
 			"Show Update Info",
-			"Enter markdown to render (leave empty to load from URL)",
+			"Enter markdown to render, or JSON with markdown/buttons (leave empty to load from URL)",
 			"This version of {0} does not have release notes online",
 			"&&Update"
 		],
@@ -45318,9 +47551,6 @@
 			"Initializing update service...",
 			"Initializing",
 			"Install",
-			"See release notes for details on what's new in this release.",
-			"New Update Installed",
-			"New in {0}",
 			"Installing update, please wait...",
 			"Installing Update",
 			"Latest Version: {0}",
@@ -46003,16 +48233,13 @@
 			"Welcome to Visual Studio Code",
 			"You can change this anytime in Settings.",
 			"Choose your AI collaboration style",
+			"{0} selected",
 			"Back",
+			"Close",
 			"Continue without Signing In",
-			"Install",
-			"Installed",
-			"Could not install extension. You can install it later from the Extensions view.",
-			"Installing...",
-			"Recommended extensions",
-			"{0} by {1}: {2}",
 			"Get Started",
 			"Could not install {0} keymap. You can install it later from Extensions.",
+			"{0} keyboard mapping selected",
 			"Continue",
 			"Keyboard Mapping",
 			"Coming from another editor? Import your keyboard mapping to feel right at home.",
@@ -46025,20 +48252,18 @@
 			"Tip: Press ",
 			"Shift",
 			" to access all VS Code commands.",
+			"Agent",
+			"Describe a goal. The agent plans the approach, edits files, runs commands, and self-corrects. You review and approve along the way.",
 			"Agents tutorial",
-			"Cloud",
-			"Delegate tasks to a cloud agent that creates a branch, implements changes, and opens a pull request. The agent continues working even if you close VS Code.",
-			"Inline Suggestions",
-			"As you type, AI suggests completions and next edit predictions inline. Press ",
-			" to accept or ",
-			" to dismiss.",
-			"Esc",
-			"Tab",
-			"Local",
-			"Run agents interactively in the editor with full access to your workspace, tools, and terminal. Best for hands-on work where you want to review changes as they happen.",
+			"Customize Your Agents",
+			"Tailor Copilot to your project with custom instructions and agents, skills, reusable prompts, and MCP servers that connect to the tools and context you rely on.",
+			"Choose Your Agent",
+			"Agents That Work Your Way",
+			"Plan",
+			"Produce a structured implementation plan before any code changes, then hand it off to an implementation agent to execute.",
+			"Run Agents Anywhere",
+			"Run agents locally for interactive work, in the background with Copilot CLI, or in the cloud with cloud agents that open a pull request your team can review.",
 			"Sign in for AI Powered Features",
-			"Copilot CLI",
-			"Run agents autonomously in an isolated worktree on your machine. Work on something else while the agent builds, tests, and iterates in the background.",
 			"Continue with Apple",
 			". {0} Copilot may show ",
 			" suggestions and use your data to improve the product.",
@@ -46063,11 +48288,10 @@
 			"Continue with Google",
 			"Sign in to continue with AI-powered development.",
 			"Welcome to VS Code",
-			"Skip",
-			" to open Chat",
-			"Tip: Press ",
+			"Open Chat anytime with ",
 			"Step {0} of {1}: {2}",
-			"{0} of {1}"
+			"{0} of {1}",
+			"{0} theme selected"
 		],
 		"vs/workbench/contrib/welcomeOnboarding/browser/welcomeOnboarding.contribution": [
 			"Welcome Onboarding 2026"
@@ -46079,12 +48303,10 @@
 			"Inline suggestions plus a chat panel for deeper collaboration. A balance of writing and delegating.",
 			"I Write the Code",
 			"AI assists with suggestions and answers questions when you ask. You stay in control of every edit.",
-			"Meet Your Agentic Coding Partner",
-			"Tip: Press {0} to open Chat",
+			"Build with AI Agents",
+			"Open Chat anytime with {0}",
 			"Your AI Style",
 			"Choose how much AI collaboration fits your workflow",
-			"Supercharge Your Editor",
-			"Install extensions to enhance your workflow",
 			"Make It Yours",
 			"Choose your theme and keyboard mapping",
 			"Sign In",
@@ -46167,6 +48389,8 @@
 			"Restricted Mode is intended for safe code browsing. Trust this folder to enable all features.",
 			"Restricted Mode is intended for safe code browsing. Trust this window to enable all features.",
 			"Restricted Mode is intended for safe code browsing. Trust this workspace to enable all features.",
+			"Trusting this folder will also mark it as trusted in {0}.",
+			"Trusting this workspace will also mark it as trusted in {0}.",
 			"If you don't trust the authors of these files, we recommend to continue in restricted mode as the files may be malicious. See [our docs](https://aka.ms/vscode-workspace-trust) to learn more.",
 			"Restricted Mode: Some features are disabled because this folder is not trusted.",
 			"Restricted Mode: Some features are disabled because this window is not trusted.",
@@ -46311,6 +48535,7 @@
 			"&&Zoom Out",
 			"&&Reset Zoom",
 			"Quick Switch Window...",
+			"Switch to Main Window",
 			"Switch Window...",
 			"Select a window to switch to",
 			"Toggle Window Always on Top",
@@ -46475,13 +48700,15 @@
 			"The contributed issue reporter menu",
 			"Keyboard Shortcuts",
 			"Menu Contexts",
+			"The Changes view inline menu in the agents window.",
+			"The Changes view toolbar primary action submenu in the agents window.",
+			"The Changes view toolbar of the agents window.",
 			"The Source Control artifact context menu",
 			"The Source Control artifact group context menu",
 			"The Source Control inline change menu",
 			"Actions in the chat context usage details popup.",
 			"The create button in the Chat Customizations management editor.",
-			"Submenu for apply actions in the Chat Editing session changes toolbar.",
-			"The Chat Editing widget toolbar menu for session changes.",
+			"The item context menu in the Chat Customizations management editor, including inline actions.",
 			"The Chat Editing widget toolbar menu for session changes.",
 			"The Chat Editing widget toolbar menu for session title.",
 			"The inline gutter menu in the chat editor.",
@@ -46641,9 +48868,10 @@
 			"Learn More",
 			"OK",
 			"Copilot Business",
-			"Copilot EDU",
+			"Copilot Student",
 			"Copilot Enterprise",
 			"Copilot Free",
+			"Copilot Max",
 			"Copilot Pro",
 			"Copilot Pro+",
 			"Retry",
@@ -46806,6 +49034,7 @@
 			"Select new default editor for '{0}'"
 		],
 		"vs/workbench/services/editor/common/editorResolverService": [
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for diff views (for example `\"*.md\": \"vscode.markdown.preview.editor\"`). These override `workbench.editorAssociations` for diffs.",
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."
 		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
@@ -47195,6 +49424,17 @@
 		],
 		"vs/workbench/services/notification/common/notificationService": [
 			"Don't Show Again"
+		],
+		"vs/workbench/services/policies/browser/accountPolicyGateContribution": [
+			"Learn More",
+			"Your administrator restricts AI features to GitHub accounts in the following organizations: {0}. The account \"{1}\" is not a member of any of these.",
+			"Your administrator restricts AI features to specific GitHub accounts. The account \"{0}\" does not qualify.",
+			"Your administrator restricts AI features to specific GitHub accounts.",
+			"Sign In",
+			"Your administrator restricts AI features to GitHub accounts in the following organizations: {0}."
+		],
+		"vs/workbench/services/policies/common/accountPolicyService": [
+			"True when the 'Require Approved Account' policy is in effect and the user is not yet signed into an approved GitHub organization, so all AI features are disabled until they sign in."
 		],
 		"vs/workbench/services/preferences/browser/keybindingsEditorInput": [
 			"Icon of the keybindings editor label.",

--- a/packages/preferences/src/browser/views/components/preference-file-input.ts
+++ b/packages/preferences/src/browser/views/components/preference-file-input.ts
@@ -79,7 +79,7 @@ export class PreferenceSingleFilePathInputRenderer extends PreferenceStringInput
     protected createBrowseButton(parent: HTMLElement): void {
         const button = document.createElement('button');
         button.classList.add('theia-button', 'main', 'preference-file-button');
-        button.textContent = nls.localizeByDefault('Browse');
+        button.textContent = nls.localize('theia/preferences/input/browse', 'Browse');
         const handler = this.browse.bind(this);
         button.onclick = handler;
         button.onkeydown = handler;

--- a/packages/terminal-manager/src/browser/terminal-manager-tree-model.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-tree-model.ts
@@ -144,7 +144,7 @@ export class TerminalManagerTreeModel extends TreeModelImpl {
         const currentGroupNum = this.getNextGroupCounterForPage(pageId);
         return {
             id: groupId,
-            label: `${nls.localize('theia/terminal-manager/group', 'Group')} (${currentGroupNum})`,
+            label: `${nls.localizeByDefault('Group')} (${currentGroupNum})`,
             parent: undefined,
             selected: false,
             children: [],


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Bump API compatibility to 1.121.0
  - The bump unblocks extensions targeting 1.121.0
- Update nls.metadata for vscode API 1.121.0
  - Fix suggestions to use `nls.localizeByDefault` or replace removed defaults

No public API changes: `src/vscode-dts/vscode.d.ts` is unchanged between 1.116.1 and 1.121.0, so no `theia.d.ts` updates are required this cycle.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Check the filtered [vscode-theia-comparator/status](https://eclipse-theia.github.io/vscode-theia-comparator/status.html) with the current Theia master and VS Code 1.121.0
- Regarding nls update: CI Lint step is successful and no localization related warnings are shown on startup

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
