### PR TITLE
Clean up two on-start logs

### DIFF
--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -394,6 +394,8 @@ export class ElectronMainApplication {
         const cancelTokenSource = new CancellationTokenSource();
         const minTime = timeout(splashScreenOptions.minDuration ?? 0, cancelTokenSource.token);
         const maxTime = timeout(splashScreenOptions.maxDuration ?? 30000, cancelTokenSource.token);
+        // Swallow rejections that occur when the cancellation token is cancelled after one of the timers wins.
+        const ignoreCancellation = () => { /* timer was cancelled, intentionally ignored */ };
 
         const showWindowAndCloseSplashScreen = () => {
             cancelTokenSource.cancel();
@@ -404,10 +406,10 @@ export class ElectronMainApplication {
         };
         TheiaRendererAPI.onApplicationStateChanged(mainWindow.webContents, state => {
             if (state === 'ready') {
-                minTime.then(() => showWindowAndCloseSplashScreen());
+                minTime.then(() => showWindowAndCloseSplashScreen(), ignoreCancellation);
             }
         });
-        maxTime.then(() => showWindowAndCloseSplashScreen());
+        maxTime.then(() => showWindowAndCloseSplashScreen(), ignoreCancellation);
         return splashScreenWindow;
     }
 

--- a/packages/plugin-ext/src/plugin/languages/diagnostics.ts
+++ b/packages/plugin-ext/src/plugin/languages/diagnostics.ts
@@ -30,6 +30,7 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
     ];
 
     private collectionName: string;
+    private ownerId: string;
     private diagnosticsLimitPerResource: number;
     private proxy: LanguagesMain;
     private onDidChangeDiagnosticsEmitter: Emitter<theia.DiagnosticChangeEvent>;
@@ -38,8 +39,9 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
     private isDisposed: boolean;
     private onDisposeCallback: (() => void) | undefined;
 
-    constructor(name: string, maxCountPerFile: number, proxy: LanguagesMain, onDidChangeDiagnosticsEmitter: Emitter<theia.DiagnosticChangeEvent>) {
+    constructor(name: string, owner: string, maxCountPerFile: number, proxy: LanguagesMain, onDidChangeDiagnosticsEmitter: Emitter<theia.DiagnosticChangeEvent>) {
         this.collectionName = name;
+        this.ownerId = owner;
         this.diagnosticsLimitPerResource = maxCountPerFile;
         this.proxy = proxy;
         this.onDidChangeDiagnosticsEmitter = onDidChangeDiagnosticsEmitter;
@@ -51,6 +53,10 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
 
     get name(): string {
         return this.collectionName;
+    }
+
+    get owner(): string {
+        return this.ownerId;
     }
 
     set(uri: theia.Uri, diagnostics: theia.Diagnostic[] | undefined): void;
@@ -115,7 +121,7 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
         if (this.has(uri)) {
             this.fireDiagnosticChangeEvent(uri);
             this.diagnostics.delete(uri.toString());
-            this.proxy.$changeDiagnostics(this.name, [[uri.toString(), []]]);
+            this.proxy.$changeDiagnostics(this.ownerId, [[uri.toString(), []]]);
         }
     }
 
@@ -123,7 +129,7 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
         this.ensureNotDisposed();
         this.fireDiagnosticChangeEvent(this.getAllResourcesUris());
         this.diagnostics.clear();
-        this.proxy.$clearDiagnostics(this.name);
+        this.proxy.$clearDiagnostics(this.ownerId);
     }
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -247,7 +253,7 @@ export class DiagnosticCollection implements theia.DiagnosticCollection {
             }
         }
 
-        this.proxy.$changeDiagnostics(this.name, markers);
+        this.proxy.$changeDiagnostics(this.ownerId, markers);
     }
 }
 
@@ -256,7 +262,12 @@ export class Diagnostics {
     private static GENERATED_DIAGNOSTIC_COLLECTION_NAME_PREFIX = '_generated_diagnostic_collection_name_#';
 
     private proxy: LanguagesMain;
-    private diagnosticCollections: Map<string, DiagnosticCollection>; // id -> diagnostic collection
+    // Collections are keyed by their unique `owner` id (which is the same as `name` for the first
+    // collection with that name, but is suffixed when a duplicate name is requested). This matches
+    // VS Code's behavior and prevents collisions on the main side's marker owner namespace as well
+    // as a latent bug where disposing the first collection would evict the second from the map.
+    private diagnosticCollections: Map<string, DiagnosticCollection>;
+    private nextOwnerSuffix = 1;
 
     private diagnosticsChangedEmitter = new Emitter<theia.DiagnosticChangeEvent>();
     public readonly onDidChangeDiagnostics: Event<theia.DiagnosticChangeEvent> = this.diagnosticsChangedEmitter.event;
@@ -278,19 +289,26 @@ export class Diagnostics {
     }
 
     createDiagnosticCollection(name?: string): theia.DiagnosticCollection {
+        let owner: string;
         if (!name) {
             do {
                 name = Diagnostics.GENERATED_DIAGNOSTIC_COLLECTION_NAME_PREFIX + this.getNextId();
             } while (this.diagnosticCollections.has(name));
-        } else if (this.diagnosticCollections.has(name)) {
-            console.warn(`Diagnostic collection with name '${name}' already exist.`);
+            owner = name;
+        } else if (!this.diagnosticCollections.has(name)) {
+            owner = name;
+        } else {
+            console.warn(`Diagnostic collection with name '${name}' already exists.`);
+            do {
+                owner = name + this.nextOwnerSuffix++;
+            } while (this.diagnosticCollections.has(owner));
         }
 
-        const diagnosticCollection = new DiagnosticCollection(name, Diagnostics.MAX_DIAGNOSTICS_PER_FILE, this.proxy, this.diagnosticsChangedEmitter);
+        const diagnosticCollection = new DiagnosticCollection(name, owner, Diagnostics.MAX_DIAGNOSTICS_PER_FILE, this.proxy, this.diagnosticsChangedEmitter);
         diagnosticCollection.setOnDisposeCallback(() => {
-            this.diagnosticCollections.delete(name!);
+            this.diagnosticCollections.delete(owner);
         });
-        this.diagnosticCollections.set(name, diagnosticCollection);
+        this.diagnosticCollections.set(owner, diagnosticCollection);
         return diagnosticCollection;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

There were two on-start errors that consistently appeared and bothered me, one about a cancellation error, and one about double registration of a diagnostic collection with the name `eslint`. This PR fixes the first and fixes a bug adjacent to the latter, but in a way that means the log is still present.

The first one was simple: we were creating a cancellation error and failing to catch it. Now I catch it and ignore it. The second is a bug in the ESLint plugin, probably, since for some reason it's registering two diagnostic collections in different parts of its activation, but our handling differed from VSCode's. In VSCode, a warning is logged, but they disambiguate the identifier and retain both collections. I've adjusted our plugin system to do that, as well.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Start the Electron application
2. See no warning about an uncaught cancellation error.
3. If you have the ESLint plugin installed, you'll still see a warning about duplicate registration, but under the hood, both will be retained. This may mean that we correctly report errors we weren't reporting before, but I'm not sure exactly what the different collections do in ESLint, so I'm not sure where you could observe the difference. In any case, make some lint errors in your code, and they should still show up correctly.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
