### PR TITLE
feat(ai-registry): add skill registry support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31262,6 +31262,7 @@
       "version": "1.72.0",
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
+        "@theia/ai-core": "1.72.0",
         "@theia/ai-mcp": "1.72.0",
         "@theia/core": "1.72.0",
         "@theia/vsx-registry": "1.72.0"

--- a/packages/ai-core/src/browser/skill-service.spec.ts
+++ b/packages/ai-core/src/browser/skill-service.spec.ts
@@ -311,6 +311,7 @@ description: Skill with no content
         let fileServiceMock: any;
         let loggerWarnSpy: sinon.SinonStub;
         let loggerInfoSpy: sinon.SinonStub;
+        let loggerDebugSpy: sinon.SinonStub;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let envVariablesServerMock: any;
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -328,6 +329,7 @@ description: Skill with no content
             const loggerMock: ILogger = sinon.createStubInstance(Logger);
             loggerMock.warn = loggerWarnSpy;
             loggerMock.info = loggerInfoSpy;
+            loggerMock.debug = loggerDebugSpy;
             (service as unknown as { logger: unknown }).logger = loggerMock;
             (service as unknown as { envVariablesServer: unknown }).envVariablesServer = envVariablesServerMock;
             (service as unknown as { workspaceService: unknown }).workspaceService = workspaceServiceMock;
@@ -348,6 +350,7 @@ description: Skill with no content
 
             loggerWarnSpy = sinon.stub();
             loggerInfoSpy = sinon.stub();
+            loggerDebugSpy = sinon.stub();
 
             envVariablesServerMock = {
                 getHomeDirUri: sinon.stub().resolves('file:///home/testuser'),
@@ -395,13 +398,17 @@ description: Skill with no content
                 sinon.match({ recursive: false, excludes: [] })
             )).to.be.true;
 
-            // Verify info log about watching parent
-            expect(loggerInfoSpy.calledWith(
+            // Verify debug log about watching parent (demoted from info to keep startup quiet)
+            expect(loggerDebugSpy.calledWith(
                 sinon.match(/Watching parent directory.*for skills folder creation/)
             )).to.be.true;
+            // And the same line must not be emitted at info level any more.
+            expect(loggerInfoSpy.calledWith(
+                sinon.match(/Watching parent directory/)
+            )).to.be.false;
         });
 
