### PR TITLE
fix(plugin-ext): render viewsWelcome for views without a TreeDataProvider

### DIFF
--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.spec.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.spec.ts
@@ -24,7 +24,8 @@ FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
 import { Disposable } from '@theia/core/lib/common';
-import { PluginViewRegistry, ViewContainerInfo } from './plugin-view-registry';
+import { PluginViewRegistry, ViewContainerInfo, PLUGIN_VIEW_DATA_FACTORY_ID } from './plugin-view-registry';
+import type { ViewWelcome } from '../../../common';
 
 disableJSDOM();
 
@@ -100,6 +101,73 @@ describe('PluginViewRegistry - view menu labels', () => {
 
         expect(menus.actions.get(toggleCommandId('a'))?.label).to.equal('Claude Code');
         expect(menus.actions.has(toggleCommandId('b'))).to.equal(false);
+    });
+
+});
+
+describe('PluginViewRegistry - welcome-only views', () => {
+
+    interface FakeTreeViewWidget {
+        model: { root?: unknown };
+        welcomeArg?: ViewWelcome[];
+        handleViewWelcomeContentChange(welcomes: ViewWelcome[]): void;
+    }
+
+    let registry: PluginViewRegistry;
+    let createdWidget: FakeTreeViewWidget;
+    let getOrCreateCalls: Array<{ factoryId: string; options: unknown }>;
+
+    const welcome = (view: string): ViewWelcome => ({ view, content: `[Hi](command:${view}.hi)`, order: 0 });
+
+    const internals = (): {
+        views: Map<string, [string, { type?: unknown }]>;
+        viewDataProviders: Map<string, unknown>;
+        viewsWelcome: Map<string, ViewWelcome[]>;
+        createViewDataWidget(viewId: string): Promise<unknown>;
+    } => registry as unknown as {
+        views: Map<string, [string, { type?: unknown }]>;
+        viewDataProviders: Map<string, unknown>;
+        viewsWelcome: Map<string, ViewWelcome[]>;
+        createViewDataWidget(viewId: string): Promise<unknown>;
+    };
+
+    beforeEach(() => {
+        registry = new PluginViewRegistry();
+        getOrCreateCalls = [];
+        createdWidget = {
+            model: {},
+            handleViewWelcomeContentChange(welcomes: ViewWelcome[]): void {
+                this.welcomeArg = welcomes;
+            }
+        };
+        (registry as unknown as { widgetManager: unknown }).widgetManager = {
+            getOrCreateWidget: async (factoryId: string, options: unknown) => {
+                getOrCreateCalls.push({ factoryId, options });
+                return createdWidget;
+            }
+        };
+        internals().views.set('actions', ['container', {}]);
+    });
+
+    it('creates a welcome widget for a view with welcomes but no data provider', async () => {
+        const welcomes = [welcome('actions')];
+        internals().viewsWelcome.set('actions', welcomes);
+
+        const widget = await internals().createViewDataWidget('actions');
+
+        expect(widget).to.equal(createdWidget);
+        expect(getOrCreateCalls).to.have.lengthOf(1);
+        expect(getOrCreateCalls[0].factoryId).to.equal(PLUGIN_VIEW_DATA_FACTORY_ID);
+        expect(getOrCreateCalls[0].options).to.deep.equal({ id: 'actions' });
+        expect(createdWidget.welcomeArg).to.equal(welcomes);
+        expect(createdWidget.model.root).to.not.equal(undefined);
+    });
+
+    it('returns undefined for a view with neither a provider nor welcomes', async () => {
+        const widget = await internals().createViewDataWidget('actions');
+
+        expect(widget).to.equal(undefined);
+        expect(getOrCreateCalls).to.have.lengthOf(0);
     });
 
 });

--- a/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
+++ b/packages/plugin-ext/src/main/browser/view/plugin-view-registry.ts
@@ -19,6 +19,7 @@ import {
     ApplicationShell, ViewContainer as ViewContainerWidget, WidgetManager, QuickViewService,
     ViewContainerIdentifier, ViewContainerTitleOptions, Widget, FrontendApplicationContribution,
     StatefulWidget, CommonMenus, TreeViewWelcomeWidget, ViewContainerPart, BaseWidget,
+    CompositeTreeNode, ExpandableTreeNode,
 } from '@theia/core/lib/browser';
 import { ViewContainer, View, ViewWelcome, PluginViewType } from '../../../common';
 import { PluginSharedStyle } from '../plugin-shared-style';
