### PR TITLE
align icon, caption, id of custom editors with defualt editors

### DIFF
--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-opener.tsx
@@ -105,6 +105,7 @@ export class CustomEditorOpener implements OpenHandler {
                     try {
                         w.viewType = this.editor.viewType;
                         w.resource = uri;
+                        w.updateID();
                         await this.editorRegistry.resolveWidget(w);
                         if (options?.widgetOptions) {
                             await this.shell.addWidget(w, options.widgetOptions);

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -65,6 +65,10 @@ export class CustomEditorWidget extends WebviewWidget implements CustomEditorWid
         }));
     }
 
+    updateID(): void {
+        this.id = CustomEditorWidget.FACTORY_ID + `:${this.resource.toString()}:${this.identifier.id}`;
+    }
+
     undo(): void {
         this._modelRef.object?.undo();
     }

--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editors-main.ts
@@ -145,6 +145,8 @@ export class CustomEditorsMainImpl implements CustomEditorsMain, Disposable {
 
                 this.webviewsMain.hookWebview(widget);
                 widget.title.label = this.labelProvider.getName(resource);
+                widget.title.caption = resource.path.fsPath();
+                widget.title.iconClass = this.labelProvider.getIcon(resource) + ' file-icon';
 
                 const _cancellationSource = new CancellationTokenSource();
                 await this.proxy.$resolveWebviewEditor(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Solves [17611](https://github.com/eclipse-theia/theia/issues/17611) by aligning the id, icon, and caption of custom editors and default editors.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Open a custom editor.
Confirm the file icon is the same as default editor.
Hover on the tab. Confirm the path of the editor shows up.
Open developer tools, find the elements corresponding to the tab of the editor and the editor itself, and confirm they have the path uri in their id.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)