### PR TITLE
fix(filesystem): resolve provider activation on registration

### DIFF
--- a/packages/filesystem/src/browser/file-service-activation.spec.ts
+++ b/packages/filesystem/src/browser/file-service-activation.spec.ts
@@ -1,0 +1,93 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { Disposable, URI } from '@theia/core';
+import { expect } from 'chai';
+import { FileSystemProvider, FileSystemProviderCapabilities, WatchOptions } from '../common/files';
+import { FileService } from './file-service';
+
+disableJSDOM();
+
+function createMockProvider(): FileSystemProvider {
+    return {
+        capabilities: FileSystemProviderCapabilities.PathCaseSensitive,
+        onDidChangeCapabilities: () => Disposable.NULL,
+        onDidChangeFile: () => Disposable.NULL,
+        onFileWatchError: () => Disposable.NULL,
+        watch: (_resource: URI, _options: WatchOptions): Disposable => Disposable.NULL,
+        stat: () => { throw new Error('not implemented'); },
+        readdir: () => { throw new Error('not implemented'); },
+        readFile: () => { throw new Error('not implemented'); },
+        writeFile: () => { throw new Error('not implemented'); },
+        delete: () => { throw new Error('not implemented'); },
+        mkdir: () => { throw new Error('not implemented'); },
+        rename: () => { throw new Error('not implemented'); },
+    } as FileSystemProvider;
+}
+
+/** Resolve to the given value, or to `'PENDING'` if `promise` does not settle within `millis`. */
+function withinTimeout<T>(promise: Promise<T>, millis = 200): Promise<T | 'PENDING'> {
+    return Promise.race([
+        promise,
+        new Promise<'PENDING'>(resolve => setTimeout(() => resolve('PENDING'), millis))
+    ]);
+}
+
+describe('FileService activateProvider resilience (#17506)', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    it('resolves a pending activation once a provider is registered, even if an onWillActivate listener never settles', async () => {
+        const fileService = new FileService();
+        const scheme = 'user-storage';
+        const provider = createMockProvider();
+
+        // Reproduce the real-world hang: an `onWillActivateFileSystemProvider` listener whose
+        // `waitUntil` promise never settles. In the wild this happens when an awaited dependency
+        // inside the listener (e.g. a lost RPC reply, or a detached microtask in `createProvider`)
+        // never resolves, leaving `WaitUntilEvent.fire`'s `Promise.all(waitables)` pending forever.
+        fileService.onWillActivateFileSystemProvider(event => {
+            if (event.scheme === scheme) {
+                event.waitUntil(new Promise<void>(() => { /* never settles */ }));
+            }
+        });
+
+        const activation = fileService.activateProvider(scheme);
+
+        // The provider does become available (as the reporter demonstrated by registering it
+        // manually against the live, hung frontend container).
+        fileService.registerProvider(scheme, provider);
+
+        // Before the fix: `activateProvider` is coupled to the settlement of every listener's
+        // `waitUntil` promise, so the dangling listener wedges the activation permanently and
+        // this resolves to 'PENDING'. After the fix: registering the provider resolves the
+        // pending activation immediately.
+        const resolved = await withinTimeout(activation);
+        expect(resolved).to.equal(provider);
+    });
+});

--- a/packages/filesystem/src/browser/file-service-activation.spec.ts
+++ b/packages/filesystem/src/browser/file-service-activation.spec.ts
@@ -27,6 +27,16 @@ import { FileService } from './file-service';
 
 disableJSDOM();
 
