### PR TITLE
ai-mcp: focus window and reveal registry view on install link

### DIFF
--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.spec.ts
@@ -28,6 +28,7 @@ try {
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
 import { MessageService, PreferenceService } from '@theia/core';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import URI from '@theia/core/lib/common/uri';
 import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
 import { MCPFrontendService } from '../common/mcp-server-manager';
@@ -60,9 +61,17 @@ class FakeMessageService {
     }
 }
 
+class FakeWindowService {
+    public focusCount = 0;
+    focus(): void {
+        this.focusCount++;
+    }
+}
+
 class FakeRegistryBridge implements MCPRegistryUiBridge {
     readonly onDidChange = () => ({ dispose: () => undefined });
     private readonly entries = new Map<string, MCPInstallEntry>();
+    public openedServerIds: (string | undefined)[] = [];
     setEntry(serverId: string, entry: MCPInstallEntry): void {
         this.entries.set(serverId, entry);
     }
@@ -73,7 +82,9 @@ class FakeRegistryBridge implements MCPRegistryUiBridge {
     getInstallEntry(serverId: string): MCPInstallEntry | undefined {
         return this.entries.get(serverId);
     }
-    async openRegistry(): Promise<void> { /* no-op */ }
+    async openRegistry(serverId?: string): Promise<void> {
+        this.openedServerIds.push(serverId);
+    }
 }
 
 class FakeConfiguration extends MCPInstallUriConfiguration {
@@ -87,20 +98,31 @@ function buildHandler(options: {
     scheme?: string;
     prefs?: FakePreferenceService;
     messages?: FakeMessageService;
-} = {}): { handler: InstallMcpUriHandler; messages: FakeMessageService; prefs: FakePreferenceService; bridge: FakeRegistryBridge | undefined } {
+    windowService?: FakeWindowService;
+    installDialogFactory?: MCPServerInstallDialogFactory;
+} = {}): {
+    handler: InstallMcpUriHandler;
+    messages: FakeMessageService;
+    prefs: FakePreferenceService;
+    windowService: FakeWindowService;
+    bridge: FakeRegistryBridge | undefined;
+} {
     const container = new Container();
     const prefs = options.prefs ?? new FakePreferenceService();
     const messages = options.messages ?? new FakeMessageService();
+    const windowService = options.windowService ?? new FakeWindowService();
     container.bind(PreferenceService).toConstantValue(prefs as unknown as PreferenceService);
     container.bind(MessageService).toConstantValue(messages as unknown as MessageService);
+    container.bind(WindowService).toConstantValue(windowService as unknown as WindowService);
     container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
-    // The error-path tests never open a dialog; bind factories that fail loudly if used.
+    // The error-path tests never open a dialog; bind a factory that fails loudly if used,
+    // unless a test supplies its own.
     container.bind(MCPServerEditDialogFactory).toConstantValue(() => {
         throw new Error('MCPServerEditDialogFactory should not be invoked in these tests');
     });
-    container.bind(MCPServerInstallDialogFactory).toConstantValue(() => {
+    container.bind(MCPServerInstallDialogFactory).toConstantValue(options.installDialogFactory ?? (() => {
         throw new Error('MCPServerInstallDialogFactory should not be invoked in these tests');
-    });
+    }));
     container.bind(MCPServerEditorImpl).toSelf().inSingletonScope();
     container.bind(MCPServerEditor).toService(MCPServerEditorImpl);
     container.bind(MCPInstallUriConfiguration).toConstantValue(new FakeConfiguration(options.scheme ?? 'theia'));
@@ -108,7 +130,7 @@ function buildHandler(options: {
         container.bind(MCPRegistryUiBridge).toConstantValue(options.bridge);
     }
     container.bind(InstallMcpUriHandler).toSelf().inSingletonScope();
-    return { handler: container.get(InstallMcpUriHandler), messages, prefs, bridge: options.bridge };
+    return { handler: container.get(InstallMcpUriHandler), messages, prefs, windowService, bridge: options.bridge };
 }
 
 describe('InstallMcpUriHandler.canHandle', () => {
@@ -132,11 +154,12 @@ describe('InstallMcpUriHandler.canHandle', () => {
 
 describe('InstallMcpUriHandler.open', () => {
 
-    it('reports an error and does not write the preference when the URI carries no id', async () => {
-        const { handler, messages, prefs } = buildHandler({ bridge: new FakeRegistryBridge() });
+    it('focuses the window and reports an error and does not write the preference when the URI carries no id', async () => {
+        const { handler, messages, prefs, windowService } = buildHandler({ bridge: new FakeRegistryBridge() });
 
         await handler.open(new URI('theia://install-mcp'));
 
+        expect(windowService.focusCount).to.equal(1);
         expect(messages.errors).to.have.length(1);
         expect(messages.errors[0]).to.match(/missing the required "id"/i);
         expect(prefs.get(MCP_SERVERS_PREF)).to.be.undefined;
@@ -160,6 +183,7 @@ describe('InstallMcpUriHandler.open', () => {
 
         expect(messages.errors).to.have.length(1);
         expect(messages.errors[0]).to.match(/is not listed in your AI registry/i);
+        expect(bridge.openedServerIds).to.be.empty;
     });
 
     it('trims whitespace around the id parameter and treats an empty id as missing', async () => {
@@ -168,5 +192,23 @@ describe('InstallMcpUriHandler.open', () => {
         await handler.open(new URI('theia://install-mcp?id=%20%20'));
 
         expect(messages.errors[0]).to.match(/missing the required "id"/i);
+    });
+
+    it('focuses the window, reveals the registry search for the id, then opens the install dialog for a known id', async () => {
+        const bridge = new FakeRegistryBridge();
+        bridge.setEntry('io.example/foo', { localName: 'foo', config: { command: 'npx', args: [] }, serverId: 'io.example/foo' });
+        let dialogOpened = false;
+        // Cancel the dialog (open resolves undefined) so the test stops before the actual install.
+        const installDialogFactory = (() => ({
+            open: async () => { dialogOpened = true; return undefined; }
+        })) as unknown as MCPServerInstallDialogFactory;
+        const { handler, windowService } = buildHandler({ bridge, installDialogFactory });
+
+        await handler.open(new URI('theia://install-mcp?id=io.example/foo'));
+
+        expect(windowService.focusCount).to.equal(1);
+        // The registry view is revealed and the id searched before the install dialog opens.
+        expect(bridge.openedServerIds).to.deep.equal(['io.example/foo']);
+        expect(dialogOpened).to.be.true;
     });
 });

--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
@@ -18,6 +18,7 @@ import { MessageService, nls, PreferenceService } from '@theia/core';
 import URI from '@theia/core/lib/common/uri';
 import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
 import { OpenHandler } from '@theia/core/lib/browser/opener-service';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { MCP_SERVERS_PREF } from '../common/mcp-preferences';
 import { MCPServerEditor } from './mcp-server-editor';
@@ -32,6 +33,10 @@ const ID_PARAM = 'id';
  * minimal: the install configuration, version, display name and content hash are all
  * read from the configured AI registry by id. This guarantees the user installs exactly
  * what the registry currently publishes and keeps install links short and stable.
+ *
+ * Opening such a link brings the IDE window to the foreground, reveals the AI registry
+ * (Extensions) view with the `serverId` searched so the entry is in focus, and then opens
+ * the install dialog for that entry.
  *
  * Lives in `@theia/ai-mcp` so products without the registry package still receive the
  * URL - but installation only succeeds when an `MCPRegistryUiBridge` is bound and the
@@ -50,6 +55,9 @@ export class InstallMcpUriHandler implements OpenHandler {
 
     @inject(MessageService)
     protected readonly messageService: MessageService;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
 
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
@@ -71,6 +79,7 @@ export class InstallMcpUriHandler implements OpenHandler {
 
     async open(uri: URI): Promise<object | undefined> {
         const serverId = this.extractServerId(uri);
+        this.windowService.focus();
         if (!serverId) {
             this.messageService.error(nls.localize(
                 'theia/ai-mcp/installUri/missingId',
@@ -98,6 +107,7 @@ export class InstallMcpUriHandler implements OpenHandler {
             ));
             return undefined;
         }
+        await this.registryBridge.openRegistry(serverId);
         if (this.isAlreadyInstalled(entry.localName) && !await this.confirmOverwrite(entry.localName)) {
             return undefined;
         }

--- a/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
@@ -15,12 +15,11 @@
 // *****************************************************************************
 
 import { Emitter, Event } from '@theia/core';
-import { ApplicationShell, WidgetManager } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
 import { MCPInstallEntry } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
-import { VSXExtensionsViewContainer } from '@theia/vsx-registry/lib/browser/vsx-extensions-view-container';
+import { VSXExtensionsContribution } from '@theia/vsx-registry/lib/browser/vsx-extensions-contribution';
 import { VSXExtensionsSearchModel } from '@theia/vsx-registry/lib/browser/vsx-extensions-search-model';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
@@ -31,11 +30,8 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
     @inject(RegistryFetchService)
     protected readonly fetchService: RegistryFetchService;
 
-    @inject(WidgetManager)
-    protected readonly widgetManager: WidgetManager;
-
-    @inject(ApplicationShell)
-    protected readonly shell: ApplicationShell;
+    @inject(VSXExtensionsContribution)
+    protected readonly viewContribution: VSXExtensionsContribution;
 
     @inject(VSXExtensionsSearchModel)
     protected readonly searchModel: VSXExtensionsSearchModel;
@@ -88,11 +84,7 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
         if (serverId && this.hasServer(serverId)) {
             this.searchModel.query = serverId;
         }
-        // Reveal-and-activate rather than toggle: a second click on "Browse AI registry"
-        // must keep the view visible, not collapse it again.
-        const widget = await this.widgetManager.getOrCreateWidget(VSXExtensionsViewContainer.ID);
-        await this.shell.revealWidget(widget.id);
-        await this.shell.activateWidget(widget.id);
+        await this.viewContribution.openView({ activate: true });
     }
 
     protected async refreshCache(): Promise<void> {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
When an install MCP URI is opened, bring the IDE window to the foreground and reveal the AI registry view with the serverId searched before showing the install dialog, so the targeted entry is in focus.

Use VSXExtensionsContribution.openView instead of manually reveal/activate-ing the widget in MCPRegistryUiBridgeImpl.
<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
1. Start the electron app: `npm run start:electron`.
2. Open DevTools (Help → Toggle Developer Tools) → Console.
3. Paste:

   ```js
   const { default: URI } = window.theia['@theia/core/lib/common/uri'];
   const { OpenerService } = window.theia['@theia/core/lib/browser/opener-service'];
   const open = async id => {
       const uri = new URI(`theia://install-mcp?id=${encodeURIComponent(id)}`);
       const opener = await window.theia.container.get(OpenerService).getOpener(uri);
       return opener.open(uri);
   };
   ```

4. Test that the window gets focues, the extensions view is opened and we search for the id:
   ```js
   open('io.github.ChromeDevTools/chrome-devtools-mcp')
   ```
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
