### PR TITLE
feat(ai-chat-ui): add shortcuts and bulk approve for tool confirmation

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -70,6 +70,7 @@ import { ChatFocusContribution } from './chat-focus-contribution';
 import { ChatCapabilitiesService, ChatCapabilitiesServiceImpl } from './chat-capabilities-service';
 import { ChatInputCapabilitiesContribution } from './chat-input-capabilities-contribution';
 import { GenericCapabilitiesContribution, GenericCapabilitiesService, GenericCapabilitiesServiceImpl } from './generic-capabilities-service';
+import { ToolConfirmationKeybindingContribution } from './tool-confirmation-keybinding-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindChatViewPreferences(bind);
@@ -109,6 +110,10 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(ChatInputCapabilitiesContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(ChatInputCapabilitiesContribution);
     bind(KeybindingContribution).toService(ChatInputCapabilitiesContribution);
+
+    bind(ToolConfirmationKeybindingContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(ToolConfirmationKeybindingContribution);
+    bind(KeybindingContribution).toService(ToolConfirmationKeybindingContribution);
 
     bindRootContributionProvider(bind, ChatResponsePartRenderer);
     bindRootContributionProvider(bind, ChatWelcomeMessageProvider);

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -18,15 +18,20 @@ import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { ChatRequestInvocation, ChatResponseContent, ChatResponseModel, InteractiveContent, ToolCallChatResponseContent } from '@theia/ai-chat';
 import { ChatAgentService } from '@theia/ai-chat/lib/common/chat-agent-service';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
 import { AGENT_DELEGATION_FUNCTION_ID } from '@theia/ai-core/lib/common/tool-constants';
 import { ToolInvocationRegistry } from '@theia/ai-core';
 import { AgentDelegationTool } from '@theia/ai-chat/lib/browser/agent-delegation-tool';
 import { ChatResponsePartRenderer } from '../chat-response-part-renderer';
 import { ResponseNode } from '../chat-tree-view';
 import { SubChatWidgetFactory } from '../chat-tree-view/sub-chat-widget';
-import { withToolCallConfirmation } from './tool-confirmation';
+import { ToolConfirmationKeybindingHints, withToolCallConfirmation } from './tool-confirmation';
+import {
+    APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND,
+    DENY_LATEST_TOOL_CONFIRMATION_COMMAND
+} from '../tool-confirmation-keybinding-contribution';
 import { extractJsonStringField } from './toolcall-utils';
-import { CompositeTreeNode, ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
+import { CompositeTreeNode, ContextMenuRenderer, KeybindingRegistry, MarkdownRenderer, OpenerService } from '@theia/core/lib/browser';
 import { ContributionProvider, DisposableCollection, nls } from '@theia/core';
 import * as React from '@theia/core/shared/react';
 
@@ -53,6 +58,15 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
 
     @inject(OpenerService)
     protected openerService: OpenerService;
+
+    @inject(PendingToolConfirmationTracker)
+    protected pendingToolConfirmationTracker: PendingToolConfirmationTracker;
+
+    @inject(KeybindingRegistry)
+    protected keybindingRegistry: KeybindingRegistry;
+
+    @inject(MarkdownRenderer)
+    protected markdownRenderer: MarkdownRenderer;
 
     @inject(ContributionProvider) @named(ChatResponsePartRenderer)
     protected chatResponsePartRenderers: ContributionProvider<ChatResponsePartRenderer<ChatResponseContent>>;
@@ -111,9 +125,26 @@ export class DelegationToolRenderer implements ChatResponsePartRenderer<ToolCall
                 chatId,
                 requestCanceled: parentNode.response.isCanceled,
                 contextMenuRenderer: this.contextMenuRenderer,
-                openerService: this.openerService
+                openerService: this.openerService,
+                pendingTracker: this.pendingToolConfirmationTracker,
+                keybindingHints: this.getKeybindingHints(),
+                markdownRenderer: this.markdownRenderer
             }}
         />;
+    }
+
+    protected getKeybindingHints(): ToolConfirmationKeybindingHints {
+        const allow = this.formatKeybinding(APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        const deny = this.formatKeybinding(DENY_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        return { allow, deny };
+    }
+
+    protected formatKeybinding(commandId: string): string | undefined {
+        const bindings = this.keybindingRegistry.getKeybindingsForCommand(commandId);
+        if (!bindings.length) {
+            return undefined;
+        }
+        return this.keybindingRegistry.acceleratorFor(bindings[0], '+').join('+');
     }
 }
 

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -16,13 +16,14 @@
 
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core/lib/common/nls';
-import { codicon, ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
+import { codicon, ContextMenuRenderer, LocalizedMarkdown, MarkdownRenderer, OpenerService } from '@theia/core/lib/browser';
 import { ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ToolRequest } from '@theia/ai-core';
 import { CommandMenu, ContextExpressionMatcher, MenuPath } from '@theia/core/lib/common/menu';
 import { GroupImpl } from '@theia/core/lib/browser/menu/composite-menu-node';
 import { ToolConfirmationMode as ToolConfirmationPreferenceMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
 import { MarkdownRender } from './markdown-part-renderer';
 import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
 
@@ -160,9 +161,16 @@ export interface ToolConfirmationCallbacks {
     onDeny: (scope: ConfirmationScope, reason?: string) => void;
 }
 
+export interface ToolConfirmationKeybindingHints {
+    allow?: string;
+    deny?: string;
+}
+
 export interface ToolConfirmationActionsProps extends ToolConfirmationCallbacks {
     toolName: string;
     contextMenuRenderer: ContextMenuRenderer;
+    autoFocus?: boolean;
+    keybindingHints?: ToolConfirmationKeybindingHints;
 }
 
 export class InlineActionMenuNode implements CommandMenu {
@@ -196,7 +204,9 @@ export const ToolConfirmationActions: React.FC<ToolConfirmationActionsProps> = (
     toolRequest,
     onAllow,
     onDeny,
-    contextMenuRenderer
+    contextMenuRenderer,
+    autoFocus,
+    keybindingHints
 }) => {
     const [allowScope, setAllowScope] = React.useState<ConfirmationScope>('once');
     const [denyScope, setDenyScope] = React.useState<ConfirmationScope>('once');
@@ -205,6 +215,14 @@ export const ToolConfirmationActions: React.FC<ToolConfirmationActionsProps> = (
     const [denyReason, setDenyReason] = React.useState('');
     // eslint-disable-next-line no-null/no-null
     const denyReasonInputRef = React.useRef<HTMLInputElement>(null);
+    // eslint-disable-next-line no-null/no-null
+    const allowButtonRef = React.useRef<HTMLButtonElement>(null);
+
+    React.useEffect(() => {
+        if (autoFocus && allowButtonRef.current) {
+            allowButtonRef.current.focus();
+        }
+    }, [autoFocus]);
 
     const handleAllow = React.useCallback(() => {
         if ((allowScope === 'forever' || allowScope === 'session') && toolRequest?.confirmAlwaysAllow) {
@@ -334,6 +352,9 @@ export const ToolConfirmationActions: React.FC<ToolConfirmationActionsProps> = (
         const selectedScope = type === 'allow' ? allowScope : denyScope;
         const setScope = type === 'allow' ? setAllowScope : setDenyScope;
         const handleMain = type === 'allow' ? handleAllow : handleDeny;
+        const keybindingHint = type === 'allow' ? keybindingHints?.allow : keybindingHints?.deny;
+        const mainLabel = scopeLabel(type, selectedScope);
+        const mainTitle = keybindingHint && selectedScope === 'once' ? `${mainLabel} (${keybindingHint})` : undefined;
 
         return (
             <div
@@ -341,10 +362,12 @@ export const ToolConfirmationActions: React.FC<ToolConfirmationActionsProps> = (
                 style={{ display: 'inline-flex', position: 'relative' }}
             >
                 <button
+                    ref={type === 'allow' ? allowButtonRef : undefined}
                     className={`theia-button ${type === 'allow' ? 'main' : 'secondary'} theia-tool-confirmation-main-btn`}
                     onClick={handleMain}
+                    title={mainTitle}
                 >
-                    {scopeLabel(type, selectedScope)}
+                    {mainLabel}
                 </button>
                 <button
                     className={`theia-button ${type === 'allow' ? 'main' : 'secondary'} theia-tool-confirmation-chevron-btn`}
@@ -433,10 +456,43 @@ export interface ToolConfirmationProps extends Pick<ToolConfirmationCallbacks, '
     onDeny: (scope?: ConfirmationScope, reason?: string) => void;
     contextMenuRenderer: ContextMenuRenderer;
     openerService: OpenerService;
+    pendingTracker?: PendingToolConfirmationTracker;
+    keybindingHints?: ToolConfirmationKeybindingHints;
+    chatId?: string;
+    markdownRenderer?: MarkdownRenderer;
 }
 
-export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, toolRequest, onAllow, onDeny, contextMenuRenderer, openerService }) => {
+/**
+ * Command that opens the AI Configuration view on the Tools tab; its id is duplicated here as a
+ * string constant to keep ai-chat-ui free of an ai-ide dependency.
+ */
+const OPEN_TOOLS_CONFIGURATION_COMMAND_ID = 'aiConfiguration:openTools';
+
+const ToolConfirmationIntro: React.FC<{ markdownRenderer: MarkdownRenderer }> = ({ markdownRenderer }) => (
+    <div className="theia-tool-confirmation-intro">
+        <LocalizedMarkdown
+            localizationKey="theia/ai/chat-ui/toolconfirmation/intro"
+            defaultMarkdown={
+                'AI agents may want to use tools to act on your workspace. ' +
+                'By default each tool call needs your confirmation. ' +
+                'You can change this default or pre-approve individual tools in the [Tools configuration view]({0}).'
+            }
+            args={[`command:${OPEN_TOOLS_CONFIGURATION_COMMAND_ID}`]}
+            markdownRenderer={markdownRenderer}
+            markdownOptions={{
+                isTrusted: { enabledCommands: [OPEN_TOOLS_CONFIGURATION_COMMAND_ID] }
+            }}
+        />
+    </div>
+);
+
+export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
+    response, toolRequest, onAllow, onDeny, contextMenuRenderer, openerService, pendingTracker, keybindingHints, chatId, markdownRenderer
+}) => {
     const [state, setState] = React.useState<ToolConfirmationState>('waiting');
+    const [showIntro] = React.useState<boolean>(
+        () => !!(pendingTracker && chatId && markdownRenderer && pendingTracker.shouldShowIntro(chatId))
+    );
 
     const handleAllow = React.useCallback((scope: ConfirmationScope) => {
         setState('allowed');
@@ -447,6 +503,18 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, to
         setState('denied');
         onDeny(scope, reason);
     }, [onDeny]);
+
+    React.useEffect(() => {
+        if (!pendingTracker || state !== 'waiting') {
+            return;
+        }
+        const disposable = pendingTracker.register({
+            response,
+            allow: () => handleAllow('once'),
+            deny: () => handleDeny('once')
+        });
+        return () => disposable.dispose();
+    }, [pendingTracker, response, handleAllow, handleDeny, state]);
 
     if (state === 'allowed') {
         return (
@@ -472,32 +540,37 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({ response, to
     );
 
     return (
-        <div className="theia-tool-confirmation">
-            <div className="theia-tool-confirmation-header">
-                <span className={codicon('shield')}></span> {nls.localize('theia/ai/chat-ui/toolconfirmation/header', 'Confirm Tool Execution')}
+        <>
+            {showIntro && markdownRenderer && <ToolConfirmationIntro markdownRenderer={markdownRenderer} />}
+            <div className="theia-tool-confirmation">
+                <div className="theia-tool-confirmation-header">
+                    <span className={codicon('shield')}></span> {nls.localize('theia/ai/chat-ui/toolconfirmation/header', 'Confirm Tool Execution')}
+                </div>
+                <div className="theia-tool-confirmation-info">
+                    {toolRequest?.description ? (
+                        <details className="theia-tool-confirmation-name">
+                            <summary>{toolNameContent}</summary>
+                            <div className="theia-tool-confirmation-description">
+                                {toolRequest.description}
+                            </div>
+                        </details>
+                    ) : (
+                        <div className="theia-tool-confirmation-name">{toolNameContent}</div>
+                    )}
+                    <ToolArgsDisplay args={response.arguments} openerService={openerService} />
+                </div>
+                <ToolConfirmationActions
+                    toolName={response.name ?? 'unknown'}
+                    toolRequest={toolRequest}
+                    onAllow={handleAllow}
+                    onDeny={handleDeny}
+                    contextMenuRenderer={contextMenuRenderer}
+                    autoFocus={true}
+                    keybindingHints={keybindingHints}
+                />
+                <CountdownTimer response={response} />
             </div>
-            <div className="theia-tool-confirmation-info">
-                {toolRequest?.description ? (
-                    <details className="theia-tool-confirmation-name">
-                        <summary>{toolNameContent}</summary>
-                        <div className="theia-tool-confirmation-description">
-                            {toolRequest.description}
-                        </div>
-                    </details>
-                ) : (
-                    <div className="theia-tool-confirmation-name">{toolNameContent}</div>
-                )}
-                <ToolArgsDisplay args={response.arguments} openerService={openerService} />
-            </div>
-            <ToolConfirmationActions
-                toolName={response.name ?? 'unknown'}
-                toolRequest={toolRequest}
-                onAllow={handleAllow}
-                onDeny={handleDeny}
-                contextMenuRenderer={contextMenuRenderer}
-            />
-            <CountdownTimer response={response} />
-        </div>
+        </>
     );
 };
 
@@ -539,6 +612,9 @@ export interface WithToolCallConfirmationProps {
     requestCanceled: boolean;
     contextMenuRenderer: ContextMenuRenderer;
     openerService: OpenerService;
+    pendingTracker?: PendingToolConfirmationTracker;
+    keybindingHints?: ToolConfirmationKeybindingHints;
+    markdownRenderer?: MarkdownRenderer;
 }
 
 export function withToolCallConfirmation<P extends object>(
@@ -559,7 +635,10 @@ export function withToolCallConfirmation<P extends object>(
             showArgsTooltip,
             requestCanceled,
             contextMenuRenderer,
-            openerService
+            openerService,
+            pendingTracker,
+            keybindingHints,
+            markdownRenderer
         } = toolConfirmation;
 
         const { confirmationState } = useToolConfirmationState(response, confirmationMode);
@@ -622,6 +701,10 @@ export function withToolCallConfirmation<P extends object>(
                     onDeny={handleDeny}
                     contextMenuRenderer={contextMenuRenderer}
                     openerService={openerService}
+                    pendingTracker={pendingTracker}
+                    keybindingHints={keybindingHints}
+                    chatId={chatId}
+                    markdownRenderer={markdownRenderer}
                 />
             );
         }

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/tool-confirmation.tsx
@@ -490,8 +490,10 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
     response, toolRequest, onAllow, onDeny, contextMenuRenderer, openerService, pendingTracker, keybindingHints, chatId, markdownRenderer
 }) => {
     const [state, setState] = React.useState<ToolConfirmationState>('waiting');
+    // Pure initializer (no side effects): decide whether the intro should render. Marking the chat
+    // as "intro shown" happens in the effect below to keep the initializer pure for StrictMode.
     const [showIntro] = React.useState<boolean>(
-        () => !!(pendingTracker && chatId && markdownRenderer && pendingTracker.shouldShowIntro(chatId))
+        () => !!(pendingTracker && chatId && markdownRenderer && !pendingTracker.hasShownIntro(chatId))
     );
 
     const handleAllow = React.useCallback((scope: ConfirmationScope) => {
@@ -505,16 +507,23 @@ export const ToolConfirmation: React.FC<ToolConfirmationProps> = ({
     }, [onDeny]);
 
     React.useEffect(() => {
-        if (!pendingTracker || state !== 'waiting') {
+        if (showIntro && pendingTracker && chatId) {
+            pendingTracker.markIntroShown(chatId);
+        }
+    }, []);
+
+    React.useEffect(() => {
+        if (!pendingTracker || !chatId || state !== 'waiting') {
             return;
         }
         const disposable = pendingTracker.register({
+            chatId,
             response,
             allow: () => handleAllow('once'),
             deny: () => handleDeny('once')
         });
         return () => disposable.dispose();
-    }, [pendingTracker, response, handleAllow, handleDeny, state]);
+    }, [pendingTracker, chatId, response, handleAllow, handleDeny, state]);
 
     if (state === 'allowed') {
         return (

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.tsx
@@ -19,14 +19,19 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatResponseContent, ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ReactNode } from '@theia/core/shared/react';
 import { nls } from '@theia/core/lib/common/nls';
-import { codicon, ContextMenuRenderer, HoverService, OpenerService } from '@theia/core/lib/browser';
+import { codicon, ContextMenuRenderer, HoverService, KeybindingRegistry, MarkdownRenderer, OpenerService } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
-import { createConfirmationHandlers, ToolConfirmation, useToolConfirmationState } from './tool-confirmation';
+import { createConfirmationHandlers, ToolConfirmation, ToolConfirmationKeybindingHints, useToolConfirmationState } from './tool-confirmation';
 import { ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
 import { ResponseNode } from '../chat-tree-view';
 import { MarkdownRender } from './markdown-part-renderer';
 import { isToolCallContent, ToolCallResult, ToolInvocationRegistry, ToolRequest } from '@theia/ai-core';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
+import {
+    APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND,
+    DENY_LATEST_TOOL_CONFIRMATION_COMMAND
+} from '../tool-confirmation-keybinding-contribution';
 import { condenseArguments, formatArgsForTooltip } from './toolcall-utils';
 
 @injectable()
@@ -46,6 +51,15 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
 
     @inject(ContextMenuRenderer)
     protected contextMenuRenderer: ContextMenuRenderer;
+
+    @inject(PendingToolConfirmationTracker)
+    protected pendingToolConfirmationTracker: PendingToolConfirmationTracker;
+
+    @inject(KeybindingRegistry)
+    protected keybindingRegistry: KeybindingRegistry;
+
+    @inject(MarkdownRenderer)
+    protected markdownRenderer: MarkdownRenderer;
 
     canHandle(response: ChatResponseContent): number {
         if (ToolCallChatResponseContent.is(response)) {
@@ -68,6 +82,10 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
             onDeny={handleDeny}
             contextMenuRenderer={this.contextMenuRenderer}
             openerService={this.openerService}
+            pendingTracker={this.pendingToolConfirmationTracker}
+            keybindingHints={this.getKeybindingHints()}
+            chatId={chatId}
+            markdownRenderer={this.markdownRenderer}
         />;
     }
 
@@ -86,7 +104,24 @@ export class ToolCallPartRenderer implements ChatResponsePartRenderer<ToolCallCh
             responseRenderer={this.renderResult.bind(this)}
             requestCanceled={parentNode.response.isCanceled}
             contextMenuRenderer={this.contextMenuRenderer}
-            openerService={this.openerService} />;
+            openerService={this.openerService}
+            pendingTracker={this.pendingToolConfirmationTracker}
+            keybindingHints={this.getKeybindingHints()}
+            markdownRenderer={this.markdownRenderer} />;
+    }
+
+    protected getKeybindingHints(): ToolConfirmationKeybindingHints {
+        const allow = this.formatKeybinding(APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        const deny = this.formatKeybinding(DENY_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        return { allow, deny };
+    }
+
+    protected formatKeybinding(commandId: string): string | undefined {
+        const bindings = this.keybindingRegistry.getKeybindingsForCommand(commandId);
+        if (!bindings.length) {
+            return undefined;
+        }
+        return this.keybindingRegistry.acceleratorFor(bindings[0], '+').join('+');
     }
 
     protected renderResult(response: ToolCallChatResponseContent): ReactNode {
@@ -190,6 +225,9 @@ interface ToolCallContentProps {
     requestCanceled: boolean;
     contextMenuRenderer: ContextMenuRenderer;
     openerService: OpenerService;
+    pendingTracker?: PendingToolConfirmationTracker;
+    keybindingHints?: ToolConfirmationKeybindingHints;
+    markdownRenderer?: MarkdownRenderer;
 }
 
 /**
@@ -206,7 +244,10 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
     requestCanceled,
     showArgsTooltip,
     contextMenuRenderer,
-    openerService
+    openerService,
+    pendingTracker,
+    keybindingHints,
+    markdownRenderer
 }) => {
     const { confirmationState, rejectionReason } = useToolConfirmationState(response, confirmationMode);
     const summaryRef = React.useRef<HTMLElement | undefined>(undefined);
@@ -297,6 +338,10 @@ const ToolCallContent: React.FC<ToolCallContentProps> = ({
                         onDeny={handleDeny}
                         contextMenuRenderer={contextMenuRenderer}
                         openerService={openerService}
+                        pendingTracker={pendingTracker}
+                        keybindingHints={keybindingHints}
+                        chatId={chatId}
+                        markdownRenderer={markdownRenderer}
                     />
                 </span>
             )}

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -341,6 +341,10 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
     getSettings(): ChatSessionSettings | undefined {
         return this.chatSession.model.settings;
     }
+
+    get sessionId(): string {
+        return this.chatSession.id;
+    }
 }
 
 export namespace ChatViewWidget {

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -991,6 +991,15 @@ div:last-child>.theia-ChatNode {
   cursor: default;
 }
 
+.theia-tool-confirmation-intro {
+  margin: calc(var(--theia-ui-padding) * 2) 0;
+  line-height: var(--theia-content-line-height);
+}
+
+.theia-tool-confirmation-intro p {
+  margin: 0;
+}
+
 .theia-tool-confirmation-header {
   font-weight: bold;
   margin-bottom: 8px;

--- a/packages/ai-chat-ui/src/browser/tool-confirmation-keybinding-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/tool-confirmation-keybinding-contribution.ts
@@ -15,12 +15,19 @@
 // *****************************************************************************
 
 import { Command, CommandContribution, CommandRegistry } from '@theia/core';
-import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
+import { ApplicationShell, KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
+import { PendingToolConfirmation, PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
+import { ChatViewWidget } from './chat-view-widget';
 
 export const HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY = 'theiaAi.hasPendingToolConfirmation';
+
+/**
+ * Only fire the approve/deny shortcuts while the chat view is focused, so e.g. `Ctrl+Enter` in an
+ * editor is never shadowed by a confirmation pending in some background chat.
+ */
+const CHAT_VIEW_FOCUS_WHEN = '(chatInputFocus || chatResponseFocus)';
 
 export const APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND = Command.toLocalizedCommand({
     id: 'theia.ai.chat.approveLatestToolConfirmation',
@@ -41,6 +48,9 @@ export class ToolConfirmationKeybindingContribution implements CommandContributi
     @inject(ContextKeyService)
     protected readonly contextKeyService: ContextKeyService;
 
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
     protected hasPendingKey: ContextKey<boolean>;
 
     @postConstruct()
@@ -51,12 +61,12 @@ export class ToolConfirmationKeybindingContribution implements CommandContributi
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND, {
-            isEnabled: () => this.pendingTracker.hasPending(),
-            execute: () => this.pendingTracker.getLatest()?.allow()
+            isEnabled: () => this.hasPendingInActiveChat(),
+            execute: () => this.getLatestInActiveChat()?.allow()
         });
         commands.registerCommand(DENY_LATEST_TOOL_CONFIRMATION_COMMAND, {
-            isEnabled: () => this.pendingTracker.hasPending(),
-            execute: () => this.pendingTracker.getLatest()?.deny()
+            isEnabled: () => this.hasPendingInActiveChat(),
+            execute: () => this.getLatestInActiveChat()?.deny()
         });
     }
 
@@ -64,12 +74,31 @@ export class ToolConfirmationKeybindingContribution implements CommandContributi
         keybindings.registerKeybinding({
             command: APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND.id,
             keybinding: 'ctrlcmd+enter',
-            when: HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY
+            when: `${HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY} && ${CHAT_VIEW_FOCUS_WHEN}`
         });
         keybindings.registerKeybinding({
             command: DENY_LATEST_TOOL_CONFIRMATION_COMMAND.id,
             keybinding: 'ctrlcmd+shift+backspace',
-            when: HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY
+            when: `${HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY} && ${CHAT_VIEW_FOCUS_WHEN}`
         });
+    }
+
+    /**
+     * The id of the chat the user is currently interacting with, or `undefined` if no chat view is
+     * focused. Used to target the shortcuts at the visible confirmation rather than the globally
+     * newest one.
+     */
+    protected getActiveChatId(): string | undefined {
+        return ChatViewWidget.findActive(this.shell)?.sessionId;
+    }
+
+    protected hasPendingInActiveChat(): boolean {
+        const chatId = this.getActiveChatId();
+        return chatId !== undefined && this.pendingTracker.hasPending(chatId);
+    }
+
+    protected getLatestInActiveChat(): PendingToolConfirmation | undefined {
+        const chatId = this.getActiveChatId();
+        return chatId === undefined ? undefined : this.pendingTracker.getLatest(chatId);
     }
 }

--- a/packages/ai-chat-ui/src/browser/tool-confirmation-keybinding-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/tool-confirmation-keybinding-contribution.ts
@@ -1,0 +1,75 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Command, CommandContribution, CommandRegistry } from '@theia/core';
+import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser';
+import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
+
+export const HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY = 'theiaAi.hasPendingToolConfirmation';
+
+export const APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND = Command.toLocalizedCommand({
+    id: 'theia.ai.chat.approveLatestToolConfirmation',
+    label: 'Approve Latest Tool Confirmation'
+}, 'theia/ai/chat-ui/toolconfirmation/approveLatest');
+
+export const DENY_LATEST_TOOL_CONFIRMATION_COMMAND = Command.toLocalizedCommand({
+    id: 'theia.ai.chat.denyLatestToolConfirmation',
+    label: 'Deny Latest Tool Confirmation'
+}, 'theia/ai/chat-ui/toolconfirmation/denyLatest');
+
+@injectable()
+export class ToolConfirmationKeybindingContribution implements CommandContribution, KeybindingContribution {
+
+    @inject(PendingToolConfirmationTracker)
+    protected readonly pendingTracker: PendingToolConfirmationTracker;
+
+    @inject(ContextKeyService)
+    protected readonly contextKeyService: ContextKeyService;
+
+    protected hasPendingKey: ContextKey<boolean>;
+
+    @postConstruct()
+    protected init(): void {
+        this.hasPendingKey = this.contextKeyService.createKey<boolean>(HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY, false);
+        this.pendingTracker.onChanged(() => this.hasPendingKey.set(this.pendingTracker.hasPending()));
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND, {
+            isEnabled: () => this.pendingTracker.hasPending(),
+            execute: () => this.pendingTracker.getLatest()?.allow()
+        });
+        commands.registerCommand(DENY_LATEST_TOOL_CONFIRMATION_COMMAND, {
+            isEnabled: () => this.pendingTracker.hasPending(),
+            execute: () => this.pendingTracker.getLatest()?.deny()
+        });
+    }
+
+    registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND.id,
+            keybinding: 'ctrlcmd+enter',
+            when: HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY
+        });
+        keybindings.registerKeybinding({
+            command: DENY_LATEST_TOOL_CONFIRMATION_COMMAND.id,
+            keybinding: 'ctrlcmd+shift+backspace',
+            when: HAS_PENDING_TOOL_CONFIRMATION_CONTEXT_KEY
+        });
+    }
+}

--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -60,6 +60,7 @@ import { DefaultPendingImageRegistry, PendingImageRegistry } from './pending-ima
 import { AgentDelegationTool } from './agent-delegation-tool';
 import { ToolConfirmationManager } from './chat-tool-preference-bindings';
 import { bindChatToolPreferences } from '../common/chat-tool-preferences';
+import { PendingToolConfirmationTracker } from './pending-tool-confirmation-tracker';
 import { ChatSessionStore } from '../common/chat-session-store';
 import { ChatSessionStoreImpl } from './chat-session-store-impl';
 import {
@@ -127,6 +128,7 @@ export default new ContainerModule(bind => {
     // Tool confirmation preferences
     bindChatToolPreferences(bind);
     bind(ToolConfirmationManager).toSelf().inSingletonScope();
+    bind(PendingToolConfirmationTracker).toSelf().inSingletonScope();
 
     bind(CustomChatAgent).toSelf();
     bind(CustomAgentFactory).toFactory<CustomChatAgent, [string, string, string, string, string, boolean | undefined]>(

--- a/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
+++ b/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
@@ -115,6 +115,29 @@ export class ToolConfirmationManager {
     }
 
     /**
+     * Apply multiple per-tool confirmation modes with a single preference write.
+     *
+     * Preserves the same "remove entry if it matches the effective default" behavior as
+     * {@link setConfirmationMode}. Use this for bulk operations to avoid one preference
+     * round-trip per tool.
+     */
+    setConfirmationModes(updates: Iterable<{ toolId: string; mode: ToolConfirmationMode; toolRequest?: ToolRequest }>): Promise<void> {
+        const current = this.trustAwareReader.get<Record<string, ToolConfirmationMode>>(
+            TOOL_CONFIRMATION_PREFERENCE, {}
+        ) ?? {};
+        const next: Record<string, ToolConfirmationMode> = { ...current };
+        for (const { toolId, mode, toolRequest } of updates) {
+            const effectiveDefault = this.computeEffectiveDefaultForTool(toolId, toolRequest);
+            if (mode === effectiveDefault) {
+                delete next[toolId];
+            } else {
+                next[toolId] = mode;
+            }
+        }
+        return this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, next);
+    }
+
+    /**
      * Set the confirmation mode for a specific tool for this session only (not persisted, per chat)
      */
     setSessionConfirmationMode(toolId: string, mode: ToolConfirmationMode, chatId: string): void {

--- a/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
+++ b/packages/ai-chat/src/browser/chat-tool-preference-bindings.ts
@@ -126,13 +126,22 @@ export class ToolConfirmationManager {
             TOOL_CONFIRMATION_PREFERENCE, {}
         ) ?? {};
         const next: Record<string, ToolConfirmationMode> = { ...current };
+        let changed = false;
         for (const { toolId, mode, toolRequest } of updates) {
             const effectiveDefault = this.computeEffectiveDefaultForTool(toolId, toolRequest);
             if (mode === effectiveDefault) {
-                delete next[toolId];
-            } else {
+                if (toolId in next) {
+                    delete next[toolId];
+                    changed = true;
+                }
+            } else if (next[toolId] !== mode) {
                 next[toolId] = mode;
+                changed = true;
             }
+        }
+        // Avoid a redundant preference write (and the change event it fires) when nothing changed.
+        if (!changed) {
+            return Promise.resolve();
         }
         return this.preferenceService.updateValue(TOOL_CONFIRMATION_PREFERENCE, next);
     }

--- a/packages/ai-chat/src/browser/pending-tool-confirmation-tracker.ts
+++ b/packages/ai-chat/src/browser/pending-tool-confirmation-tracker.ts
@@ -1,0 +1,81 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { Disposable, Emitter, Event } from '@theia/core';
+import { ToolCallChatResponseContent } from '../common';
+
+export interface PendingToolConfirmation {
+    readonly response: ToolCallChatResponseContent;
+    allow(): void;
+    deny(): void;
+}
+
+/**
+ * Tracks tool confirmations that are currently awaiting user input across all chats.
+ *
+ * Used to drive keyboard shortcuts that approve or deny the most recently surfaced
+ * pending confirmation without requiring the user to click on the confirmation card.
+ */
+@injectable()
+export class PendingToolConfirmationTracker {
+
+    protected readonly pending: PendingToolConfirmation[] = [];
+    protected readonly onChangedEmitter = new Emitter<void>();
+    protected readonly introShownChats = new Set<string>();
+
+    readonly onChanged: Event<void> = this.onChangedEmitter.event;
+
+    /**
+     * Returns `true` the first time it is called for a given chat id (and `false` thereafter),
+     * marking the chat as having had the tool-confirmation intro shown.
+     *
+     * Used by the UI to decide whether to render a one-time explainer above the first
+     * tool-confirmation card in a chat session.
+     */
+    shouldShowIntro(chatId: string): boolean {
+        if (this.introShownChats.has(chatId)) {
+            return false;
+        }
+        this.introShownChats.add(chatId);
+        return true;
+    }
+
+    register(entry: PendingToolConfirmation): Disposable {
+        this.pending.push(entry);
+        this.onChangedEmitter.fire();
+        return Disposable.create(() => this.unregister(entry));
+    }
+
+    unregister(entry: PendingToolConfirmation): void {
+        const index = this.pending.indexOf(entry);
+        if (index >= 0) {
+            this.pending.splice(index, 1);
+            this.onChangedEmitter.fire();
+        }
+    }
+
+    /**
+     * Returns the most recently registered pending confirmation, or `undefined` if none are pending.
+     */
+    getLatest(): PendingToolConfirmation | undefined {
+        return this.pending[this.pending.length - 1];
+    }
+
+    hasPending(): boolean {
+        return this.pending.length > 0;
+    }
+}

--- a/packages/ai-chat/src/browser/pending-tool-confirmation-tracker.ts
+++ b/packages/ai-chat/src/browser/pending-tool-confirmation-tracker.ts
@@ -19,6 +19,7 @@ import { Disposable, Emitter, Event } from '@theia/core';
 import { ToolCallChatResponseContent } from '../common';
 
 export interface PendingToolConfirmation {
+    readonly chatId: string;
     readonly response: ToolCallChatResponseContent;
     allow(): void;
     deny(): void;
@@ -28,7 +29,8 @@ export interface PendingToolConfirmation {
  * Tracks tool confirmations that are currently awaiting user input across all chats.
  *
  * Used to drive keyboard shortcuts that approve or deny the most recently surfaced
- * pending confirmation without requiring the user to click on the confirmation card.
+ * pending confirmation. Queries are scoped by chat id so a shortcut only ever targets a
+ * confirmation in the chat the user is interacting with, never one in a different chat.
  */
 @injectable()
 export class PendingToolConfirmationTracker {
@@ -40,18 +42,21 @@ export class PendingToolConfirmationTracker {
     readonly onChanged: Event<void> = this.onChangedEmitter.event;
 
     /**
-     * Returns `true` the first time it is called for a given chat id (and `false` thereafter),
-     * marking the chat as having had the tool-confirmation intro shown.
+     * Whether the one-time tool-confirmation intro has already been shown for the given chat.
      *
-     * Used by the UI to decide whether to render a one-time explainer above the first
-     * tool-confirmation card in a chat session.
+     * Pure query - call {@link markIntroShown} to record that it was shown. Kept separate so it
+     * can be used from a React render without side effects.
      */
-    shouldShowIntro(chatId: string): boolean {
-        if (this.introShownChats.has(chatId)) {
-            return false;
-        }
+    hasShownIntro(chatId: string): boolean {
+        return this.introShownChats.has(chatId);
+    }
+
+    /**
+     * Marks the tool-confirmation intro as shown for the given chat, so it is only rendered once
+     * per chat session.
+     */
+    markIntroShown(chatId: string): void {
         this.introShownChats.add(chatId);
-        return true;
     }
 
     register(entry: PendingToolConfirmation): Disposable {
@@ -69,13 +74,26 @@ export class PendingToolConfirmationTracker {
     }
 
     /**
-     * Returns the most recently registered pending confirmation, or `undefined` if none are pending.
+     * Returns the most recently registered pending confirmation, optionally restricted to a single
+     * chat. Without a `chatId` it considers all chats (e.g. to drive a global context key); with a
+     * `chatId` it only returns a confirmation belonging to that chat.
      */
-    getLatest(): PendingToolConfirmation | undefined {
-        return this.pending[this.pending.length - 1];
+    getLatest(chatId?: string): PendingToolConfirmation | undefined {
+        for (let i = this.pending.length - 1; i >= 0; i--) {
+            if (chatId === undefined || this.pending[i].chatId === chatId) {
+                return this.pending[i];
+            }
+        }
+        return undefined;
     }
 
-    hasPending(): boolean {
-        return this.pending.length > 0;
+    /**
+     * Whether there is a pending confirmation, optionally restricted to a single chat.
+     */
+    hasPending(chatId?: string): boolean {
+        if (chatId === undefined) {
+            return this.pending.length > 0;
+        }
+        return this.pending.some(entry => entry.chatId === chatId);
     }
 }

--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-view-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-view-contribution.ts
@@ -21,11 +21,17 @@ import { FrontendApplication } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { AIConfigurationContainerWidget } from './ai-configuration-widget';
 import { AIConfigurationSelectionService } from './ai-configuration-service';
+import { AIToolsConfigurationWidget } from './tools-configuration-widget';
 
 export const AI_CONFIGURATION_TOGGLE_COMMAND_ID = 'aiConfiguration:toggle';
 export const OPEN_AI_CONFIG_VIEW = Command.toLocalizedCommand({
     id: 'aiConfiguration:open',
     label: 'Open AI Configuration view',
+});
+
+export const OPEN_AI_CONFIG_VIEW_TOOLS = Command.toLocalizedCommand({
+    id: 'aiConfiguration:openTools',
+    label: 'Open AI Tools Configuration',
 });
 
 @injectable()
@@ -54,11 +60,19 @@ export class AIAgentConfigurationViewContribution extends AIViewContribution<AIC
         super.registerCommands(commands);
         commands.registerCommand(OPEN_AI_CONFIG_VIEW, {
             execute: async (tabId?: string) => {
-                await this.openView({ activate: true });
+                // Only open/reveal the view if it isn't already visible; switching tabs on an
+                // already-visible view doesn't need a (re-)activation of the whole view.
+                const widget = this.tryGetWidget();
+                if (!widget?.isVisible) {
+                    await this.openView({ activate: true });
+                }
                 if (typeof tabId === 'string') {
                     this.aiConfigurationSelectionService.selectConfigurationTab(tabId);
                 }
             },
+        });
+        commands.registerCommand(OPEN_AI_CONFIG_VIEW_TOOLS, {
+            execute: () => commands.executeCommand(OPEN_AI_CONFIG_VIEW.id, AIToolsConfigurationWidget.ID),
         });
     }
 

--- a/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/tools-configuration-widget.tsx
@@ -197,29 +197,118 @@ export class AIToolsConfigurationWidget extends AITableConfigurationWidget<ToolI
 
     protected override renderHeader(): React.ReactNode {
         return (
-            <div className="ai-tools-configuration-header">
-                <div style={{ fontWeight: 500 }}>
-                    {nls.localize('theia/ai/ide/toolsConfiguration/default/label', 'Default Tool Confirmation Mode:')}
+            <>
+                <div className="ai-tools-configuration-header">
+                    <div style={{ fontWeight: 500 }}>
+                        {nls.localize('theia/ai/ide/toolsConfiguration/default/label', 'Default Tool Confirmation Mode:')}
+                    </div>
+                    <select
+                        className="theia-select"
+                        value={this.defaultState}
+                        onChange={this.handleDefaultStateChange}
+                    >
+                        {TOOL_OPTIONS.map(opt => (
+                            <option key={opt.value} value={opt.value}>{opt.label}</option>
+                        ))}
+                    </select>
+                    <button
+                        className='theia-button secondary ai-tools-reset-button'
+                        style={{ marginLeft: 'auto' }}
+                        title={nls.localize('theia/ai/ide/toolsConfiguration/resetAllTooltip', 'Reset all tools to default')}
+                        onClick={() => this.resetAllToolsToDefault()}
+                    >
+                        {nls.localize('theia/ai/ide/toolsConfiguration/resetAll', 'Reset All')}
+                    </button>
                 </div>
-                <select
-                    className="theia-select"
-                    value={this.defaultState}
-                    onChange={this.handleDefaultStateChange}
-                >
-                    {TOOL_OPTIONS.map(opt => (
-                        <option key={opt.value} value={opt.value}>{opt.label}</option>
-                    ))}
-                </select>
+                {this.renderRecommendedDefaultsBanner()}
+            </>
+        );
+    }
+
+    protected renderRecommendedDefaultsBanner(): React.ReactNode {
+        if (this.defaultState !== ToolConfirmationMode.CONFIRM) {
+            return undefined;
+        }
+        return (
+            <div className="ai-tools-recommended-defaults-banner">
+                <span className="ai-tools-recommended-defaults-text">
+                    {nls.localize(
+                        'theia/ai/ide/toolsConfiguration/recommendedDefaults/message',
+                        'Tool calls currently require approval. Auto-allow all built-in tools at once.' +
+                        ' Tools that require extra confirmation (e.g. shell execution), MCP tools,' +
+                        ' and any tools added later will still ask before running.'
+                    )}
+                </span>
                 <button
-                    className='theia-button secondary ai-tools-reset-button'
-                    style={{ marginLeft: 'auto' }}
-                    title={nls.localize('theia/ai/ide/toolsConfiguration/resetAllTooltip', 'Reset all tools to default')}
-                    onClick={() => this.resetAllToolsToDefault()}
+                    className='theia-button main'
+                    onClick={() => this.allowCurrentTools()}
                 >
-                    {nls.localize('theia/ai/ide/toolsConfiguration/resetAll', 'Reset All')}
+                    {nls.localize('theia/ai/ide/toolsConfiguration/recommendedDefaults/apply', 'Allow Default Tools')}
                 </button>
             </div>
         );
+    }
+
+    protected async allowCurrentTools(): Promise<void> {
+        const dialog = new ConfirmDialog({
+            title: nls.localize('theia/ai/ide/toolsConfiguration/recommendedDefaults/dialogTitle', 'Allow Default Tools?'),
+            msg: this.buildAllowCurrentToolsMessage(),
+            ok: nls.localize('theia/ai/ide/toolsConfiguration/recommendedDefaults/dialogConfirm', 'I understand, allow'),
+            cancel: nls.localizeByDefault('Cancel')
+        });
+        const confirmed = await dialog.open();
+        if (!confirmed) {
+            return;
+        }
+        // Leave the global default at CONFIRM so any tool added later still requires confirmation.
+        // Skip tools that require extra consent (confirmAlwaysAllow), MCP tools (third-party code
+        // that should require informed per-tool consent), and tools the user has explicitly disabled.
+        const updates: Array<{ toolId: string; mode: ToolConfirmationMode; toolRequest: ToolRequest }> = [];
+        for (const tool of this.toolInvocationRegistry.getAllFunctions()) {
+            if (tool.confirmAlwaysAllow) {
+                continue;
+            }
+            if (tool.name.startsWith('mcp_')) {
+                continue;
+            }
+            if (this.toolConfirmationModes[tool.name] === ToolConfirmationMode.DISABLED) {
+                continue;
+            }
+            updates.push({ toolId: tool.name, mode: ToolConfirmationMode.ALWAYS_ALLOW, toolRequest: tool });
+        }
+        await this.confirmationManager.setConfirmationModes(updates);
+    }
+
+    protected buildAllowCurrentToolsMessage(): HTMLElement {
+        const container = document.createElement('div');
+        const lines = [
+            nls.localize(
+                'theia/ai/ide/toolsConfiguration/recommendedDefaults/msg/line1',
+                'This sets all currently registered built-in tools to "Always Allow".'
+            ),
+            nls.localize(
+                'theia/ai/ide/toolsConfiguration/recommendedDefaults/msg/line2',
+                'Tools that require extra confirmation (such as shell execution) will still ask before running.'
+            ),
+            nls.localize(
+                'theia/ai/ide/toolsConfiguration/recommendedDefaults/msg/line3',
+                'MCP tools are third-party and are not included. You can allow them individually in this view.'
+            ),
+            nls.localize(
+                'theia/ai/ide/toolsConfiguration/recommendedDefaults/msg/line4',
+                'Tools added later will still default to "Confirm" so you can review them.'
+            ),
+            nls.localize(
+                'theia/ai/ide/toolsConfiguration/recommendedDefaults/msg/line5',
+                'You can change this later in this view.'
+            )
+        ];
+        for (const line of lines) {
+            const p = document.createElement('p');
+            p.textContent = line;
+            container.appendChild(p);
+        }
+        return container;
     }
 
     protected getEffectiveState(toolName: string): ToolConfirmationMode {

--- a/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/ide-chat-welcome-message-provider.tsx
@@ -24,7 +24,9 @@ import { AgentService, FrontendLanguageModelRegistry } from '@theia/ai-core/lib/
 import { PreferenceService } from '@theia/core/lib/common';
 import { DEFAULT_CHAT_AGENT_PREF, BYPASS_MODEL_REQUIREMENT_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
 import { ChatAgentRecommendationService, ChatAgentService } from '@theia/ai-chat/lib/common';
-import { OPEN_AI_CONFIG_VIEW } from './ai-configuration/ai-configuration-view-contribution';
+import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { DEFAULT_TOOL_CONFIRMATION_PREFERENCE, TOOL_CONFIRMATION_PREFERENCE, ToolConfirmationMode } from '@theia/ai-chat/lib/common/chat-tool-preferences';
+import { OPEN_AI_CONFIG_VIEW, OPEN_AI_CONFIG_VIEW_TOOLS } from './ai-configuration/ai-configuration-view-contribution';
 import { AIActivationService } from '@theia/ai-core/lib/browser';
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { WorkspaceCommands } from '@theia/workspace/lib/browser/workspace-commands';
@@ -83,6 +85,9 @@ export class IdeChatWelcomeMessageProvider implements ChatWelcomeMessageProvider
     @inject(AgentService)
     protected agentService: AgentService;
 
+    @inject(ToolConfirmationManager)
+    protected readonly toolConfirmationManager: ToolConfirmationManager;
+
     @inject(AIActivationService)
     protected readonly activationService: AIActivationService;
 
@@ -120,6 +125,9 @@ export class IdeChatWelcomeMessageProvider implements ChatWelcomeMessageProvider
                         this._modelRequirementBypassed = effectiveValue;
                         this.notifyStateChanged();
                     }
+                } else if (e.preferenceName === DEFAULT_TOOL_CONFIRMATION_PREFERENCE || e.preferenceName === TOOL_CONFIRMATION_PREFERENCE) {
+                    // Re-render so the tool-confirmation explainer is hidden once the user configures confirmation behavior.
+                    this.notifyStateChanged();
                 }
             })
         );
@@ -186,6 +194,19 @@ export class IdeChatWelcomeMessageProvider implements ChatWelcomeMessageProvider
         return this._defaultAgent;
     }
 
+    /**
+     * Whether to show the tool-confirmation explainer on the welcome screen.
+     *
+     * Only shown while the user is still in the default state, i.e. every tool call is confirmed and
+     * no per-tool overrides exist. Once the user has changed the default mode (e.g. to always allow
+     * or to disable tools) or pre-approved individual tools (including via bulk approval), they are
+     * already aware of the mechanism, so the explainer is suppressed.
+     */
+    protected get shouldShowToolConfirmationInfo(): boolean {
+        return this.toolConfirmationManager.getDefaultConfirmationMode() === ToolConfirmationMode.CONFIRM
+            && Object.keys(this.toolConfirmationManager.getAllConfirmationSettings()).length === 0;
+    }
+
     protected setModelRequirementBypassed(bypassed: boolean): void {
         this.preferenceService.set(BYPASS_MODEL_REQUIREMENT_PREF, bypassed, PreferenceScope.User);
     }
@@ -227,6 +248,27 @@ Attach context with *#{3}*, *#{4}*, *#{5}*, or click {6}. [Learn more](https://t
                 className="theia-WelcomeMessage-Content"
                 markdownOptions={{ supportHtml: true }}
             />
+            {this.shouldShowToolConfirmationInfo && (
+                <div className="theia-alert theia-info-alert theia-WelcomeMessage-Alert">
+                    <div className="theia-message-header">
+                        <span className={codicon('info')}></span>
+                        <span>{nls.localize('theia/ai/ide/toolConfirmationInfo/header', 'Tool confirmation')}</span>
+                    </div>
+                    <div className="theia-message-content">
+                        <LocalizedMarkdown
+                            localizationKey="theia/ai/ide/toolConfirmationInfo"
+                            defaultMarkdown={
+                                'AI agents may want to use tools to act on your workspace. ' +
+                                'By default each tool call needs your confirmation. ' +
+                                'You can change this default or pre-approve individual tools in the [Tools configuration view]({0}).'
+                            }
+                            args={[`command:${OPEN_AI_CONFIG_VIEW_TOOLS.id}`]}
+                            markdownRenderer={this.markdownRenderer}
+                            markdownOptions={{ isTrusted: { enabledCommands: [OPEN_AI_CONFIG_VIEW_TOOLS.id] } }}
+                        />
+                    </div>
+                </div>
+            )}
         </div>;
     }
 

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1250,6 +1250,22 @@
   border-radius: 3px;
 }
 
+.ai-tools-recommended-defaults-banner {
+  display: flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding) * 2);
+  margin-bottom: calc(var(--theia-ui-padding) * 2);
+  padding: calc(var(--theia-ui-padding) * 1.5);
+  background-color: var(--theia-editorInfo-background, var(--theia-editor-background));
+  border: var(--theia-border-width) solid var(--theia-editorInfo-border, var(--theia-widget-border));
+  border-radius: 3px;
+}
+
+.ai-tools-recommended-defaults-text {
+  flex: 1;
+  line-height: var(--theia-content-line-height);
+}
+
 .ai-tools-configuration-default-section {
   margin-bottom: calc(var(--theia-ui-padding) * 2);
 }

--- a/packages/ai-ide/src/browser/todo-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/todo-tool-renderer.tsx
@@ -20,11 +20,16 @@ import { ResponseNode } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { ChatResponseContent, ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ReactNode } from '@theia/core/shared/react';
 import * as React from '@theia/core/shared/react';
-import { codicon, ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
+import { codicon, ContextMenuRenderer, KeybindingRegistry, OpenerService } from '@theia/core/lib/browser';
 import { nls } from '@theia/core';
 import { TODO_WRITE_FUNCTION_ID, TodoItem, isValidTodoItem } from '../common/todo-tool';
-import { withToolCallConfirmation } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/tool-confirmation';
+import { ToolConfirmationKeybindingHints, withToolCallConfirmation } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/tool-confirmation';
+import {
+    APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND,
+    DENY_LATEST_TOOL_CONFIRMATION_COMMAND
+} from '@theia/ai-chat-ui/lib/browser/tool-confirmation-keybinding-contribution';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
 import { ToolInvocationRegistry } from '@theia/ai-core';
 
 interface TodoListComponentProps {
@@ -95,6 +100,12 @@ export class TodoToolRenderer implements ChatResponsePartRenderer<ToolCallChatRe
     @inject(ToolInvocationRegistry)
     protected toolInvocationRegistry: ToolInvocationRegistry;
 
+    @inject(PendingToolConfirmationTracker)
+    protected pendingToolConfirmationTracker: PendingToolConfirmationTracker;
+
+    @inject(KeybindingRegistry)
+    protected keybindingRegistry: KeybindingRegistry;
+
     canHandle(response: ChatResponseContent): number {
         if (ToolCallChatResponseContent.is(response) && response.name === TODO_WRITE_FUNCTION_ID) {
             return 20;
@@ -128,7 +139,9 @@ export class TodoToolRenderer implements ChatResponsePartRenderer<ToolCallChatRe
                     chatId,
                     requestCanceled: parentNode.response.isCanceled,
                     contextMenuRenderer: this.contextMenuRenderer,
-                    openerService: this.openerService
+                    openerService: this.openerService,
+                    pendingTracker: this.pendingToolConfirmationTracker,
+                    keybindingHints: this.getKeybindingHints()
                 }}
             />
         );
@@ -155,5 +168,19 @@ export class TodoToolRenderer implements ChatResponsePartRenderer<ToolCallChatRe
         } catch {
             return undefined;
         }
+    }
+
+    protected getKeybindingHints(): ToolConfirmationKeybindingHints {
+        const allow = this.formatKeybinding(APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        const deny = this.formatKeybinding(DENY_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        return { allow, deny };
+    }
+
+    protected formatKeybinding(commandId: string): string | undefined {
+        const bindings = this.keybindingRegistry.getKeybindingsForCommand(commandId);
+        if (!bindings.length) {
+            return undefined;
+        }
+        return this.keybindingRegistry.acceleratorFor(bindings[0], '+').join('+');
     }
 }

--- a/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
@@ -20,11 +20,16 @@ import { ResponseNode } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { ChatResponseContent, ToolCallChatResponseContent } from '@theia/ai-chat/lib/common';
 import { ReactNode } from '@theia/core/shared/react';
 import * as React from '@theia/core/shared/react';
-import { codicon, ContextMenuRenderer, OpenerService } from '@theia/core/lib/browser';
+import { codicon, ContextMenuRenderer, KeybindingRegistry, OpenerService } from '@theia/core/lib/browser';
 import { nls } from '@theia/core/lib/common/nls';
 import { useMarkdownRendering } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/markdown-part-renderer';
-import { withToolCallConfirmation } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/tool-confirmation';
+import { ToolConfirmationKeybindingHints, withToolCallConfirmation } from '@theia/ai-chat-ui/lib/browser/chat-response-renderer/tool-confirmation';
+import {
+    APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND,
+    DENY_LATEST_TOOL_CONFIRMATION_COMMAND
+} from '@theia/ai-chat-ui/lib/browser/tool-confirmation-keybinding-contribution';
 import { ToolConfirmationManager } from '@theia/ai-chat/lib/browser/chat-tool-preference-bindings';
+import { PendingToolConfirmationTracker } from '@theia/ai-chat/lib/browser/pending-tool-confirmation-tracker';
 import { ToolInvocationRegistry } from '@theia/ai-core';
 import { UserInteractionTool } from './user-interaction-tool';
 import {
@@ -499,6 +504,12 @@ export class UserInteractionToolRenderer implements ChatResponsePartRenderer<Too
     @inject(OpenerService)
     protected openerService: OpenerService;
 
+    @inject(PendingToolConfirmationTracker)
+    protected pendingToolConfirmationTracker: PendingToolConfirmationTracker;
+
+    @inject(KeybindingRegistry)
+    protected keybindingRegistry: KeybindingRegistry;
+
     canHandle(response: ChatResponseContent): number {
         if (ToolCallChatResponseContent.is(response) && response.name === USER_INTERACTION_FUNCTION_ID) {
             return 20;
@@ -551,9 +562,25 @@ export class UserInteractionToolRenderer implements ChatResponsePartRenderer<Too
                     chatId,
                     requestCanceled: parentNode.response.isCanceled,
                     contextMenuRenderer: this.contextMenuRenderer,
-                    openerService: this.openerService
+                    openerService: this.openerService,
+                    pendingTracker: this.pendingToolConfirmationTracker,
+                    keybindingHints: this.getKeybindingHints()
                 }}
             />
         );
+    }
+
+    protected getKeybindingHints(): ToolConfirmationKeybindingHints {
+        const allow = this.formatKeybinding(APPROVE_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        const deny = this.formatKeybinding(DENY_LATEST_TOOL_CONFIRMATION_COMMAND.id);
+        return { allow, deny };
+    }
+
+    protected formatKeybinding(commandId: string): string | undefined {
+        const bindings = this.keybindingRegistry.getKeybindingsForCommand(commandId);
+        if (!bindings.length) {
+            return undefined;
+        }
+        return this.keybindingRegistry.acceleratorFor(bindings[0], '+').join('+');
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Follow-ups to #17452 that reduce friction with the `confirm` default without loosening the security model:

- `Ctrl+Enter` / `Ctrl+Shift+Backspace` approve/deny the latest pending confirmation. Gated by a context key so they don't fire when none is waiting. Allow button auto-focuses on render
- One-time intro snippet above the first confirmation in each chat, linking to the Tools tab
- Tool-confirmation info box on the chat welcome page, shown until the user configures tool confirmation (changes the default or sets any per-tool mode)
- "Allow Default Tools" in the Tools tab bulk-approves built-in tools in a single preference write. Default stays at `confirm`; skips MCP, `confirmAlwaysAllow`, and disabled tools
- Add `aiConfiguration:openTools` to open the AI Configuration view on the Tools tab; the view is only opened/revealed when not already visible

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Preparation: open the AI Configuration view, switch to the Tools tab, set "Default Tool Confirmation Mode" to `Confirm`, and click "Reset All" so no per-tool overrides are in place.

1. Start a fresh chat with a tool-using agent (e.g. Coder).
2. With a fresh, unconfigured setup (default `Confirm`, no per-tool overrides), open the chat. Verify the welcome screen shows an info box explaining tool confirmation, with a link to the Tools tab. After running "Allow Default Tools" or changing the default, reopen the chat and verify the box no longer appears.
3. Trigger a tool call. Verify the intro snippet appears above the first confirmation card, with a link that opens the AI Configuration view on the Tools tab (this has slow performance though to open the tools tab, see follow ups).
4. With a confirmation card visible: press `Ctrl+Enter` to allow, `Ctrl+Shift+Backspace` to deny. Confirm both work whether the chat input or the card itself is focused. Confirm `Ctrl+Enter` still does nothing when no confirmation is pending.
5. Open the AI Configuration view, switch to the Tools tab. With the default at `Confirm`, the "Allow Default Tools" banner should be visible. Click it, confirm the dialog, and verify:
   - All built-in tools (non-MCP, non-`confirmAlwaysAllow`) flip to `Always Allow`.
   - `shell_execute` stays on `Confirm`.
   - Tools whose ids start with `mcp_` stay on `Confirm`.
   - The global "Default Tool Confirmation Mode" stays on `Confirm`.
   - The update is effectively instant (single preference write).
 6. Send a second prompt that triggers another tool; the snippet should not appear again.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- Tool categories (read-only / workspace writes / external calls / system) with per-category bulk actions, so users can reason about classes of capability instead of individual tools.
- Optional shortcut for "Allow for this chat" (e.g. `Ctrl+Shift+Enter`)
- Mark MCP tools with `confirmAlwaysAllow` at registration time, so even the per-tool "Always Allow" dropdown triggers the "I understand" modal for third-party code.
- Diagnose AI Configuration view tab switching slowness. Appears unrelated to this PR but is noticeable; likely candidates are unmemoized `loadData()` on activation and synchronous prompt parsing in the Agents tab.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
