### PR TITLE
fix(filesystem): fix file dialog location input navigation

### DIFF
--- a/packages/filesystem/src/browser/location/location-renderer.spec.ts
+++ b/packages/filesystem/src/browser/location/location-renderer.spec.ts
@@ -43,11 +43,36 @@ class TestableLocationListRenderer extends LocationListRenderer {
     testRenderSelectInput(): React.ReactNode {
         return this.renderSelectInput();
     }
+
+    testTrySetNewLocation(newLocation: URI): void {
+        this.trySetNewLocation(newLocation);
+    }
 }
 
 function createMockService(): LocationService {
     return {
         location: undefined,
+        drives: () => Promise.resolve([])
+    };
+}
+
+/**
+ * A `LocationService` that tracks how often its `location` setter is invoked,
+ * so tests can distinguish "navigation skipped" from "re-navigated to the same location".
+ */
+function createTrackingService(initial?: URI): LocationService & { locationSetCount: number } {
+    const state = { current: initial, count: 0 };
+    return {
+        get location(): URI | undefined {
+            return state.current;
+        },
+        set location(uri: URI | undefined) {
+            state.current = uri;
+            state.count++;
+        },
+        get locationSetCount(): number {
+            return state.count;
+        },
         drives: () => Promise.resolve([])
     };
 }
@@ -193,6 +218,63 @@ describe('LocationListRenderer', () => {
             const selectElement = r.testRenderSelectInput() as React.ReactElement;
 
             expect(selectElement.props.value).to.equal(newLocation.toString());
+            r.dispose();
+        });
+    });
+
+    describe('trySetNewLocation', () => {
+        it('should not navigate when the target equals the current location', () => {
+            const host = document.createElement('div');
+            const service = createTrackingService(URI.fromFilePath('/home'));
+            const r = new TestableLocationListRenderer({ model: service as unknown as FileDialogModel, host });
+
+            r.testTrySetNewLocation(URI.fromFilePath('/home'));
+
+            // The location setter must not be invoked, otherwise a duplicate entry is added to the history.
+            expect(service.locationSetCount).to.equal(0);
+            expect(service.location?.path.toString()).to.equal('/home');
+            r.dispose();
+        });
+
+        it('should navigate when the target differs from the current location', () => {
+            const host = document.createElement('div');
+            const service = createTrackingService(URI.fromFilePath('/home'));
+            const r = new TestableLocationListRenderer({ model: service as unknown as FileDialogModel, host });
+
+            r.testTrySetNewLocation(URI.fromFilePath('/work'));
+
+            expect(service.locationSetCount).to.equal(1);
+            expect(service.location?.path.toString()).to.equal('/work');
+            r.dispose();
+        });
+
+        it('should navigate when there is no current location yet', () => {
+            const host = document.createElement('div');
+            const service = createTrackingService(undefined);
+            const r = new TestableLocationListRenderer({ model: service as unknown as FileDialogModel, host });
+
+            r.testTrySetNewLocation(URI.fromFilePath('/home'));
+
+            expect(service.location?.path.toString()).to.equal('/home');
+            r.dispose();
+        });
+
+        it('should navigate to a previously visited location after it was left by other means', () => {
+            const host = document.createElement('div');
+            const service = createTrackingService(URI.fromFilePath('/home'));
+            const r = new TestableLocationListRenderer({ model: service as unknown as FileDialogModel, host });
+
+            // Navigate to '/home' via the location input (no-op, already there).
+            r.testTrySetNewLocation(URI.fromFilePath('/home'));
+
+            // Simulate leaving '/home' through another mechanism, e.g. the "Navigate Up" button,
+            // which sets the model location directly without going through `trySetNewLocation`.
+            service.location = URI.fromFilePath('/');
+
+            // Navigating back to '/home' via the location input must work and not be silently blocked.
+            r.testTrySetNewLocation(URI.fromFilePath('/home'));
+
+            expect(service.location?.path.toString()).to.equal('/home');
             r.dispose();
         });
     });

--- a/packages/filesystem/src/browser/location/location-renderer.tsx
+++ b/packages/filesystem/src/browser/location/location-renderer.tsx
@@ -100,7 +100,6 @@ export class LocationListRenderer extends ReactRenderer {
             this.initResolveDirectoryCache();
         }
     }
-    protected lastUniqueTextInputLocation: URI | undefined;
     protected previousAutocompleteMatch: string;
     protected doAttemptAutocomplete = true;
 
@@ -303,12 +302,11 @@ export class LocationListRenderer extends ReactRenderer {
     }
 
     protected trySetNewLocation(newLocation: URI): void {
-        if (this.lastUniqueTextInputLocation === undefined) {
-            this.lastUniqueTextInputLocation = this.service.location;
-        }
-        // prevent consecutive repeated locations from being added to location history
-        if (this.lastUniqueTextInputLocation?.path.toString() !== newLocation.path.toString()) {
-            this.lastUniqueTextInputLocation = newLocation;
+        // Compare against the actual current location rather than a cached value. A cached value goes stale
+        // whenever the location is changed by other means (navigation buttons, opening a directory in the tree, etc.),
+        // which would then silently block navigating back to a previously visited location via the location input.
+        // Skipping navigation to the location we are already at still avoids adding a duplicate entry to the location history.
+        if (this.service.location?.path.toString() !== newLocation.path.toString()) {
             this.service.location = newLocation;
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17664

- compare the requested location against the live current location in `trySetNewLocation` instead of a cached `lastUniqueTextInputLocation`
- the cached value went stale after navigating via the Up/Back/Forward/Home buttons or the tree, silently blocking navigation to a previously visited path typed into the location input
- remove the now-unused `lastUniqueTextInputLocation` field
- add regression tests for `trySetNewLocation`

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Start the example browser application
2. Open a file dialog (e.g. File > Open... or Open Workspace...).
3. Click the edit (pencil) icon to switch the location bar to text input.
4. Type an absolute path, e.g. /home, and press Enter. The dialog navigates to /home.
5. Move to a different folder without using the text input, for example click the Navigate Up button (or Back), or double-click a folder in the tree.
6. Click the edit (pencil) icon again, type the same path as in step 3 (/home), and press Enter.
7. Verify that everytime you enter a (valid) path manually, it is accepted and the file dialog navigates there

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
