### PR TITLE
fix(ai-chat): filter out thinking content from agent delegation tool result

### DIFF
--- a/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
@@ -14,26 +14,30 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
-import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 FrontendApplicationConfigProvider.set({});
 
+import { AIVariableResolutionRequest } from '@theia/ai-core';
+import { Event } from '@theia/core';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { AgentDelegationTool } from './agent-delegation-tool';
-import { TASK_CONTEXT_VARIABLE } from './task-context-variable';
-import { AIVariableResolutionRequest } from '@theia/ai-core';
 import {
     ActiveSessionChangedEvent,
     ChatAgentService,
+    ChatResponseContent,
     ChatService,
     SessionCreatedEvent,
     SessionDeletedEvent,
     SessionRenamedEvent,
+    TextChatResponseContentImpl,
+    ThinkingChatResponseContentImpl,
+    ToolCallChatResponseContentImpl,
 } from '../common';
 import { ChatAgentServiceImpl } from '../common/chat-agent-service';
-import { Event } from '@theia/core';
+import { AgentDelegationTool } from './agent-delegation-tool';
+import { TASK_CONTEXT_VARIABLE } from './task-context-variable';
 
 disableJSDOM();
 
@@ -117,9 +121,10 @@ function makeChatContext(): {
 
 type SessionEvent = ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent;
 
-function makeChatService(newSession: ReturnType<typeof makeNewSession>): ChatService {
+function makeChatService(newSession: ReturnType<typeof makeNewSession>, responseContent?: ChatResponseContent[]): ChatService {
+    const content = responseContent ?? [{ kind: 'text', content: 'agent response', asString: () => 'agent response' }];
     const responseCompleted = Promise.resolve({
-        response: { asString: () => 'agent response' }
+        response: { content }
     });
     return {
         onSessionEvent: sinon.stub() as Event<SessionEvent>,
@@ -191,6 +196,56 @@ describe('AgentDelegationTool', () => {
             await tool.getTool().handler(argString, ctx);
 
             expect(contextManager.addVariables.called).to.be.false;
+        });
+    });
+
+    describe('delegateToAgent() — thinking content filtering', () => {
+        it('excludes thinking content from the tool result', async () => {
+            const thinkingContent = new ThinkingChatResponseContentImpl('some internal thinking', 'sig123');
+            const textContent = new TextChatResponseContentImpl('final answer');
+
+            const newSession = makeNewSession();
+            const agentService = makeChatAgentService();
+            const chatService = makeChatService(newSession, [thinkingContent, textContent]);
+            const tool = makeAgentDelegationTool(agentService, chatService);
+            const ctx = makeChatContext();
+
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect(result).to.equal('final answer');
+            expect(result).to.not.include('thinking');
+        });
+
+        it('excludes tool call content from the tool result', async () => {
+            const toolCallContent = new ToolCallChatResponseContentImpl('call-1', 'someTool', '{}');
+            const textContent = new TextChatResponseContentImpl('final answer');
+
+            const newSession = makeNewSession();
+            const agentService = makeChatAgentService();
+            const chatService = makeChatService(newSession, [toolCallContent, textContent]);
+            const tool = makeAgentDelegationTool(agentService, chatService);
+            const ctx = makeChatContext();
+
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect(result).to.equal('final answer');
+        });
+
+        it('returns empty string when all content is thinking', async () => {
+            const thinkingContent = new ThinkingChatResponseContentImpl('internal', 'sig');
+
+            const newSession = makeNewSession();
+            const agentService = makeChatAgentService();
+            const chatService = makeChatService(newSession, [thinkingContent]);
+            const tool = makeAgentDelegationTool(agentService, chatService);
+            const ctx = makeChatContext();
+
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect(result).to.equal('');
         });
     });
 });

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -23,6 +23,7 @@ import {
     ChatAgentServiceFactory,
     ChatChangeEvent,
     ChatRequest,
+    ChatResponseContent,
     ChatService,
     ChatServiceFactory,
     ChatToolContext,
@@ -30,6 +31,8 @@ import {
     MutableChatRequestModel,
     MutableChatResponseModel,
     ChatRequestInvocation,
+    ThinkingChatResponseContent,
+    ToolCallChatResponseContent,
 } from '../common';
 import { TASK_CONTEXT_VARIABLE } from './task-context-variable';
 
@@ -210,7 +213,11 @@ export class AgentDelegationTool implements ToolProvider {
                 try {
                     // Wait for completion to return the final result as tool output
                     const result = await response.responseCompleted;
-                    const stringResult = result.response.asString();
+                    const filteredContent = result.response.content.filter(c => !ThinkingChatResponseContent.is(c) && !ToolCallChatResponseContent.is(c));
+                    const stringResult = filteredContent
+                        .map(c => ChatResponseContent.hasAsString(c) ? c.asString() : undefined)
+                        .filter((text): text is string => text !== undefined && text !== '')
+                        .join('\n\n');
 
                     // Clean up the session and parent-child link after completion
                     childModelDisposable?.dispose();

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -340,7 +340,7 @@ describe('ChatRequestParserImpl', () => {
 
             return {
                 requestCompleted: Promise.resolve({ cancel: () => undefined }),
-                responseCompleted: Promise.resolve({ response: { asString: () => 'ok' } }),
+                responseCompleted: Promise.resolve({ response: { content: [{ kind: 'text', content: 'ok', asString: () => 'ok' }] } }),
             };
         });
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

This PR filters out thinking content from the `delegateToAgent` tool result.

Here's an example session containing thinking messages from the agent called by the `delegateToAgent` tool:

<img width="1441" height="727" alt="Screenshot 2026-06-09 at 16 53 16" src="https://github.com/user-attachments/assets/dbc44e0d-9bac-4cdd-9b55-73b58d8b8c3e" />

The thinking message is not present anymore.

Closes #17618 

#### How to test

1. Configure two agents, one that can call the other via `delegateToAgent` tool.
2. Use a model with reasoning enabled like claude-sonnet-4.6 so you get some thinking type messages.
3. In the chat view ask the agent to call the other agent so it does some thinking before to return a final message.
4. Check the session and verify that the thinking message you see in the chat view is not present in the tool call result.

Example `customAgents.yml` file:
```yaml
- id: my_agent3
  name: My Agent3
  description: This is an example agent. Please adapt the properties to fit your needs.
  prompt: >-
    You are a dummy agent. Delegate a sample task to `my_agent4` via the ~{delegateToAgent} tool
    then report on the result.
  defaultLLM: default/universal
  showInChat: true
- id: my_agent4
  name: My Agent4
  description: This is an example agent. Please adapt the properties to fit your needs.
  prompt: >-
    You are a dummy agent do some thinking and then reply with one last message.
  defaultLLM: default/universal
  showInChat: true
```

#### Attribution

Contributed on behalf of Lonti.com Pty Ltd.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
