### PR TITLE
fix(ai-chat): update chat agent retrieval methods to optionally include hidden agents

### DIFF
--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -105,10 +105,10 @@ export class AgentDelegationTool implements ToolProvider {
             }
 
             // Check if the specified agent exists
-            const agent = this.getChatAgentService().getAgent(agentId);
+            const agent = this.getChatAgentService().getAgent(agentId, true);
             if (!agent) {
                 const availableAgents = this.getChatAgentService()
-                    .getAgents()
+                    .getAgents(true)
                     .map(a => a.id);
                 const errorMsg = `Agent '${agentId}' not found or not enabled. Available agents: ${availableAgents.join(', ')}`;
                 console.error(errorMsg);

--- a/packages/ai-chat/src/common/chat-agent-service.spec.ts
+++ b/packages/ai-chat/src/common/chat-agent-service.spec.ts
@@ -170,6 +170,18 @@ describe('ChatAgentServiceImpl', () => {
                 expect(agents[0].id).to.equal('agent3');
             });
 
+            it('includes hidden agents when includeHidden is true', async () => {
+                await initializeService({
+                    agent1: { showInChat: false },
+                    agent2: { showInChat: false }
+                });
+
+                const agents = chatAgentService.getAgents(true);
+
+                expect(agents).to.have.lengthOf(3);
+                expect(agents.map(a => a.id)).to.include.members(['agent1', 'agent2', 'agent3']);
+            });
+
             it('includes agents where showInChat preference is true', async () => {
                 await initializeService({
                     agent1: { showInChat: true },
@@ -555,6 +567,33 @@ describe('ChatAgentServiceImpl', () => {
 
                 expect(agents.map(a => a.id)).to.include('disabled-agent');
                 expect(agents.map(a => a.id)).to.include('mentioned-agent');
+            });
+        });
+
+        describe('getAgent with includeHidden parameter', () => {
+            it('should return agent when includeHidden is true', () => {
+                service = container.get(ChatAgentServiceImpl);
+
+                const agent = service.getAgent('mentioned-agent', true);
+
+                expect(agent).to.equal(mockMentionedAgent);
+            });
+
+            it('should return agent when includeHidden is false and agent is not hidden', () => {
+                service = container.get(ChatAgentServiceImpl);
+
+                const agent = service.getAgent('mentioned-agent', false);
+
+                expect(agent).to.equal(mockMentionedAgent);
+            });
+
+            it('should return undefined for disabled agent even when includeHidden is true', () => {
+                service = container.get(ChatAgentServiceImpl);
+                mockAgentService.disableAgent('disabled-agent');
+
+                const agent = service.getAgent('disabled-agent', true);
+
+                expect(agent).to.be.undefined;
             });
         });
 

--- a/packages/ai-chat/src/common/chat-agent-service.ts
+++ b/packages/ai-chat/src/common/chat-agent-service.ts
@@ -50,12 +50,15 @@ export const ChatAgentServiceFactory = Symbol('ChatAgentServiceFactory');
 export interface ChatAgentService {
     /**
      * Returns all available agents.
+     * @param includeHidden whether to include agents that are hidden from chat (showInChat set to false). Defaults to false, meaning hidden agents will not be returned.
      */
-    getAgents(): ChatAgent[];
+    getAgents(includeHidden?: boolean): ChatAgent[];
     /**
      * Returns the specified agent, if available
+     * @param id the agent id
+     * @param includeHidden whether to include agents that are hidden from chat (showInChat set to false). Defaults to false, meaning hidden agents will not be returned.
      */
-    getAgent(id: string): ChatAgent | undefined;
+    getAgent(id: string, includeHidden?: boolean): ChatAgent | undefined;
     /**
      * Returns all agents, including disabled ones.
      */
@@ -212,14 +215,16 @@ export class ChatAgentServiceImpl implements ChatAgentService {
         this.onDidChangeAgentsEmitter.fire();
     }
 
-    getAgent(id: string): ChatAgent | undefined {
+    getAgent(id: string, includeHidden: boolean = false): ChatAgent | undefined {
         if (!this._agentIsEnabled(id)) {
             return undefined;
         }
-        return this.getAgents().find(agent => agent.id === id);
+
+        return this.getAgents(includeHidden).find(agent => agent.id === id);
     }
-    getAgents(): ChatAgent[] {
-        return this.agents.filter(a => this._agentIsEnabled(a.id) && this._agentShowsInChat(a.id));
+
+    getAgents(includeHidden: boolean = false): ChatAgent[] {
+        return this.agents.filter(a => this._agentIsEnabled(a.id) && (includeHidden || this._agentShowsInChat(a.id)));
     }
     getAllAgents(): ChatAgent[] {
         return this.agents;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR improves the `ChatAgentService` so the `getAgents` and `getAgent` methods can optionally return hidden agents (`showInChat=false`). This is used in the `delegateToAgent` tool so it can use agents that are not visible in chat but still enabled.

<img width="1423" height="685" alt="feature" src="https://github.com/user-attachments/assets/4d451a22-9649-4986-82eb-7acc1cfbdac3" />

Closes #17509 

#### How to test

1. Create an agent called `my_agent1`, give it access to the `delegateToAgent` tool and configure its prompt so it can call that tool with `my_agent2` id.
2. Create a second agent called `my_agent2`, give it a dummy prompt.
3. Toggle the "Show in Chat" setting of `my_agent2` so it's set to false.
4. Confirm that the hidden agent `my_agent2` is not visible in chat view.
5. In the chat few, tag `my_agent1` with a test prompt so it uses the `delegateToAgent` tool.
6. Verify that the tool call was successful.

#### Attribution

Contributed on behalf of Lonti.com Pty Ltd.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
