### PR TITLE
fix(core): render codicons in viewsWelcome button and link labels

### DIFF
--- a/packages/core/src/browser/tree/tree-view-welcome-widget.spec.ts
+++ b/packages/core/src/browser/tree/tree-view-welcome-widget.spec.ts
@@ -1,0 +1,80 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '../test/jsdom';
+
+// The widget module transitively imports `@lumino/widgets`, which touches `document` at load time.
+const disableJSDOM = enableJSDOM();
+
+import { Container } from 'inversify';
+import { expect } from 'chai';
+import { ReactElement } from 'react';
+import { CommandService } from '../../common';
+import { LabelParser } from '../label-parser';
+import { codicon } from '../widgets';
+import { TreeViewWelcomeWidget } from './tree-view-welcome-widget';
+
+disableJSDOM();
+
+let labelParser: LabelParser;
+
+before(() => {
+    const container = new Container();
+    container.bind(LabelParser).toSelf().inSingletonScope();
+    container.bind(CommandService).toDynamicValue(() => ({
+        executeCommand<T>(): Promise<T | undefined> {
+            return Promise.resolve(undefined);
+        }
+    })).inSingletonScope();
+    labelParser = container.get(LabelParser);
+});
+
+describe('TreeViewWelcomeWidget#renderLabelWithIcons', () => {
+
+    // Exercise the protected helper without standing up the full TreeWidget DI graph.
+    function render(label: string): ReactElement[] {
+        const widget = Object.create(TreeViewWelcomeWidget.prototype) as {
+            labelParser: LabelParser;
+            renderLabelWithIcons(label: string): ReactElement[];
+        };
+        widget.labelParser = labelParser;
+        return widget.renderLabelWithIcons(label);
+    }
+
+    it('renders a leading $(codicon) as a codicon span and keeps the trailing text', () => {
+        const nodes = render('$(robot) Launch AI Agent');
+        expect(nodes).to.have.lengthOf(2);
+        expect(nodes[0].props.className).to.equal(codicon('robot'));
+        expect(nodes[0].props.children).to.be.undefined;
+        expect(nodes[1].props.className).to.be.undefined;
+        expect(nodes[1].props.children).to.equal(' Launch AI Agent');
+    });
+
+    it('renders a plain label as a single text span with no codicon', () => {
+        const nodes = render('Open Documentation');
+        expect(nodes).to.have.lengthOf(1);
+        expect(nodes[0].props.className).to.be.undefined;
+        expect(nodes[0].props.children).to.equal('Open Documentation');
+    });
+
+    it('renders multiple codicons interleaved with text', () => {
+        const nodes = render('$(package) Import $(gear) Library');
+        const iconNodes = nodes.filter(n => typeof n.props.className === 'string' && n.props.className.includes('codicon-'));
+        expect(iconNodes).to.have.lengthOf(2);
+        expect(iconNodes[0].props.className).to.equal(codicon('package'));
+        expect(iconNodes[1].props.className).to.equal(codicon('gear'));
+    });
+});

--- a/packages/core/src/browser/tree/tree-view-welcome-widget.tsx
+++ b/packages/core/src/browser/tree/tree-view-welcome-widget.tsx
@@ -209,22 +209,14 @@ export class TreeViewWelcomeWidget extends TreeWidget {
                     className='theia-button theia-WelcomeViewButton'
                     disabled={!this.isEnabledClick(enablement)}
                     onClick={e => this.openLinkOrCommand(e, node.href)}>
-                    {node.label}
+                    {this.renderLabelWithIcons(node.label)}
                 </button>
             </div>
         );
     }
 
     protected renderTextNode(node: string, textKey: string | number): React.ReactNode {
-        return <span key={`text-${textKey}`}>
-            {this.labelParser.parse(node)
-                .map((segment, index) =>
-                    LabelIcon.is(segment)
-                        ? <span
-                            key={index}
-                            className={codicon(segment.name)}
-                        />
-                        : <span key={index}>{segment}</span>)}</span>;
+        return <span key={`text-${textKey}`}>{this.renderLabelWithIcons(node)}</span>;
     }
 
     protected renderLinkNode(node: ILink, linkKey: string | number, enablement: string | undefined): React.ReactNode {
@@ -233,9 +225,16 @@ export class TreeViewWelcomeWidget extends TreeWidget {
                 className={this.getLinkClassName(node.href, enablement)}
                 title={node.title || ''}
                 onClick={e => this.openLinkOrCommand(e, node.href)}>
-                {node.label}
+                {this.renderLabelWithIcons(node.label)}
             </a>
         );
+    }
+
+    protected renderLabelWithIcons(label: string): React.ReactNode[] {
+        return this.labelParser.parse(label).map((segment, index) =>
+            LabelIcon.is(segment)
+                ? <span key={index} className={codicon(segment.name)} />
+                : <span key={index}>{segment}</span>);
     }
 
     protected getLinkClassName(href: string, enablement: string | undefined): string {


### PR DESCRIPTION
#### What it does

In the tree welcome view (`viewsWelcome`), text content already renders `$(codicon)` markup as icons via the label parser, but **button and link labels were emitted as the raw string**. A welcome label such as `$(robot) Launch AI Agent` therefore showed the literal `$(robot)` text instead of the icon. VS Code renders codicons in welcome text, buttons, and links alike.

The fix routes every welcome label — text, button, and link — through a single shared `labelParser`-based helper (`renderLabelWithIcons`), so `$(codicon)` markup renders consistently in all three. This also removes the parse/map logic that was previously duplicated in the text path. Icon names continue to be applied as `codicon(...)` CSS class names and text segments as React children, so escaping and label sanitisation are unchanged.

#### How to test

1. Use (or write) a plugin whose `viewsWelcome` content includes a button or link label with codicon markup, e.g. a line like `[$(robot) Launch AI Agent](command:my.command)`.
2. Open the view so the welcome content shows.
   - Before: the label reads literally as `$(robot) Launch AI Agent`.
   - After: the robot icon renders in the button/link, followed by the text.
3. Confirm plain text welcome lines and labels without codicons are unchanged.

A convenient real-world reproduction is the JuliaComputing Dyad Studio extension: its `Actions` view welcome buttons use codicon labels such as `$(robot) Launch AI Agent` and `$(package) Import Library`, which show as literal `$(…)` text in Theia without this fix and render as icons with it.

A unit spec added in `tree-view-welcome-widget.spec.ts` covers a leading codicon plus trailing text, a plain label, and multiple interleaved codicons.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service — N/A, no new user-facing text is introduced (welcome labels come from the plugin manifest)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)

---

> _Disclaimer: this change was generated with AI assistance, but reviewed, guided, and validated by me. I take full responsibility for its correctness and for it meeting the project's standards._
