### PR TITLE
fix(ai-ide): speed up workspace file tools and fix external-path matching

### DIFF
--- a/packages/ai-ide/package.json
+++ b/packages/ai-ide/package.json
@@ -23,6 +23,7 @@
     "@theia/core": "1.72.0",
     "@theia/debug": "1.72.0",
     "@theia/editor": "1.72.0",
+    "@theia/file-search": "1.72.0",
     "@theia/filesystem": "1.72.0",
     "@theia/markers": "1.72.0",
     "@theia/monaco": "1.72.0",

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -40,6 +40,43 @@ import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ProblemManager } from '@theia/markers/lib/browser';
 import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-model-service';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
+import { Minimatch } from 'minimatch';
+
+const makeFileSearchService = (
+    impl?: (searchPattern: string, options: FileSearchService.Options) => Promise<string[]>
+): FileSearchService & { calls: Array<{ searchPattern: string; options: FileSearchService.Options }> } => {
+    const calls: Array<{ searchPattern: string; options: FileSearchService.Options }> = [];
+    return {
+        calls,
+        find: async (searchPattern: string, options: FileSearchService.Options) => {
+            calls.push({ searchPattern, options });
+            return impl ? impl(searchPattern, options) : [];
+        }
+    } as unknown as FileSearchService & { calls: Array<{ searchPattern: string; options: FileSearchService.Options }> };
+};
+
+/**
+ * A FileSearchService stand-in that mimics ripgrep: given a flat map of file URIs per
+ * root, it returns the files under the requested root that match the include globs and
+ * are not removed by the exclude globs (matched against each file's root-relative path).
+ */
+const makeRipgrepLikeSearchService = (filesByRoot: Record<string, string[]>) =>
+    makeFileSearchService(async (_searchPattern, options) => {
+        const root = options.rootUris?.[0];
+        if (!root) {
+            return [];
+        }
+        const rootUri = new URI(root);
+        const includes = (options.includePatterns ?? []).map(pattern => new Minimatch(pattern, { dot: true }));
+        const excludes = (options.excludePatterns ?? []).map(pattern => new Minimatch(pattern, { dot: true }));
+        return (filesByRoot[root] ?? []).filter(file => {
+            const relativePath = rootUri.relative(new URI(file))?.toString() ?? '';
+            const included = includes.length === 0 || includes.some(matcher => matcher.match(relativePath));
+            const excluded = excludes.some(matcher => matcher.match(relativePath));
+            return included && !excluded;
+        });
+    });
 
 const makeTrustAwareReader = (overrides: { [pref: string]: unknown } = {}): TrustAwarePreferenceReader => ({
     get: <T>(name: string, fallback?: T) => (name in overrides ? overrides[name] as T : fallback),
@@ -136,6 +173,7 @@ describe('Workspace Functions Cancellation Tests', () => {
         container.bind(MonacoTextModelService).toConstantValue(mockMonacoTextModelService);
         container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
         container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(FileSearchService).toConstantValue(makeFileSearchService());
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(GetWorkspaceDirectoryStructure).toSelf();
         container.bind(FileContentFunction).toSelf();
@@ -740,6 +778,7 @@ describe('FindFilesByPattern.getArgumentsShortLabel', () => {
         container.bind(PreferenceService).toConstantValue(mockPreferenceService);
         container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
         container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(FileSearchService).toConstantValue(makeFileSearchService());
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(FindFilesByPattern).toSelf();
 
@@ -766,6 +805,121 @@ describe('FindFilesByPattern.getArgumentsShortLabel', () => {
     it('returns undefined when pattern key is missing', () => {
         const result = getArgumentsShortLabel(JSON.stringify({ glob: '**/*.ts' }));
         expect(result).to.be.undefined;
+    });
+});
+
+describe('FindFilesByPattern.findFiles', () => {
+    let container: Container;
+    let findFilesByPattern: FindFilesByPattern;
+    let fileSearchService: ReturnType<typeof makeFileSearchService>;
+    let searchResults: string[];
+    let roots: Array<{ resource: URI }>;
+    let prefs: { [key: string]: unknown };
+    let allowedExternal: string[];
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        searchResults = [];
+        roots = [{ resource: new URI('file:///workspace') }];
+        prefs = {
+            'ai-features.workspaceFunctions.considerGitIgnore': true,
+            'ai-features.workspaceFunctions.userExcludes': ['node_modules', 'lib']
+        };
+        allowedExternal = [];
+
+        const mockWorkspaceService = {
+            roots: Promise.resolve(roots),
+            tryGetRoots: () => roots,
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            exists: async () => true,
+            resolve: async (uri: URI) => ({ isDirectory: true, children: [], resource: uri }),
+            read: async () => ({ value: { toString: () => '' } })
+        } as unknown as FileService;
+
+        const mockPreferenceService = {
+            get: <T>(path: string, defaultValue: T) => (path in prefs ? prefs[path] as T : defaultValue)
+        };
+
+        const trustAwareReader = {
+            get: <T>(name: string, fallback?: T) =>
+                (name === 'ai-features.workspaceFunctions.allowedExternalPaths' ? (allowedExternal as unknown as T) : fallback),
+            ready: Promise.resolve(),
+            onDidChangeTrust: () => ({ dispose: () => { /* noop */ } })
+        } as unknown as TrustAwarePreferenceReader;
+
+        fileSearchService = makeFileSearchService(async () => searchResults);
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(trustAwareReader);
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(FileSearchService).toConstantValue(fileSearchService);
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(FindFilesByPattern).toSelf();
+
+        findFilesByPattern = container.get(FindFilesByPattern);
+    });
+
+    const call = (args: object, ctx?: ToolInvocationContext) =>
+        findFilesByPattern.getTool().handler(JSON.stringify(args), ctx) as Promise<string>;
+
+    it('returns root-prefixed workspace-relative paths', async () => {
+        searchResults = ['file:///workspace/src/a.ts', 'file:///workspace/src/b.ts'];
+        const result = JSON.parse(await call({ pattern: '**/*.ts' }));
+        expect(result.files).to.deep.equal(['workspace/src/a.ts', 'workspace/src/b.ts']);
+    });
+
+    it('passes the glob, user excludes, gitignore flag and root to the search service', async () => {
+        await call({ pattern: '**/*.ts', exclude: ['**/*.spec.ts'] });
+        expect(fileSearchService.calls).to.have.length(1);
+        const options = fileSearchService.calls[0].options;
+        expect(options.includePatterns).to.deep.equal(['**/*.ts']);
+        expect(options.excludePatterns).to.deep.equal(['node_modules', 'lib', '**/*.spec.ts']);
+        expect(options.useGitIgnore).to.equal(true);
+        expect(options.rootUris).to.deep.equal(['file:///workspace']);
+        expect(options.fuzzyMatch).to.equal(false);
+    });
+
+    it('does not use gitignore when the preference is disabled', async () => {
+        prefs['ai-features.workspaceFunctions.considerGitIgnore'] = false;
+        await call({ pattern: '**/*.ts' });
+        expect(fileSearchService.calls[0].options.useGitIgnore).to.equal(false);
+    });
+
+    it('reports an error when no workspace is open', async () => {
+        roots.length = 0;
+        const result = JSON.parse(await call({ pattern: '**/*.ts' }));
+        expect(result.error).to.equal('No workspace has been opened yet');
+    });
+
+    it('respects the cancellation token', async () => {
+        const cts = new CancellationTokenSource();
+        cts.cancel();
+        const result = JSON.parse(await call({ pattern: '**/*.ts' }, { cancellationToken: cts.token }));
+        expect(result.error).to.equal('Operation cancelled by user');
+    });
+
+    it('truncates to 200 results and flags truncation', async () => {
+        searchResults = Array.from({ length: 250 }, (_, i) => `file:///workspace/f${i}.ts`);
+        const result = JSON.parse(await call({ pattern: '**/*.ts' }));
+        expect(result.files).to.have.length(200);
+        expect(result.truncated).to.equal(true);
+    });
+
+    it('returns absolute paths for an allow-listed external searchRoot', async () => {
+        allowedExternal = ['/external/data'];
+        searchResults = ['file:///external/data/x.ts'];
+        const result = JSON.parse(await call({ pattern: '**/*.ts', searchRoot: '/external/data' }));
+        expect(result.files).to.deep.equal(['/external/data/x.ts']);
+        expect(fileSearchService.calls[0].options.rootUris).to.deep.equal(['file:///external/data']);
     });
 });
 
@@ -1041,12 +1195,9 @@ describe('FindFilesByPattern with searchRoot', () => {
     let findFilesByPattern: FindFilesByPattern;
     let allowedPaths: string[];
 
-    const FS_TREE: Record<string, { isDirectory: boolean; children?: string[] }> = {
-        'file:///workspace': { isDirectory: true, children: ['file:///workspace/a.ts'] },
-        'file:///workspace/a.ts': { isDirectory: false },
-        'file:///external/configs': { isDirectory: true, children: ['file:///external/configs/myapp.json', 'file:///external/configs/other.txt'] },
-        'file:///external/configs/myapp.json': { isDirectory: false },
-        'file:///external/configs/other.txt': { isDirectory: false }
+    const FILES_BY_ROOT: Record<string, string[]> = {
+        'file:///workspace': ['file:///workspace/a.ts'],
+        'file:///external/configs': ['file:///external/configs/myapp.json', 'file:///external/configs/other.txt']
     };
 
     let disableJSDOMInner: () => void;
@@ -1065,24 +1216,8 @@ describe('FindFilesByPattern with searchRoot', () => {
 
         const mockFileService = {
             exists: async () => true,
-            resolve: async (uri: URI) => {
-                const node = FS_TREE[uri.toString()];
-                if (!node) {
-                    throw new Error('not found');
-                }
-                return {
-                    isDirectory: node.isDirectory,
-                    isFile: !node.isDirectory,
-                    resource: uri,
-                    children: node.children?.map(child => ({
-                        isDirectory: !!FS_TREE[child]?.isDirectory,
-                        isFile: !FS_TREE[child]?.isDirectory,
-                        resource: new URI(child),
-                        path: { base: child.split('/').pop() }
-                    })) ?? []
-                };
-            },
-            read: async () => ({ value: '' })
+            resolve: async (uri: URI) => ({ isDirectory: true, children: [], resource: uri }),
+            read: async () => ({ value: { toString: () => '' } })
         } as unknown as FileService;
 
         const mockPreferenceService = {
@@ -1100,6 +1235,7 @@ describe('FindFilesByPattern with searchRoot', () => {
         container.bind(PreferenceService).toConstantValue(mockPreferenceService);
         container.bind(TrustAwarePreferenceReader).toConstantValue(trustAwareReader);
         container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(FileSearchService).toConstantValue(makeRipgrepLikeSearchService(FILES_BY_ROOT));
         container.bind(WorkspaceFunctionScope).toSelf();
         container.bind(FindFilesByPattern).toSelf();
 

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -34,7 +34,7 @@ import { TrustAwarePreferenceReader } from '@theia/ai-core/lib/browser/trust-awa
 import { Container } from '@theia/core/shared/inversify';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
+import { FileOperationError, FileOperationResult, FileStat } from '@theia/filesystem/lib/common/files';
 import { URI } from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { ProblemManager } from '@theia/markers/lib/browser';
@@ -920,6 +920,199 @@ describe('FindFilesByPattern.findFiles', () => {
         const result = JSON.parse(await call({ pattern: '**/*.ts', searchRoot: '/external/data' }));
         expect(result.files).to.deep.equal(['/external/data/x.ts']);
         expect(fileSearchService.calls[0].options.rootUris).to.deep.equal(['file:///external/data']);
+    });
+});
+
+describe('WorkspaceFunctionScope gitignore caching', () => {
+    let container: Container;
+    let scope: WorkspaceFunctionScope;
+    let resolveCount: number;
+    let gitignoreReadCount: number;
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        resolveCount = 0;
+        gitignoreReadCount = 0;
+
+        const mockWorkspaceService = {
+            roots: Promise.resolve([{ resource: new URI('file:///workspace') }]),
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            resolve: async (uri: URI) => { resolveCount++; return { isDirectory: true, resource: uri }; },
+            read: async (uri: URI) => {
+                if (uri.path.base === '.gitignore') {
+                    gitignoreReadCount++;
+                    return { value: 'dist/\n' };
+                }
+                throw new Error('not found');
+            },
+            watch: () => ({ dispose: () => { } }),
+            onDidFilesChange: () => ({ dispose: () => { } })
+        } as unknown as FileService;
+
+        const mockPreferenceService = {
+            get: <T>(path: string, defaultValue: T) =>
+                (path === 'ai-features.workspaceFunctions.considerGitIgnore' ? (true as unknown as T) : defaultValue)
+        };
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(WorkspaceFunctionScope).toSelf();
+
+        scope = container.get(WorkspaceFunctionScope);
+    });
+
+    const stat = (path: string, isDirectory = false) => ({
+        resource: new URI(path),
+        isDirectory,
+        path: { base: path.split('/').pop() }
+    }) as unknown as FileStat;
+
+    it('still excludes gitignored paths and keeps others', async () => {
+        expect(await scope.shouldExclude(stat('file:///workspace/dist/a.js'))).to.be.true;
+        expect(await scope.shouldExclude(stat('file:///workspace/src/b.ts'))).to.be.false;
+    });
+
+    it('reads .gitignore at most once and issues no per-check resolve RPC', async () => {
+        for (let i = 0; i < 25; i++) {
+            await scope.shouldExclude(stat(`file:///workspace/src/file${i}.ts`));
+        }
+        expect(gitignoreReadCount).to.equal(1);
+        expect(resolveCount).to.equal(0);
+    });
+});
+
+describe('GetWorkspaceFileList resolves the target directory once', () => {
+    let container: Container;
+    let tool: GetWorkspaceFileList;
+    let resolveCount: number;
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        resolveCount = 0;
+
+        const mockWorkspaceService = {
+            roots: Promise.resolve([{ resource: new URI('file:///workspace') }]),
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            exists: async () => true,
+            resolve: async (uri: URI) => {
+                resolveCount++;
+                return {
+                    isDirectory: true,
+                    resource: uri,
+                    children: [
+                        { isDirectory: false, resource: new URI('file:///workspace/sub/a.ts'), path: { base: 'a.ts' } },
+                        { isDirectory: true, resource: new URI('file:///workspace/sub/dir'), path: { base: 'dir' } }
+                    ]
+                };
+            },
+            read: async () => ({ value: { toString: () => '' } }),
+            watch: () => ({ dispose: () => { } }),
+            onDidFilesChange: () => ({ dispose: () => { } })
+        } as unknown as FileService;
+
+        const mockPreferenceService = { get: <T>(_path: string, def: T) => def };
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(GetWorkspaceFileList).toSelf();
+
+        tool = container.get(GetWorkspaceFileList);
+    });
+
+    it('lists one level and resolves the directory only once', async () => {
+        const result = JSON.parse(await tool.getTool().handler(JSON.stringify({ path: 'workspace/sub' }), undefined) as string);
+        expect(result).to.deep.equal({ 'a.ts': 'file', 'dir': 'directory' });
+        expect(resolveCount).to.equal(1);
+    });
+});
+
+describe('GetWorkspaceDirectoryStructure preserves empty folders', () => {
+    let container: Container;
+    let tool: GetWorkspaceDirectoryStructure;
+
+    const TREE: Record<string, string[]> = {
+        'file:///workspace': ['file:///workspace/src', 'file:///workspace/empty', 'file:///workspace/node_modules'],
+        'file:///workspace/src': ['file:///workspace/src/nested'],
+        'file:///workspace/src/nested': [],
+        'file:///workspace/empty': [],
+        'file:///workspace/node_modules': ['file:///workspace/node_modules/pkg']
+    };
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+
+        const mockWorkspaceService = {
+            roots: Promise.resolve([{ resource: new URI('file:///workspace') }]),
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            resolve: async (uri: URI) => ({
+                isDirectory: true,
+                resource: uri,
+                children: (TREE[uri.toString()] ?? []).map(child => ({
+                    isDirectory: true,
+                    resource: new URI(child),
+                    path: { base: child.split('/').pop() }
+                }))
+            }),
+            read: async () => ({ value: { toString: () => '' } }),
+            watch: () => ({ dispose: () => { } }),
+            onDidFilesChange: () => ({ dispose: () => { } })
+        } as unknown as FileService;
+
+        const mockPreferenceService = {
+            get: <T>(path: string, def: T) =>
+                (path === 'ai-features.workspaceFunctions.userExcludes' ? (['node_modules'] as unknown as T) : def)
+        };
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue(mockPreferenceService);
+        container.bind(TrustAwarePreferenceReader).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(GetWorkspaceDirectoryStructure).toSelf();
+
+        tool = container.get(GetWorkspaceDirectoryStructure);
+    });
+
+    it('includes empty directories and excludes user-excluded ones', async () => {
+        const result = await tool.getTool().handler(JSON.stringify({}), undefined);
+        expect(result).to.deep.equal({
+            workspace: {
+                src: { nested: {} },
+                empty: {}
+            }
+        });
     });
 });
 

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -921,6 +921,37 @@ describe('FindFilesByPattern.findFiles', () => {
         expect(result.files).to.deep.equal(['/external/data/x.ts']);
         expect(fileSearchService.calls[0].options.rootUris).to.deep.equal(['file:///external/data']);
     });
+
+    it('does not apply gitignore to external roots (it is scoped to workspace roots)', async () => {
+        prefs['ai-features.workspaceFunctions.considerGitIgnore'] = true;
+        allowedExternal = ['/external/data'];
+        await call({ pattern: '**/*.ts', searchRoot: '/external/data' });
+        const options = fileSearchService.calls[0].options;
+        expect(options.useGitIgnore).to.equal(false);
+        expect(options.excludePatterns).to.include('.git');
+    });
+
+    it('still applies gitignore to workspace roots', async () => {
+        prefs['ai-features.workspaceFunctions.considerGitIgnore'] = true;
+        await call({ pattern: '**/*.ts' });
+        expect(fileSearchService.calls[0].options.useGitIgnore).to.equal(true);
+    });
+
+    it('matches an allow-list entry with a trailing slash against a searchRoot without one', async () => {
+        allowedExternal = ['/external/data/']; // trailing slash, as a user/file-picker may enter it
+        searchResults = ['file:///external/data/x.ts'];
+        const result = JSON.parse(await call({ pattern: '**/*.ts', searchRoot: '/external/data' }));
+        expect(result.error).to.be.undefined;
+        expect(result.files).to.deep.equal(['/external/data/x.ts']);
+    });
+
+    it('matches an allow-list entry without a trailing slash against a searchRoot that has one', async () => {
+        allowedExternal = ['/external/data'];
+        searchResults = ['file:///external/data/x.ts'];
+        const result = JSON.parse(await call({ pattern: '**/*.ts', searchRoot: '/external/data/' }));
+        expect(result.error).to.be.undefined;
+        expect(result.files).to.deep.equal(['/external/data/x.ts']);
+    });
 });
 
 describe('WorkspaceFunctionScope gitignore caching', () => {

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -20,6 +20,7 @@ import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat, FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
+import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import {
     FILE_CONTENT_FUNCTION_ID, GET_FILE_DIAGNOSTICS_ID,
@@ -1224,8 +1225,8 @@ export class FindFilesByPattern implements ToolProvider {
     @inject(PreferenceService)
     protected readonly preferences: PreferenceService;
 
-    @inject(FileService)
-    protected readonly fileService: FileService;
+    @inject(FileSearchService)
+    protected readonly fileSearchService: FileSearchService;
 
     getTool(): ToolRequest {
         return {
@@ -1239,8 +1240,6 @@ export class FindFilesByPattern implements ToolProvider {
                 '\'src/**/*.js\' for JavaScript files in the src directory. The function respects gitignore patterns and user exclusions, ' +
                 'returns workspace-relative paths (e.g., "my-project/src/index.ts") or absolute paths for external roots, ' +
                 'and limits results to 200 files maximum. ' +
-                'Performance note: This traverses directories recursively which may be slow in large workspaces. ' +
-                'For better performance, use specific subdirectory patterns (e.g., \'src/**/*.ts\' instead of \'**/*.ts\'). ' +
                 'Use this to find files by name/extension. Do NOT use this for searching file contents - use searchInWorkspace instead.',
             parameters: {
                 type: 'object',
@@ -1249,8 +1248,7 @@ export class FindFilesByPattern implements ToolProvider {
                         type: 'string',
                         description: 'Glob pattern to match files against. ' +
                             'Examples: \'**/*.ts\' (all TypeScript files), \'src/**/*.js\' (JS files in src), ' +
-                            '\'**/*.{js,ts}\' (JS or TS files), \'**/test/**/*.spec.ts\' (test files). ' +
-                            'Use specific subdirectory prefixes for better performance (e.g., \'packages/core/**/*.ts\' instead of \'**/*.ts\').'
+                            '\'**/*.{js,ts}\' (JS or TS files), \'**/test/**/*.spec.ts\' (test files).'
                     },
                     exclude: {
                         type: 'array',
@@ -1303,76 +1301,55 @@ export class FindFilesByPattern implements ToolProvider {
         }
 
         try {
-            const patternMatcher = new Minimatch(pattern, { dot: false });
-            const files: string[] = [];
             const maxResults = 200;
+            const useGitIgnore = this.preferences.get(CONSIDER_GITIGNORE_PREF, true);
+            const userExcludes = this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, []);
+            const excludes = [...userExcludes, ...(excludePatterns ?? [])];
 
+            // Resolve the set of roots to search and how each root's results should be rendered.
+            const targets: { rootUri: URI; rootName?: string; emitAbsolutePaths: boolean }[] = [];
             if (searchRoot) {
                 const resolved = await this.workspaceScope.resolveToUri(searchRoot);
                 if (!resolved) {
                     return JSON.stringify({ error: `Invalid searchRoot: '${searchRoot}'` });
                 }
-                const rootUri = resolved;
-                const isExternalRoot = !this.workspaceScope.isInWorkspace(rootUri);
-                await this.workspaceScope.ensureAccessible(rootUri);
-
-                const ignorePatterns = isExternalRoot
-                    ? this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, [])
-                    : await this.buildIgnorePatterns(rootUri);
-                const allExcludes = [...ignorePatterns];
-                if (excludePatterns && excludePatterns.length > 0) {
-                    allExcludes.push(...excludePatterns);
-                }
-
-                if (cancellationToken?.isCancellationRequested) {
-                    return JSON.stringify({ error: 'Operation cancelled by user' });
-                }
-
-                const excludeMatchers = allExcludes.map(excludePattern => new Minimatch(excludePattern, { dot: true }));
-
-                await this.traverseDirectory(
-                    rootUri,
-                    rootUri,
-                    undefined,
-                    patternMatcher,
-                    excludeMatchers,
-                    files,
-                    maxResults,
-                    cancellationToken,
-                    isExternalRoot
-                );
+                await this.workspaceScope.ensureAccessible(resolved);
+                targets.push({ rootUri: resolved, emitAbsolutePaths: !this.workspaceScope.isInWorkspace(resolved) });
             } else {
                 const rootMapping = this.workspaceScope.getRootMapping();
                 if (rootMapping.size === 0) {
                     return JSON.stringify({ error: 'No workspace has been opened yet' });
                 }
-
                 for (const [rootName, rootUri] of rootMapping) {
-                    if (cancellationToken?.isCancellationRequested) {
-                        return JSON.stringify({ error: 'Operation cancelled by user' });
-                    }
+                    targets.push({ rootUri, rootName, emitAbsolutePaths: false });
+                }
+            }
 
-                    if (files.length >= maxResults) {
-                        break;
+            // Delegate the actual traversal to the backend ripgrep-based file search.
+            // It runs natively on the backend filesystem (no per-directory RPC),
+            // honors `.gitignore` (and excludes `.git`), and applies include/exclude globs.
+            const files: string[] = [];
+            for (const target of targets) {
+                if (cancellationToken?.isCancellationRequested) {
+                    return JSON.stringify({ error: 'Operation cancelled by user' });
+                }
+                if (files.length > maxResults) {
+                    break;
+                }
+                // Request one extra result across all roots so we can detect truncation.
+                const matches = await this.fileSearchService.find('', {
+                    rootUris: [target.rootUri.toString()],
+                    includePatterns: [pattern],
+                    excludePatterns: excludes,
+                    useGitIgnore,
+                    fuzzyMatch: false,
+                    limit: maxResults - files.length + 1
+                }, cancellationToken);
+                for (const match of matches) {
+                    const display = this.toDisplayPath(new URI(match), target);
+                    if (display !== undefined) {
+                        files.push(display);
                     }
-
-                    const ignorePatterns = await this.buildIgnorePatterns(rootUri);
-                    const allExcludes = [...ignorePatterns];
-                    if (excludePatterns && excludePatterns.length > 0) {
-                        allExcludes.push(...excludePatterns);
-                    }
-                    const excludeMatchers = allExcludes.map(excludePattern => new Minimatch(excludePattern, { dot: true }));
-
-                    await this.traverseDirectory(
-                        rootUri,
-                        rootUri,
-                        rootName,
-                        patternMatcher,
-                        excludeMatchers,
-                        files,
-                        maxResults,
-                        cancellationToken
-                    );
                 }
             }
 
@@ -1380,12 +1357,10 @@ export class FindFilesByPattern implements ToolProvider {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
             }
 
-            const result: { files: string[]; totalFound?: number; truncated?: boolean } = {
+            const result: { files: string[]; truncated?: boolean } = {
                 files: files.slice(0, maxResults)
             };
-
             if (files.length > maxResults) {
-                result.totalFound = files.length;
                 result.truncated = true;
             }
 
@@ -1396,94 +1371,19 @@ export class FindFilesByPattern implements ToolProvider {
         }
     }
 
-    private async buildIgnorePatterns(workspaceRoot: URI): Promise<string[]> {
-        const patterns: string[] = [];
-
-        // Get user exclude patterns from preferences
-        const userExcludePatterns = this.preferences.get<string[]>(USER_EXCLUDE_PATTERN_PREF, []);
-        patterns.push(...userExcludePatterns);
-
-        // Add gitignore patterns if enabled
-        const shouldConsiderGitIgnore = this.preferences.get(CONSIDER_GITIGNORE_PREF, false);
-        if (shouldConsiderGitIgnore) {
-            try {
-                const gitignoreUri = workspaceRoot.resolve('.gitignore');
-                const gitignoreContent = await this.fileService.read(gitignoreUri);
-                const gitignoreLines = gitignoreContent.value
-                    .split('\n')
-                    .map(line => line.trim())
-                    .filter(line => line && !line.startsWith('#'));
-                patterns.push(...gitignoreLines);
-            } catch {
-                // Gitignore file doesn't exist or can't be read, continue without it
-            }
+    /**
+     * Renders a search-result URI in the format expected by the caller: an absolute
+     * path for external roots, or a `<rootName>/<relativePath>` (or bare relative
+     * path when no root name is available) for workspace roots.
+     */
+    protected toDisplayPath(match: URI, target: { rootUri: URI; rootName?: string; emitAbsolutePaths: boolean }): string | undefined {
+        if (target.emitAbsolutePaths) {
+            return match.path.toString();
         }
-
-        return patterns;
-    }
-
-    private async traverseDirectory(
-        currentUri: URI,
-        searchRoot: URI,
-        rootName: string | undefined,
-        patternMatcher: Minimatch,
-        excludeMatchers: Minimatch[],
-        results: string[],
-        maxResults: number,
-        cancellationToken?: CancellationToken,
-        emitAbsolutePaths = false
-    ): Promise<void> {
-        if (cancellationToken?.isCancellationRequested || results.length >= maxResults) {
-            return;
+        const relativePath = target.rootUri.relative(match)?.toString();
+        if (relativePath === undefined) {
+            return undefined;
         }
-
-        try {
-            const stat = await this.fileService.resolve(currentUri);
-            if (!stat || !stat.isDirectory || !stat.children) {
-                return;
-            }
-
-            for (const child of stat.children) {
-                if (cancellationToken?.isCancellationRequested || results.length >= maxResults) {
-                    break;
-                }
-
-                const relativePath = searchRoot.relative(child.resource)?.toString();
-                if (!relativePath) {
-                    continue;
-                }
-
-                const shouldExclude = excludeMatchers.some(matcher => matcher.match(relativePath)) ||
-                    (await this.workspaceScope.shouldExclude(child));
-
-                if (shouldExclude) {
-                    continue;
-                }
-
-                if (child.isDirectory) {
-                    await this.traverseDirectory(
-                        child.resource,
-                        searchRoot,
-                        rootName,
-                        patternMatcher,
-                        excludeMatchers,
-                        results,
-                        maxResults,
-                        cancellationToken,
-                        emitAbsolutePaths
-                    );
-                } else if (patternMatcher.match(relativePath)) {
-                    if (emitAbsolutePaths) {
-                        results.push(child.resource.path.toString());
-                    } else if (rootName) {
-                        results.push(`${rootName}/${relativePath}`);
-                    } else {
-                        results.push(relativePath);
-                    }
-                }
-            }
-        } catch {
-            // If we can't access a directory, skip it
-        }
+        return target.rootName ? `${target.rootName}/${relativePath}` : relativePath;
     }
 }

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -399,7 +399,9 @@ export class WorkspaceFunctionScope {
             }
             const uri = await this.toExternalUri(trimmed);
             if (uri && uri.scheme === 'file') {
-                result.push(uri.normalizePath());
+                // Strip a trailing separator so an entry like `/foo/` still matches the
+                // directory `/foo` itself (URI.isEqualOrParent compares the last segment exactly).
+                result.push(WorkspaceFunctionScope.withoutTrailingSeparator(uri.normalizePath()));
             }
         }
         return result;
@@ -472,6 +474,20 @@ export class WorkspaceFunctionScope {
             return true;
         }
         return /^[A-Za-z]:\//.test(normalized);
+    }
+
+    /**
+     * Returns the URI without a trailing path separator (except for a root path). This makes
+     * directory comparisons via {@link URI.isEqualOrParent} insensitive to a trailing slash, so
+     * an allow-list entry such as `/foo/` matches the directory `/foo` itself, not only its
+     * children.
+     */
+    static withoutTrailingSeparator(uri: URI): URI {
+        const path = uri.path.toString();
+        if (path.length > 1 && path.endsWith('/')) {
+            return uri.withPath(path.substring(0, path.length - 1));
+        }
+        return uri;
     }
 
     protected getHomeDirUri(): Promise<URI | undefined> {
@@ -1320,27 +1336,27 @@ export class FindFilesByPattern implements ToolProvider {
             const excludes = [...userExcludes, ...(excludePatterns ?? [])];
 
             // Resolve the set of roots to search and how each root's results should be rendered.
-            const targets: { rootUri: URI; rootName?: string; emitAbsolutePaths: boolean }[] = [];
+            const targets: { rootUri: URI; rootName?: string; external: boolean }[] = [];
             if (searchRoot) {
                 const resolved = await this.workspaceScope.resolveToUri(searchRoot);
                 if (!resolved) {
                     return JSON.stringify({ error: `Invalid searchRoot: '${searchRoot}'` });
                 }
                 await this.workspaceScope.ensureAccessible(resolved);
-                targets.push({ rootUri: resolved, emitAbsolutePaths: !this.workspaceScope.isInWorkspace(resolved) });
+                targets.push({ rootUri: resolved, external: !this.workspaceScope.isInWorkspace(resolved) });
             } else {
                 const rootMapping = this.workspaceScope.getRootMapping();
                 if (rootMapping.size === 0) {
                     return JSON.stringify({ error: 'No workspace has been opened yet' });
                 }
                 for (const [rootName, rootUri] of rootMapping) {
-                    targets.push({ rootUri, rootName, emitAbsolutePaths: false });
+                    targets.push({ rootUri, rootName, external: false });
                 }
             }
 
             // Delegate the actual traversal to the backend ripgrep-based file search.
-            // It runs natively on the backend filesystem (no per-directory RPC),
-            // honors `.gitignore` (and excludes `.git`), and applies include/exclude globs.
+            // It runs natively on the backend filesystem (no per-directory RPC) and applies
+            // include/exclude globs.
             const files: string[] = [];
             for (const target of targets) {
                 if (cancellationToken?.isCancellationRequested) {
@@ -1349,12 +1365,16 @@ export class FindFilesByPattern implements ToolProvider {
                 if (files.length > maxResults) {
                     break;
                 }
+                // `considerGitIgnore` is scoped to workspace roots (see its preference description),
+                // so external allow-listed roots are searched with user/caller excludes only (plus
+                // `.git`). Applying gitignore there would also leak the user's *global* gitignore
+                // into an explicitly allow-listed directory and silently hide files.
                 // Request one extra result across all roots so we can detect truncation.
                 const matches = await this.fileSearchService.find('', {
                     rootUris: [target.rootUri.toString()],
                     includePatterns: [pattern],
-                    excludePatterns: excludes,
-                    useGitIgnore,
+                    excludePatterns: target.external ? [...excludes, '.git'] : excludes,
+                    useGitIgnore: target.external ? false : useGitIgnore,
                     fuzzyMatch: false,
                     limit: maxResults - files.length + 1
                 }, cancellationToken);
@@ -1389,8 +1409,8 @@ export class FindFilesByPattern implements ToolProvider {
      * path for external roots, or a `<rootName>/<relativePath>` (or bare relative
      * path when no root name is available) for workspace roots.
      */
-    protected toDisplayPath(match: URI, target: { rootUri: URI; rootName?: string; emitAbsolutePaths: boolean }): string | undefined {
-        if (target.emitAbsolutePaths) {
+    protected toDisplayPath(match: URI, target: { rootUri: URI; rootName?: string; external: boolean }): string | undefined {
+        if (target.external) {
             return match.path.toString();
         }
         const relativePath = target.rootUri.relative(match)?.toString();

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -60,7 +60,7 @@ export class WorkspaceFunctionScope {
     @inject(EnvVariablesServer)
     protected readonly envVariablesServer: EnvVariablesServer;
 
-    private gitignoreMatchers = new Map<string, ReturnType<typeof ignore>>();
+    private gitignoreMatchers = new Map<string, ReturnType<typeof ignore> | undefined>();
     private gitignoreWatchersInitialized = new Set<string>();
 
     private _rootMapping: Map<string, URI> | undefined;
@@ -534,33 +534,43 @@ export class WorkspaceFunctionScope {
     }
 
     protected async isGitIgnored(stat: FileStat, workspaceRoot: URI): Promise<boolean> {
+        const matcher = await this.getGitignoreMatcher(workspaceRoot);
+        if (!matcher) {
+            return false;
+        }
+        const relativePath = workspaceRoot.relative(stat.resource);
+        if (!relativePath) {
+            return false;
+        }
+        const relativePathStr = relativePath.toString() + (stat.isDirectory ? '/' : '');
+        return matcher.ignores(relativePathStr);
+    }
+
+    /**
+     * Returns the cached `.gitignore` matcher for the given root, reading the file at most
+     * once per root. A root with no (or unreadable) `.gitignore` is cached as `undefined`.
+     * The cache is invalidated by {@link initializeGitignoreWatcher} when the `.gitignore` is
+     * created, changed, or deleted, so individual exclusion checks need no filesystem RPC.
+     */
+    protected async getGitignoreMatcher(workspaceRoot: URI): Promise<ReturnType<typeof ignore> | undefined> {
         await this.initializeGitignoreWatcher(workspaceRoot);
 
         const rootKey = workspaceRoot.toString();
-        const gitignoreUri = workspaceRoot.resolve(this.GITIGNORE_FILE_NAME);
-
-        try {
-            const fileStat = await this.fileService.resolve(gitignoreUri);
-            if (fileStat) {
-                let matcher = this.gitignoreMatchers.get(rootKey);
-                if (!matcher) {
-                    const gitignoreContent = await this.fileService.read(gitignoreUri);
-                    matcher = ignore().add(gitignoreContent.value);
-                    this.gitignoreMatchers.set(rootKey, matcher);
-                }
-                const relativePath = workspaceRoot.relative(stat.resource);
-                if (relativePath) {
-                    const relativePathStr = relativePath.toString() + (stat.isDirectory ? '/' : '');
-                    if (matcher.ignores(relativePathStr)) {
-                        return true;
-                    }
-                }
-            }
-        } catch {
-            // If .gitignore does not exist or cannot be read, continue without error
+        if (this.gitignoreMatchers.has(rootKey)) {
+            return this.gitignoreMatchers.get(rootKey);
         }
 
-        return false;
+        let matcher: ReturnType<typeof ignore> | undefined;
+        try {
+            const gitignoreUri = workspaceRoot.resolve(this.GITIGNORE_FILE_NAME);
+            const gitignoreContent = await this.fileService.read(gitignoreUri);
+            matcher = ignore().add(gitignoreContent.value);
+        } catch {
+            // No .gitignore (or it cannot be read): cache the absence so we don't retry on every check.
+            matcher = undefined;
+        }
+        this.gitignoreMatchers.set(rootKey, matcher);
+        return matcher;
     }
 }
 
@@ -654,17 +664,25 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
         const result: Record<string, unknown> = {};
 
         if (stat && stat.isDirectory && stat.children) {
+            // Determine which child directories to include (the exclusion check may be async)...
+            const childDirs: URI[] = [];
             for (const child of stat.children) {
                 if (cancellationToken?.isCancellationRequested) {
                     return { error: 'Operation cancelled by user' };
                 }
-
-                if (!child.isDirectory || (await this.workspaceScope.shouldExclude(child))) {
-                    continue;
+                if (child.isDirectory && !(await this.workspaceScope.shouldExclude(child))) {
+                    childDirs.push(child.resource);
                 }
-                const dirName = child.resource.path.base;
-                result[dirName] = await this.buildDirectoryStructure(child.resource, cancellationToken);
             }
+            // ...then resolve their subtrees concurrently, so the traversal costs O(depth)
+            // round-trips instead of one serial round-trip per directory. Empty directories
+            // are preserved (they resolve to an empty object).
+            const subtrees = await Promise.all(
+                childDirs.map(childUri => this.buildDirectoryStructure(childUri, cancellationToken))
+            );
+            childDirs.forEach((childUri, index) => {
+                result[childUri.path.base] = subtrees[index];
+            });
         }
 
         return result;
@@ -1029,37 +1047,32 @@ export class GetWorkspaceFileList implements ToolProvider {
             if (!stat || !stat.isDirectory) {
                 return JSON.stringify({ error: 'Directory not found' });
             }
-            return await this.listFilesDirectly(targetUri, cancellationToken);
+            return await this.listFilesDirectly(stat, cancellationToken);
         } catch (error) {
             return JSON.stringify({ error: 'Directory not found' });
         }
     }
 
-    private async listFilesDirectly(uri: URI, cancellationToken?: CancellationToken): Promise<string> {
+    private async listFilesDirectly(stat: FileStat, cancellationToken?: CancellationToken): Promise<string> {
         if (cancellationToken?.isCancellationRequested) {
             return JSON.stringify({ error: 'Operation cancelled by user' });
         }
 
-        const stat = await this.fileService.resolve(uri);
         const result: Record<string, 'directory' | 'file'> = {};
 
-        if (stat && stat.isDirectory) {
-            if (await this.workspaceScope.shouldExclude(stat)) {
-                return JSON.stringify(result);
+        if (await this.workspaceScope.shouldExclude(stat)) {
+            return JSON.stringify(result);
+        }
+        // `stat` already carries one level of children from the caller's resolve, so no extra RPC.
+        for (const child of stat.children ?? []) {
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
             }
-            const children = await this.fileService.resolve(uri);
-            if (children.children) {
-                for (const child of children.children) {
-                    if (cancellationToken?.isCancellationRequested) {
-                        return JSON.stringify({ error: 'Operation cancelled by user' });
-                    }
 
-                    if (await this.workspaceScope.shouldExclude(child)) {
-                        continue;
-                    }
-                    result[child.resource.path.base] = child.isDirectory ? 'directory' : 'file';
-                }
+            if (await this.workspaceScope.shouldExclude(child)) {
+                continue;
             }
+            result[child.resource.path.base] = child.isDirectory ? 'directory' : 'file';
         }
 
         return JSON.stringify(result);

--- a/packages/ai-ide/tsconfig.json
+++ b/packages/ai-ide/tsconfig.json
@@ -37,6 +37,9 @@
       "path": "../editor"
     },
     {
+      "path": "../file-search"
+    },
+    {
       "path": "../filesystem"
     },
     {


### PR DESCRIPTION
#### What it does

The AI workspace file tools (`findFilesByPattern`, `getWorkspaceDirectoryStructure`, `getWorkspaceFileList`) traversed the workspace from the **frontend**, issuing one `FileService.resolve` RPC per directory — and, with `.gitignore` consideration enabled (the default), an extra RPC per child to check for a `.gitignore`. On a large workspace, a single tool call therefore became **hundreds to thousands of sequential frontend↔backend round-trips**. That is barely noticeable locally, but on a remote/cloud backend where every round-trip carries network latency it could take **minutes** to return.

This PR removes that round-trip explosion:

- **`findFilesByPattern`** now delegates traversal to the backend ripgrep-based `FileSearchService` — **one call per root** instead of thousands of round-trips. It preserves the existing default preferences (`considerGitIgnore`, `userExcludes`), honors `.gitignore` and excludes `.git` for workspace roots, and reports truncation when results are capped. Fixes #17622.
- **`getWorkspaceDirectoryStructure`** resolves each directory's child directories **concurrently** (O(depth) waves instead of one serial round-trip per directory). Empty directories are still listed.
- **`getWorkspaceFileList`** resolved the same directory three times — now once.
- **`WorkspaceFunctionScope.isGitIgnored`** caches the `.gitignore` matcher per root (it previously resolved `.gitignore` on every single exclusion check), so checks need no per-file RPC. The cache is invalidated by the existing `.gitignore` watcher.
- **Allow-listed external paths**: an `allowedExternalPaths` entry written with a trailing slash (e.g. `/some/dir/`) now matches the directory itself, not only its children — previously such a directory was rejected as "not allowed" when used as a `searchRoot`/path. External roots are searched without `.gitignore` filtering, matching the other tools and the preference's documented workspace-root scope.

Net effect: a full-tree query on a large workspace drops from thousands of sequential round-trips (seconds locally, minutes on a remote backend) to a single backend search returning in the order of **tens of milliseconds**.

#### How to test

1. Open a large workspace (thousands of files/directories), ideally with the backend on a remote/high-latency connection.
2. Ask an agent (e.g. Architect/Coder) to find files by a glob pattern — this triggers `findFilesByPattern`. Verify it returns promptly instead of taking many seconds/minutes.
3. Ask for the workspace directory structure and a directory file listing; verify correctness (empty directories still appear) and responsiveness.
4. Add a directory to `ai-features.workspaceFunctions.allowedExternalPaths` (try an entry *with* a trailing slash) and search it via `searchRoot`; verify files are returned rather than an "is not allowed" error.

#### Follow-ups

- Results may now include files inside dot-directories (e.g. `.github`) that the previous `Minimatch` (`dot: false`) traversal skipped. This is intentional and consistent with the `considerGitIgnore`/`userExcludes` defaults.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no new user-facing UI text is introduced by this PR)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
