### PR TITLE
feat(ai-anthropic): discover official models from /v1/models

### DIFF
--- a/packages/ai-anthropic/README.md
+++ b/packages/ai-anthropic/README.md
@@ -12,9 +12,15 @@
 
 ## Description
 
-The `@theia/anthropic` integrates Anthropic's models with Theia AI.
-The Anthropic API key and the models to use can be configured via preferences.
-Alternatively the API key can also be handed in via the `ANTHROPIC_API_KEY` environment variable.
+The `@theia/anthropic` extension integrates Anthropic's models with Theia AI.
+
+The set of *official* Anthropic models is no longer configured via preferences. On startup, the extension fetches the available models from Anthropic's [`/v1/models`](https://docs.anthropic.com/en/api/models-list) endpoint, registers them with the Theia language model registry, and persists the response under the Theia configuration directory as `anthropic-models.json`. Subsequent startups read from the persisted snapshot to avoid hitting the network on every launch.
+
+Use the `Anthropic: Refresh Available Models` command (command palette) to force a re-fetch, e.g. after Anthropic publishes a new model.
+
+The Anthropic API key is configured via the `ai-features.anthropic.AnthropicApiKey` preference or, more securely, via the `ANTHROPIC_API_KEY` environment variable. Without a key (and without a previously persisted snapshot), no official models are registered until a key is provided.
+
+Custom Anthropic-API-compatible endpoints are still configured via the `ai-features.anthropicCustom.customAnthropicModels` preference.
 
 ## Additional Information
 

--- a/packages/ai-anthropic/src/browser/anthropic-command-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-command-contribution.ts
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Command, CommandContribution, CommandRegistry, MessageService, nls } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { AnthropicLanguageModelsManager } from '../common';
+
+const ANTHROPIC_CATEGORY = 'Anthropic';
+const ANTHROPIC_CATEGORY_KEY = nls.localize('theia/ai/anthropic/category', ANTHROPIC_CATEGORY);
+
+export const REFRESH_ANTHROPIC_MODELS_COMMAND = Command.toLocalizedCommand({
+    id: 'ai-features.anthropic.refreshModels',
+    category: ANTHROPIC_CATEGORY,
+    label: 'Refresh Available Models'
+}, 'theia/ai/anthropic/refreshModels', ANTHROPIC_CATEGORY_KEY);
+
+@injectable()
+export class AnthropicCommandContribution implements CommandContribution {
+
+    @inject(AnthropicLanguageModelsManager)
+    protected readonly manager: AnthropicLanguageModelsManager;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(REFRESH_ANTHROPIC_MODELS_COMMAND, {
+            execute: () => this.refresh()
+        });
+    }
+
+    protected async refresh(): Promise<void> {
+        try {
+            await this.manager.refreshModels();
+            this.messageService.info(nls.localize(
+                'theia/ai/anthropic/refreshModels/success',
+                'Anthropic models refreshed.'
+            ));
+        } catch (error) {
+            const message = error instanceof Error ? error.message : String(error);
+            this.messageService.error(nls.localize(
+                'theia/ai/anthropic/refreshModels/error',
+                'Failed to refresh Anthropic models: {0}',
+                message
+            ));
+        }
+    }
+}

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -17,11 +17,9 @@
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../common';
-import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF } from '../common/anthropic-preferences';
+import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF } from '../common/anthropic-preferences';
 import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES } from '@theia/ai-core/lib/common/ai-core-preferences';
 import { PreferenceService } from '@theia/core';
