### PR TITLE
fix(task): emit onDidStartTaskProcess for created process tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [ai-core] discovered skills from `.agents/skills` directories alongside `.prompts/skills` (workspace and home directory) [#17553](https://github.com/eclipse-theia/theia/pull/17553)
 - [ai-mcp] added OAuth 2.1 authorization for remote MCP servers, including interactive sign-in/sign-out, automatic token refresh and storage, and a command to retrieve the OAuth redirect URL [#17638](https://github.com/eclipse-theia/theia/pull/17638)
+- [task] fixed `onDidStartTaskProcess` never firing for process tasks because `TaskServer.runTask` omitted the `task` argument to `fireTaskCreatedEvent` [#17663](https://github.com/eclipse-theia/theia/pull/17663)
 - [terminal] fixed Cmd+V / Ctrl+V paste in the integrated terminal and restored the effect of the `terminal.enablePaste` and `terminal.enableCopy` preferences [#17603](https://github.com/eclipse-theia/theia/pull/17603)
 
 <a name="breaking_changes_1.73.0">[Breaking Changes:](#breaking_changes_1.73.0)</a>

--- a/packages/task/src/node/task-server.slow-spec.ts
+++ b/packages/task/src/node/task-server.slow-spec.ts
@@ -359,6 +359,52 @@ describe('Task server / back-end', function (): void {
         expect(exitStatus).eq(0);
     });
 
+    it('onDidStartTaskProcess is fired when a terminal-process task is created', async function (): Promise<void> {
+        const command = isWindows ? commandShortRunningWindows : (isOSX ? commandShortRunningOsx : commandShortRunning);
+        let startEvent: TaskInfo | undefined;
+        const toDispose = taskWatcher.onDidStartTaskProcess(event => { startEvent = event; });
+        const taskInfo = await taskServer.run(createProcessTaskConfig('shell', command, undefined), wsRoot);
+        toDispose.dispose();
+
+        if (startEvent === undefined) {
+            throw new Error('onDidStartTaskProcess was not fired');
+        }
+        expect(startEvent.taskId).equals(taskInfo.taskId);
+        expect(startEvent.processId).to.be.a('number');
+        await checkSuccessfulProcessExit(taskInfo, taskWatcher);
+    });
+
+    it('onDidStartTaskProcess is fired when a raw-process task is created', async function (): Promise<void> {
+        const command = isWindows ? commandShortRunningWindows : (isOSX ? commandShortRunningOsx : commandShortRunning);
+        const executable = FileUri.fsPath(wsRootUri.resolve(command));
+        let startEvent: TaskInfo | undefined;
+        const toDispose = taskWatcher.onDidStartTaskProcess(event => { startEvent = event; });
+        const taskInfo = await taskServer.run(createProcessTaskConfig('process', executable, []), wsRoot);
+        toDispose.dispose();
+
+        if (startEvent === undefined) {
+            throw new Error('onDidStartTaskProcess was not fired');
+        }
+        expect(startEvent.taskId).equals(taskInfo.taskId);
+        expect(startEvent.processId).to.be.a('number');
+        await checkSuccessfulProcessExit(taskInfo, taskWatcher);
+    });
+
+    it('onDidStartTaskProcess is not fired for a non-process (custom) task', async function (): Promise<void> {
+        let processStarted = false;
+        let taskCreated = false;
+        const disposeStart = taskWatcher.onDidStartTaskProcess(() => { processStarted = true; });
+        const disposeCreated = taskWatcher.onTaskCreated(() => { taskCreated = true; });
+        const taskInfo = await taskServer.run(createCustomTaskConfig(), wsRoot);
+        disposeStart.dispose();
+        disposeCreated.dispose();
+
+        // The events are fired synchronously while `run` is awaited, so by now they have either fired or not.
+        expect(taskCreated, 'onTaskCreated was expected to fire for a custom task').to.equal(true);
+        expect(processStarted, 'onDidStartTaskProcess should not fire for a non-process task').to.equal(false);
+        await taskServer.kill(taskInfo.taskId);
+    });
+
 });
 
 function createTaskConfig(taskType: string, command: string, args: string[]): TaskConfiguration {
@@ -394,6 +440,15 @@ function createProcessTaskConfig2(processType: ProcessType, command: string, arg
         command,
         args,
         options: { cwd: wsRoot },
+    };
+}
+
+function createCustomTaskConfig(): TaskConfiguration {
+    return {
+        label: 'test custom task',
+        type: 'customExecution',
+        _source: '/source/folder',
+        _scope: '/source/folder'
     };
 }
 

--- a/packages/task/src/node/task-server.ts
+++ b/packages/task/src/node/task-server.ts
@@ -163,7 +163,7 @@ export class TaskServerImpl implements TaskServer, Disposable {
         this.toDispose.get(task.id)!.push(task);
 
         const taskInfo = await task.getRuntimeInfo();
-        this.fireTaskCreatedEvent(taskInfo);
+        this.fireTaskCreatedEvent(taskInfo, task);
         return taskInfo;
     }
 


### PR DESCRIPTION
#### What it does

`TaskServer.runTask` calls `fireTaskCreatedEvent(taskInfo)` without its optional `task` argument:

```ts
const taskInfo = await task.getRuntimeInfo();
this.fireTaskCreatedEvent(taskInfo); // task not passed
```

`fireTaskCreatedEvent` only emits `onDidStartTaskProcess` when `task && task instanceof ProcessTask` holds. Because `task` is always `undefined` at the call site, that guard is never satisfied and **`onDidStartTaskProcess` is never fired for any task**. Plugins that await `vscode.tasks.onDidStartTaskProcess` for a process task therefore never observe it.

This passes the in-scope `task` local so the event fires for `ProcessTask` instances, matching VS Code semantics. Non-process (`CustomExecution`) tasks are unaffected — consistent with VS Code, where `onDidStartTaskProcess` does not fire for process-less executions.

#### How to test

Automated (added in this PR, `packages/task/src/node/task-server.slow-spec.ts`):

- `onDidStartTaskProcess` fires for a terminal-process task, with a numeric `processId`;
- `onDidStartTaskProcess` fires for a raw-process task;
- `onDidStartTaskProcess` does **not** fire for a non-process (custom) task, while `onTaskCreated` still does.

Manual:

1. Register an extension that runs a shell/process task and subscribes to `vscode.tasks.onDidStartTaskProcess`.
2. Execute the task.
3. Before: the handler never fires. After: it fires once the process starts, with the task's `processId`.

#### Follow-ups

None. Behavior-restoring fix; no API surface change.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- No attribution needed. -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/eclipse-theia/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines) — N/A, this change adds no user-facing text

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)

---

_Disclosure: the initial patch and this description were drafted with AI assistance (Claude) and were reviewed, tested, and are submitted by me; I take full responsibility for the contribution under the ECA and DCO sign-off._
