### PR TITLE
feat(ai): default custom agents to the .agents workspace folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ## 1.73.0 - tbd
 
 - [ai-core] discovered skills from `.agents/skills` directories alongside `.prompts/skills` (workspace and home directory) [#17553](https://github.com/eclipse-theia/theia/pull/17553)
+- [ai-core] discovered custom agents from the workspace `.agents` folder alongside `.prompts`, and made `.agents/agents/<id>/agent.md` the default location for newly created agents [#17692](https://github.com/eclipse-theia/theia/issues/17692)
 - [ai-core] reorganized custom agents into per-agent folders (`agents/<id>/agent.md` with YAML frontmatter); existing `customAgents.yml` files are auto-migrated on startup and preserved as `customAgents.yml.bak`, and the default prompt-override file is now `prompt.prompttemplate` [#17523](https://github.com/eclipse-theia/theia/pull/17523)
 - [ai-chat-ui] replaced the back/forward navigation stack with a single Home button in the chat view header (hidden on the overview); added `Ctrl/Cmd+Shift+L` to trigger it
 - [ai-ide] redesigned the chat session overview as a list with Active/Restored sections, agent icon per row, contextual toolbar (Home, Browse all chats..., lock/summarize hidden on the overview), and keybindings `Ctrl+Shift+L` (Home) and `Ctrl+Alt+L` (Browse all chats...)

--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -117,6 +117,18 @@ Custom agents are no longer stored in a single `customAgents.yml` per scope. Eac
 - `PromptFragmentCustomizationService` gained two required methods, `createCustomAgentFile` and `migrateCustomAgentsYaml`. If you implement this interface directly, you must provide them.
 - `PromptFragmentCustomizationService.getCustomAgentsLocations()` now returns `CustomAgentsLocation[]`. Each element gained a required `kind: 'agents-dir' | 'legacy-yaml'` field, and the result interleaves per-agent `agents/` directory entries with legacy `customAgents.yml` entries (one of each per scope). Code that previously iterated the result assuming only `customAgents.yml` files should branch on `kind` instead.
 
+#### Custom agents default to the `.agents` workspace folder
+
+Custom agents are now scanned from both the `.agents/` and `.prompts/` folders of each workspace root, independent of the `ai-features.promptTemplates.WorkspaceTemplateDirectories` preference. `.agents/` is preferred and is the default location for newly created agents (matching the skills convention introduced in [#17553](https://github.com/eclipse-theia/theia/pull/17553)); `.prompts/agents/` continues to be discovered for backward compatibility.
+
+**End-user-facing:**
+
+- New custom agents are created under `.agents/agents/<id>/agent.md` by default. Existing agents under `.prompts/agents/` keep working and are still listed as a creation location.
+
+**Adopter-facing:**
+
+- `PromptFragmentCustomizationProperties` gained an optional `agentDirectoryPaths` field carrying the absolute parent directories scanned for custom agents. The `.agents`/`.prompts` parents are exported as `CUSTOM_AGENT_WORKSPACE_DIRECTORIES`.
+
 ### v1.70.0
 
 #### Removal of deprecated @theia/git extension from Theia codebase [#17148](https://github.com/eclipse-theia/theia/pull/17148)

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
@@ -682,3 +682,38 @@ describe('DefaultPromptFragmentCustomizationService - custom agent scopes', () =
         expect(agents[0].description).to.equal('agents version');
     });
 });
+
+describe('DefaultPromptFragmentCustomizationService - custom agent change detection', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    class ChangeDetectionTestService extends DefaultPromptFragmentCustomizationService {
+        protected override init(): void { }
+        isAgentChange(path: string): boolean {
+            return this.isCustomAgentChange(path);
+        }
+    }
+
+    let service: ChangeDetectionTestService;
+    beforeEach(() => { service = new ChangeDetectionTestService(); });
+
+    it('detects deletion of the whole agents directory', () => {
+        expect(service.isAgentChange('file:///ws/.agents/agents')).to.be.true;
+    });
+
+    it('detects changes to an agent.md inside the agents directory', () => {
+        expect(service.isAgentChange('file:///ws/.agents/agents/foo/agent.md')).to.be.true;
+    });
+
+    it('detects changes to a legacy customAgents.yml', () => {
+        expect(service.isAgentChange('file:///ws/.prompts/customAgents.yml')).to.be.true;
+    });
+
+    it('ignores the scope directory itself', () => {
+        expect(service.isAgentChange('file:///ws/.agents')).to.be.false;
+    });
+
+    it('ignores unrelated files such as skills', () => {
+        expect(service.isAgentChange('file:///ws/.agents/skills/foo/SKILL.md')).to.be.false;
+    });
+});

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
@@ -618,3 +618,67 @@ describe('DefaultPromptFragmentCustomizationService - customAgents.yml migration
         expect(await fileService.exists(yamlURI)).to.be.true;
     });
 });
