### PR TITLE
fix(monaco): inject theme CSS variables at startup

### DIFF
--- a/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
+++ b/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
@@ -103,6 +103,13 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
         });
     }
     onStart(): void {
+        // Monaco exposes its theme colors as `--vscode-*` CSS variables only through the `monaco-colors`
+        // stylesheet that `registerEditorContainer` injects. That stylesheet is otherwise created lazily,
+        // when the first standalone editor is opened, so popups that rely on those variables (e.g. the chat
+        // input's suggest widget) are unstyled until then. Register the main window up front so the variables
+        // are available document-wide from launch; `_updateCSS` keeps the stylesheet in sync on theme changes.
+        (StandaloneServices.get(IStandaloneThemeService) as StandaloneThemeService).registerEditorContainer(document.body);
+
         this.secondaryWindowHandler.onDidAddWidget(([widget, window]) => {
             if (widget instanceof EditorWidget && widget.editor instanceof MonacoEditor) {
                 const themeService = StandaloneServices.get(IStandaloneThemeService) as StandaloneThemeService;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

This should fix the issue "Monaco theme color variables are missing until a standalone editor is opened, breaking the styling of popups like the chat input's suggest widget" mentioned in the 1.72.2 patch issue.

Register the main window's editor container in onStart() so Monaco's `--vscode-*` theme variables are available document-wide from launch, instead of only after the first standalone editor is opened. Fixes unstyled popups (e.g. the chat input's suggest widget) on a fresh start.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
1. Open Theia browser sample app
2. Go directly to the Chat AI (don't open any Monaco editor before)
3. The chat input's suggest widget should work as before.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