-
-const ANTHROPIC_PROVIDER_ID = 'anthropic';
 
 @injectable()
 export class AnthropicFrontendApplicationContribution implements FrontendApplicationContribution {
@@ -35,7 +33,6 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
     @inject(AICorePreferences)
     protected aiCorePreferences: AICorePreferences;
 
-    protected prevModels: string[] = [];
     protected prevCustomModels: Partial<AnthropicModelDescription>[] = [];
 
     onStart(): void {
@@ -46,9 +43,11 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             const proxyUri = this.preferenceService.get<string>('http.proxy', undefined);
             this.manager.setProxyUrl(proxyUri);
 
-            const models = this.preferenceService.get<string[]>(MODELS_PREF, []);
-            this.manager.createOrUpdateLanguageModels(...models.map(modelId => this.createAnthropicModelDescription(modelId)));
-            this.prevModels = [...models];
+            this.manager.setMaxRetries(this.aiCorePreferences.get(PREFERENCE_NAME_MAX_RETRIES) ?? 3);
+
+            // Kicks off discovery of official Anthropic models from `/v1/models`. Uses the persisted snapshot
+            // when present; otherwise fetches once. Subsequent refreshes are user-triggered via the command.
+            this.discoverModels();
 
             const customModels = this.preferenceService.get<Partial<AnthropicModelDescription>[]>(CUSTOM_ENDPOINTS_PREF, []);
             this.manager.createOrUpdateLanguageModels(...this.createCustomModelDescriptionsFromPreferences(customModels));
@@ -56,13 +55,17 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
 
             this.preferenceService.onPreferenceChanged(event => {
                 if (event.preferenceName === API_KEY_PREF) {
-                    this.manager.setApiKey(this.preferenceService.get<string>(API_KEY_PREF, undefined));
-                    this.updateAllModels();
-                } else if (event.preferenceName === MODELS_PREF) {
-                    this.handleModelChanges(this.preferenceService.get<string[]>(MODELS_PREF, []));
+                    const newKey = this.preferenceService.get<string>(API_KEY_PREF, undefined);
+                    this.manager.setApiKey(newKey);
+                    this.refreshCustomModels();
+                    // Re-discover when a key is configured so the user gets the model list as soon as one is available.
+                    // The discovery itself short-circuits when no key is set, so we can call it unconditionally.
+                    if (newKey) {
+                        this.discoverModels();
+                    }
                 } else if (event.preferenceName === 'http.proxy') {
                     this.manager.setProxyUrl(this.preferenceService.get<string>('http.proxy', undefined));
-                    this.updateAllModels();
+                    this.refreshCustomModels();
                 } else if (event.preferenceName === CUSTOM_ENDPOINTS_PREF) {
                     this.handleCustomModelChanges(this.preferenceService.get<Partial<AnthropicModelDescription>[]>(CUSTOM_ENDPOINTS_PREF, []));
                 }
@@ -70,22 +73,13 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
 
             this.aiCorePreferences.onPreferenceChanged(event => {
                 if (event.preferenceName === PREFERENCE_NAME_MAX_RETRIES) {
-                    this.updateAllModels();
+                    this.manager.setMaxRetries(this.aiCorePreferences.get(PREFERENCE_NAME_MAX_RETRIES) ?? 3);
+                    this.refreshCustomModels();
+                    // Re-apply the new retry count to the already-registered discovered models.
+                    this.discoverModels();
                 }
             });
         });
-    }
-
-    protected handleModelChanges(newModels: string[]): void {
-        const oldModels = new Set(this.prevModels);
-        const updatedModels = new Set(newModels);
-
-        const modelsToRemove = [...oldModels].filter(model => !updatedModels.has(model));
-        const modelsToAdd = [...updatedModels].filter(model => !oldModels.has(model));
-
-        this.manager.removeLanguageModels(...modelsToRemove.map(model => `${ANTHROPIC_PROVIDER_ID}/${model}`));
-        this.manager.createOrUpdateLanguageModels(...modelsToAdd.map(modelId => this.createAnthropicModelDescription(modelId)));
-        this.prevModels = newModels;
     }
 
     protected handleCustomModelChanges(newCustomModels: Partial<AnthropicModelDescription>[]): void {
@@ -108,27 +102,16 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
         this.prevCustomModels = [...newCustomModels];
     }
 
-    protected updateAllModels(): void {
-        const models = this.preferenceService.get<string[]>(MODELS_PREF, []);
-        this.manager.createOrUpdateLanguageModels(...models.map(modelId => this.createAnthropicModelDescription(modelId)));
-
-        const customModels = this.preferenceService.get<Partial<AnthropicModelDescription>[]>(CUSTOM_ENDPOINTS_PREF, []);
-        this.manager.createOrUpdateLanguageModels(...this.createCustomModelDescriptionsFromPreferences(customModels));
+    /** Fire-and-forget wrapper that logs unexpected errors instead of leaving them as unhandled rejections. */
+    protected discoverModels(): void {
+        this.manager.discoverModels().catch(error => {
+            console.warn('Anthropic: model discovery failed:', error instanceof Error ? error.message : error);
+        });
     }
 
-    /** Per-model details are resolved by the backend from the Anthropic /v1/models endpoint. */
-    protected createAnthropicModelDescription(modelId: string): AnthropicModelDescription {
-        const id = `${ANTHROPIC_PROVIDER_ID}/${modelId}`;
-        const maxRetries = this.aiCorePreferences.get(PREFERENCE_NAME_MAX_RETRIES) ?? 3;
-
-        return {
-            id: id,
-            model: modelId,
-            apiKey: true,
-            enableStreaming: true,
-            useCaching: true,
-            maxRetries: maxRetries
-        };
+    protected refreshCustomModels(): void {
+        const customModels = this.preferenceService.get<Partial<AnthropicModelDescription>[]>(CUSTOM_ENDPOINTS_PREF, []);
+        this.manager.createOrUpdateLanguageModels(...this.createCustomModelDescriptionsFromPreferences(customModels));
     }
 
     protected createCustomModelDescriptionsFromPreferences(preferences: Partial<AnthropicModelDescription>[]): AnthropicModelDescription[] {

--- a/packages/ai-anthropic/src/browser/anthropic-frontend-module.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-module.ts
@@ -18,13 +18,16 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { AnthropicPreferencesSchema } from '../common/anthropic-preferences';
 import { FrontendApplicationContribution, RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
 import { AnthropicFrontendApplicationContribution } from './anthropic-frontend-application-contribution';
+import { AnthropicCommandContribution } from './anthropic-command-contribution';
 import { ANTHROPIC_LANGUAGE_MODELS_MANAGER_PATH, AnthropicLanguageModelsManager } from '../common';
-import { PreferenceContribution } from '@theia/core';
+import { CommandContribution, PreferenceContribution } from '@theia/core';
 
 export default new ContainerModule(bind => {
     bind(PreferenceContribution).toConstantValue({ schema: AnthropicPreferencesSchema });
     bind(AnthropicFrontendApplicationContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(AnthropicFrontendApplicationContribution);
+    bind(AnthropicCommandContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(AnthropicCommandContribution);
     bind(AnthropicLanguageModelsManager).toDynamicValue(ctx => {
         const provider = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
         return provider.createProxy<AnthropicLanguageModelsManager>(ANTHROPIC_LANGUAGE_MODELS_MANAGER_PATH);

--- a/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
+++ b/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
@@ -36,6 +36,21 @@ export interface AnthropicLanguageModelsManager {
     apiKey: string | undefined;
     setApiKey(key: string | undefined): void;
     setProxyUrl(proxyUrl: string | undefined): void;
+    /**
+     * Sets the maximum number of retries to use when (re-)registering discovered official models.
+     * Custom endpoints carry their own `maxRetries` in their description.
+     */
+    setMaxRetries(maxRetries: number): void;
     createOrUpdateLanguageModels(...models: AnthropicModelDescription[]): Promise<void>;
-    removeLanguageModels(...modelIds: string[]): void
+    removeLanguageModels(...modelIds: string[]): void;
+    /**
+     * Discovers official Anthropic models from `/v1/models`, registers them with the language model registry,
+     * and persists the response under the Theia config directory so subsequent startups can skip the network call.
+     * Uses the persisted snapshot when present unless `force` is set.
+     */
+    discoverModels(force?: boolean): Promise<void>;
+    /**
+     * Invalidates the persisted snapshot and re-runs {@link discoverModels}.
+     */
+    refreshModels(): Promise<void>;
 }

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -18,7 +18,6 @@ import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-pre
 import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.anthropic.AnthropicApiKey';
-export const MODELS_PREF = 'ai-features.anthropic.AnthropicModels';
 export const CUSTOM_ENDPOINTS_PREF = 'ai-features.anthropicCustom.customAnthropicModels';
 
 export const AnthropicPreferencesSchema: PreferenceSchema = {
@@ -29,20 +28,6 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
                 'Enter an API Key of your official Anthropic Account. **Please note:** By using this preference the Anthropic API key will be stored in clear text\
             on the machine running Theia. Use the environment variable `ANTHROPIC_API_KEY` to set the key securely.') + LINUX_ENV_HINT,
             title: AI_CORE_PREFERENCES_TITLE,
-        },
-        [MODELS_PREF]: {
-            type: 'array',
-            description: nls.localize('theia/ai/anthropic/models/description', 'Official Anthropic models to use'),
-            title: AI_CORE_PREFERENCES_TITLE,
-            default: [
-                'claude-opus-4-7',
-                'claude-sonnet-4-6',
-                'claude-haiku-4-5',
-                'claude-opus-4-6',
-            ],
-            items: {
-                type: 'string'
-            }
         },
         [CUSTOM_ENDPOINTS_PREF]: {
             type: 'array',

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -238,7 +238,11 @@ export class AnthropicModel implements LanguageModel {
         public reasoningSupport?: ReasoningSupport,
         public reasoningApi?: ReasoningApi,
         public supportsXHighEffort?: boolean,
-        public maxInputTokens?: number
+        public maxInputTokens?: number,
+        public name?: string,
+        public vendor?: string,
+        public family?: string,
+        public maxOutputTokens?: number
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.spec.ts
@@ -16,9 +16,10 @@
 
 import { expect } from 'chai';
 import type { ModelInfo } from '@anthropic-ai/sdk/resources/models';
-import { ReasoningApi } from '@theia/ai-core';
+import { LanguageModel, ReasoningApi, ReasoningSupport } from '@theia/ai-core';
 import { AnthropicLanguageModelsManagerImpl } from './anthropic-language-models-manager-impl';
 import { AnthropicModelDescription } from '../common';
+import { AnthropicModel } from './anthropic-language-model';
 
 class TestableAnthropicManager extends AnthropicLanguageModelsManagerImpl {
     public retrieveCalls: string[] = [];
@@ -30,6 +31,10 @@ class TestableAnthropicManager extends AnthropicLanguageModelsManagerImpl {
 
     public callDeriveSupportsXHighEffort(info: ModelInfo | undefined): boolean | undefined {
         return this.deriveSupportsXHighEffort(info);
+    }
+
+    public callDeriveReasoningSupport(info: ModelInfo | undefined): ReasoningSupport | undefined {
+        return this.deriveReasoningSupport(info);
     }
 
     public callFetchModelInfo(
@@ -158,6 +163,111 @@ describe('AnthropicLanguageModelsManagerImpl - metadata derivation', () => {
             expect(manager.callDeriveSupportsXHighEffort(unsupported)).to.equal(false);
         });
     });
+
+    describe('deriveReasoningSupport', () => {
+        it('returns undefined when thinking is not supported', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: false, types: { adaptive: { supported: false }, enabled: { supported: false } } }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningSupport(info)).to.equal(undefined);
+        });
+
+        it('returns undefined when info is missing', () => {
+            expect(manager.callDeriveReasoningSupport(undefined)).to.equal(undefined);
+        });
+
+        it('exposes the full level set on the legacy budget API (budget_tokens scales continuously)', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: false }, enabled: { supported: true } } }
+                    // no effort capability — budget API does not advertise per-level flags
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningSupport(info)).to.deep.equal({
+                supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+                defaultLevel: 'auto'
+            });
+        });
+
+        it('returns [off, auto] on adaptive thinking when effort is not supported (e.g. Haiku 4.5)', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: true }, enabled: { supported: true } } },
+                    effort: {
+                        supported: false,
+                        low: { supported: false },
+                        medium: { supported: false },
+                        high: { supported: false },
+                        max: { supported: false }
+                    }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningSupport(info)).to.deep.equal({
+                supportedLevels: ['off', 'auto'],
+                defaultLevel: 'auto'
+            });
+        });
+
+        it('derives the full graded set on adaptive thinking when low/medium/high/max are all supported', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: true }, enabled: { supported: true } } },
+                    effort: {
+                        supported: true,
+                        low: { supported: true },
+                        medium: { supported: true },
+                        high: { supported: true },
+                        max: { supported: true }
+                    }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningSupport(info)).to.deep.equal({
+                supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+                defaultLevel: 'auto'
+            });
+        });
+
+        it('treats effort.xhigh as a substitute for effort.high when only xhigh is reported', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: true }, enabled: { supported: true } } },
+                    effort: {
+                        supported: true,
+                        low: { supported: true },
+                        medium: { supported: true },
+                        high: { supported: false },
+                        max: { supported: true },
+                        xhigh: { supported: true }
+                    }
+                }
+            } as Partial<ModelInfo>);
+            // medium still surfaces because xhigh.supported acts as the alternate carrier for 'medium' in
+            // the level→effort mapping in `anthropicReasoningFor`.
+            const result = manager.callDeriveReasoningSupport(info);
+            expect(result?.supportedLevels).to.deep.equal(['off', 'minimal', 'low', 'medium', 'high', 'auto']);
+        });
+
+        it('omits levels whose carrier effort value is not supported', () => {
+            const info = modelInfo({
+                capabilities: {
+                    thinking: { supported: true, types: { adaptive: { supported: true }, enabled: { supported: true } } },
+                    effort: {
+                        supported: true,
+                        low: { supported: false },   // -> minimal hidden
+                        medium: { supported: true }, // -> low
+                        high: { supported: true },   // -> medium
+                        max: { supported: false }    // -> high hidden
+                    }
+                }
+            } as Partial<ModelInfo>);
+            expect(manager.callDeriveReasoningSupport(info)).to.deep.equal({
+                supportedLevels: ['off', 'low', 'medium', 'auto'],
+                defaultLevel: 'auto'
+            });
+        });
+    });
 });
 
 describe('AnthropicLanguageModelsManagerImpl - fetchModelInfo cache', () => {
@@ -236,5 +346,230 @@ describe('AnthropicLanguageModelsManagerImpl - fetchModelInfo cache', () => {
         expect(r1).to.equal(expectedInfo);
         expect(r2).to.equal(expectedInfo);
         expect(manager.retrieveCalls).to.deep.equal(['::claude-x']);
+    });
+});
+
+class FakeLanguageModelRegistry {
+    public readonly models = new Map<string, LanguageModel>();
+    public readonly addCalls: string[][] = [];
+    public readonly removeCalls: string[][] = [];
+    public readonly patchCalls: string[] = [];
+
+    addLanguageModels(models: LanguageModel[]): void {
+        this.addCalls.push(models.map(m => m.id));
+        for (const m of models) {
+            this.models.set(m.id, m);
+        }
+    }
+    async getLanguageModel(id: string): Promise<LanguageModel | undefined> {
+        return this.models.get(id);
+    }
+    removeLanguageModels(ids: string[]): void {
+        this.removeCalls.push([...ids]);
+        for (const id of ids) {
+            this.models.delete(id);
+        }
+    }
+    async patchLanguageModel<T extends LanguageModel>(id: string, patch: Partial<T>): Promise<void> {
+        this.patchCalls.push(id);
+        const existing = this.models.get(id);
+        if (existing) {
+            Object.assign(existing, patch);
+        }
+    }
+}
+
+class DiscoveryTestableManager extends AnthropicLanguageModelsManagerImpl {
+    public stubbedSnapshotData: ModelInfo[] | undefined;
+    public stubbedSnapshotError: Error | undefined;
+    public fetchCount = 0;
+    public savedSnapshots: ModelInfo[][] = [];
+    public persistedSnapshot: ModelInfo[] | undefined;
+
+    constructor(registry: FakeLanguageModelRegistry) {
+        super();
+        (this as unknown as { languageModelRegistry: FakeLanguageModelRegistry }).languageModelRegistry = registry;
+    }
+
+    protected override async fetchSnapshot(_apiKey: string): Promise<{
+        readonly fetchedAt: string;
+        readonly endpoint: string;
+        readonly response: { readonly data: ModelInfo[] };
+    }> {
+        this.fetchCount += 1;
+        if (this.stubbedSnapshotError) {
+            throw this.stubbedSnapshotError;
+        }
+        return {
+            fetchedAt: '2026-05-29T00:00:00.000Z',
+            endpoint: 'https://api.anthropic.com',
+            response: { data: this.stubbedSnapshotData ?? [] }
+        };
+    }
+
+    protected override async loadSnapshot(): Promise<{
+        readonly fetchedAt: string;
+        readonly endpoint: string;
+        readonly response: { readonly data: ModelInfo[] };
+    } | undefined> {
+        if (!this.persistedSnapshot) {
+            return undefined;
+        }
+        return {
+            fetchedAt: '2026-05-29T00:00:00.000Z',
+            endpoint: 'https://api.anthropic.com',
+            response: { data: this.persistedSnapshot }
+        };
+    }
+
+    protected override async saveSnapshot(snapshot: {
+        readonly response: { readonly data: ModelInfo[] };
+    }): Promise<void> {
+        this.savedSnapshots.push(snapshot.response.data);
+        this.persistedSnapshot = snapshot.response.data;
+    }
+}
+
+function richInfo(id: string, overrides: Partial<ModelInfo> = {}): ModelInfo {
+    return ({
+        id,
+        type: 'model',
+        created_at: '2026-01-01T00:00:00Z',
+        display_name: `Display ${id}`,
+        max_input_tokens: 200000,
+        max_tokens: 64000,
+        ...overrides
+    }) as unknown as ModelInfo;
+}
+
+describe('AnthropicLanguageModelsManagerImpl - discoverModels', () => {
+    let registry: FakeLanguageModelRegistry;
+    let manager: DiscoveryTestableManager;
+
+    beforeEach(() => {
+        registry = new FakeLanguageModelRegistry();
+        manager = new DiscoveryTestableManager(registry);
+        manager.setApiKey('test-key');
+    });
+
+    it('does nothing when no API key and no persisted snapshot', async () => {
+        manager.setApiKey(undefined);
+        delete process.env.ANTHROPIC_API_KEY;
+        manager.stubbedSnapshotData = [richInfo('claude-opus-4-8')];
+        await manager.discoverModels();
+        expect(manager.fetchCount).to.equal(0);
+        expect(registry.addCalls).to.deep.equal([]);
+    });
+
+    it('fetches and registers all models on first run, persisting the snapshot', async () => {
+        manager.stubbedSnapshotData = [richInfo('claude-opus-4-8'), richInfo('claude-sonnet-4-6')];
+        await manager.discoverModels();
+        expect(manager.fetchCount).to.equal(1);
+        expect(registry.addCalls).to.have.lengthOf(2);
+        expect(registry.models.has('anthropic/claude-opus-4-8')).to.equal(true);
+        expect(registry.models.has('anthropic/claude-sonnet-4-6')).to.equal(true);
+        expect(manager.savedSnapshots).to.have.lengthOf(1);
+        expect(manager.savedSnapshots[0].map(m => m.id)).to.deep.equal(['claude-opus-4-8', 'claude-sonnet-4-6']);
+    });
+
+    it('uses the persisted snapshot on subsequent runs without re-fetching', async () => {
+        manager.persistedSnapshot = [richInfo('claude-opus-4-8')];
+        await manager.discoverModels();
+        expect(manager.fetchCount).to.equal(0);
+        expect(registry.models.has('anthropic/claude-opus-4-8')).to.equal(true);
+    });
+
+    it('forces re-fetch and rewrites the snapshot when refreshModels is called', async () => {
+        manager.persistedSnapshot = [richInfo('claude-opus-4-7')];
+        await manager.discoverModels();
+        expect(manager.fetchCount).to.equal(0);
+        // Now refresh with new data.
+        manager.stubbedSnapshotData = [richInfo('claude-opus-4-8')];
+        await manager.refreshModels();
+        expect(manager.fetchCount).to.equal(1);
+        // The previously registered model should be pruned.
+        expect(registry.models.has('anthropic/claude-opus-4-7')).to.equal(false);
+        expect(registry.models.has('anthropic/claude-opus-4-8')).to.equal(true);
+    });
+
+    it('shares an in-flight discovery between concurrent callers', async () => {
+        manager.stubbedSnapshotData = [richInfo('claude-x')];
+        const p1 = manager.discoverModels();
+        const p2 = manager.discoverModels();
+        await Promise.all([p1, p2]);
+        expect(manager.fetchCount).to.equal(1);
+    });
+
+    it('populates rich metadata on the registered model (name, max_input_tokens, vendor, family)', async () => {
+        // `name` is populated from the API's `display_name` so selectors / settings UI / tooltips can use it,
+        // while the chat-input dropdown renders the id directly for consistency — see the UI renderers.
+        manager.stubbedSnapshotData = [richInfo('claude-opus-4-8', {
+            display_name: 'Claude Opus 4.8',
+            max_input_tokens: 1000000,
+            max_tokens: 128000
+        })];
+        await manager.discoverModels();
+        const model = registry.models.get('anthropic/claude-opus-4-8') as AnthropicModel | undefined;
+        expect(model).to.not.equal(undefined);
+        expect(model!.name).to.equal('Claude Opus 4.8');
+        expect(model!.vendor).to.equal('Anthropic');
+        expect(model!.family).to.equal('claude-opus');
+        expect(model!.maxInputTokens).to.equal(1000000);
+        expect(model!.maxOutputTokens).to.equal(128000);
+        expect(model!.maxTokens).to.equal(128000);
+    });
+
+    it('does not persist a snapshot when fetching fails', async () => {
+        manager.stubbedSnapshotError = new Error('network down');
+        await manager.discoverModels();
+        expect(manager.savedSnapshots).to.deep.equal([]);
+        expect(registry.addCalls).to.deep.equal([]);
+    });
+
+    it('populates metadata from the persisted snapshot even when no API key is set', async () => {
+        // Realistic scenario: discovery succeeded previously, then the user cleared the API key.
+        // The snapshot still drives the token-usage warning, so name/maxInputTokens/maxOutputTokens must survive.
+        manager.setApiKey(undefined);
+        delete process.env.ANTHROPIC_API_KEY;
+        manager.persistedSnapshot = [richInfo('claude-opus-4-8', {
+            display_name: 'Claude Opus 4.8',
+            max_input_tokens: 1000000,
+            max_tokens: 128000
+        })];
+        await manager.discoverModels();
+        expect(manager.fetchCount).to.equal(0);
+        const model = registry.models.get('anthropic/claude-opus-4-8') as AnthropicModel | undefined;
+        expect(model).to.not.equal(undefined);
+        expect(model!.name).to.equal('Claude Opus 4.8');
+        expect(model!.maxInputTokens).to.equal(1000000);
+        expect(model!.maxOutputTokens).to.equal(128000);
+        // The status should reflect that there is no key yet — the model is registered but not ready.
+        expect(model!.status.status).to.equal('unavailable');
+    });
+
+    it('refresh always performs a real fetch even when a non-force discovery is in flight', async () => {
+        // Reproduces the race where a user triggers the refresh command right after startup.
+        manager.persistedSnapshot = [richInfo('claude-opus-4-7')];
+        manager.stubbedSnapshotData = [richInfo('claude-opus-4-8')];
+        const inFlight = manager.discoverModels(); // non-force, will load the persisted snapshot
+        const refresh = manager.refreshModels();   // must force-fetch, not piggy-back on the non-force load
+        await Promise.all([inFlight, refresh]);
+        expect(manager.fetchCount).to.equal(1);
+        expect(registry.models.has('anthropic/claude-opus-4-7')).to.equal(false);
+        expect(registry.models.has('anthropic/claude-opus-4-8')).to.equal(true);
+    });
+
+    it('clears the in-flight slot after a force discovery so subsequent non-force calls still run', async () => {
+        // Regression: `Promise.finally` returns a new promise, so the identity guard in the force branch
+        // must compare against the wrapped promise that is actually stored in `discoveryInFlight`.
+        // If the guard fails to clear the slot, the maxRetries-changed and API-key-changed handlers in the
+        // frontend contribution silently no-op after any refresh.
+        manager.persistedSnapshot = [richInfo('claude-x')];
+        manager.stubbedSnapshotData = [richInfo('claude-x')];
+        await manager.refreshModels(); // force — must release the in-flight slot in `finally`
+        manager.persistedSnapshot = [richInfo('claude-y')];
+        await manager.discoverModels(); // non-force — must actually run, not return a stale resolved promise
+        expect(registry.models.has('anthropic/claude-x')).to.equal(false);
+        expect(registry.models.has('anthropic/claude-y')).to.equal(true);
     });
 });

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -14,25 +14,50 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { LanguageModelRegistry, LanguageModelStatus, ReasoningApi, ReasoningSupport } from '@theia/ai-core';
+import { LanguageModelRegistry, LanguageModelStatus, ReasoningApi, ReasoningLevel, ReasoningSupport } from '@theia/ai-core';
 import { createProxyFetch, getProxyUrl } from '@theia/ai-core/lib/node';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { FileUri } from '@theia/core/lib/common/file-uri';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { Anthropic } from '@anthropic-ai/sdk';
 import type { ModelInfo } from '@anthropic-ai/sdk/resources/models';
