### PR TITLE
fix(vsx-registry): enable 'Install Specific Version' for installed extensions

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.spec.ts
@@ -28,6 +28,7 @@ if (canvasProto) {
 try { FrontendApplicationConfigProvider.set({}); } catch { /* already set by a sibling spec */ }
 
 import { expect } from 'chai';
+import { QuickPickItem } from '@theia/core/lib/browser';
 import { Command, CommandHandler, CommandRegistry } from '@theia/core/lib/common/command';
 import { VSXExtension } from './vsx-extension';
 import { VSXExtensionsCommands } from './vsx-extension-commands';
@@ -67,5 +68,30 @@ describe('VSXExtensionsContribution: "Install Specific Version" enablement', () 
         const handler = registerHandler();
         const extension = { builtin: true, downloadUrl: 'http://example.com/ext.vsix' } as unknown as VSXExtension;
         expect(handler.isEnabled!(extension)).to.equal(false);
+    });
+});
+
+describe('VSXExtensionsContribution: "Install Specific Version" with no available versions', () => {
+
+    it('shows a "No other versions are available." item instead of an empty quick pick', async () => {
+        const contribution = new VSXExtensionsContribution();
+        let shownItems: QuickPickItem[] | undefined;
+        Object.assign(contribution, {
+            // The extension is not on the registry (e.g. VSIX or private install), so no versions are returned.
+            clientProvider: async () => ({ query: async () => ({ extensions: [] }) }),
+            vsxApiFilter: async () => ({ findLatestCompatibleExtension: async () => undefined }),
+            applicationServer: { getApplicationPlatform: async () => 'linux-x64' },
+            quickInput: {
+                showQuickPick: async (items: QuickPickItem[]) => {
+                    shownItems = items;
+                    return undefined;
+                }
+            }
+        });
+        const extension = { id: 'foo.bar', version: '1.0.0', builtin: false } as unknown as VSXExtension;
+        await (contribution as unknown as { installAnotherVersion(e: VSXExtension): Promise<void> }).installAnotherVersion(extension);
+        expect(shownItems, 'a quick pick should be shown').to.not.equal(undefined);
+        expect(shownItems!).to.have.lengthOf(1);
+        expect(shownItems![0].label).to.equal('No other versions are available.');
     });
 });

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.spec.ts
@@ -1,0 +1,71 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+// xterm.js (pulled in transitively via plugin-ext from VSXExtensionsModel) calls
+// HTMLCanvasElement.prototype.getContext at module-load time. JSDOM's default impl
+// throws 'Not implemented' without the optional `canvas` package; replace it with a
+// no-op so the module graph evaluates.
+const canvasProto = (globalThis as { HTMLCanvasElement?: { prototype: { getContext?: unknown } } }).HTMLCanvasElement?.prototype;
+if (canvasProto) {
+    canvasProto.getContext = () => undefined;
+}
+try { FrontendApplicationConfigProvider.set({}); } catch { /* already set by a sibling spec */ }
+
+import { expect } from 'chai';
+import { Command, CommandHandler, CommandRegistry } from '@theia/core/lib/common/command';
+import { VSXExtension } from './vsx-extension';
+import { VSXExtensionsCommands } from './vsx-extension-commands';
+import { VSXExtensionsContribution } from './vsx-extensions-contribution';
+
+after(() => disableJSDOM());
+
+/** Records the handler registered for each command id so registered predicates can be asserted. */
+class RecordingCommandRegistry {
+    readonly handlers = new Map<string, CommandHandler>();
+    registerCommand(command: Command, handler?: CommandHandler): void {
+        if (handler) {
+            this.handlers.set(command.id, handler);
+        }
+    }
+}
+
+function registerHandler(): CommandHandler {
+    const contribution = new VSXExtensionsContribution();
+    const registry = new RecordingCommandRegistry();
+    contribution.registerCommands(registry as unknown as CommandRegistry);
+    const handler = registry.handlers.get(VSXExtensionsCommands.INSTALL_ANOTHER_VERSION.id);
+    expect(handler, 'INSTALL_ANOTHER_VERSION should be registered').to.not.equal(undefined);
+    return handler!;
+}
+
+describe('VSXExtensionsContribution: "Install Specific Version" enablement', () => {
+
+    it('is enabled for an installed extension even without downloadUrl (regression for #17607)', () => {
+        const handler = registerHandler();
+        // An already installed extension after a restart has no registry data, so downloadUrl is undefined.
+        const extension = { builtin: false, downloadUrl: undefined } as unknown as VSXExtension;
+        expect(handler.isEnabled!(extension)).to.equal(true);
+    });
+
+    it('is disabled for built-in extensions', () => {
+        const handler = registerHandler();
+        const extension = { builtin: true, downloadUrl: 'http://example.com/ext.vsix' } as unknown as VSXExtension;
+        expect(handler.isEnabled!(extension)).to.equal(false);
+    });
+});

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -115,8 +115,10 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         );
 
         commands.registerCommand(VSXExtensionsCommands.INSTALL_ANOTHER_VERSION, {
-            // Check downloadUrl to ensure we have an idea of where to look for other versions.
-            isEnabled: (extension: VSXExtension) => !extension.builtin && !!extension.downloadUrl,
+            // Versions are queried from the registry on execution, so only built-in extensions are excluded here.
+            // `downloadUrl` must not be required: it is registry-only data that is not populated for already
+            // installed extensions after a restart (see #17607).
+            isEnabled: (extension: VSXExtension) => !extension.builtin,
             execute: async (extension: VSXExtension) => this.installAnotherVersion(extension),
         });
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -360,6 +360,16 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
             }
         }
 
+        if (filteredExtensions.length === 0) {
+            // Extensions not on the registry (e.g. VSIX or private installs) have no other versions to offer.
+            // Show feedback instead of an empty quick pick, matching the `NO_TASKS_FOUND` pattern in the task package.
+            await this.quickInput.showQuickPick(
+                [{ label: nls.localize('theia/vsx-registry/vsx-extensions-contribution/no-other-versions', 'No other versions are available.') }],
+                { placeholder: nls.localizeByDefault('Select Version to Install') }
+            );
+            return;
+        }
+
         const items: QuickPickItem[] = filteredExtensions.map(ext => {
             const item = {
                 label: ext.version,


### PR DESCRIPTION
#### What it does

Fixes #17607.

The "Install Specific Version..." command was gated on `extension.downloadUrl`, which is registry-only data. After a restart, installed extensions are populated from deployed plugin metadata (which has no `downloadUrl`) and are no longer refreshed against the registry, so the command stayed permanently disabled.

Versions are already queried from the registry when the command runs, so it does not need `downloadUrl` — the gate is now just `!extension.builtin`.

#### How to test

1. Install an extension from Open VSX.
2. Restart the application.
3. Right-click the installed extension → "Install Specific Version..." is enabled and lists versions.

#### Follow-ups


#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.


#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
