### PR TITLE
Preserve toolbar menu delegate arguments

### DIFF
--- a/packages/core/src/browser/menu/composite-menu-node.ts
+++ b/packages/core/src/browser/menu/composite-menu-node.ts
@@ -31,11 +31,11 @@ export class SubMenuLink implements CompoundMenuNode {
 
     get sortString(): string { return this._sortString || this.delegate.sortString; };
     isVisible<T>(effectiveMenuPath: MenuPath, contextMatcher: ContextExpressionMatcher<T>, context: T | undefined, ...args: unknown[]): boolean {
-        return this.delegate.isVisible(effectiveMenuPath, contextMatcher, context) && (!this._when || contextMatcher.match(this._when, context));
+        return this.delegate.isVisible(effectiveMenuPath, contextMatcher, context, ...args) && (!this._when || contextMatcher.match(this._when, context));
     }
 
     isEmpty<T>(effectiveMenuPath: MenuPath, contextMatcher: ContextExpressionMatcher<T>, context: T | undefined, ...args: unknown[]): boolean {
-        return this.delegate.isEmpty(effectiveMenuPath, contextMatcher, context, args);
+        return this.delegate.isEmpty(effectiveMenuPath, contextMatcher, context, ...args);
     }
 }
 
@@ -78,8 +78,8 @@ export abstract class AbstractCompoundMenuImpl implements MenuNode {
 
     isEmpty<T>(effectiveMenuPath: MenuPath, contextMatcher: ContextExpressionMatcher<T>, context: T | undefined, ...args: unknown[]): boolean {
         for (const child of this.children) {
-            if (child.isVisible(effectiveMenuPath, contextMatcher, context, args)) {
-                if (!CompoundMenuNode.is(child) || !child.isEmpty(effectiveMenuPath, contextMatcher, context, args)) {
+            if (child.isVisible(effectiveMenuPath, contextMatcher, context, ...args)) {
+                if (!CompoundMenuNode.is(child) || !child.isEmpty(effectiveMenuPath, contextMatcher, context, ...args)) {
                     return false;
                 }
             }

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
@@ -96,7 +96,7 @@ abstract class AbstractToolbarMenuWrapper {
         const icon = this.icon || 'ellipsis';
         const contextMatcher: ContextMatcher = this.contextKeyService;
         const className = `${icon} ${ACTION_ITEM}`;
-        if (CompoundMenuNode.is(this.menuNode) && !this.menuNode.isEmpty(this.effectiveMenuPath, this.contextKeyService, widget.node)) {
+        if (CompoundMenuNode.is(this.menuNode) && !this.menuNode.isEmpty(this.effectiveMenuPath, this.contextKeyService, widget.node, widget)) {
             return <div key={this.id} className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled menu'}>
                 <div className={className}
                     title={this.tooltip || this.text}
@@ -308,7 +308,7 @@ abstract class AbstractMenuNodeAsToolbarItemWrapper<T extends MenuNode> {
     }
 
     isVisible<K>(effectiveMenuPath: MenuPath, contextMatcher: ContextExpressionMatcher<K>, context: K | undefined, ...args: unknown[]): boolean {
-        return this.menuNode!.isVisible(this.effectiveMenuPath, contextMatcher, context, args);
+        return this.menuNode!.isVisible(this.effectiveMenuPath, contextMatcher, context, ...args);
     }
 }
 
@@ -321,7 +321,7 @@ class ToolbarItemAsSubmenuWrapper extends AbstractMenuNodeAsToolbarItemWrapper<C
         return this.menuNode.contextKeyOverlays;
     }
     isEmpty<T>(effectiveMenuPath: MenuPath, contextMatcher: ContextExpressionMatcher<T>, context: T | undefined, ...args: unknown[]): boolean {
-        return this.menuNode.isEmpty(this.effectiveMenuPath, contextMatcher, context, args);
+        return this.menuNode.isEmpty(this.effectiveMenuPath, contextMatcher, context, ...args);
     }
     get children(): MenuNode[] {
         return this.menuNode.children;
@@ -340,7 +340,7 @@ class ToolbarItemAsCommandMenuWrapper extends AbstractMenuNodeAsToolbarItemWrapp
         return this.menuNode.isToggled(this.effectiveMenuPath, ...args);
     }
     run(effectiveMenuPath: MenuPath, ...args: unknown[]): Promise<void> {
-        return this.menuNode.run(this.effectiveMenuPath, args);
+        return this.menuNode.run(this.effectiveMenuPath, ...args);
     }
 
     override get label(): string {

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-registry.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-registry.ts
@@ -141,11 +141,11 @@ export class TabBarToolbarRegistry implements FrontendApplicationContribution {
                 const menu = this.menuRegistry.getMenu(delegate.menuPath);
                 if (menu) {
                     for (const child of menu.children) {
-                        if (child.isVisible([...delegate.menuPath, child.id], this.contextKeyService, widget.node)) {
+                        if (child.isVisible([...delegate.menuPath, child.id], this.contextKeyService, widget.node, widget)) {
                             if (CompoundMenuNode.is(child)) {
                                 for (const grandchild of child.children) {
                                     if (grandchild.isVisible([...delegate.menuPath, child.id, grandchild.id],
-                                        this.contextKeyService, widget.node) && RenderedMenuNode.is(grandchild)) {
+                                        this.contextKeyService, widget.node, widget) && RenderedMenuNode.is(grandchild)) {
                                         if (CommandMenu.is(grandchild)) {
                                             result.push(new CommandMenuAsToolbarItemWrapper([...delegate.menuPath, child.id, grandchild.id], this.commandRegistry,
                                                 this.menuRegistry, this.contextKeyService, this.contextMenuRenderer, grandchild, child.id));

--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.spec.ts
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar.spec.ts
@@ -18,7 +18,16 @@ import { enableJSDOM } from '../../test/jsdom';
 
 let disableJSDOM = enableJSDOM();
 import { expect } from 'chai';
-import { TabBarToolbarAction } from './tab-bar-toolbar-types';
+import {
+    CommandMenu, CommandRegistry, CompoundMenuNode, Group, GroupImpl, MenuAction, MenuModelRegistry, MenuNode, MenuNodeFactory, MutableCompoundMenuNode,
+    Submenu, SubmenuImpl, SubMenuLink
+} from '../../../common';
+import { ContextKeyServiceDummyImpl } from '../../context-key-service';
+import { ContextMenuRenderer } from '../../context-menu-renderer';
+import { Widget } from '../../widgets';
+import { TOOLBAR_WRAPPER_ID_SUFFIX } from './tab-bar-toolbar-menu-adapters';
+import { TabBarToolbarRegistry } from './tab-bar-toolbar-registry';
+import { TAB_BAR_TOOLBAR_CONTEXT_MENU, TabBarToolbarAction } from './tab-bar-toolbar-types';
 
 disableJSDOM();
 
@@ -59,4 +68,153 @@ describe('tab-bar-toolbar', () => {
 
     });
 
+    describe('menu delegates', () => {
+
+        const TEST_MENU_PATH = ['test-toolbar-delegate'];
+        const TEST_COMMAND = 'test.toolbar.command';
+        const TEST_SUBMENU_COMMAND = 'test.toolbar.submenu.command';
+
+        let contextKeyService: ContextKeyServiceDummyImpl;
+
+        before(() => {
+            disableJSDOM = enableJSDOM();
+        });
+
+        beforeEach(() => {
+            contextKeyService = new ContextKeyServiceDummyImpl();
+        });
+
+        after(() => {
+            disableJSDOM();
+        });
+
+        it('passes the delegated widget to command visibility', () => {
+            const testWidget = new TestToolbarWidget();
+            const commands = createCommandRegistry();
+            commands.registerCommand({ id: TEST_COMMAND, label: 'Test Command' }, {
+                execute: () => { },
+                isVisible: widget => TestToolbarWidget.is(widget) && widget === testWidget
+            });
+            const menuRegistry = createMenuRegistry(commands);
+            menuRegistry.registerMenuAction([...TEST_MENU_PATH, 'other'], { commandId: TEST_COMMAND });
+            const registry = createToolbarRegistry(commands, menuRegistry, contextKeyService);
+            registry.registerMenuDelegate(TEST_MENU_PATH, TestToolbarWidget.is);
+
+            const commandItem = registry.visibleItems(testWidget).find(item => item.id === `${TEST_COMMAND}${TOOLBAR_WRAPPER_ID_SUFFIX}`);
+
+            expect(commandItem).to.exist;
+            testWidget.dispose();
+        });
+
+        it('preserves the widget for wrapped command menu visibility, enablement, toggled state, and execution', async () => {
+            const testWidget = new TestToolbarWidget();
+            let executedWith: unknown;
+            const commands = createCommandRegistry();
+            commands.registerCommand({ id: TEST_COMMAND, label: 'Test Command' }, {
+                execute: widget => executedWith = widget,
+                isVisible: widget => TestToolbarWidget.is(widget) && widget === testWidget,
+                isEnabled: widget => TestToolbarWidget.is(widget) && widget === testWidget,
+                isToggled: widget => TestToolbarWidget.is(widget) && widget === testWidget
+            });
+            const menuRegistry = createMenuRegistry(commands);
+            menuRegistry.registerMenuAction([...TEST_MENU_PATH, 'other'], { commandId: TEST_COMMAND });
+            const registry = createToolbarRegistry(commands, menuRegistry, contextKeyService);
+            registry.registerMenuDelegate(TEST_MENU_PATH, TestToolbarWidget.is);
+            const commandItem = registry.visibleItems(testWidget).find(item => item.id === `${TEST_COMMAND}${TOOLBAR_WRAPPER_ID_SUFFIX}`);
+            const node = commandItem?.toMenuNode?.();
+
+            expect(CommandMenu.is(node)).to.be.true;
+            if (!CommandMenu.is(node)) {
+                throw new Error('Expected a command menu node.');
+            }
+            expect(node.isVisible(TAB_BAR_TOOLBAR_CONTEXT_MENU, contextKeyService, testWidget.node, testWidget)).to.be.true;
+            expect(node.isEnabled(TAB_BAR_TOOLBAR_CONTEXT_MENU, testWidget)).to.be.true;
+            expect(node.isToggled(TAB_BAR_TOOLBAR_CONTEXT_MENU, testWidget)).to.be.true;
+            await node.run(TAB_BAR_TOOLBAR_CONTEXT_MENU, testWidget);
+            expect(executedWith).to.equal(testWidget);
+            testWidget.dispose();
+        });
+
+        it('preserves the widget for wrapped submenu emptiness checks', () => {
+            const testWidget = new TestToolbarWidget();
+            const commands = createCommandRegistry();
+            commands.registerCommand({ id: TEST_SUBMENU_COMMAND, label: 'Test Submenu Command' }, {
+                execute: () => { },
+                isVisible: widget => TestToolbarWidget.is(widget) && widget === testWidget
+            });
+            const menuRegistry = createMenuRegistry(commands);
+            menuRegistry.registerSubmenu([...TEST_MENU_PATH, 'other', 'test-submenu'], 'Test Submenu');
+            menuRegistry.registerMenuAction([...TEST_MENU_PATH, 'other', 'test-submenu'], { commandId: TEST_SUBMENU_COMMAND });
+            const registry = createToolbarRegistry(commands, menuRegistry, contextKeyService);
+            registry.registerMenuDelegate(TEST_MENU_PATH, TestToolbarWidget.is);
+            const submenuItem = registry.visibleItems(testWidget).find(item => item.id === `test-submenu${TOOLBAR_WRAPPER_ID_SUFFIX}`);
+            const node = submenuItem?.toMenuNode?.();
+
+            expect(CompoundMenuNode.is(node)).to.be.true;
+            if (!CompoundMenuNode.is(node)) {
+                throw new Error('Expected a compound menu node.');
+            }
+            expect(node.isEmpty(TAB_BAR_TOOLBAR_CONTEXT_MENU, contextKeyService, testWidget.node, testWidget)).to.be.false;
+            testWidget.dispose();
+        });
+
+    });
+
 });
+
+class TestToolbarWidget extends Widget {
+    static is(candidate?: Widget): candidate is TestToolbarWidget {
+        return candidate instanceof TestToolbarWidget;
+    }
+}
+
+class TestMenuNodeFactory implements MenuNodeFactory {
+
+    constructor(protected readonly commands: CommandRegistry) { }
+
+    createGroup(id: string, orderString?: string, when?: string): Group & MutableCompoundMenuNode {
+        return new GroupImpl(id, orderString, when);
+    }
+
+    createSubmenu(id: string, label: string, contextKeyOverlays: Record<string, string> | undefined, orderString?: string, icon?: string, when?: string):
+        Submenu & MutableCompoundMenuNode {
+        return new SubmenuImpl(id, label, contextKeyOverlays, orderString, icon, when);
+    }
+
+    createSubmenuLink(delegate: Submenu, sortString?: string, when?: string): MenuNode {
+        return new SubMenuLink(delegate, sortString, when);
+    }
+
+    createCommandMenu(item: MenuAction): CommandMenu {
+        return {
+            isVisible: (_path, _contextMatcher, _context, ...args) => this.commands.isVisible(item.commandId, ...args),
+            isEnabled: (_path, ...args) => this.commands.isEnabled(item.commandId, ...args),
+            isToggled: (_path, ...args) => this.commands.isToggled(item.commandId, ...args),
+            id: item.commandId,
+            label: item.label || this.commands.getCommand(item.commandId)?.label || '',
+            icon: item.icon,
+            when: item.when,
+            sortString: item.order || '',
+            run: async (_path, ...args) => { await this.commands.executeCommand(item.commandId, ...args); }
+        };
+    }
+}
+
+function createCommandRegistry(): CommandRegistry {
+    return new CommandRegistry({ getContributions: () => [] });
+}
+
+function createMenuRegistry(commands: CommandRegistry): MenuModelRegistry {
+    return new MenuModelRegistry({ getContributions: () => [] }, commands, new TestMenuNodeFactory(commands));
+}
+
+function createToolbarRegistry(commands: CommandRegistry, menuRegistry: MenuModelRegistry, contextKeyService: ContextKeyServiceDummyImpl): TabBarToolbarRegistry {
+    const registry = new TabBarToolbarRegistry();
+    Reflect.set(registry, 'commandRegistry', commands);
+    Reflect.set(registry, 'contextKeyService', contextKeyService);
+    Reflect.set(registry, 'menuRegistry', menuRegistry);
+    Reflect.set(registry, 'keybindingRegistry', {});
+    Reflect.set(registry, 'labelParser', {});
+    Reflect.set(registry, 'contextMenuRenderer', { render: () => undefined } as unknown as ContextMenuRenderer);
+    return registry;
+}


### PR DESCRIPTION
#### What it does

This PR fixes argument forwarding for tab bar toolbar menu delegates registered via `TabBarToolbarRegistry.registerMenuDelegate(...)`.

It is related to PR #16826, which made direct tab bar toolbar items pass the widget consistently to command enablement and toggled handling. Delegated toolbar menus still had similar gaps.

Before this fix:

* delegated menu visibility was evaluated without passing the active or delegated widget
* some toolbar menu wrapper classes forwarded command arguments as a single array argument
* submenu emptiness checks could evaluate child command visibility with the wrong arguments

As a result, commands contributed through delegated tab bar toolbar menus could disappear from the `More Actions...` menu if their `isVisible`, `isEnabled`, or `isToggled` handlers depended on receiving the widget argument.

This PR makes delegated menu handling consistent with direct toolbar item handling by passing the relevant widget through command visibility, enablement, toggled state, submenu emptiness checks, and execution.


#### How to test

1. Contribute a menu via `TabBarToolbarRegistry.registerMenuDelegate(...)`.
2. Add commands to that menu whose visibility, toggled state, enabled state, or execution depends on receiving the delegated widget.
3. Open the widget.
4. Open the tab bar toolbar `More Actions...` menu.
5. Verify that widget dependent commands are visible, have the correct state, and execute with the widget argument.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

I do not consider this a breaking change, although it is somewhat debatable.
The previous behavior appears to have been a bug. Delegated toolbar menu command handlers either did not receive the expected widget argument or received it in the wrong shape.
This PR aligns delegated menu handling with direct toolbar item handling.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