+import * as fs from 'fs/promises';
+import * as path from 'path';
 import { AnthropicModel, DEFAULT_MAX_TOKENS } from './anthropic-language-model';
 import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../common';
 
-const ANTHROPIC_REASONING_SUPPORT: ReasoningSupport = {
-    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
-    defaultLevel: 'auto'
-};
+/**
+ * Full set of graded levels for Anthropic reasoning. Used as the default when the API does not
+ * publish per-level effort flags (legacy `'budget'` API, where `budget_tokens` is a continuous knob).
+ */
+const ANTHROPIC_FULL_REASONING_LEVELS: readonly ReasoningLevel[] = ['off', 'minimal', 'low', 'medium', 'high', 'auto'];
+
+const ANTHROPIC_PROVIDER_ID = 'anthropic';
+const DEFAULT_ANTHROPIC_ENDPOINT = 'https://api.anthropic.com';
+const SNAPSHOT_FILE_NAME = 'anthropic-models.json';
+const LIST_PAGE_SIZE = 100;
 
 interface ResolvedModelMetadata {
+    name?: string;
+    vendor?: string;
+    family?: string;
     maxInputTokens?: number;
     maxTokens: number;
+    maxOutputTokens?: number;
     reasoningSupport?: ReasoningSupport;
     reasoningApi?: ReasoningApi;
     supportsXHighEffort?: boolean;
+}
+
+interface ModelSnapshot {
+    /** ISO timestamp of when the snapshot was fetched. */
+    readonly fetchedAt: string;
+    /** Endpoint the snapshot was fetched against (default: official Anthropic endpoint). */
+    readonly endpoint: string;
+    /** The raw `/v1/models` response data array. */
+    readonly response: {
+        readonly data: ModelInfo[];
+    };
 }
 
 @injectable()
