### PR TITLE
fix: harden WebSocket and HTTP request validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - [vsx-registry] `VSXExtensionsContribution` no longer injects `OVSXClientProvider` or `OVSXApiFilterProvider`. It now uses `VSXRegistryService`. Extensions that subclass `VSXExtensionsContribution` and relied on `clientProvider` or `vsxApiFilter` must migrate to `vsxRegistryService`.
 - [vsx-registry] `VSXLanguageQuickPickService` no longer injects `RequestService` or `OVSXClientProvider`. It now uses `VSXRegistryService`.
 - [vsx-registry] The `OVSXClientProvider` binding from `vsx-registry-common-module` is still available but no longer used on the frontend by any Theia code. On the frontend, `OVSXHttpClient` uses the browser `RequestService`, which falls back to `BackendRequestFacade` for CORS bypass — these requests will be rejected by the URL allowlist unless a `BackendRequestAllowedContribution` is registered. Frontend code that depends on `OVSXClientProvider` should migrate to `VSXRegistryService` or register an appropriate allowlist contribution.
+- [core] WebSocket connections now enforce same-origin validation by default when `THEIA_HOSTS` is not set, and require a `SameSite=Strict` connection token cookie. The internal `fix-origin` header mechanism has been removed. Custom deployments that relied on `fix-origin` to pass origin validation must update accordingly. [#17701](https://github.com/eclipse-theia/theia/pull/17701)
 
 ## 1.72.0 - 5/28/2026
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -164,7 +164,7 @@ Where `root` is the name of the logger and `INFO` is the log level. These are op
     - e.g: `theia.app.com,some.other.domain:3000`
   - The port number is important if your application is not hosted on either `80` or `443`.
   - If possible, you should set this environment variable:
-    - When not set, Theia will allow any origin to access the WebSocket services.
+    - When not set, Theia will enforce same-origin access to the WebSocket services.
     - When set, Theia will only allow the origins defined in this environment variable.
 - `FRONTEND_CONNECTION_TIMEOUT`
   - The duration in milliseconds during which the backend keeps the connection contexts for the frontend to reconnect.

--- a/packages/core/README_TEMPLATE.md
+++ b/packages/core/README_TEMPLATE.md
@@ -132,7 +132,7 @@ Where `root` is the name of the logger and `INFO` is the log level. These are op
     - e.g: `theia.app.com,some.other.domain:3000`
   - The port number is important if your application is not hosted on either `80` or `443`.
   - If possible, you should set this environment variable:
-    - When not set, Theia will allow any origin to access the WebSocket services.
+    - When not set, Theia will enforce same-origin access to the WebSocket services.
     - When set, Theia will only allow the origins defined in this environment variable.
 - `FRONTEND_CONNECTION_TIMEOUT`
   - The duration in milliseconds during which the backend keeps the connection contexts for the frontend to reconnect.

--- a/packages/core/src/browser/messaging/ws-connection-source.ts
+++ b/packages/core/src/browser/messaging/ws-connection-source.ts
@@ -208,12 +208,7 @@ export class WebSocketConnectionSource implements ConnectionSource {
             reconnection: true,
             reconnectionDelay: 1000,
             reconnectionDelayMax: 10000,
-            reconnectionAttempts: Infinity,
-            extraHeaders: {
-                // Socket.io strips the `origin` header
-                // We need to provide our own for validation
-                'fix-origin': window.location.origin
-            }
+            reconnectionAttempts: Infinity
         });
     }
 

--- a/packages/core/src/electron-node/hosting/electron-ws-origin-validator.spec.ts
+++ b/packages/core/src/electron-node/hosting/electron-ws-origin-validator.spec.ts
@@ -1,0 +1,69 @@
+// *****************************************************************************
+// Copyright (C) 2026 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as http from 'http';
+import { ElectronWsOriginValidator } from './electron-ws-origin-validator';
+import { BackendRemoteService } from '../../node/remote/backend-remote-service';
+
+describe('ElectronWsOriginValidator', () => {
+
+    function createValidator(isRemote = false): ElectronWsOriginValidator {
+        const remoteService = { isRemoteServer: () => isRemote } as BackendRemoteService;
+        const validator = new ElectronWsOriginValidator();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (validator as any)['backendRemoteService'] = remoteService;
+        return validator;
+    }
+
+    function createRequest(origin?: string): http.IncomingMessage {
+        const request = {
+            headers: {} as http.IncomingHttpHeaders
+        } as http.IncomingMessage;
+        if (origin !== undefined) {
+            request.headers.origin = origin;
+        }
+        return request;
+    }
+
+    it('should allow file:// origin (standard Electron case)', () => {
+        expect(createValidator().allowWsUpgrade(createRequest('file://'))).to.be.true;
+    });
+
+    it('should allow null origin (opaque origin from file:// pages)', () => {
+        expect(createValidator().allowWsUpgrade(createRequest('null'))).to.be.true;
+    });
+
+    it('should allow absent origin (same-origin polling requests)', () => {
+        expect(createValidator().allowWsUpgrade(createRequest(undefined))).to.be.true;
+    });
+
+    it('should reject cross-origin requests', () => {
+        expect(createValidator().allowWsUpgrade(createRequest('http://evil.com'))).to.be.false;
+    });
+
+    it('should reject http://localhost origin (not expected in Electron)', () => {
+        expect(createValidator().allowWsUpgrade(createRequest('http://localhost:3000'))).to.be.false;
+    });
+
+    it('should allow empty string origin (treated as absent)', () => {
+        expect(createValidator().allowWsUpgrade(createRequest(''))).to.be.true;
+    });
+
+    it('should allow any origin when running as remote server', () => {
+        expect(createValidator(true).allowWsUpgrade(createRequest('http://remote-host.com'))).to.be.true;
+    });
+});

