### PR TITLE
fix(bundle-plugin): restore Linux trash file deletion in esbuild bundle

### DIFF
--- a/dev-packages/bundle-plugin/src/esbuild-plugin.spec.ts
+++ b/dev-packages/bundle-plugin/src/esbuild-plugin.spec.ts
@@ -1,0 +1,80 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as chai from 'chai';
+import * as fs from 'fs';
+import { nativeDependenciesPlugin } from './esbuild-plugin';
+
+const expect = chai.expect;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyCallback = (args: any) => any;
+
+interface Resolvers {
+    filter: RegExp;
+    callback: AnyCallback;
+}
+
+function createFakeBuild(): { build: unknown, resolvers: Resolvers[] } {
+    const resolvers: Resolvers[] = [];
+    const build = {
+        initialOptions: { outdir: '/tmp/fake-outdir' },
+        onResolve: () => undefined,
+        onLoad: (options: { filter: RegExp }, callback: AnyCallback) => {
+            resolvers.push({ filter: options.filter, callback });
+        },
+        onStart: () => undefined,
+        onEnd: () => undefined,
+    };
+    return { build, resolvers };
+}
+
+describe('nativeDependenciesPlugin', () => {
+
+    it('rewrites the @stroncium/procfs parsers.js dynamic require to append `.js` so esbuild\'s glob lookup matches at runtime', async () => {
+        // Regression test for the Linux trash bug: @stroncium/procfs (used by
+        // `trash` on Linux to map device IDs to mount points) calls
+        // `require(`./parsers/${name}`)`. esbuild expands this into a glob map
+        // whose keys carry the `.js` extension, but the runtime call passes the
+        // bare name, missing every entry and breaking file deletion via trash
+        // on esbuild-bundled backends. The onLoad handler is run against the
+        // real upstream parsers.js so this test fails if @stroncium/procfs
+        // ever changes the dynamic require pattern out from under our patch.
+        const { build, resolvers } = createFakeBuild();
+
+        const plugin = nativeDependenciesPlugin({
+            trash: false,
+            ripgrep: false,
+            pty: false,
+            nativeBindings: {}
+        });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        plugin.setup(build as any);
+
+        const parsersPath = require.resolve('@stroncium/procfs/lib/parsers.js');
+        const parsersLoader = resolvers.find(l => l.filter.test(parsersPath));
+        expect(parsersLoader, 'plugin should register an onLoad for @stroncium/procfs parsers.js').to.not.equal(undefined);
+
+        const original = await fs.promises.readFile(parsersPath, 'utf8');
+        expect(original, 'upstream parsers.js must still contain the bare dynamic require we patch').to.include('require(`./parsers/${name}`)');
+
+        const result = await parsersLoader!.callback({ path: parsersPath });
+        expect(result, 'callback must return a load result').to.be.an('object');
+        expect(result.loader, 'result must be emitted as JS').to.equal('js');
+        expect(result.contents, 'patched contents must append `.js` to the dynamic require').to.include('require(`./parsers/${name}.js`)');
+        expect(result.contents, 'patched contents must no longer contain the bare dynamic require').to.not.include('require(`./parsers/${name}`)');
+    });
+});

--- a/dev-packages/bundle-plugin/src/esbuild-plugin.ts
+++ b/dev-packages/bundle-plugin/src/esbuild-plugin.ts
@@ -271,6 +271,14 @@ class PluginImpl implements Plugin {
             contents = 'const __nativePtyRequire = require;\n' + contents.replace(/\brequire\(/g, '__nativePtyRequire(');
             return { contents, loader: 'js' };
         });
+        build.onLoad({ filter: /node_modules[/\\]@stroncium[/\\]procfs[/\\]lib[/\\]parsers\.js$/ }, async args => {
+            let contents = await fs.promises.readFile(args.path, 'utf8');
+            // esbuild expands `require(`./parsers/${name}`)` into a glob lookup whose
+            // keys include the `.js` extension, but the runtime call passes the bare
+            // name and misses. Append `.js` so the runtime key matches the map.
+            contents = contents.replace('require(`./parsers/${name}`)', 'require(`./parsers/${name}.js`)');
+            return { contents, loader: 'js' };
+        });
         build.onEnd(() => {
             if (this.options.trash) {
                 copyTrashHelper(outdir);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Deleting a file via trash failed on Linux in esbuild-bundled backends with "Module not found in bundle: ./parsers/processMountinfo". @stroncium/procfs (used by `trash` on Linux to map device IDs to mount points) does `require(`./parsers/${name}`)`; esbuild expands this into a glob lookup whose keys include the `.js` extension, but the runtime call passes the bare name and misses every entry.
- Rewrite @stroncium/procfs/lib/parsers.js at bundle time to append `.js` to the dynamic require, so the runtime key matches the emitted glob map.
- Add regression test exercising the onLoad handler against the real parsers.js to catch upstream drift.

Fixes GH-17614

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. On Linux, build and start the example apps with the esbuild bundler:
   ```
   npm run build
   npm run start:browser or start:electron
   ```
2. In the running app, right-click any file in the Explorer and choose "Delete" or delete via Keyboard.
3. Verify that the file is deleted and put in the trash as expected.

Note: #17609 tackles the file watcher problems, and both touch the esbuild bundle plugin, but the two fixes are independent but can be tested togehter.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