+
+describe('DefaultPromptFragmentCustomizationService - custom agent scopes', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    /** Test subclass: skip @postConstruct and pin the global templates directory. */
+    class AgentScopeTestService extends DefaultPromptFragmentCustomizationService {
+        globalDir = new URI('file:///global/prompt-templates');
+        protected override init(): void { }
+        protected override getTemplatesDirectoryURI(): Promise<URI> {
+            return Promise.resolve(this.globalDir);
+        }
+        setCustomAgentDirs(paths: string[]): void {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (this as any).customAgentDirs = new Set(paths);
+        }
+    }
+
+    const agentMd = (scope: URI, id: string): URI => scope.resolve(CUSTOM_AGENTS_DIRECTORY).resolve(id).resolve(CUSTOM_AGENT_FILE_NAME);
+    const agentFile = (name: string, description: string): string =>
+        `---\nname: ${name}\ndescription: ${description}\ndefaultLLM: default/universal\n---\n${name} prompt`;
+
+    let fileService: FakeFileService;
+    let service: AgentScopeTestService;
+
+    beforeEach(() => {
+        fileService = new FakeFileService();
+        service = new AgentScopeTestService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).fileService = fileService;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any).logger = { debug(): void { }, info(): void { }, warn(): void { }, error(): void { } };
+    });
+
+    it('lists the built-in .agents scope before .prompts and the global directory', async () => {
+        service.setCustomAgentDirs(['/ws/.agents', '/ws/.prompts']);
+
+        const locations = await service.getCustomAgentsLocations();
+
+        const agentDirParents = locations.filter(l => l.kind === 'agents-dir').map(l => l.uri.parent.path.toString());
+        expect(agentDirParents).to.deep.equal(['/ws/.agents', '/ws/.prompts', '/global/prompt-templates']);
+    });
+
+    it('discovers custom agents stored under the .agents directory', async () => {
+        service.setCustomAgentDirs(['/ws/.agents']);
+        fileService.write(agentMd(new URI('file:///ws/.agents'), 'foo'), agentFile('Foo', 'Foo agent'));
+
+        const agents = await service.getCustomAgents();
+
+        expect(agents.map(a => a.id)).to.deep.equal(['foo']);
+        expect(agents[0].name).to.equal('Foo');
+    });
+
+    it('prefers an agent in .agents over one with the same id in .prompts', async () => {
+        service.setCustomAgentDirs(['/ws/.agents', '/ws/.prompts']);
+        fileService.write(agentMd(new URI('file:///ws/.agents'), 'shared'), agentFile('FromAgents', 'agents version'));
+        fileService.write(agentMd(new URI('file:///ws/.prompts'), 'shared'), agentFile('FromPrompts', 'prompts version'));
+
+        const agents = await service.getCustomAgents();
+
+        expect(agents).to.have.lengthOf(1);
+        expect(agents[0].description).to.equal('agents version');
+    });
+});

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -50,6 +50,14 @@ export const CUSTOM_AGENT_FILE_NAME = 'agent.md';
  */
 export const CUSTOM_AGENT_DEFAULT_PROMPT_STEM = 'prompt';
 
