### PR TITLE
feat(ai-chat): enhance command parsing and integrate PromptService for command disambiguation

### DIFF
--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -20,7 +20,7 @@ import { ChatRequestParserImpl } from './chat-request-parser';
 import { ChatAgent, ChatAgentLocation } from './chat-agents';
 import { ChatContext, ChatRequest } from './chat-model';
 import { expect } from 'chai';
-import { AIVariable, DefaultAIVariableService, ResolvedAIVariable, ToolInvocationRegistryImpl, ToolRequest } from '@theia/ai-core';
+import { AIVariable, DefaultAIVariableService, PromptService, ResolvedAIVariable, ToolInvocationRegistryImpl, ToolRequest } from '@theia/ai-core';
 import { ILogger, Logger } from '@theia/core';
 import { ParsedChatRequestAgentPart, ParsedChatRequestFunctionPart, ParsedChatRequestTextPart, ParsedChatRequestVariablePart } from './parsed-chat-request';
 import { AgentDelegationTool } from '../browser/agent-delegation-tool';
@@ -274,6 +274,56 @@ describe('ChatRequestParserImpl', () => {
 
         const varPart = result.parts[0] as ParsedChatRequestVariablePart;
         expect(varPart.variableArg).to.equal('cmd|"arg with \\"quote\\"" other');
+    });
+
+    it('parses multiple commands in one message', async () => {
+        const req: ChatRequest = {
+            text: '/skill-one /skill-two'
+        };
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
+
+        expect(result.parts.length).to.equal(3);
+        const firstCommand = result.parts[0] as ParsedChatRequestVariablePart;
+        const separator = result.parts[1] as ParsedChatRequestTextPart;
+        const secondCommand = result.parts[2] as ParsedChatRequestVariablePart;
+        expect(firstCommand.variableName).to.equal('prompt');
+        expect(firstCommand.variableArg).to.equal('skill-one');
+        expect(separator.text).to.equal(' ');
+        expect(secondCommand.variableName).to.equal('prompt');
+        expect(secondCommand.variableArg).to.equal('skill-two');
+    });
+
+    it('keeps path-like slash arguments as command arguments', async () => {
+        const req: ChatRequest = {
+            text: '/explain /path/to/file'
+        };
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
+
+        expect(result.parts.length).to.equal(1);
+        const varPart = result.parts[0] as ParsedChatRequestVariablePart;
+        expect(varPart.variableName).to.equal('prompt');
+        expect(varPart.variableArg).to.equal('explain|/path/to/file');
+    });
+
+    it('uses known command names to disambiguate slash command arguments', async () => {
+        const promptService = {
+            getCommands: () => [
+                { id: 'command-skill-one', template: '', isCommand: true, commandName: 'skill-one' },
+                { id: 'command-skill-two', template: '', isCommand: true, commandName: 'skill-two' },
+            ]
+        } as unknown as PromptService;
+        const parserWithPromptService = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry, logger, promptService);
+        const context: ChatContext = { variables: [] };
+
+        const multipleCommands = await parserWithPromptService.parseChatRequest({ text: '/skill-one /skill-two' }, ChatAgentLocation.Panel, context);
+        expect((multipleCommands.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-one');
+        expect((multipleCommands.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-two');
+
+        const pathArgument = await parserWithPromptService.parseChatRequest({ text: '/skill-one /tmp' }, ChatAgentLocation.Panel, context);
+        expect(pathArgument.parts.length).to.equal(1);
+        expect((pathArgument.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-one|/tmp');
     });
 
     it('treats the first @agent mention as the selector and does not allow later mentions to override it', async () => {

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -294,6 +294,23 @@ describe('ChatRequestParserImpl', () => {
         expect(secondCommand.variableArg).to.equal('skill-two');
     });
 
+    it('inserts a separator between two argument-taking commands', async () => {
+        const req: ChatRequest = {
+            text: '/summarize foo /hello bar'
+        };
+        const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
+
+        expect(result.parts.length).to.equal(3);
+        const firstCommand = result.parts[0] as ParsedChatRequestVariablePart;
+        const separator = result.parts[1] as ParsedChatRequestTextPart;
+        const secondCommand = result.parts[2] as ParsedChatRequestVariablePart;
+        expect(firstCommand.variableArg).to.equal('summarize|foo');
+        expect(separator.kind).to.equal('text');
+        expect(separator.text).to.equal(' ');
+        expect(secondCommand.variableArg).to.equal('hello|bar');
+    });
+
     it('keeps path-like slash arguments as command arguments', async () => {
         const req: ChatRequest = {
             text: '/explain /path/to/file'
@@ -314,7 +331,8 @@ describe('ChatRequestParserImpl', () => {
                 { id: 'command-skill-two', template: '', isCommand: true, commandName: 'skill-two' },
             ]
         } as unknown as PromptService;
-        const parserWithPromptService = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry, logger, promptService);
+        const parserWithPromptService = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry, logger);
+        (parserWithPromptService as unknown as { promptService: PromptService }).promptService = promptService;
         const context: ChatContext = { variables: [] };
 
         const multipleCommands = await parserWithPromptService.parseChatRequest({ text: '/skill-one /skill-two' }, ChatAgentLocation.Panel, context);

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -19,7 +19,7 @@
  *--------------------------------------------------------------------------------------------*/
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatRequestParser.ts
 
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { ChatAgentService } from './chat-agent-service';
 import { ChatAgentLocation } from './chat-agents';
 import { ChatContext, ChatRequest } from './chat-model';
@@ -37,7 +37,7 @@ import {
     ParsedChatRequestPart,
 } from './parsed-chat-request';
 import {
-    AIVariable, AIVariableService, createAIResolveVariableCache, getAllResolvedAIVariables, parseFunctionReference, ToolInvocationRegistry, ToolRequest
+    AIVariable, AIVariableService, createAIResolveVariableCache, getAllResolvedAIVariables, parseFunctionReference, PromptService, ToolInvocationRegistry, ToolRequest
 } from '@theia/ai-core';
 import { ILogger } from '@theia/core';
 
@@ -47,7 +47,8 @@ const agentReg = /^@([\w_\-\.]+)(?=(\s|$|\b))/i; // An @-agent
 const functionReg = /^~(\??[\w_\-\.]+)(?=(\s|$|\b))/i;
 const functionPromptFormatReg = /^\~\{\s*(.*?)\s*\}/i;
 const variableReg = /^#([\w_\-]+)(?::([\w_\-_\/\\.:]+))?(?=(\s|$|\b))/i; // A #-variable with an optional : arg (#file:workspace/path/name.ext)
-const commandReg = /^\/([\w_\-]+)(?:\s+(.+?))?(?=\s*$)/; // A /-command with optional arguments (/commandname arg1 arg2)
+const commandReg = /^\/([\w_\-]+)/; // A /-command (/commandname) with optional arguments parsed separately
+const nextCommandReg = /\s+\/([\w_\-]+)(?=\s|$)/g;
 
 export const ChatRequestParser = Symbol('ChatRequestParser');
 export interface ChatRequestParser {
@@ -66,7 +67,8 @@ export class ChatRequestParserImpl implements ChatRequestParser {
         @inject(ChatAgentService) private readonly agentService: ChatAgentService,
         @inject(AIVariableService) private readonly variableService: AIVariableService,
         @inject(ToolInvocationRegistry) private readonly toolInvocationRegistry: ToolInvocationRegistry,
-        @inject(ILogger) private readonly logger: ILogger
+        @inject(ILogger) private readonly logger: ILogger,
+        @inject(PromptService) @optional() private readonly promptService?: PromptService
     ) { }
 
     async parseChatRequest(request: ChatRequest, location: ChatAgentLocation, context: ChatContext): Promise<ParsedChatRequest> {
@@ -185,6 +187,7 @@ export class ChatRequestParserImpl implements ChatRequestParser {
                 }
 
                 parts.push(newPart);
+                i = newPart.range.endExclusive - 1;
             }
         }
 
@@ -292,11 +295,41 @@ export class ChatRequestParserImpl implements ChatRequestParser {
             return;
         }
 
-        const [full, commandName, commandArgs] = nextCommandMatch;
-        const commandRange = offsetRange(offset, offset + full.length);
+        const [commandText, commandName] = nextCommandMatch;
+        let commandEnd = commandText.length;
+        let commandArgs: string | undefined;
+
+        const nextCommandOffset = this.findNextCommandOffset(message, commandEnd);
+        const argsEnd = nextCommandOffset ?? message.length;
+        const args = message.slice(commandEnd, argsEnd).trim();
+        if (args) {
+            commandArgs = args;
+            commandEnd = argsEnd;
+        }
+
+        const commandRange = offsetRange(offset, offset + commandEnd);
 
         const variableArg = commandArgs ? `${commandName}|${commandArgs}` : commandName;
         return new ParsedChatRequestVariablePart(commandRange, 'prompt', variableArg);
+    }
+
+    private findNextCommandOffset(message: string, startOffset: number): number | undefined {
+        nextCommandReg.lastIndex = startOffset;
+        let match = nextCommandReg.exec(message);
+        while (match) {
+            const commandName = match[1];
+            if (!this.promptService || this.isKnownCommand(commandName)) {
+                return match.index + match[0].indexOf(chatSubcommandLeader);
+            }
+            match = nextCommandReg.exec(message);
+        }
+        return undefined;
+    }
+
+    private isKnownCommand(commandName: string): boolean {
+        return this.promptService?.getCommands().some(command =>
+            (command.commandName ?? command.id) === commandName
+        ) ?? false;
     }
 
     private tryToParseFunction(message: string, offset: number): ParsedChatRequestFunctionPart | undefined {

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -63,12 +63,15 @@ function offsetRange(start: number, endExclusive: number): OffsetRange {
 }
 @injectable()
 export class ChatRequestParserImpl implements ChatRequestParser {
+
+    @inject(PromptService) @optional()
+    protected readonly promptService?: PromptService;
+
     constructor(
         @inject(ChatAgentService) private readonly agentService: ChatAgentService,
         @inject(AIVariableService) private readonly variableService: AIVariableService,
         @inject(ToolInvocationRegistry) private readonly toolInvocationRegistry: ToolInvocationRegistry,
         @inject(ILogger) private readonly logger: ILogger,
-        @inject(PromptService) @optional() private readonly promptService?: PromptService
     ) { }
 
     async parseChatRequest(request: ChatRequest, location: ChatAgentLocation, context: ChatContext): Promise<ParsedChatRequest> {
@@ -301,10 +304,15 @@ export class ChatRequestParserImpl implements ChatRequestParser {
 
         const nextCommandOffset = this.findNextCommandOffset(message, commandEnd);
         const argsEnd = nextCommandOffset ?? message.length;
-        const args = message.slice(commandEnd, argsEnd).trim();
+        const rawArgs = message.slice(commandEnd, argsEnd);
+        const args = rawArgs.trim();
         if (args) {
             commandArgs = args;
-            commandEnd = argsEnd;
+            // Advance the consumed range only up to the end of the trimmed argument, not up to the
+            // next command. This keeps the whitespace between the argument and a following command
+            // out of this part's range, so parseParts emits it as a separator text part. Otherwise
+            // the two resolved prompt fragments would run into each other with no space between them.
+            commandEnd = argsEnd - (rawArgs.length - rawArgs.trimEnd().length);
         }
 
         const commandRange = offsetRange(offset, offset + commandEnd);
@@ -318,6 +326,10 @@ export class ChatRequestParserImpl implements ChatRequestParser {
         let match = nextCommandReg.exec(message);
         while (match) {
             const commandName = match[1];
+            // Deliberate behavior difference: without a PromptService we cannot tell commands from
+            // path-like arguments, so any `/word` token is treated as a command boundary. With a
+            // PromptService we only break on known command names and keep unknown `/word` tokens
+            // (e.g. `/tmp`, `/path/to/file`) as part of the current command's arguments.
             if (!this.promptService || this.isKnownCommand(commandName)) {
                 return match.index + match[0].indexOf(chatSubcommandLeader);
             }


### PR DESCRIPTION
#### What it does

Fixes chat slash command parsing when multiple skill slash commands are added in the same message, for example `/skill-one /skill-two`. Previously, the parser could treat the remaining message as part of the first command and then scan the second slash again, which could prevent the chat request from being submitted correctly.

This PR updates the parser to skip already consumed ranges, parse multiple slash commands as separate `#prompt` variable parts, and keep path-like slash arguments such as `/path/to/file` as command arguments. It also adds regression tests for multiple slash commands and slash-style command arguments.

#### How to test

Open the chat input, add two skills via slash commands such as `/skill-one /skill-two`, then press Enter. Verify that the chat request is submitted and both skills are parsed as prompt command variables.

Automated checks run:

```bash
npm run compile
npm test --workspace @theia/ai-chat -- --grep ChatRequestParserImpl
```

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