-        it('should log warning when parent directory does not exist', async () => {
+        it('should log a debug entry when parent directory does not exist', async () => {
             const service = createService();
 
             // Neither skills directory nor parent exists
@@ -412,10 +419,42 @@ description: Skill with no content
             await workspaceServiceMock.ready;
             await new Promise(resolve => setTimeout(resolve, 10));
 
-            // Verify warning is logged about parent not existing
-            expect(loggerWarnSpy.calledWith(
+            // The absent-default-tree case is expected on fresh machines and is now debug-level only.
+            expect(loggerDebugSpy.calledWith(
                 sinon.match(/Cannot watch skills directory.*parent directory does not exist/)
             )).to.be.true;
+            // It must no longer surface as a startup warning.
+            expect(loggerWarnSpy.calledWith(
+                sinon.match(/Cannot watch skills directory.*parent directory does not exist/)
+            )).to.be.false;
+        });
+
+        it('coalesces concurrent update() calls so a single scan runs at a time', async () => {
+            const service = createService();
+
+            // Default skills directory does not exist, but parent does, so each update logs once.
+            fileServiceMock.exists
+                .withArgs(sinon.match((uri: URI) => uri.path.toString() === '/home/testuser/.theia-ide/skills'))
+                .resolves(false);
+            fileServiceMock.exists
+                .withArgs(sinon.match((uri: URI) => uri.path.toString() === '/home/testuser/.theia-ide'))
+                .resolves(true);
+
+            // Drive two updates in the same tick - the second must be coalesced into a follow-up
+            // re-schedule rather than racing the first and producing duplicated log lines.
+            const update = (service as unknown as { update: () => Promise<void> }).update.bind(service);
+            await Promise.all([update(), update()]);
+            // Give the rescheduled run (debounced via scheduleUpdate) time to fire.
+            await new Promise(resolve => setTimeout(resolve, 80));
+
+            // The watcher must be installed (the underlying scan must have run); the same log line
+            // must have been emitted at most once per scan, never twice from interleaved scans.
+            const matchingDebugCalls = loggerDebugSpy.getCalls().filter(call =>
+                /Watching parent directory.*for skills folder creation/.test(String(call.args[0]))
+            );
+            // Two scans (initial + rescheduled) are allowed, but never more, and never zero.
+            expect(matchingDebugCalls.length).to.be.greaterThan(0);
+            expect(matchingDebugCalls.length).to.be.lessThan(3);
         });
 
         it('should log warning for non-existent configured directories', async () => {

--- a/packages/ai-core/src/browser/skill-service.ts
+++ b/packages/ai-core/src/browser/skill-service.ts
@@ -79,6 +79,11 @@ export class DefaultSkillService implements SkillService {
 
     protected updateDebounceTimeout: ReturnType<typeof setTimeout> | undefined;
 
+    /** True while {@link update} is running, so concurrent callers do not duplicate the scan and its log output. */
+    protected updateInProgress = false;
+    /** Set when {@link update} is called while another run is in progress; triggers a follow-up scan when the current one finishes. */
+    protected updateRescheduled = false;
+
     protected _ready = new Deferred<void>();
     get ready(): Promise<void> {
         return this._ready.promise;
@@ -174,6 +179,28 @@ export class DefaultSkillService implements SkillService {
             clearTimeout(this.updateDebounceTimeout);
             this.updateDebounceTimeout = undefined;
         }
+        // Serialise concurrent update() calls: a workspace-ready trigger and a file-change-driven
+        // scheduleUpdate() can fire within the same async tick, in which case both runs would
+        // scan and log everything, producing the duplicated log lines that motivated this guard.
+        // The second caller records a pending request and lets the first finish; the follow-up
+        // is then re-scheduled through the debouncer so any further events coalesce into it.
+        if (this.updateInProgress) {
+            this.updateRescheduled = true;
+            return;
+        }
+        this.updateInProgress = true;
+        try {
+            await this.doUpdate();
+        } finally {
+            this.updateInProgress = false;
+            if (this.updateRescheduled) {
+                this.updateRescheduled = false;
+                this.scheduleUpdate();
+            }
+        }
+    }
+
+    protected async doUpdate(): Promise<void> {
         this.toDispose.dispose();
         const newDisposables = new DisposableCollection();
         const newSkills = new Map<string, Skill>();
@@ -258,9 +285,9 @@ export class DefaultSkillService implements SkillService {
                     const parentUriString = parentURI.toString();
                     disposables.push(this.fileService.watch(parentURI, { recursive: false, excludes: [] }));
                     parentWatchers.set(parentUriString, directoryPath);
-                    this.logger.info(`Watching parent directory '${parentPath}' for skills folder creation`);
+                    this.logger.debug(`Watching parent directory '${parentPath}' for skills folder creation`);
                 } else {
-                    this.logger.warn(`Cannot watch skills directory '${directoryPath}': parent directory does not exist`);
+                    this.logger.debug(`Cannot watch skills directory '${directoryPath}': parent directory does not exist`);
                 }
             }
         } catch (error) {

--- a/packages/ai-registry/package.json
+++ b/packages/ai-registry/package.json
@@ -3,6 +3,7 @@
   "version": "1.72.0",
   "description": "Theia - AI Registry Integration",
   "dependencies": {
+    "@theia/ai-core": "1.72.0",
     "@theia/ai-mcp": "1.72.0",
     "@theia/core": "1.72.0",
     "@theia/vsx-registry": "1.72.0"
@@ -13,7 +14,8 @@
   "main": "lib/common",
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/ai-registry-frontend-module"
+      "frontend": "lib/browser/ai-registry-frontend-module",
+      "backend": "lib/node/ai-registry-backend-module"
     }
   ],
   "keywords": [

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -15,23 +15,37 @@
 // *****************************************************************************
 
 import '../../src/browser/style/mcp-entries.css';
+import '../../src/browser/style/skill-entries.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { PreferenceContribution } from '@theia/core';
+import { RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
+import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ExtensionsSourceContribution } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../common/mcp/mcp-registry-entry-resolver';
 import { RegistryFetchService, RegistryFetchServiceImpl } from '../common/registry-fetch-service';
+import { SkillRegistryEntryResolver, SkillRegistryEntryResolverImpl } from '../common/skill/skill-registry-entry-resolver';
+import { SkillInstallBackendService, SkillInstallBackendServicePath, SkillInstallClient } from '../common/skill/skill-install-protocol';
+import { SkillRegistryPreferencesSchema } from '../common/skill/skill-registry-preferences';
 import { MCPInstallService, MCPInstallServiceImpl } from './mcp/mcp-install-service';
 import { MCPExtensionsContribution } from './mcp/mcp-extensions-contribution';
 import { MCPRegistryUiBridgeImpl } from './mcp/mcp-registry-ui-bridge-impl';
+import { SkillInstallService, SkillInstallServiceImpl } from './skill/skill-install-service';
+import { SkillInstallClientImpl } from './skill/skill-install-client';
+import { SkillExtensionsContribution } from './skill/skill-extensions-contribution';
+import { InstallSkillUriConfiguration } from './skill/install-skill-uri-configuration';
+import { InstallSkillUriHandler } from './skill/install-skill-uri-handler';
 import { AIRegistryToolbarContribution } from './ai-registry-toolbar-contribution';
 
 export default new ContainerModule(bind => {
     bind(AIRegistryConfiguration).toSelf().inSingletonScope();
     bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
     bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
+    bind(SkillRegistryEntryResolverImpl).toSelf().inSingletonScope();
+    bind(SkillRegistryEntryResolver).toService(SkillRegistryEntryResolverImpl);
     bind(RegistryFetchServiceImpl).toSelf().inSingletonScope();
     bind(RegistryFetchService).toService(RegistryFetchServiceImpl);
     bind(MCPInstallServiceImpl).toSelf().inSingletonScope();
@@ -42,6 +56,23 @@ export default new ContainerModule(bind => {
 
     bind(MCPRegistryUiBridgeImpl).toSelf().inSingletonScope();
     bind(MCPRegistryUiBridge).toService(MCPRegistryUiBridgeImpl);
+
+    bind(PreferenceContribution).toConstantValue({ schema: SkillRegistryPreferencesSchema });
+    bind(SkillInstallClientImpl).toSelf().inSingletonScope();
+    bind(SkillInstallClient).toService(SkillInstallClientImpl);
+    bind(SkillInstallBackendService).toDynamicValue(ctx => {
+        const connection = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
+        return connection.createProxy<SkillInstallBackendService>(SkillInstallBackendServicePath, ctx.container.get(SkillInstallClientImpl));
+    }).inSingletonScope();
+    bind(SkillInstallServiceImpl).toSelf().inSingletonScope();
+    bind(SkillInstallService).toService(SkillInstallServiceImpl);
+
+    bind(SkillExtensionsContribution).toSelf().inSingletonScope();
+    bind(ExtensionsSourceContribution).toService(SkillExtensionsContribution);
+
+    bind(InstallSkillUriConfiguration).toSelf().inSingletonScope();
+    bind(InstallSkillUriHandler).toSelf().inSingletonScope();
+    bind(OpenHandler).toService(InstallSkillUriHandler);
 
     bind(AIRegistryToolbarContribution).toSelf().inSingletonScope();
     bind(TabBarToolbarContribution).toService(AIRegistryToolbarContribution);

--- a/packages/ai-registry/src/browser/skill/install-skill-uri-configuration.ts
+++ b/packages/ai-registry/src/browser/skill/install-skill-uri-configuration.ts
@@ -1,0 +1,44 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+
+/**
+ * Configuration for the `install-skill` deep-link URL handler.
+ *
+ * Defaults to `<electron-uri-scheme>://install-skill` - products override by rebinding
+ * this class in their frontend module. The same scheme/authority is used by the registry
+ * maintainer when generating per-entry install URLs in the registry JSON, so that a click
+ * on such a link is routed to Theia and dispatched to this package's
+ * `InstallSkillUriHandler`.
+ */
+@injectable()
+export class InstallSkillUriConfiguration {
+
+    /**
+     * Scheme of the install URL - must match the product's Electron protocol
+     * registration (see `theia.frontend.config.electron.uriScheme` in `package.json`).
+     */
+    getScheme(): string {
+        return FrontendApplicationConfigProvider.get().electron?.uriScheme ?? 'theia';
+    }
+
+    /** URL authority that identifies install-skill links. */
+    getAuthority(): string {
+        return 'install-skill';
+    }
+}

--- a/packages/ai-registry/src/browser/skill/install-skill-uri-configuration.ts
+++ b/packages/ai-registry/src/browser/skill/install-skill-uri-configuration.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/install-skill-uri-handler.spec.ts
+++ b/packages/ai-registry/src/browser/skill/install-skill-uri-handler.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/install-skill-uri-handler.spec.ts
+++ b/packages/ai-registry/src/browser/skill/install-skill-uri-handler.spec.ts
@@ -1,0 +1,184 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+try {
+    FrontendApplicationConfigProvider.set({});
+} catch {
+    // The provider is a global singleton - ignore if a sibling spec has already set it.
+}
+
+import { expect } from 'chai';
+import { MessageService } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { InstallSkillUriConfiguration } from './install-skill-uri-configuration';
+import { InstallSkillUriHandler } from './install-skill-uri-handler';
+import { SkillInstallService } from './skill-install-service';
+
+disableJSDOM();
+
+const entry: ResolvedSkillEntry = {
+    skillId: 'io.github.example/example-skill',
+    name: 'Example Skill',
+    description: 'An example skill',
+    sourceUrl: 'https://github.com/example/skills',
+    sourcePath: 'skills/example',
+    contentHash: 'hash-v1'
+};
+
+interface RecordedMessages {
+    info: string[];
+    error: string[];
+}
+
+function newMessageService(record: RecordedMessages): MessageService {
+    return {
+        info: (message: string) => { record.info.push(message); return Promise.resolve(undefined); },
+        error: (message: string) => { record.error.push(message); return Promise.resolve(undefined); }
+    } as unknown as MessageService;
+}
+
+const configuration: InstallSkillUriConfiguration = {
+    getScheme: () => 'theia',
+    getAuthority: () => 'install-skill'
+} as InstallSkillUriConfiguration;
+
+/**
+ * Test handler that bypasses the real {@link ConfirmDialog} so the handler's branching
+ * logic can be exercised without touching the DOM.
+ */
+class TestInstallSkillUriHandler extends InstallSkillUriHandler {
+    confirmResult = true;
+    confirmCalls = 0;
+    protected override async confirmInstall(_entry: ResolvedSkillEntry): Promise<boolean> {
+        this.confirmCalls += 1;
+        return this.confirmResult;
+    }
+}
+
+function createHandler(options: {
+    entries?: ResolvedSkillEntry[];
+    fetchError?: Error;
+    installError?: Error;
+}): { handler: TestInstallSkillUriHandler; messages: RecordedMessages; installCalls: ResolvedSkillEntry[] } {
+    const installCalls: ResolvedSkillEntry[] = [];
+    const fetchService = {
+        getSkillEntries: () => options.fetchError ? Promise.reject(options.fetchError) : Promise.resolve(options.entries ?? [])
+    } as unknown as RegistryFetchService;
+    const installService = {
+        install: (e: ResolvedSkillEntry) => {
+            installCalls.push(e);
+            return options.installError ? Promise.reject(options.installError) : Promise.resolve();
+        }
+    } as unknown as SkillInstallService;
+    const messages: RecordedMessages = { info: [], error: [] };
+    const handler = new TestInstallSkillUriHandler();
+    Object.assign(handler, {
+        configuration,
+        fetchService,
+        installService,
+        messageService: newMessageService(messages)
+    });
+    return { handler, messages, installCalls };
+}
+
+describe('InstallSkillUriHandler', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    it('reports an error and does not install when the id query parameter is missing', async () => {
+        const { handler, messages, installCalls } = createHandler({ entries: [entry] });
+
+        await handler.open(new URI('theia://install-skill'));
+
+        expect(messages.error).to.have.lengthOf(1);
+        expect(messages.error[0]).to.match(/missing.*id/i);
+        expect(messages.info).to.deep.equal([]);
+        expect(installCalls).to.deep.equal([]);
+        expect(handler.confirmCalls).to.equal(0);
+    });
+
+    it('reports an error and does not install when the id is not listed in the registry', async () => {
+        const { handler, messages, installCalls } = createHandler({ entries: [entry] });
+
+        await handler.open(new URI('theia://install-skill?id=io.github.example/unknown'));
+
+        expect(messages.error).to.have.lengthOf(1);
+        expect(messages.error[0]).to.match(/not listed/i);
+        expect(messages.error[0]).to.include('io.github.example/unknown');
+        expect(installCalls).to.deep.equal([]);
+        expect(handler.confirmCalls).to.equal(0);
+    });
+
+    it('reports an error and does not install when the registry fetch fails', async () => {
+        const { handler, messages, installCalls } = createHandler({ fetchError: new Error('boom') });
+
+        await handler.open(new URI(`theia://install-skill?id=${entry.skillId}`));
+
+        expect(messages.error).to.have.lengthOf(1);
+        expect(messages.error[0]).to.match(/could not load/i);
+        expect(installCalls).to.deep.equal([]);
+        expect(handler.confirmCalls).to.equal(0);
+    });
+
+    it('does not install when the user cancels the confirmation dialog', async () => {
+        const { handler, messages, installCalls } = createHandler({ entries: [entry] });
+        handler.confirmResult = false;
+
+        await handler.open(new URI(`theia://install-skill?id=${entry.skillId}`));
+
+        expect(handler.confirmCalls).to.equal(1);
+        expect(installCalls).to.deep.equal([]);
+        expect(messages.info).to.deep.equal([]);
+        expect(messages.error).to.deep.equal([]);
+    });
+
+    it('reports an error when the install service throws after confirmation', async () => {
+        const { handler, messages, installCalls } = createHandler({
+            entries: [entry],
+            installError: new Error('disk full')
+        });
+
+        await handler.open(new URI(`theia://install-skill?id=${entry.skillId}`));
+
+        expect(handler.confirmCalls).to.equal(1);
+        expect(installCalls).to.deep.equal([entry]);
+        expect(messages.error).to.deep.equal(['disk full']);
+        expect(messages.info).to.deep.equal([]);
+    });
+
+    it('installs the skill and reports success on the happy path', async () => {
+        const { handler, messages, installCalls } = createHandler({ entries: [entry] });
+
+        await handler.open(new URI(`theia://install-skill?id=${entry.skillId}`));
+
+        expect(handler.confirmCalls).to.equal(1);
+        expect(installCalls).to.deep.equal([entry]);
+        expect(messages.info).to.have.lengthOf(1);
+        expect(messages.info[0]).to.include(entry.name);
+        expect(messages.error).to.deep.equal([]);
+    });
+});

--- a/packages/ai-registry/src/browser/skill/install-skill-uri-handler.ts
+++ b/packages/ai-registry/src/browser/skill/install-skill-uri-handler.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/install-skill-uri-handler.ts
+++ b/packages/ai-registry/src/browser/skill/install-skill-uri-handler.ts
@@ -67,7 +67,18 @@ export class InstallSkillUriHandler implements OpenHandler {
             ));
             return undefined;
         }
-        const entry = await this.resolveEntry(skillId);
+        let entries: ResolvedSkillEntry[];
+        try {
+            entries = await this.fetchService.getSkillEntries();
+        } catch {
+            this.messageService.error(nls.localize(
+                'theia/ai-registry/skill/installUri/fetchFailed',
+                'Could not load the AI registry to install skill "{0}".',
+                skillId
+            ));
+            return undefined;
+        }
+        const entry = entries.find(candidate => candidate.skillId === skillId);
         if (!entry) {
             this.messageService.error(nls.localize(
                 'theia/ai-registry/skill/installUri/unknownId',
@@ -90,22 +101,6 @@ export class InstallSkillUriHandler implements OpenHandler {
             this.messageService.error(error instanceof Error ? error.message : String(error));
         }
         return undefined;
-    }
-
-    /** Loads the registry (awaiting the first fetch) and looks the id up. */
-    protected async resolveEntry(skillId: string): Promise<ResolvedSkillEntry | undefined> {
-        let entries: ResolvedSkillEntry[];
-        try {
-            entries = await this.fetchService.getSkillEntries();
-        } catch (error) {
-            this.messageService.error(nls.localize(
-                'theia/ai-registry/skill/installUri/fetchFailed',
-                'Could not load the AI registry to install skill "{0}".',
-                skillId
-            ));
-            return undefined;
-        }
-        return entries.find(entry => entry.skillId === skillId);
     }
 
     protected async confirmInstall(entry: ResolvedSkillEntry): Promise<boolean> {

--- a/packages/ai-registry/src/browser/skill/install-skill-uri-handler.ts
+++ b/packages/ai-registry/src/browser/skill/install-skill-uri-handler.ts
@@ -1,0 +1,129 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MessageService, nls } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
+import { ConfirmDialog } from '@theia/core/lib/browser/dialogs';
+import { OpenHandler } from '@theia/core/lib/browser/opener-service';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { SkillInstallService } from './skill-install-service';
+import { InstallSkillUriConfiguration } from './install-skill-uri-configuration';
+
+const ID_PARAM = 'id';
+
+/**
+ * Handles `theia://install-skill?id=<skillId>` deep links. The URL is intentionally
+ * minimal: the source, name and content hash are all read from the configured AI registry
+ * by id, so the user installs exactly what the registry currently publishes.
+ *
+ * Unlike the MCP handler, the registry lookup lives in this same package, so the handler
+ * consults the fetch service directly instead of going through a bridge interface.
+ */
+@injectable()
+export class InstallSkillUriHandler implements OpenHandler {
+
+    readonly id = 'install-skill-uri-handler';
+
+    @inject(InstallSkillUriConfiguration)
+    protected readonly configuration: InstallSkillUriConfiguration;
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    @inject(SkillInstallService)
+    protected readonly installService: SkillInstallService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    canHandle(uri: URI): number {
+        return uri.scheme === this.configuration.getScheme()
+            && uri.authority === this.configuration.getAuthority()
+            ? 500
+            : 0;
+    }
+
+    async open(uri: URI): Promise<object | undefined> {
+        const skillId = this.extractSkillId(uri);
+        if (!skillId) {
+            this.messageService.error(nls.localize(
+                'theia/ai-registry/skill/installUri/missingId',
+                'Install link is missing the required "id" parameter.'
+            ));
+            return undefined;
+        }
+        const entry = await this.resolveEntry(skillId);
+        if (!entry) {
+            this.messageService.error(nls.localize(
+                'theia/ai-registry/skill/installUri/unknownId',
+                'Skill "{0}" is not listed in your AI registry.',
+                skillId
+            ));
+            return undefined;
+        }
+        if (!await this.confirmInstall(entry)) {
+            return undefined;
+        }
+        try {
+            await this.installService.install(entry);
+            this.messageService.info(nls.localize(
+                'theia/ai-registry/skill/installUri/success',
+                'Installed skill "{0}" from the AI registry.',
+                entry.name
+            ));
+        } catch (error) {
+            this.messageService.error(error instanceof Error ? error.message : String(error));
+        }
+        return undefined;
+    }
+
+    /** Loads the registry (awaiting the first fetch) and looks the id up. */
+    protected async resolveEntry(skillId: string): Promise<ResolvedSkillEntry | undefined> {
+        let entries: ResolvedSkillEntry[];
+        try {
+            entries = await this.fetchService.getSkillEntries();
+        } catch (error) {
+            this.messageService.error(nls.localize(
+                'theia/ai-registry/skill/installUri/fetchFailed',
+                'Could not load the AI registry to install skill "{0}".',
+                skillId
+            ));
+            return undefined;
+        }
+        return entries.find(entry => entry.skillId === skillId);
+    }
+
+    protected async confirmInstall(entry: ResolvedSkillEntry): Promise<boolean> {
+        const dialog = new ConfirmDialog({
+            title: nls.localize('theia/ai-registry/skill/installUri/confirm/title', 'Install skill'),
+            msg: nls.localize(
+                'theia/ai-registry/skill/installUri/confirm/msg',
+                'Install the skill "{0}" by downloading its files from {1}?',
+                entry.name,
+                entry.sourceUrl
+            ),
+            ok: nls.localizeByDefault('Install'),
+            cancel: nls.localizeByDefault('Cancel')
+        });
+        return !!await dialog.open();
+    }
+
+    protected extractSkillId(uri: URI): string | undefined {
+        return new URLSearchParams(uri.query).get(ID_PARAM)?.trim() || undefined;
+    }
+}

--- a/packages/ai-registry/src/browser/skill/skill-entries.tsx
+++ b/packages/ai-registry/src/browser/skill/skill-entries.tsx
@@ -1,0 +1,236 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { TypeBadge } from '@theia/vsx-registry/lib/browser/type-badge';
+import { ExtensionCard } from '@theia/vsx-registry/lib/browser/extension-card';
+import { InstalledSkillInfo, ResolvedSkillEntry, SkillClassificationResult } from '../../common/skill/skill-registry-types';
+
+/**
+ * Per-entry action callbacks provided by the contribution. Entries close over these so
+ * their card render functions can dispatch user actions without pulling the install
+ * service through dependency injection at the React level.
+ */
+export interface SkillEntryHandlers {
+    install(entry: ResolvedSkillEntry): Promise<void>;
+    uninstall(name: string): Promise<void>;
+    unlink(name: string): Promise<void>;
+    update(entry: ResolvedSkillEntry): Promise<void>;
+    link(entry: ResolvedSkillEntry): Promise<void>;
+    fixSkill(entry: ResolvedSkillEntry): Promise<void>;
+}
+
+/** An entry surfacing a locally installed skill in the Installed section. */
+export class SkillInstalledEntry implements TreeElement {
+
+    readonly id: string;
+
+    constructor(
+        readonly local: InstalledSkillInfo,
+        readonly matchedEntry: ResolvedSkillEntry | undefined,
+        readonly state: SkillClassificationResult,
+        readonly handlers: SkillEntryHandlers,
+        readonly hoverService: HoverService
+    ) {
+        this.id = `skill-installed-${local.name}`;
+    }
+
+    render(): React.ReactNode {
+        return (
+            <SkillCard
+                title={this.matchedEntry?.name ?? this.local.name}
+                description={this.matchedEntry?.description}
+                identifier={this.matchedEntry?.skillId ?? this.local.skillId}
+                hoverService={this.hoverService}
+                actions={renderActions(this.state, this.matchedEntry, this.local.name, this.handlers)}
+            />
+        );
+    }
+}
+
+/** An entry surfacing a registry-resolved skill in the Search Results section. */
+export class SkillSearchResultEntry implements TreeElement {
+
+    readonly id: string;
+
+    constructor(
+        readonly entry: ResolvedSkillEntry,
+        readonly state: SkillClassificationResult,
+        readonly handlers: SkillEntryHandlers,
+        readonly hoverService: HoverService
+    ) {
+        this.id = `skill-search-${entry.skillId}`;
+    }
+
+    render(): React.ReactNode {
+        return (
+            <SkillCard
+                title={this.entry.name}
+                description={this.entry.description}
+                identifier={this.entry.skillId}
+                hoverService={this.hoverService}
+                actions={renderActions(this.state, this.entry, this.entry.name, this.handlers)}
+            />
+        );
+    }
+}
+
+interface SkillCardProps {
+    title: string;
+    description?: string;
+    /** Stable identifier shown in the publisher-row slot - the registry skillId. */
+    identifier?: string;
+    hoverService: HoverService;
+    actions?: React.ReactNode;
+}
+
+/** Build the markdown tooltip shown on hover, mirroring the depth of the VSX card's tooltip. */
+function buildHoverContent(props: SkillCardProps): MarkdownStringImpl {
+    const lines = [`**${props.title}**`];
+    if (props.description) {
+        lines.push('', props.description);
+    }
+    if (props.identifier) {
+        lines.push('', `_${props.identifier}_`);
+    }
+    return new MarkdownStringImpl(lines.join('\n'));
+}
+
+/**
+ * Skill entry card. Renders against the shared {@link ExtensionCard} shell so skill
+ * entries sit visually alongside extensions and MCP servers in the unified Extensions
+ * view, sharing the layout and hover tooltip.
+ */
+const SkillCard: React.FC<SkillCardProps> = props => (
+    <ExtensionCard
+        title={props.title}
+        description={props.description}
+        icon={<i className="codicon codicon-mortar-board" />}
+        iconClassName="theia-skill-extension-icon"
+        typeBadge={
+            <TypeBadge
+                icon={<i className="codicon codicon-mortar-board" />}
+                label={nls.localizeByDefault('Skills')}
+                variant="skill"
+            />
+        }
+        publisher={props.identifier}
+        publisherTitle={props.identifier}
+        trust="verified"
+        hover={{ content: buildHoverContent(props), hoverService: props.hoverService }}
+        actions={
+            <div className="theia-skill-extension-actions">
+                {props.actions}
+                <div
+                    className="codicon codicon-settings-gear action theia-skill-extension-gear-placeholder"
+                    aria-hidden="true"
+                />
+            </div>
+        }
+    />
+);
+
+/**
+ * Buttons are state-driven and identical in the Installed and Search sections:
+ *
+ * - `not-installed`           -> [Install]
+ * - `installed-from-registry` -> [Update?] [Uninstall]   (Update only when the registry content hash differs)
+ * - `installed-manually`      -> [Link to registry]       (no Uninstall - adopt the local folder first)
+ * - `fix-skill`               -> warning [Fix Skill] [Uninstall]
+ * - `installed-link-stale`    -> warning "Not in registry" [Unlink] [Uninstall]
+ * - `installed-user-added`    -> filtered out before reaching this view
+ */
+function renderActions(
+    state: SkillClassificationResult,
+    registryEntry: ResolvedSkillEntry | undefined,
+    name: string,
+    handlers: SkillEntryHandlers
+): React.ReactNode {
+    switch (state.kind) {
+        case 'not-installed':
+            return registryEntry && (
+                <button className="theia-button prominent action" onClick={() => handlers.install(registryEntry)}>
+                    {nls.localizeByDefault('Install')}
+                </button>
+            );
+        case 'installed-from-registry':
+            return (
+                <>
+                    {state.updateAvailable && registryEntry && (
+                        <button className="theia-button prominent action" onClick={() => handlers.update(registryEntry)}>
+                            {nls.localizeByDefault('Update')}
+                        </button>
+                    )}
+                    <button className="theia-button action" onClick={() => handlers.uninstall(name)}>
+                        {nls.localizeByDefault('Uninstall')}
+                    </button>
+                </>
+            );
+        case 'installed-manually':
+            return registryEntry && (
+                <button className="theia-button action" onClick={() => handlers.link(registryEntry)}>
+                    {nls.localize('theia/ai-registry/skill/action/link', 'Link to registry')}
+                </button>
+            );
+        case 'fix-skill':
+            return (
+                <>
+                    <i
+                        className="codicon codicon-warning theia-skill-extension-warning"
+                        title={nls.localize(
+                            'theia/ai-registry/skill/warning/fix',
+                            "This skill's files differ from the registry. Click 'Fix Skill' to restore them."
+                        )}
+                    />
+                    {registryEntry && (
+                        <button className="theia-button prominent action" onClick={() => handlers.fixSkill(registryEntry)}>
+                            {nls.localize('theia/ai-registry/skill/action/fix', 'Fix Skill')}
+                        </button>
+                    )}
+                    <button className="theia-button action" onClick={() => handlers.uninstall(name)}>
+                        {nls.localizeByDefault('Uninstall')}
+                    </button>
+                </>
+            );
+        case 'installed-link-stale': {
+            const tooltip = nls.localize(
+                'theia/ai-registry/skill/warning/linkStale',
+                'This skill was installed from the registry, but the registry no longer lists it. '
+                + 'Click Unlink to drop the registry link and keep the files, or Uninstall to remove the skill.'
+            );
+            return (
+                <>
+                    <span className="theia-skill-extension-link-stale-message" title={tooltip}>
+                        <i className="codicon codicon-warning theia-skill-extension-warning" />
+                        {nls.localize('theia/ai-registry/skill/warning/notInRegistry', 'Not in registry')}
+                    </span>
+                    <button className="theia-button action" title={tooltip} onClick={() => handlers.unlink(name)}>
+                        {nls.localize('theia/ai-registry/skill/action/unlink', 'Unlink')}
+                    </button>
+                    <button className="theia-button action" onClick={() => handlers.uninstall(name)}>
+                        {nls.localizeByDefault('Uninstall')}
+                    </button>
+                </>
+            );
+        }
+        case 'installed-user-added':
+            return undefined;
+    }
+}

--- a/packages/ai-registry/src/browser/skill/skill-entries.tsx
+++ b/packages/ai-registry/src/browser/skill/skill-entries.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/skill-entries.tsx
+++ b/packages/ai-registry/src/browser/skill/skill-entries.tsx
@@ -231,6 +231,8 @@ function renderActions(
             );
         }
         case 'installed-user-added':
+            // Unreachable: SkillExtensionsContribution.resolveInstalled filters these out
+            // before they reach the view. Kept as a switch-exhaustiveness guard.
             return undefined;
     }
 }

--- a/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
@@ -14,8 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { Disposable, DisposableCollection, Emitter, Event, MessageService, nls } from '@theia/core';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { Disposable, DisposableCollection, Emitter, Event, ILogger, MessageService, nls } from '@theia/core';
 import { HoverService } from '@theia/core/lib/browser';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
@@ -51,6 +51,9 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
 
     @inject(SkillInstallClientImpl)
     protected readonly installClient: SkillInstallClientImpl;
+
+    @inject(ILogger) @named('ai-registry:SkillExtensionsContribution')
+    protected readonly logger: ILogger;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
@@ -162,7 +165,7 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
         try {
             return await this.fetchService.getSkillEntries();
         } catch (error) {
-            console.warn('AI registry fetch failed; skill entries unavailable.', error);
+            this.logger.warn('AI registry fetch failed; skill entries unavailable.', error);
             return [];
         }
     }

--- a/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
@@ -1,0 +1,185 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { Disposable, DisposableCollection, Emitter, Event, MessageService, nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { SkillInstallService } from './skill-install-service';
+import { SkillInstallClientImpl } from './skill-install-client';
+import { SkillEntryHandlers, SkillInstalledEntry, SkillSearchResultEntry } from './skill-entries';
+
+@injectable()
+export class SkillExtensionsContribution implements ExtensionsSourceContribution, Disposable {
+
+    readonly type = 'skill';
+    readonly displayName = nls.localizeByDefault('Skills');
+    // Skills sort below MCP servers (priority 100), which in turn sort below extensions.
+    readonly priority = 200;
+
+    @inject(SkillInstallService)
+    protected readonly installService: SkillInstallService;
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    @inject(HoverService)
+    protected readonly hoverService: HoverService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+
+    @inject(SkillInstallClientImpl)
+    protected readonly installClient: SkillInstallClientImpl;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection(this.onDidChangeEmitter);
+
+    protected handlers: SkillEntryHandlers;
+
+    @postConstruct()
+    protected init(): void {
+        this.handlers = {
+            install: entry => this.runAction(
+                () => this.installService.install(entry),
+                nls.localize('theia/ai-registry/skill/installed', 'Installed skill "{0}".', entry.name)
+            ),
+            uninstall: name => this.runAction(
+                () => this.installService.uninstall(name),
+                nls.localize('theia/ai-registry/skill/uninstalled', 'Uninstalled skill "{0}".', name)
+            ),
+            unlink: name => this.runAction(
+                () => this.installService.unlink(name),
+                nls.localize('theia/ai-registry/skill/unlinked', 'Unlinked skill "{0}".', name)
+            ),
+            update: entry => this.runAction(
+                () => this.installService.update(entry),
+                nls.localize('theia/ai-registry/skill/updated', 'Updated skill "{0}".', entry.name)
+            ),
+            link: entry => this.runAction(
+                () => this.installService.link(entry),
+                nls.localize('theia/ai-registry/skill/linked', 'Linked skill "{0}".', entry.name)
+            ),
+            fixSkill: entry => this.runAction(
+                () => this.installService.fixSkill(entry),
+                nls.localize('theia/ai-registry/skill/fixed', 'Restored skill "{0}".', entry.name)
+            )
+        };
+        this.toDispose.push(this.fetchService.onDidChange(() => this.onDidChangeEmitter.fire()));
+        // The backend watches `~/.agents/skills` and pushes a change event when the folder
+        // changes outside our own actions (manual edits, external installs/removals).
+        this.toDispose.push(this.installClient.onDidChangeInstalledSkills(() => this.onDidChangeEmitter.fire()));
+        // The backend stops its watcher after an irrecoverable watcher error; live refreshes
+        // are then lost until the window is reloaded, so prompt the user to do so.
+        this.toDispose.push(this.installClient.onDidStopWatching(() => this.promptWatcherReload()));
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    async resolveInstalled(): Promise<Iterable<TreeElement>> {
+        const installed = await this.installService.listInstalledSkills();
+        const registryEntries = await this.safeGetSkillEntries();
+        const bySkillId = new Map(registryEntries.map(entry => [entry.skillId, entry]));
+        const byName = new Map(registryEntries.map(entry => [entry.name, entry]));
+        const result: TreeElement[] = [];
+        for (const info of installed) {
+            const state = this.installService.classifyInstalledSkill(info, registryEntries);
+            // Hand-added skills with no registry counterpart belong to the user's own
+            // management, not this view.
+            if (state.kind === 'installed-user-added') {
+                continue;
+            }
+            const matchedEntry = (info.skillId && bySkillId.get(info.skillId)) || byName.get(info.name);
+            result.push(new SkillInstalledEntry(info, matchedEntry, state, this.handlers, this.hoverService));
+        }
+        return result;
+    }
+
+    async resolveSearchResults(query: string, context: SearchContext): Promise<Iterable<SearchResult>> {
+        if (!query.trim()) {
+            return [];
+        }
+        const registryEntries = await this.safeGetSkillEntries();
+        const installed = await this.installService.listInstalledSkills();
+        const result: SearchResult[] = [];
+        for (const entry of registryEntries) {
+            const state = this.installService.classifyRegistryEntry(entry, installed);
+            result.push({
+                element: new SkillSearchResultEntry(entry, state, this.handlers, this.hoverService),
+                searchableText: `${entry.name} ${entry.skillId} ${entry.description}`
+            });
+        }
+        return result;
+    }
+
+    async refresh(): Promise<void> {
+        await this.fetchService.getSkillEntries(true);
+    }
+
+    /**
+     * Warns the user that automatic skill refreshes stopped (the backend watcher failed) and
+     * offers to reload the window, which restarts the watcher.
+     */
+    protected async promptWatcherReload(): Promise<void> {
+        const reload = nls.localizeByDefault('Reload Window');
+        const answer = await this.messageService.warn(
+            nls.localize(
+                'theia/ai-registry/skill/watcherStopped',
+                'Stopped watching the skills folder for changes. Installed skills may no longer refresh automatically. Reload the window to resume.'
+            ),
+            reload
+        );
+        if (answer === reload) {
+            this.windowService.reload();
+        }
+    }
+
+    protected async safeGetSkillEntries(): Promise<ResolvedSkillEntry[]> {
+        try {
+            return await this.fetchService.getSkillEntries();
+        } catch (error) {
+            console.warn('AI registry fetch failed; skill entries unavailable.', error);
+            return [];
+        }
+    }
+
+    /**
+     * Runs a mutation action, reporting success or failure via the message service and
+     * refreshing the view once it settles. Kept here (rather than in the entries) so the
+     * view stays in sync with on-disk state after every action.
+     */
+    protected async runAction(action: () => Promise<void>, successMessage: string): Promise<void> {
+        try {
+            await action();
+            this.messageService.info(successMessage);
+        } catch (error) {
+            this.messageService.error(error instanceof Error ? error.message : String(error));
+        } finally {
+            this.onDidChangeEmitter.fire();
+        }
+    }
+}

--- a/packages/ai-registry/src/browser/skill/skill-install-client.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-client.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { Emitter, Event } from '@theia/core';
+import { SkillInstallClient } from '../../common/skill/skill-install-protocol';
+
+/**
+ * Frontend endpoint for the backend's skill-folder watcher. The backend invokes
+ * {@link notifyDidChangeInstalledSkills} over RPC whenever `~/.agents/skills` changes;
+ * consumers (the Extensions view contribution) subscribe to {@link onDidChangeInstalledSkills}
+ * to refresh their cards.
+ */
+@injectable()
+export class SkillInstallClientImpl implements SkillInstallClient {
+
+    protected readonly onDidChangeInstalledSkillsEmitter = new Emitter<void>();
+    readonly onDidChangeInstalledSkills: Event<void> = this.onDidChangeInstalledSkillsEmitter.event;
+
+    protected readonly onDidStopWatchingEmitter = new Emitter<void>();
+    readonly onDidStopWatching: Event<void> = this.onDidStopWatchingEmitter.event;
+
+    notifyDidChangeInstalledSkills(): void {
+        this.onDidChangeInstalledSkillsEmitter.fire();
+    }
+
+    notifyWatcherStopped(): void {
+        this.onDidStopWatchingEmitter.fire();
+    }
+}

--- a/packages/ai-registry/src/browser/skill/skill-install-client.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-client.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
@@ -35,17 +35,17 @@ describe('SkillInstallService.classifyInstalledSkill', () => {
         service = new SkillInstallServiceImpl();
     });
 
-    it('returns installed-user-added when the folder has no sidecar and the registry does not know its name', () => {
+    it('returns installed-user-added when the folder has no registry metadata file and the registry does not know its name', () => {
         const info: InstalledSkillInfo = { name: 'unrelated', drifted: false };
         expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-user-added' });
     });
 
-    it('returns installed-manually when the folder has no sidecar but the registry knows its name', () => {
+    it('returns installed-manually when the folder has no registry metadata file but the registry knows its name', () => {
         const info: InstalledSkillInfo = { name: 'Example Skill', drifted: false };
         expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-manually' });
     });
 
-    it('returns installed-link-stale when the sidecar points at a skillId the registry no longer lists', () => {
+    it('returns installed-link-stale when the registry metadata file points at a skillId the registry no longer lists', () => {
         const info: InstalledSkillInfo = { name: 'Example Skill', skillId: 'io.github.example/gone', contentHash: 'hash-v1', drifted: false };
         expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-link-stale' });
     });
@@ -60,12 +60,12 @@ describe('SkillInstallService.classifyInstalledSkill', () => {
         expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
     });
 
-    it('returns installed-from-registry with no update when the sidecar hash matches the registry hash', () => {
+    it('returns installed-from-registry with no update when the recorded hash matches the registry hash', () => {
         const info: InstalledSkillInfo = { name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v1', drifted: false };
         expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
     });
 
-    it('returns installed-from-registry with an update available when the registry hash differs from the sidecar hash', () => {
+    it('returns installed-from-registry with an update available when the registry hash differs from the recorded hash', () => {
         const info: InstalledSkillInfo = { name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v0', drifted: false };
         expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
     });

--- a/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
@@ -1,0 +1,110 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { InstalledSkillInfo, ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { SkillInstallService, SkillInstallServiceImpl } from './skill-install-service';
+
+const entry: ResolvedSkillEntry = {
+    skillId: 'io.github.example/example-skill',
+    name: 'Example Skill',
+    description: 'An example skill',
+    sourceUrl: 'https://github.com/example/skills',
+    sourcePath: 'skills/example',
+    contentHash: 'hash-v1'
+};
+
+describe('SkillInstallService.classifyInstalledSkill', () => {
+
+    let service: SkillInstallService;
+
+    beforeEach(() => {
+        service = new SkillInstallServiceImpl();
+    });
+
+    it('returns installed-user-added when the folder has no sidecar and the registry does not know its name', () => {
+        const info: InstalledSkillInfo = { name: 'unrelated', drifted: false };
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-user-added' });
+    });
+
+    it('returns installed-manually when the folder has no sidecar but the registry knows its name', () => {
+        const info: InstalledSkillInfo = { name: 'Example Skill', drifted: false };
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns installed-link-stale when the sidecar points at a skillId the registry no longer lists', () => {
+        const info: InstalledSkillInfo = { name: 'Example Skill', skillId: 'io.github.example/gone', contentHash: 'hash-v1', drifted: false };
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-link-stale' });
+    });
+
+    it('returns fix-skill when the registry hash matches but the local files have drifted', () => {
+        const info: InstalledSkillInfo = { name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v1', drifted: true };
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'fix-skill' });
+    });
+
+    it('prefers Update over Fix when the registry hash differs even if the local files have also drifted', () => {
+        const info: InstalledSkillInfo = { name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v0', drifted: true };
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('returns installed-from-registry with no update when the sidecar hash matches the registry hash', () => {
+        const info: InstalledSkillInfo = { name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v1', drifted: false };
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('returns installed-from-registry with an update available when the registry hash differs from the sidecar hash', () => {
+        const info: InstalledSkillInfo = { name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v0', drifted: false };
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+});
+
+describe('SkillInstallService.classifyRegistryEntry', () => {
+
+    let service: SkillInstallService;
+
+    beforeEach(() => {
+        service = new SkillInstallServiceImpl();
+    });
+
+    it('returns not-installed when no local folder matches the entry by skillId or name', () => {
+        expect(service.classifyRegistryEntry(entry, [])).to.deep.equal({ kind: 'not-installed' });
+    });
+
+    it('returns installed-from-registry with no update when a folder is linked by skillId and the hashes match', () => {
+        const installed: InstalledSkillInfo[] = [{ name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v1', drifted: false }];
+        expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+
+    it('returns installed-from-registry with an update available when a linked folder has an older hash', () => {
+        const installed: InstalledSkillInfo[] = [{ name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v0', drifted: false }];
+        expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('returns fix-skill when the registry hash matches but a linked folder has drifted on disk', () => {
+        const installed: InstalledSkillInfo[] = [{ name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v1', drifted: true }];
+        expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'fix-skill' });
+    });
+
+    it('prefers Update over Fix when the registry hash differs even if a linked folder has also drifted', () => {
+        const installed: InstalledSkillInfo[] = [{ name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v0', drifted: true }];
+        expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('returns installed-manually when a folder of the same name exists but is not linked to this skill', () => {
+        const installed: InstalledSkillInfo[] = [{ name: 'Example Skill', drifted: false }];
+        expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'installed-manually' });
+    });
+});

--- a/packages/ai-registry/src/browser/skill/skill-install-service.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.ts
@@ -1,0 +1,120 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { SkillInstallBackendService } from '../../common/skill/skill-install-protocol';
+import { InstalledSkillInfo, ResolvedSkillEntry, SkillClassificationResult } from '../../common/skill/skill-registry-types';
+
+export const SkillInstallService = Symbol('SkillInstallService');
+export interface SkillInstallService {
+    /** Downloads and installs a registry skill into `~/.agents/skills/<name>`. */
+    install(entry: ResolvedSkillEntry): Promise<void>;
+    /** Clean-replaces an installed skill with the latest registry content. */
+    update(entry: ResolvedSkillEntry): Promise<void>;
+    /** Restores a drifted skill from the registry content. */
+    fixSkill(entry: ResolvedSkillEntry): Promise<void>;
+    /** Adopts an existing local skill folder by stamping the registry sidecar. */
+    link(entry: ResolvedSkillEntry): Promise<void>;
+    /** Drops the registry sidecar from a skill folder while keeping its files. */
+    unlink(name: string): Promise<void>;
+    /** Removes an installed (registry-managed) skill folder. */
+    uninstall(name: string): Promise<void>;
+    /** Lists every skill folder under `~/.agents/skills`. */
+    listInstalledSkills(): Promise<InstalledSkillInfo[]>;
+    /** Classifies a local skill folder against the registry (for the Installed view). */
+    classifyInstalledSkill(info: InstalledSkillInfo, entries: ResolvedSkillEntry[]): SkillClassificationResult;
+    /** Classifies a registry entry against the local skill folders (for the Search view). */
+    classifyRegistryEntry(entry: ResolvedSkillEntry, installed: InstalledSkillInfo[]): SkillClassificationResult;
+}
+
+@injectable()
+export class SkillInstallServiceImpl implements SkillInstallService {
+
+    @inject(SkillInstallBackendService)
+    protected readonly backend: SkillInstallBackendService;
+
+    install(entry: ResolvedSkillEntry): Promise<void> {
+        return this.backend.install(entry);
+    }
+
+    update(entry: ResolvedSkillEntry): Promise<void> {
+        return this.backend.update(entry);
+    }
+
+    fixSkill(entry: ResolvedSkillEntry): Promise<void> {
+        return this.backend.fixSkill(entry);
+    }
+
+    link(entry: ResolvedSkillEntry): Promise<void> {
+        return this.backend.link(entry);
+    }
+
+    unlink(name: string): Promise<void> {
+        return this.backend.unlink(name);
+    }
+
+    uninstall(name: string): Promise<void> {
+        return this.backend.uninstall(name);
+    }
+
+    listInstalledSkills(): Promise<InstalledSkillInfo[]> {
+        return this.backend.listInstalledSkills();
+    }
+
+    classifyInstalledSkill(info: InstalledSkillInfo, entries: ResolvedSkillEntry[]): SkillClassificationResult {
+        if (info.skillId !== undefined) {
+            const matched = entries.find(entry => entry.skillId === info.skillId);
+            if (!matched) {
+                // Sidecar points at a skillId the registry no longer lists.
+                return { kind: 'installed-link-stale' };
+            }
+            // Update takes precedence: a changed registry content hash always means an
+            // Update is available, even if the local files have also drifted. Only when the
+            // registry hash still matches do local edits surface as a Fix.
+            if (matched.contentHash !== info.contentHash) {
+                return { kind: 'installed-from-registry', updateAvailable: true };
+            }
+            if (info.drifted) {
+                return { kind: 'fix-skill' };
+            }
+            return { kind: 'installed-from-registry', updateAvailable: false };
+        }
+        // No sidecar: a hand-placed folder. Offer Link only when the registry knows the name.
+        const byName = entries.find(entry => entry.name === info.name);
+        return byName ? { kind: 'installed-manually' } : { kind: 'installed-user-added' };
+    }
+
+    classifyRegistryEntry(entry: ResolvedSkillEntry, installed: InstalledSkillInfo[]): SkillClassificationResult {
+        const linked = installed.find(info => info.skillId === entry.skillId);
+        if (linked) {
+            // Update takes precedence over Fix, mirroring classifyInstalledSkill.
+            if (entry.contentHash !== linked.contentHash) {
+                return { kind: 'installed-from-registry', updateAvailable: true };
+            }
+            if (linked.drifted) {
+                return { kind: 'fix-skill' };
+            }
+            return { kind: 'installed-from-registry', updateAvailable: false };
+        }
+        const byName = installed.find(info => info.name === entry.name);
+        if (!byName) {
+            return { kind: 'not-installed' };
+        }
+        // A folder of this name exists but is not linked to this skill - offer Link before
+        // any download (Install would refuse to overwrite an existing folder).
+        return { kind: 'installed-manually' };
+    }
+}

--- a/packages/ai-registry/src/browser/skill/skill-install-service.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/skill/skill-install-service.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.ts
@@ -26,9 +26,9 @@ export interface SkillInstallService {
     update(entry: ResolvedSkillEntry): Promise<void>;
     /** Restores a drifted skill from the registry content. */
     fixSkill(entry: ResolvedSkillEntry): Promise<void>;
-    /** Adopts an existing local skill folder by stamping the registry sidecar. */
+    /** Adopts an existing local skill folder by writing the registry metadata file. */
     link(entry: ResolvedSkillEntry): Promise<void>;
-    /** Drops the registry sidecar from a skill folder while keeping its files. */
+    /** Removes the registry metadata file from a skill folder while keeping its other files. */
     unlink(name: string): Promise<void>;
     /** Removes an installed (registry-managed) skill folder. */
     uninstall(name: string): Promise<void>;
@@ -78,7 +78,7 @@ export class SkillInstallServiceImpl implements SkillInstallService {
         if (info.skillId !== undefined) {
             const matched = entries.find(entry => entry.skillId === info.skillId);
             if (!matched) {
-                // Sidecar points at a skillId the registry no longer lists.
+                // The registry metadata file points at a skillId the registry no longer lists.
                 return { kind: 'installed-link-stale' };
             }
             // Update takes precedence: a changed registry content hash always means an
@@ -92,7 +92,7 @@ export class SkillInstallServiceImpl implements SkillInstallService {
             }
             return { kind: 'installed-from-registry', updateAvailable: false };
         }
-        // No sidecar: a hand-placed folder. Offer Link only when the registry knows the name.
+        // No registry metadata file: a hand-placed folder. Offer Link only when the registry knows the name.
         const byName = entries.find(entry => entry.name === info.name);
         return byName ? { kind: 'installed-manually' } : { kind: 'installed-user-added' };
     }

--- a/packages/ai-registry/src/browser/style/skill-entries.css
+++ b/packages/ai-registry/src/browser/style/skill-entries.css
@@ -24,7 +24,6 @@
 }
 
 .theia-vsx-extension-icon.theia-skill-extension-icon .codicon {
-    font-size: calc(var(--theia-vsx-extension-icon-size) * 0.65);
     color: var(--theia-descriptionForeground);
 }
 

--- a/packages/ai-registry/src/browser/style/skill-entries.css
+++ b/packages/ai-registry/src/browser/style/skill-entries.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2026 EclipseSource GmbH.
+ * Copyright (C) 2026 EclipseSource GmbH and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -40,14 +40,14 @@
 
 .theia-skill-extension-warning {
     color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
-    font-size: 14px;
+    font-size: var(--theia-ui-font-size1);
 }
 
 .theia-skill-extension-link-stale-message {
     display: inline-flex;
     align-items: center;
     gap: calc(var(--theia-ui-padding) / 2);
-    font-size: 90%;
+    font-size: var(--theia-ui-font-size0);
     color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
 }
 

--- a/packages/ai-registry/src/browser/style/skill-entries.css
+++ b/packages/ai-registry/src/browser/style/skill-entries.css
@@ -1,0 +1,58 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource GmbH.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/** Skill-specific tweaks layered on top of the shared `.theia-vsx-extension` card. */
+
+.theia-vsx-extension-icon.theia-skill-extension-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image: none;
+}
+
+.theia-vsx-extension-icon.theia-skill-extension-icon .codicon {
+    font-size: calc(var(--theia-vsx-extension-icon-size) * 0.65);
+    color: var(--theia-descriptionForeground);
+}
+
+.theia-skill-extension-actions {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+}
+
+.theia-skill-extension-gear-placeholder {
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.theia-skill-extension-warning {
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+    font-size: 14px;
+}
+
+.theia-skill-extension-link-stale-message {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) / 2);
+    font-size: 90%;
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+}
+
+.theia-extensions-type-badge--skill {
+    background-color: var(--theia-inputValidation-warningBackground, var(--theia-badge-background));
+    color: var(--theia-inputValidation-warningForeground, var(--theia-badge-foreground));
+}

--- a/packages/ai-registry/src/common/registry-fetch-service.spec.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.spec.ts
@@ -19,6 +19,7 @@ import { Container } from '@theia/core/shared/inversify';
 import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
 import { AIRegistryConfiguration } from './ai-registry-configuration';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from './mcp/mcp-registry-entry-resolver';
+import { SkillRegistryEntryResolver, SkillRegistryEntryResolverImpl } from './skill/skill-registry-entry-resolver';
 import { RegistryFetchService, RegistryFetchServiceImpl } from './registry-fetch-service';
 
 class FakeRequestService implements RequestService {
@@ -63,6 +64,18 @@ function payload(): string {
                     config: { servers: { example: { command: 'npx', args: ['-y', 'example-mcp'] } } }
                 }]
             }]
+        }],
+        skills: [{
+            skillId: 'io.github.example/example-skill',
+            name: 'Example Skill',
+            description: 'Example skill',
+            source: { url: 'https://github.com/example/skills', path: 'skills/example' },
+            contentHash: 'abc123abc123',
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                installConfigs: [{ tool: 'theia-ide', installUrl: 'theia://install-skill?id=io.github.example/example-skill' }]
+            }]
         }]
     });
 }
@@ -75,6 +88,8 @@ describe('RegistryFetchService', () => {
         container.bind(AIRegistryConfiguration).toConstantValue(config);
         container.bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
         container.bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
+        container.bind(SkillRegistryEntryResolverImpl).toSelf().inSingletonScope();
+        container.bind(SkillRegistryEntryResolver).toService(SkillRegistryEntryResolverImpl);
         container.bind(RegistryFetchServiceImpl).toSelf().inSingletonScope();
         container.bind(RegistryFetchService).toService(RegistryFetchServiceImpl);
         return container;
@@ -99,6 +114,34 @@ describe('RegistryFetchService', () => {
             configHash: 'hash-v1',
             mcpRegistryVerified: true
         });
+    });
+
+    it('fetches and resolves skill entries from the same per-tool JSON', async () => {
+        const request = new FakeRequestService(payload());
+        const config = new FakeConfiguration('theia-ide', 'https://example.test/api/v1/');
+        const service = buildContainer(request, config).get<RegistryFetchService>(RegistryFetchService);
+
+        const skills = await service.getSkillEntries();
+
+        expect(skills).to.have.length(1);
+        expect(skills[0]).to.deep.equal({
+            skillId: 'io.github.example/example-skill',
+            name: 'Example Skill',
+            description: 'Example skill',
+            sourceUrl: 'https://github.com/example/skills',
+            sourcePath: 'skills/example',
+            contentHash: 'abc123abc123'
+        });
+    });
+
+    it('shares a single HTTP request between MCP and skill slices', async () => {
+        const request = new FakeRequestService(payload());
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get<RegistryFetchService>(RegistryFetchService);
+
+        await service.getEntries();
+        await service.getSkillEntries();
+
+        expect(request.callCount).to.equal(1);
     });
 
     it('serves cached entries on a second call without issuing a new request', async () => {

--- a/packages/ai-registry/src/common/registry-fetch-service.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.ts
@@ -20,17 +20,22 @@ import { RequestContext, RequestService } from '@theia/core/shared/@theia/reques
 import { AIRegistryConfiguration } from './ai-registry-configuration';
 import { MCPRegistryEntryResolver } from './mcp/mcp-registry-entry-resolver';
 import { RegistryMCPServer, ResolvedRegistryEntry } from './mcp/mcp-registry-types';
+import { SkillRegistryEntryResolver } from './skill/skill-registry-entry-resolver';
+import { RegistrySkill, ResolvedSkillEntry } from './skill/skill-registry-types';
 
 interface RegistryResponse {
     mcp?: RegistryMCPServer[];
+    skills?: RegistrySkill[];
 }
 
 export const RegistryFetchService = Symbol('RegistryFetchService');
 export interface RegistryFetchService {
     /** Fires whenever the cached set of resolved entries changes (initial load, manual refresh). */
     readonly onDidChange: Event<void>;
-    /** Returns the resolved registry entries, fetching (and caching) them on first use or when `forceRefresh` is set. */
+    /** Returns the resolved MCP registry entries, fetching (and caching) them on first use or when `forceRefresh` is set. */
     getEntries(forceRefresh?: boolean): Promise<ResolvedRegistryEntry[]>;
+    /** Returns the resolved skill registry entries, fetching (and caching) them on first use or when `forceRefresh` is set. */
+    getSkillEntries(forceRefresh?: boolean): Promise<ResolvedSkillEntry[]>;
 }
 
 @injectable()
@@ -45,15 +50,45 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
     @inject(MCPRegistryEntryResolver)
     protected readonly resolver: MCPRegistryEntryResolver;
 
-    protected cached: ResolvedRegistryEntry[] | undefined;
+    @inject(SkillRegistryEntryResolver)
+    protected readonly skillResolver: SkillRegistryEntryResolver;
+
+    protected cachedResponse: RegistryResponse | undefined;
+    protected cachedEntries: ResolvedRegistryEntry[] | undefined;
+    protected cachedSkills: ResolvedSkillEntry[] | undefined;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     /** Fires whenever the cached set of resolved entries changes (initial load, manual refresh). */
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
 
     async getEntries(forceRefresh: boolean = false): Promise<ResolvedRegistryEntry[]> {
-        if (this.cached && !forceRefresh) {
-            return this.cached;
+        const data = await this.fetchResponse(forceRefresh);
+        if (!this.cachedEntries) {
+            this.cachedEntries = (data.mcp ?? [])
+                .map(server => this.resolver.resolve(server))
+                .filter((entry): entry is ResolvedRegistryEntry => entry !== undefined);
+        }
+        return this.cachedEntries;
+    }
+
+    async getSkillEntries(forceRefresh: boolean = false): Promise<ResolvedSkillEntry[]> {
+        const data = await this.fetchResponse(forceRefresh);
+        if (!this.cachedSkills) {
+            this.cachedSkills = (data.skills ?? [])
+                .map(skill => this.skillResolver.resolve(skill))
+                .filter((entry): entry is ResolvedSkillEntry => entry !== undefined);
+        }
+        return this.cachedSkills;
+    }
+
+    /**
+     * Fetches and caches the raw registry response. One HTTP request backs both the MCP
+     * and skill slices; the resolved slices are memoized separately and invalidated
+     * whenever the raw response is (re-)fetched.
+     */
+    protected async fetchResponse(forceRefresh: boolean): Promise<RegistryResponse> {
+        if (this.cachedResponse && !forceRefresh) {
+            return this.cachedResponse;
         }
         const url = this.buildEndpointUrl();
         const context = await this.requestService.request({ url });
@@ -61,12 +96,11 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
             throw new Error(`Failed to fetch AI registry from ${url}: HTTP ${context.res.statusCode ?? 'unknown'}`);
         }
         const data = RequestContext.asJson<RegistryResponse>(context);
-        const entries = (data.mcp ?? [])
-            .map(server => this.resolver.resolve(server))
-            .filter((entry): entry is ResolvedRegistryEntry => entry !== undefined);
-        this.cached = entries;
+        this.cachedResponse = data;
+        this.cachedEntries = undefined;
+        this.cachedSkills = undefined;
         this.onDidChangeEmitter.fire();
-        return entries;
+        return data;
     }
 
     protected buildEndpointUrl(): string {

--- a/packages/ai-registry/src/common/skill/skill-content-hash.spec.ts
+++ b/packages/ai-registry/src/common/skill/skill-content-hash.spec.ts
@@ -1,0 +1,82 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { computeSkillContentHash, SkillFileContent } from './skill-content-hash';
+
+function file(relativePath: string, content: string): SkillFileContent {
+    return { relativePath, content: new TextEncoder().encode(content) };
+}
+
+describe('computeSkillContentHash', () => {
+
+    it('hashes an empty file set to the sha256-of-nothing 12-char prefix', () => {
+        // sha256('') = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
+        expect(computeSkillContentHash([])).to.equal('e3b0c44298fc');
+    });
+
+    it('produces a 12-character lowercase hex prefix', () => {
+        const hash = computeSkillContentHash([file('SKILL.md', '# Example')]);
+        expect(hash).to.match(/^[0-9a-f]{12}$/);
+    });
+
+    it('is independent of the input order (paths are sorted lexicographically)', () => {
+        const a = computeSkillContentHash([file('a.txt', 'A'), file('b.txt', 'B'), file('c/d.txt', 'D')]);
+        const b = computeSkillContentHash([file('c/d.txt', 'D'), file('b.txt', 'B'), file('a.txt', 'A')]);
+        expect(a).to.equal(b);
+    });
+
+    it('excludes dot-prefixed files at the root (e.g. the .registry.json sidecar)', () => {
+        const withoutSidecar = computeSkillContentHash([file('SKILL.md', '# Example')]);
+        const withSidecar = computeSkillContentHash([
+            file('SKILL.md', '# Example'),
+            file('.registry.json', '{"skillId":"x"}')
+        ]);
+        expect(withSidecar).to.equal(withoutSidecar);
+    });
+
+    it('excludes files inside dot-prefixed directories at any level', () => {
+        const baseline = computeSkillContentHash([file('SKILL.md', '# Example')]);
+        const withHidden = computeSkillContentHash([
+            file('SKILL.md', '# Example'),
+            file('.git/config', 'ignored'),
+            file('docs/.hidden/note.txt', 'ignored')
+        ]);
+        expect(withHidden).to.equal(baseline);
+    });
+
+    it('excludes the empty set and a dot-only set identically', () => {
+        expect(computeSkillContentHash([file('.registry.json', '{}')])).to.equal(computeSkillContentHash([]));
+    });
+
+    it('normalises backslash separators to POSIX so Windows and Linux backends agree', () => {
+        const windows = computeSkillContentHash([file('docs\\guide.md', 'content')]);
+        const posix = computeSkillContentHash([file('docs/guide.md', 'content')]);
+        expect(windows).to.equal(posix);
+    });
+
+    it('changes when a file path changes', () => {
+        const first = computeSkillContentHash([file('SKILL.md', 'same')]);
+        const renamed = computeSkillContentHash([file('OTHER.md', 'same')]);
+        expect(first).to.not.equal(renamed);
+    });
+
+    it('changes when file content changes', () => {
+        const first = computeSkillContentHash([file('SKILL.md', 'one')]);
+        const second = computeSkillContentHash([file('SKILL.md', 'two')]);
+        expect(first).to.not.equal(second);
+    });
+});

--- a/packages/ai-registry/src/common/skill/skill-content-hash.spec.ts
+++ b/packages/ai-registry/src/common/skill/skill-content-hash.spec.ts
@@ -39,13 +39,13 @@ describe('computeSkillContentHash', () => {
         expect(a).to.equal(b);
     });
 
-    it('excludes dot-prefixed files at the root (e.g. the .registry.json sidecar)', () => {
-        const withoutSidecar = computeSkillContentHash([file('SKILL.md', '# Example')]);
-        const withSidecar = computeSkillContentHash([
+    it('excludes dot-prefixed files at the root (e.g. the .registry.json registry metadata file)', () => {
+        const withoutMetadata = computeSkillContentHash([file('SKILL.md', '# Example')]);
+        const withMetadata = computeSkillContentHash([
             file('SKILL.md', '# Example'),
             file('.registry.json', '{"skillId":"x"}')
         ]);
-        expect(withSidecar).to.equal(withoutSidecar);
+        expect(withMetadata).to.equal(withoutMetadata);
     });
 
     it('excludes files inside dot-prefixed directories at any level', () => {

--- a/packages/ai-registry/src/common/skill/skill-content-hash.spec.ts
+++ b/packages/ai-registry/src/common/skill/skill-content-hash.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/skill/skill-content-hash.ts
+++ b/packages/ai-registry/src/common/skill/skill-content-hash.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/skill/skill-content-hash.ts
+++ b/packages/ai-registry/src/common/skill/skill-content-hash.ts
@@ -42,7 +42,7 @@ function hasDotSegment(posixPath: string): boolean {
  * Reproduces the registry's skill content hash byte-for-byte (registry `src/skill-source.ts`):
  *
  * - Recursively considers all files, skipping any entry whose name starts with `.` at any
- *   directory level (this excludes the `.registry.json` sidecar automatically).
+ *   directory level (this excludes the `.registry.json` registry metadata file automatically).
  * - Normalises relative paths to POSIX separators and sorts them lexicographically.
  * - For each file in order: `sha256.update(relativePath)` then `sha256.update(rawBytes)`.
  * - Returns the first {@link HASH_PREFIX_LENGTH} hex characters of the digest.

--- a/packages/ai-registry/src/common/skill/skill-content-hash.ts
+++ b/packages/ai-registry/src/common/skill/skill-content-hash.ts
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { createHash } from 'crypto';
+
+/**
+ * A single file participating in the skill content hash, identified by its path relative
+ * to the skill root (any path separator) and its raw bytes.
+ */
+export interface SkillFileContent {
+    relativePath: string;
+    content: Uint8Array;
+}
+
+/** Number of leading hex characters kept from the sha256 digest, matching the registry. */
+const HASH_PREFIX_LENGTH = 12;
+
+/** Normalises a relative path to POSIX separators so Windows backends match the Linux registry. */
+function toPosix(relativePath: string): string {
+    return relativePath.replace(/\\/g, '/');
+}
+
+/** True when any path segment is dot-prefixed; such files are excluded from the hash at every level. */
+function hasDotSegment(posixPath: string): boolean {
+    return posixPath.split('/').some(segment => segment.startsWith('.'));
+}
+
+/**
+ * Reproduces the registry's skill content hash byte-for-byte (registry `src/skill-source.ts`):
+ *
+ * - Recursively considers all files, skipping any entry whose name starts with `.` at any
+ *   directory level (this excludes the `.registry.json` sidecar automatically).
+ * - Normalises relative paths to POSIX separators and sorts them lexicographically.
+ * - For each file in order: `sha256.update(relativePath)` then `sha256.update(rawBytes)`.
+ * - Returns the first {@link HASH_PREFIX_LENGTH} hex characters of the digest.
+ */
+export function computeSkillContentHash(files: SkillFileContent[]): string {
+    const normalized = files
+        .map(file => ({ relativePath: toPosix(file.relativePath), content: file.content }))
+        .filter(file => !hasDotSegment(file.relativePath))
+        .sort((a, b) => (a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0));
+    const hash = createHash('sha256');
+    for (const file of normalized) {
+        hash.update(file.relativePath);
+        hash.update(Buffer.from(file.content));
+    }
+    return hash.digest('hex').slice(0, HASH_PREFIX_LENGTH);
+}

--- a/packages/ai-registry/src/common/skill/skill-install-protocol.ts
+++ b/packages/ai-registry/src/common/skill/skill-install-protocol.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/skill/skill-install-protocol.ts
+++ b/packages/ai-registry/src/common/skill/skill-install-protocol.ts
@@ -41,17 +41,17 @@ export const SkillInstallBackendService = Symbol('SkillInstallBackendService');
  * FileService sandbox, so all fetch + filesystem writes happen here.
  */
 export interface SkillInstallBackendService {
-    /** Downloads a skill into `~/.agents/skills/<name>` and writes the registry sidecar. Refuses to overwrite an existing folder. */
+    /** Downloads a skill into `~/.agents/skills/<name>` and writes the registry metadata file. Refuses to overwrite an existing folder. */
     install(entry: ResolvedSkillEntry): Promise<void>;
     /** Clean-replaces an installed skill with the latest registry content (delete folder + re-download). */
     update(entry: ResolvedSkillEntry): Promise<void>;
     /** Clean-replaces a drifted skill with the registry content (delete folder + re-download). */
     fixSkill(entry: ResolvedSkillEntry): Promise<void>;
-    /** Removes a skill folder - only when it carries our registry sidecar. */
+    /** Removes a skill folder - only when it carries our registry metadata file. */
     uninstall(name: string): Promise<void>;
-    /** Adopts an existing local skill folder by stamping the registry sidecar without overwriting any files. */
+    /** Adopts an existing local skill folder by writing the registry metadata file without overwriting any other files. */
     link(entry: ResolvedSkillEntry): Promise<void>;
-    /** Drops the registry sidecar from a skill folder while keeping its files. */
+    /** Removes the registry metadata file from a skill folder while keeping its other files. */
     unlink(name: string): Promise<void>;
     /** Lists every skill folder under `~/.agents/skills`, including drift information for registry-managed ones. */
     listInstalledSkills(): Promise<InstalledSkillInfo[]>;

--- a/packages/ai-registry/src/common/skill/skill-install-protocol.ts
+++ b/packages/ai-registry/src/common/skill/skill-install-protocol.ts
@@ -1,0 +1,58 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { InstalledSkillInfo, ResolvedSkillEntry } from './skill-registry-types';
+
+export const SkillInstallBackendServicePath = '/services/ai-registry/skill-install';
+
+export const SkillInstallClient = Symbol('SkillInstallClient');
+/**
+ * Frontend-side client the backend notifies whenever the on-disk set of skills under
+ * `~/.agents/skills` changes (installs, removals, or external edits picked up by the
+ * backend watcher), so the Extensions view can refresh its cards.
+ */
+export interface SkillInstallClient {
+    notifyDidChangeInstalledSkills(): void;
+    /**
+     * Notifies the frontend that the skills-folder watcher stopped after an error, so live
+     * refreshes are no longer delivered until the window is reloaded.
+     */
+    notifyWatcherStopped(): void;
+}
+
+export const SkillInstallBackendService = Symbol('SkillInstallBackendService');
+
+/**
+ * Backend service that performs all skill filesystem and network work. The browser only
+ * triggers actions and renders results - `~/.agents/skills` is outside the browser
+ * FileService sandbox, so all fetch + filesystem writes happen here.
+ */
+export interface SkillInstallBackendService {
+    /** Downloads a skill into `~/.agents/skills/<name>` and writes the registry sidecar. Refuses to overwrite an existing folder. */
+    install(entry: ResolvedSkillEntry): Promise<void>;
+    /** Clean-replaces an installed skill with the latest registry content (delete folder + re-download). */
+    update(entry: ResolvedSkillEntry): Promise<void>;
+    /** Clean-replaces a drifted skill with the registry content (delete folder + re-download). */
+    fixSkill(entry: ResolvedSkillEntry): Promise<void>;
+    /** Removes a skill folder - only when it carries our registry sidecar. */
+    uninstall(name: string): Promise<void>;
+    /** Adopts an existing local skill folder by stamping the registry sidecar without overwriting any files. */
+    link(entry: ResolvedSkillEntry): Promise<void>;
+    /** Drops the registry sidecar from a skill folder while keeping its files. */
+    unlink(name: string): Promise<void>;
+    /** Lists every skill folder under `~/.agents/skills`, including drift information for registry-managed ones. */
+    listInstalledSkills(): Promise<InstalledSkillInfo[]>;
+}

--- a/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.spec.ts
@@ -1,0 +1,100 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { SkillRegistryEntryResolver, SkillRegistryEntryResolverImpl } from './skill-registry-entry-resolver';
+import { RegistrySkill } from './skill-registry-types';
+
+function createResolver(): SkillRegistryEntryResolver {
+    return new SkillRegistryEntryResolverImpl();
+}
+
+describe('SkillRegistryEntryResolver.resolve', () => {
+
+    let resolver: SkillRegistryEntryResolver;
+
+    beforeEach(() => {
+        resolver = createResolver();
+    });
+
+    it('normalises an approved skill, carrying the top-level contentHash', () => {
+        const raw: RegistrySkill = {
+            skillId: 'io.github.example/example-skill',
+            name: 'Example Skill',
+            description: 'An example skill',
+            source: { url: 'https://github.com/example/skills', path: 'skills/example' },
+            contentHash: 'abc123abc123',
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                installConfigs: [{ tool: 'theia-ide', installUrl: 'theia://install-skill?id=io.github.example/example-skill' }]
+            }]
+        };
+
+        expect(resolver.resolve(raw)).to.deep.equal({
+            skillId: 'io.github.example/example-skill',
+            name: 'Example Skill',
+            description: 'An example skill',
+            sourceUrl: 'https://github.com/example/skills',
+            sourcePath: 'skills/example',
+            contentHash: 'abc123abc123'
+        });
+    });
+
+    it('omits sourcePath when it is absent', () => {
+        const raw: RegistrySkill = {
+            skillId: 'io.github.example/root-skill',
+            name: 'Root Skill',
+            description: 'Skill at the repository root',
+            source: { url: 'https://github.com/example/root-skill' },
+            contentHash: 'def456def456',
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                installConfigs: [{ tool: 'theia-ide' }]
+            }]
+        };
+
+        const resolved = resolver.resolve(raw);
+        expect(resolved).to.not.have.property('sourcePath');
+        expect(resolved?.sourceUrl).to.equal('https://github.com/example/root-skill');
+        expect(resolved?.contentHash).to.equal('def456def456');
+    });
+
+    it('returns undefined when the skill has no approvals', () => {
+        const raw: RegistrySkill = {
+            skillId: 'io.github.example/orphan',
+            name: 'Orphan',
+            description: 'No approvals',
+            source: { url: 'https://github.com/example/orphan' },
+            contentHash: 'aaa',
+            approvals: []
+        };
+        expect(resolver.resolve(raw)).to.be.undefined;
+    });
+
+    it('returns undefined when the source URL is missing', () => {
+        const raw = {
+            skillId: 'io.github.example/no-source',
+            name: 'No Source',
+            description: 'Missing source url',
+            source: {},
+            contentHash: 'bbb',
+            approvals: [{ organizationId: 'theia', date: '2026-04-01', installConfigs: [{ tool: 'theia-ide' }] }]
+        } as unknown as RegistrySkill;
+        expect(resolver.resolve(raw)).to.be.undefined;
+    });
+});

--- a/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { RegistrySkill, ResolvedSkillEntry } from './skill-registry-types';
+
+export const SkillRegistryEntryResolver = Symbol('SkillRegistryEntryResolver');
+export interface SkillRegistryEntryResolver {
+    /** Normalises a raw registry skill entry into the shape the install path uses, or undefined when it is not approved/usable. */
+    resolve(raw: RegistrySkill): ResolvedSkillEntry | undefined;
+}
+
+@injectable()
+export class SkillRegistryEntryResolverImpl implements SkillRegistryEntryResolver {
+
+    resolve(raw: RegistrySkill): ResolvedSkillEntry | undefined {
+        if (!raw.source?.url) {
+            return undefined;
+        }
+        // A skill is only installable once at least one organization has approved it.
+        if (!raw.approvals?.length) {
+            return undefined;
+        }
+        return {
+            skillId: raw.skillId,
+            name: raw.name,
+            description: raw.description,
+            sourceUrl: raw.source.url,
+            ...(raw.source.path !== undefined && { sourcePath: raw.source.path }),
+            contentHash: raw.contentHash
+        };
+    }
+}

--- a/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-entry-resolver.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/skill/skill-registry-preferences.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-preferences.ts
@@ -20,7 +20,6 @@ import { LINUX_ENV_HINT, nls, PreferenceSchema, PreferenceScope } from '@theia/c
 export const GITHUB_TOKEN_PREF = 'ai-features.registry.githubToken';
 
 export const SkillRegistryPreferencesSchema: PreferenceSchema = {
-    scope: PreferenceScope.User,
     properties: {
         [GITHUB_TOKEN_PREF]: {
             type: 'string',

--- a/packages/ai-registry/src/common/skill/skill-registry-preferences.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-preferences.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/skill/skill-registry-preferences.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-preferences.ts
@@ -1,0 +1,35 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
+import { LINUX_ENV_HINT, nls, PreferenceSchema, PreferenceScope } from '@theia/core';
+
+export const GITHUB_TOKEN_PREF = 'ai-features.registry.githubToken';
+
+export const SkillRegistryPreferencesSchema: PreferenceSchema = {
+    scope: PreferenceScope.User,
+    properties: {
+        [GITHUB_TOKEN_PREF]: {
+            type: 'string',
+            scope: PreferenceScope.User,
+            markdownDescription: nls.localize('theia/ai-registry/skill/githubToken/mdDescription',
+                'Optional GitHub personal access token used when downloading skills from GitHub. A token raises GitHub\'s rate limit from 60 to \
+5000 requests per hour. **Please note:** By using this preference the token is stored in clear text on the \
+machine running Theia. Prefer the environment variable `GITHUB_TOKEN` to provide it securely.') + LINUX_ENV_HINT,
+            title: AI_CORE_PREFERENCES_TITLE
+        }
+    }
+};

--- a/packages/ai-registry/src/common/skill/skill-registry-types.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-types.ts
@@ -72,7 +72,7 @@ export interface ResolvedSkillEntry {
     sourceUrl: string;
     /** Path within the repository pointing at the skill root. Omitted means the repository root. */
     sourcePath?: string;
-    /** Content hash published by the registry - compared against the installed sidecar to detect updates. */
+    /** Content hash published by the registry - compared against the installed registry metadata file to detect updates. */
     contentHash: string;
 }
 
@@ -80,8 +80,8 @@ export interface ResolvedSkillEntry {
  * Information about a skill folder found under `~/.agents/skills`.
  *
  * `skillId` and `contentHash` are present only when the folder carries our
- * `.registry.json` sidecar (i.e. it is registry-managed). `drifted` is true when the
- * on-disk content hash no longer matches the sidecar's recorded hash.
+ * `.registry.json` registry metadata file (i.e. it is registry-managed). `drifted` is
+ * true when the on-disk content hash no longer matches the recorded hash.
  */
 export interface InstalledSkillInfo {
     name: string;
@@ -97,8 +97,8 @@ export interface InstalledSkillInfo {
  *
  * - `not-installed` is only produced by `classifyRegistryEntry`.
  * - `installed-user-added` is only produced by `classifyInstalledSkill`.
- * - `installed-link-stale` surfaces a sidecar pointing at a skillId the registry no
- *   longer lists.
+ * - `installed-link-stale` surfaces a registry metadata file pointing at a skillId the
+ *   registry no longer lists.
  * - `installed-from-registry`, `installed-manually`, and `fix-skill` are common.
  */
 export type SkillClassificationResult =

--- a/packages/ai-registry/src/common/skill/skill-registry-types.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-types.ts
@@ -1,0 +1,110 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/**
+ * The git source of a skill. The registry only points to the skill's content - it does
+ * not host it. Installing downloads `path` (or the repository root when omitted) from
+ * `url` into `~/.agents/skills/<name>`.
+ */
+export interface RegistrySkillSource {
+    url: string;
+    path?: string;
+}
+
+/**
+ * A single install config inside a skill approval. Pre-filtered per-tool by the registry
+ * for the per-tool view (`<baseUrl>/<toolName>.json`).
+ */
+export interface RegistrySkillInstallConfig {
+    tool?: string;
+    installUrl?: string;
+}
+
+/**
+ * One organization's approval of a skill entry, with the install configs for the tools
+ * that organization approved.
+ */
+export interface RegistrySkillApproval {
+    organizationId: string;
+    date: string;
+    configHash?: string;
+    installConfigs: RegistrySkillInstallConfig[];
+}
+
+/**
+ * Top-level skill entry as returned by the registry's per-tool JSON endpoint. The
+ * registry points to the skill (a git repo) and carries the `contentHash` of the
+ * referenced content; it does not host the content itself.
+ */
+export interface RegistrySkill {
+    skillId: string;
+    name: string;
+    description: string;
+    source: RegistrySkillSource;
+    contentHash: string;
+    approvals: RegistrySkillApproval[];
+}
+
+/**
+ * A registry skill entry after resolving its (potentially multiple) approvals down to the
+ * single shape the install service operates on.
+ *
+ * Resolution lives in the fetch layer; the install service expects this normalised shape.
+ */
+export interface ResolvedSkillEntry {
+    skillId: string;
+    name: string;
+    description: string;
+    /** Git repository URL the skill content is downloaded from. */
+    sourceUrl: string;
+    /** Path within the repository pointing at the skill root. Omitted means the repository root. */
+    sourcePath?: string;
+    /** Content hash published by the registry - compared against the installed sidecar to detect updates. */
+    contentHash: string;
+}
+
+/**
+ * Information about a skill folder found under `~/.agents/skills`.
+ *
+ * `skillId` and `contentHash` are present only when the folder carries our
+ * `.registry.json` sidecar (i.e. it is registry-managed). `drifted` is true when the
+ * on-disk content hash no longer matches the sidecar's recorded hash.
+ */
+export interface InstalledSkillInfo {
+    name: string;
+    skillId?: string;
+    contentHash?: string;
+    drifted: boolean;
+}
+
+/**
+ * Outcome of classifying a skill against the opposite side (registry -> local folders
+ * for search, or local folders -> registry for the Installed view). Mirrors the MCP
+ * {@link ClassificationResult} union:
+ *
+ * - `not-installed` is only produced by `classifyRegistryEntry`.
+ * - `installed-user-added` is only produced by `classifyInstalledSkill`.
+ * - `installed-link-stale` surfaces a sidecar pointing at a skillId the registry no
+ *   longer lists.
+ * - `installed-from-registry`, `installed-manually`, and `fix-skill` are common.
+ */
+export type SkillClassificationResult =
+    | { kind: 'installed-from-registry'; updateAvailable: boolean }
+    | { kind: 'installed-manually' }
+    | { kind: 'fix-skill' }
+    | { kind: 'not-installed' }
+    | { kind: 'installed-link-stale' }
+    | { kind: 'installed-user-added' };

--- a/packages/ai-registry/src/common/skill/skill-registry-types.ts
+++ b/packages/ai-registry/src/common/skill/skill-registry-types.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/node/ai-registry-backend-module.ts
+++ b/packages/ai-registry/src/node/ai-registry-backend-module.ts
@@ -1,0 +1,35 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ContainerModule } from '@theia/core/shared/inversify';
+import { ConnectionHandler, PreferenceContribution, RpcConnectionHandler } from '@theia/core';
+import { SkillInstallBackendService, SkillInstallBackendServicePath, SkillInstallClient } from '../common/skill/skill-install-protocol';
+import { SkillRegistryPreferencesSchema } from '../common/skill/skill-registry-preferences';
+import { SkillInstallBackendServiceImpl } from './skill-install-backend-service';
+
+export default new ContainerModule(bind => {
+    bind(PreferenceContribution).toConstantValue({ schema: SkillRegistryPreferencesSchema });
+    bind(SkillInstallBackendServiceImpl).toSelf().inSingletonScope();
+    bind(SkillInstallBackendService).toService(SkillInstallBackendServiceImpl);
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler<SkillInstallClient>(SkillInstallBackendServicePath, client => {
+            const server = ctx.container.get<SkillInstallBackendServiceImpl>(SkillInstallBackendService);
+            server.setClient(client);
+            client.onDidCloseConnection(() => server.disconnectClient(client));
+            return server;
+        })
+    ).inSingletonScope();
+});

--- a/packages/ai-registry/src/node/ai-registry-backend-module.ts
+++ b/packages/ai-registry/src/node/ai-registry-backend-module.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
@@ -1,0 +1,326 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { PreferenceService } from '@theia/core';
+import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
+import { ResolvedSkillEntry } from '../common/skill/skill-registry-types';
+import { computeSkillContentHash } from '../common/skill/skill-content-hash';
+import { SkillInstallBackendServiceImpl } from './skill-install-backend-service';
+
+const SIDECAR_FILE = '.registry.json';
+
+const SKILL_MD = '---\nname: example-skill\n---\n# Example';
+const HELPER_MD = 'helper content';
+
+// The registry hash equals the hash our backend computes for the faithfully-downloaded
+// content: reproducing the registry algorithm is exactly what lets a single stored hash
+// drive both update detection (registry hash changed) and drift detection (on-disk changed).
+function encode(text: string): Uint8Array {
+    return new TextEncoder().encode(text);
+}
+const REGISTRY_HASH = computeSkillContentHash([
+    { relativePath: 'SKILL.md', content: encode(SKILL_MD) },
+    { relativePath: 'helper.md', content: encode(HELPER_MD) }
+]);
+
+const entry: ResolvedSkillEntry = {
+    skillId: 'io.github.example/example-skill',
+    name: 'example-skill',
+    description: 'An example skill',
+    sourceUrl: 'https://github.com/example/skills',
+    sourcePath: 'skills/example',
+    contentHash: REGISTRY_HASH
+};
+
+const API_URL = 'https://api.github.com/repos/example/skills/contents/skills/example';
+
+class FakeRequestService implements RequestService {
+    constructor(private readonly responses: Record<string, string>) { }
+    async configure(): Promise<void> { /* no-op */ }
+    async resolveProxy(): Promise<string | undefined> { return undefined; }
+    async request(options: RequestOptions): Promise<RequestContext> {
+        const body = this.responses[options.url];
+        if (body === undefined) {
+            return { url: options.url, res: { headers: {}, statusCode: 404 }, buffer: new Uint8Array() };
+        }
+        return { url: options.url, res: { headers: {}, statusCode: 200 }, buffer: new TextEncoder().encode(body) };
+    }
+}
+
+const fakePreferenceService = { get: () => undefined } as unknown as PreferenceService;
+
+class TestSkillInstallBackendService extends SkillInstallBackendServiceImpl {
+    constructor(private readonly root: string, request: RequestService) {
+        super();
+        Object.assign(this, { requestService: request, preferenceService: fakePreferenceService });
+    }
+    protected override skillsRoot(): string {
+        return this.root;
+    }
+    /** Exposes the in-memory drift-hash cache size so eviction can be asserted. */
+    cacheSize(): number {
+        return this.hashCache.size;
+    }
+    /** Simulates an irrecoverable watcher error path so client notification can be asserted. */
+    triggerWatcherStopped(): void {
+        this.notifyWatcherStopped();
+    }
+}
+
+/** Builds a fake GitHub Contents API + raw responses for a skill with the given SKILL.md content. */
+function githubResponses(skillMd: string): Record<string, string> {
+    return {
+        [API_URL]: JSON.stringify([
+            { type: 'file', name: 'SKILL.md', path: 'skills/example/SKILL.md', download_url: 'https://raw.example/SKILL.md' },
+            { type: 'file', name: 'helper.md', path: 'skills/example/helper.md', download_url: 'https://raw.example/helper.md' }
+        ]),
+        'https://raw.example/SKILL.md': skillMd,
+        'https://raw.example/helper.md': HELPER_MD
+    };
+}
+
+async function exists(target: string): Promise<boolean> {
+    try {
+        await fs.stat(target);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+describe('SkillInstallBackendService', () => {
+
+    let root: string;
+
+    const created: TestSkillInstallBackendService[] = [];
+
+    beforeEach(async () => {
+        root = await fs.mkdtemp(path.join(os.tmpdir(), 'skill-install-test-'));
+        created.length = 0;
+    });
+
+    afterEach(async () => {
+        created.forEach(svc => svc.dispose());
+        await fs.rm(root, { recursive: true, force: true });
+    });
+
+    function service(responses: Record<string, string>): TestSkillInstallBackendService {
+        const svc = new TestSkillInstallBackendService(root, new FakeRequestService(responses));
+        created.push(svc);
+        return svc;
+    }
+
+    it('installs a skill into <root>/<name>, writing the downloaded files and a sidecar', async () => {
+        await service(githubResponses(SKILL_MD)).install(entry);
+
+        const dir = path.join(root, 'example-skill');
+        expect(await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8')).to.equal(SKILL_MD);
+        expect(await fs.readFile(path.join(dir, 'helper.md'), 'utf8')).to.equal('helper content');
+        const sidecar = JSON.parse(await fs.readFile(path.join(dir, SIDECAR_FILE), 'utf8'));
+        expect(sidecar.skillId).to.equal(entry.skillId);
+        // The registry hash is stored verbatim - the single baseline for update and drift.
+        expect(sidecar.contentHash).to.equal(entry.contentHash);
+    });
+
+    it('reports no drift after a faithful install and drift once local files diverge', async () => {
+        const svc = service(githubResponses(SKILL_MD));
+        await svc.install(entry);
+
+        let installed = await svc.listInstalledSkills();
+        expect(installed[0].contentHash).to.equal(entry.contentHash);
+        expect(installed[0].drifted).to.equal(false);
+
+        await fs.writeFile(path.join(root, 'example-skill', 'helper.md'), 'edited locally to a clearly different length');
+        installed = await svc.listInstalledSkills();
+        expect(installed[0].drifted).to.equal(true);
+        expect(installed[0].contentHash).to.equal(entry.contentHash);
+    });
+
+    it('notifies a registered client when the skills folder changes on disk', async function (): Promise<void> {
+        this.timeout(8000);
+        const svc = service(githubResponses(SKILL_MD));
+        let notifications = 0;
+        svc.setClient({ notifyDidChangeInstalledSkills: () => { notifications += 1; }, notifyWatcherStopped: () => { } });
+        // Allow the (async) recursive watcher to start before triggering a change.
+        await new Promise(resolve => setTimeout(resolve, 700));
+        await fs.mkdir(path.join(root, 'externally-added'), { recursive: true });
+        // Wait past the debounce window for the notification to land.
+        await new Promise(resolve => setTimeout(resolve, 1000));
+        expect(notifications).to.be.greaterThan(0);
+    });
+
+    it('refuses to install a skill whose name would escape the skills root', async () => {
+        let caught: Error | undefined;
+        try {
+            await service(githubResponses(SKILL_MD)).install({ ...entry, name: '../escaped' });
+        } catch (error) {
+            caught = error as Error;
+        }
+        expect(caught?.message).to.match(/invalid skill name/i);
+        // Nothing must be written outside the skills root.
+        expect(await exists(path.join(root, '..', 'escaped'))).to.equal(false);
+    });
+
+    it('refuses an uninstall whose name contains a path separator', async () => {
+        let caught: Error | undefined;
+        try {
+            await service(githubResponses(SKILL_MD)).uninstall('nested/skill');
+        } catch (error) {
+            caught = error as Error;
+        }
+        expect(caught?.message).to.match(/invalid skill name/i);
+    });
+
+    it('refuses to install over an existing folder of the same name', async () => {
+        await fs.mkdir(path.join(root, 'example-skill'), { recursive: true });
+
+        let caught: Error | undefined;
+        try {
+            await service(githubResponses(SKILL_MD)).install(entry);
+        } catch (error) {
+            caught = error as Error;
+        }
+        expect(caught?.message).to.match(/already exists/i);
+    });
+
+    it('aborts when the downloaded SKILL.md frontmatter name disagrees with the registry entry name', async () => {
+        let caught: Error | undefined;
+        try {
+            await service(githubResponses('---\nname: wrong-name\n---\n# Example')).install(entry);
+        } catch (error) {
+            caught = error as Error;
+        }
+        expect(caught?.message).to.match(/name mismatch/i);
+        // The folder must not be left behind on a failed install.
+        expect(await exists(path.join(root, 'example-skill'))).to.equal(false);
+    });
+
+    it('aborts when SKILL.md is missing from the downloaded content', async () => {
+        const responses: Record<string, string> = {
+            [API_URL]: JSON.stringify([
+                { type: 'file', name: 'helper.md', path: 'skills/example/helper.md', download_url: 'https://raw.example/helper.md' }
+            ]),
+            'https://raw.example/helper.md': 'helper content'
+        };
+
+        let caught: Error | undefined;
+        try {
+            await service(responses).install(entry);
+        } catch (error) {
+            caught = error as Error;
+        }
+        expect(caught?.message).to.match(/no SKILL\.md/i);
+    });
+
+    it('links an existing local folder by stamping a sidecar without overwriting files', async () => {
+        const dir = path.join(root, 'example-skill');
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(path.join(dir, 'SKILL.md'), '---\nname: example-skill\n---\nlocal');
+
+        await service(githubResponses(SKILL_MD)).link(entry);
+
+        expect(await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8')).to.equal('---\nname: example-skill\n---\nlocal');
+        const sidecar = JSON.parse(await fs.readFile(path.join(dir, SIDECAR_FILE), 'utf8'));
+        expect(sidecar.skillId).to.equal(entry.skillId);
+    });
+
+    it('fixSkill clean-replaces drifted files and clears the drift', async () => {
+        const svc = service(githubResponses(SKILL_MD));
+        await svc.install(entry);
+        const dir = path.join(root, 'example-skill');
+        await fs.writeFile(path.join(dir, 'helper.md'), 'locally drifted');
+
+        let installed = await svc.listInstalledSkills();
+        expect(installed[0].drifted).to.equal(true);
+
+        await svc.fixSkill(entry);
+
+        expect(await fs.readFile(path.join(dir, 'helper.md'), 'utf8')).to.equal('helper content');
+        installed = await svc.listInstalledSkills();
+        expect(installed[0].drifted).to.equal(false);
+    });
+
+    it('uninstall removes a folder that carries our sidecar', async () => {
+        const svc = service(githubResponses(SKILL_MD));
+        await svc.install(entry);
+
+        await svc.uninstall('example-skill');
+
+        expect(await exists(path.join(root, 'example-skill'))).to.equal(false);
+    });
+
+    it('uninstall leaves a folder without our sidecar untouched', async () => {
+        const dir = path.join(root, 'manual-skill');
+        await fs.mkdir(dir, { recursive: true });
+        await fs.writeFile(path.join(dir, 'SKILL.md'), 'manual');
+
+        await service(githubResponses(SKILL_MD)).uninstall('manual-skill');
+
+        expect(await exists(dir)).to.equal(true);
+    });
+
+    it('unlink removes the sidecar while keeping the files', async () => {
+        const svc = service(githubResponses(SKILL_MD));
+        await svc.install(entry);
+        const dir = path.join(root, 'example-skill');
+
+        await svc.unlink('example-skill');
+
+        expect(await exists(path.join(dir, SIDECAR_FILE))).to.equal(false);
+        expect(await exists(path.join(dir, 'SKILL.md'))).to.equal(true);
+    });
+
+    it('evicts cached drift hashes for skills that no longer exist', async () => {
+        const svc = service(githubResponses(SKILL_MD));
+        await svc.install(entry);
+        await svc.listInstalledSkills();
+        expect(svc.cacheSize()).to.equal(1);
+
+        await svc.uninstall('example-skill');
+        await svc.listInstalledSkills();
+        expect(svc.cacheSize()).to.equal(0);
+    });
+
+    it('notifies registered clients when the watcher stops', async () => {
+        const svc = service(githubResponses(SKILL_MD));
+        let stopped = 0;
+        svc.setClient({ notifyDidChangeInstalledSkills: () => { }, notifyWatcherStopped: () => { stopped += 1; } });
+
+        svc.triggerWatcherStopped();
+
+        expect(stopped).to.equal(1);
+    });
+
+    it('lists installed skills, distinguishing registry-managed folders from hand-placed ones', async () => {
+        const svc = service(githubResponses(SKILL_MD));
+        await svc.install(entry);
+        await fs.mkdir(path.join(root, 'manual-skill'), { recursive: true });
+        await fs.writeFile(path.join(root, 'manual-skill', 'SKILL.md'), 'manual');
+
+        const installed = await svc.listInstalledSkills();
+        const managed = installed.find(i => i.name === 'example-skill');
+        const manual = installed.find(i => i.name === 'manual-skill');
+
+        expect(managed?.skillId).to.equal(entry.skillId);
+        expect(managed?.drifted).to.equal(false);
+        expect(manual?.skillId).to.equal(undefined);
+        expect(manual?.drifted).to.equal(false);
+    });
+});

--- a/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
@@ -18,13 +18,13 @@ import { expect } from 'chai';
 import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
-import { PreferenceService } from '@theia/core';
+import { ILogger, PreferenceService } from '@theia/core';
 import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
 import { ResolvedSkillEntry } from '../common/skill/skill-registry-types';
 import { computeSkillContentHash } from '../common/skill/skill-content-hash';
 import { SkillInstallBackendServiceImpl } from './skill-install-backend-service';
 
-const SIDECAR_FILE = '.registry.json';
+const REGISTRY_METADATA_FILE = '.registry.json';
 
 const SKILL_MD = '---\nname: example-skill\n---\n# Example';
 const HELPER_MD = 'helper content';
@@ -65,11 +65,18 @@ class FakeRequestService implements RequestService {
 }
 
 const fakePreferenceService = { get: () => undefined } as unknown as PreferenceService;
+const silentLogger = {
+    warn: () => Promise.resolve(),
+    error: () => Promise.resolve(),
+    info: () => Promise.resolve(),
+    debug: () => Promise.resolve(),
+    trace: () => Promise.resolve()
+} as unknown as ILogger;
 
 class TestSkillInstallBackendService extends SkillInstallBackendServiceImpl {
     constructor(private readonly root: string, request: RequestService) {
         super();
-        Object.assign(this, { requestService: request, preferenceService: fakePreferenceService });
+        Object.assign(this, { requestService: request, preferenceService: fakePreferenceService, logger: silentLogger });
     }
     protected override skillsRoot(): string {
         return this.root;
@@ -81,6 +88,10 @@ class TestSkillInstallBackendService extends SkillInstallBackendServiceImpl {
     /** Simulates an irrecoverable watcher error path so client notification can be asserted. */
     triggerWatcherStopped(): void {
         this.notifyWatcherStopped();
+    }
+    /** Exposes the startup staging-folder sweep so it can be asserted without going through @postConstruct. */
+    sweepStaging(): Promise<void> {
+        return this.sweepStagingFolders();
     }
 }
 
@@ -127,16 +138,16 @@ describe('SkillInstallBackendService', () => {
         return svc;
     }
 
-    it('installs a skill into <root>/<name>, writing the downloaded files and a sidecar', async () => {
+    it('installs a skill into <root>/<name>, writing the downloaded files and a registry metadata file', async () => {
         await service(githubResponses(SKILL_MD)).install(entry);
 
         const dir = path.join(root, 'example-skill');
         expect(await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8')).to.equal(SKILL_MD);
         expect(await fs.readFile(path.join(dir, 'helper.md'), 'utf8')).to.equal('helper content');
-        const sidecar = JSON.parse(await fs.readFile(path.join(dir, SIDECAR_FILE), 'utf8'));
-        expect(sidecar.skillId).to.equal(entry.skillId);
+        const metadata = JSON.parse(await fs.readFile(path.join(dir, REGISTRY_METADATA_FILE), 'utf8'));
+        expect(metadata.skillId).to.equal(entry.skillId);
         // The registry hash is stored verbatim - the single baseline for update and drift.
-        expect(sidecar.contentHash).to.equal(entry.contentHash);
+        expect(metadata.contentHash).to.equal(entry.contentHash);
     });
 
     it('reports no drift after a faithful install and drift once local files diverge', async () => {
@@ -210,6 +221,56 @@ describe('SkillInstallBackendService', () => {
         expect(caught?.message).to.match(/name mismatch/i);
         // The folder must not be left behind on a failed install.
         expect(await exists(path.join(root, 'example-skill'))).to.equal(false);
+        // The finally block in writeSkill must also clean up the sibling staging folder.
+        const leftovers = (await fs.readdir(root)).filter(name => name.startsWith('.installing-'));
+        expect(leftovers).to.deep.equal([]);
+    });
+
+    it('refuses to clobber an existing folder of the same name when install() races with another install', async () => {
+        // Simulate the race the existence check cannot catch: the target folder is created
+        // after install() passes its exists(target) === false check but before the rename.
+        // The rename onto a non-empty directory must fail rather than silently overwrite.
+        const svc = service(githubResponses(SKILL_MD));
+        const target = path.join(root, 'example-skill');
+        // Wedge a non-empty folder into place after the existence check would have run.
+        const originalExists = (svc as unknown as { exists: (target: string) => Promise<boolean> }).exists.bind(svc);
+        let firstCall = true;
+        (svc as unknown as { exists: (target: string) => Promise<boolean> }).exists = async (path_: string) => {
+            if (firstCall && path_ === target) {
+                firstCall = false;
+                return false;
+            }
+            return originalExists(path_);
+        };
+        await fs.mkdir(target, { recursive: true });
+        await fs.writeFile(path.join(target, 'pre-existing.txt'), 'do not clobber');
+
+        let caught: Error | undefined;
+        try {
+            await svc.install(entry);
+        } catch (error) {
+            caught = error as Error;
+        }
+        expect(caught).to.not.equal(undefined);
+        // The pre-existing folder content must be preserved untouched.
+        expect(await fs.readFile(path.join(target, 'pre-existing.txt'), 'utf8')).to.equal('do not clobber');
+        // The staging folder must also be cleaned up by the finally block.
+        const leftovers = (await fs.readdir(root)).filter(name => name.startsWith('.installing-'));
+        expect(leftovers).to.deep.equal([]);
+    });
+
+    it('sweepStagingFolders removes any leftover .installing-* folders from previous backend crashes', async () => {
+        await fs.mkdir(path.join(root, '.installing-example-skill-123'), { recursive: true });
+        await fs.writeFile(path.join(root, '.installing-example-skill-123', 'partial.txt'), 'leftover');
+        await fs.mkdir(path.join(root, '.installing-another-456'), { recursive: true });
+        // A non-staging dot-folder must be preserved.
+        await fs.mkdir(path.join(root, '.other'), { recursive: true });
+
+        await service(githubResponses(SKILL_MD)).sweepStaging();
+
+        expect(await exists(path.join(root, '.installing-example-skill-123'))).to.equal(false);
+        expect(await exists(path.join(root, '.installing-another-456'))).to.equal(false);
+        expect(await exists(path.join(root, '.other'))).to.equal(true);
     });
 
     it('aborts when SKILL.md is missing from the downloaded content', async () => {
@@ -229,7 +290,7 @@ describe('SkillInstallBackendService', () => {
         expect(caught?.message).to.match(/no SKILL\.md/i);
     });
 
-    it('links an existing local folder by stamping a sidecar without overwriting files', async () => {
+    it('links an existing local folder by writing the registry metadata file without overwriting other files', async () => {
         const dir = path.join(root, 'example-skill');
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(path.join(dir, 'SKILL.md'), '---\nname: example-skill\n---\nlocal');
@@ -237,8 +298,8 @@ describe('SkillInstallBackendService', () => {
         await service(githubResponses(SKILL_MD)).link(entry);
 
         expect(await fs.readFile(path.join(dir, 'SKILL.md'), 'utf8')).to.equal('---\nname: example-skill\n---\nlocal');
-        const sidecar = JSON.parse(await fs.readFile(path.join(dir, SIDECAR_FILE), 'utf8'));
-        expect(sidecar.skillId).to.equal(entry.skillId);
+        const metadata = JSON.parse(await fs.readFile(path.join(dir, REGISTRY_METADATA_FILE), 'utf8'));
+        expect(metadata.skillId).to.equal(entry.skillId);
     });
 
     it('fixSkill clean-replaces drifted files and clears the drift', async () => {
@@ -257,7 +318,7 @@ describe('SkillInstallBackendService', () => {
         expect(installed[0].drifted).to.equal(false);
     });
 
-    it('uninstall removes a folder that carries our sidecar', async () => {
+    it('uninstall removes a folder that carries our registry metadata file', async () => {
         const svc = service(githubResponses(SKILL_MD));
         await svc.install(entry);
 
@@ -266,7 +327,7 @@ describe('SkillInstallBackendService', () => {
         expect(await exists(path.join(root, 'example-skill'))).to.equal(false);
     });
 
-    it('uninstall leaves a folder without our sidecar untouched', async () => {
+    it('uninstall leaves a folder without our registry metadata file untouched', async () => {
         const dir = path.join(root, 'manual-skill');
         await fs.mkdir(dir, { recursive: true });
         await fs.writeFile(path.join(dir, 'SKILL.md'), 'manual');
@@ -276,14 +337,14 @@ describe('SkillInstallBackendService', () => {
         expect(await exists(dir)).to.equal(true);
     });
 
-    it('unlink removes the sidecar while keeping the files', async () => {
+    it('unlink removes the registry metadata file while keeping the other files', async () => {
         const svc = service(githubResponses(SKILL_MD));
         await svc.install(entry);
         const dir = path.join(root, 'example-skill');
 
         await svc.unlink('example-skill');
 
-        expect(await exists(path.join(dir, SIDECAR_FILE))).to.equal(false);
+        expect(await exists(path.join(dir, REGISTRY_METADATA_FILE))).to.equal(false);
         expect(await exists(path.join(dir, 'SKILL.md'))).to.equal(true);
     });
 

--- a/packages/ai-registry/src/node/skill-install-backend-service.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/node/skill-install-backend-service.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.ts
@@ -1,0 +1,512 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { AsyncSubscription, subscribe } from '@theia/core/shared/@parcel/watcher';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { Disposable, PreferenceService } from '@theia/core';
+import { Headers, RequestContext, RequestService } from '@theia/core/shared/@theia/request';
+import { SkillInstallBackendService, SkillInstallClient } from '../common/skill/skill-install-protocol';
+import { InstalledSkillInfo, ResolvedSkillEntry } from '../common/skill/skill-registry-types';
+import { computeSkillContentHash, SkillFileContent } from '../common/skill/skill-content-hash';
+import { GITHUB_TOKEN_PREF } from '../common/skill/skill-registry-preferences';
+
+/** File name of the per-skill provenance sidecar. Dot-prefixed so it is excluded from the content hash. */
+const SIDECAR_FILE = '.registry.json';
+/** Skill manifest that must exist at the root of every skill. */
+const SKILL_MANIFEST = 'SKILL.md';
+const USER_AGENT = 'Theia-AI-Registry';
+/** Quiet period (ms) collapsing a burst of filesystem events into a single change notification. */
+const WATCH_DEBOUNCE_MS = 300;
+
+interface SkillSidecar {
+    skillId: string;
+    /**
+     * Registry content hash recorded at install/link time. It is the baseline for both
+     * update detection (registry's current hash differs) and drift detection (the on-disk
+     * content hash differs), which works because {@link computeSkillContentHash} reproduces
+     * the registry's hash byte-for-byte.
+     */
+    contentHash: string;
+    installedAt: string;
+}
+
+interface GitHubContentItem {
+    type: string;
+    name: string;
+    path: string;
+    download_url?: string;
+}
+
+/** A hash-relevant file discovered while traversing a skill folder, with the stats that form its drift signature. */
+interface SkillStatEntry {
+    relativePath: string;
+    full: string;
+    size: number;
+    mtimeMs: number;
+}
+
+@injectable()
+export class SkillInstallBackendServiceImpl implements SkillInstallBackendService, Disposable {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(RequestService)
+    protected readonly requestService: RequestService;
+
+    protected readonly clients = new Set<SkillInstallClient>();
+    protected subscription: AsyncSubscription | undefined;
+    protected watching = false;
+    protected notifyTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    /** Caches each skill folder's content hash keyed on a cheap stat signature, so drift detection avoids re-reading unchanged files. */
+    protected readonly hashCache = new Map<string, { signature: string; contentHash: string }>();
+
+    /** Registers a frontend client and starts watching `~/.agents/skills` for external changes. */
+    setClient(client: SkillInstallClient | undefined): void {
+        if (!client) {
+            return;
+        }
+        this.clients.add(client);
+        this.ensureWatching();
+    }
+
+    /** Removes a disconnected client and stops the watcher once no clients remain. */
+    disconnectClient(client: SkillInstallClient): void {
+        this.clients.delete(client);
+        if (this.clients.size === 0) {
+            this.stopWatching();
+        }
+    }
+
+    dispose(): void {
+        this.clients.clear();
+        this.stopWatching();
+    }
+
+    async install(entry: ResolvedSkillEntry): Promise<void> {
+        const target = this.skillDir(entry.name);
+        if (await this.exists(target)) {
+            throw new Error(`A skill folder named "${entry.name}" already exists. Use Update or Fix Skill instead.`);
+        }
+        const files = await this.download(entry);
+        this.validateSkill(entry, files);
+        await this.writeSkill(entry, files);
+    }
+
+    async update(entry: ResolvedSkillEntry): Promise<void> {
+        await this.cleanReplace(entry);
+    }
+
+    async fixSkill(entry: ResolvedSkillEntry): Promise<void> {
+        await this.cleanReplace(entry);
+    }
+
+    async link(entry: ResolvedSkillEntry): Promise<void> {
+        const target = this.skillDir(entry.name);
+        if (!await this.exists(target)) {
+            throw new Error(`No local skill folder named "${entry.name}" to link.`);
+        }
+        await this.writeSidecar(target, entry.skillId, entry.contentHash);
+    }
+
+    async unlink(name: string): Promise<void> {
+        const sidecar = path.join(this.skillDir(name), SIDECAR_FILE);
+        if (await this.exists(sidecar)) {
+            await fs.rm(sidecar, { force: true });
+        }
+    }
+
+    async uninstall(name: string): Promise<void> {
+        const target = this.skillDir(name);
+        // Only delete folders we manage - a folder without our sidecar may be a
+        // hand-placed skill the user does not want us to remove.
+        if (!await this.exists(path.join(target, SIDECAR_FILE))) {
+            return;
+        }
+        await fs.rm(target, { recursive: true, force: true });
+    }
+
+    async listInstalledSkills(): Promise<InstalledSkillInfo[]> {
+        const root = this.skillsRoot();
+        if (!await this.exists(root)) {
+            this.hashCache.clear();
+            return [];
+        }
+        const dirents = await fs.readdir(root, { withFileTypes: true });
+        const result: InstalledSkillInfo[] = [];
+        const presentDirs = new Set<string>();
+        for (const dirent of dirents) {
+            if (!dirent.isDirectory() || dirent.name.startsWith('.')) {
+                continue;
+            }
+            const dir = path.join(root, dirent.name);
+            presentDirs.add(dir);
+            const sidecar = await this.readSidecar(dir);
+            if (sidecar) {
+                const onDisk = await this.computeDriftHash(dir);
+                result.push({
+                    name: dirent.name,
+                    skillId: sidecar.skillId,
+                    contentHash: sidecar.contentHash,
+                    // Drift = on-disk content differs from the registry hash we recorded;
+                    // update detection (registry hash changed) is decided by the classifier.
+                    drifted: onDisk !== sidecar.contentHash
+                });
+            } else {
+                result.push({ name: dirent.name, drifted: false });
+            }
+        }
+        // Drop cached drift hashes for folders that no longer exist so the cache cannot grow
+        // unbounded across many install/uninstall cycles.
+        for (const cachedDir of this.hashCache.keys()) {
+            if (!presentDirs.has(cachedDir)) {
+                this.hashCache.delete(cachedDir);
+            }
+        }
+        return result;
+    }
+
+    /** Delete the existing folder (if any) and re-download fresh registry content. */
+    protected async cleanReplace(entry: ResolvedSkillEntry): Promise<void> {
+        const target = this.skillDir(entry.name);
+        // Only clean-replace folders we manage; refuse to clobber a hand-placed folder that
+        // exists but carries no sidecar (it must be adopted via Link first).
+        if (await this.exists(target) && !await this.exists(path.join(target, SIDECAR_FILE))) {
+            throw new Error(`The skill folder "${entry.name}" is not managed by the registry. Link it first, then Update.`);
+        }
+        const files = await this.download(entry);
+        this.validateSkill(entry, files);
+        await this.writeSkill(entry, files);
+    }
+
+    /**
+     * Writes a freshly-downloaded skill plus its sidecar into a sibling temp folder and
+     * then atomically swaps it into place, so an interrupted download never leaves a
+     * partially-written skill folder behind.
+     */
+    protected async writeSkill(entry: ResolvedSkillEntry, files: SkillFileContent[]): Promise<void> {
+        const root = this.skillsRoot();
+        await fs.mkdir(root, { recursive: true });
+        const target = this.skillDir(entry.name);
+        const staging = path.join(root, `.installing-${entry.name}-${Date.now()}`);
+        try {
+            for (const file of files) {
+                const segments = file.relativePath.split('/');
+                if (segments.some(segment => segment === '' || segment === '.' || segment === '..' || segment.includes('\\'))) {
+                    throw new Error(`Refusing to write skill file with an unsafe path: "${file.relativePath}".`);
+                }
+                const dest = path.join(staging, ...segments);
+                await fs.mkdir(path.dirname(dest), { recursive: true });
+                await fs.writeFile(dest, Buffer.from(file.content));
+            }
+            await this.writeSidecarFile(path.join(staging, SIDECAR_FILE), entry.skillId, entry.contentHash);
+            await fs.rm(target, { recursive: true, force: true });
+            await fs.rename(staging, target);
+        } catch (error) {
+            await fs.rm(staging, { recursive: true, force: true });
+            throw error;
+        }
+    }
+
+    protected validateSkill(entry: ResolvedSkillEntry, files: SkillFileContent[]): void {
+        const manifest = files.find(file => file.relativePath === SKILL_MANIFEST);
+        if (!manifest) {
+            throw new Error(`Skill "${entry.name}" has no ${SKILL_MANIFEST} at ${entry.sourcePath ?? 'the repository root'}.`);
+        }
+        const declaredName = this.extractFrontmatterName(new TextDecoder().decode(manifest.content));
+        if (declaredName !== undefined && declaredName !== entry.name) {
+            throw new Error(`Skill name mismatch: registry entry is "${entry.name}" but ${SKILL_MANIFEST} declares "${declaredName}".`);
+        }
+    }
+
+    /** Extracts the `name` field from a leading YAML frontmatter block, if present. */
+    protected extractFrontmatterName(content: string): string | undefined {
+        const match = /^---\s*\r?\n([\s\S]*?)\r?\n---/.exec(content);
+        if (!match) {
+            return undefined;
+        }
+        const line = match[1].split(/\r?\n/).find(entry => /^\s*name\s*:/.test(entry));
+        if (!line) {
+            return undefined;
+        }
+        return line.replace(/^\s*name\s*:/, '').trim().replace(/^['"]|['"]$/g, '');
+    }
+
+    protected async download(entry: ResolvedSkillEntry): Promise<SkillFileContent[]> {
+        const { owner, repo } = this.parseGitHub(entry.sourceUrl);
+        const token = this.resolveToken();
+        return this.downloadDir(owner, repo, entry.sourcePath ?? '', '', token);
+    }
+
+    protected async downloadDir(owner: string, repo: string, repoPath: string, relativeBase: string, token?: string): Promise<SkillFileContent[]> {
+        const suffix = this.encodePath(repoPath);
+        const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents${suffix ? '/' + suffix : ''}`;
+        const items = await this.githubJson(apiUrl, token);
+        if (!Array.isArray(items)) {
+            throw new Error(`Expected a directory at ${repoPath || 'the repository root'} of ${owner}/${repo}.`);
+        }
+        const files: SkillFileContent[] = [];
+        for (const item of items as GitHubContentItem[]) {
+            const rel = relativeBase ? `${relativeBase}/${item.name}` : item.name;
+            if (item.type === 'dir') {
+                files.push(...await this.downloadDir(owner, repo, item.path, rel, token));
+            } else if (item.type === 'file' && item.download_url) {
+                files.push({ relativePath: rel, content: await this.downloadRaw(item.download_url, token) });
+            }
+        }
+        return files;
+    }
+
+    protected parseGitHub(sourceUrl: string): { owner: string; repo: string } {
+        let url: URL;
+        try {
+            url = new URL(sourceUrl);
+        } catch {
+            throw new Error(`Invalid skill source URL: ${sourceUrl}`);
+        }
+        if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
+            throw new Error(`Only GitHub skill sources are supported; "${url.hostname}" is not GitHub.`);
+        }
+        const segments = url.pathname.split('/').filter(Boolean);
+        if (segments.length < 2) {
+            throw new Error(`Cannot determine owner/repo from skill source URL: ${sourceUrl}`);
+        }
+        return { owner: segments[0], repo: segments[1].replace(/\.git$/, '') };
+    }
+
+    protected encodePath(repoPath: string): string {
+        return repoPath.split('/').filter(Boolean).map(encodeURIComponent).join('/');
+    }
+
+    protected async githubJson(url: string, token?: string): Promise<unknown> {
+        const context = await this.requestService.request({
+            url,
+            headers: this.headers(token, 'application/vnd.github+json')
+        });
+        if (!RequestContext.isSuccess(context)) {
+            throw new Error(`GitHub API request failed (${url}): HTTP ${context.res.statusCode ?? 'unknown'}`);
+        }
+        return RequestContext.asJson(context);
+    }
+
+    protected async downloadRaw(url: string, token?: string): Promise<Uint8Array> {
+        const context = await this.requestService.request({ url, headers: this.headers(token) });
+        if (!RequestContext.isSuccess(context)) {
+            throw new Error(`Failed to download skill file (${url}): HTTP ${context.res.statusCode ?? 'unknown'}`);
+        }
+        return this.toBytes(context);
+    }
+
+    protected headers(token?: string, accept?: string): Headers {
+        const headers: Headers = { 'User-Agent': USER_AGENT };
+        if (accept) {
+            headers['Accept'] = accept;
+        }
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+        }
+        return headers;
+    }
+
+    protected toBytes(context: RequestContext): Uint8Array {
+        // The backend's NodeRequestService returns raw bytes; the string branch only
+        // applies to the compressed (base64) form used when a context crosses the RPC wire.
+        const buffer = context.buffer;
+        return typeof buffer === 'string' ? Buffer.from(buffer, 'base64') : buffer;
+    }
+
+    /** Preference value (trimmed) when set, otherwise `GITHUB_TOKEN` from the environment. */
+    protected resolveToken(): string | undefined {
+        const fromPreference = this.preferenceService.get<string>(GITHUB_TOKEN_PREF, undefined)?.trim();
+        const token = fromPreference || process.env.GITHUB_TOKEN?.trim();
+        return token || undefined;
+    }
+
+    /**
+     * Content hash of a skill folder, reusing the cached result while the folder's file
+     * stats (size + mtime of the hash-relevant files) are unchanged. Any install, update,
+     * fix, or external edit changes those stats and invalidates the cache automatically.
+     *
+     * A single recursive traversal collects the stats that form the cheap drift signature;
+     * the file contents are read (and hashed) only on a cache miss, so an unchanged folder
+     * is walked once and never re-read.
+     */
+    protected async computeDriftHash(dir: string): Promise<string> {
+        const stats = await this.readSkillStats(dir);
+        const signature = stats
+            .map(stat => `${stat.relativePath}:${stat.size}:${stat.mtimeMs}`)
+            .sort()
+            .join('|');
+        const cached = this.hashCache.get(dir);
+        if (cached && cached.signature === signature) {
+            return cached.contentHash;
+        }
+        const files: SkillFileContent[] = await Promise.all(stats.map(async stat =>
+            ({ relativePath: stat.relativePath, content: await fs.readFile(stat.full) })));
+        const contentHash = computeSkillContentHash(files);
+        this.hashCache.set(dir, { signature, contentHash });
+        return contentHash;
+    }
+
+    /**
+     * Single recursive traversal of the hash-relevant files under `dir`, capturing each
+     * file's POSIX relative path, absolute path, size and mtime. Dot-prefixed entries are
+     * skipped at every level, matching {@link computeSkillContentHash}.
+     */
+    protected async readSkillStats(dir: string, relativeBase: string = ''): Promise<SkillStatEntry[]> {
+        const dirents = await fs.readdir(dir, { withFileTypes: true });
+        const entries: SkillStatEntry[] = [];
+        for (const dirent of dirents) {
+            if (dirent.name.startsWith('.')) {
+                continue;
+            }
+            const rel = relativeBase ? `${relativeBase}/${dirent.name}` : dirent.name;
+            const full = path.join(dir, dirent.name);
+            if (dirent.isDirectory()) {
+                entries.push(...await this.readSkillStats(full, rel));
+            } else if (dirent.isFile()) {
+                const stat = await fs.stat(full);
+                entries.push({ relativePath: rel, full, size: stat.size, mtimeMs: stat.mtimeMs });
+            }
+        }
+        return entries;
+    }
+
+    protected async readSidecar(dir: string): Promise<SkillSidecar | undefined> {
+        const sidecarPath = path.join(dir, SIDECAR_FILE);
+        try {
+            const raw = await fs.readFile(sidecarPath, 'utf8');
+            const parsed = JSON.parse(raw) as Partial<SkillSidecar>;
+            if (typeof parsed.skillId === 'string' && typeof parsed.contentHash === 'string') {
+                return { skillId: parsed.skillId, contentHash: parsed.contentHash, installedAt: parsed.installedAt ?? '' };
+            }
+        } catch {
+            // Missing or malformed sidecar - treat as not registry-managed.
+        }
+        return undefined;
+    }
+
+    protected async writeSidecar(dir: string, skillId: string, contentHash: string): Promise<void> {
+        await this.writeSidecarFile(path.join(dir, SIDECAR_FILE), skillId, contentHash);
+    }
+
+    protected async writeSidecarFile(sidecarPath: string, skillId: string, contentHash: string): Promise<void> {
+        const sidecar: SkillSidecar = { skillId, contentHash, installedAt: new Date().toISOString() };
+        await fs.writeFile(sidecarPath, JSON.stringify(sidecar, undefined, 2));
+    }
+
+    /**
+     * Lazily starts a debounced recursive watch on `~/.agents/skills`, notifying clients on
+     * change. Uses `@parcel/watcher` (the same backend as Theia's filesystem watcher) so
+     * additions and removals - including bare directory deletions - are reported reliably
+     * across platforms.
+     */
+    protected ensureWatching(): void {
+        if (this.watching) {
+            return;
+        }
+        this.watching = true;
+        const root = this.skillsRoot();
+        fs.mkdir(root, { recursive: true })
+            .then(() => subscribe(root, (error, events) => {
+                if (error) {
+                    console.warn('Stopped watching the skills directory after a watcher error.', error);
+                    this.stopWatching();
+                    this.notifyWatcherStopped();
+                    return;
+                }
+                if (events.length > 0) {
+                    this.scheduleNotify();
+                }
+            }))
+            .then(subscription => {
+                // A disconnect (stopWatching) or a concurrent ensureWatching may have run
+                // while the subscription was pending; tear it down if we were superseded so
+                // we never leak an orphaned watcher.
+                if (!this.watching || this.subscription) {
+                    subscription.unsubscribe();
+                    return;
+                }
+                this.subscription = subscription;
+            })
+            .catch(error => {
+                this.watching = false;
+                console.warn('Could not watch the skills directory for changes.', error);
+            });
+    }
+
+    protected stopWatching(): void {
+        this.watching = false;
+        if (this.notifyTimeout) {
+            clearTimeout(this.notifyTimeout);
+            this.notifyTimeout = undefined;
+        }
+        this.subscription?.unsubscribe();
+        this.subscription = undefined;
+    }
+
+    protected scheduleNotify(): void {
+        if (this.notifyTimeout) {
+            clearTimeout(this.notifyTimeout);
+        }
+        this.notifyTimeout = setTimeout(() => {
+            this.notifyTimeout = undefined;
+            for (const client of this.clients) {
+                client.notifyDidChangeInstalledSkills();
+            }
+        }, WATCH_DEBOUNCE_MS);
+    }
+
+    /** Tells every connected client that the watcher stopped, so the UI can prompt a reload. */
+    protected notifyWatcherStopped(): void {
+        for (const client of this.clients) {
+            client.notifyWatcherStopped();
+        }
+    }
+
+    protected skillsRoot(): string {
+        return path.join(os.homedir(), '.agents', 'skills');
+    }
+
+    protected skillDir(name: string): string {
+        this.assertValidSkillName(name);
+        return path.join(this.skillsRoot(), name);
+    }
+
+    /**
+     * Rejects skill names that are not a single, safe path segment. The name originates from
+     * registry JSON, so guarding here prevents a `..` or separator from escaping the skills
+     * root when it is joined into a filesystem path.
+     */
+    protected assertValidSkillName(name: string): void {
+        if (!name || name === '.' || name === '..' || /[/\\]/.test(name) || path.isAbsolute(name)) {
+            throw new Error(`Invalid skill name "${name}": a skill name must be a single path segment without separators.`);
+        }
+    }
+
+    protected async exists(target: string): Promise<boolean> {
+        try {
+            await fs.stat(target);
+            return true;
+        } catch {
+            return false;
+        }
+    }
+}

--- a/packages/ai-registry/src/node/skill-install-backend-service.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.ts
@@ -18,23 +18,25 @@ import * as fs from 'fs/promises';
 import * as os from 'os';
 import * as path from 'path';
 import { AsyncSubscription, subscribe } from '@theia/core/shared/@parcel/watcher';
-import { inject, injectable } from '@theia/core/shared/inversify';
-import { Disposable, PreferenceService } from '@theia/core';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { Disposable, ILogger, PreferenceService } from '@theia/core';
 import { Headers, RequestContext, RequestService } from '@theia/core/shared/@theia/request';
 import { SkillInstallBackendService, SkillInstallClient } from '../common/skill/skill-install-protocol';
 import { InstalledSkillInfo, ResolvedSkillEntry } from '../common/skill/skill-registry-types';
 import { computeSkillContentHash, SkillFileContent } from '../common/skill/skill-content-hash';
 import { GITHUB_TOKEN_PREF } from '../common/skill/skill-registry-preferences';
 
-/** File name of the per-skill provenance sidecar. Dot-prefixed so it is excluded from the content hash. */
-const SIDECAR_FILE = '.registry.json';
+/** File name of the per-skill registry metadata. Dot-prefixed so it is excluded from the content hash. */
+const REGISTRY_METADATA_FILE = '.registry.json';
+/** Prefix of the sibling staging folders used by {@link writeSkill} during atomic installs. */
+const STAGING_PREFIX = '.installing-';
 /** Skill manifest that must exist at the root of every skill. */
 const SKILL_MANIFEST = 'SKILL.md';
 const USER_AGENT = 'Theia-AI-Registry';
 /** Quiet period (ms) collapsing a burst of filesystem events into a single change notification. */
 const WATCH_DEBOUNCE_MS = 300;
 
-interface SkillSidecar {
+interface SkillRegistryMetadata {
     skillId: string;
     /**
      * Registry content hash recorded at install/link time. It is the baseline for both
@@ -43,7 +45,7 @@ interface SkillSidecar {
      * the registry's hash byte-for-byte.
      */
     contentHash: string;
-    installedAt: string;
+    installedAt?: string;
 }
 
 interface GitHubContentItem {
@@ -70,6 +72,9 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
     @inject(RequestService)
     protected readonly requestService: RequestService;
 
+    @inject(ILogger) @named('ai-registry:SkillInstallBackendServiceImpl')
+    protected readonly logger: ILogger;
+
     protected readonly clients = new Set<SkillInstallClient>();
     protected subscription: AsyncSubscription | undefined;
     protected watching = false;
@@ -77,6 +82,16 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
 
     /** Caches each skill folder's content hash keyed on a cheap stat signature, so drift detection avoids re-reading unchanged files. */
     protected readonly hashCache = new Map<string, { signature: string; contentHash: string }>();
+
+    /**
+     * Runs once after construction to sweep any stale staging folders left behind by a
+     * backend crash mid-install (see {@link writeSkill}). Best-effort: failures are logged
+     * and swallowed so an unreachable skills root never blocks the service from starting.
+     */
+    @postConstruct()
+    protected init(): void {
+        this.sweepStagingFolders().catch(error => this.logger.warn('Could not sweep stale skill staging folders at startup.', error));
+    }
 
     /** Registers a frontend client and starts watching `~/.agents/skills` for external changes. */
     setClient(client: SkillInstallClient | undefined): void {
@@ -107,7 +122,9 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         }
         const files = await this.download(entry);
         this.validateSkill(entry, files);
-        await this.writeSkill(entry, files);
+        // Pass replaceExisting=false: install must not clobber a folder that appeared
+        // between the existence check above and the rename below (e.g. a concurrent install).
+        await this.writeSkill(entry, files, false);
     }
 
     async update(entry: ResolvedSkillEntry): Promise<void> {
@@ -123,21 +140,21 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         if (!await this.exists(target)) {
             throw new Error(`No local skill folder named "${entry.name}" to link.`);
         }
-        await this.writeSidecar(target, entry.skillId, entry.contentHash);
+        await this.writeRegistryMetadata(target, entry.skillId, entry.contentHash);
     }
 
     async unlink(name: string): Promise<void> {
-        const sidecar = path.join(this.skillDir(name), SIDECAR_FILE);
-        if (await this.exists(sidecar)) {
-            await fs.rm(sidecar, { force: true });
+        const metadataPath = path.join(this.skillDir(name), REGISTRY_METADATA_FILE);
+        if (await this.exists(metadataPath)) {
+            await fs.rm(metadataPath, { force: true });
         }
     }
 
     async uninstall(name: string): Promise<void> {
         const target = this.skillDir(name);
-        // Only delete folders we manage - a folder without our sidecar may be a
-        // hand-placed skill the user does not want us to remove.
-        if (!await this.exists(path.join(target, SIDECAR_FILE))) {
+        // Only delete folders we manage - a folder without our registry metadata may be
+        // a hand-placed skill the user does not want us to remove.
+        if (!await this.exists(path.join(target, REGISTRY_METADATA_FILE))) {
             return;
         }
         await fs.rm(target, { recursive: true, force: true });
@@ -158,16 +175,16 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
             }
             const dir = path.join(root, dirent.name);
             presentDirs.add(dir);
-            const sidecar = await this.readSidecar(dir);
-            if (sidecar) {
+            const metadata = await this.readRegistryMetadata(dir);
+            if (metadata) {
                 const onDisk = await this.computeDriftHash(dir);
                 result.push({
                     name: dirent.name,
-                    skillId: sidecar.skillId,
-                    contentHash: sidecar.contentHash,
+                    skillId: metadata.skillId,
+                    contentHash: metadata.contentHash,
                     // Drift = on-disk content differs from the registry hash we recorded;
                     // update detection (registry hash changed) is decided by the classifier.
-                    drifted: onDisk !== sidecar.contentHash
+                    drifted: onDisk !== metadata.contentHash
                 });
             } else {
                 result.push({ name: dirent.name, drifted: false });
@@ -187,25 +204,35 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
     protected async cleanReplace(entry: ResolvedSkillEntry): Promise<void> {
         const target = this.skillDir(entry.name);
         // Only clean-replace folders we manage; refuse to clobber a hand-placed folder that
-        // exists but carries no sidecar (it must be adopted via Link first).
-        if (await this.exists(target) && !await this.exists(path.join(target, SIDECAR_FILE))) {
+        // exists but carries no registry metadata (it must be adopted via Link first).
+        if (await this.exists(target) && !await this.exists(path.join(target, REGISTRY_METADATA_FILE))) {
             throw new Error(`The skill folder "${entry.name}" is not managed by the registry. Link it first, then Update.`);
         }
         const files = await this.download(entry);
         this.validateSkill(entry, files);
-        await this.writeSkill(entry, files);
+        // Pass replaceExisting=true: the user explicitly asked us to overwrite the folder.
+        await this.writeSkill(entry, files, true);
     }
 
     /**
-     * Writes a freshly-downloaded skill plus its sidecar into a sibling temp folder and
-     * then atomically swaps it into place, so an interrupted download never leaves a
-     * partially-written skill folder behind.
+     * Writes a freshly-downloaded skill plus its registry metadata into a sibling staging
+     * folder and then atomically swaps it into place, so an interrupted download never
+     * leaves a partially-written skill folder behind.
+     *
+     * `replaceExisting` controls whether an existing target folder is removed first:
+     * - `false` (install): the target must not exist; the staging rename surfaces the race
+     *   if a concurrent install or external mkdir wins between the caller's existence check
+     *   and the rename, instead of silently clobbering that folder.
+     * - `true` (update/fix): the user explicitly asked us to replace the folder.
+     *
+     * The staging folder is always cleaned up in `finally`, so a thrown error or an
+     * already-existing target never leaves an orphan `.installing-*` folder behind.
      */
-    protected async writeSkill(entry: ResolvedSkillEntry, files: SkillFileContent[]): Promise<void> {
+    protected async writeSkill(entry: ResolvedSkillEntry, files: SkillFileContent[], replaceExisting: boolean): Promise<void> {
         const root = this.skillsRoot();
         await fs.mkdir(root, { recursive: true });
         const target = this.skillDir(entry.name);
-        const staging = path.join(root, `.installing-${entry.name}-${Date.now()}`);
+        const staging = path.join(root, `${STAGING_PREFIX}${entry.name}-${Date.now()}`);
         try {
             for (const file of files) {
                 const segments = file.relativePath.split('/');
@@ -216,12 +243,16 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
                 await fs.mkdir(path.dirname(dest), { recursive: true });
                 await fs.writeFile(dest, Buffer.from(file.content));
             }
-            await this.writeSidecarFile(path.join(staging, SIDECAR_FILE), entry.skillId, entry.contentHash);
-            await fs.rm(target, { recursive: true, force: true });
+            await this.writeRegistryMetadataFile(path.join(staging, REGISTRY_METADATA_FILE), entry.skillId, entry.contentHash);
+            if (replaceExisting) {
+                await fs.rm(target, { recursive: true, force: true });
+            }
             await fs.rename(staging, target);
-        } catch (error) {
+        } finally {
+            // After a successful rename the staging path no longer exists; force makes the
+            // call a no-op in that case. Otherwise (thrown error, or rename failure because
+            // the target was raced into existence) this removes the partial staging folder.
             await fs.rm(staging, { recursive: true, force: true });
-            throw error;
         }
     }
 
@@ -389,27 +420,27 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         return entries;
     }
 
-    protected async readSidecar(dir: string): Promise<SkillSidecar | undefined> {
-        const sidecarPath = path.join(dir, SIDECAR_FILE);
+    protected async readRegistryMetadata(dir: string): Promise<SkillRegistryMetadata | undefined> {
+        const metadataPath = path.join(dir, REGISTRY_METADATA_FILE);
         try {
-            const raw = await fs.readFile(sidecarPath, 'utf8');
-            const parsed = JSON.parse(raw) as Partial<SkillSidecar>;
+            const raw = await fs.readFile(metadataPath, 'utf8');
+            const parsed = JSON.parse(raw) as Partial<SkillRegistryMetadata>;
             if (typeof parsed.skillId === 'string' && typeof parsed.contentHash === 'string') {
-                return { skillId: parsed.skillId, contentHash: parsed.contentHash, installedAt: parsed.installedAt ?? '' };
+                return { skillId: parsed.skillId, contentHash: parsed.contentHash, installedAt: parsed.installedAt };
             }
         } catch {
-            // Missing or malformed sidecar - treat as not registry-managed.
+            // Missing or malformed metadata - treat as not registry-managed.
         }
         return undefined;
     }
 
-    protected async writeSidecar(dir: string, skillId: string, contentHash: string): Promise<void> {
-        await this.writeSidecarFile(path.join(dir, SIDECAR_FILE), skillId, contentHash);
+    protected async writeRegistryMetadata(dir: string, skillId: string, contentHash: string): Promise<void> {
+        await this.writeRegistryMetadataFile(path.join(dir, REGISTRY_METADATA_FILE), skillId, contentHash);
     }
 
-    protected async writeSidecarFile(sidecarPath: string, skillId: string, contentHash: string): Promise<void> {
-        const sidecar: SkillSidecar = { skillId, contentHash, installedAt: new Date().toISOString() };
-        await fs.writeFile(sidecarPath, JSON.stringify(sidecar, undefined, 2));
+    protected async writeRegistryMetadataFile(metadataPath: string, skillId: string, contentHash: string): Promise<void> {
+        const metadata: SkillRegistryMetadata = { skillId, contentHash, installedAt: new Date().toISOString() };
+        await fs.writeFile(metadataPath, JSON.stringify(metadata, undefined, 2));
     }
 
     /**
@@ -427,7 +458,7 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         fs.mkdir(root, { recursive: true })
             .then(() => subscribe(root, (error, events) => {
                 if (error) {
-                    console.warn('Stopped watching the skills directory after a watcher error.', error);
+                    this.logger.warn('Stopped watching the skills directory after a watcher error.', error);
                     this.stopWatching();
                     this.notifyWatcherStopped();
                     return;
@@ -448,7 +479,7 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
             })
             .catch(error => {
                 this.watching = false;
-                console.warn('Could not watch the skills directory for changes.', error);
+                this.logger.warn('Could not watch the skills directory for changes.', error);
             });
     }
 
@@ -508,5 +539,23 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         } catch {
             return false;
         }
+    }
+
+    /**
+     * Removes any `.installing-*` staging folders left under the skills root by a backend
+     * crash mid-install. Same-process installs always clean their own staging in the
+     * `finally` of {@link writeSkill}; this sweep handles the cross-process-crash case so
+     * those folders do not accumulate forever.
+     */
+    protected async sweepStagingFolders(): Promise<void> {
+        const root = this.skillsRoot();
+        if (!await this.exists(root)) {
+            return;
+        }
+        const dirents = await fs.readdir(root, { withFileTypes: true });
+        await Promise.all(dirents
+            .filter(dirent => dirent.isDirectory() && dirent.name.startsWith(STAGING_PREFIX))
+            .map(dirent => fs.rm(path.join(root, dirent.name), { recursive: true, force: true })
+                .catch(error => this.logger.warn(`Could not remove stale skill staging folder "${dirent.name}".`, error))));
     }
 }

--- a/packages/ai-registry/tsconfig.json
+++ b/packages/ai-registry/tsconfig.json
@@ -10,6 +10,9 @@
   ],
   "references": [
     {
+      "path": "../ai-core"
+    },
+    {
       "path": "../ai-mcp"
     },
     {


### PR DESCRIPTION
#### What it does

Adds support for browsing, installing and managing **skills** from the [AI Registry](https://eclipsefdn-ai-registry.github.io/ai-registry-core/) in Theia's existing Extensions view, alongside Open VSX extensions and MCP servers. Builds on the AI Registry support added in #17546.

Technical highlights:

- **New "Skills" artifact type in `@theia/ai-registry`.** `SkillExtensionsContribution` implements the generalised `ExtensionsContribution` API from `@theia/vsx-registry`, so skills are searched and ranked alongside extensions and MCP servers. Skill entries render on the shared `ExtensionCard` with a mortar-board icon and a "Skills" type badge.
- **Backend-only filesystem and network work.** `~/.agents/skills` is outside the browser `FileService` sandbox, so all downloading and filesystem writes happen in `SkillInstallBackendServiceImpl` (node), exposed over RPC. The browser only triggers actions and renders results.
- **Git-sourced installs.** The registry points to a skill's content (a GitHub repo + path) and carries its `contentHash`; it does not host the content. Installing downloads the source into `~/.agents/skills/<name>` and writes a `.registry.json` sidecar recording `skillId` + `contentHash`. Writes go through a staging folder and an atomic rename so an interrupted download never leaves a partial skill behind.
- **Update and drift detection from a single content hash.** A content hash that reproduces the registry's hash byte for byte drives both **update detection** (the registry's hash changed) and **drift detection** (the on-disk files changed). These show up as per-entry **Install / Update / Fix Skill / Link / Unlink / Uninstall** actions. The on-disk hash is cached behind a cheap stat signature, so it does not re-read unchanged folders.
- **External-change watcher.** The backend watches `~/.agents/skills` (via `@parcel/watcher`) and pushes a change notification so the view refreshes on external installs, removals and edits. If the watcher fails irrecoverably, Theia prompts the user to reload the window to resume live refreshes.
- **New `install-skill` deep-link handler.** `theia://install-skill?id=<skillId>` resolves the skill from the configured registry by id and installs it after a confirmation dialog. The URL carries only the id; source, name and content hash are read from the registry at install time. The scheme follows the product's `electron.uriScheme`, so derived products (e.g. `theia-next://install-skill?...`) work without extra wiring.
- **Optional GitHub token.** `ai-features.registry.githubToken` (or the `GITHUB_TOKEN` environment variable) raises GitHub's rate limit from 60 to 5000 requests/hour when downloading skills.

#### How to test

> **Prerequisite:** include `@theia/ai-registry` in the bundle and rebind `AIRegistryConfiguration` to point at a registry that publishes `skills`. With that in place the Extensions view shows skill entries. Skills install into `~/.agents/skills/<name>` on the machine running the **backend**.

**1 - Browse and install from the registry**

1. Open the Extensions view and search for a skill keyword. Confirm **Skills** entries appear interleaved with extension/MCP results (mortar-board icon, "Skills" badge), ranked by fuzzy match.
2. Click **Install** on a skill. Confirm a success message (`Installed skill "<name>".`) appears.
3. On the backend machine, verify `~/.agents/skills/<name>/` now contains the downloaded files (at least `SKILL.md`) plus a `.registry.json` sidecar. Confirm the sidecar contains `skillId`, `contentHash` and `installedAt`, and that `contentHash` equals the registry entry's hash.
4. Confirm the entry now appears in the **Installed** section and its card shows only **Uninstall**.

**2 - Walk every button state by editing the skill folder**

With the skill from step 1 installed, change the folder/sidecar under `~/.agents/skills/<name>` and observe how the card buttons change. The backend watcher refreshes the view automatically after each change (give it ~1s).

| Change | Visible buttons |
| --- | --- |
| (baseline, fresh install) | **Uninstall** |
| Edit `.registry.json` → set `contentHash` to any other value | **Update** + **Uninstall** |
| Restore `contentHash`, then edit a skill file (e.g. append a line to `SKILL.md`'s body) | warning + **Fix Skill** + **Uninstall** |
| Delete `.registry.json` (keep the files); the folder name **is** a registry skill name | **Link to registry** |
| Edit `.registry.json` → set `skillId` to an id not in the registry | warning "Not in registry" + **Unlink** + **Uninstall** (Installed section only) |
| Delete `.registry.json`; the folder name is **not** a registry skill name | (hidden from the Skills section) |

- After clicking **Fix Skill**, confirm the edited file snaps back to the registry content and the warning disappears.
- After clicking **Update**, confirm the files are replaced with the latest registry content and `.registry.json`'s `contentHash` is rewritten.
- After clicking **Link to registry**, confirm a sidecar is stamped **without** modifying your existing files, and the card switches to the registry-managed state.
- After clicking **Unlink**, confirm the sidecar is removed while the files are kept.

**3 - External-change watcher refresh**

1. With the Extensions view open, create a new folder under `~/.agents/skills/` from a terminal (or delete an installed skill folder).
2. Confirm the Skills section refreshes automatically within ~1s, without a manual reload.

**4 - Hand-placed (unmanaged) skill**

1. Manually create `~/.agents/skills/<name>/SKILL.md` (no `.registry.json`).
2. If `<name>` matches a registry skill name: confirm it appears with a **Link to registry** button. Clicking **Link** adopts it (sidecar stamped, files untouched).
3. If `<name>` does **not** match any registry skill: confirm it does **not** appear in the Skills section (it is the user's own, unmanaged skill).

**5 - Deep-link install (`install-skill` URL handler)**

> **Caveat:** browser-to-app routing of `theia://...` links requires OS-level protocol registration, which only happens when the app is **packaged and installed** (macOS `Info.plist`, Linux `.desktop`, Windows `setAsDefaultProtocolClient`). Neither the `npm run start:electron` dev launcher nor the `--open-url` CLI flag dispatches into a running Theia in dev mode, so reviewers cannot click a `theia://` link to test the handler.
>
> The handler itself runs in-process. The cleanest path in dev mode is to dispatch a URI directly through Theia's `OpenerService` from the renderer's DevTools console. That is exactly what a real protocol-routed click triggers.

1. Start the electron app: `npm run start:electron`.
2. Open DevTools (Help → Toggle Developer Tools) → Console.
3. Paste:

   ```js
   const { default: URI } = window.theia['@theia/core/lib/common/uri'];
   const { OpenerService } = window.theia['@theia/core/lib/browser/opener-service'];
   const open = async id => {
       const uri = new URI(`theia://install-skill?id=${encodeURIComponent(id)}`);
       const opener = await window.theia.container.get(OpenerService).getOpener(uri);
       return opener.open(uri);
   };
   ```

4. Test the **happy path**: a confirmation dialog opens, naming the skill and its GitHub source. Confirm it to download and install the skill (use a real `skillId` from the Skills search results in step 1):
   ```js
   open('<a skillId shown in the Skills search results>')
   ```
5. Test the **missing-id error path**: Theia shows "Install link is missing the required \"id\" parameter.":
   ```js
   open('')
   ```
6. Test the **unknown-id error path**: Theia shows "Skill ... is not listed in your AI registry.":
   ```js
   open('com.example/unknown-skill')
   ```

**6 - GitHub token (optional, rate limits)**

If installs start failing with GitHub rate-limit errors, set `ai-features.registry.githubToken` in Settings, or export `GITHUB_TOKEN` before starting the backend, then retry an install. Confirm the install succeeds.

#### Follow-ups

- The GitHub Contents API lists up to ~1000 entries per directory without pagination; very large skill repositories are not yet paginated.
- Richer skill metadata (version, author, links) could be surfaced on the card and hover tooltip once the registry exposes it.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
