### PR TITLE
Enable multi select for problems view

### DIFF
--- a/packages/markers/src/browser/problem/problem-container.ts
+++ b/packages/markers/src/browser/problem/problem-container.ts
@@ -24,7 +24,8 @@ import { PROBLEM_KIND } from '../../common/problem-marker';
 export const PROBLEM_TREE_PROPS = <TreeProps>{
     ...defaultTreeProps,
     contextMenuPath: [PROBLEM_KIND],
-    globalSelection: true
+    globalSelection: true,
+    multiSelect: true,
 };
 
 export const PROBLEM_OPTIONS = <MarkerOptions>{

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -30,7 +30,6 @@ import { MarkerNode } from '../marker-tree';
 import { MenuPath, MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
-import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { ProblemSelection } from './problem-selection';
 import { nls } from '@theia/core/lib/common/nls';
 
@@ -71,7 +70,6 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
 
     @inject(ProblemManager) protected readonly problemManager: ProblemManager;
     @inject(StatusBar) protected readonly statusBar: StatusBar;
-    @inject(SelectionService) protected readonly selectionService: SelectionService;
 
     constructor() {
         super({
@@ -168,9 +166,9 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             })
         });
         commands.registerCommand(ProblemsCommands.SELECT_ALL, {
-            isEnabled: () => true,
-            isVisible: () => true,
-            execute: () => this.selectAllProblems()
+            isEnabled: () => this.withWidget(undefined, () => true),
+            isVisible: () => this.withWidget(undefined, () => true),
+            execute: () => this.withWidget(undefined, widget => this.selectAllProblems(widget))
         });
         commands.registerCommand(ProblemsCommands.CLEAR_ALL, {
             isEnabled: widget => this.withWidget(widget, () => true),
@@ -228,8 +226,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
     }
 
-    protected async selectAllProblems(): Promise<void> {
-        const widget = await this.widget;
+    protected async selectAllProblems(widget: ProblemWidget): Promise<void> {
         const { model } = widget;
         const root = model.root as CompositeTreeNode;
         if (root) {
@@ -238,7 +235,6 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
     }
 
-    // Helper method to recursively select all nodes
     protected selectAllNodes(node: TreeNode, model: ProblemTreeModel): void {
         if (SelectableTreeNode.is(node)) {
             model.addSelection({ node, type: TreeSelection.SelectionType.TOGGLE });

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -146,13 +146,10 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         });
 
         commands.registerCommand(ProblemsCommands.COPY, {
-            isVisible: () => this.withWidget(undefined, widget => {
-                const markerNodes = widget.model.selectedNodes.filter(MarkerNode.is);
-                return markerNodes.length > 0;
-            }),
+            isEnabled: () => this.withWidget(undefined, () => true),
+            isVisible: () => this.withWidget(undefined, widget => this.getSelectedMarkerNodes(widget).length > 0),
             execute: () => this.withWidget(undefined, widget => {
-                const selections = widget.model.selectedNodes
-                    .filter(MarkerNode.is)
+                const selections = this.getSelectedMarkerNodes(widget)
                     .map(node => ({ marker: node.marker }));
                 if (selections.length > 0) {
                     this.copy(selections);
@@ -160,13 +157,10 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             })
         });
         commands.registerCommand(ProblemsCommands.COPY_MESSAGE, {
-            isVisible: () => this.withWidget(undefined, widget => {
-                const markerNodes = widget.model.selectedNodes.filter(MarkerNode.is);
-                return markerNodes.length > 0;
-            }),
+            isEnabled: () => this.withWidget(undefined, () => true),
+            isVisible: () => this.withWidget(undefined, widget => this.getSelectedMarkerNodes(widget).length > 0),
             execute: () => this.withWidget(undefined, widget => {
-                const selections = widget.model.selectedNodes
-                    .filter(MarkerNode.is)
+                const selections = this.getSelectedMarkerNodes(widget)
                     .map(node => ({ marker: node.marker }));
                 if (selections.length > 0) {
                     this.copyMessage(selections);
@@ -234,7 +228,6 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
     }
 
-    // New method added to support Select All functionality
     protected async selectAllProblems(): Promise<void> {
         const widget = await this.widget;
         const { model } = widget;
@@ -245,7 +238,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
     }
 
-    // New helper method to recursively select all nodes
+    // Helper method to recursively select all nodes
     protected selectAllNodes(node: TreeNode, model: ProblemTreeModel): void {
         if (SelectableTreeNode.is(node)) {
             model.addSelection({ node, type: TreeSelection.SelectionType.TOGGLE });
@@ -255,6 +248,10 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
                 this.selectAllNodes(child, model);
             }
         }
+    }
+
+    protected getSelectedMarkerNodes(widget: ProblemWidget): MarkerNode[] {
+        return widget.model.selectedNodes.filter(MarkerNode.is);
     }
 
     protected addToClipboard(content: string): void {

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -16,12 +16,17 @@
 
 import debounce = require('@theia/core/shared/lodash.debounce');
 import { injectable, inject } from '@theia/core/shared/inversify';
-import { FrontendApplication, FrontendApplicationContribution, CompositeTreeNode, SelectableTreeNode, Widget, codicon } from '@theia/core/lib/browser';
+import {
+    FrontendApplication, FrontendApplicationContribution, CompositeTreeNode, SelectableTreeNode, Widget, codicon,
+    TreeNode, TreeSelection
+} from '@theia/core/lib/browser';
 import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser/status-bar/status-bar';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { PROBLEM_KIND, ProblemMarker } from '../../common/problem-marker';
 import { ProblemManager, ProblemStat } from './problem-manager';
 import { ProblemWidget, PROBLEMS_WIDGET_ID } from './problem-widget';
+import { ProblemTreeModel } from './problem-tree-model';
+import { MarkerNode } from '../marker-tree';
 import { MenuPath, MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
@@ -49,6 +54,9 @@ export namespace ProblemsCommands {
     };
     export const COPY_MESSAGE: Command = {
         id: 'problems.copy.message',
+    };
+    export const SELECT_ALL: Command = {
+        id: 'problems.select.all'
     };
     export const CLEAR_ALL = Command.toLocalizedCommand({
         id: 'problems.clear.all',
@@ -136,22 +144,40 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             isVisible: widget => this.withWidget(widget, () => true),
             execute: widget => this.withWidget(widget, () => this.collapseAllProblems())
         });
-        commands.registerCommand(ProblemsCommands.COPY,
-            new ProblemSelection.CommandHandler(this.selectionService, {
-                multi: false,
-                isEnabled: () => true,
-                isVisible: () => true,
-                execute: selection => this.copy(selection)
+
+        commands.registerCommand(ProblemsCommands.COPY, {
+            isVisible: () => this.withWidget(undefined, widget => {
+                const markerNodes = widget.model.selectedNodes.filter(MarkerNode.is);
+                return markerNodes.length > 0;
+            }),
+            execute: () => this.withWidget(undefined, widget => {
+                const selections = widget.model.selectedNodes
+                    .filter(MarkerNode.is)
+                    .map(node => ({ marker: node.marker }));
+                if (selections.length > 0) {
+                    this.copy(selections);
+                }
             })
-        );
-        commands.registerCommand(ProblemsCommands.COPY_MESSAGE,
-            new ProblemSelection.CommandHandler(this.selectionService, {
-                multi: false,
-                isEnabled: () => true,
-                isVisible: () => true,
-                execute: selection => this.copyMessage(selection)
+        });
+        commands.registerCommand(ProblemsCommands.COPY_MESSAGE, {
+            isVisible: () => this.withWidget(undefined, widget => {
+                const markerNodes = widget.model.selectedNodes.filter(MarkerNode.is);
+                return markerNodes.length > 0;
+            }),
+            execute: () => this.withWidget(undefined, widget => {
+                const selections = widget.model.selectedNodes
+                    .filter(MarkerNode.is)
+                    .map(node => ({ marker: node.marker }));
+                if (selections.length > 0) {
+                    this.copyMessage(selections);
+                }
             })
-        );
+        });
+        commands.registerCommand(ProblemsCommands.SELECT_ALL, {
+            isEnabled: () => true,
+            isVisible: () => true,
+            execute: () => this.selectAllProblems()
+        });
         commands.registerCommand(ProblemsCommands.CLEAR_ALL, {
             isEnabled: widget => this.withWidget(widget, () => true),
             isVisible: widget => this.withWidget(widget, () => true),
@@ -175,6 +201,11 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             commandId: ProblemsCommands.COLLAPSE_ALL.id,
             label: nls.localizeByDefault('Collapse All'),
             order: '2'
+        });
+        menus.registerMenuAction(ProblemsMenu.PROBLEMS, {
+            commandId: ProblemsCommands.SELECT_ALL.id,
+            label: nls.localizeByDefault('Select All'),
+            order: '3'
         });
     }
 
@@ -203,6 +234,29 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
     }
 
+    // New method added to support Select All functionality
+    protected async selectAllProblems(): Promise<void> {
+        const widget = await this.widget;
+        const { model } = widget;
+        const root = model.root as CompositeTreeNode;
+        if (root) {
+            model.clearSelection();
+            this.selectAllNodes(root, model);
+        }
+    }
+
+    // New helper method to recursively select all nodes
+    protected selectAllNodes(node: TreeNode, model: ProblemTreeModel): void {
+        if (SelectableTreeNode.is(node)) {
+            model.addSelection({ node, type: TreeSelection.SelectionType.TOGGLE });
+        }
+        if (CompositeTreeNode.is(node) && node.children) {
+            for (const child of node.children) {
+                this.selectAllNodes(child, model);
+            }
+        }
+    }
+
     protected addToClipboard(content: string): void {
         const handleCopy = (e: ClipboardEvent) => {
             document.removeEventListener('copy', handleCopy);
@@ -215,27 +269,33 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         document.execCommand('copy');
     }
 
-    protected copy(selection: ProblemSelection): void {
-        const marker = selection.marker as ProblemMarker;
-        const serializedProblem = JSON.stringify({
-            resource: marker.uri,
-            owner: marker.owner,
-            code: marker.data.code,
-            severity: marker.data.severity,
-            message: marker.data.message,
-            source: marker.data.source,
-            startLineNumber: marker.data.range.start.line,
-            startColumn: marker.data.range.start.character,
-            endLineNumber: marker.data.range.end.line,
-            endColumn: marker.data.range.end.character
-        }, undefined, '\t');
-
-        this.addToClipboard(serializedProblem);
+    protected copy(selections: ProblemSelection | ProblemSelection[]): void {
+        const selectionsArray = Array.isArray(selections) ? selections : [selections];
+        const serializedProblems = selectionsArray.map(selection => {
+            const marker = selection.marker as ProblemMarker;
+            return {
+                resource: marker.uri,
+                owner: marker.owner,
+                code: marker.data.code,
+                severity: marker.data.severity,
+                message: marker.data.message,
+                source: marker.data.source,
+                startLineNumber: marker.data.range.start.line,
+                startColumn: marker.data.range.start.character,
+                endLineNumber: marker.data.range.end.line,
+                endColumn: marker.data.range.end.character
+            };
+        });
+        this.addToClipboard(JSON.stringify(serializedProblems, undefined, '\t'));
     }
 
-    protected copyMessage(selection: ProblemSelection): void {
-        const marker = selection.marker as ProblemMarker;
-        this.addToClipboard(marker.data.message);
+    protected copyMessage(selections: ProblemSelection | ProblemSelection[]): void {
+        const selectionsArray = Array.isArray(selections) ? selections : [selections];
+        const messages = selectionsArray.map(selection => {
+            const marker = selection.marker as ProblemMarker;
+            return marker.data.message;
+        });
+        this.addToClipboard(messages.join('\n'));
     }
 
     protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), cb: (problems: ProblemWidget) => T): T | false {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Implements https://github.com/eclipse-theia/theia/issues/17667.

- Allow multi-select in Problems view.
- Extend existing "Copy" and "Copy Message" context menus to work when multiple problems are selected: The behavior when no or only one problem message is selected is kept the same. The copy command would be invisible if no marker node is selected, and outputs a json object same as it currently does. When multiple are selected, it would output a list of the objects.
- Add a "Select All" context menu that selects all the items.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the Problems view.
2. Create at least two problems.
3. Right click on any node, see there is a "select all" in the context menu.
4. Click "select all".
5. Observe all nodes are now selected.
6. Right click on any node, click "copy" in the context menu.
7. Paste the content somewhere, confirm it is the correct list of json object.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

There are two things I would like to discuss. 

1. Currently, without multi select, copying a single problem would only output a json object. I am keeping this behaviour in the current implementation. However, I'm not sure if it would be better if we just output a list with only one object in it, to be consistent with muti-selected case.
2. Currently, "copy" and "copy message" are not visible when the selected node is not a marker (message) node, but only the file name. I am keeping this behaviour in the current implementation. However, I'm not sure if it would be better to copy all of its children in this case.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