--- a/packages/core/src/electron-node/hosting/electron-ws-origin-validator.ts
+++ b/packages/core/src/electron-node/hosting/electron-ws-origin-validator.ts
@@ -30,8 +30,11 @@ export class ElectronWsOriginValidator implements WsRequestValidatorContribution
         if (this.backendRemoteService.isRemoteServer()) {
             return true;
         }
+        const origin = request.headers.origin;
         // On Electron the main page is served from the `file` protocol.
-        // We don't expect the requests to come from anywhere else.
-        return request.headers.origin === 'file://';
+        // Chromium may send "file://" or "null" (opaque origin) or omit the
+        // header entirely depending on the request type (WebSocket upgrade vs
+        // HTTP polling). All three are expected for same-origin Electron requests.
+        return !origin || origin === 'file://' || origin === 'null';
     }
 }

--- a/packages/core/src/node/backend-application-module.ts
+++ b/packages/core/src/node/backend-application-module.ts
@@ -36,7 +36,7 @@ import {
 } from '../common';
 import {
     BackendApplication, BackendApplicationContribution, BackendApplicationCliContribution,
-    BackendApplicationServer, BackendApplicationPath, RootContainer
+    BackendApplicationServer, BackendApplicationPath, EarlyExpressMiddleware, RootContainer
 } from './backend-application';
 import { CliManager, CliContribution } from './cli';
 import { IPCConnectionProvider } from './messaging';
