### PR TITLE
fix: sync telemetry logger enable states

### DIFF
--- a/packages/plugin-ext/src/plugin/telemetry-ext.spec.ts
+++ b/packages/plugin-ext/src/plugin/telemetry-ext.spec.ts
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright (C) 2026 suzunn and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as chai from 'chai';
+import { TelemetryExtImpl } from './telemetry-ext';
+
+const expect = chai.expect;
+
+describe('TelemetryLogger', () => {
+    const sender = {
+        sendEventData: () => { },
+        sendErrorData: () => { }
+    };
+
+    it('reflects the current telemetry enabled state', () => {
+        const telemetry = new TelemetryExtImpl();
+        const logger = telemetry.createTelemetryLogger(sender);
+
+        expect(logger.telemetryEnabled).to.equal(false);
+        expect(logger.isUsageEnabled).to.equal(false);
+        expect(logger.isErrorsEnabled).to.equal(false);
+
+        telemetry.isTelemetryEnabled = true;
+
+        expect(logger.telemetryEnabled).to.equal(true);
+        expect(logger.isUsageEnabled).to.equal(true);
+        expect(logger.isErrorsEnabled).to.equal(true);
+
+        telemetry.isTelemetryEnabled = false;
+
+        expect(logger.telemetryEnabled).to.equal(false);
+        expect(logger.isUsageEnabled).to.equal(false);
+        expect(logger.isErrorsEnabled).to.equal(false);
+    });
+
+    it('emits enable-state changes when telemetry is toggled', () => {
+        const telemetry = new TelemetryExtImpl();
+        const logger = telemetry.createTelemetryLogger(sender);
+        let changes = 0;
+
+        logger.onDidChangeEnableStates(() => changes++);
+
+        telemetry.isTelemetryEnabled = true;
+        telemetry.isTelemetryEnabled = false;
+
+        expect(changes).to.equal(2);
+    });
+});

--- a/packages/plugin-ext/src/plugin/telemetry-ext.ts
+++ b/packages/plugin-ext/src/plugin/telemetry-ext.ts
@@ -49,7 +49,7 @@ export class TelemetryLogger {
     readonly options: TelemetryLoggerOptions | undefined;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     readonly commonProperties: Record<string, any>;
-    telemetryEnabled: boolean;
+    private _telemetryEnabled: boolean;
 
     private readonly onDidChangeEnableStatesEmitter: Emitter<TelemetryLogger> = new Emitter();
     readonly onDidChangeEnableStates: Event<TelemetryLogger> = this.onDidChangeEnableStatesEmitter.event;
@@ -60,9 +60,20 @@ export class TelemetryLogger {
         this.sender = sender;
         this.options = options;
         this.commonProperties = this.getCommonProperties();
-        this._isErrorsEnabled = true;
-        this._isUsageEnabled = true;
-        this.telemetryEnabled = telemetryEnabled;
+        this._telemetryEnabled = telemetryEnabled;
+        this._isErrorsEnabled = telemetryEnabled;
+        this._isUsageEnabled = telemetryEnabled;
+    }
+
+    get telemetryEnabled(): boolean {
+        return this._telemetryEnabled;
+    }
+
+    set telemetryEnabled(telemetryEnabled: boolean) {
+        if (this._telemetryEnabled !== telemetryEnabled) {
+            this._telemetryEnabled = telemetryEnabled;
+            this.updateEnableStates(telemetryEnabled, telemetryEnabled);
+        }
     }
 
     get isUsageEnabled(): boolean {
@@ -82,6 +93,14 @@ export class TelemetryLogger {
 
     set isErrorsEnabled(isErrorsEnabled: boolean) {
         if (this._isErrorsEnabled !== isErrorsEnabled) {
+            this._isErrorsEnabled = isErrorsEnabled;
+            this.onDidChangeEnableStatesEmitter.fire(this);
+        }
+    }
+
+    private updateEnableStates(isUsageEnabled: boolean, isErrorsEnabled: boolean): void {
+        if (this._isUsageEnabled !== isUsageEnabled || this._isErrorsEnabled !== isErrorsEnabled) {
+            this._isUsageEnabled = isUsageEnabled;
             this._isErrorsEnabled = isErrorsEnabled;
             this.onDidChangeEnableStatesEmitter.fire(this);
         }


### PR DESCRIPTION
#### What it does

`TelemetryLogger` initialized `isUsageEnabled` and `isErrorsEnabled` to `true` regardless of the current telemetry setting. That means extensions can see telemetry as enabled even when `env.isTelemetryEnabled` is false, which can cause telemetry senders to initialize unnecessarily.

This PR updates `TelemetryLogger` so its usage and error enable states mirror the current telemetry-enabled state when a logger is created and whenever telemetry is toggled.

Fixes #17592

#### How to test

1. Follow the reproduction steps from #17592: with telemetry disabled, create a `TelemetryLogger` from a plugin and inspect `isUsageEnabled` / `isErrorsEnabled` — they now report `false`.
2. Toggle the telemetry setting and verify the logger states follow it, with `onDidChangeEnableStates` firing on each change.
3. Unit coverage: `packages/plugin-ext/src/plugin/telemetry-ext.spec.ts` covers the initial disabled state, toggling back and forth, and `onDidChangeEnableStates` notifications.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (not applicable — no user-facing text in this change)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)