+/** A `FileService` with a short, overridable activation timeout so tests need not wait the production duration. */
+class TestFileService extends FileService {
+    constructor(protected readonly timeout: number) {
+        super();
+    }
+    protected override getActivationTimeout(): number {
+        return this.timeout;
+    }
+}
+
 function createMockProvider(): FileSystemProvider {
     return {
         capabilities: FileSystemProviderCapabilities.PathCaseSensitive,
@@ -89,5 +99,46 @@ describe('FileService activateProvider resilience (#17506)', () => {
         // pending activation immediately.
         const resolved = await withinTimeout(activation);
         expect(resolved).to.equal(provider);
+    });
+
+    it('rejects an activation that never registers a provider once the timeout elapses, instead of hanging forever', async () => {
+        const fileService = new TestFileService(50);
+        const scheme = 'user-storage';
+
+        // A listener whose `waitUntil` never settles and which never registers a provider:
+        // the worst case where the provider's own (normally fast) backend dependency dangles.
+        fileService.onWillActivateFileSystemProvider(event => {
+            if (event.scheme === scheme) {
+                event.waitUntil(new Promise<void>(() => { /* never settles */ }));
+            }
+        });
+
+        // Before the fix this never settles (the test would hit 'PENDING'); after the fix the
+        // activation rejects once the timeout elapses, so startup can proceed (degraded).
+        const outcome = await withinTimeout(
+            fileService.activateProvider(scheme).then(() => 'RESOLVED', () => 'REJECTED'),
+            300
+        );
+        expect(outcome).to.equal('REJECTED');
+    });
+
+    it('does not poison the scheme after a timed-out activation: a later activation can still succeed', async () => {
+        const fileService = new TestFileService(50);
+        const scheme = 'user-storage';
+
+        fileService.onWillActivateFileSystemProvider(event => {
+            if (event.scheme === scheme) {
+                event.waitUntil(new Promise<void>(() => { /* never settles */ }));
+            }
+        });
+
+        // First attempt times out and rejects.
+        await fileService.activateProvider(scheme).then(() => { throw new Error('should have rejected'); }, () => undefined);
+
+        // A fresh attempt must be able to succeed once a provider becomes available.
+        const provider = createMockProvider();
+        const retry = fileService.activateProvider(scheme);
+        fileService.registerProvider(scheme, provider);
+        expect(await withinTimeout(retry)).to.equal(provider);
     });
 });

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -406,6 +406,15 @@ export class FileService {
         if (!activation) {
             const deferredActivation = new Deferred<FileSystemProvider>();
             this.activations.set(scheme, activation = deferredActivation.promise);
+            // Resolve the activation as soon as a provider is registered for the scheme. Otherwise a
+            // slow or dangling `onWillActivateFileSystemProvider` listener whose `waitUntil` promise
+            // never settles would wedge this activation (and everything awaiting it) forever. See #17506.
+            const registration = this.onDidChangeFileSystemProviderRegistrations(event => {
+                if (event.added && event.scheme === scheme && event.provider) {
+                    deferredActivation.resolve(event.provider);
+                }
+            });
+            deferredActivation.promise.then(() => registration.dispose(), () => registration.dispose());
             WaitUntilEvent.fire(this.onWillActivateFileSystemProviderEmitter, { scheme }).then(() => {
                 provider = this.providers.get(scheme);
                 if (!provider) {

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -274,6 +274,12 @@ export class TextFileOperationError extends FileOperationError {
 }
 
 /**
+ * The default time, in milliseconds, after which {@link FileService.activateProvider} gives up waiting
+ * for a provider to be registered for a scheme and rejects the activation instead of hanging forever.
+ */
+export const DEFAULT_PROVIDER_ACTIVATION_TIMEOUT = 90_000;
+
+/**
  * The {@link FileService} is the common facade responsible for all interactions with file systems.
  * It manages all registered {@link FileSystemProvider}s and
  *  forwards calls to the responsible {@link FileSystemProvider}, determined by the scheme.
@@ -414,7 +420,19 @@ export class FileService {
                     deferredActivation.resolve(event.provider);
                 }
             });
-            deferredActivation.promise.then(() => registration.dispose(), () => registration.dispose());
+            // Backstop: reject the activation if no provider is registered within the timeout, rather than
+            // hanging forever when a listener's `waitUntil` promise never settles. On rejection the scheme is
+            // removed from `activations` so that a later attempt can retry once the connection recovers.
+            const timeout = setTimeout(() => {
+                const error = new Error();
+                error.name = 'ENOPRO';
+                error.message = `Activation of file system provider for scheme ${scheme} timed out`;
+                deferredActivation.reject(error);
+            }, this.getActivationTimeout());
+            deferredActivation.promise.then(
+                () => { registration.dispose(); clearTimeout(timeout); },
+                () => { registration.dispose(); clearTimeout(timeout); this.activations.delete(scheme); }
+            );
             WaitUntilEvent.fire(this.onWillActivateFileSystemProviderEmitter, { scheme }).then(() => {
                 provider = this.providers.get(scheme);
                 if (!provider) {
@@ -428,6 +446,10 @@ export class FileService {
             }).catch(e => deferredActivation.reject(e));
         }
         return activation;
+    }
+
+    protected getActivationTimeout(): number {
+        return DEFAULT_PROVIDER_ACTIVATION_TIMEOUT;
     }
 
     hasProvider(scheme: string): boolean {


### PR DESCRIPTION
#### What it does

Hardens `FileService.activateProvider` against a dangling `onWillActivateFileSystemProvider` listener, which can wedge frontend startup indefinitely.

Fixes #17506

`activateProvider` tied a scheme's activation to the settlement of `WaitUntilEvent.fire(...)`, i.e. `Promise.all` of every listener's `waitUntil` promise. If any one of those promises never settles (the `user-storage` emitter carries several listeners), the activation, and everything awaiting it, hangs forever. In #17506 this stalls all four `User`-scope preference providers → `UserConfigsPreferenceProvider.ready` → `PreferenceServiceImpl.initializeProviders` → `FrontendApplication.start`, so the workbench never comes up. As the reporter found, even registering the provider by hand against the live container did not help: the `activations` deferred stayed pending.

This PR is split into two independently reviewable commits:

1. **resolve provider activation on registration** (core fix, low risk): resolve the pending activation as soon as a provider is registered for the scheme. This decouples activation completion from unrelated listeners and restores registration as a recovery path.
2. **time out provider activation as a backstop** (deferrable): if no provider is registered within a timeout, reject the activation so callers fail fast (e.g. `readPreferencesFromFile` treats the file as absent and startup proceeds degraded) instead of hanging, and remove the scheme from `activations` so a later attempt can retry once the connection recovers. The default timeout (`DEFAULT_PROVIDER_ACTIVATION_TIMEOUT`, 90s, overridable via the `protected getActivationTimeout()`) is not less than the websocket heartbeat detection window (`checkAliveTimeout` 30s + `pingTimeout` 60s), so a genuinely dropped connection is detected and rejects in-flight RPCs before this
  fires. Activation only ever awaits constant-time backend calls (capability handshake, config-directory lookup), so the timeout cannot abort legitimate long-running work.

> [!CAUTION]
> The second commit is a containment/blast-radius measure; the underlying dangling-promise cause (a lost RPC reply on a connection that still appears alive) belongs to the family addressed by #17334 and is left as a follow-up. Reviewers may choose to take only the first commit.

#### How to test

The root-cause hang is timing-dependent and not reliably reproducible in the example apps, so verification is via the new automated tests, which fail without the fix (TDD).

To gut-check the first test against the bug, revert commit 1 and confirm it goes from passing to a 'PENDING' assertion failure.

#### Follow-ups

- the true root cause is a `waitUntil`/RPC promise that never settles on a still-open connection (lost reply, detached continuation), the same class #17334 began addressing. Worth a dedicated issue to audit remaining RPC loss points (reply decode failure, a reply routed to an already-closed multiplexer sub-channel) and reject the pending request at the point of loss.
- a general per-request RPC timeout was considered and rejected: it can be made efficient (a single self-cancelling sweep per active protocol, no per-request timers) but not correct, since a pure age-based timeout cannot distinguish a lost reply from a legitimately long-running backend call and would break such APIs. The scoped activation timeout here is safe precisely because its dependencies are constant-time.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [X] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