+/**
+ * Workspace-relative parent folders scanned for custom agents, independent of the configurable
+ * prompt-templates directories. `.agents` is listed first so it becomes the default location for
+ * newly created agents (matching the skills convention); `.prompts` is retained for backward
+ * compatibility with agents authored before the move to `.agents`.
+ */
+export const CUSTOM_AGENT_WORKSPACE_DIRECTORIES = ['.agents', '.prompts'];
+
 interface CustomAgentFrontmatter {
     name: string;
     description: string;
@@ -129,6 +137,13 @@ export interface PromptFragmentCustomizationProperties {
 
     /** Array of file extensions to consider as template files */
     extensions?: string[];
+
+    /**
+     * Absolute parent directories scanned for custom agents (their `agents/` and legacy
+     * `customAgents.yml`), independent of {@link directoryPaths}. Resolved from
+     * {@link CUSTOM_AGENT_WORKSPACE_DIRECTORIES} against the workspace roots.
+     */
+    agentDirectoryPaths?: string[];
 }
 
 /**
@@ -207,6 +222,13 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
     /** Stores additional directory paths for loading template files. */
     protected additionalTemplateDirs = new Set<string>();
 
+    /**
+     * Built-in parent directories scanned for custom agents (`.agents`, `.prompts`), independent of
+     * {@link additionalTemplateDirs}. Insertion order is preserved so the first entry (`.agents`)
+     * acts as the default location for newly created agents.
+     */
+    protected customAgentDirs = new Set<string>();
+
     /** Contains file extensions that identify prompt template files. */
     protected templateExtensions = new Set<string>([PROMPT_TEMPLATE_EXTENSION]);
 
@@ -272,9 +294,26 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
         // resolves to the main templates directory — a user can set both prefs to the same
         // path; re-processing the same dir overwrites the priority-1 entries with priority-2,
         // which then hides them from `editBuiltIn`'s priority-1-only lookup.
+        const processedScopeKeys = new Set<string>([templatesURI.toString()]);
         for (const dirURI of this.getDedupedAdditionalScopes(templatesURI)) {
+            processedScopeKeys.add(dirURI.toString());
             await this.processTemplateDirectory(
                 activeCustomizationsCopy, trackedTemplateURIsCopy, allCustomizationsCopy, dirURI, 2, CustomizationSource.FOLDER); // Priority 2 for folder fragments
+        }
+
+        // Process built-in custom-agent directories (`.agents`/`.prompts`) not already covered as
+        // template directories above: register the prompt fragments inside their `agents/<id>/`
+        // folders and watch them, so agents under `.agents` get the same live refresh and
+        // prompt-fragment editing as those under template directories — without loading loose
+        // prompt templates from `.agents` itself.
+        for (const dirPath of this.customAgentDirs) {
+            const scopeURI = URI.fromFilePath(dirPath);
+            if (processedScopeKeys.has(scopeURI.toString())) {
+                continue;
+            }
+            processedScopeKeys.add(scopeURI.toString());
+            await this.processCustomAgentScope(
+                activeCustomizationsCopy, trackedTemplateURIsCopy, allCustomizationsCopy, scopeURI, 2, CustomizationSource.FOLDER);
         }
 
         // Process specific template files (highest priority)
@@ -646,6 +685,36 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
     }
 
     /**
+     * Processes a built-in custom-agent scope (`.agents`/`.prompts`): registers the prompt fragments
+     * inside its `agents/<id>/` folders and watches the scope for changes. Unlike
+     * {@link processTemplateDirectory} it does not scan loose `*.prompttemplate` files in the scope
+     * root, so `.agents` does not become a general prompt-template directory.
+     * @param dirURI URI of the agent scope directory
+     * @param priority Priority level for customizations in this scope
+     * @param customizationSource Source type of the customization
+     */
+    protected async processCustomAgentScope(
+        activeCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        trackedTemplateURIsCopy: Set<string>,
+        allCustomizationsCopy: Map<string, PromptFragmentCustomization>,
+        dirURI: URI,
+        priority: number,
+        customizationSource: CustomizationSource
+    ): Promise<void> {
+        await this.processCustomAgentFolders(
+            activeCustomizationsCopy,
+            trackedTemplateURIsCopy,
+            allCustomizationsCopy,
+            dirURI,
+            priority,
+            customizationSource
+        );
+        // Watch for changes (works for both existing and non-existing directories), restricted to
+        // agent folders so newly created/edited agents under `.agents` are picked up live.
+        this.setupDirectoryWatcher(dirURI, priority, customizationSource, true);
+    }
+
+    /**
      * Scan `<dirURI>/agents/<id>/*.prompttemplate` files and register each as a customized
      * prompt fragment so they appear in the Prompt Fragments configuration view and so
      * `editPromptFragmentCustomization` / `removePromptFragmentCustomization` can find their
@@ -796,11 +865,15 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
      * @param dirURI URI of the directory to watch
      * @param priority Priority level for customizations in this directory
      * @param customizationSource Source type of the customization
+     * @param agentsOnly When true, only `agents/<id>/` prompt files are registered on add; loose
+     * `*.prompttemplate` files in the scope root are ignored. Used for built-in agent scopes
+     * (`.agents`) that must not become general prompt-template directories.
      */
     protected setupDirectoryWatcher(
         dirURI: URI,
         priority: number,
-        customizationSource: CustomizationSource
+        customizationSource: CustomizationSource,
+        agentsOnly = false
     ): void {
         this.toDispose.push(this.fileService.watch(dirURI, { recursive: true, excludes: [] }));
         this.toDispose.push(this.fileService.onDidFilesChange(async (event: FileChangesEvent) => {
@@ -874,7 +947,7 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
                 if (!this.isPromptTemplateExtension(addedFile.resource.path.ext)) {
                     continue;
                 }
-                const isScopeRoot = addedFile.resource.parent.toString() === dirURI.toString();
+                const isScopeRoot = !agentsOnly && addedFile.resource.parent.toString() === dirURI.toString();
                 const agentFolderURI = this.matchesCustomAgentFolder(addedFile.resource, dirURI);
                 if (!isScopeRoot && !agentFolderURI) {
                     continue;
@@ -961,6 +1034,13 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
             }
         }
 
+        if (properties.agentDirectoryPaths !== undefined) {
+            this.customAgentDirs.clear();
+            for (const path of properties.agentDirectoryPaths) {
+                this.customAgentDirs.add(path);
+            }
+        }
+
         if (properties.extensions !== undefined) {
             this.templateExtensions.clear();
             for (const ext of properties.extensions) {
@@ -1010,6 +1090,33 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
             }
         }
         return result;
+    }
+
+    /**
+     * The deduplicated parent directories scanned for custom agents, in precedence order:
+     * the built-in {@link customAgentDirs} (`.agents` then `.prompts`) first, so `.agents` is both
+     * the discovery winner and the default creation target; then any configured
+     * {@link additionalTemplateDirs} that may also hold agents; then the global templates directory.
+     * Independent of the prompt-templates preference, mirroring how skills resolve their folders.
+     */
+    protected async getCustomAgentScopes(): Promise<URI[]> {
+        const seen = new Set<string>();
+        const scopes: URI[] = [];
+        const add = (uri: URI): void => {
+            const key = uri.toString();
+            if (!seen.has(key)) {
+                seen.add(key);
+                scopes.push(uri);
+            }
+        };
+        for (const dirPath of this.customAgentDirs) {
+            add(URI.fromFilePath(dirPath));
+        }
+        for (const dirPath of this.additionalTemplateDirs) {
+            add(URI.fromFilePath(dirPath));
+        }
+        add(await this.getTemplatesDirectoryURI());
+        return scopes;
     }
 
     /**
@@ -1344,16 +1451,12 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
 
     async getCustomAgents(): Promise<CustomAgentDescription[]> {
         const agentsById = new Map<string, CustomAgentDescription>();
-        // First, process additional (workspace) template directories to give them precedence
-        for (const dirPath of this.additionalTemplateDirs) {
-            const dirURI = URI.fromFilePath(dirPath);
-            await this.loadCustomAgentsFromAgentsDirectory(dirURI, agentsById);
-            await this.loadCustomAgentsFromDirectory(dirURI, agentsById);
+        // Process scopes in precedence order (`.agents`/`.prompts` first, global last). The map only
+        // keeps the first agent seen per id, so earlier scopes win on conflicts.
+        for (const scope of await this.getCustomAgentScopes()) {
+            await this.loadCustomAgentsFromAgentsDirectory(scope, agentsById);
+            await this.loadCustomAgentsFromDirectory(scope, agentsById);
         }
-        // Then process global templates directory (only adding agents that don't conflict)
-        const globalTemplatesDir = await this.getTemplatesDirectoryURI();
-        await this.loadCustomAgentsFromAgentsDirectory(globalTemplatesDir, agentsById);
-        await this.loadCustomAgentsFromDirectory(globalTemplatesDir, agentsById);
         // Note: customAgentFolderByFragmentId is intentionally not cleared here. It grows
         // monotonically — stale entries (renamed/removed agents) at worst point at a folder
         // that no longer exists, which the file-create path mkdirps if needed. Clearing it
@@ -1591,25 +1694,16 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
 
     /**
      * Returns all locations of existing customAgents.yml files and `agents/` directories,
-     * plus the canonical locations where new agents would be created (one per scope).
+     * plus the canonical locations where new agents would be created (one per scope). Scopes are
+     * returned in precedence order, so the first `agents-dir` entry is the default creation target.
      */
     async getCustomAgentsLocations(): Promise<CustomAgentsLocation[]> {
         const locations: CustomAgentsLocation[] = [];
-
-        const collect = async (parentDir: URI): Promise<void> => {
+        for (const parentDir of await this.getCustomAgentScopes()) {
             const agentsDirURI = parentDir.resolve(CUSTOM_AGENTS_DIRECTORY);
             locations.push({ uri: agentsDirURI, exists: await this.fileService.exists(agentsDirURI), kind: 'agents-dir' });
             const yamlURI = parentDir.resolve('customAgents.yml');
             locations.push({ uri: yamlURI, exists: await this.fileService.exists(yamlURI), kind: 'legacy-yaml' });
-        };
-
-        // Global templates directory
-        const templatesDir = await this.getTemplatesDirectoryURI();
-        await collect(templatesDir);
-        // Workspace / additional template directories — skip any that resolve to the global
-        // templates directory to avoid showing the same scope twice in the picker.
-        for (const dirURI of this.getDedupedAdditionalScopes(templatesDir)) {
-            await collect(dirURI);
         }
         return locations;
     }
@@ -1656,8 +1750,7 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
     }
 
     protected async doMigrateCustomAgentsYaml(): Promise<MigrationReport[]> {
-        const templatesURI = await this.getTemplatesDirectoryURI();
-        const scopes: URI[] = [templatesURI, ...this.getDedupedAdditionalScopes(templatesURI)];
+        const scopes = await this.getCustomAgentScopes();
         const reports: MigrationReport[] = [];
         for (const scope of scopes) {
             const report = await this.migrateSingleScope(scope);

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -52,9 +52,12 @@ export const CUSTOM_AGENT_DEFAULT_PROMPT_STEM = 'prompt';
 
 /**
  * Workspace-relative parent folders scanned for custom agents, independent of the configurable
- * prompt-templates directories. `.agents` is listed first so it becomes the default location for
- * newly created agents (matching the skills convention); `.prompts` is retained for backward
- * compatibility with agents authored before the move to `.agents`.
+ * prompt-templates directories. Scanning both folders mirrors the skills convention introduced
+ * in #17553, but the duplicate-id precedence is intentionally inverted: here `.agents` is listed
+ * first, so it becomes the default location for newly created agents and wins over `.prompts`,
+ * whereas for skills `.prompts` wins over `.agents` (see `combineSkillDirectories` in
+ * `skill-service.ts`). `.prompts` is retained for backward compatibility with agents authored
+ * before the move to `.agents`.
  */
 export const CUSTOM_AGENT_WORKSPACE_DIRECTORIES = ['.agents', '.prompts'];
 
@@ -303,9 +306,9 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
 
         // Process built-in custom-agent directories (`.agents`/`.prompts`) not already covered as
         // template directories above: register the prompt fragments inside their `agents/<id>/`
-        // folders and watch them, so agents under `.agents` get the same live refresh and
+        // folders and watch them, so agents under these scopes get the same live refresh and
         // prompt-fragment editing as those under template directories — without loading loose
-        // prompt templates from `.agents` itself.
+        // prompt templates from these built-in scopes themselves.
         for (const dirPath of this.customAgentDirs) {
             const scopeURI = URI.fromFilePath(dirPath);
             if (processedScopeKeys.has(scopeURI.toString())) {

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -861,6 +861,18 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
     }
 
     /**
+     * Whether a changed resource path affects custom agents, i.e. it is (or is inside) an `agents/`
+     * directory, or a legacy `customAgents.yml`. Matches the `agents` directory itself (e.g. when the
+     * whole folder is deleted), not only files within it, so removing `agents/` triggers a reload.
+     * @param path The string form of the changed resource URI
+     */
+    protected isCustomAgentChange(path: string): boolean {
+        return path.endsWith('customAgents.yml')
+            || path.includes(`/${CUSTOM_AGENTS_DIRECTORY}/`)
+            || path.endsWith(`/${CUSTOM_AGENTS_DIRECTORY}`);
+    }
+
+    /**
      * Sets up file watching for a template directory (works for both existing and non-existing directories)
      * @param dirURI URI of the directory to watch
      * @param priority Priority level for customizations in this directory
@@ -890,11 +902,7 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
                 return;
             }
 
-            const agentsDirSegment = `/${CUSTOM_AGENTS_DIRECTORY}/`;
-            if (event.changes.some(change => {
-                const path = change.resource.toString();
-                return path.endsWith('customAgents.yml') || path.includes(agentsDirSegment);
-            })) {
+            if (event.changes.some(change => this.isCustomAgentChange(change.resource.toString()))) {
                 this.onDidChangeCustomAgentsEmitter.fire();
             }
 

--- a/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.spec.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.spec.ts
@@ -1,0 +1,71 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { CustomAgentsLocation } from '@theia/ai-core/lib/common';
+import { AIAgentConfigurationWidget } from './agent-configuration-widget';
+
+disableJSDOM();
+
+describe('AIAgentConfigurationWidget - selectAgentScopeOptions', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    let widget: AIAgentConfigurationWidget;
+    beforeEach(() => { widget = new AIAgentConfigurationWidget(); });
+
+    const agentsDir = (scope: string): CustomAgentsLocation =>
+        ({ uri: new URI(`file:///ws/${scope}`).resolve('agents'), exists: false, kind: 'agents-dir' });
+    const existingAgentsDir = (scope: string): CustomAgentsLocation =>
+        ({ uri: new URI(`file:///ws/${scope}`).resolve('agents'), exists: true, kind: 'agents-dir' });
+    const legacyYaml = (scope: string): CustomAgentsLocation =>
+        ({ uri: new URI(`file:///ws/${scope}`).resolve('customAgents.yml'), exists: false, kind: 'legacy-yaml' });
+
+    const select = (locations: CustomAgentsLocation[]): string[] =>
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (widget as any).selectAgentScopeOptions(locations).map((o: { scopeDir: URI }) => o.scopeDir.path.toString());
+
+    it('keeps only the default .agents scope when no scope has an agents folder', () => {
+        const locations = [
+            agentsDir('.agents'), legacyYaml('.agents'),
+            agentsDir('.prompts'), legacyYaml('.prompts')
+        ];
+
+        expect(select(locations)).to.deep.equal(['/ws/.agents']);
+    });
+
+    it('keeps a non-default scope that already contains an agents folder', () => {
+        const locations = [
+            agentsDir('.agents'), legacyYaml('.agents'),
+            existingAgentsDir('.prompts'), legacyYaml('.prompts')
+        ];
+
+        expect(select(locations)).to.deep.equal(['/ws/.agents', '/ws/.prompts']);
+    });
+
+    it('ignores legacy customAgents.yml entries', () => {
+        const locations = [agentsDir('.agents'), legacyYaml('.agents')];
+
+        expect(select(locations)).to.deep.equal(['/ws/.agents']);
+    });
+});

--- a/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -27,6 +27,7 @@ import {
     ParsedCapability,
     parseCapabilitiesFromTemplate,
     PromptFragmentCustomizationService,
+    CustomAgentsLocation,
     PromptService,
     NotificationType,
     PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE,
@@ -42,7 +43,7 @@ import { AIConfigurationSelectionService } from './ai-configuration-service';
 import { LanguageModelRenderer } from './language-model-renderer';
 import { LanguageModelAliasRegistry, LanguageModelAlias } from '@theia/ai-core/lib/common/language-model-alias';
 import { AIVariableConfigurationWidget } from './variable-configuration-widget';
-import { MessageService, nls } from '@theia/core';
+import { MessageService, nls, URI } from '@theia/core';
 import { PromptVariantRenderer } from './template-settings-renderer';
 import { AIListDetailConfigurationWidget } from './base/ai-list-detail-configuration-widget';
 import { AgentNotificationSettings } from './components/agent-notification-settings';
@@ -53,6 +54,12 @@ interface ParsedPrompt {
     agentSpecificVariables: string[];
     capabilities: ParsedCapability[];
 };
+
+/** A candidate location for creating a new custom agent: its scope directory and `agents/` folder. */
+interface CustomAgentScopeOption {
+    scopeDir: URI;
+    agentsDir: URI;
+}
 
 @injectable()
 export class AIAgentConfigurationWidget extends AIListDetailConfigurationWidget<Agent> {
@@ -486,14 +493,23 @@ export class AIAgentConfigurationWidget extends AIListDetailConfigurationWidget<
         this.aiConfigurationSelectionService.selectConfigurationTab(AIVariableConfigurationWidget.ID);
     }
 
+    /**
+     * Selects the candidate creation locations from the reported agent locations. Only `agents/`
+     * directories are considered (legacy `customAgents.yml` entries exist for discovery only). A
+     * scope is offered when it already contains an `agents/` folder; the preferred scope (the first
+     * one, i.e. `.agents`) is always kept so a fresh workspace defaults to `.agents` without
+     * surfacing empty fallback folders such as `.prompts`.
+     */
+    protected selectAgentScopeOptions(locations: CustomAgentsLocation[]): CustomAgentScopeOption[] {
+        return locations
+            .filter(location => location.kind === 'agents-dir')
+            .filter((location, index) => index === 0 || location.exists)
+            .map(location => ({ scopeDir: location.uri.parent, agentsDir: location.uri }));
+    }
+
     protected async addCustomAgent(): Promise<void> {
-        // Locations are reported as `<scope>/agents/` directories + legacy `customAgents.yml`
-        // entries (one of each per scope). For new agents we only consider the `agents/` form;
-        // the YAML entries exist only for backward-compat / discovery.
         const allLocations = await this.promptFragmentCustomizationService.getCustomAgentsLocations();
-        const scopeOptions = allLocations
-            .filter(l => l.kind === 'agents-dir')
-            .map(l => ({ scopeDir: l.uri.parent, agentsDir: l.uri }));
+        const scopeOptions = this.selectAgentScopeOptions(allLocations);
         if (scopeOptions.length === 0) {
             this.messageService.warn(nls.localize('theia/ai/ide/agentConfiguration/newAgent/noLocation',
                 'Cannot create a custom agent: no prompt-templates location is configured. Set a global or workspace prompt-templates folder and try again.'));

--- a/packages/ai-ide/src/browser/template-preference-contribution.ts
+++ b/packages/ai-ide/src/browser/template-preference-contribution.ts
@@ -16,7 +16,9 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { DefaultPromptFragmentCustomizationService, PromptFragmentCustomizationProperties } from '@theia/ai-core/lib/browser/frontend-prompt-customization-service';
+import {
+    CUSTOM_AGENT_WORKSPACE_DIRECTORIES, DefaultPromptFragmentCustomizationService, PromptFragmentCustomizationProperties
+} from '@theia/ai-core/lib/browser/frontend-prompt-customization-service';
 import {
     PROMPT_TEMPLATE_WORKSPACE_DIRECTORIES_PREF,
     PROMPT_TEMPLATE_ADDITIONAL_EXTENSIONS_PREF,
@@ -120,6 +122,18 @@ export class TemplatePreferenceContribution implements FrontendApplicationContri
                 );
             } else {
                 configProperties.filePaths = [];
+            }
+        }
+
+        // The built-in custom-agent directories (`.agents`/`.prompts`) depend only on the workspace
+        // roots and trust state, not on any preference, so they are recomputed on every full update.
+        if (!changedPreference) {
+            if (trusted) {
+                configProperties.agentDirectoryPaths = workspaceRoots.flatMap(root =>
+                    CUSTOM_AGENT_WORKSPACE_DIRECTORIES.map(dir => root.resource.resolve(dir).path.toString())
+                );
+            } else {
+                configProperties.agentDirectoryPaths = [];
             }
         }
 


### PR DESCRIPTION
#### What it does

Closes #17692.

Makes `.agents` the default workspace folder for custom agents, aligning with the skills convention introduced in #17553. Custom agents are now discovered from both `.agents/` and `.prompts/` of each workspace root, independent of the `ai-features.promptTemplates.WorkspaceTemplateDirectories` preference, and new agents are created under `.agents/agents/<id>/agent.md` by default. `.prompts/agents/` keeps being discovered for backward compatibility. `CHANGELOG.md` and `doc/Migration.md` are updated.


#### How to test

1. Open a workspace with the AI features enabled.
2. In the AI Configuration view, add a custom agent. In a fresh workspace it is created under `.agents/agents/<id>/agent.md` with no location prompt.
3. Confirm the agent appears both in the AI Configuration view and in the chat agent list.
4. Delete the agent's folder, the whole `.agents/agents` folder, or the `.agents` folder, and confirm the agent disappears from both lists.
5. Put an agent under `.prompts/agents/<id>/agent.md`: confirm it is still discovered, and that both `.agents` and `.prompts` are offered when creating a new agent.

Automated tests:

```
npx lerna run test --scope @theia/ai-core
npx lerna run test --scope @theia/ai-ide
```

New specs cover agent scope resolution and precedence, the change-detection predicate (including deleting the whole `agents/` folder), and the creation-location selection.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

The change is backward compatible: `.prompts/agents/` agents keep working. `PromptFragmentCustomizationProperties` gains an optional `agentDirectoryPaths` field and `getCustomAgentsLocations()` now returns scopes in preference order; both are additive and documented in `doc/Migration.md`.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

