### PR TITLE
feat(ai-chat): surface when a chat is waiting for user input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 1.73.0 - tbd
 
+- [ai-chat] indicated and notified when a chat session is waiting for user input: the chat overview marks the session (bell icon, attention dot, bold title, tooltip badge) and a notification is shown; agent questions, tool confirmations, and the user-interaction tool now share this state
 - [ai-core] discovered skills from `.agents/skills` directories alongside `.prompts/skills` (workspace and home directory) [#17553](https://github.com/eclipse-theia/theia/pull/17553)
 - [ai-core] reorganized custom agents into per-agent folders (`agents/<id>/agent.md` with YAML frontmatter); existing `customAgents.yml` files are auto-migrated on startup and preserved as `customAgents.yml.bak`, and the default prompt-override file is now `prompt.prompttemplate` [#17523](https://github.com/eclipse-theia/theia/pull/17523)
 - [ai-chat-ui] replaced the back/forward navigation stack with a single Home button in the chat view header (hidden on the overview); added `Ctrl/Cmd+Shift+L` to trigger it
@@ -24,6 +25,7 @@
 - [ai-core] `combineSkillDirectories` signature changed: `workspaceSkillsDir` and `defaultSkillsDir` parameters are now `string[]` (previously `string | undefined`), and the return type is now `SkillDirectoryEntry[]` (an array of `{ path, tier }` entries) instead of `string[]` [#17553](https://github.com/eclipse-theia/theia/pull/17553)
 - [ai-core] `PromptFragmentCustomizationService` gained two required methods, `createCustomAgentFile` and `migrateCustomAgentsYaml`; adopters implementing this interface directly must provide them [#17523](https://github.com/eclipse-theia/theia/pull/17523)
 - [ai-core] `PromptFragmentCustomizationService.getCustomAgentsLocations()` now returns `CustomAgentsLocation[]`; each element gained a required `kind: 'agents-dir' | 'legacy-yaml'` field and the result mixes per-agent `agents/` directory entries with legacy `customAgents.yml` entries, so consumers must branch on `kind` instead of assuming yml-only results [#17523](https://github.com/eclipse-theia/theia/pull/17523)
+- [ai-core] renamed `AgentCompletionNotificationService` to `AgentNotificationService`, `CompletionNotificationOptions` to `AgentNotificationOptions`, and the `showCompletionNotification(agentId, options)` method to `showNotification(agentId, kind, options)`; `OSNotificationService.showAgentCompletionNotification(...)` was renamed to `showAgentNotification(agentName, kind, ...)`. These now cover both task-completion and input-needed notifications via a notification kind
 - [ai-mcp] `MCPServerManager.removeServer` and `MCPServerManager.addOrUpdateServer` are now asynchronous (return `Promise<void>` instead of `void`); callers must await them to ensure lifecycle cleanup (e.g. OAuth cancellation, credential removal) and consistent manager state [#17638](https://github.com/eclipse-theia/theia/pull/17638)
 - [debug] Made DebugSession injectable [#17510](https://github.com/eclipse-theia/theia/pull/17510)
   - removed public constructors from DebugSession and PluginDebugSession in favor of dependency injection

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -70,6 +70,7 @@ import { ChatCapabilitiesService, ChatCapabilitiesServiceImpl } from './chat-cap
 import { ChatInputCapabilitiesContribution } from './chat-input-capabilities-contribution';
 import { GenericCapabilitiesContribution, GenericCapabilitiesService, GenericCapabilitiesServiceImpl } from './generic-capabilities-service';
 import { ToolConfirmationKeybindingContribution } from './tool-confirmation-keybinding-contribution';
+import { ChatInputNeededNotificationContribution } from './chat-input-needed-notification-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindChatViewPreferences(bind);
@@ -111,6 +112,9 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(ToolConfirmationKeybindingContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(ToolConfirmationKeybindingContribution);
     bind(KeybindingContribution).toService(ToolConfirmationKeybindingContribution);
+
+    bind(ChatInputNeededNotificationContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(ChatInputNeededNotificationContribution);
 
     bindRootContributionProvider(bind, ChatResponsePartRenderer);
     bindRootContributionProvider(bind, ChatWelcomeMessageProvider);

--- a/packages/ai-chat-ui/src/browser/chat-input-needed-notification-contribution.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-needed-notification-contribution.spec.ts
@@ -1,0 +1,223 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { Emitter } from '@theia/core';
+import { ApplicationShell } from '@theia/core/lib/browser';
+import {
+    ChatModel,
+    ChatRequestModel,
+    ChatService,
+    ChatSession
+} from '@theia/ai-chat';
+import {
+    AgentNotificationKind,
+    AGENT_NOTIFICATION_KIND_INPUT_NEEDED
+} from '@theia/ai-core';
+import { AgentNotificationService, AgentNotificationOptions } from '@theia/ai-core/lib/browser';
+import { ChatInputNeededNotificationContribution } from './chat-input-needed-notification-contribution';
+
+disableJSDOM();
+
+interface FakeRequest {
+    agentId?: string;
+    response: { isWaitingForInput: boolean; agentId?: string };
+}
+
+interface NotificationCall {
+    agentId: string;
+    kind: AgentNotificationKind;
+    options?: AgentNotificationOptions;
+}
+
+class FakeChatModel {
+    readonly id = 'test-model';
+    protected readonly emitter = new Emitter<void>();
+    readonly onDidChange = this.emitter.event;
+    requests: FakeRequest[] = [];
+
+    getRequests(): ChatRequestModel[] {
+        return this.requests as unknown as ChatRequestModel[];
+    }
+
+    fireChange(): void {
+        this.emitter.fire();
+    }
+}
+
+function createSession(id: string, model: FakeChatModel, title = 'Session ' + id): ChatSession {
+    return {
+        id,
+        title,
+        model: model as unknown as ChatModel,
+        isActive: false
+    };
+}
+
+class TestableContribution extends ChatInputNeededNotificationContribution {
+    // Expose protected hooks so we can drive the contribution from tests without going through DI.
+    setChatService(service: ChatService): void {
+        (this as unknown as { chatService: ChatService }).chatService = service;
+    }
+    setNotificationService(service: AgentNotificationService): void {
+        (this as unknown as { notificationService: AgentNotificationService }).notificationService = service;
+    }
+    setShell(shell: ApplicationShell): void {
+        (this as unknown as { shell: ApplicationShell }).shell = shell;
+    }
+}
+
+describe('ChatInputNeededNotificationContribution', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    let contribution: TestableContribution;
+    let chatModel: FakeChatModel;
+    let session: ChatSession;
+    let notifications: NotificationCall[];
+    let chatService: ChatService;
+    let sessionEventEmitter: Emitter<unknown>;
+
+    beforeEach(() => {
+        chatModel = new FakeChatModel();
+        session = createSession('session-1', chatModel);
+
+        notifications = [];
+        const notificationService = {
+            async showNotification(agentId: string, kind: AgentNotificationKind, options?: AgentNotificationOptions): Promise<void> {
+                notifications.push({ agentId, kind, options });
+            }
+        } as unknown as AgentNotificationService;
+
+        sessionEventEmitter = new Emitter<unknown>();
+        chatService = {
+            getSessions: () => [session],
+            getSession: (id: string) => (id === session.id ? session : undefined),
+            onSessionEvent: sessionEventEmitter.event,
+            setActiveSession: () => { /* no-op */ }
+        } as unknown as ChatService;
+
+        const shell = { currentWidget: undefined } as unknown as ApplicationShell;
+
+        contribution = new TestableContribution();
+        contribution.setChatService(chatService);
+        contribution.setNotificationService(notificationService);
+        contribution.setShell(shell);
+        contribution.onStart();
+    });
+
+    it('fires a notification on the false → true transition', () => {
+        chatModel.requests = [{
+            agentId: 'agent-a',
+            response: { isWaitingForInput: true }
+        }];
+        chatModel.fireChange();
+
+        expect(notifications).to.have.lengthOf(1);
+        expect(notifications[0].agentId).to.equal('agent-a');
+        expect(notifications[0].kind).to.equal(AGENT_NOTIFICATION_KIND_INPUT_NEEDED);
+        expect(notifications[0].options?.sessionTitle).to.equal(session.title);
+    });
+
+    it('does not re-fire on repeated changes while still waiting', () => {
+        chatModel.requests = [{
+            agentId: 'agent-a',
+            response: { isWaitingForInput: true }
+        }];
+        chatModel.fireChange();
+        chatModel.fireChange();
+        chatModel.fireChange();
+
+        expect(notifications).to.have.lengthOf(1);
+    });
+
+    it('fires again after the waiting state cleared and then started again', () => {
+        chatModel.requests = [{
+            agentId: 'agent-a',
+            response: { isWaitingForInput: true }
+        }];
+        chatModel.fireChange();
+
+        // Clear the waiting state — e.g. confirmation was answered.
+        chatModel.requests = [{
+            agentId: 'agent-a',
+            response: { isWaitingForInput: false }
+        }];
+        chatModel.fireChange();
+
+        // A new waiting-for-input request appears.
+        chatModel.requests = [{
+            agentId: 'agent-a',
+            response: { isWaitingForInput: true }
+        }];
+        chatModel.fireChange();
+
+        expect(notifications).to.have.lengthOf(2);
+    });
+
+    it('does not fire when nothing is waiting for input', () => {
+        chatModel.requests = [{
+            agentId: 'agent-a',
+            response: { isWaitingForInput: false }
+        }];
+        chatModel.fireChange();
+
+        expect(notifications).to.have.lengthOf(0);
+    });
+
+    it('falls back to the response.agentId when the request has no agentId', () => {
+        chatModel.requests = [{
+            response: { isWaitingForInput: true, agentId: 'response-agent' }
+        }];
+        chatModel.fireChange();
+
+        expect(notifications).to.have.lengthOf(1);
+        expect(notifications[0].agentId).to.equal('response-agent');
+    });
+
+    it('does not fire when no agent id is available on the waiting request', () => {
+        chatModel.requests = [{
+            response: { isWaitingForInput: true }
+        }];
+        chatModel.fireChange();
+
+        expect(notifications).to.have.lengthOf(0);
+    });
+
+    it('does not double-watch a session when a created event arrives after onStart', () => {
+        // The session was already returned from getSessions() in onStart, so re-watching it via
+        // the 'created' event must not install a second listener that would fire duplicate
+        // notifications.
+        sessionEventEmitter.fire({ type: 'created', sessionId: session.id });
+
+        chatModel.requests = [{
+            agentId: 'agent-a',
+            response: { isWaitingForInput: true }
+        }];
+        chatModel.fireChange();
+
+        expect(notifications).to.have.lengthOf(1);
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-input-needed-notification-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/chat-input-needed-notification-contribution.ts
@@ -1,0 +1,103 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatService, ChatSession } from '@theia/ai-chat';
+import { DisposableCollection } from '@theia/core';
+import { ApplicationShell, FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { AGENT_NOTIFICATION_KIND_INPUT_NEEDED } from '@theia/ai-core';
+import { AgentNotificationService } from '@theia/ai-core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { isChatSessionFocused } from './chat-session-focus';
+
+interface SessionWaitingState {
+    /** Whether any request in the session was waiting for input at the last observed change. */
+    waiting: boolean;
+    listener: DisposableCollection;
+}
+
+/**
+ * Fires an agent notification when a chat session starts waiting for user input (e.g. a tool
+ * confirmation or an agent question). Watches all sessions, not just the active one, so that a
+ * background session requesting input still reaches the user. The agent completion notification
+ * (handled in the chat input widget) and this input-needed notification share the same delivery
+ * channel and user preference via {@link AgentNotificationService}.
+ */
+@injectable()
+export class ChatInputNeededNotificationContribution implements FrontendApplicationContribution {
+
+    @inject(ChatService)
+    protected readonly chatService: ChatService;
+
+    @inject(AgentNotificationService)
+    protected readonly notificationService: AgentNotificationService;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    protected readonly states = new Map<string, SessionWaitingState>();
+
+    onStart(): void {
+        this.chatService.getSessions().forEach(session => this.watchSession(session));
+        this.chatService.onSessionEvent(event => {
+            if (event.type === 'created') {
+                const session = this.chatService.getSession(event.sessionId);
+                if (session) {
+                    this.watchSession(session);
+                }
+            } else if (event.type === 'deleted') {
+                this.unwatchSession(event.sessionId);
+            }
+        });
+    }
+
+    protected watchSession(session: ChatSession): void {
+        if (this.states.has(session.id)) {
+            return;
+        }
+        const state: SessionWaitingState = {
+            waiting: session.model.getRequests().some(request => request.response.isWaitingForInput),
+            listener: new DisposableCollection()
+        };
+        this.states.set(session.id, state);
+        session.model.onDidChange(() => this.handleSessionChanged(session, state), undefined, state.listener);
+    }
+
+    protected handleSessionChanged(session: ChatSession, state: SessionWaitingState): void {
+        const waitingRequest = session.model.getRequests().find(request => request.response.isWaitingForInput);
+        const nowWaiting = waitingRequest !== undefined;
+        // Only notify on the transition into waiting, so repeated model changes while still
+        // waiting do not produce duplicate notifications.
+        if (nowWaiting && !state.waiting) {
+            const agentId = waitingRequest.agentId ?? waitingRequest.response.agentId;
+            if (agentId) {
+                this.notificationService.showNotification(agentId, AGENT_NOTIFICATION_KIND_INPUT_NEEDED, {
+                    shouldSuppress: () => isChatSessionFocused(this.shell, this.chatService, session.id),
+                    onActivate: () => this.chatService.setActiveSession(session.id, { focus: true }),
+                    sessionTitle: session.title
+                });
+            }
+        }
+        state.waiting = nowWaiting;
+    }
+
+    protected unwatchSession(sessionId: string): void {
+        const state = this.states.get(sessionId);
+        if (state) {
+            state.listener.dispose();
+            this.states.delete(sessionId);
+        }
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -23,12 +23,12 @@ import { ParsedChatRequest } from '@theia/ai-chat/lib/common/parsed-chat-request
 import {
     GenericCapabilitySelections, AIVariableResolutionRequest, ParsedCapability,
     FrontendLanguageModelRegistry, ReasoningLevel, ReasoningSettings, ReasoningSupport,
-    PREFERENCE_NAME_REASONING, ReasoningPreferenceEntry
+    PREFERENCE_NAME_REASONING, ReasoningPreferenceEntry, AGENT_NOTIFICATION_KIND_COMPLETED
 } from '@theia/ai-core';
 import { mergeReasoningSettings } from '@theia/ai-core/lib/browser/frontend-language-model-service';
 import { ChangeSetDecoratorService } from '@theia/ai-chat/lib/browser/change-set-decorator-service';
 import { ImageContextVariable } from '@theia/ai-chat/lib/common/image-context-variable';
-import { AgentCompletionNotificationService, FrontendVariableService, AIActivationService, CompletionNotificationOptions } from '@theia/ai-core/lib/browser';
+import { AgentNotificationService, FrontendVariableService, AIActivationService, AgentNotificationOptions } from '@theia/ai-core/lib/browser';
 import { AISettingsService, PromptService } from '@theia/ai-core/lib/common';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 import { CommandService, DisposableCollection, Emitter, InMemoryResources, MessageService, URI, nls, Disposable, ILogger } from '@theia/core';
@@ -74,6 +74,7 @@ import {
     getUsageColorClass
 } from './chat-token-usage-indicator-util';
 import { AI_CHAT_HOME, ChatCommands } from './chat-view-commands';
+import { isChatSessionFocused } from './chat-session-focus';
 
 type Query = (query: string, mode?: string, capabilityOverrides?: Record<string, boolean>, genericCapabilitySelections?: GenericCapabilitySelections) => Promise<void>;
 type Unpin = () => void;
@@ -121,8 +122,8 @@ export class AIChatInputWidget extends ReactWidget {
     @inject(ChangeSetActionService)
     protected readonly changeSetActionService: ChangeSetActionService;
 
-    @inject(AgentCompletionNotificationService)
-    protected readonly agentNotificationService: AgentCompletionNotificationService;
+    @inject(AgentNotificationService)
+    protected readonly agentNotificationService: AgentNotificationService;
 
     @inject(ChangeSetDecoratorService)
     protected readonly changeSetDecoratorService: ChangeSetDecoratorService;
@@ -1218,12 +1219,12 @@ export class AIChatInputWidget extends ReactWidget {
                 const session = this.chatService.getSession(sessionId);
                 const sessionTitle = session?.title;
 
-                const options: CompletionNotificationOptions = {
+                const options: AgentNotificationOptions = {
                     shouldSuppress: () => this.isChatSessionFocused(sessionId),
                     onActivate: () => this.focusChatSession(sessionId),
                     sessionTitle,
                 };
-                await this.agentNotificationService.showCompletionNotification(agentId, options);
+                await this.agentNotificationService.showNotification(agentId, AGENT_NOTIFICATION_KIND_COMPLETED, options);
             }
         } catch (error) {
             this.logger.error('Failed to handle agent completion notification:', error);
@@ -1235,12 +1236,7 @@ export class AIChatInputWidget extends ReactWidget {
      * Returns true only if the chat widget is focused AND viewing the same session.
      */
     protected isChatSessionFocused(sessionId: string): boolean {
-        const activeWidget = this.applicationShell.activeWidget;
-        if (!activeWidget || activeWidget.id !== 'chat-view-widget') {
-            return false;
-        }
-        const activeSession = this.chatService.getActiveSession();
-        return activeSession?.id === sessionId;
+        return isChatSessionFocused(this.applicationShell, this.chatService, sessionId);
     }
 
     /**

--- a/packages/ai-chat-ui/src/browser/chat-session-focus.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-session-focus.spec.ts
@@ -1,0 +1,122 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import { ApplicationShell } from '@theia/core/lib/browser';
+import { ChatService, ChatSession } from '@theia/ai-chat';
+import { isChatSessionFocused } from './chat-session-focus';
+
+disableJSDOM();
+
+const CHAT_VIEW_WIDGET_ID = 'chat-view-widget';
+
+interface FakeWidget {
+    id: string;
+    isVisible: boolean;
+}
+
+function createShell(currentWidget?: FakeWidget): ApplicationShell {
+    return { currentWidget } as unknown as ApplicationShell;
+}
+
+function createChatService(activeSessionId?: string): ChatService {
+    return {
+        getActiveSession(): ChatSession | undefined {
+            return activeSessionId ? ({ id: activeSessionId } as ChatSession) : undefined;
+        }
+    } as unknown as ChatService;
+}
+
+describe('isChatSessionFocused', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    let originalHasFocus: typeof document.hasFocus;
+
+    beforeEach(() => {
+        originalHasFocus = document.hasFocus.bind(document);
+    });
+
+    afterEach(() => {
+        // Restore the original implementation so other tests are unaffected.
+        Object.defineProperty(document, 'hasFocus', { value: originalHasFocus, configurable: true });
+    });
+
+    function mockDocumentFocus(focused: boolean): void {
+        Object.defineProperty(document, 'hasFocus', { value: () => focused, configurable: true });
+    }
+
+    it('returns false when the window does not have focus', () => {
+        mockDocumentFocus(false);
+        const shell = createShell({ id: CHAT_VIEW_WIDGET_ID, isVisible: true });
+        const chatService = createChatService('session-1');
+
+        // Even with the chat view visible and the matching session active, switching to a
+        // different application should still let notifications through.
+        expect(isChatSessionFocused(shell, chatService, 'session-1')).to.equal(false);
+    });
+
+    it('returns false when the active session does not match', () => {
+        mockDocumentFocus(true);
+        const shell = createShell({ id: CHAT_VIEW_WIDGET_ID, isVisible: true });
+        const chatService = createChatService('session-other');
+
+        expect(isChatSessionFocused(shell, chatService, 'session-1')).to.equal(false);
+    });
+
+    it('returns false when no widget is current', () => {
+        mockDocumentFocus(true);
+        const shell = createShell(undefined);
+        const chatService = createChatService('session-1');
+
+        expect(isChatSessionFocused(shell, chatService, 'session-1')).to.equal(false);
+    });
+
+    it('returns false when the current widget is not the chat view', () => {
+        mockDocumentFocus(true);
+        const shell = createShell({ id: 'some-other-widget', isVisible: true });
+        const chatService = createChatService('session-1');
+
+        expect(isChatSessionFocused(shell, chatService, 'session-1')).to.equal(false);
+    });
+
+    it('returns false when the chat view is the current widget but not visible', () => {
+        mockDocumentFocus(true);
+        const shell = createShell({ id: CHAT_VIEW_WIDGET_ID, isVisible: false });
+        const chatService = createChatService('session-1');
+
+        expect(isChatSessionFocused(shell, chatService, 'session-1')).to.equal(false);
+    });
+
+    it('returns true when window is focused, chat view is current and visible, and session matches', () => {
+        mockDocumentFocus(true);
+        const shell = createShell({ id: CHAT_VIEW_WIDGET_ID, isVisible: true });
+        const chatService = createChatService('session-1');
+
+        // This is the suppression case: the user is already looking at the waiting session, so
+        // any agent notification for it should be suppressed.
+        expect(isChatSessionFocused(shell, chatService, 'session-1')).to.equal(true);
+    });
+});

--- a/packages/ai-chat-ui/src/browser/chat-session-focus.ts
+++ b/packages/ai-chat-ui/src/browser/chat-session-focus.ts
@@ -1,0 +1,50 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatService } from '@theia/ai-chat';
+import { ApplicationShell } from '@theia/core/lib/browser';
+
+/** Id of the chat view widget. Kept in sync with `ChatViewWidget.ID`. */
+const CHAT_VIEW_WIDGET_ID = 'chat-view-widget';
+
+/**
+ * Whether the user is currently looking at the given session in the chat view. In that case the
+ * user is already aware of what is happening, so notifications about it (completion, input
+ * needed) should be suppressed.
+ *
+ * This deliberately uses {@link ApplicationShell.currentWidget} rather than the focused widget:
+ * while an agent is running, the chat input editor is disabled and loses DOM focus, but the user
+ * is still looking at the chat. `currentWidget` remains the chat view until the user activates a
+ * different widget, whereas `activeWidget` would already be `undefined`. The window must also have
+ * focus, otherwise the user has switched to another application and should still be notified.
+ *
+ * Lives in this standalone module (rather than on the `ChatViewWidget` namespace) so that
+ * `chat-input-widget` can use it without importing `chat-view-widget`, which would form a
+ * load-time import cycle (chat-view-widget → chat tree widgets → chat-input-widget). For the same
+ * reason it matches the chat view by id rather than `instanceof ChatViewWidget`.
+ */
+export function isChatSessionFocused(shell: ApplicationShell, chatService: ChatService, sessionId: string): boolean {
+    if (!document.hasFocus()) {
+        return false;
+    }
+    if (chatService.getActiveSession()?.id !== sessionId) {
+        return false;
+    }
+    // currentWidget rather than activeWidget: the chat view stays the current widget even when
+    // its input editor is disabled and blurred while the agent runs.
+    const current = shell.currentWidget;
+    return current?.id === CHAT_VIEW_WIDGET_ID && current.isVisible;
+}

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -85,7 +85,14 @@ export class FrontendChatToolRequestService extends ChatToolRequestService {
                             toolCallContent.confirmationTimeout = timeoutSeconds;
                             toolCallContent.requestUserConfirmation();
                             request.response.fireInteractionNeeded(toolCallContent);
-                            confirmed = await raceConfirmationWithTimeout(toolCallContent, timeoutSeconds);
+                            // Mark the response as waiting for input so the pending confirmation is
+                            // surfaced consistently with agent questions (e.g. in the session overview).
+                            request.response.waitForInput();
+                            try {
+                                confirmed = await raceConfirmationWithTimeout(toolCallContent, timeoutSeconds);
+                            } finally {
+                                request.response.stopWaitingForInput();
+                            }
                         }
 
                         if (confirmed) {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -2909,7 +2909,10 @@ export class MutableChatResponseModel implements ChatResponseModel {
     protected _progressMessages: ChatProgressMessage[];
     protected _response: ChatResponseImpl;
     protected _isComplete: boolean;
-    protected _isWaitingForInput: boolean;
+    // Reference count of in-flight requests for user input (agent questions and pending tool-call
+    // confirmations). The response is "waiting for input" while this is greater than zero, so that
+    // multiple parallel confirmations all have to resolve before the waiting state clears.
+    protected _waitingForInputCount: number = 0;
     protected _agentId?: string;
     protected _isError: boolean;
     protected _errorObject: Error | undefined;
@@ -2936,7 +2939,7 @@ export class MutableChatResponseModel implements ChatResponseModel {
             this._id = generateUuid();
             this._progressMessages = [];
             this._isComplete = false;
-            this._isWaitingForInput = false;
+            this._waitingForInputCount = 0;
             this._isError = false;
         }
 
@@ -2956,7 +2959,7 @@ export class MutableChatResponseModel implements ChatResponseModel {
 
         // Do not restore waitingForInput state - when a session is restored,
         // the agent that was waiting for input is no longer running
-        this._isWaitingForInput = false;
+        this._waitingForInputCount = 0;
         // TODO: Restore progressMessages?
         this._progressMessages = [];
         this._promptVariantId = data.promptVariantId;
@@ -3026,7 +3029,7 @@ export class MutableChatResponseModel implements ChatResponseModel {
     }
 
     get isWaitingForInput(): boolean {
-        return this._isWaitingForInput;
+        return this._waitingForInputCount > 0;
     }
 
     get agentId(): string | undefined {
@@ -3071,14 +3074,14 @@ export class MutableChatResponseModel implements ChatResponseModel {
 
     complete(): void {
         this._isComplete = true;
-        this._isWaitingForInput = false;
+        this._waitingForInputCount = 0;
         this._onDidChangeEmitter.fire();
     }
 
     cancel(): void {
         this._cancellationToken.cancel();
         this._isComplete = true;
-        this._isWaitingForInput = false;
+        this._waitingForInputCount = 0;
 
         // Ensure any pending tool confirmations are canceled when the chat is canceled
         try {
@@ -3100,12 +3103,14 @@ export class MutableChatResponseModel implements ChatResponseModel {
     }
 
     waitForInput(): void {
-        this._isWaitingForInput = true;
+        this._waitingForInputCount++;
         this._onDidChangeEmitter.fire();
     }
 
     stopWaitingForInput(): void {
-        this._isWaitingForInput = false;
+        if (this._waitingForInputCount > 0) {
+            this._waitingForInputCount--;
+        }
         this._onDidChangeEmitter.fire();
     }
 
@@ -3119,7 +3124,7 @@ export class MutableChatResponseModel implements ChatResponseModel {
 
     error(error: Error): void {
         this._isComplete = true;
-        this._isWaitingForInput = false;
+        this._waitingForInputCount = 0;
         this._isError = true;
         this._errorObject = error;
         this._onDidChangeEmitter.fire();

--- a/packages/ai-chat/src/common/chat-response-model.spec.ts
+++ b/packages/ai-chat/src/common/chat-response-model.spec.ts
@@ -63,4 +63,91 @@ describe('MutableChatResponseModel', () => {
             expect(response.tokenUsageEntries[1]).to.deep.equal(usage2);
         });
     });
+
+    describe('waiting-for-input ref counting', () => {
+        it('should not be waiting for input initially', () => {
+            const response = new MutableChatResponseModel('req-1');
+            expect(response.isWaitingForInput).to.equal(false);
+        });
+
+        it('should be waiting after a single waitForInput call', () => {
+            const response = new MutableChatResponseModel('req-1');
+            response.waitForInput();
+            expect(response.isWaitingForInput).to.equal(true);
+        });
+
+        it('should stay waiting until all parallel waitForInput calls are released', () => {
+            const response = new MutableChatResponseModel('req-1');
+
+            response.waitForInput();
+            response.waitForInput();
+            expect(response.isWaitingForInput).to.equal(true);
+
+            response.stopWaitingForInput();
+            // Still waiting because the second waitForInput has not been released yet.
+            expect(response.isWaitingForInput).to.equal(true);
+
+            response.stopWaitingForInput();
+            expect(response.isWaitingForInput).to.equal(false);
+        });
+
+        it('should clamp at zero on extra stopWaitingForInput calls (underflow guard)', () => {
+            const response = new MutableChatResponseModel('req-1');
+
+            response.waitForInput();
+            response.stopWaitingForInput();
+            // Extra release: must not push the counter negative, otherwise a later waitForInput
+            // would have to be called twice before isWaitingForInput becomes true again.
+            response.stopWaitingForInput();
+            expect(response.isWaitingForInput).to.equal(false);
+
+            response.waitForInput();
+            expect(response.isWaitingForInput).to.equal(true);
+        });
+
+        it('should fire onDidChange on each waitForInput / stopWaitingForInput', () => {
+            const response = new MutableChatResponseModel('req-1');
+            let fireCount = 0;
+            response.onDidChange(() => { fireCount++; });
+
+            response.waitForInput();
+            response.stopWaitingForInput();
+
+            expect(fireCount).to.equal(2);
+        });
+
+        it('should hard-reset the waiting state on complete()', () => {
+            const response = new MutableChatResponseModel('req-1');
+            response.waitForInput();
+            response.waitForInput();
+
+            response.complete();
+
+            expect(response.isWaitingForInput).to.equal(false);
+            // Counter is fully reset, not merely decremented: a subsequent stopWaitingForInput
+            // must not flip the state back via underflow.
+            response.stopWaitingForInput();
+            expect(response.isWaitingForInput).to.equal(false);
+        });
+
+        it('should hard-reset the waiting state on cancel()', () => {
+            const response = new MutableChatResponseModel('req-1');
+            response.waitForInput();
+            response.waitForInput();
+
+            response.cancel();
+
+            expect(response.isWaitingForInput).to.equal(false);
+        });
+
+        it('should hard-reset the waiting state on error()', () => {
+            const response = new MutableChatResponseModel('req-1');
+            response.waitForInput();
+            response.waitForInput();
+
+            response.error(new Error('boom'));
+
+            expect(response.isWaitingForInput).to.equal(false);
+        });
+    });
 });

--- a/packages/ai-core/src/browser/agent-notification-service.ts
+++ b/packages/ai-core/src/browser/agent-notification-service.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2025 EclipseSource GmbH.
+// Copyright (C) 2025 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -30,13 +30,15 @@ import {
     NOTIFICATION_TYPE_OS_NOTIFICATION,
     NOTIFICATION_TYPE_MESSAGE,
     NOTIFICATION_TYPE_BLINK,
+    AgentNotificationKind,
+    AGENT_NOTIFICATION_KIND_INPUT_NEEDED,
 } from '../common/notification-types';
 import { PreferenceService, ILogger } from '@theia/core';
 
 /**
- * Options for showing a completion notification.
+ * Options for showing an agent notification.
  */
-export interface CompletionNotificationOptions {
+export interface AgentNotificationOptions {
     /**
      * Callback to check if the notification should be suppressed.
      * If returns true, the notification will not be shown.
@@ -55,7 +57,7 @@ export interface CompletionNotificationOptions {
 }
 
 @injectable()
-export class AgentCompletionNotificationService {
+export class AgentNotificationService {
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
 
@@ -74,18 +76,20 @@ export class AgentCompletionNotificationService {
     @inject(WindowBlinkService)
     protected readonly windowBlinkService: WindowBlinkService;
 
-    @inject(ILogger) @named('ai-core:AgentCompletionNotificationService')
+    @inject(ILogger) @named('ai-core:AgentNotificationService')
     protected readonly logger: ILogger;
 
     /**
-     * Show a completion notification for the specified agent if enabled in preferences.
+     * Show a notification for the specified agent if enabled in preferences.
      *
      * @param agentId The unique identifier of the agent
+     * @param kind Whether the agent completed its task or needs user input
      * @param options Optional configuration for the notification
      */
-    async showCompletionNotification(
+    async showNotification(
         agentId: string,
-        options?: CompletionNotificationOptions,
+        kind: AgentNotificationKind,
+        options?: AgentNotificationOptions,
     ): Promise<void> {
         const notificationType =
             await this.getNotificationTypeForAgent(agentId);
@@ -103,13 +107,14 @@ export class AgentCompletionNotificationService {
             const agentName = this.resolveAgentName(agentId);
             await this.executeNotificationType(
                 agentName,
+                kind,
                 notificationType,
                 options?.onActivate,
                 options?.sessionTitle,
             );
         } catch (error) {
             this.logger.error(
-                'Failed to show agent completion notification:',
+                'Failed to show agent notification:',
                 error,
             );
         }
@@ -162,16 +167,17 @@ export class AgentCompletionNotificationService {
      */
     private async executeNotificationType(
         agentName: string,
+        kind: AgentNotificationKind,
         type: NotificationType,
         onActivate?: () => void,
         sessionTitle?: string,
     ): Promise<void> {
         switch (type) {
             case NOTIFICATION_TYPE_OS_NOTIFICATION:
-                await this.showOSNotification(agentName, onActivate, sessionTitle);
+                await this.showOSNotification(agentName, kind, onActivate, sessionTitle);
                 break;
             case NOTIFICATION_TYPE_MESSAGE:
-                await this.showMessageServiceNotification(agentName, onActivate, sessionTitle);
+                await this.showMessageServiceNotification(agentName, kind, onActivate, sessionTitle);
                 break;
             case NOTIFICATION_TYPE_BLINK:
                 await this.showBlinkNotification(agentName);
@@ -186,12 +192,14 @@ export class AgentCompletionNotificationService {
      */
     protected async showOSNotification(
         agentName: string,
+        kind: AgentNotificationKind,
         onActivate?: () => void,
         sessionTitle?: string,
     ): Promise<void> {
         const result =
-            await this.osNotificationService.showAgentCompletionNotification(
+            await this.osNotificationService.showAgentNotification(
                 agentName,
+                kind,
                 sessionTitle,
                 onActivate,
             );
@@ -205,21 +213,35 @@ export class AgentCompletionNotificationService {
      */
     protected async showMessageServiceNotification(
         agentName: string,
+        kind: AgentNotificationKind,
         onActivate?: () => void,
         sessionTitle?: string,
     ): Promise<void> {
-        const message = sessionTitle
-            ? nls.localize(
-                'theia/ai-core/agentCompletionMessageWithSession',
-                'Agent "{0}" has completed its task in "{1}".',
-                agentName,
-                sessionTitle,
-            )
-            : nls.localize(
-                'theia/ai-core/agentCompletionMessage',
-                'Agent "{0}" has completed its task.',
-                agentName,
-            );
+        const message = kind === AGENT_NOTIFICATION_KIND_INPUT_NEEDED
+            ? (sessionTitle
+                ? nls.localize(
+                    'theia/ai-core/agentInputNeededMessageWithSession',
+                    'Agent "{0}" needs your input in "{1}".',
+                    agentName,
+                    sessionTitle,
+                )
+                : nls.localize(
+                    'theia/ai-core/agentInputNeededMessage',
+                    'Agent "{0}" needs your input.',
+                    agentName,
+                ))
+            : (sessionTitle
+                ? nls.localize(
+                    'theia/ai-core/agentCompletionMessageWithSession',
+                    'Agent "{0}" has completed its task in "{1}".',
+                    agentName,
+                    sessionTitle,
+                )
+                : nls.localize(
+                    'theia/ai-core/agentCompletionMessage',
+                    'Agent "{0}" has completed its task.',
+                    agentName,
+                ));
         const showChatAction = nls.localize('theia/ai-core/showChat', 'Show Chat');
         const action = await this.messageService.info(message, showChatAction);
         if (action === showChatAction && onActivate) {

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -84,7 +84,7 @@ import { FrontendLanguageModelServiceImpl } from './frontend-language-model-serv
 import { TokenUsageFrontendService } from './token-usage-frontend-service';
 import { TokenUsageFrontendServiceImpl, TokenUsageServiceClientImpl } from './token-usage-frontend-service-impl';
 import { AIVariableUriLabelProvider } from './ai-variable-uri-label-provider';
-import { AgentCompletionNotificationService } from './agent-completion-notification-service';
+import { AgentNotificationService } from './agent-notification-service';
 import { OSNotificationService } from './os-notification-service';
 import { WindowBlinkService } from './window-blink-service';
 
@@ -208,7 +208,7 @@ export default new ContainerModule(bind => {
     bind(AIVariableUriLabelProvider).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(AIVariableUriLabelProvider);
 
-    bind(AgentCompletionNotificationService).toSelf().inSingletonScope();
+    bind(AgentNotificationService).toSelf().inSingletonScope();
     bind(OSNotificationService).toSelf().inSingletonScope();
     bind(WindowBlinkService).toSelf().inSingletonScope();
     bind(ConfigurableInMemoryResources).toSelf().inSingletonScope();

--- a/packages/ai-core/src/browser/index.ts
+++ b/packages/ai-core/src/browser/index.ts
@@ -14,7 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-export * from './agent-completion-notification-service';
+export * from './agent-notification-service';
 export * from './os-notification-service';
 export * from './window-blink-service';
 export * from './ai-activation-service';

--- a/packages/ai-core/src/browser/os-notification-service.ts
+++ b/packages/ai-core/src/browser/os-notification-service.ts
@@ -17,6 +17,7 @@
 import { injectable, inject, named } from '@theia/core/shared/inversify';
 import { nls } from '@theia/core/lib/common/nls';
 import { environment, ILogger } from '@theia/core';
+import { AgentNotificationKind, AGENT_NOTIFICATION_KIND_INPUT_NEEDED } from '../common/notification-types';
 
 /**
  * Configuration options for OS notifications
@@ -152,33 +153,44 @@ export class OSNotificationService {
     }
 
     /**
-     * Show a notification specifically for agent completion
-     * This is a convenience method with pre-configured options for agent notifications
+     * Show a notification for an agent event (task completed or input needed).
+     * This is a convenience method with pre-configured options for agent notifications.
      *
-     * @param agentName The name of the agent that completed
+     * @param agentName The name of the agent
+     * @param kind Whether the agent completed its task or needs user input
      * @param sessionTitle Optional title of the chat session for identification
      * @param onClickCallback Optional callback to invoke when the notification is clicked
      * @returns Promise resolving to the notification result
      */
-    async showAgentCompletionNotification(
+    async showAgentNotification(
         agentName: string,
+        kind: AgentNotificationKind,
         sessionTitle?: string,
         onClickCallback?: () => void,
     ): Promise<OSNotificationResult> {
-        const title = nls.localize('theia/ai-core/agentCompletionTitle', 'Agent "{0}" Task Completed', agentName);
-        const body = sessionTitle
-            ? nls.localize('theia/ai-core/agentCompletionMessageWithSession',
-                'Agent "{0}" has completed its task in "{1}".', agentName, sessionTitle)
-            : nls.localize('theia/ai-core/agentCompletionMessage',
-                'Agent "{0}" has completed its task.', agentName);
+        const inputNeeded = kind === AGENT_NOTIFICATION_KIND_INPUT_NEEDED;
+        const title = inputNeeded
+            ? nls.localize('theia/ai-core/agentInputNeededTitle', 'Agent "{0}" Needs Your Input', agentName)
+            : nls.localize('theia/ai-core/agentCompletionTitle', 'Agent "{0}" Task Completed', agentName);
+        const body = inputNeeded
+            ? (sessionTitle
+                ? nls.localize('theia/ai-core/agentInputNeededMessageWithSession',
+                    'Agent "{0}" needs your input in "{1}".', agentName, sessionTitle)
+                : nls.localize('theia/ai-core/agentInputNeededMessage',
+                    'Agent "{0}" needs your input.', agentName))
+            : (sessionTitle
+                ? nls.localize('theia/ai-core/agentCompletionMessageWithSession',
+                    'Agent "{0}" has completed its task in "{1}".', agentName, sessionTitle)
+                : nls.localize('theia/ai-core/agentCompletionMessage',
+                    'Agent "{0}" has completed its task.', agentName));
 
         return this.showNotification(title, {
             body,
-            icon: this.getAgentCompletionIcon(),
-            tag: `agent-completion-${agentName}-${sessionTitle ?? 'default'}`,
+            icon: this.getAgentNotificationIcon(),
+            tag: `agent-${kind}-${agentName}-${sessionTitle ?? 'default'}`,
             requireInteraction: false,
             data: {
-                type: 'agent-completion',
+                type: `agent-${kind}`,
                 agentName,
                 sessionTitle,
                 timestamp: Date.now()
@@ -279,11 +291,11 @@ export class OSNotificationService {
     }
 
     /**
-     * Get the icon URL for agent completion notifications
+     * Get the icon URL for agent notifications
      *
      * @returns The icon URL or undefined if not available
      */
-    private getAgentCompletionIcon(): string | undefined {
+    private getAgentNotificationIcon(): string | undefined {
         // This could return a path to an icon file
         // For now, we'll return undefined to use the default system icon
         return undefined;

--- a/packages/ai-core/src/common/agent-preferences.ts
+++ b/packages/ai-core/src/common/agent-preferences.ts
@@ -79,9 +79,10 @@ export const AgentSettingsPreferenceSchema: PreferenceSchema = {
                     completionNotification: {
                         type: 'string',
                         enum: [...NOTIFICATION_TYPES],
-                        title: nls.localize('theia/ai/agents/completionNotification/title', 'Completion Notification'),
+                        title: nls.localize('theia/ai/agents/completionNotification/title', 'Notification'),
                         markdownDescription: nls.localize('theia/ai/agents/completionNotification/mdDescription',
-                            'Notification behavior when this agent completes a task. If not set, the global default notification setting will be used.\n\
+                            'Notification behavior when this agent needs your attention, i.e. it completed a task or requests your input. \
+                    If not set, the global default notification setting will be used.\n\
                     - `os-notification`: Show OS/system notifications\n\
                     - `message`: Show notifications in the status bar/message area\n\
                     - `blink`: Blink or highlight the UI\n\

--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -133,7 +133,8 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
         [PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE]: {
             title: nls.localize('theia/ai/core/defaultNotification/title', 'Default Notification Type'),
             markdownDescription: nls.localize('theia/ai/core/defaultNotification/mdDescription',
-                'The default notification method used when an AI agent completes a task. Individual agents can override this setting.'),
+                'The default notification method used when an AI agent needs your attention, i.e. it completed a task or requests your input. '
+                + 'Individual agents can override this setting.'),
             type: 'string',
             enum: [...NOTIFICATION_TYPES],
             enumItemLabels: NOTIFICATION_TYPES.map(type => NOTIFICATION_TYPE_LABELS[type]),

--- a/packages/ai-core/src/common/notification-types.ts
+++ b/packages/ai-core/src/common/notification-types.ts
@@ -45,3 +45,13 @@ export const NOTIFICATION_TYPE_DESCRIPTIONS: Record<NotificationType, string> = 
     [NOTIFICATION_TYPE_MESSAGE]: nls.localize('theia/ai/core/notification/message/description', 'Show a notification message inside the application'),
     [NOTIFICATION_TYPE_BLINK]: nls.localize('theia/ai/core/notification/windowBlink/description', 'Blink the application title to attract attention'),
 };
+
+/**
+ * The event that triggered an agent notification. Drives the notification wording while
+ * sharing the same delivery channel and user preference.
+ */
+export const AGENT_NOTIFICATION_KIND_COMPLETED = 'completed';
+export const AGENT_NOTIFICATION_KIND_INPUT_NEEDED = 'inputNeeded';
+export type AgentNotificationKind =
+    | typeof AGENT_NOTIFICATION_KIND_COMPLETED
+    | typeof AGENT_NOTIFICATION_KIND_INPUT_NEEDED;

--- a/packages/ai-ide/src/browser/ai-configuration/components/agent-notification-settings.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/components/agent-notification-settings.tsx
@@ -76,7 +76,7 @@ const NotificationDescription = ({ onOpenNotificationSettings }: { onOpenNotific
     return (
         <div className="ai-configuration-description">
             {nls.localize('theia/ai/core/agentConfiguration/completionNotificationDescriptionPrefix',
-                'Select how you want to be notified when this agent completes its task. "Default" uses the ')}
+                'Select how you want to be notified when this agent needs your attention, i.e. it completes its task or requests your input. "Default" uses the ')}
             <a href="#" onClick={e => { e.preventDefault(); onOpenNotificationSettings(); }}>{linkText}</a>.
         </div>
     );

--- a/packages/ai-ide/src/browser/app-tester-chat-agent.ts
+++ b/packages/ai-ide/src/browser/app-tester-chat-agent.ts
@@ -71,6 +71,7 @@ export class AppTesterChatAgent extends AbstractStreamParsingChatAgent {
                     ],
                     request,
                     async selectedOption => {
+                        request.response.stopWaitingForInput();
                         if (selectedOption.value === 'yes') {
                             const progress = request.response.addProgressMessage({
                                 content: isPlaywrightVariant

--- a/packages/ai-ide/src/browser/chat-session-item.tsx
+++ b/packages/ai-ide/src/browser/chat-session-item.tsx
@@ -100,6 +100,7 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
 
     const timeAgo = useTimeAgo(session.saveDate, formatTimeAgo);
     const [isWorking, setIsWorking] = React.useState(false);
+    const [isWaitingForInput, setIsWaitingForInput] = React.useState(false);
     const [hasError, setHasError] = React.useState(session.hasError === true);
     const hasUnread = useUnreadMessages(session.sessionId, unreadState);
 
@@ -120,6 +121,7 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
             const recompute = () => {
                 const requests = s.model.getRequests();
                 setIsWorking(requests.some(ChatRequestModel.isInProgress));
+                setIsWaitingForInput(requests.some(r => r.response.isWaitingForInput));
                 const lastReq = requests.at(-1);
                 setHasError(lastReq?.response.isComplete === true && lastReq?.response.isError === true);
             };
@@ -157,13 +159,13 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
         // once the session is actually opened.
         const loadedSession = chatService.getSession(session.sessionId);
         const tooltip = loadedSession
-            ? buildSessionTooltip(loadedSession, session, chatAgentService, markdownRenderer, hasUnread, isWorking, hasError)
+            ? buildSessionTooltip(loadedSession, session, chatAgentService, markdownRenderer, hasUnread, isWorking, hasError, isWaitingForInput)
             : buildRestoredSessionTooltip(session, chatAgentService);
         // The tooltip may hold a markdown render result; dispose it once the hover is torn down
         // (or right away if we no longer intend to show it).
         if (!hoverActiveRef.current) { tooltip.dispose(); return; }
         hoverService.requestHover({ content: tooltip.element, target, position: 'left', onHide: () => tooltip.dispose() });
-    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread, isWorking, hasError]);
+    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread, isWorking, hasError, isWaitingForInput]);
 
     React.useEffect(() => () => { hoverActiveRef.current = false; }, []);
 
@@ -186,15 +188,25 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
         }
     }, [onClick]);
 
+    // A session waiting for input is still "in progress" (ChatRequestModel.isInProgress is true),
+    // so the waiting state takes precedence over the generic working spinner: it signals that the
+    // user, not the agent, needs to act.
+    const showWorking = isWorking && !isWaitingForInput;
     const showUnread = hasUnread && !isWorking && !hasError;
+    const waitingForInputLabel = nls.localize('theia/ai/ide/waitingForInput', 'Waiting for your input');
     const itemClasses = [
         'theia-chat-session-item',
-        isWorking && 'theia-chat-session-item-working',
+        isWaitingForInput && 'theia-chat-session-item-attention',
+        showWorking && 'theia-chat-session-item-working',
         hasError && !isWorking && 'theia-chat-session-item-error',
         showUnread && 'theia-chat-session-item-unread'
     ].filter(Boolean).join(' ');
 
-    const iconClass = isWorking ? `${codicon('loading')} theia-animation-spin` : agentIcon;
+    const iconClass = isWaitingForInput
+        ? codicon('bell')
+        : showWorking
+            ? `${codicon('loading')} theia-animation-spin`
+            : agentIcon;
 
     return (
         <div ref={itemRef}
@@ -216,6 +228,10 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
                 {showUnread && (
                     <span className="theia-chat-session-item-unread-dot"
                         aria-label={nls.localize('theia/ai/ide/tooltip/unread', 'Unread')} />
+                )}
+                {isWaitingForInput && (
+                    <span className="theia-chat-session-item-attention-dot"
+                        aria-label={waitingForInputLabel} />
                 )}
             </div>
             <div className="theia-chat-session-item-content">

--- a/packages/ai-ide/src/browser/chat-session-tooltip.ts
+++ b/packages/ai-ide/src/browser/chat-session-tooltip.ts
@@ -89,7 +89,7 @@ function addDefinitionEntry(definitionList: HTMLDListElement, term: string, deta
 export function buildSessionTooltip(
     session: ChatSession, metadata: ChatSessionMetadata,
     agentService: ChatAgentService, markdownRenderer: MarkdownRenderer,
-    isUnread: boolean, isRunning: boolean, hasError: boolean
+    isUnread: boolean, isRunning: boolean, hasError: boolean, isWaitingForInput: boolean
 ): SessionTooltip {
     const toDispose = new DisposableCollection();
     const requests = session.model.getRequests();
@@ -98,7 +98,13 @@ export function buildSessionTooltip(
     const container = document.createElement('div');
     container.className = 'theia-chat-session-tooltip';
 
-    if (isRunning) {
+    // A session waiting for input is also "running", so check it first to give it precedence.
+    if (isWaitingForInput) {
+        const badge = document.createElement('div');
+        badge.className = 'theia-chat-session-badge-attention-tooltip';
+        badge.textContent = nls.localize('theia/ai/ide/waitingForInput', 'Waiting for your input');
+        container.appendChild(badge);
+    } else if (isRunning) {
         const badge = document.createElement('div');
         badge.className = 'theia-chat-session-badge-running-tooltip';
         badge.textContent = nls.localizeByDefault('Running');

--- a/packages/ai-ide/src/browser/github-chat-agent.ts
+++ b/packages/ai-ide/src/browser/github-chat-agent.ts
@@ -79,6 +79,7 @@ export class GitHubChatAgent extends AbstractStreamParsingChatAgent {
                     ],
                     request,
                     async selectedOption => {
+                        request.response.stopWaitingForInput();
                         if (selectedOption.value === 'configure') {
                             await this.offerConfiguration();
                             request.response.response.addContent(new MarkdownChatResponseContentImpl(nls.localize('theia/ai/ide/github/configureGitHubServer/followup',
@@ -108,6 +109,7 @@ export class GitHubChatAgent extends AbstractStreamParsingChatAgent {
                     ],
                     request,
                     async selectedOption => {
+                        request.response.stopWaitingForInput();
                         if (selectedOption.value === 'yes') {
                             const progress = request.response.addProgressMessage({
                                 content: nls.localize('theia/ai/ide/github/startGitHubServer/progress', 'Starting GitHub MCP server.'),

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1194,19 +1194,28 @@
   flex-shrink: 0;
 }
 
-.theia-chat-session-item-unread-dot {
+.theia-chat-session-item-unread-dot,
+.theia-chat-session-item-attention-dot {
   position: absolute;
   top: -1px;
   left: -2px;
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background-color: var(--theia-activityBarBadge-background);
   border: 1px solid var(--theia-editor-background);
   pointer-events: none;
 }
 
-.theia-chat-session-item-unread .theia-chat-session-item-title {
+.theia-chat-session-item-unread-dot {
+  background-color: var(--theia-activityBarBadge-background);
+}
+
+.theia-chat-session-item-attention-dot {
+  background-color: var(--theia-editorWarning-foreground);
+}
+
+.theia-chat-session-item-unread .theia-chat-session-item-title,
+.theia-chat-session-item-attention .theia-chat-session-item-title {
   font-weight: 600;
 }
 
@@ -1220,6 +1229,10 @@
 
 .theia-chat-session-item-working .theia-chat-session-item-agent-icon {
   color: var(--theia-focusBorder);
+}
+
+.theia-chat-session-item-attention .theia-chat-session-item-agent-icon {
+  color: var(--theia-editorWarning-foreground);
 }
 
 .theia-chat-session-item-error .theia-chat-session-item-agent-icon,
@@ -1310,6 +1323,7 @@
 
 .theia-chat-session-badge-unread-tooltip,
 .theia-chat-session-badge-running-tooltip,
+.theia-chat-session-badge-attention-tooltip,
 .theia-chat-session-badge-error-tooltip,
 .theia-chat-session-badge-restored-tooltip {
   font-size: var(--theia-ui-font-size0);
@@ -1328,6 +1342,11 @@
 .theia-chat-session-badge-running-tooltip {
   color: var(--theia-activityBarBadge-foreground);
   background-color: var(--theia-progressBar-background);
+}
+
+.theia-chat-session-badge-attention-tooltip {
+  color: var(--theia-activityBarBadge-foreground);
+  background-color: var(--theia-editorWarning-foreground);
 }
 
 .theia-chat-session-badge-error-tooltip {

--- a/packages/ai-ide/src/browser/user-interaction-tool.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.ts
@@ -16,6 +16,7 @@
 
 import { ToolProvider, ToolRequest, ToolRequestParameterProperty, ToolRequestParameters } from '@theia/ai-core';
 import { ToolInvocationContext } from '@theia/ai-core/lib/common/language-model';
+import { ChatToolContext } from '@theia/ai-chat';
 import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import { open, OpenerService } from '@theia/core/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
@@ -346,9 +347,15 @@ export class UserInteractionTool implements ToolProvider {
         const cancellationToken = ToolInvocationContext.getCancellationToken(ctx);
         const cancellationListener = cancellationToken?.onCancellationRequested(() => this.cancelPending(toolCallId));
 
+        // Mark the response as waiting for input while the interaction is pending, so it is
+        // surfaced consistently with agent questions and tool confirmations (e.g. in the
+        // session overview and notifications).
+        const response = ChatToolContext.is(ctx) ? ctx.response : undefined;
+        response?.waitForInput();
         try {
             return await pending.deferred.promise;
         } finally {
+            response?.stopWaitingForInput();
             cancellationListener?.dispose();
             this.pendingInteractions.delete(toolCallId);
         }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- chat overview: mark sessions waiting for input with a bell icon, attention-colored dot and bold title; add a "Waiting for your input" tooltip badge. Takes precedence over the running indicator
- add ChatInputNeededNotificationContribution: watches all sessions, notifies when one starts waiting for input, suppressed while focused
- treat tool-call confirmations and the user-interaction tool as waiting-for-input, like agent questions
- reference-count the response waiting-for-input state so parallel tool confirmations clear it only once all resolve
- rename AgentCompletionNotificationService to AgentNotificationService; generalize it and OSNotificationService over a notification kind (completion / input-needed). Per-agent setting key kept for back-compat
- share ChatViewWidget.isSessionFocused between completion and input-needed notifications; key it off shell.currentWidget + window focus instead of the focused widget, so notifications are suppressed while the chat is open (the input editor blurs while the agent runs)
- fix a latent bug in the GitHub and App Tester chat agents where the MCP startup question called `waitForInput()` but never released it on the success branch, so the overview indicator stayed on for the rest of the agent run  

<img height="400" alt="image" src="https://github.com/user-attachments/assets/9cb64cf0-a4e5-4718-bd15-d90583475171" />


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Overview indicators (waiting on a tool confirmation)
   - Set `ai-features.chat.toolConfirmation` to `Confirm` (Ask for confirmation before executing tools).
   - In a chat, pick an agent that uses tools (e.g. Coder) and send a prompt that triggers one, e.g. "List the files in the workspace".
   - When the tool confirmation appears in the response, open the chat session overview (Home / sessions list).
   - Verify the session shows the bell icon, an attention-colored dot, and a bold title, and that this replaces the running spinner.
   - Hover the session and verify the tooltip shows the "Waiting for your input" badge.
   - Accept/deny the confirmation and verify the indicators clear.

2. Agent question (user-interaction tool)
   - Trigger an agent flow (e.g. Pr reviewer agent) that asks you a question via the user-interaction tool.
   - Verify the same overview indicators and tooltip badge appear while the question is pending.

3. Notification when the chat is not focused
   - Set `ai-features.notifications.default` to `Message` (repeat optionally with `OS Notification` and `Blink`) or set the notification for a specific agent in the AI Configuration view.
   - Start a request that ends up waiting for input, then switch to a different session/widget or blur the window before it does.
   - Verify the configured notification fires once, on the transition into waiting.
   - Activating the OS notification should focus the waiting session.
   - Repeat with the waiting chat open and focused and verify no notification is shown.

4. Parallel tool confirmations (reference counting)
   - Trigger a response that issues multiple tool calls requiring confirmation at once.
   - Verify the waiting indicator stays until the last confirmation is resolved, then clears.

5. GitHub / App Tester startup question (regression check)                                                                                                  
   - With the GitHub MCP server stopped, send a request to the GitHub agent so the "start the server" question appears.
   - Click "Yes, start the server" and open the overview while the agent continues.
   - Verify the session tile no longer shows the bell once the question is answered and also shows the running state as expected.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
