### PR TITLE
fix(ai-chat-ui): guard tool-call result rendering against non-array content

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.spec.ts
@@ -15,6 +15,10 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
+import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
+import { OpenerService } from '@theia/core/lib/browser';
+import { ReactNode } from '@theia/core/shared/react';
+import { ToolCallPartRenderer } from './toolcall-part-renderer';
 import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
 
 describe('condenseArguments', () => {
@@ -271,6 +275,129 @@ describe('formatArgsForTooltip', () => {
         const result = formatArgsForTooltip(args);
         expect(result.value).to.contain('\\[0\\]');
         expect(result.value).to.contain('\\[1\\]');
+    });
+
+});
+
+/**
+ * Test-only subclass that exposes the protected `renderResult` method and
+ * accepts a minimal `OpenerService` stub. `renderResult` only references the
+ * opener service indirectly through `<MarkdownRender>`, and the React tree is
+ * never mounted in these unit tests, so an empty stub is sufficient.
+ */
+class TestableToolCallPartRenderer extends ToolCallPartRenderer {
+    constructor() {
+        super();
+        this.openerService = {} as OpenerService;
+    }
+    callRenderResult(response: ToolCallChatResponseContent): ReactNode {
+        return this.renderResult(response);
+    }
+}
+
+interface RenderedNode {
+    type: string;
+    props: { children?: unknown; className?: string };
+}
+
+describe('ToolCallPartRenderer.renderResult', () => {
+
+    function renderResult(result: unknown): RenderedNode | undefined {
+        const renderer = new TestableToolCallPartRenderer();
+        const response = { kind: 'toolCall', result } as unknown as ToolCallChatResponseContent;
+        return renderer.callRenderResult(response) as RenderedNode | undefined;
+    }
+
+    it('returns undefined for an undefined result', () => {
+        expect(renderResult(undefined)).to.be.undefined;
+    });
+
+    it('returns undefined for an empty-string result (falsy after tryParse)', () => {
+        expect(renderResult('')).to.be.undefined;
+    });
+
+    it('renders primitive numeric result via <pre>{String(result)}</pre>', () => {
+        const node = renderResult(42)!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal('42');
+    });
+
+    it('renders unparseable string result via <pre>{String(result)}</pre>', () => {
+        const node = renderResult('not json at all')!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal('not json at all');
+    });
+
+    it('renders proper ToolCallContent (array) via the response-content branch', () => {
+        const node = renderResult({ content: [{ type: 'text', text: 'hello' }] })!;
+        expect(node.type).to.equal('div');
+        expect(node.props.className).to.equal('theia-toolCall-response-content');
+    });
+
+    it('renders ToolCallContent that arrived as a JSON string via the response-content branch', () => {
+        const node = renderResult(JSON.stringify({ content: [{ type: 'text', text: 'hello' }] }))!;
+        expect(node.type).to.equal('div');
+        expect(node.props.className).to.equal('theia-toolCall-response-content');
+    });
+
+    // Regression: an object whose `content` field is not an array must not crash.
+    // This is the exact shape produced by `getWorkspaceFileList` (after multi-root
+    // support landed in v1.72.0) when a workspace entry happens to be literally
+    // named "content" (e.g. Hugo sites).
+    it('falls back to <pre>JSON</pre> when result has a non-array "content" key (regression)', () => {
+        const result = {
+            '.devcontainer': 'directory',
+            'config.yaml': 'file',
+            'content': 'directory',
+            'go.mod': 'file'
+        };
+        const node = renderResult(result)!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
+    });
+
+    it('falls back to <pre>JSON</pre> when content is a string (regression)', () => {
+        const result = { content: 'directory' };
+        const node = renderResult(result)!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
+    });
+
+    it('falls back to <pre>JSON</pre> when content is an object (regression)', () => {
+        const result = { content: { nested: true } };
+        const node = renderResult(result)!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
+    });
+
+    it('falls back to <pre>JSON</pre> when content is a number (regression)', () => {
+        const result = { content: 42 };
+        const node = renderResult(result)!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
+    });
+
+    it('falls back to <pre>JSON</pre> for JSON-string result whose parsed object has a non-array content key (regression)', () => {
+        // Byte-for-byte shape persisted by getWorkspaceFileList for a Hugo workspace.
+        const raw = '{".devcontainer":"directory","config.yaml":"file","content":"directory","go.mod":"file"}';
+        const node = renderResult(raw)!;
+        expect(node.type).to.equal('pre');
+        // The fallback stringifies the *parsed* object, not the original string.
+        expect(node.props.children).to.equal(JSON.stringify(JSON.parse(raw), undefined, 2));
+    });
+
+    it('falls back to <pre>JSON</pre> for plain objects without a content key', () => {
+        const result = { files: [] };
+        const node = renderResult(result)!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
+    });
+
+    it('falls back to <pre>JSON</pre> for top-level array results', () => {
+        const result = [{ file: 'a', matches: [] }];
+        const node = renderResult(result)!;
+        expect(node.type).to.equal('pre');
+        expect(node.props.children).to.equal(JSON.stringify(result, undefined, 2));
     });
 
 });

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -25,7 +25,7 @@ import { createConfirmationHandlers, ToolConfirmation, useToolConfirmationState 
 import { ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ResponseNode } from '../chat-tree-view';
 import { MarkdownRender } from './markdown-part-renderer';
-import { ToolCallResult, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
+import { isToolCallContent, ToolCallResult, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
 import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
 
@@ -98,7 +98,7 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
         if (typeof result !== 'object' || result === null) {
             return <pre>{String(result)}</pre>;
         }
-        if ('content' in result) {
+        if (isToolCallContent(result)) {
             return <div className='theia-toolCall-response-content'>
                 {result.content.map((content, idx) => {
                     switch (content.type) {

--- a/packages/ai-core/src/common/language-model.spec.ts
+++ b/packages/ai-core/src/common/language-model.spec.ts
@@ -14,8 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { isModelMatching, LanguageModel, LanguageModelSelector } from './language-model';
 import { expect } from 'chai';
+import { isModelMatching, isToolCallContent, LanguageModel, LanguageModelSelector } from './language-model';
 
 describe('isModelMatching', () => {
     it('returns false with one of two parameter mismatches', () => {
@@ -83,4 +83,83 @@ describe('isModelMatching', () => {
             )
         ).eql(true);
     });
+});
+
+describe('isToolCallContent', () => {
+
+    it('accepts a well-formed ToolCallContent with a text item', () => {
+        expect(isToolCallContent({ content: [{ type: 'text', text: 'hello' }] })).to.be.true;
+    });
+
+    it('accepts an empty content array', () => {
+        expect(isToolCallContent({ content: [] })).to.be.true;
+    });
+
+    it('accepts content with mixed item types', () => {
+        const value = {
+            content: [
+                { type: 'text', text: 'hello' },
+                { type: 'image', mimeType: 'image/png', base64data: 'abc' },
+                { type: 'error', data: 'boom' }
+            ]
+        };
+        expect(isToolCallContent(value)).to.be.true;
+    });
+
+    it('rejects undefined', () => {
+        expect(isToolCallContent(undefined)).to.be.false;
+    });
+
+    it('rejects null', () => {
+        // eslint-disable-next-line no-null/no-null
+        expect(isToolCallContent(null)).to.be.false;
+    });
+
+    it('rejects primitive values', () => {
+        expect(isToolCallContent('not an object')).to.be.false;
+        expect(isToolCallContent(42)).to.be.false;
+        expect(isToolCallContent(true)).to.be.false;
+    });
+
+    it('rejects objects without a content key', () => {
+        expect(isToolCallContent({ files: [] })).to.be.false;
+        expect(isToolCallContent({})).to.be.false;
+    });
+
+    // Regression: this is the exact shape that triggered the chat-flicker bug.
+    // `getWorkspaceFileList` echoes workspace entry names into the result keys,
+    // and a workspace containing a directory literally named `content` produces
+    // an object where `content` is a plain string, not a ToolCallContentResult
+    // array.
+    it('rejects an object whose content is a string (regression)', () => {
+        expect(isToolCallContent({ content: 'directory' })).to.be.false;
+    });
+
+    it('rejects an object whose content is a nested object', () => {
+        expect(isToolCallContent({ content: { nested: true } })).to.be.false;
+    });
+
+    it('rejects an object whose content is a number', () => {
+        expect(isToolCallContent({ content: 42 })).to.be.false;
+    });
+
+    it('rejects an object whose content is null', () => {
+        // eslint-disable-next-line no-null/no-null
+        expect(isToolCallContent({ content: null })).to.be.false;
+    });
+
+    it('rejects a top-level array (no content key)', () => {
+        expect(isToolCallContent([{ type: 'text', text: 'hello' }])).to.be.false;
+    });
+
+    it('rejects a directory-listing-shaped object containing a "content" entry (regression)', () => {
+        const value = {
+            '.devcontainer': 'directory',
+            'config.yaml': 'file',
+            'content': 'directory',
+            'go.mod': 'file'
+        };
+        expect(isToolCallContent(value)).to.be.false;
+    });
+
 });


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17599

- Tighten the check that decides when a tool result should be rendered as structured tool-call content, so the renderer no longer assumes the content field is an array
- Prevents a chat UI crash and flicker when a tool returns an object whose content field is not an array
- Add tests covering the regression shapes

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open a workspace that contains a top-level folder named `content`
- In AI Chat, ask an agent to list the workspace files (triggers getWorkspaceFileList)
- Verify that the results are reported now correctly and the console is not showing the errors described in the issue anymore

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
