### PR TITLE
Fix pasting in terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## 1.73.0 - tbd
+
+- [terminal] fixed Cmd+V / Ctrl+V paste in the integrated terminal and restored the effect of the `terminal.enablePaste` and `terminal.enableCopy` preferences [#17603](https://github.com/eclipse-theia/theia/pull/17603)
+
+<a name="breaking_changes_1.73.0">[Breaking Changes:](#breaking_changes_1.73.0)</a>
+
+- [terminal] `TerminalWidget` gained a new abstract method `paste(text: string)`; downstream subclasses must implement it (consistent with `getSelection()` / `hasSelection()` added in [#17290](https://github.com/eclipse-theia/theia/pull/17290)) [#17603](https://github.com/eclipse-theia/theia/pull/17603)
+
 ## 1.72.0 - 5/28/2026
 
 - [ai] continued ai white label [#17447](https://github.com/eclipse-theia/theia/pull/17447)

--- a/packages/terminal/src/browser/base/terminal-widget.ts
+++ b/packages/terminal/src/browser/base/terminal-widget.ts
@@ -181,6 +181,13 @@ export abstract class TerminalWidget extends BaseWidget {
      */
     abstract hasSelection(): boolean;
 
+    /**
+     * Paste the given text into the terminal as if it were typed by the user.
+     * Honors bracketed paste mode when enabled by the running program.
+     * @param text the text to paste
+     */
+    abstract paste(text: string): void;
+
     abstract writeLine(line: string): void;
 
     abstract write(data: string): void;

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -685,33 +685,44 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             execute: () => this.currentTerminal?.selectAll()
         });
         commands.registerCommand(TerminalCommands.PASTE_TERMINAL, {
-            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget && this.terminalPreferences['terminal.enablePaste'],
+            isEnabled: () => !!this.getPasteTargetTerminal(),
             execute: async () => {
-                const terminal = this.shell.activeWidget;
-                if (terminal instanceof TerminalWidget && this.terminalPreferences['terminal.enablePaste']) {
-                    const text = await this.clipboardService.readText();
-                    if (text) {
-                        terminal.paste(text);
-                    }
+                const terminal = this.getPasteTargetTerminal();
+                if (!terminal) {
+                    return;
+                }
+                const text = await this.clipboardService.readText();
+                if (text) {
+                    terminal.paste(text);
                 }
             }
         });
         commands.registerCommand(TerminalCommands.COPY_TERMINAL_SELECTION, {
-            isEnabled: () => {
-                const terminal = this.shell.activeWidget;
-                return terminal instanceof TerminalWidget
-                    && terminal.hasSelection()
-                    && this.terminalPreferences['terminal.enableCopy'];
-            },
+            isEnabled: () => !!this.getCopySourceTerminal(),
             execute: () => {
-                const terminal = this.shell.activeWidget;
-                if (terminal instanceof TerminalWidget
-                    && terminal.hasSelection()
-                    && this.terminalPreferences['terminal.enableCopy']) {
-                    this.copyHandler.syncCopy(terminal.getSelection());
+                const terminal = this.getCopySourceTerminal();
+                if (!terminal) {
+                    return;
                 }
+                this.copyHandler.syncCopy(terminal.getSelection());
             }
         });
+    }
+
+    protected getPasteTargetTerminal(): TerminalWidget | undefined {
+        const terminal = this.shell.activeWidget;
+        if (terminal instanceof TerminalWidget && this.terminalPreferences['terminal.enablePaste']) {
+            return terminal;
+        }
+        return undefined;
+    }
+
+    protected getCopySourceTerminal(): TerminalWidget | undefined {
+        const terminal = this.shell.activeWidget;
+        if (terminal instanceof TerminalWidget && terminal.hasSelection() && this.terminalPreferences['terminal.enableCopy']) {
+            return terminal;
+        }
+        return undefined;
     }
 
     protected toggleTerminal(): void {

--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -37,6 +37,7 @@ import {
     KeybindingRegistry, LabelProvider, WidgetOpenerOptions, StorageService, QuickInputService,
     codicon, CommonCommands, FrontendApplicationContribution, OnWillStopAction, Dialog, ConfirmDialog, FrontendApplication, Widget, SHELL_TABBAR_CONTEXT_MENU
 } from '@theia/core/lib/browser';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { TERMINAL_WIDGET_FACTORY_ID, TerminalWidgetFactoryOptions, TerminalWidgetImpl } from './terminal-widget-impl';
 import { TerminalService } from './base/terminal-service';
@@ -164,6 +165,16 @@ export namespace TerminalCommands {
         label: 'Select All',
         category: TERMINAL_CATEGORY,
     });
+    export const PASTE_TERMINAL = Command.toDefaultLocalizedCommand({
+        id: 'workbench.action.terminal.paste',
+        category: TERMINAL_CATEGORY,
+        label: 'Paste into Active Terminal'
+    });
+    export const COPY_TERMINAL_SELECTION = Command.toDefaultLocalizedCommand({
+        id: 'workbench.action.terminal.copySelection',
+        category: TERMINAL_CATEGORY,
+        label: 'Copy Selection'
+    });
 
     /**
      * Command that displays all terminals that are currently opened
@@ -229,6 +240,9 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
 
     @inject(TerminalCopyOnSelectionHandler)
     protected readonly copyHandler: TerminalCopyOnSelectionHandler;
+
+    @inject(ClipboardService)
+    protected readonly clipboardService: ClipboardService;
 
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
@@ -670,16 +684,32 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             isEnabled: () => !!this.currentTerminal,
             execute: () => this.currentTerminal?.selectAll()
         });
-        commands.registerHandler(CommonCommands.COPY.id, {
-            execute: () => {
+        commands.registerCommand(TerminalCommands.PASTE_TERMINAL, {
+            isEnabled: () => this.shell.activeWidget instanceof TerminalWidget && this.terminalPreferences['terminal.enablePaste'],
+            execute: async () => {
                 const terminal = this.shell.activeWidget;
-                if (terminal instanceof TerminalWidget && terminal.hasSelection()) {
-                    this.copyHandler.syncCopy(terminal.getSelection());
+                if (terminal instanceof TerminalWidget && this.terminalPreferences['terminal.enablePaste']) {
+                    const text = await this.clipboardService.readText();
+                    if (text) {
+                        terminal.paste(text);
+                    }
                 }
-            },
+            }
+        });
+        commands.registerCommand(TerminalCommands.COPY_TERMINAL_SELECTION, {
             isEnabled: () => {
                 const terminal = this.shell.activeWidget;
-                return terminal instanceof TerminalWidget && terminal.hasSelection();
+                return terminal instanceof TerminalWidget
+                    && terminal.hasSelection()
+                    && this.terminalPreferences['terminal.enableCopy'];
+            },
+            execute: () => {
+                const terminal = this.shell.activeWidget;
+                if (terminal instanceof TerminalWidget
+                    && terminal.hasSelection()
+                    && this.terminalPreferences['terminal.enableCopy']) {
+                    this.copyHandler.syncCopy(terminal.getSelection());
+                }
             }
         });
     }
@@ -765,10 +795,12 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             commandId: TerminalCommands.SPLIT.id
         });
         menus.registerMenuAction([...TerminalMenus.TERMINAL_CONTEXT_MENU, '_2'], {
-            commandId: CommonCommands.COPY.id
+            commandId: TerminalCommands.COPY_TERMINAL_SELECTION.id,
+            label: nls.localizeByDefault('Copy')
         });
         menus.registerMenuAction([...TerminalMenus.TERMINAL_CONTEXT_MENU, '_2'], {
-            commandId: CommonCommands.PASTE.id
+            commandId: TerminalCommands.PASTE_TERMINAL.id,
+            label: nls.localizeByDefault('Paste')
         });
         menus.registerMenuAction([...TerminalMenus.TERMINAL_CONTEXT_MENU, '_2'], {
             commandId: TerminalCommands.SELECT_ALL.id
@@ -896,6 +928,16 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
         keybindings.registerKeybinding({
             command: TerminalCommands.TERMINAL_CLEAR.id,
             keybinding: 'ctrlcmd+k',
+            when: 'terminalFocus'
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.PASTE_TERMINAL.id,
+            keybinding: 'ctrlcmd+v',
+            when: 'terminalFocus'
+        });
+        keybindings.registerKeybinding({
+            command: TerminalCommands.COPY_TERMINAL_SELECTION.id,
+            keybinding: 'ctrlcmd+c',
             when: 'terminalFocus'
         });
         keybindings.registerKeybinding({

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -53,6 +53,7 @@ import { EnhancedPreviewWidget } from '@theia/core/lib/browser/widgets/enhanced-
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { ColorRegistry } from '@theia/core/lib/browser/color-registry';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { cleanTerminalTitle, guessShellTypeFromExecutable } from '../common/shell-type';
 import { TerminalCommandHistoryStateFactory } from './terminal-command-history';
 
@@ -147,6 +148,7 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
     @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer;
     @inject(MarkdownRendererFactory) protected readonly markdownRendererFactory: MarkdownRendererFactory;
     @inject(TerminalCommandHistoryStateFactory) protected readonly commandHistoryStateFactory: TerminalCommandHistoryStateFactory;
+    @inject(ContextKeyService) protected readonly contextKeyService: ContextKeyService;
 
     protected _markdownRenderer: MarkdownRenderer | undefined;
     protected get markdownRenderer(): MarkdownRenderer {
@@ -210,6 +212,14 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         this.title.label = initialTitle;
         this.title.caption = initialTitle;
         this.setIconClass();
+
+        // Declare 'terminalFocus' as a local context key on this widget's DOM scope so that
+        // terminal-scoped keybindings (e.g. ctrlcmd+v) take precedence over global bindings
+        // for the same keystroke when focus is inside the terminal.
+        // See KeybindingRegistry.selectBindingByLocalContext.
+        const localContext = this.contextKeyService.createScoped(this.node);
+        localContext.createKey('terminalFocus', true);
+        this.toDispose.push(localContext);
 
         if (this.options.kind) {
             this.terminalKind = this.options.kind;
@@ -738,6 +748,10 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
 
     hasSelection(): boolean {
         return this.term.hasSelection();
+    }
+
+    paste(text: string): void {
+        this.term.paste(text);
     }
 
     async hasChildProcesses(): Promise<boolean> {


### PR DESCRIPTION
#### What it does

Fixes paste (Cmd+V / Ctrl+V) in the integrated terminal, and along the way restores the documented effect of the `terminal.enablePaste` and `terminal.enableCopy` preferences.

**Root cause.** The global `ctrlcmd+v` keybinding for `CommonCommands.PASTE` (see [`common-frontend-contribution.ts:841`](https://github.com/eclipse-theia/theia/blob/8ed51a5e94d15a6003725683a14773c6f8d64ac6/packages/core/src/browser/common-frontend-contribution.ts#L841), enabled in Electron) intercepts the keystroke at the document level before xterm.js's hidden textarea can fire its native `paste` event. xterm's own paste pipeline — which would call `Terminal.paste()` and forward to the PTY, including bracketed-paste sequences — never runs. The same dynamic made `terminal.enablePaste` / `terminal.enableCopy` effectively dead, since they were only checked by `TerminalWidgetImpl.customKeyHandler`, which the global keybinding preempts.

**Approach.** Follow VSCode's terminal-clipboard pattern, using the keybinding priority mechanism from #16763:

- Register terminal-specific commands `workbench.action.terminal.paste` and `workbench.action.terminal.copySelection`, each with its own `ctrlcmd+v` / `ctrlcmd+c` keybinding scoped `when: 'terminalFocus'`.
- Each `TerminalWidgetImpl` declares `terminalFocus` as a **local** context key on its own DOM scope (`contextKeyService.createScoped(this.node).createKey('terminalFocus', true)`). When focus is inside a terminal, `KeybindingRegistry.selectBindingByLocalContext` prefers the terminal-scoped binding over the unconstrained global `CommonCommands.PASTE` / `CommonCommands.COPY`.
- Paste routes through a new `TerminalWidget.paste(text)` method that delegates to xterm's `Terminal.paste()` (preserving bracketed-paste handling). Copy keeps using `TerminalCopyOnSelectionHandler.syncCopy()`.
- Handlers honor `terminal.enablePaste` / `terminal.enableCopy`. When a preference is off, the keybinding's `isEnabled` returns false and falls through to the global binding — matching the literal reading of the preferences' descriptions.

**Outcomes.**

- Cmd+V / Ctrl+V and Cmd+C / Ctrl+C work in the terminal (keystroke, terminal context menu).
- `terminal.enablePaste` / `terminal.enableCopy` regain their effect on the keystroke and context-menu entries; no effect on editor / Command Palette / input-field paste-copy.
- `CommonCommands.PASTE` and `CommonCommands.COPY` are no longer overridden by the terminal package. The `registerHandler(CommonCommands.COPY.id, …)` from #17290 is removed; the user-visible fix it landed (context-menu Copy) is preserved by the new structure.

#### How to test

1. Open Theia (esp. macOS Electron) and a terminal.
2. **Paste:** copy text, then in the terminal use Cmd+V / Ctrl+V and right-click → Paste; both should insert at the prompt.
3. **Bracketed paste:** paste a multi-line snippet into `bash`/`zsh`/`python` REPL; lines should not be executed individually or auto-indented.
4. **Copy:** select text, use Cmd+C / Ctrl+C and right-click → Copy; verify by pasting elsewhere.
5. **Preferences:** with `terminal.enablePaste: false` (resp. `enableCopy: false`), the corresponding keystroke and menu entry should no-op in the terminal but still work in editors. Reset and re-verify.
6. **Non-terminal contexts:** confirm Cmd+V / Cmd+C are unchanged in editors, Command Palette, dialogs, input fields.
7. **#17290 regression check:** right-click → Copy with a selection still copies.

#### Follow-ups

- **Electron Edit menu bypasses Theia commands.** `electron-main-menu-factory.ts:240` deletes `menuItem.execute` when assigning `role: 'paste'` / `'copy'`, so Edit → Paste / Copy runs Electron's native role and skips the new terminal commands (and the `terminal.enable*` preferences). Paste still lands in xterm's textarea via the synthetic DOM event and reaches the PTY, so it works — but it isn't gated by the preferences. VSCode keeps a `click` handler alongside the role and re-dispatches through the renderer's keybinding service so a focused terminal resolves the correct command; aligning Theia's Electron menu factory with that pattern is tracked as a follow-up.
- **`customKeyHandler` Cmd+V / Cmd+C branches are now mostly dead** with the renderer-level keybindings handling both. Worth removing or scoping to browser-only modes in a follow-up.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

Note: `TerminalWidget` gains a new abstract method `paste(text: string)`. Downstream subclasses will need to implement it. Consistent with `getSelection()` / `hasSelection()` added in #17290.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)