@@ -1055,9 +1056,14 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         if (view?.[1]?.type === PluginViewType.Webview) {
             return this.createWebviewWidget(viewId, webviewId);
         }
-        const provider = this.viewDataProviders.get(viewId);
-        if (!view || !provider) {
+        if (!view) {
             return undefined;
+        }
+        const provider = this.viewDataProviders.get(viewId);
+        if (!provider) {
+            return this.getViewWelcomes(viewId).length > 0
+                ? this.createViewWelcomeWidget(viewId)
+                : undefined;
         }
         const [, viewInfo] = view;
         const state = this.viewDataState.get(viewId);
@@ -1068,6 +1074,25 @@ export class PluginViewRegistry implements FrontendApplicationContribution {
         } else {
             this.viewDataState.delete(viewId);
         }
+        return widget;
+    }
+
+    protected async createViewWelcomeWidget(viewId: string): Promise<TreeViewWidget> {
+        const widget = await this.widgetManager.getOrCreateWidget<TreeViewWidget>(PLUGIN_VIEW_DATA_FACTORY_ID, { id: viewId });
+        if (!widget.model.root) {
+            const root: CompositeTreeNode & ExpandableTreeNode = {
+                id: '',
+                parent: undefined,
+                name: '',
+                visible: false,
+                expanded: true,
+                children: []
+            };
+            widget.model.root = root;
+        }
+        // An undefined `model.proxy` keeps `shouldShowWelcomeView()` true, so the welcome content
+        // renders instead of an empty node list.
+        widget.handleViewWelcomeContentChange(this.getViewWelcomes(viewId));
         return widget;
     }
 


### PR DESCRIPTION
#### What it does

A plugin view that declares `viewsWelcome` but never registers a `TreeDataProvider` — a *welcome-only* view — renders an empty body. The content widget that hosts welcome content is only ever created as a side-effect of registering a data provider, so `PluginViewRegistry.createViewDataWidget` returns `undefined` and the welcome content has nowhere to render. The outer view widget (header + `view/title` toolbar) is still created, so the user sees a section header and toolbar over a blank panel. In VS Code the same manifest renders the `viewsWelcome` buttons for such a view whether or not a `TreeDataProvider` is registered; this restores that parity.

The fix: in `createViewDataWidget`, when a declared (non-webview) view has registered `viewsWelcome` but no data provider, create a bare content widget via the existing `plugin-view-data` factory and apply the welcome content to it. `model.proxy` is deliberately left undefined so `TreeViewWelcomeWidget.shouldShowWelcomeView()` stays true and the welcome content renders instead of an empty node list.

A plugin can work around this today by registering a trivial empty `TreeDataProvider` purely to force the content widget into existence. That works, but it's a per-plugin hack for a framework gap — this change fixes it once for every plugin, so it would be nice to land it as-is rather than have each plugin carry the workaround.

#### How to test

1. Use (or write) a plugin that contributes a view with `viewsWelcome` content but **no** `TreeDataProvider` for that view.
2. Open the view in its container.
   - Before: the view shows its header and `view/title` toolbar over an empty body.
   - After: the `viewsWelcome` buttons/content render in the body.
3. Confirm that views which *do* register a `TreeDataProvider` are unaffected (welcome still shows only when the tree is empty), and that registering a provider later for a welcome-only view reuses the same widget instance.

A convenient real-world reproduction is the JuliaComputing Dyad Studio extension: its `Actions` view is welcome-only (it contributes `viewsWelcome` content but no `TreeDataProvider`), so its action buttons render in VS Code but appear as a blank panel under the view header in Theia without this fix.

Unit specs added in `plugin-view-registry.spec.ts` cover both new branches (welcome-only view → welcome widget created and applied; view with neither provider nor welcomes → `undefined`).

#### Follow-ups

None. A `CHANGELOG.md` entry under the next release's *Bug fixes* can be added if desired.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service — N/A, no new user-facing text is introduced (welcome labels come from the plugin manifest)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)

---

> _Disclaimer: this change was generated with AI assistance, but reviewed, guided, and validated by me. I take full responsibility for its correctness and for it meeting the project's standards._