@@ -89,6 +89,7 @@ export const backendApplicationModule = new ContainerModule(bind => {
     bind(BackendApplicationCliContribution).toSelf().inSingletonScope();
     bind(CliContribution).toService(BackendApplicationCliContribution);
 
+    bind(EarlyExpressMiddleware).toSelf().inSingletonScope();
     bind(BackendApplication).toSelf().inSingletonScope();
     bind(RootContainer).toDynamicValue(({ container }) => {
         let root = container;

--- a/packages/core/src/node/backend-application.spec.ts
+++ b/packages/core/src/node/backend-application.spec.ts
@@ -25,6 +25,7 @@ import {
     BackendApplication,
     BackendApplicationCliContribution,
     BackendApplicationContribution,
+    EarlyExpressMiddleware,
     RootContainer
 } from './backend-application';
 import { CliContribution } from './cli';
@@ -87,6 +88,7 @@ describe('BackendApplication', () => {
         container.bind(ProcessUtils).toSelf().inSingletonScope();
         container.bind(BackendApplicationCliContribution).toSelf().inSingletonScope();
         container.bind(CliContribution).toService(BackendApplicationCliContribution);
+        container.bind(EarlyExpressMiddleware).toSelf().inSingletonScope();
         bindContributionProvider(container, BackendApplicationContribution);
 
         container.bind(TestBackendApplication).toSelf().inSingletonScope();

--- a/packages/core/src/node/backend-application.ts
+++ b/packages/core/src/node/backend-application.ts
@@ -54,6 +54,16 @@ const DEFAULT_HOST = 'localhost';
 const DEFAULT_SSL = false;
 const DEFAULT_DNS_DEFAULT_RESULT_ORDER: DnsResultOrder = 'ipv4first';
 
+/**
+ * Shared registry for Express middleware that must run before static file handlers.
+ * Contributions push handlers during `initialize()`, and `BackendApplication`
+ * applies them at the start of `configure()`, before gzipped handlers and `express.static()`.
+ */
+@injectable()
+export class EarlyExpressMiddleware {
+    readonly handlers: express.Handler[] = [];
+}
+
 export const BackendApplicationServer = Symbol('BackendApplicationServer');
 /**
  * This service is responsible for serving the frontend files.
@@ -175,6 +185,9 @@ export class BackendApplication {
 
     protected readonly app: express.Application = express();
 
+    @inject(EarlyExpressMiddleware)
+    protected readonly earlyMiddleware: EarlyExpressMiddleware;
+
     @inject(ProcessUtils)
     protected readonly processUtils: ProcessUtils;
 
@@ -243,6 +256,11 @@ export class BackendApplication {
 
     protected async configure(): Promise<void> {
         await this.initialize();
+
+        // Apply early middleware before static file handlers.
+        for (const handler of this.earlyMiddleware.handlers) {
+            this.app.use(handler);
+        }
 
         this.app.get('*.js', this.serveGzipped.bind(this, 'text/javascript'));
         this.app.get('*.js.map', this.serveGzipped.bind(this, 'application/json'));

--- a/packages/core/src/node/hosting/backend-hosting-module.ts
+++ b/packages/core/src/node/hosting/backend-hosting-module.ts
@@ -15,12 +15,22 @@
 // *****************************************************************************
 
 import { ContainerModule } from 'inversify';
+import { BackendApplicationContribution } from '../backend-application';
 import { WsRequestValidatorContribution } from '../ws-request-validators';
 import { BackendApplicationHosts } from './backend-application-hosts';
+import {
+    BrowserConnectionToken, BrowserConnectionTokenBackendContribution, createBrowserConnectionToken
+} from './browser-connection-token';
 import { WsOriginValidator } from './ws-origin-validator';
 
 export default new ContainerModule(bind => {
     bind(BackendApplicationHosts).toSelf().inSingletonScope();
     bind(WsOriginValidator).toSelf().inSingletonScope();
     bind(WsRequestValidatorContribution).toService(WsOriginValidator);
+
+    // Cookie-based connection token protects both HTTP and WebSocket endpoints.
+    bind(BrowserConnectionToken).toConstantValue(createBrowserConnectionToken());
+    bind(BrowserConnectionTokenBackendContribution).toSelf().inSingletonScope();
+    bind(BackendApplicationContribution).toService(BrowserConnectionTokenBackendContribution);
+    bind(WsRequestValidatorContribution).toService(BrowserConnectionTokenBackendContribution);
 });

--- a/packages/core/src/node/hosting/browser-connection-token.spec.ts
+++ b/packages/core/src/node/hosting/browser-connection-token.spec.ts
@@ -1,0 +1,167 @@
+// *****************************************************************************
+// Copyright (C) 2026 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as http from 'http';
+import {
+    BrowserConnectionToken,
+    BrowserConnectionTokenBackendContribution,
+    BROWSER_TOKEN_COOKIE_NAME,
+    createBrowserConnectionToken
+} from './browser-connection-token';
+
+describe('BrowserConnectionToken', () => {
+
+    it('should generate unique tokens', () => {
+        const token1 = createBrowserConnectionToken();
+        const token2 = createBrowserConnectionToken();
+        expect(token1.value).to.not.equal(token2.value);
+    });
+
+    it('should generate tokens of sufficient length', () => {
+        const token = createBrowserConnectionToken();
+        expect(token.value.length).to.be.greaterThan(16);
+    });
+});
+
+describe('BrowserConnectionTokenBackendContribution', () => {
+
+    const token: BrowserConnectionToken = createBrowserConnectionToken();
+
+    function createContribution(): BrowserConnectionTokenBackendContribution {
+        const contribution = new BrowserConnectionTokenBackendContribution();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (contribution as any)['browserConnectionToken'] = token;
+        return contribution;
+    }
+
+    function createRequest(cookieValue?: string): http.IncomingMessage {
+        const request = {
+            headers: {} as http.IncomingHttpHeaders
+        } as http.IncomingMessage;
+        if (cookieValue !== undefined) {
+            request.headers.cookie = `${BROWSER_TOKEN_COOKIE_NAME}=${cookieValue}`;
+        }
+        return request;
+    }
+
+    describe('allowWsUpgrade (WebSocket validation)', () => {
+
+        it('should allow WebSocket with valid token cookie', () => {
+            const contribution = createContribution();
+            expect(contribution.allowWsUpgrade(createRequest(token.value))).to.be.true;
+        });
+
+        it('should reject WebSocket with no cookie', () => {
+            const contribution = createContribution();
+            expect(contribution.allowWsUpgrade(createRequest())).to.be.false;
+        });
+
+        it('should reject WebSocket with invalid token', () => {
+            const contribution = createContribution();
+            expect(contribution.allowWsUpgrade(createRequest('wrong-token'))).to.be.false;
+        });
+
+        it('should reject WebSocket with stale token from previous server', () => {
+            const contribution = createContribution();
+            const staleToken = createBrowserConnectionToken().value;
+            expect(contribution.allowWsUpgrade(createRequest(staleToken))).to.be.false;
+        });
+
+        it('should reject WebSocket with empty token', () => {
+            const contribution = createContribution();
+            expect(contribution.allowWsUpgrade(createRequest(''))).to.be.false;
+        });
+
+        it('should handle multiple cookies correctly', () => {
+            const contribution = createContribution();
+            const request = {
+                headers: {
+                    cookie: `other-cookie=foo; ${BROWSER_TOKEN_COOKIE_NAME}=${token.value}; another=bar`
+                } as http.IncomingHttpHeaders
+            } as http.IncomingMessage;
+            expect(contribution.allowWsUpgrade(request)).to.be.true;
+        });
+    });
+
+    describe('expressMiddleware (HTTP cookie flow)', () => {
+
+        interface CookieCall {
+            name: string;
+            value: string;
+            options: Record<string, unknown>;
+        }
+
+        interface MockResponse {
+            cookieCalls: CookieCall[];
+            nextCalled: boolean;
+        }
+
+        function callMiddleware(cookieValue?: string): MockResponse {
+            const contribution = createContribution();
+            const result: MockResponse = { cookieCalls: [], nextCalled: false };
+
+            const req = {
+                headers: {} as Record<string, string | undefined>,
+                socket: { remoteAddress: '127.0.0.1' }
+            };
+            if (cookieValue !== undefined) {
+                req.headers.cookie = `${BROWSER_TOKEN_COOKIE_NAME}=${cookieValue}`;
+            }
+
+            const res = {
+                cookie: (name: string, value: string, options: Record<string, unknown>) => {
+                    result.cookieCalls.push({ name, value, options });
+                }
+            };
+
+            const next = (): void => { result.nextCalled = true; };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (contribution as any).expressMiddleware(req, res, next);
+            return result;
+        }
+
+        it('should set cookie and allow request when no cookie present', () => {
+            const result = callMiddleware();
+            expect(result.nextCalled).to.be.true;
+            expect(result.cookieCalls).to.have.length(1);
+            expect(result.cookieCalls[0].name).to.equal(BROWSER_TOKEN_COOKIE_NAME);
+            expect(result.cookieCalls[0].value).to.equal(token.value);
+        });
+
+        it('should set cookie with HttpOnly, SameSite=Strict, and path=/', () => {
+            const result = callMiddleware();
+            const opts = result.cookieCalls[0].options;
+            expect(opts.httpOnly).to.be.true;
+            expect(opts.sameSite).to.equal('strict');
+            expect(opts.path).to.equal('/');
+        });
+
+        it('should allow request with valid cookie without re-setting it', () => {
+            const result = callMiddleware(token.value);
+            expect(result.nextCalled).to.be.true;
+            expect(result.cookieCalls).to.have.length(0);
+        });
+
+        it('should refresh stale cookie and allow request', () => {
+            const result = callMiddleware('stale-token-from-old-server');
+            expect(result.nextCalled).to.be.true;
+            expect(result.cookieCalls).to.have.length(1);
+            expect(result.cookieCalls[0].value).to.equal(token.value);
+        });
+    });
+});

--- a/packages/core/src/node/hosting/browser-connection-token.ts
+++ b/packages/core/src/node/hosting/browser-connection-token.ts
@@ -1,0 +1,126 @@
+// *****************************************************************************
+// Copyright (C) 2026 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as cookie from 'cookie';
+import * as crypto from 'crypto';
+import * as http from 'http';
+import express = require('express');
+import { inject, injectable } from 'inversify';
+import { environment } from '../../common/index';
+import { MaybePromise } from '../../common';
+import { BackendApplicationContribution, EarlyExpressMiddleware } from '../backend-application';
+import { WsRequestValidatorContribution } from '../ws-request-validators';
+import { generateUuid } from '../../common/uuid';
+
+export const BrowserConnectionToken = Symbol('BrowserConnectionToken');
+
+export const BROWSER_TOKEN_COOKIE_NAME = 'theia-connection-token';
+
+export interface BrowserConnectionToken {
+    value: string;
+}
+
+/**
+ * Validates WebSocket and HTTP requests using a cookie-based connection token.
+ *
+ * In browser deployments, the server generates a random token at startup and sets it
+ * as a `SameSite=Strict; HttpOnly` cookie on the first page load. Cross-origin pages
+ * cannot obtain or send this cookie, so their requests are rejected.
+ *
+ * This complements the origin validator: non-browser callers that omit the Origin
+ * header (e.g. Node.js scripts) still cannot reach the backend without the cookie.
+ *
+ * Skipped in Electron deployments (which use their own `ElectronSecurityToken`).
+ */
+@injectable()
+export class BrowserConnectionTokenBackendContribution implements BackendApplicationContribution, WsRequestValidatorContribution {
+
+    @inject(BrowserConnectionToken)
+    protected readonly browserConnectionToken: BrowserConnectionToken;
+
+    @inject(EarlyExpressMiddleware)
+    protected readonly earlyMiddleware: EarlyExpressMiddleware;
+
+    /**
+     * Register the cookie middleware during `initialize()` via `EarlyExpressMiddleware`
+     * so it runs before `express.static()` (which is registered later during `configure()`).
+     * This ensures the browser receives the token cookie on the initial page load.
+     */
+    initialize(): void {
+        if (environment.electron.is()) {
+            return;
+        }
+        this.earlyMiddleware.handlers.push((req, res, next) => this.expressMiddleware(req, res, next));
+    }
+
+    /**
+     * Validate the connection token cookie on WebSocket upgrade requests.
+     * Non-browser callers that omit the Origin header (e.g. Node.js scripts)
+     * cannot provide the `SameSite=Strict` cookie either, so they are rejected.
+     */
+    allowWsUpgrade(request: http.IncomingMessage): MaybePromise<boolean> {
+        if (environment.electron.is()) {
+            return true;
+        }
+        const token = this.getTokenFromCookie(request);
+        if (token) {
+            return this.isTokenValid(token);
+        }
+        // No cookie: reject. Legitimate browsers always have the cookie
+        // because it is set on the initial page load.
+        return false;
+    }
+
+    protected expressMiddleware(req: express.Request, res: express.Response, next: express.NextFunction): void {
+        const existing = this.getTokenFromCookie(req);
+        if (!existing || !this.isTokenValid(existing)) {
+            // No cookie or stale cookie (e.g. after server restart) so (re-)issue it.
+            // The browser will use the fresh token on subsequent requests.
+            res.cookie(BROWSER_TOKEN_COOKIE_NAME, this.browserConnectionToken.value, {
+                httpOnly: true,
+                sameSite: 'strict',
+                path: '/'
+            });
+        }
+        next();
+    }
+
+    protected getTokenFromCookie(req: http.IncomingMessage): string | undefined {
+        const cookieHeader = req.headers.cookie;
+        if (cookieHeader) {
+            return cookie.parse(cookieHeader)[BROWSER_TOKEN_COOKIE_NAME];
+        }
+        return undefined;
+    }
+
+    protected isTokenValid(token: string): boolean {
+        try {
+            const received = Buffer.from(token, 'utf8');
+            const expected = Buffer.from(this.browserConnectionToken.value, 'utf8');
+            return received.byteLength === expected.byteLength && crypto.timingSafeEqual(received, expected);
+        } catch (error) {
+            console.error(error);
+        }
+        return false;
+    }
+}
+
+/**
+ * Creates a new browser connection token.
+ */
+export function createBrowserConnectionToken(): BrowserConnectionToken {
+    return { value: generateUuid() };
+}

--- a/packages/core/src/node/hosting/ws-origin-validator.spec.ts
+++ b/packages/core/src/node/hosting/ws-origin-validator.spec.ts
@@ -1,0 +1,193 @@
+// *****************************************************************************
+// Copyright (C) 2026 STMicroelectronics and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as http from 'http';
+import { WsOriginValidator } from './ws-origin-validator';
+import { BackendApplicationHosts } from './backend-application-hosts';
+
+describe('WsOriginValidator', () => {
+
+    function createValidator(hosts?: string[]): WsOriginValidator {
+        const backendHosts = new BackendApplicationHosts();
+        if (hosts) {
+            for (const h of hosts) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (backendHosts as any)['_hosts'].add(h);
+            }
+        }
+        const validator = new WsOriginValidator();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (validator as any)['backendApplicationHosts'] = backendHosts;
+        return validator;
+    }
+
+    function createRequest(origin?: string, host?: string): http.IncomingMessage {
+        const request = {
+            headers: {} as http.IncomingHttpHeaders
+        } as http.IncomingMessage;
+        if (origin !== undefined) {
+            request.headers.origin = origin;
+        }
+        if (host !== undefined) {
+            request.headers.host = host;
+        }
+        return request;
+    }
+
+    describe('when THEIA_HOSTS is not set', () => {
+
+        it('should allow same-origin requests', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('http://localhost:3000', 'localhost:3000')
+            )).to.be.true;
+        });
+
+        it('should allow same-origin requests on default ports', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('http://myhost.com', 'myhost.com')
+            )).to.be.true;
+        });
+
+        it('should reject cross-origin requests', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('http://evil.com', 'localhost:3000')
+            )).to.be.false;
+        });
+
+        it('should allow requests with no Origin header (same-origin polling)', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest(undefined, 'localhost:3000')
+            )).to.be.true;
+        });
+
+        it('should reject requests with no Host header when Origin is present', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('http://localhost:3000', undefined)
+            )).to.be.false;
+        });
+
+        it('should reject requests with malformed Origin', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('not-a-valid-url', 'localhost:3000')
+            )).to.be.false;
+        });
+    });
+
+    describe('when THEIA_HOSTS is set', () => {
+
+        it('should allow requests from a listed host', () => {
+            const validator = createValidator(['myhost.com']);
+            expect(validator.allowWsUpgrade(
+                createRequest('http://myhost.com', 'myhost.com')
+            )).to.be.true;
+        });
+
+        it('should allow requests from a listed host with port', () => {
+            const validator = createValidator(['myhost.com:8080']);
+            expect(validator.allowWsUpgrade(
+                createRequest('http://myhost.com:8080', 'myhost.com:8080')
+            )).to.be.true;
+        });
+
+        it('should reject requests from an unlisted host', () => {
+            const validator = createValidator(['myhost.com']);
+            expect(validator.allowWsUpgrade(
+                createRequest('http://evil.com', 'myhost.com')
+            )).to.be.false;
+        });
+
+        it('should allow requests with no Origin header (same-origin polling)', () => {
+            const validator = createValidator(['myhost.com']);
+            expect(validator.allowWsUpgrade(
+                createRequest(undefined, 'myhost.com')
+            )).to.be.true;
+        });
+
+        it('should allow when origin host is in the allowlist regardless of Host header', () => {
+            const validator = createValidator(['myhost.com']);
+            expect(validator.allowWsUpgrade(
+                createRequest('http://myhost.com', 'internal-host:3000')
+            )).to.be.true;
+        });
+
+        it('should reject malformed Origin even with THEIA_HOSTS', () => {
+            const validator = createValidator(['myhost.com']);
+            expect(validator.allowWsUpgrade(
+                createRequest('not-a-valid-url', 'myhost.com')
+            )).to.be.false;
+        });
+    });
+
+    describe('edge cases', () => {
+
+        it('should reject cross-origin with port mismatch', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('http://localhost:4000', 'localhost:3000')
+            )).to.be.false;
+        });
+
+        it('should handle HTTPS origins', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('https://localhost:3000', 'localhost:3000')
+            )).to.be.true;
+        });
+
+        it('should reject Origin: null (opaque origin from sandboxed pages)', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('null', 'localhost:3000')
+            )).to.be.false;
+        });
+
+        it('should allow empty Origin string (treated as absent)', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('', 'localhost:3000')
+            )).to.be.true;
+        });
+
+        it('should handle IPv6 same-origin', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('http://[::1]:3000', '[::1]:3000')
+            )).to.be.true;
+        });
+
+        it('should strip credentials from Origin when comparing', () => {
+            const validator = createValidator();
+            // new URL('http://user:pass@localhost:3000').host === 'localhost:3000'
+            expect(validator.allowWsUpgrade(
+                createRequest('http://user:pass@localhost:3000', 'localhost:3000')
+            )).to.be.true;
+        });
+
+        it('should ignore path component in Origin', () => {
+            const validator = createValidator();
+            expect(validator.allowWsUpgrade(
+                createRequest('http://localhost:3000/some/path', 'localhost:3000')
+            )).to.be.true;
+        });
+    });
+});

