### PR TITLE
revert(core): restore console.* in electron-main services 

### DIFF
--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -30,12 +30,14 @@ import { ElectronMessagingContribution } from './messaging/electron-messaging-co
 import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { ElectronMessagingService } from './messaging/electron-messaging-service';
 import { ElectronConnectionHandler } from './messaging/electron-connection-handler';
+import { bindLogger } from '../node/logger-backend-module';
 
 const electronSecurityToken: ElectronSecurityToken = { value: generateUuid() };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (global as any)[ElectronSecurityToken] = electronSecurityToken;
 
 export default new ContainerModule(bind => {
+    bindLogger(bind);
     bind(Stopwatch).toConstantValue(new SimpleStopwatch('electron main', () => performance.now()));
     bind(ElectronMainApplication).toSelf().inSingletonScope();
     bind(ElectronMessagingContribution).toSelf().inSingletonScope();

--- a/packages/core/src/electron-main/electron-main-application-module.ts
+++ b/packages/core/src/electron-main/electron-main-application-module.ts
@@ -30,14 +30,12 @@ import { ElectronMessagingContribution } from './messaging/electron-messaging-co
 import { ElectronSecurityTokenService } from './electron-security-token-service';
 import { ElectronMessagingService } from './messaging/electron-messaging-service';
 import { ElectronConnectionHandler } from './messaging/electron-connection-handler';
-import { bindLogger } from '../node/logger-backend-module';
 
 const electronSecurityToken: ElectronSecurityToken = { value: generateUuid() };
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (global as any)[ElectronSecurityToken] = electronSecurityToken;
 
 export default new ContainerModule(bind => {
-    bindLogger(bind);
     bind(Stopwatch).toConstantValue(new SimpleStopwatch('electron main', () => performance.now()));
     bind(ElectronMainApplication).toSelf().inSingletonScope();
     bind(ElectronMessagingContribution).toSelf().inSingletonScope();

--- a/packages/core/src/electron-main/electron-main-application.ts
+++ b/packages/core/src/electron-main/electron-main-application.ts
@@ -45,7 +45,6 @@ import { StopReason } from '../common/frontend-application-state';
 import { dynamicRequire } from '../node/dynamic-require';
 import { ThemeMode } from '../common/theme';
 import { backendGlobal } from '../node/backend-global';
-import { ILogger } from '../common/logger';
 
 export { ElectronMainApplicationGlobals };
 
@@ -175,9 +174,6 @@ export class ElectronMainApplication {
     @inject(TheiaElectronWindowFactory)
     protected readonly windowFactory: TheiaElectronWindowFactory;
 
-    @inject(ILogger) @named('core:ElectronMainApplication')
-    protected readonly logger: ILogger;
-
     @inject(Stopwatch)
     protected readonly stopwatch: Stopwatch;
 
@@ -235,7 +231,7 @@ export class ElectronMainApplication {
                     .positional('file', { type: 'string' }),
                 async args => {
                     if (args.electronUserData) {
-                        this.logger.info(`using electron user data area : '${args.electronUserData}'`);
+                        console.info(`using electron user data area : '${args.electronUserData}'`);
                         await fs.mkdir(args.electronUserData, { recursive: true });
                         app.setPath('userData', args.electronUserData);
                     }
@@ -302,7 +298,7 @@ export class ElectronMainApplication {
         if (browserWindow) {
             this.saveWindowState(browserWindow);
         } else {
-            this.logger.warn(`no BrowserWindow with id: ${webContents.id}`);
+            console.warn(`no BrowserWindow with id: ${webContents.id}`);
         }
     }
 
@@ -369,7 +365,7 @@ export class ElectronMainApplication {
 
     protected async configureAndShowSplashScreen(mainWindow: BrowserWindow): Promise<BrowserWindow> {
         const splashScreenOptions = this.getSplashScreenOptions()!;
-        this.logger.debug('SplashScreen options', splashScreenOptions);
+        console.debug('SplashScreen options', splashScreenOptions);
 
         const splashScreenBounds = await this.determineSplashScreenBounds(mainWindow.getBounds());
         const splashScreenWindow = new BrowserWindow({
@@ -562,7 +558,7 @@ export class ElectronMainApplication {
             try {
                 workspacePath = await fs.realpath(path.resolve(options.cwd, options.file));
             } catch {
-                this.logger.error(`Could not resolve the workspace path. "${options.file}" is not a valid 'file' option. Falling back to the default workspace location.`);
+                console.error(`Could not resolve the workspace path. "${options.file}" is not a valid 'file' option. Falling back to the default workspace location.`);
             }
         }
         if (workspacePath !== undefined) {
@@ -640,13 +636,13 @@ export class ElectronMainApplication {
         // On Wayland, screen.getCursorScreenPoint() causes a native crash (SIGSEGV)
         // before any window is opened. Detect Wayland and use primary display instead.
         if (this.isWaylandSession()) {
-            this.logger.debug('Running under Wayland, using primary display for new window.');
+            console.debug('Running under Wayland, using primary display for new window.');
             return screen.getPrimaryDisplay();
         }
         try {
             return screen.getDisplayNearestPoint(screen.getCursorScreenPoint());
         } catch (error) {
-            this.logger.warn('Failed to get cursor screen point, falling back to primary display.', error);
+            console.warn('Failed to get cursor screen point, falling back to primary display.', error);
             return screen.getPrimaryDisplay();
         }
     }
@@ -717,7 +713,7 @@ export class ElectronMainApplication {
             };
             this.electronStore.set('windowstate', options);
         } catch (e) {
-            this.logger.error('Error while saving window state:', e);
+            console.error('Error while saving window state:', e);
         }
     }
 

--- a/packages/core/src/electron-main/messaging/electron-messaging-contribution.ts
+++ b/packages/core/src/electron-main/messaging/electron-messaging-contribution.ts
@@ -25,7 +25,6 @@ import { MessagingService } from '../../node';
 import { ElectronMessagingService } from './electron-messaging-service';
 import { ElectronConnectionHandler } from './electron-connection-handler';
 import { ElectronMainApplicationContribution } from '../electron-main-application';
-import { ILogger } from '../../common/logger';
 
 /**
  * This component replicates the role filled by `MessagingContribution` but for Electron.
@@ -42,9 +41,6 @@ export class ElectronMessagingContribution implements ElectronMainApplicationCon
 
     @inject(ContributionProvider) @named(ElectronConnectionHandler)
     protected readonly connectionHandlers: ContributionProvider<ConnectionHandler>;
-
-    @inject(ILogger) @named('core:ElectronMessagingContribution')
-    protected readonly logger: ILogger;
 
     protected readonly channelHandlers = new ConnectionHandlers<Channel>();
 
@@ -80,7 +76,7 @@ export class ElectronMessagingContribution implements ElectronMainApplicationCon
             const windowChannel = this.openChannels.get(sender.id) ?? this.createWindowChannel(sender);
             windowChannel.onMessageEmitter.fire(() => new Uint8ArrayReadBuffer(data));
         } catch (error) {
-            this.logger.error('IPC: Failed to handle message', { error, data });
+            console.error('IPC: Failed to handle message', { error, data });
         }
     }
 
@@ -92,8 +88,8 @@ export class ElectronMessagingContribution implements ElectronMainApplicationCon
         multiplexer.onDidOpenChannel(openEvent => {
             const { channel, id } = openEvent;
             if (this.channelHandlers.route(id, channel)) {
-                this.logger.debug(`Opening channel for service path '${id}'.`);
-                channel.onClose(() => this.logger.debug(`Closing channel on service path '${id}'.`));
+                console.debug(`Opening channel for service path '${id}'.`);
+                channel.onClose(() => console.debug(`Closing channel on service path '${id}'.`));
             }
         });
         sender.once('did-navigate', () => this.deleteChannel(sender.id, 'Window was refreshed'));


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Reverts the two ILogger migrations from https://github.com/eclipse-theia/theia/pull/17541 in
ElectronMainApplication and ElectronMessagingContribution, and drops
the now-unused bindLogger call in electron-main-application-module.

The electron-main bootstrap does not run a CliManager, so
LogLevelCliContribution is never invoked and the ILogger output
would be pinned at INFO with no way to configure it. Restore the
prior console.* calls until proper electron-main log configuration
(CLI parsing, setRootLogger, loggerPath RPC) is wired up.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Build the electron example app from this repo (e.g. `npm run build` and start an electron example `npm run start:electron` or start the `Launch Electron Backend` launch configuration.
2. Verify it reaches the window-creation phase without the `No matching bindings` error.
3. Confirm startup log output from `ElectronMainApplication` (e.g. the `using electron user data area : ...` info line) appears.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
