### PR TITLE
chore(ai): update default models and aliases

### DIFF
--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -35,9 +35,11 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             description: nls.localize('theia/ai/anthropic/models/description', 'Official Anthropic models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
             default: [
+                'claude-opus-4-8',
                 'claude-opus-4-7',
                 'claude-sonnet-4-6',
                 'claude-haiku-4-5',
+                'claude-fable-5',
                 'claude-opus-4-6',
             ],
             items: {

--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -29,7 +29,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code',
             defaultModelIds: [
-                'anthropic/claude-opus-4-7',
+                'anthropic/claude-opus-4-8',
                 'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
@@ -38,7 +38,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/universal',
             defaultModelIds: [
-                'anthropic/claude-opus-4-7',
+                'anthropic/claude-opus-4-8',
                 'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],
@@ -56,7 +56,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/summarize',
             defaultModelIds: [
-                'anthropic/claude-opus-4-7',
+                'anthropic/claude-opus-4-8',
                 'openai/gpt-5.5',
                 'google/gemini-3.1-pro-preview'
             ],


### PR DESCRIPTION
Added Opus 4.8 as a new default.
Added Fable 5 (although it is currently not available)

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