--- a/packages/core/src/node/hosting/ws-origin-validator.ts
+++ b/packages/core/src/node/hosting/ws-origin-validator.ts
@@ -16,7 +16,6 @@
 
 import * as http from 'http';
 import { inject, injectable } from 'inversify';
-import * as url from 'url';
 import { WsRequestValidatorContribution } from '../ws-request-validators';
 import { BackendApplicationHosts } from './backend-application-hosts';
 
@@ -27,10 +26,30 @@ export class WsOriginValidator implements WsRequestValidatorContribution {
     protected readonly backendApplicationHosts: BackendApplicationHosts;
 
     allowWsUpgrade(request: http.IncomingMessage): boolean {
-        if (!this.backendApplicationHosts.hasKnownHosts() || !request.headers.origin) {
+        if (!request.headers.origin) {
+            // Browsers omit the Origin header for same-origin requests (e.g. Socket.IO polling).
+            // Absent Origin is safe: cross-origin browser requests always include it.
             return true;
         }
-        const origin = url.parse(request.headers.origin);
-        return this.backendApplicationHosts.hosts.has(origin.host!);
+
+        let originHost: string;
+        try {
+            originHost = new URL(request.headers.origin).host;
+        } catch {
+            return false;
+        }
+
+        if (this.backendApplicationHosts.hasKnownHosts()) {
+            // When THEIA_HOSTS is configured, validate against the explicit allowlist.
+            return this.backendApplicationHosts.hosts.has(originHost);
+        }
+
+        // When THEIA_HOSTS is not configured (the common development/default case),
+        // enforce same-origin: the Origin's host must match the request's Host header.
+        const hostHeader = request.headers.host;
+        if (!hostHeader) {
+            return false;
+        }
+        return originHost === hostHeader;
     }
 }

--- a/packages/core/src/node/messaging/websocket-endpoint.ts
+++ b/packages/core/src/node/messaging/websocket-endpoint.ts
@@ -48,14 +48,21 @@ export class WebsocketEndpoint implements BackendApplicationContribution {
         const socketServer = new Server(server, {
             pingInterval: this.checkAliveTimeout,
             pingTimeout: this.checkAliveTimeout * 2,
-            maxHttpBufferSize: this.maxHttpBufferSize
+            maxHttpBufferSize: this.maxHttpBufferSize,
+            allowRequest: (req, callback) => {
+                // eslint-disable-next-line no-null/no-null
+                const noError = null;
+                this.wsRequestValidator.allowWsUpgrade(req).then(
+                    allowed => callback(noError, allowed),
+                    error => {
+                        console.error('Error during WebSocket allowRequest validation:', error);
+                        callback(error?.message ?? 'Validation error', false);
+                    }
+                );
+            }
         });
         // Accept every namespace by using /.*/
         socketServer.of(/.*/).on('connection', async socket => {
-            const request = socket.request;
-            // Socket.io strips the `origin` header of the incoming request
-            // We provide a `fix-origin` header in the `WebSocketConnectionProvider`
-            request.headers.origin = request.headers['fix-origin'] as string;
             if (await this.allowConnect(socket.request)) {
                 await this.handleConnection(socket);
                 this.messagingListener.onDidWebSocketUpgrade(socket.request, socket);
@@ -65,6 +72,11 @@ export class WebsocketEndpoint implements BackendApplicationContribution {
         });
     }
 
+    /**
+     * Secondary validation after connection. The primary check happens in the
+     * Socket.IO `allowRequest` callback at handshake time; this is kept as
+     * defense-in-depth in case a Socket.IO upgrade path bypasses `allowRequest`.
+     */
     protected async allowConnect(request: http.IncomingMessage): Promise<boolean> {
         try {
             return this.wsRequestValidator.allowWsUpgrade(request);

--- a/packages/terminal/src/node/shell-terminal-server.spec.ts
+++ b/packages/terminal/src/node/shell-terminal-server.spec.ts
@@ -14,8 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import * as chai from 'chai';
+import * as os from 'os';
+import * as path from 'path';
+import { FileUri } from '@theia/core/lib/common/file-uri';
 import { createTerminalTestContainer } from './test/terminal-test-container';
-import { IShellTerminalServer } from '../common/shell-terminal-protocol';
+import { IShellTerminalServer, IShellTerminalServerOptions } from '../common/shell-terminal-protocol';
 
 /**
  * Globals
@@ -36,5 +39,120 @@ describe('ShellServer', function (): void {
         const createResult = shellTerminalServer.create({});
 
         expect(await createResult).to.be.greaterThan(-1);
+    });
+
+    describe('validateTerminalOptions', () => {
+
+        // Access the protected method for direct testing
+        function validate(options: IShellTerminalServerOptions): IShellTerminalServerOptions {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (shellTerminalServer as any).validateTerminalOptions(options);
+            return options;
+        }
+
+        it('should accept valid options unchanged', () => {
+            const options = validate({ cols: 80, rows: 24 });
+            expect(options.cols).to.equal(80);
+            expect(options.rows).to.equal(24);
+        });
+
+        it('should reset cols/rows outside valid range', () => {
+            const options = validate({ cols: -1, rows: 9999 });
+            expect(options.cols).to.be.undefined;
+            expect(options.rows).to.be.undefined;
+        });
+
+        it('should reset non-integer cols/rows', () => {
+            const options = validate({ cols: 80.5, rows: NaN });
+            expect(options.cols).to.be.undefined;
+            expect(options.rows).to.be.undefined;
+        });
+
+        it('should accept valid string args', () => {
+            const options = validate({ args: ['-l', '--color'] });
+            expect(options.args).to.deep.equal(['-l', '--color']);
+        });
+
+        it('should accept a single string as args', () => {
+            const options = validate({ args: '-l' });
+            expect(options.args).to.equal('-l');
+        });
+
+        it('should reset args with non-string elements', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const options = validate({ args: ['-l', 42 as any] });
+            expect(options.args).to.be.undefined;
+        });
+
+        it('should reset non-array non-string args', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const options = validate({ args: { cmd: 'evil' } as any });
+            expect(options.args).to.be.undefined;
+        });
+
+        it('should accept rootURI pointing to an existing directory', () => {
+            const uri = FileUri.create(os.tmpdir()).toString();
+            const options = validate({ rootURI: uri });
+            expect(options.rootURI).to.equal(uri);
+        });
+
+        it('should reset rootURI pointing to a non-existent path', () => {
+            const options = validate({ rootURI: 'file:///nonexistent/path/xyz123' });
+            expect(options.rootURI).to.be.undefined;
+        });
+
+        it('should reset rootURI pointing to a file instead of directory', () => {
+            const filePath = path.join(os.tmpdir(), 'theia-test-' + Date.now());
+            require('fs').writeFileSync(filePath, 'test');
+            try {
+                const options = validate({ rootURI: FileUri.create(filePath).toString() });
+                expect(options.rootURI).to.be.undefined;
+            } finally {
+                require('fs').unlinkSync(filePath);
+            }
+        });
+
+        it('should reset shell that does not exist', () => {
+            const options = validate({ shell: '/nonexistent/shell' });
+            expect(options.shell).to.be.undefined;
+        });
+
+        it('should accept a valid shell', () => {
+            // process.execPath is the Node binary used to run the tests, so it always exists
+            // and is executable on every platform - making it a reliable cross-platform shell value.
+            const options = validate({ shell: process.execPath });
+            expect(options.shell).to.equal(process.execPath);
+        });
+
+        it('should reset non-string shell type', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const options = validate({ shell: 42 as any });
+            expect(options.shell).to.be.undefined;
+        });
+
+        it('should reset malformed rootURI', () => {
+            const options = validate({ rootURI: 'not-a-valid-uri' });
+            expect(options.rootURI).to.be.undefined;
+        });
+
+        it('should reject cols: 0 (below minimum)', () => {
+            const options = validate({ cols: 0 });
+            expect(options.cols).to.be.undefined;
+        });
+
+        it('should accept cols: 500 (upper boundary)', () => {
+            const options = validate({ cols: 500 });
+            expect(options.cols).to.equal(500);
+        });
+
+        it('should reject cols: 501 (above maximum)', () => {
+            const options = validate({ cols: 501 });
+            expect(options.cols).to.be.undefined;
+        });
+
+        it('should accept rows: 1 (lower boundary)', () => {
+            const options = validate({ rows: 1 });
+            expect(options.rows).to.equal(1);
+        });
     });
 });

--- a/packages/terminal/src/node/shell-terminal-server.ts
+++ b/packages/terminal/src/node/shell-terminal-server.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { exec } from 'child_process';
+import * as fs from 'fs';
 
 import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { ILogger } from '@theia/core/lib/common/logger';
@@ -58,6 +59,7 @@ export class ShellTerminalServer extends BaseTerminalServer implements IShellTer
 
     async create(options: IShellTerminalServerOptions): Promise<number> {
         try {
+            this.validateTerminalOptions(options);
             if (options.strictEnv !== true) {
                 options.env = this.environmentUtils.mergeProcessEnv(options.env);
                 this.applyToProcessEnvironment(URI.fromFilePath(getRootPath(options.rootURI)), options.env);
@@ -68,6 +70,74 @@ export class ShellTerminalServer extends BaseTerminalServer implements IShellTer
         } catch (error) {
             this.logger.error('Error while creating terminal', error);
             return -1;
+        }
+    }
+
+    /**
+     * Validates and sanitizes terminal options received from the client.
+     * Invalid values are replaced with safe defaults rather than rejecting the request,
+     * so legitimate users with misconfigured preferences still get a working terminal.
+     */
+    protected validateTerminalOptions(options: IShellTerminalServerOptions): void {
+        // Validate shell: must be an existing, executable file. Fall back to default otherwise.
+        if (options.shell !== undefined) {
+            if (typeof options.shell !== 'string' || !this.isValidShell(options.shell)) {
+                this.logger.warn(`Invalid shell "${options.shell}": falling back to default shell.`);
+                options.shell = undefined;
+            }
+        }
+
+        // Validate rootURI: must resolve to an existing directory.
+        if (options.rootURI !== undefined) {
+            try {
+                const rootPath = getRootPath(options.rootURI);
+                if (!fs.existsSync(rootPath) || !fs.statSync(rootPath).isDirectory()) {
+                    this.logger.warn(`Invalid rootURI "${options.rootURI}": falling back to home directory.`);
+                    options.rootURI = undefined;
+                }
+            } catch {
+                this.logger.warn(`Invalid rootURI "${options.rootURI}": falling back to home directory.`);
+                options.rootURI = undefined;
+            }
+        }
+
+        // Validate cols/rows: must be positive integers within reasonable bounds.
+        if (options.cols !== undefined) {
+            if (typeof options.cols !== 'number' || !Number.isInteger(options.cols) || options.cols < 1 || options.cols > 500) {
+                options.cols = undefined;
+            }
+        }
+        if (options.rows !== undefined) {
+            if (typeof options.rows !== 'number' || !Number.isInteger(options.rows) || options.rows < 1 || options.rows > 500) {
+                options.rows = undefined;
+            }
+        }
+
+        // Validate args: must be a string array or a single string.
+        if (options.args !== undefined) {
+            if (typeof options.args === 'string') {
+                // single string is fine
+            } else if (Array.isArray(options.args)) {
+                if (!options.args.every(arg => typeof arg === 'string')) {
+                    options.args = undefined;
+                }
+            } else {
+                options.args = undefined;
+            }
+        }
+    }
+
+    protected isValidShell(shell: string): boolean {
+        try {
+            // On Windows, cmd.exe and powershell.exe are resolved from PATH,
+            // so we only check accessibility for absolute paths.
+            if (isWindows && !/[/\\]/.test(shell)) {
+                return true;
+            }
+            fs.accessSync(shell, fs.constants.X_OK);
+            return true;
+        } catch {
+            return false;
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Enforce same-origin check when THEIA_HOSTS is not configured
- Remove the client-supplied fix-origin header in Socket.IO connection handling and read the real Origin header instead
- Add allowRequest callback to validate at engine.io HTTP transport level
- Add SameSite cookie-based connection token that gates both HTTP API and WebSocket access (covers non-browser callers without the cookie)
- Add EarlyExpressMiddleware registry so the cookie is set before express.static() serves the initial page
- Update ElectronWsOriginValidator to accept file://, null, and absent Origin headers after fix-origin removal
- Validate and sanitize terminal creation options for robustness

Contributed on behalf of STMicroelectronics

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Browser deployment:

1. `npm install && npm run build:browser && npm run start:browser`.
2. Open `http://localhost:3000`: app loads normally; verify the `theia-connection-token` cookie is set (`HttpOnly`, `SameSite=Strict`) and that the WebSocket connection establishes.
3. From a different origin (e.g. a page served on a different port), attempt a WebSocket / HTTP API call to `localhost:3000`: request should be rejected.
4. From a Node.js script with no cookie, attempt to open a WS to `/services` the connection should be rejected (no cookie, no valid same-origin context).
5. With `THEIA_HOSTS` unset, confirm a request whose `Origin` does not match the host is rejected (previously accepted).
6. With `THEIA_HOSTS=example.com`, confirm requests from `example.com` continue to work.

Electron:

7. `npm run start:electron`: verify the app still launches and connects (origin validator still accepts `file://`/`null`/absent `Origin`, token cookie path is skipped).

Terminal:

8. Run unit tests: `npx lerna run test --scope @theia/terminal --scope @theia/core`.
9. Open a terminal in the running app to confirm normal use still works.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