@@ -40,12 +65,22 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
 
     protected _apiKey: string | undefined;
     protected _proxyUrl: string | undefined;
+    /** Retry count applied to discovered official model descriptors; mirrors `ai-features.maxRetries`. */
+    protected _maxRetries: number = 3;
     // Cached `/v1/models` lookups keyed by `${baseURL}::${model}`. Successful lookups are kept for the process lifetime;
     // failed lookups are evicted so the next call retries.
     protected readonly modelInfoCache = new Map<string, Promise<ModelInfo>>();
 
+    /** IDs (`provider/model`) of officially discovered models, tracked so we can prune entries that disappear on refresh. */
+    protected readonly discoveredModelIds = new Set<string>();
+    /** Shared in-flight discovery promise so concurrent callers do not trigger redundant work. */
+    protected discoveryInFlight: Promise<void> | undefined;
+
     @inject(LanguageModelRegistry)
     protected readonly languageModelRegistry: LanguageModelRegistry;
+
+    @inject(EnvVariablesServer)
+    protected readonly envVariablesServer: EnvVariablesServer;
 
     get apiKey(): string | undefined {
         return this._apiKey ?? process.env.ANTHROPIC_API_KEY;
@@ -66,7 +101,7 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
             }
             return undefined;
         };
-        const proxyUrl = getProxyUrl(modelDescription.url ?? 'https://api.anthropic.com', this._proxyUrl);
+        const proxyUrl = getProxyUrl(modelDescription.url ?? DEFAULT_ANTHROPIC_ENDPOINT, this._proxyUrl);
 
         const apiKey = apiKeyProvider();
         const status = this.calculateStatus(modelDescription, apiKey);
@@ -90,7 +125,11 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                 reasoningSupport: metadata.reasoningSupport,
                 reasoningApi: metadata.reasoningApi,
                 supportsXHighEffort: metadata.supportsXHighEffort,
-                maxInputTokens: metadata.maxInputTokens
+                maxInputTokens: metadata.maxInputTokens,
+                name: metadata.name,
+                vendor: metadata.vendor,
+                family: metadata.family,
+                maxOutputTokens: metadata.maxOutputTokens
             });
         } else {
             this.languageModelRegistry.addLanguageModels([
@@ -108,7 +147,11 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                     metadata.reasoningSupport,
                     metadata.reasoningApi,
                     metadata.supportsXHighEffort,
-                    metadata.maxInputTokens
+                    metadata.maxInputTokens,
+                    metadata.name,
+                    metadata.vendor,
+                    metadata.family,
+                    metadata.maxOutputTokens
                 )
             ]);
         }
@@ -122,10 +165,20 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
     ): Promise<ResolvedModelMetadata> {
         const info = await this.fetchModelInfo(description, apiKey, proxyUrl);
         const reasoningApi = this.deriveReasoningApi(info);
+        const maxTokens = info?.max_tokens ?? DEFAULT_MAX_TOKENS;
+        // The API's `display_name` is the canonical human-readable name; it populates `name` so other
+        // consumers (selectors, settings UI, tooltips) can use it. The chat-input dropdown intentionally
+        // renders `model.id` rather than `model.name` so its label always equals the value actually selected
+        // — see `language-model-renderer.tsx` and `model-aliases-configuration-widget.tsx`.
         return {
+            name: info?.display_name,
+            vendor: 'Anthropic',
+            family: this.deriveFamily(description.model),
             maxInputTokens: info?.max_input_tokens ?? undefined,
-            maxTokens: info?.max_tokens ?? DEFAULT_MAX_TOKENS,
-            reasoningSupport: reasoningApi ? ANTHROPIC_REASONING_SUPPORT : undefined,
+            maxTokens,
+            // The Messages API returns a single output cap; mirror it onto the metadata so the UI sees it.
+            maxOutputTokens: info?.max_tokens ?? undefined,
+            reasoningSupport: this.deriveReasoningSupport(info),
             reasoningApi,
             supportsXHighEffort: this.deriveSupportsXHighEffort(info)
         };
@@ -136,13 +189,15 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
         apiKey: string | undefined,
         proxyUrl: string | undefined
     ): Promise<ModelInfo | undefined> {
-        if (!apiKey) {
-            return undefined;
-        }
-        const cacheKey = `${modelDescription.url ?? ''}::${modelDescription.model}`;
+        // Consult the cache first — discovered models prime it from the snapshot, so the metadata is still
+        // available even when no API key is currently configured (e.g. user cleared the key after discovery).
+        const cacheKey = this.cacheKeyFor(modelDescription.url, modelDescription.model);
         const cached = this.modelInfoCache.get(cacheKey);
         if (cached) {
             return cached;
+        }
+        if (!apiKey) {
+            return undefined;
         }
         const fetchPromise = this.retrieveModelInfo(modelDescription, apiKey, proxyUrl);
         this.modelInfoCache.set(cacheKey, fetchPromise);
@@ -175,10 +230,10 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
         if (!thinking?.supported) {
             return undefined;
         }
-        if (thinking.types.adaptive.supported) {
+        if (thinking.types?.adaptive?.supported) {
             return 'effort';
         }
-        if (thinking.types.enabled.supported) {
+        if (thinking.types?.enabled?.supported) {
             return 'budget';
         }
         return undefined;
@@ -186,11 +241,212 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
 
     protected deriveSupportsXHighEffort(info: ModelInfo | undefined): boolean | undefined {
         const xhigh = info?.capabilities?.effort?.xhigh;
-        return xhigh ? xhigh.supported : undefined;
+        return xhigh ? !!xhigh.supported : undefined;
+    }
+
+    /**
+     * Derives a per-model {@link ReasoningSupport} from the API's `capabilities.thinking` /
+     * `capabilities.effort` flags.
+     *
+     * - Models without `thinking.supported` get `undefined` — the chat-input selector is hidden.
+     * - Models on the legacy `'budget'` API expose all six levels (budget tokens scale smoothly).
+     * - Models on the adaptive `'effort'` API expose `off`/`auto` plus whichever graded levels the API
+     *   reports. The mapping mirrors {@link anthropicReasoningFor}:
+     *   - `minimal` requires `effort.low`
+     *   - `low`     requires `effort.medium`
+     *   - `medium`  requires `effort.high` or `effort.xhigh`
+     *   - `high`    requires `effort.max`
+     *
+     *   When `effort.supported === false` (e.g. Haiku 4.5 — adaptive thinking only, no graded effort),
+     *   the result collapses to `['off', 'auto']`.
+     */
+    protected deriveReasoningSupport(info: ModelInfo | undefined): ReasoningSupport | undefined {
+        const thinking = info?.capabilities?.thinking;
+        if (!thinking?.supported) {
+            return undefined;
+        }
+        const reasoningApi = this.deriveReasoningApi(info);
+        if (!reasoningApi) {
+            // thinking is supported but neither known API shape is — nothing actionable to expose.
+            return undefined;
+        }
+        if (reasoningApi === 'budget') {
+            return { supportedLevels: [...ANTHROPIC_FULL_REASONING_LEVELS], defaultLevel: 'auto' };
+        }
+        // 'effort' API: derive the graded set from per-level supported flags.
+        const effort = info?.capabilities?.effort;
+        const levels: ReasoningLevel[] = ['off'];
+        if (effort?.supported) {
+            if (effort.low?.supported) {
+                levels.push('minimal');
+            }
+            if (effort.medium?.supported) {
+                levels.push('low');
+            }
+            if (effort.high?.supported || effort.xhigh?.supported) {
+                levels.push('medium');
+            }
+            if (effort.max?.supported) {
+                levels.push('high');
+            }
+        }
+        levels.push('auto');
+        return { supportedLevels: levels, defaultLevel: 'auto' };
+    }
+
+    /** Returns a coarse family identifier (e.g. 'claude-opus', 'claude-sonnet'); falls back to undefined for unrecognized ids. */
+    protected deriveFamily(modelId: string): string | undefined {
+        const match = modelId.match(/^(claude-(?:opus|sonnet|haiku))(?:-|$)/i);
+        return match ? match[1].toLowerCase() : undefined;
+    }
+
+    /**
+     * Discovers official Anthropic models. Uses the persisted snapshot when present unless {@link force} is true.
+     * Concurrent non-force invocations share the same in-flight promise. A {@link force} call always runs
+     * a real fetch — if one is already in flight, it is chained after it so the user always gets fresh data.
+     */
+    async discoverModels(force: boolean = false): Promise<void> {
+        if (force) {
+            const previous = this.discoveryInFlight ?? Promise.resolve();
+            // Capture the wrapped promise so the finally cleanup can identity-compare against the same
+            // object that we store in `discoveryInFlight` (`Promise.finally` returns a *new* promise).
+            const wrapped: Promise<void> = previous
+                .catch(() => undefined)
+                .then(() => this.doDiscoverModels(true))
+                .finally(() => {
+                    if (this.discoveryInFlight === wrapped) {
+                        this.discoveryInFlight = undefined;
+                    }
+                });
+            this.discoveryInFlight = wrapped;
+            return wrapped;
+        }
+        if (!this.discoveryInFlight) {
+            this.discoveryInFlight = this.doDiscoverModels(false).finally(() => {
+                this.discoveryInFlight = undefined;
+            });
+        }
+        return this.discoveryInFlight;
+    }
+
+    async refreshModels(): Promise<void> {
+        await this.discoverModels(true);
+    }
+
+    protected async doDiscoverModels(force: boolean): Promise<void> {
+        const apiKey = this.apiKey;
+        let snapshot: ModelSnapshot | undefined;
+        if (!force) {
+            snapshot = await this.loadSnapshot();
+        }
+        if (!snapshot) {
+            if (!apiKey) {
+                // No key and no cached snapshot: nothing to register. Frontend retries this on key change.
+                return;
+            }
+            try {
+                snapshot = await this.fetchSnapshot(apiKey);
+                await this.saveSnapshot(snapshot);
+            } catch (error) {
+                console.warn('Anthropic: failed to discover models from /v1/models:',
+                    error instanceof Error ? error.message : error);
+                return;
+            }
+        }
+
+        const entries = snapshot.response.data;
+        const newIds = new Set<string>();
+        const descriptions: AnthropicModelDescription[] = [];
+        for (const info of entries) {
+            const id = `${ANTHROPIC_PROVIDER_ID}/${info.id}`;
+            newIds.add(id);
+            // Prime the per-model cache so createOrUpdateLanguageModel does not trigger a separate retrieve() call.
+            const cacheKey = this.cacheKeyFor(undefined, info.id);
+            if (!this.modelInfoCache.has(cacheKey)) {
+                this.modelInfoCache.set(cacheKey, Promise.resolve(info));
+            }
+            descriptions.push({
+                id,
+                model: info.id,
+                apiKey: true,
+                enableStreaming: true,
+                useCaching: true,
+                maxRetries: this._maxRetries
+            });
+        }
+
+        // Remove previously discovered models that disappeared from the new list.
+        const toRemove = [...this.discoveredModelIds].filter(id => !newIds.has(id));
+        if (toRemove.length > 0) {
+            this.removeLanguageModels(...toRemove);
+        }
+
+        await this.createOrUpdateLanguageModels(...descriptions);
+
+        this.discoveredModelIds.clear();
+        newIds.forEach(id => this.discoveredModelIds.add(id));
+    }
+
+    /** Drains the auto-paginating `/v1/models` response into a snapshot. */
+    protected async fetchSnapshot(apiKey: string): Promise<ModelSnapshot> {
+        const anthropic = new Anthropic({
+            apiKey,
+            fetch: createProxyFetch(this._proxyUrl)
+        });
+        const data: ModelInfo[] = [];
+        for await (const info of anthropic.models.list({ limit: LIST_PAGE_SIZE })) {
+            data.push(info);
+        }
+        return {
+            fetchedAt: new Date().toISOString(),
+            endpoint: DEFAULT_ANTHROPIC_ENDPOINT,
+            response: { data }
+        };
+    }
+
+    protected async getSnapshotPath(): Promise<string> {
+        const configDirUri = await this.envVariablesServer.getConfigDirUri();
+        const configDirPath = FileUri.fsPath(configDirUri);
+        return path.join(configDirPath, SNAPSHOT_FILE_NAME);
+    }
+
+    protected async loadSnapshot(): Promise<ModelSnapshot | undefined> {
+        try {
+            const filePath = await this.getSnapshotPath();
+            const content = await fs.readFile(filePath, 'utf8');
+            const parsed = JSON.parse(content) as Partial<ModelSnapshot>;
+            if (!parsed?.response?.data || !Array.isArray(parsed.response.data)) {
+                return undefined;
+            }
+            return parsed as ModelSnapshot;
+        } catch (error) {
+            const code = (error as NodeJS.ErrnoException | undefined)?.code;
+            if (code !== 'ENOENT') {
+                console.warn('Anthropic: failed to read model snapshot:',
+                    error instanceof Error ? error.message : error);
+            }
+            return undefined;
+        }
+    }
+
+    protected async saveSnapshot(snapshot: ModelSnapshot): Promise<void> {
+        try {
+            const filePath = await this.getSnapshotPath();
+            await fs.mkdir(path.dirname(filePath), { recursive: true });
+            await fs.writeFile(filePath, JSON.stringify(snapshot, undefined, 2), 'utf8');
+        } catch (error) {
+            console.warn('Anthropic: failed to persist model snapshot:',
+                error instanceof Error ? error.message : error);
+        }
+    }
+
+    protected cacheKeyFor(baseUrl: string | undefined, model: string): string {
+        return `${baseUrl ?? ''}::${model}`;
     }
 
     removeLanguageModels(...modelIds: string[]): void {
         this.languageModelRegistry.removeLanguageModels(modelIds);
+        modelIds.forEach(id => this.discoveredModelIds.delete(id));
     }
 
     setApiKey(apiKey: string | undefined): void {
@@ -207,6 +463,10 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
         } else {
             this._proxyUrl = undefined;
         }
+    }
+
+    setMaxRetries(maxRetries: number): void {
+        this._maxRetries = maxRetries;
     }
 
     protected calculateStatus(modelDescription: AnthropicModelDescription, effectiveApiKey: string | undefined): LanguageModelStatus {

--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -65,7 +65,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/fast',
             defaultModelIds: [
-                'anthropic/claude-haiku-4-5',
+                'anthropic/claude-haiku-4-5-20251001',
                 'openai/gpt-5.4-mini',
                 'google/gemini-3.5-flash'
             ],

--- a/packages/ai-ide/src/browser/ai-configuration/language-model-renderer.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/language-model-renderer.tsx
@@ -114,16 +114,16 @@ export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
                                     {nls.localize('theia/ai/core/languageModelRenderer/alias', '[alias] {0}', alias.id)}
                                 </option>
                             ))}
-                            {languageModels?.sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id)).map(model => {
+                            {languageModels?.sort((a, b) => a.id.localeCompare(b.id)).map(model => {
                                 const isNotReady = model.status.status !== 'ready';
                                 return (
                                     <option
                                         key={model.id}
                                         value={model.id}
                                         className={isNotReady ? 'ai-language-model-item-not-ready' : 'ai-language-model-item-ready'}
-                                        title={isNotReady && model.status.message ? model.status.message : undefined}
+                                        title={isNotReady && model.status.message ? model.status.message : model.name}
                                     >
-                                        {model.name ?? model.id} {isNotReady ? '✗' : '✓'}
+                                        {model.id} {isNotReady ? '✗' : '✓'}
                                     </option>
                                 );
                             })}
@@ -134,8 +134,8 @@ export const LanguageModelRenderer: React.FC<LanguageModelSettingsProps> = (
                         <div className="ai-configuration-value-row">
                             <span className="ai-configuration-value-row-label">{nls.localize('theia/ai/core/modelAliasesConfiguration/evaluatesTo', 'Evaluates to')}:</span>
                             {resolvedModel ? (
-                                <span className="ai-configuration-value-row-value">
-                                    {resolvedModel.name ?? resolvedModel.id}
+                                <span className="ai-configuration-value-row-value" title={resolvedModel.name}>
+                                    {resolvedModel.id}
                                     {resolvedModel.status.status === 'ready' ? (
                                         <span className="ai-model-status-ready"
                                             title={nls.localize('theia/ai/core/modelAliasesConfiguration/modelReadyTooltip', 'Ready')}>✓</span>

--- a/packages/ai-ide/src/browser/ai-configuration/model-aliases-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/model-aliases-configuration-widget.tsx
@@ -176,7 +176,7 @@ export class ModelAliasesConfigurationWidget extends AIListDetailConfigurationWi
                             {nls.localize('theia/ai/core/modelAliasesConfiguration/defaultList', '[Default list]')}
                         </option>
                         {[...this.languageModels]
-                            .sort((a, b) => (a.name ?? a.id).localeCompare(b.name ?? b.id))
+                            .sort((a, b) => a.id.localeCompare(b.id))
                             .map(model => {
                                 const isNotReady = model.status.status !== 'ready';
                                 return (
@@ -184,9 +184,9 @@ export class ModelAliasesConfigurationWidget extends AIListDetailConfigurationWi
                                         key={model.id}
                                         value={model.id}
                                         className={isNotReady ? 'ai-language-model-item-not-ready' : 'ai-language-model-item-ready'}
-                                        title={isNotReady && model.status.message ? model.status.message : undefined}
+                                        title={isNotReady && model.status.message ? model.status.message : model.name}
                                     >
-                                        {model.name ?? model.id} {isNotReady ? '✗' : '✓'}
+                                        {model.id} {isNotReady ? '✗' : '✓'}
                                     </option>
                                 );
                             }
@@ -228,8 +228,8 @@ export class ModelAliasesConfigurationWidget extends AIListDetailConfigurationWi
                             className="ai-alias-evaluates-to-section"
                         >
                             {resolvedModel ? (
-                                <span className="ai-alias-evaluates-to-value">
-                                    {resolvedModel.name ?? resolvedModel.id}
+                                <span className="ai-alias-evaluates-to-value" title={resolvedModel.name}>
+                                    {resolvedModel.id}
                                     {resolvedModel.status.status === 'ready' ? (
                                         <span className="ai-model-status-ready"
                                             title={nls.localize('theia/ai/core/modelAliasesConfiguration/modelReadyTooltip', 'Ready')}>✓</span>


### PR DESCRIPTION
#### What it does

The set of *official* Anthropic models is no longer driven by a hard-coded preference. On startup, `@theia/ai-anthropic` calls `anthropic.models.list()` once, registers one `LanguageModel` per returned entry, and persists the response to `<configDir>/anthropic-models.json`. A new command `Anthropic: Refresh Available Models` force-refreshes the snapshot from the API.

This removes the `ai-features.anthropic.AnthropicModels` preference and its stale defaults — notably the default `claude-haiku-4-5`, which never existed (the real id is `claude-haiku-4-5-20251001`). The `default/fast` alias in `@theia/ai-core` is also corrected to the real Haiku id so the alias actually resolves to an Anthropic model. The `ai-features.anthropicCustom.customAnthropicModels` preference is unchanged.

The richer fields returned by `/v1/models` populate per-model metadata that was previously empty or hard-coded:

- `display_name` → `LanguageModelMetaData.name` (used for selectors / tooltips)
- `max_input_tokens` → `maxInputTokens` (drives the chat token-usage warning with real per-model context windows instead of the 200 k fallback)
- `max_tokens` → `maxTokens` / `maxOutputTokens`
- `capabilities.thinking` + `capabilities.effort` → per-model `ReasoningSupport.supportedLevels` (e.g. Haiku 4.5 reports `effort.supported === false`, so its dropdown collapses to `['off', 'auto']`; Opus 4.7/4.8 expose the full graded set)
- constant `vendor='Anthropic'` and a `family` derived from the id

The chat-input model dropdown now renders `model.id` instead of `model.name ?? model.id`, so the visible label equals the persisted value (consistent with every other provider). The display name remains accessible as a tooltip via the option's `title` attribute and in the "evaluates to" row of the alias config.

#### How to test

1. Configure an Anthropic API key. Start the app — the official Anthropic models appear in the model selector with their full ids (`anthropic/claude-opus-4-8`, `anthropic/claude-haiku-4-5-20251001`, …) and `<configDir>/anthropic-models.json` exists after first run. Hover any option to see the display name as a tooltip.
2. Token-usage warning: switch the agent to an Anthropic model with a 1 M context window (e.g. Sonnet 4) and confirm the threshold is computed against 1 M instead of the 200 k fallback.
3. Reasoning selector: switch the agent to `claude-haiku-4-5-20251001` and confirm only `Off` / `Auto` are shown. Switch to `claude-opus-4-8` and confirm all six levels are shown.
4. Run "Anthropic: Refresh Available Models" — a success toast appears and the snapshot file is rewritten.
5. Verify the `ai-features.anthropic.AnthropicModels` preference is gone and `ai-features.anthropicCustom.customAnthropicModels` still works.
6. Pick an agent that uses the `default/fast` alias and confirm it resolves to a real Anthropic Haiku model.

#### Follow-ups

- **Generalize to other providers.** Anthropic-only for this PR; OpenAI's `/v1/models` returns only id/created/owned_by so the same approach wouldn't add metadata, and Google needs a different endpoint shape. The snapshot path is namespaced (`<configDir>/<provider>-models.json`) so a future extraction is mechanical.

#### Breaking changes

- [] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- N/A -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
