### PR TITLE
feat(ai-registry): address skill/MCP registry review follow-ups

### DIFF
--- a/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
+++ b/packages/ai-mcp/src/browser/install-mcp-uri-handler.ts
@@ -115,6 +115,7 @@ export class InstallMcpUriHandler implements OpenHandler {
             name: entry.localName,
             autostart: true,
             requireAuthToken: 'serverAuthToken' in entry.config,
+            requireOAuth: 'oauth' in entry.config,
             // Bridge already resolved this id, so trust is always "verified" here.
             trust: { status: 'verified', serverId } satisfies MCPServerInstallTrust
         });

--- a/packages/ai-mcp/src/browser/mcp-frontend-module.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-module.ts
@@ -59,8 +59,11 @@ export default new ContainerModule(bind => {
             parameters.isEditing,
             () => ctx.container.get<MCPOAuthFrontendDelegate>(MCPOAuthFrontendDelegate).getEffectiveRedirectUrl()
         ));
-    bind(MCPServerInstallDialogFactory).toFactory(() =>
-        (options: MCPServerInstallDialogOptions) => new MCPServerInstallDialog(options));
+    bind(MCPServerInstallDialogFactory).toFactory(ctx =>
+        (options: MCPServerInstallDialogOptions) => new MCPServerInstallDialog(
+            options,
+            () => ctx.container.get<MCPOAuthFrontendDelegate>(MCPOAuthFrontendDelegate).getEffectiveRedirectUrl()
+        ));
     bind(MCPServerEditorImpl).toSelf().inSingletonScope();
     bind(MCPServerEditor).toService(MCPServerEditorImpl);
 

--- a/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
@@ -137,6 +137,35 @@ describe('MCPServerEditor.installFromEntry', () => {
         expect(prefs.snapshot<Record<string, Record<string, unknown>>>(MCP_SERVERS_PREF)!.example).to.not.have.property('serverAuthToken');
     });
 
+    it('fills the OAuth client credentials while keeping the registry-fixed OAuth parts', async () => {
+        const entry: MCPInstallEntry = {
+            localName: 'example',
+            config: {
+                serverUrl: 'https://mcp.example.com/mcp',
+                oauth: { clientId: '<clientId>', clientSecret: '<clientSecret>', resource: 'https://mcp.example.com' }
+            }
+        };
+
+        await editor.installFromEntry(entry, { oauthClientId: 'real-id', oauthClientSecret: 'real-secret' });
+
+        expect(prefs.snapshot<Record<string, { oauth?: object }>>(MCP_SERVERS_PREF)!.example.oauth).to.deep.equal({
+            clientId: 'real-id',
+            clientSecret: 'real-secret',
+            resource: 'https://mcp.example.com'
+        });
+    });
+
+    it('ignores OAuth credentials when the entry config does not advertise an oauth block', async () => {
+        const entry: MCPInstallEntry = {
+            localName: 'example',
+            config: { command: 'npx', args: ['-y', 'example-mcp'] }
+        };
+
+        await editor.installFromEntry(entry, { oauthClientId: 'should-be-ignored', oauthClientSecret: 'should-be-ignored' });
+
+        expect(prefs.snapshot<Record<string, Record<string, unknown>>>(MCP_SERVERS_PREF)!.example).to.not.have.property('oauth');
+    });
+
     it('preserves unrelated servers already in the preference', async () => {
         await prefs.set(MCP_SERVERS_PREF, {
             other: { command: 'node', args: ['unrelated.js'] }

--- a/packages/ai-mcp/src/browser/mcp-server-editor.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.ts
@@ -74,6 +74,10 @@ export interface MCPInstallOverrides {
     autostart?: boolean;
     /** Filled into a remote server's `serverAuthToken` slot when supplied by the user. */
     serverAuthToken?: string;
+    /** Filled into the entry's `oauth.clientId` slot when supplied by the user. */
+    oauthClientId?: string;
+    /** Filled into the entry's `oauth.clientSecret` slot when supplied by the user. */
+    oauthClientSecret?: string;
 }
 
 /**
@@ -203,6 +207,15 @@ export class MCPServerEditorImpl implements MCPServerEditor {
         // Sanity-check: only persist a token when the config actually has the slot.
         if (overrides.serverAuthToken !== undefined && 'serverAuthToken' in config) {
             merged.serverAuthToken = overrides.serverAuthToken;
+        }
+        // Replace the registry's OAuth client placeholders with the user-supplied credentials,
+        // keeping the registry-fixed parts (scopes, authorization server, resource) intact.
+        if (config.oauth && (overrides.oauthClientId !== undefined || overrides.oauthClientSecret !== undefined)) {
+            merged.oauth = {
+                ...config.oauth,
+                ...(overrides.oauthClientId !== undefined && { clientId: overrides.oauthClientId }),
+                ...(overrides.oauthClientSecret !== undefined && { clientSecret: overrides.oauthClientSecret })
+            };
         }
         return merged;
     }

--- a/packages/ai-mcp/src/browser/mcp-server-install-dialog.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-install-dialog.spec.ts
@@ -33,10 +33,14 @@ import { MCPServerInstallDialog, MCPServerInstallDialogOptions } from './mcp-ser
 // is robust to other specs in the package toggling the shared JSDOM globals.
 disableJSDOM();
 
-/** Exposes the protected validation hook and token field so we can assert on them directly. */
+/** Exposes the protected validation hook and credential fields so we can assert on them directly. */
 class TestInstallDialog extends MCPServerInstallDialog {
     setToken(token: string): void {
         this.serverAuthToken = token;
+    }
+    setOAuthCredentials(clientId: string, clientSecret: string): void {
+        this.oauthClientId = clientId;
+        this.oauthClientSecret = clientSecret;
     }
     runValidation(): DialogError {
         return this.isValid(this.value, 'open') as DialogError;
@@ -72,5 +76,19 @@ describe('MCPServerInstallDialog.isValid', () => {
         const d = dialog({ requireAuthToken: true });
         d.setToken('real-token');
         expect(d.runValidation()).to.equal('');
+    });
+
+    it('rejects missing OAuth credentials when the server requires OAuth', () => {
+        const d = dialog({ requireOAuth: true });
+        expect(d.runValidation()).to.match(/client ID and client secret are required/i);
+        d.setOAuthCredentials('client-id', '');
+        expect(d.runValidation()).to.match(/client ID and client secret are required/i);
+    });
+
+    it('accepts and returns OAuth credentials when both are provided', () => {
+        const d = dialog({ requireOAuth: true });
+        d.setOAuthCredentials('client-id', 'client-secret');
+        expect(d.runValidation()).to.equal('');
+        expect(d.value).to.deep.include({ oauthClientId: 'client-id', oauthClientSecret: 'client-secret' });
     });
 });

--- a/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
@@ -24,6 +24,10 @@ export interface MCPServerInstallParameters {
     autostart: boolean;
     /** Authentication token entered by the user; only collected for remote servers that need one. */
     serverAuthToken?: string;
+    /** OAuth client id entered by the user; only collected for servers that advertise OAuth. */
+    oauthClientId?: string;
+    /** OAuth client secret entered by the user; only collected for servers that advertise OAuth. */
+    oauthClientSecret?: string;
 }
 
 /**
@@ -46,6 +50,12 @@ export interface MCPServerInstallDialogOptions {
     readonly autostart?: boolean;
     /** Whether to show the auth-token field; set when the entry advertises an auth token slot. */
     readonly requireAuthToken?: boolean;
+    /**
+     * Whether to show the OAuth client-id / client-secret fields; set when the entry advertises an
+     * `oauth` block. Only the confidential-client credentials and the (read-only) redirect URL are
+     * surfaced - scopes, authorization server and resource stay fixed by the registry.
+     */
+    readonly requireOAuth?: boolean;
     /** When set, renders a trust banner explaining the registry approval status. */
     readonly trust?: MCPServerInstallTrust;
 }
@@ -68,8 +78,18 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
 
     protected autostart: boolean;
     protected serverAuthToken: string = '';
+    protected oauthClientId: string = '';
+    protected oauthClientSecret: string = '';
 
-    constructor(protected readonly options: MCPServerInstallDialogOptions) {
+    /** Resolved OAuth redirect URL shown read-only so the user can register it with their provider. */
+    protected oauthRedirectUrl: string | undefined;
+    protected oauthRedirectUrlRequested = false;
+    protected redirectUrlCopied = false;
+
+    constructor(
+        protected readonly options: MCPServerInstallDialogOptions,
+        protected readonly redirectUrlProvider?: () => Promise<string>
+    ) {
         super({
             title: nls.localize('theia/ai-mcp/installDialog/title', 'Install MCP Server'),
             maxWidth: 460
@@ -84,21 +104,33 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
             autostart: this.autostart,
             ...(this.options.requireAuthToken && this.serverAuthToken.trim()
                 ? { serverAuthToken: this.serverAuthToken.trim() }
+                : {}),
+            ...(this.options.requireOAuth && this.oauthClientId.trim()
+                ? { oauthClientId: this.oauthClientId.trim() }
+                : {}),
+            ...(this.options.requireOAuth && this.oauthClientSecret.trim()
+                ? { oauthClientSecret: this.oauthClientSecret.trim() }
                 : {})
         };
     }
 
     /**
-     * Guard the auth-token field: when the server requires a token, an empty value must
-     * block the install. Otherwise the registry-supplied placeholder (e.g.
-     * `<github-pat-or-app-token>`) would survive into settings.json and the server would
-     * fail later with an opaque error.
+     * Guard the credential fields: when the server requires them, empty values must block the
+     * install. Otherwise the registry-supplied placeholders (e.g. `<github-pat-or-app-token>`,
+     * `<clientId>`) would survive into settings.json and the server would fail later with an
+     * opaque error.
      */
     protected override isValid(_value: MCPServerInstallParameters | undefined, _mode: DialogMode): MaybePromise<DialogError> {
         if (this.options.requireAuthToken && !this.serverAuthToken.trim()) {
             return nls.localize(
                 'theia/ai-mcp/installDialog/authTokenRequired',
                 'An auth token is required to install this server.'
+            );
+        }
+        if (this.options.requireOAuth && (!this.oauthClientId.trim() || !this.oauthClientSecret.trim())) {
+            return nls.localize(
+                'theia/ai-mcp/installDialog/oauthCredentialsRequired',
+                'An OAuth client ID and client secret are required to install this server.'
             );
         }
         return '';
@@ -112,6 +144,49 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
     protected handleAuthTokenChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
         this.serverAuthToken = e.target.value;
         this.update();
+    };
+
+    protected handleClientIdChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        this.oauthClientId = e.target.value;
+        this.update();
+    };
+
+    protected handleClientSecretChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        this.oauthClientSecret = e.target.value;
+        this.update();
+    };
+
+    /**
+     * Resolves the OAuth redirect URL once (through the backend, which knows whether the Electron
+     * loopback callback server overrides the frontend origin) so the user can register it with
+     * their OAuth provider.
+     */
+    protected ensureOAuthRedirectUrl(): void {
+        if (this.oauthRedirectUrlRequested || !this.redirectUrlProvider) {
+            return;
+        }
+        this.oauthRedirectUrlRequested = true;
+        this.redirectUrlProvider().then(url => {
+            this.oauthRedirectUrl = url;
+            this.update();
+        }).catch(error => {
+            console.warn('Failed to determine the MCP OAuth redirect URL; the redirect URL hint will not be shown.', error);
+        });
+    }
+
+    protected handleCopyRedirectUrl = (): void => {
+        if (!this.oauthRedirectUrl) {
+            return;
+        }
+        navigator.clipboard.writeText(this.oauthRedirectUrl);
+        this.redirectUrlCopied = true;
+        this.update();
+        setTimeout(() => {
+            this.redirectUrlCopied = false;
+            if (!this.isDisposed) {
+                this.update();
+            }
+        }, 1500);
     };
 
     protected renderTrustBanner(): React.ReactNode {
@@ -161,7 +236,77 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
         }
     }
 
+    /**
+     * Renders the user-settable OAuth credentials (confidential client id + secret) and the
+     * read-only redirect URL the user must register with their provider. The remaining OAuth
+     * parameters (scopes, authorization server, resource) are fixed by the registry and are not
+     * shown here.
+     */
+    protected renderOAuthFields(): React.ReactNode {
+        return (
+            <>
+                <div className="mcp-form-description">
+                    {nls.localize(
+                        'theia/ai-mcp/installDialog/oauthDescription',
+                        'This server uses OAuth with a pre-registered confidential client. Provide the client ID and secret from your OAuth provider.'
+                    )}
+                </div>
+
+                {this.oauthRedirectUrl && (
+                    <div className="mcp-form-field">
+                        <label>{nls.localize('theia/ai/mcpConfiguration/oauthRedirectUrl', 'Redirect URL')}:</label>
+                        <div className="mcp-oauth-redirect-url-row">
+                            <span className="mcp-form-static-value">{this.oauthRedirectUrl}</span>
+                            <button
+                                type="button"
+                                className="mcp-icon-button"
+                                title={nls.localizeByDefault('Copy')}
+                                onClick={this.handleCopyRedirectUrl}
+                            >
+                                <i className={this.redirectUrlCopied ? 'codicon codicon-check' : 'codicon codicon-copy'}></i>
+                            </button>
+                        </div>
+                        <div className="mcp-form-description">
+                            {nls.localize(
+                                'theia/ai/mcpConfiguration/form/oauthRedirectUrlDescription',
+                                'Authorization callbacks are delivered to this URL. With a static client ID, register it as a redirect URI with your OAuth provider.'
+                            )}
+                        </div>
+                    </div>
+                )}
+
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/oauthClientId', 'OAuth Client ID')}:</label>
+                    <input
+                        type="text"
+                        className="theia-input"
+                        value={this.oauthClientId}
+                        onChange={this.handleClientIdChange}
+                        placeholder={nls.localize('theia/ai-mcp/installDialog/oauthClientIdPlaceholder', 'Required by this server to connect')}
+                        spellCheck={false}
+                        autoFocus
+                    />
+                </div>
+
+                <div className="mcp-form-field">
+                    <label>{nls.localize('theia/ai/mcpConfiguration/oauthClientSecret', 'OAuth Client Secret')}:</label>
+                    <input
+                        type="password"
+                        className="theia-input"
+                        value={this.oauthClientSecret}
+                        onChange={this.handleClientSecretChange}
+                        placeholder={nls.localize('theia/ai-mcp/installDialog/oauthClientSecretPlaceholder', 'Required by this server to connect')}
+                        spellCheck={false}
+                    />
+                </div>
+            </>
+        );
+    }
+
     protected render(): React.ReactNode {
+        if (this.options.requireOAuth) {
+            this.ensureOAuthRedirectUrl();
+        }
         return (
             <div className="mcp-dialog-form">
                 {this.renderTrustBanner()}
@@ -187,6 +332,8 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
                         />
                     </div>
                 )}
+
+                {this.options.requireOAuth && this.renderOAuthFields()}
 
                 <div className="mcp-form-field mcp-form-checkbox">
                     <label>

--- a/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-install-dialog.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import * as React from '@theia/core/shared/react';
-import { MaybePromise, nls } from '@theia/core';
+import { Disposable, MaybePromise, nls } from '@theia/core';
 import { DialogError, DialogMode } from '@theia/core/lib/browser/dialogs';
 import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
 
@@ -97,6 +97,11 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
         this.autostart = options.autostart ?? true;
         this.appendCloseButton(nls.localizeByDefault('Cancel'));
         this.appendAcceptButton(nls.localizeByDefault('Install'));
+        // Kick off the OAuth redirect URL resolution lazily after construction (rather than from
+        // `render()`, which must stay free of state-mutating side effects).
+        if (this.options.requireOAuth) {
+            this.ensureOAuthRedirectUrl();
+        }
     }
 
     get value(): MCPServerInstallParameters | undefined {
@@ -167,6 +172,9 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
         }
         this.oauthRedirectUrlRequested = true;
         this.redirectUrlProvider().then(url => {
+            if (this.isDisposed) {
+                return;
+            }
             this.oauthRedirectUrl = url;
             this.update();
         }).catch(error => {
@@ -178,15 +186,29 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
         if (!this.oauthRedirectUrl) {
             return;
         }
-        navigator.clipboard.writeText(this.oauthRedirectUrl);
-        this.redirectUrlCopied = true;
-        this.update();
-        setTimeout(() => {
-            this.redirectUrlCopied = false;
-            if (!this.isDisposed) {
-                this.update();
+        // `writeText` returns a promise; on rejection (e.g. permissions denied, non-secure
+        // context) we reset the "copied" indicator so the UI doesn't falsely confirm success.
+        navigator.clipboard.writeText(this.oauthRedirectUrl).then(() => {
+            if (this.isDisposed) {
+                return;
             }
-        }, 1500);
+            this.redirectUrlCopied = true;
+            this.update();
+            const handle = setTimeout(() => {
+                this.redirectUrlCopied = false;
+                if (!this.isDisposed) {
+                    this.update();
+                }
+            }, 1500);
+            this.toDispose.push(Disposable.create(() => clearTimeout(handle)));
+        }).catch(error => {
+            console.warn('Failed to copy the MCP OAuth redirect URL to the clipboard.', error);
+            if (this.isDisposed) {
+                return;
+            }
+            this.redirectUrlCopied = false;
+            this.update();
+        });
     };
 
     protected renderTrustBanner(): React.ReactNode {
@@ -284,7 +306,9 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
                         onChange={this.handleClientIdChange}
                         placeholder={nls.localize('theia/ai-mcp/installDialog/oauthClientIdPlaceholder', 'Required by this server to connect')}
                         spellCheck={false}
-                        autoFocus
+                        // Only autofocus when the auth-token field above isn't present; otherwise two
+                        // inputs would carry `autoFocus` and browser behaviour is undefined.
+                        autoFocus={!this.options.requireAuthToken}
                     />
                 </div>
 
@@ -304,9 +328,6 @@ export class MCPServerInstallDialog extends ReactDialog<MCPServerInstallParamete
     }
 
     protected render(): React.ReactNode {
-        if (this.options.requireOAuth) {
-            this.ensureOAuthRedirectUrl();
-        }
         return (
             <div className="mcp-dialog-form">
                 {this.renderTrustBanner()}

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -197,6 +197,12 @@ export interface MCPInstallEntryConfig {
     serverAuthToken?: string;
     serverAuthTokenHeader?: string;
     headers?: Record<string, string>;
+    /**
+     * OAuth configuration for remote servers. The registry supplies the fixed parts (scopes,
+     * authorization server, resource); the confidential-client `clientId`/`clientSecret` are
+     * collected from the user at install time when the entry advertises them.
+     */
+    oauth?: MCPOAuthConfig;
 }
 
 export interface LocalMCPServerDescription extends BaseMCPServerDescription {

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -27,6 +27,7 @@ import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-b
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../common/mcp/mcp-registry-entry-resolver';
 import { RegistryFetchService, RegistryFetchServiceImpl } from '../common/registry-fetch-service';
+import { RegistrySearchFilter } from '../common/registry-search-filter';
 import { SkillRegistryEntryResolver, SkillRegistryEntryResolverImpl } from '../common/skill/skill-registry-entry-resolver';
 import { SkillInstallBackendService, SkillInstallBackendServicePath, SkillInstallClient } from '../common/skill/skill-install-protocol';
 import { SkillRegistryPreferencesSchema } from '../common/skill/skill-registry-preferences';
@@ -48,6 +49,7 @@ export default new ContainerModule(bind => {
     bind(SkillRegistryEntryResolver).toService(SkillRegistryEntryResolverImpl);
     bind(RegistryFetchServiceImpl).toSelf().inSingletonScope();
     bind(RegistryFetchService).toService(RegistryFetchServiceImpl);
+    bind(RegistrySearchFilter).toSelf().inSingletonScope();
     bind(MCPInstallServiceImpl).toSelf().inSingletonScope();
     bind(MCPInstallService).toService(MCPInstallServiceImpl);
 

--- a/packages/ai-registry/src/browser/ai-registry-toolbar-contribution.ts
+++ b/packages/ai-registry/src/browser/ai-registry-toolbar-contribution.ts
@@ -19,7 +19,6 @@ import { Widget } from '@theia/core/lib/browser';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ADD_MCP_SERVER_COMMAND } from '@theia/ai-mcp/lib/browser/mcp-configuration-command-contribution';
 import { VSXExtensionsViewContainer } from '@theia/vsx-registry/lib/browser/vsx-extensions-view-container';
-import { VSXExtensionsWidget } from '@theia/vsx-registry/lib/browser/vsx-extensions-widget';
 import { inject, injectable } from '@theia/core/shared/inversify';
 
 @injectable()
@@ -33,19 +32,36 @@ export class AIRegistryToolbarContribution implements TabBarToolbarContribution 
             id: 'ai-registry.addMcpServerManually',
             command: ADD_MCP_SERVER_COMMAND.id,
             group: 'other_1',
-            // The view container's own in-container items use `widget === getTabBarDelegate()`,
-            // which resolves to either the container itself (multi-part mode) or one of its
-            // child parts (single-part modes like Installed / Search). A separate toolbar
-            // contribution cannot reach the container instance, so we match both shapes by id
-            // and by the part-id prefix produced by `generateExtensionWidgetId`.
+            // Mirror the visibility of the view container's own items (Install from VSIX, Refresh,
+            // ...): they use `widget === getTabBarDelegate()`, which resolves to the container in
+            // multi-part mode and to the single visible part otherwise. Replicating that exact
+            // check keeps this command on the main Extensions toolbar only, not on every section
+            // header. We locate the container by walking up from the toolbar's widget rather than
+            // matching part ids, which would (wrongly) match every sub-view.
             isVisible: (widget: Widget) =>
-                this.isVsxExtensionsWidget(widget)
+                this.isOnExtensionsTabBar(widget)
                 && this.commandRegistry.getCommand(ADD_MCP_SERVER_COMMAND.id) !== undefined
         });
     }
 
-    protected isVsxExtensionsWidget(widget: Widget): boolean {
-        return widget.id === VSXExtensionsViewContainer.ID
-            || widget.id.startsWith(VSXExtensionsWidget.ID + ':');
+    /**
+     * True when `widget` is the toolbar delegate of the Extensions view container - i.e. the
+     * widget whose toolbar represents the main Extensions view, exactly as the container's own
+     * items are gated. Returns false for the individual section parts.
+     */
+    protected isOnExtensionsTabBar(widget: Widget): boolean {
+        const container = this.findExtensionsContainer(widget);
+        return !!container && widget === container.getTabBarDelegate();
+    }
+
+    protected findExtensionsContainer(widget: Widget): VSXExtensionsViewContainer | undefined {
+        let current: Widget | undefined = widget;
+        while (current) {
+            if (current instanceof VSXExtensionsViewContainer) {
+                return current;
+            }
+            current = current.parent ?? undefined;
+        }
+        return undefined;
     }
 }

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -232,19 +232,19 @@ describe('MCPExtensionsContribution.resolveSearchResults', () => {
         expect(whitespace).to.be.empty;
     });
 
-    it('returns all entries with searchableText covering name, serverId and description so the global fuzzy ranker can match any of them', async () => {
+    it('returns only entries matching the query, with searchableText covering name, serverId and description', async () => {
         const prefs = new FakePreferenceService();
         const fetch = new StubRegistryFetchService([exampleRegistryEntry, githubEntry]);
         const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
 
-        // The contribution intentionally does not filter by the query string: that's the
-        // view's job (`VSXExtensionsSource.collectSearchResults` runs `FuzzySearch.filter`
-        // across results from every contribution). The contribution's only responsibility
-        // is to supply candidates with rich `searchableText`.
+        // The contribution pre-filters to entries that genuinely match the query (the view's
+        // shared `FuzzySearch.filter` then ranks the survivors). 'repositories' matches only the
+        // GitHub entry's description, not the unrelated example server - so flooding is avoided.
         const results = [...await contribution.resolveSearchResults('REPOSITORIES', { verifiedOnly: false })];
 
-        expect(results).to.have.length(2);
-        const githubResult = results.find(r => (r.element as MCPSearchResultEntry).entry.serverId === githubEntry.serverId)!;
+        expect(results).to.have.length(1);
+        const githubResult = results[0];
+        expect((githubResult.element as MCPSearchResultEntry).entry.serverId).to.equal(githubEntry.serverId);
         expect(githubResult.searchableText).to.contain(githubEntry.name);
         expect(githubResult.searchableText).to.contain(githubEntry.serverId);
         expect(githubResult.searchableText).to.contain(githubEntry.description);
@@ -284,8 +284,10 @@ describe('MCPExtensionsContribution.resolveSearchResults', () => {
         const fetch = new StubRegistryFetchService([unverified, githubEntry]);
         const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
 
-        const all = [...await contribution.resolveSearchResults('example', { verifiedOnly: false })];
-        const verifiedOnly = [...await contribution.resolveSearchResults('example', { verifiedOnly: true })];
+        // 'mcp' matches both entries (server id / description), so the verified filter is what
+        // distinguishes them rather than the query.
+        const all = [...await contribution.resolveSearchResults('mcp', { verifiedOnly: false })];
+        const verifiedOnly = [...await contribution.resolveSearchResults('mcp', { verifiedOnly: true })];
 
         expect(all).to.have.length(2);
         expect(verifiedOnly).to.have.length(1);

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -34,6 +34,7 @@ import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager'
 import { MCPServerEditor, MCPServerEditorImpl, MCPServerEditDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
 import { MCPServerInstallDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-install-dialog';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { RegistrySearchFilter } from '../../common/registry-search-filter';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../../common/mcp/mcp-registry-entry-resolver';
 import { MCPInstallService, MCPInstallServiceImpl } from './mcp-install-service';
@@ -73,6 +74,7 @@ function buildContainer(prefs: FakePreferenceService, fetch: StubRegistryFetchSe
     const container = new Container();
     container.bind(PreferenceService).toConstantValue(prefs);
     container.bind(RegistryFetchService).toConstantValue(fetch as unknown as RegistryFetchService);
+    container.bind(RegistrySearchFilter).toSelf().inSingletonScope();
     container.bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
     container.bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
     // Editor dependencies — the contribution doesn't invoke the install path here, but

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -24,6 +24,7 @@ import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manage
 import { MCPServersPreference, MCPServersPreferenceValue } from '@theia/ai-mcp/lib/common/mcp-server-preference-validator';
 import { MCPServerInstallDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-install-dialog';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { matchesRegistrySearch } from '../../common/registry-search-filter';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { MCPInstallService } from './mcp-install-service';
 import { MCPEntryHandlers, MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
@@ -126,10 +127,13 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             if (context.verifiedOnly && !entry.mcpRegistryVerified) {
                 continue;
             }
-            // Hand all candidates to the view's global fuzzy ranker (`FuzzySearch.filter`
-            // in `VSXExtensionsSource.collectSearchResults`). It already discards entries
-            // that don't match the query, and a substring pre-filter would drop legitimate
-            // fuzzy matches such as "ChroDevTo" → "Chrome DevTools".
+            // Pre-filter to genuine matches. The shared Extensions ranker fuzzy-matches scattered
+            // characters across the combined searchable text, which - given long server descriptions
+            // and reverse-DNS ids - otherwise treats almost every server as a hit (e.g. "asana"
+            // matching every entry). The shared ranker still orders the survivors.
+            if (!matchesRegistrySearch({ name: entry.name, identifier: entry.serverId, description: entry.description }, query)) {
+                continue;
+            }
             const searchableText = `${entry.name} ${entry.serverId} ${entry.description}`;
             const state = this.installService.classifyRegistryEntry(entry, localDescriptions, registryEntries);
             result.push({
@@ -188,7 +192,9 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             autostart: true,
             // The registry sets `serverAuthToken` to mark auth as part of the connection
             // contract, even with no default value — so we check key presence, not value.
-            requireAuthToken: 'serverAuthToken' in entry.config
+            requireAuthToken: 'serverAuthToken' in entry.config,
+            // Likewise, an `oauth` block means the user must supply confidential-client credentials.
+            requireOAuth: 'oauth' in entry.config
         });
         const result = await dialog.open();
         if (!result) {

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -24,7 +24,7 @@ import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manage
 import { MCPServersPreference, MCPServersPreferenceValue } from '@theia/ai-mcp/lib/common/mcp-server-preference-validator';
 import { MCPServerInstallDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-install-dialog';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
-import { matchesRegistrySearch } from '../../common/registry-search-filter';
+import { RegistrySearchFilter } from '../../common/registry-search-filter';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { MCPInstallService } from './mcp-install-service';
 import { MCPEntryHandlers, MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
@@ -36,6 +36,7 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
 
     readonly type = 'mcp-server';
     readonly displayName = nls.localizeByDefault('MCP Servers');
+    readonly searchToken = '@mcp';
     readonly priority = 100;
 
     @inject(PreferenceService)
@@ -52,6 +53,9 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
 
     @inject(MCPServerInstallDialogFactory)
     protected readonly installDialogFactory: MCPServerInstallDialogFactory;
+
+    @inject(RegistrySearchFilter)
+    protected readonly searchFilter: RegistrySearchFilter;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
@@ -131,7 +135,7 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             // characters across the combined searchable text, which - given long server descriptions
             // and reverse-DNS ids - otherwise treats almost every server as a hit (e.g. "asana"
             // matching every entry). The shared ranker still orders the survivors.
-            if (!matchesRegistrySearch({ name: entry.name, identifier: entry.serverId, description: entry.description }, query)) {
+            if (!this.searchFilter.matches({ name: entry.name, identifier: entry.serverId, description: entry.description }, query)) {
                 continue;
             }
             const searchableText = `${entry.name} ${entry.serverId} ${entry.description}`;

--- a/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
@@ -22,6 +22,7 @@ import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { matchesRegistrySearch } from '../../common/registry-search-filter';
 import { SkillInstallService } from './skill-install-service';
 import { SkillInstallClientImpl } from './skill-install-client';
 import { SkillEntryHandlers, SkillInstalledEntry, SkillSearchResultEntry } from './skill-entries';
@@ -130,6 +131,12 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
         const installed = await this.installService.listInstalledSkills();
         const result: SearchResult[] = [];
         for (const entry of registryEntries) {
+            // Pre-filter to genuine matches. The shared Extensions ranker fuzzy-matches scattered
+            // characters across the combined searchable text, which - given long skill descriptions -
+            // otherwise treats almost every skill as a hit for any short query.
+            if (!matchesRegistrySearch({ name: entry.name, identifier: entry.skillId, description: entry.description }, query)) {
+                continue;
+            }
             const state = this.installService.classifyRegistryEntry(entry, installed);
             result.push({
                 element: new SkillSearchResultEntry(entry, state, this.handlers, this.hoverService),

--- a/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
@@ -22,7 +22,7 @@ import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
-import { matchesRegistrySearch } from '../../common/registry-search-filter';
+import { RegistrySearchFilter } from '../../common/registry-search-filter';
 import { SkillInstallService } from './skill-install-service';
 import { SkillInstallClientImpl } from './skill-install-client';
 import { SkillEntryHandlers, SkillInstalledEntry, SkillSearchResultEntry } from './skill-entries';
@@ -32,6 +32,7 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
 
     readonly type = 'skill';
     readonly displayName = nls.localizeByDefault('Skills');
+    readonly searchToken = '@skills';
     // Skills sort below MCP servers (priority 100), which in turn sort below extensions.
     readonly priority = 200;
 
@@ -52,6 +53,9 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
 
     @inject(SkillInstallClientImpl)
     protected readonly installClient: SkillInstallClientImpl;
+
+    @inject(RegistrySearchFilter)
+    protected readonly searchFilter: RegistrySearchFilter;
 
     @inject(ILogger) @named('ai-registry:SkillExtensionsContribution')
     protected readonly logger: ILogger;
@@ -134,7 +138,7 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
             // Pre-filter to genuine matches. The shared Extensions ranker fuzzy-matches scattered
             // characters across the combined searchable text, which - given long skill descriptions -
             // otherwise treats almost every skill as a hit for any short query.
-            if (!matchesRegistrySearch({ name: entry.name, identifier: entry.skillId, description: entry.description }, query)) {
+            if (!this.searchFilter.matches({ name: entry.name, identifier: entry.skillId, description: entry.description }, query)) {
                 continue;
             }
             const state = this.installService.classifyRegistryEntry(entry, installed);

--- a/packages/ai-registry/src/browser/style/skill-entries.css
+++ b/packages/ai-registry/src/browser/style/skill-entries.css
@@ -24,6 +24,8 @@
 }
 
 .theia-vsx-extension-icon.theia-skill-extension-icon .codicon {
+    /* Match the MCP card icon so skills and MCP servers render at the same visual size. */
+    font-size: calc(var(--theia-vsx-extension-icon-size) * 0.65);
     color: var(--theia-descriptionForeground);
 }
 

--- a/packages/ai-registry/src/common/ai-registry-configuration.ts
+++ b/packages/ai-registry/src/common/ai-registry-configuration.ts
@@ -48,6 +48,9 @@ export class AIRegistryConfiguration {
     }
 
     getBaseUrl(): string {
-        return 'https://eclipsefdn-ai-registry.github.io/ai-registry-core/api/v1/';
+        // TODO: temporarily pointed at the eclipsefdn-ai-registry/ai-registry-core#32 preview deploy,
+        // which serves the new `tools/<toolName>.json` layout. Revert to the production URL
+        // 'https://eclipsefdn-ai-registry.github.io/ai-registry-core/api/v1/' once that PR is merged.
+        return 'https://preview-32--ai-open-vsx-org.eclipsecontent.org/api/v1/';
     }
 }

--- a/packages/ai-registry/src/common/ai-registry-configuration.ts
+++ b/packages/ai-registry/src/common/ai-registry-configuration.ts
@@ -48,9 +48,6 @@ export class AIRegistryConfiguration {
     }
 
     getBaseUrl(): string {
-        // TODO: temporarily pointed at the eclipsefdn-ai-registry/ai-registry-core#32 preview deploy,
-        // which serves the new `tools/<toolName>.json` layout. Revert to the production URL
-        // 'https://eclipsefdn-ai-registry.github.io/ai-registry-core/api/v1/' once that PR is merged.
-        return 'https://preview-32--ai-open-vsx-org.eclipsecontent.org/api/v1/';
+        return 'https://eclipsefdn-ai-registry.github.io/ai-registry-core/api/v1/';
     }
 }

--- a/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
+++ b/packages/ai-registry/src/common/mcp/mcp-registry-types.ts
@@ -28,7 +28,7 @@ export interface RegistryMCPInstallConfigBlob {
 
 /**
  * A single install config inside an approval. Already filtered per-tool by the registry
- * for the per-tool view (`<baseUrl>/<toolName>.json`).
+ * for the per-tool view (`<baseUrl>/tools/<toolName>.json`).
  */
 export interface RegistryInstallConfig {
     tool?: string;

--- a/packages/ai-registry/src/common/registry-fetch-service.spec.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.spec.ts
@@ -95,14 +95,14 @@ describe('RegistryFetchService', () => {
         return container;
     }
 
-    it('fetches the per-tool JSON from <baseUrl>/<toolName>.json and returns resolved entries', async () => {
+    it('fetches the per-tool JSON from <baseUrl>/tools/<toolName>.json and returns resolved entries', async () => {
         const request = new FakeRequestService(payload());
         const config = new FakeConfiguration('theia-ide', 'https://example.test/api/v1/');
         const service = buildContainer(request, config).get<RegistryFetchService>(RegistryFetchService);
 
         const entries = await service.getEntries();
 
-        expect(request.lastUrl).to.equal('https://example.test/api/v1/theia-ide.json');
+        expect(request.lastUrl).to.equal('https://example.test/api/v1/tools/theia-ide.json');
         expect(entries).to.have.length(1);
         expect(entries[0]).to.deep.equal({
             serverId: 'io.github.example/example-mcp',
@@ -114,6 +114,16 @@ describe('RegistryFetchService', () => {
             configHash: 'hash-v1',
             mcpRegistryVerified: true
         });
+    });
+
+    it('fetches the aggregate registry from <baseUrl>/all.json for the default "all" tool', async () => {
+        const request = new FakeRequestService(payload());
+        const config = new FakeConfiguration('all', 'https://example.test/api/v1/');
+        const service = buildContainer(request, config).get<RegistryFetchService>(RegistryFetchService);
+
+        await service.getEntries();
+
+        expect(request.lastUrl).to.equal('https://example.test/api/v1/all.json');
     });
 
     it('fetches and resolves skill entries from the same per-tool JSON', async () => {

--- a/packages/ai-registry/src/common/registry-fetch-service.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.ts
@@ -107,6 +107,9 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
         const base = this.configuration.getBaseUrl();
         const tool = this.configuration.getToolName();
         const separator = base.endsWith('/') ? '' : '/';
-        return `${base}${separator}${tool}.json`;
+        // The aggregate registry stays at `<base>/all.json`; tool-specific views moved under
+        // `<base>/tools/<toolName>.json` (see eclipsefdn-ai-registry/ai-registry-core#32).
+        const path = tool === 'all' ? 'all.json' : `tools/${tool}.json`;
+        return `${base}${separator}${path}`;
     }
 }

--- a/packages/ai-registry/src/common/registry-search-filter.spec.ts
+++ b/packages/ai-registry/src/common/registry-search-filter.spec.ts
@@ -1,0 +1,73 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { matchesRegistrySearch, meaningfulIdentifier } from './registry-search-filter';
+
+describe('meaningfulIdentifier', () => {
+    it('reduces a reverse-DNS id to its last domain label plus path', () => {
+        expect(meaningfulIdentifier('com.asana/mcp')).to.equal('asana mcp');
+        expect(meaningfulIdentifier('io.github.anthropics/algorithmic-art')).to.equal('anthropics algorithmic-art');
+    });
+    it('leaves a plain string unchanged', () => {
+        expect(meaningfulIdentifier('Hugging Face')).to.equal('Hugging Face');
+    });
+});
+
+describe('matchesRegistrySearch', () => {
+
+    const asana = { name: 'com.asana/mcp', identifier: 'com.asana/mcp', description: 'Asana Rovo MCP Server' };
+    const grafana = { name: 'io.github.grafana/mcp-grafana', identifier: 'io.github.grafana/mcp-grafana', description: 'An MCP server giving access to Grafana dashboards.' };
+    const github = { name: 'GitHub', identifier: 'io.github.github/github-mcp-server', description: 'Connect AI assistants to GitHub.' };
+    const art = { name: 'algorithmic-art', identifier: 'io.github.anthropics/algorithmic-art', description: 'Creating algorithmic art using p5.js.' };
+    const slideshow = { name: 'html-slideshow-deck', identifier: 'io.github.anthropics/html-slideshow-deck', description: 'Generate decks similar to PowerPoint presentations.' };
+
+    it('matches the exact entry for a specific query and excludes unrelated ones', () => {
+        expect(matchesRegistrySearch(asana, 'asana')).to.equal(true);
+        expect(matchesRegistrySearch(grafana, 'asana')).to.equal(false);
+        expect(matchesRegistrySearch(github, 'asana')).to.equal(false);
+    });
+
+    it('does not match unrelated entries via the shared reverse-DNS namespace', () => {
+        // `git` must not match every `io.github.*` entry.
+        expect(matchesRegistrySearch(grafana, 'git')).to.equal(false);
+        expect(matchesRegistrySearch(art, 'git')).to.equal(false);
+        // ...but a genuine GitHub entry still matches.
+        expect(matchesRegistrySearch(github, 'git')).to.equal(true);
+    });
+
+    it('matches a substring of the kebab-case name', () => {
+        expect(matchesRegistrySearch(art, 'art')).to.equal(true);
+    });
+
+    it('matches a word prefix in the description', () => {
+        expect(matchesRegistrySearch(slideshow, 'powerpoint')).to.equal(true);
+    });
+
+    it('does not match scattered characters across a long description', () => {
+        expect(matchesRegistrySearch(art, 'pdf')).to.equal(false);
+    });
+
+    it('requires every term of a multi-word query to match', () => {
+        const pptx = { name: 'pptx', identifier: 'io.github.anthropics/pptx', description: 'Create and edit PowerPoint presentations.' };
+        expect(matchesRegistrySearch(pptx, 'powerpoint presentation')).to.equal(true);
+        expect(matchesRegistrySearch(pptx, 'powerpoint spreadsheet')).to.equal(false);
+    });
+
+    it('treats an empty query as a match', () => {
+        expect(matchesRegistrySearch(asana, '   ')).to.equal(true);
+    });
+});

--- a/packages/ai-registry/src/common/registry-search-filter.spec.ts
+++ b/packages/ai-registry/src/common/registry-search-filter.spec.ts
@@ -15,20 +15,22 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { matchesRegistrySearch, meaningfulIdentifier } from './registry-search-filter';
+import { RegistrySearchFilter } from './registry-search-filter';
 
-describe('meaningfulIdentifier', () => {
+describe('RegistrySearchFilter.meaningfulIdentifier', () => {
+    const filter = new RegistrySearchFilter();
     it('reduces a reverse-DNS id to its last domain label plus path', () => {
-        expect(meaningfulIdentifier('com.asana/mcp')).to.equal('asana mcp');
-        expect(meaningfulIdentifier('io.github.anthropics/algorithmic-art')).to.equal('anthropics algorithmic-art');
+        expect(filter.meaningfulIdentifier('com.asana/mcp')).to.equal('asana mcp');
+        expect(filter.meaningfulIdentifier('io.github.anthropics/algorithmic-art')).to.equal('anthropics algorithmic-art');
     });
     it('leaves a plain string unchanged', () => {
-        expect(meaningfulIdentifier('Hugging Face')).to.equal('Hugging Face');
+        expect(filter.meaningfulIdentifier('Hugging Face')).to.equal('Hugging Face');
     });
 });
 
-describe('matchesRegistrySearch', () => {
+describe('RegistrySearchFilter.matches', () => {
 
+    const filter = new RegistrySearchFilter();
     const asana = { name: 'com.asana/mcp', identifier: 'com.asana/mcp', description: 'Asana Rovo MCP Server' };
     const grafana = { name: 'io.github.grafana/mcp-grafana', identifier: 'io.github.grafana/mcp-grafana', description: 'An MCP server giving access to Grafana dashboards.' };
     const github = { name: 'GitHub', identifier: 'io.github.github/github-mcp-server', description: 'Connect AI assistants to GitHub.' };
@@ -36,38 +38,38 @@ describe('matchesRegistrySearch', () => {
     const slideshow = { name: 'html-slideshow-deck', identifier: 'io.github.anthropics/html-slideshow-deck', description: 'Generate decks similar to PowerPoint presentations.' };
 
     it('matches the exact entry for a specific query and excludes unrelated ones', () => {
-        expect(matchesRegistrySearch(asana, 'asana')).to.equal(true);
-        expect(matchesRegistrySearch(grafana, 'asana')).to.equal(false);
-        expect(matchesRegistrySearch(github, 'asana')).to.equal(false);
+        expect(filter.matches(asana, 'asana')).to.equal(true);
+        expect(filter.matches(grafana, 'asana')).to.equal(false);
+        expect(filter.matches(github, 'asana')).to.equal(false);
     });
 
     it('does not match unrelated entries via the shared reverse-DNS namespace', () => {
         // `git` must not match every `io.github.*` entry.
-        expect(matchesRegistrySearch(grafana, 'git')).to.equal(false);
-        expect(matchesRegistrySearch(art, 'git')).to.equal(false);
+        expect(filter.matches(grafana, 'git')).to.equal(false);
+        expect(filter.matches(art, 'git')).to.equal(false);
         // ...but a genuine GitHub entry still matches.
-        expect(matchesRegistrySearch(github, 'git')).to.equal(true);
+        expect(filter.matches(github, 'git')).to.equal(true);
     });
 
     it('matches a substring of the kebab-case name', () => {
-        expect(matchesRegistrySearch(art, 'art')).to.equal(true);
+        expect(filter.matches(art, 'art')).to.equal(true);
     });
 
     it('matches a word prefix in the description', () => {
-        expect(matchesRegistrySearch(slideshow, 'powerpoint')).to.equal(true);
+        expect(filter.matches(slideshow, 'powerpoint')).to.equal(true);
     });
 
     it('does not match scattered characters across a long description', () => {
-        expect(matchesRegistrySearch(art, 'pdf')).to.equal(false);
+        expect(filter.matches(art, 'pdf')).to.equal(false);
     });
 
     it('requires every term of a multi-word query to match', () => {
         const pptx = { name: 'pptx', identifier: 'io.github.anthropics/pptx', description: 'Create and edit PowerPoint presentations.' };
-        expect(matchesRegistrySearch(pptx, 'powerpoint presentation')).to.equal(true);
-        expect(matchesRegistrySearch(pptx, 'powerpoint spreadsheet')).to.equal(false);
+        expect(filter.matches(pptx, 'powerpoint presentation')).to.equal(true);
+        expect(filter.matches(pptx, 'powerpoint spreadsheet')).to.equal(false);
     });
 
     it('treats an empty query as a match', () => {
-        expect(matchesRegistrySearch(asana, '   ')).to.equal(true);
+        expect(filter.matches(asana, '   ')).to.equal(true);
     });
 });

--- a/packages/ai-registry/src/common/registry-search-filter.ts
+++ b/packages/ai-registry/src/common/registry-search-filter.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+const SEGMENT_SEPARATOR = /[\p{P}\s]+/u;
+
+function tokenize(text: string): string[] {
+    return text.toLowerCase().split(SEGMENT_SEPARATOR).filter(Boolean);
+}
+
+/**
+ * Reduces a registry identifier to its human-meaningful part for search matching.
+ *
+ * Registry identifiers are reverse-DNS ids with a path, e.g. `com.asana/mcp` or
+ * `io.github.anthropics/algorithmic-art`. The leading domain labels (`com`, `io`, `github`, ...)
+ * are shared boilerplate that would otherwise let a query like `git` match every `io.github.*`
+ * entry. This keeps only the last domain label plus the path: `asana mcp`, `anthropics algorithmic-art`.
+ *
+ * Plain strings without a domain or path are returned unchanged.
+ */
+export function meaningfulIdentifier(identifier: string): string {
+    const [domain, ...rest] = identifier.split('/');
+    const lastLabel = domain.split('.').pop() || domain;
+    return [lastLabel, ...rest].join(' ');
+}
+
+/**
+ * Relevance filter shared by the MCP-server and skill contributions to the Extensions view.
+ *
+ * The shared Extensions ranker fuzzy-matches scattered characters across a combined searchable
+ * text. Registry descriptions are long, keyword-rich prose, so that match treats almost every
+ * entry as a hit for any short query (e.g. `asana` matching every server). This filter narrows the
+ * candidate set to genuine matches before the shared ranker runs.
+ *
+ * An entry matches when *every* whitespace/punctuation-separated query term either:
+ * - appears as a substring of the meaningful name or identifier
+ *   (so `asana` matches `com.asana/mcp` and `art` matches `algorithmic-art`), or
+ * - is the prefix of some word in the name, identifier or description
+ *   (so `powerpoint` finds an entry whose description mentions "PowerPoint").
+ */
+export function matchesRegistrySearch(entry: { name: string; identifier: string; description: string }, query: string): boolean {
+    const terms = tokenize(query);
+    if (terms.length === 0) {
+        return true;
+    }
+    const name = meaningfulIdentifier(entry.name).toLowerCase();
+    const identifier = meaningfulIdentifier(entry.identifier).toLowerCase();
+    const words = [...tokenize(name), ...tokenize(identifier), ...tokenize(entry.description)];
+    return terms.every(term =>
+        name.includes(term)
+        || identifier.includes(term)
+        || words.some(word => word.startsWith(term))
+    );
+}

--- a/packages/ai-registry/src/common/registry-search-filter.ts
+++ b/packages/ai-registry/src/common/registry-search-filter.ts
@@ -14,26 +14,14 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { injectable } from '@theia/core/shared/inversify';
+
 const SEGMENT_SEPARATOR = /[\p{P}\s]+/u;
 
-function tokenize(text: string): string[] {
-    return text.toLowerCase().split(SEGMENT_SEPARATOR).filter(Boolean);
-}
-
-/**
- * Reduces a registry identifier to its human-meaningful part for search matching.
- *
- * Registry identifiers are reverse-DNS ids with a path, e.g. `com.asana/mcp` or
- * `io.github.anthropics/algorithmic-art`. The leading domain labels (`com`, `io`, `github`, ...)
- * are shared boilerplate that would otherwise let a query like `git` match every `io.github.*`
- * entry. This keeps only the last domain label plus the path: `asana mcp`, `anthropics algorithmic-art`.
- *
- * Plain strings without a domain or path are returned unchanged.
- */
-export function meaningfulIdentifier(identifier: string): string {
-    const [domain, ...rest] = identifier.split('/');
-    const lastLabel = domain.split('.').pop() || domain;
-    return [lastLabel, ...rest].join(' ');
+export interface RegistrySearchEntry {
+    name: string;
+    identifier: string;
+    description: string;
 }
 
 /**
@@ -49,18 +37,45 @@ export function meaningfulIdentifier(identifier: string): string {
  *   (so `asana` matches `com.asana/mcp` and `art` matches `algorithmic-art`), or
  * - is the prefix of some word in the name, identifier or description
  *   (so `powerpoint` finds an entry whose description mentions "PowerPoint").
+ *
+ * Exposed as an injectable service so adopters can rebind it to tweak search semantics for
+ * their registry contributions.
  */
-export function matchesRegistrySearch(entry: { name: string; identifier: string; description: string }, query: string): boolean {
-    const terms = tokenize(query);
-    if (terms.length === 0) {
-        return true;
+@injectable()
+export class RegistrySearchFilter {
+
+    matches(entry: RegistrySearchEntry, query: string): boolean {
+        const terms = this.tokenize(query);
+        if (terms.length === 0) {
+            return true;
+        }
+        const name = this.meaningfulIdentifier(entry.name).toLowerCase();
+        const identifier = this.meaningfulIdentifier(entry.identifier).toLowerCase();
+        const words = [...this.tokenize(name), ...this.tokenize(identifier), ...this.tokenize(entry.description)];
+        return terms.every(term =>
+            name.includes(term)
+            || identifier.includes(term)
+            || words.some(word => word.startsWith(term))
+        );
     }
-    const name = meaningfulIdentifier(entry.name).toLowerCase();
-    const identifier = meaningfulIdentifier(entry.identifier).toLowerCase();
-    const words = [...tokenize(name), ...tokenize(identifier), ...tokenize(entry.description)];
-    return terms.every(term =>
-        name.includes(term)
-        || identifier.includes(term)
-        || words.some(word => word.startsWith(term))
-    );
+
+    /**
+     * Reduces a registry identifier to its human-meaningful part for search matching.
+     *
+     * Registry identifiers are reverse-DNS ids with a path, e.g. `com.asana/mcp` or
+     * `io.github.anthropics/algorithmic-art`. The leading domain labels (`com`, `io`, `github`, ...)
+     * are shared boilerplate that would otherwise let a query like `git` match every `io.github.*`
+     * entry. This keeps only the last domain label plus the path: `asana mcp`, `anthropics algorithmic-art`.
+     *
+     * Plain strings without a domain or path are returned unchanged.
+     */
+    meaningfulIdentifier(identifier: string): string {
+        const [domain, ...rest] = identifier.split('/');
+        const lastLabel = domain.split('.').pop() || domain;
+        return [lastLabel, ...rest].join(' ');
+    }
+
+    protected tokenize(text: string): string[] {
+        return text.toLowerCase().split(SEGMENT_SEPARATOR).filter(Boolean);
+    }
 }

--- a/packages/vsx-registry/src/browser/extensions-source-contribution.ts
+++ b/packages/vsx-registry/src/browser/extensions-source-contribution.ts
@@ -71,6 +71,17 @@ export interface ExtensionsSourceContribution {
     /** Human-readable label used as the group header in the view. */
     readonly displayName: string;
 
+    /**
+     * `@`-prefixed token recognised in the search query to scope results to this contribution
+     * alone. Composable with the existing `@installed` / `@builtin` / `@recommended` mode tokens
+     * (e.g. `@installed @mcp` shows installed servers of type `mcp-server` only). When no
+     * type token appears in the query, all contributions are shown.
+     *
+     * Contributors are expected to start the token with `@`; without the prefix the search model
+     * may treat the token as a plain word in the free-text part of the query.
+     */
+    readonly searchToken: string;
+
     /** Ordering hint when multiple contributions yield entries for the same section. Lower numbers come first. Defaults to 0. */
     readonly priority?: number;
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.ts
@@ -35,6 +35,7 @@ export class VSXExtensionsContributionAdapter implements ExtensionsSourceContrib
 
     readonly type = 'extension';
     readonly displayName = nls.localizeByDefault('Extensions');
+    readonly searchToken = '@extensions';
     readonly priority = 0;
 
     @inject(VSXExtensionsModel)

--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution.ts
@@ -176,7 +176,7 @@ export class VSXExtensionsContribution extends AbstractViewContribution<VSXExten
         super.registerMenus(menus);
         menus.registerMenuAction(CommonMenus.MANAGE_SETTINGS, {
             commandId: VSXCommands.TOGGLE_EXTENSIONS.id,
-            label: nls.localizeByDefault('Extensions'),
+            label: VSXExtensionsViewContainer.LABEL,
             order: 'a20'
         });
         menus.registerMenuAction(VSXExtensionsContextMenu.COPY, {

--- a/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.spec.ts
@@ -67,46 +67,60 @@ class FakeMenuRegistry {
 
 describe('VSXExtensionsFilterContribution type filter toggles', () => {
 
-    it('starts with every type token enabled (no token in query)', () => {
+    it('starts with nothing ticked (no token in query) so the funnel shows "no filter"', () => {
         const { contribution, searchModel } = buildContribution();
         const commands = new FakeCommandRegistry();
         contribution.registerCommands(commands as unknown as CommandRegistry);
 
-        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(false);
+        expect(commands.commands.get('vsxExtensions.filterByType:mcp-server')?.isToggled?.()).to.equal(false);
+        expect(commands.commands.get('vsxExtensions.filterByType:skill')?.isToggled?.()).to.equal(false);
+        expect(searchModel.query).to.equal('');
+    });
+
+    it('narrows to a single type with one click, ticking only it', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        // From the empty (no-filter) state, clicking MCP includes only MCP - a single click.
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+
+        expect(searchModel.query).to.equal('@mcp');
+        expect(commands.commands.get('vsxExtensions.filterByType:mcp-server')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(false);
+        expect(commands.commands.get('vsxExtensions.filterByType:skill')?.isToggled?.()).to.equal(false);
+    });
+
+    it('unticking the only ticked type returns to the no-filter state', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+
+        // First click includes MCP (`@mcp`); clicking it again removes the only token, so the
+        // query goes back to empty (no filter).
+        expect(searchModel.query).to.equal('');
+    });
+
+    it('widens the selection when a second type is ticked', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+        commands.commands.get('vsxExtensions.filterByType:skill')?.execute();
+
+        // Order should mirror the contribution iteration order, so `@mcp @skills`, not `@skills @mcp`.
+        expect(searchModel.query).to.equal('@mcp @skills');
         expect(commands.commands.get('vsxExtensions.filterByType:mcp-server')?.isToggled?.()).to.equal(true);
         expect(commands.commands.get('vsxExtensions.filterByType:skill')?.isToggled?.()).to.equal(true);
-        expect(searchModel.query).to.equal('');
+        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(false);
     });
 
-    it('unticks a ticked type from the implicit all-ticked state, keeping the others ticked', () => {
-        const { contribution, searchModel } = buildContribution();
-        const commands = new FakeCommandRegistry();
-        contribution.registerCommands(commands as unknown as CommandRegistry);
-
-        // Empty query means all three are implicitly ticked. Clicking MCP must untick it (not
-        // become the sole ticked one), so the query lists the two that remain.
-        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
-
-        expect(searchModel.query).to.equal('@extensions @skills');
-        expect(commands.commands.get('vsxExtensions.filterByType:mcp-server')?.isToggled?.()).to.equal(false);
-        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(true);
-        expect(commands.commands.get('vsxExtensions.filterByType:skill')?.isToggled?.()).to.equal(true);
-    });
-
-    it('re-ticking the only unticked type returns to the implicit all-ticked state', () => {
-        const { contribution, searchModel } = buildContribution();
-        const commands = new FakeCommandRegistry();
-        contribution.registerCommands(commands as unknown as CommandRegistry);
-
-        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
-        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
-
-        // Toggling MCP off then on again: first click yields `@extensions @skills`; second
-        // re-ticks MCP, making all three ticked, which normalises back to the empty query.
-        expect(searchModel.query).to.equal('');
-    });
-
-    it('unticks a type from an explicit subset (typed-by-hand query) leaving the others alone', () => {
+    it('unticks one type from an explicit subset (typed-by-hand query) leaving the others alone', () => {
         const { contribution, searchModel } = buildContribution();
         const commands = new FakeCommandRegistry();
         contribution.registerCommands(commands as unknown as CommandRegistry);
@@ -118,19 +132,7 @@ describe('VSXExtensionsFilterContribution type filter toggles', () => {
         expect(searchModel.query).to.equal('@skills');
     });
 
-    it('ticks a previously unticked type when added back to an explicit subset', () => {
-        const { contribution, searchModel } = buildContribution();
-        const commands = new FakeCommandRegistry();
-        contribution.registerCommands(commands as unknown as CommandRegistry);
-
-        searchModel.query = '@mcp';
-        commands.commands.get('vsxExtensions.filterByType:skill')?.execute();
-
-        // Order should mirror the contribution iteration order, so `@mcp @skills`, not `@skills @mcp`.
-        expect(searchModel.query).to.equal('@mcp @skills');
-    });
-
-    it('keeps the existing mode token and free text intact when toggling a type', () => {
+    it('keeps the existing mode token and free text intact when ticking a type', () => {
         const { contribution, searchModel } = buildContribution();
         const commands = new FakeCommandRegistry();
         contribution.registerCommands(commands as unknown as CommandRegistry);
@@ -138,9 +140,30 @@ describe('VSXExtensionsFilterContribution type filter toggles', () => {
         searchModel.query = '@installed alpha';
         commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
 
-        // Mode first, then type tokens, then free text. Unticking MCP from the implicit
-        // all-ticked state under `@installed` leaves Extensions and Skills as the visible types.
-        expect(searchModel.query).to.equal('@installed @extensions @skills alpha');
+        // Mode first, then type tokens, then free text. Ticking MCP narrows to it while the
+        // `@installed` mode and the `alpha` search text stay put.
+        expect(searchModel.query).to.equal('@installed @mcp alpha');
+    });
+
+    it('ticking every type spells out all tokens (no auto-collapse) while keeping all results visible', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        commands.commands.get('vsxExtensions.filterByType:extension')?.execute();
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+        commands.commands.get('vsxExtensions.filterByType:skill')?.execute();
+
+        // Each click toggles exactly one checkbox - no surprising mass-untick - so all three
+        // tokens are spelled out in contribution-priority order.
+        expect(searchModel.query).to.equal('@extensions @mcp @skills');
+        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByType:mcp-server')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByType:skill')?.isToggled?.()).to.equal(true);
+        // Every type is still enabled for the result set (all three explicitly included).
+        expect(searchModel.isTokenEnabled('@extensions')).to.equal(true);
+        expect(searchModel.isTokenEnabled('@mcp')).to.equal(true);
+        expect(searchModel.isTokenEnabled('@skills')).to.equal(true);
     });
 });
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.spec.ts
@@ -1,0 +1,215 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { Emitter } from '@theia/core';
+import { CommandRegistry, MenuModelRegistry } from '@theia/core/lib/common';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { ExtensionsSourceContribution } from './extensions-source-contribution';
+import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
+import { VSXExtensionsFilterContribution } from './vsx-extensions-filter-contribution';
+
+class StubContribution implements ExtensionsSourceContribution {
+    readonly onDidChange = new Emitter<void>().event;
+    constructor(readonly type: string, readonly displayName: string, readonly searchToken: string, readonly priority = 0) { }
+}
+
+function defaultContributions(): StubContribution[] {
+    return [
+        new StubContribution('extension', 'Extensions', '@extensions'),
+        new StubContribution('mcp-server', 'MCP Servers', '@mcp', 100),
+        new StubContribution('skill', 'Skills', '@skills', 200)
+    ];
+}
+
+function buildContribution(types: StubContribution[] = defaultContributions()): { contribution: VSXExtensionsFilterContribution; searchModel: VSXExtensionsSearchModel } {
+    const container = new Container();
+    const provider: ContributionProvider<ExtensionsSourceContribution> = { getContributions: () => types };
+    container.bind(ContributionProvider).toConstantValue(provider).whenTargetNamed(ExtensionsSourceContribution);
+    container.bind(VSXExtensionsSearchModel).toSelf().inSingletonScope();
+    container.bind(VSXExtensionsFilterContribution).toSelf().inSingletonScope();
+    return {
+        contribution: container.get(VSXExtensionsFilterContribution),
+        searchModel: container.get(VSXExtensionsSearchModel)
+    };
+}
+
+class FakeCommandRegistry {
+    readonly commands = new Map<string, { execute: () => void; isToggled?: () => boolean }>();
+    registerCommand(command: { id: string }, handler: { execute: () => void; isToggled?: () => boolean }): void {
+        this.commands.set(command.id, handler);
+    }
+}
+
+class FakeMenuRegistry {
+    readonly menus = new Map<string, { commandId: string; label?: string; order?: string }[]>();
+    registerMenuAction(menuPath: string[], action: { commandId: string; label?: string; order?: string }): void {
+        const key = menuPath.join('/');
+        const list = this.menus.get(key) ?? [];
+        list.push(action);
+        this.menus.set(key, list);
+    }
+}
+
+describe('VSXExtensionsFilterContribution type filter toggles', () => {
+
+    it('starts with every type token enabled (no token in query)', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByType:mcp-server')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByType:skill')?.isToggled?.()).to.equal(true);
+        expect(searchModel.query).to.equal('');
+    });
+
+    it('unticks a ticked type from the implicit all-ticked state, keeping the others ticked', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        // Empty query means all three are implicitly ticked. Clicking MCP must untick it (not
+        // become the sole ticked one), so the query lists the two that remain.
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+
+        expect(searchModel.query).to.equal('@extensions @skills');
+        expect(commands.commands.get('vsxExtensions.filterByType:mcp-server')?.isToggled?.()).to.equal(false);
+        expect(commands.commands.get('vsxExtensions.filterByType:extension')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByType:skill')?.isToggled?.()).to.equal(true);
+    });
+
+    it('re-ticking the only unticked type returns to the implicit all-ticked state', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+
+        // Toggling MCP off then on again: first click yields `@extensions @skills`; second
+        // re-ticks MCP, making all three ticked, which normalises back to the empty query.
+        expect(searchModel.query).to.equal('');
+    });
+
+    it('unticks a type from an explicit subset (typed-by-hand query) leaving the others alone', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        // User explicitly typed two tokens; unticking one of them removes only that one.
+        searchModel.query = '@mcp @skills';
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+
+        expect(searchModel.query).to.equal('@skills');
+    });
+
+    it('ticks a previously unticked type when added back to an explicit subset', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        searchModel.query = '@mcp';
+        commands.commands.get('vsxExtensions.filterByType:skill')?.execute();
+
+        // Order should mirror the contribution iteration order, so `@mcp @skills`, not `@skills @mcp`.
+        expect(searchModel.query).to.equal('@mcp @skills');
+    });
+
+    it('keeps the existing mode token and free text intact when toggling a type', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        searchModel.query = '@installed alpha';
+        commands.commands.get('vsxExtensions.filterByType:mcp-server')?.execute();
+
+        // Mode first, then type tokens, then free text. Unticking MCP from the implicit
+        // all-ticked state under `@installed` leaves Extensions and Skills as the visible types.
+        expect(searchModel.query).to.equal('@installed @extensions @skills alpha');
+    });
+});
+
+describe('VSXExtensionsFilterContribution mode shortcut toggles', () => {
+
+    it('adds the mode token when toggled on and reports the matching checkmark', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        commands.commands.get('vsxExtensions.filterByMode:installed')?.execute();
+        expect(searchModel.query).to.equal('@installed');
+        expect(commands.commands.get('vsxExtensions.filterByMode:installed')?.isToggled?.()).to.equal(true);
+        expect(commands.commands.get('vsxExtensions.filterByMode:builtin')?.isToggled?.()).to.equal(false);
+    });
+
+    it('removes the mode token when the active mode is clicked again', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        commands.commands.get('vsxExtensions.filterByMode:installed')?.execute();
+        commands.commands.get('vsxExtensions.filterByMode:installed')?.execute();
+
+        expect(searchModel.query).to.equal('');
+    });
+
+    it('replaces the active mode when a different mode is selected (modes are mutually exclusive)', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        commands.commands.get('vsxExtensions.filterByMode:installed')?.execute();
+        commands.commands.get('vsxExtensions.filterByMode:builtin')?.execute();
+
+        expect(searchModel.query).to.equal('@builtin');
+    });
+
+    it('composes with type tokens and free text', () => {
+        const { contribution, searchModel } = buildContribution();
+        const commands = new FakeCommandRegistry();
+        contribution.registerCommands(commands as unknown as CommandRegistry);
+
+        searchModel.query = '@mcp asana';
+        commands.commands.get('vsxExtensions.filterByMode:installed')?.execute();
+
+        expect(searchModel.query).to.equal('@installed @mcp asana');
+    });
+});
+
+describe('VSXExtensionsFilterContribution menu registration', () => {
+
+    it('registers one menu entry per contribution and one per mode shortcut, in distinct groups', () => {
+        const { contribution } = buildContribution();
+        const menus = new FakeMenuRegistry();
+        contribution.registerMenus(menus as unknown as MenuModelRegistry);
+
+        const typeEntries = menus.menus.get('vsx-extensions-filter-by-type-context-menu/1_types') ?? [];
+        const modeEntries = menus.menus.get('vsx-extensions-filter-by-type-context-menu/2_modes') ?? [];
+
+        expect(typeEntries.map(e => e.commandId)).to.deep.equal([
+            'vsxExtensions.filterByType:extension',
+            'vsxExtensions.filterByType:mcp-server',
+            'vsxExtensions.filterByType:skill'
+        ]);
+        expect(modeEntries.map(e => e.commandId)).to.deep.equal([
+            'vsxExtensions.filterByMode:installed',
+            'vsxExtensions.filterByMode:builtin',
+            'vsxExtensions.filterByMode:recommended'
+        ]);
+    });
+});

--- a/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.ts
@@ -1,0 +1,84 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MenuPath } from '@theia/core/lib/common';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { ExtensionsSourceContribution } from './extensions-source-contribution';
+import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
+
+/** Menu path of the anchored "Filter by Type" popup opened from the Extensions search bar. */
+export const EXTENSIONS_FILTER_BY_TYPE_MENU: MenuPath = ['vsx-extensions-filter-by-type-context-menu'];
+
+/** Command id prefix for the per-contribution-type toggle commands. */
+const FILTER_COMMAND_PREFIX = 'vsxExtensions.filterByType:';
+
+/**
+ * Registers one toggle command + menu item per {@link ExtensionsSourceContribution} type so the
+ * search bar can offer an anchored "Filter by Type" popup (rendered through the
+ * {@link ContextMenuRenderer}) with a checkmark per kind of result (Extensions, MCP Servers,
+ * Skills, ...). Toggling updates {@link VSXExtensionsSearchModel.enabledTypes}.
+ */
+@injectable()
+export class VSXExtensionsFilterContribution implements CommandContribution, MenuContribution {
+
+    @inject(ContributionProvider) @named(ExtensionsSourceContribution)
+    protected readonly contributions: ContributionProvider<ExtensionsSourceContribution>;
+
+    @inject(VSXExtensionsSearchModel)
+    protected readonly searchModel: VSXExtensionsSearchModel;
+
+    registerCommands(commands: CommandRegistry): void {
+        for (const contribution of this.orderedContributions()) {
+            const type = contribution.type;
+            // No `label`: these commands exist only for the filter popup, and a labelless command
+            // is excluded from the command palette. The menu action below carries the visible label.
+            commands.registerCommand({ id: FILTER_COMMAND_PREFIX + type }, {
+                execute: () => this.toggle(type),
+                isToggled: () => this.searchModel.isTypeEnabled(type)
+            });
+        }
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        this.orderedContributions().forEach((contribution, index) => {
+            menus.registerMenuAction(EXTENSIONS_FILTER_BY_TYPE_MENU, {
+                commandId: FILTER_COMMAND_PREFIX + contribution.type,
+                label: contribution.displayName,
+                order: String(index)
+            });
+        });
+    }
+
+    protected orderedContributions(): ExtensionsSourceContribution[] {
+        return [...this.contributions.getContributions()].sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+    }
+
+    /**
+     * Toggles whether the given type is shown. A full selection is normalized to "no filter"
+     * (`enabledTypes === undefined`) so the search bar's funnel icon only lights up for a real subset.
+     */
+    protected toggle(type: string): void {
+        const allTypes = this.orderedContributions().map(c => c.type);
+        const enabled = new Set(allTypes.filter(t => this.searchModel.isTypeEnabled(t)));
+        if (enabled.has(type)) {
+            enabled.delete(type);
+        } else {
+            enabled.add(type);
+        }
+        this.searchModel.enabledTypes = enabled.size === allTypes.length ? undefined : enabled;
+    }
+}

--- a/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.ts
@@ -15,22 +15,43 @@
 // *****************************************************************************
 
 import { inject, injectable, named } from '@theia/core/shared/inversify';
-import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MenuPath } from '@theia/core/lib/common';
+import { CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, MenuPath, nls } from '@theia/core/lib/common';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { ExtensionsSourceContribution } from './extensions-source-contribution';
-import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
+import { BUILTIN_QUERY, INSTALLED_QUERY, MODE_QUERIES, RECOMMENDED_QUERY, VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 
-/** Menu path of the anchored "Filter by Type" popup opened from the Extensions search bar. */
+/** Menu path of the anchored "Filter" popup opened from the Extensions search bar. */
 export const EXTENSIONS_FILTER_BY_TYPE_MENU: MenuPath = ['vsx-extensions-filter-by-type-context-menu'];
+
+/** Menu group for the per-contribution-type toggles (Extensions, MCP Servers, Skills, ...). */
+const FILTER_BY_TYPE_GROUP: MenuPath = [...EXTENSIONS_FILTER_BY_TYPE_MENU, '1_types'];
+/** Menu group for the existing search-mode queries (`@installed`, `@builtin`, `@recommended`). */
+const FILTER_BY_MODE_GROUP: MenuPath = [...EXTENSIONS_FILTER_BY_TYPE_MENU, '2_modes'];
 
 /** Command id prefix for the per-contribution-type toggle commands. */
 const FILTER_COMMAND_PREFIX = 'vsxExtensions.filterByType:';
+/** Command id prefix for the search-mode shortcut commands shown in the same popup. */
+const FILTER_MODE_COMMAND_PREFIX = 'vsxExtensions.filterByMode:';
+
+interface ModeFilterEntry {
+    readonly id: string;
+    readonly query: string;
+    readonly label: string;
+}
 
 /**
- * Registers one toggle command + menu item per {@link ExtensionsSourceContribution} type so the
- * search bar can offer an anchored "Filter by Type" popup (rendered through the
- * {@link ContextMenuRenderer}) with a checkmark per kind of result (Extensions, MCP Servers,
- * Skills, ...). Toggling updates {@link VSXExtensionsSearchModel.enabledTypes}.
+ * Registers commands + menu items for the anchored "Filter" popup opened from the Extensions
+ * search bar. Both kinds of filter go through the search query:
+ *
+ * - Per-contribution-type toggles insert/remove the contribution's `searchToken` (e.g. `@mcp`).
+ *   When no type token is present, all contributions are enabled; adding tokens narrows the
+ *   visible types. Multiple types compose (`@mcp @skills`).
+ * - Mode shortcuts insert/remove the existing `@installed` / `@builtin` / `@recommended` token,
+ *   which the view container interprets to switch widgets. Modes are mutually exclusive: clicking
+ *   one replaces any previously selected mode.
+ *
+ * Both kinds compose freely in the query (e.g. `@installed @mcp` shows only installed MCP
+ * servers), and clearing the query (`Clear Search Results`) automatically resets both.
  */
 @injectable()
 export class VSXExtensionsFilterContribution implements CommandContribution, MenuContribution {
@@ -41,23 +62,42 @@ export class VSXExtensionsFilterContribution implements CommandContribution, Men
     @inject(VSXExtensionsSearchModel)
     protected readonly searchModel: VSXExtensionsSearchModel;
 
+    protected readonly modeEntries: readonly ModeFilterEntry[] = [
+        { id: 'installed', query: INSTALLED_QUERY, label: nls.localize('theia/vsx-registry/filter/showInstalled', 'Show Installed') },
+        { id: 'builtin', query: BUILTIN_QUERY, label: nls.localize('theia/vsx-registry/filter/showBuiltin', 'Show Built-in') },
+        { id: 'recommended', query: RECOMMENDED_QUERY, label: nls.localize('theia/vsx-registry/filter/showRecommended', 'Show Recommended') }
+    ];
+
     registerCommands(commands: CommandRegistry): void {
         for (const contribution of this.orderedContributions()) {
-            const type = contribution.type;
+            const token = contribution.searchToken;
             // No `label`: these commands exist only for the filter popup, and a labelless command
             // is excluded from the command palette. The menu action below carries the visible label.
-            commands.registerCommand({ id: FILTER_COMMAND_PREFIX + type }, {
-                execute: () => this.toggle(type),
-                isToggled: () => this.searchModel.isTypeEnabled(type)
+            commands.registerCommand({ id: FILTER_COMMAND_PREFIX + contribution.type }, {
+                execute: () => this.toggleType(token),
+                isToggled: () => this.searchModel.isTokenEnabled(token)
+            });
+        }
+        for (const mode of this.modeEntries) {
+            commands.registerCommand({ id: FILTER_MODE_COMMAND_PREFIX + mode.id }, {
+                execute: () => this.toggleMode(mode.query),
+                isToggled: () => this.queryHasToken(mode.query)
             });
         }
     }
 
     registerMenus(menus: MenuModelRegistry): void {
         this.orderedContributions().forEach((contribution, index) => {
-            menus.registerMenuAction(EXTENSIONS_FILTER_BY_TYPE_MENU, {
+            menus.registerMenuAction(FILTER_BY_TYPE_GROUP, {
                 commandId: FILTER_COMMAND_PREFIX + contribution.type,
                 label: contribution.displayName,
+                order: String(index)
+            });
+        });
+        this.modeEntries.forEach((mode, index) => {
+            menus.registerMenuAction(FILTER_BY_MODE_GROUP, {
+                commandId: FILTER_MODE_COMMAND_PREFIX + mode.id,
+                label: mode.label,
                 order: String(index)
             });
         });
@@ -68,17 +108,94 @@ export class VSXExtensionsFilterContribution implements CommandContribution, Men
     }
 
     /**
-     * Toggles whether the given type is shown. A full selection is normalized to "no filter"
-     * (`enabledTypes === undefined`) so the search bar's funnel icon only lights up for a real subset.
+     * Toggles whether the given type is currently ticked in the funnel popup.
+     *
+     * The query encoding has two equivalent representations of "every type ticked": no tokens at
+     * all, or every contribution's token spelled out. Clicking a ticked type from the implicit
+     * (no-tokens) representation must produce "all ticked except the clicked one" rather than
+     * "only the clicked one" - so the toggle materialises the effective tick set first, then flips
+     * the clicked entry, then normalises a full set back to the implicit form.
      */
-    protected toggle(type: string): void {
-        const allTypes = this.orderedContributions().map(c => c.type);
-        const enabled = new Set(allTypes.filter(t => this.searchModel.isTypeEnabled(t)));
-        if (enabled.has(type)) {
-            enabled.delete(type);
+    protected toggleType(token: string): void {
+        const allTokens = this.orderedContributions().map(c => c.searchToken);
+        const parsed = this.searchModel.parseQuery();
+        // Materialise the effective tick set: an empty `typeTokens` means all contributions are
+        // implicitly ticked, otherwise only the listed ones are ticked.
+        const ticked = parsed.typeTokens.size === 0
+            ? new Set(allTokens)
+            : new Set(parsed.typeTokens);
+        if (ticked.has(token)) {
+            ticked.delete(token);
         } else {
-            enabled.add(type);
+            ticked.add(token);
         }
-        this.searchModel.enabledTypes = enabled.size === allTypes.length ? undefined : enabled;
+        // Normalise the "every type ticked" case back to the empty-tokens representation so the
+        // funnel icon only highlights for a real subset.
+        if (ticked.size === allTokens.length) {
+            ticked.clear();
+        }
+        this.rewriteQuery({ typeTokens: ticked });
+    }
+
+    /**
+     * Toggles a search-mode token. Modes are mutually exclusive in the view container, so a new
+     * selection replaces the previous mode token; re-selecting the active mode clears it.
+     */
+    protected toggleMode(modeQuery: string): void {
+        const previous = this.modeTokenInQuery();
+        const nextMode = previous === modeQuery ? undefined : modeQuery;
+        this.rewriteQuery({ modeToken: nextMode });
+    }
+
+    /** The mode token present in the query, if any. */
+    protected modeTokenInQuery(): string | undefined {
+        for (const token of this.queryTokens()) {
+            if (MODE_QUERIES.includes(token)) {
+                return token;
+            }
+        }
+        return undefined;
+    }
+
+    /** True when the query contains the given token as a standalone word. */
+    protected queryHasToken(token: string): boolean {
+        return this.queryTokens().includes(token);
+    }
+
+    protected queryTokens(): string[] {
+        return this.searchModel.query.split(/\s+/).filter(Boolean);
+    }
+
+    /**
+     * Rebuilds the query, keeping the free-text remainder intact while swapping in the desired
+     * mode and type tokens. Tokens are emitted in a stable order (mode first, then types,
+     * then free text) so repeated toggles produce a tidy query.
+     */
+    protected rewriteQuery(update: { modeToken?: string; typeTokens?: ReadonlySet<string> }): void {
+        const parsed = this.searchModel.parseQuery();
+        const orderedTypeTokens = this.orderedContributions().map(c => c.searchToken);
+        const validTokens = new Set(orderedTypeTokens);
+        const previousModeToken = this.modeTokenInQuery();
+        // Use key presence to distinguish "caller wants to clear/replace" from "caller is only
+        // updating the other field". This applies symmetrically to both fields, so passing
+        // `{ modeToken: undefined }` or `{ typeTokens: undefined }` clears that field.
+        const nextModeToken = 'modeToken' in update ? update.modeToken : previousModeToken;
+        const nextTypeTokens = 'typeTokens' in update
+            ? new Set([...(update.typeTokens ?? [])].filter(t => validTokens.has(t)))
+            : new Set(parsed.typeTokens);
+        const parts: string[] = [];
+        if (nextModeToken) {
+            parts.push(nextModeToken);
+        }
+        // Preserve the contribution ordering so toggling later doesn't reshuffle visible tokens.
+        for (const token of orderedTypeTokens) {
+            if (nextTypeTokens.has(token)) {
+                parts.push(token);
+            }
+        }
+        if (parsed.freeText) {
+            parts.push(parsed.freeText);
+        }
+        this.searchModel.query = parts.join(' ');
     }
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-filter-contribution.ts
@@ -44,8 +44,9 @@ interface ModeFilterEntry {
  * search bar. Both kinds of filter go through the search query:
  *
  * - Per-contribution-type toggles insert/remove the contribution's `searchToken` (e.g. `@mcp`).
- *   When no type token is present, all contributions are enabled; adding tokens narrows the
- *   visible types. Multiple types compose (`@mcp @skills`).
+ *   The popup behaves as an "include this type" filter: with nothing ticked no type token is
+ *   present and every contribution is shown; ticking a type narrows the results to it. Multiple
+ *   types compose (`@mcp @skills`).
  * - Mode shortcuts insert/remove the existing `@installed` / `@builtin` / `@recommended` token,
  *   which the view container interprets to switch widgets. Modes are mutually exclusive: clicking
  *   one replaces any previously selected mode.
@@ -75,7 +76,9 @@ export class VSXExtensionsFilterContribution implements CommandContribution, Men
             // is excluded from the command palette. The menu action below carries the visible label.
             commands.registerCommand({ id: FILTER_COMMAND_PREFIX + contribution.type }, {
                 execute: () => this.toggleType(token),
-                isToggled: () => this.searchModel.isTokenEnabled(token)
+                // Ticked only when the type is explicitly included via its token. With no tokens
+                // present nothing is ticked, matching the "no filter" state of the funnel icon.
+                isToggled: () => this.searchModel.parseQuery().typeTokens.has(token)
             });
         }
         for (const mode of this.modeEntries) {
@@ -108,31 +111,16 @@ export class VSXExtensionsFilterContribution implements CommandContribution, Men
     }
 
     /**
-     * Toggles whether the given type is currently ticked in the funnel popup.
-     *
-     * The query encoding has two equivalent representations of "every type ticked": no tokens at
-     * all, or every contribution's token spelled out. Clicking a ticked type from the implicit
-     * (no-tokens) representation must produce "all ticked except the clicked one" rather than
-     * "only the clicked one" - so the toggle materialises the effective tick set first, then flips
-     * the clicked entry, then normalises a full set back to the implicit form.
+     * Toggles whether the given type is included by the filter. Nothing ticked means "no filter"
+     * (all types shown); ticking a type adds its token so the results narrow to it, and ticking
+     * a second type widens the selection to both. Unticking the last type returns to "no filter".
      */
     protected toggleType(token: string): void {
-        const allTokens = this.orderedContributions().map(c => c.searchToken);
-        const parsed = this.searchModel.parseQuery();
-        // Materialise the effective tick set: an empty `typeTokens` means all contributions are
-        // implicitly ticked, otherwise only the listed ones are ticked.
-        const ticked = parsed.typeTokens.size === 0
-            ? new Set(allTokens)
-            : new Set(parsed.typeTokens);
+        const ticked = new Set(this.searchModel.parseQuery().typeTokens);
         if (ticked.has(token)) {
             ticked.delete(token);
         } else {
             ticked.add(token);
-        }
-        // Normalise the "every type ticked" case back to the empty-tokens representation so the
-        // funnel icon only highlights for a real subset.
-        if (ticked.size === allTokens.length) {
-            ticked.clear();
         }
         this.rewriteQuery({ typeTokens: ticked });
     }

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -57,7 +57,10 @@ export class VSXExtensionsModel {
     protected searchCancellationTokenSource = new CancellationTokenSource();
     protected updateSearchResult = debounce(async () => {
         const { token } = this.resetSearchCancellationTokenSource();
-        await this.doUpdateSearchResult({ query: this.search.query, includeAllVersions: true }, token);
+        // Only the free-text portion is sent to OVSX; `@`-prefixed mode and type tokens are
+        // consumed locally by the search model and would otherwise return no OVSX matches.
+        const { freeText } = this.search.parseQuery();
+        await this.doUpdateSearchResult({ query: freeText, includeAllVersions: true }, token);
     }, 500);
 
     @inject(VSXRegistryService)

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
@@ -15,11 +15,15 @@
 // *****************************************************************************
 
 import * as React from '@theia/core/shared/react';
-import { injectable, postConstruct, inject } from '@theia/core/shared/inversify';
+import { injectable, postConstruct, inject, named } from '@theia/core/shared/inversify';
 import { ReactWidget, Message, codicon } from '@theia/core/lib/browser/widgets';
+import { ContextMenuRenderer } from '@theia/core/lib/browser';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import { VSXExtensionsModel } from './vsx-extensions-model';
+import { ExtensionsSourceContribution } from './extensions-source-contribution';
+import { EXTENSIONS_FILTER_BY_TYPE_MENU } from './vsx-extensions-filter-contribution';
 import { nls } from '@theia/core/lib/common/nls';
 
 @injectable()
@@ -34,6 +38,12 @@ export class VSXExtensionsSearchBar extends ReactWidget {
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
 
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
+
+    @inject(ContributionProvider) @named(ExtensionsSourceContribution)
+    protected readonly extensionsContributions: ContributionProvider<ExtensionsSourceContribution>;
+
     protected input: HTMLInputElement | undefined;
     protected onlyShowVerifiedExtensions: boolean | undefined;
 
@@ -43,6 +53,7 @@ export class VSXExtensionsSearchBar extends ReactWidget {
         this.id = 'vsx-extensions-search-bar';
         this.addClass('theia-vsx-extensions-search-bar');
         this.searchModel.onDidChangeQuery((query: string) => this.updateSearchTerm(query));
+        this.searchModel.onDidChangeFilter(() => this.update());
         this.preferenceService.onPreferenceChanged(change => {
             if (change.preferenceName === 'extensions.onlyShowVerifiedExtensions') {
                 const newValue = this.preferenceService.get<boolean>('extensions.onlyShowVerifiedExtensions', false);
@@ -76,9 +87,36 @@ export class VSXExtensionsSearchBar extends ReactWidget {
     }
 
     protected renderOptionContainer(): React.ReactNode {
-        const showVerifiedExtensions = this.renderShowVerifiedExtensions();
-        return <div className='option-buttons'>{showVerifiedExtensions}</div>;
+        return <div className='option-buttons'>
+            {this.renderFilterByType()}
+            {this.renderShowVerifiedExtensions()}
+        </div>;
     }
+
+    protected renderFilterByType(): React.ReactNode {
+        // Only useful when more than one result kind exists (e.g. MCP servers / skills alongside extensions).
+        if ([...this.extensionsContributions.getContributions()].length < 2) {
+            return undefined;
+        }
+        const active = this.searchModel.enabledTypes !== undefined;
+        return <span
+            className={`${codicon(active ? 'filter-filled' : 'filter')} option action-label ${active ? 'enabled' : ''}`}
+            title={nls.localize('theia/vsx-registry/filterByType', 'Filter by Type')}
+            onClick={this.handleFilterByTypeClick}>
+        </span>;
+    }
+
+    // Anchored popup (not the centered quick input) listing each result kind with a checkmark;
+    // the menu items are the toggle commands registered by VSXExtensionsFilterContribution.
+    protected handleFilterByTypeClick = (event: React.MouseEvent<HTMLElement>): void => {
+        event.stopPropagation();
+        this.contextMenuRenderer.render({
+            menuPath: EXTENSIONS_FILTER_BY_TYPE_MENU,
+            anchor: { x: event.clientX, y: event.clientY },
+            context: event.currentTarget,
+            includeAnchorArg: false
+        });
+    };
 
     protected renderShowVerifiedExtensions(): React.ReactNode {
         return <span

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-bar.tsx
@@ -52,8 +52,12 @@ export class VSXExtensionsSearchBar extends ReactWidget {
         this.onlyShowVerifiedExtensions = this.preferenceService.get('extensions.onlyShowVerifiedExtensions');
         this.id = 'vsx-extensions-search-bar';
         this.addClass('theia-vsx-extensions-search-bar');
-        this.searchModel.onDidChangeQuery((query: string) => this.updateSearchTerm(query));
-        this.searchModel.onDidChangeFilter(() => this.update());
+        this.searchModel.onDidChangeQuery((query: string) => {
+            this.updateSearchTerm(query);
+            // Funnel icon highlights when type tokens are present; re-render whenever the query
+            // changes so toggling tokens (via the popup or typing them by hand) updates the icon.
+            this.update();
+        });
         this.preferenceService.onPreferenceChanged(change => {
             if (change.preferenceName === 'extensions.onlyShowVerifiedExtensions') {
                 const newValue = this.preferenceService.get<boolean>('extensions.onlyShowVerifiedExtensions', false);
@@ -71,7 +75,7 @@ export class VSXExtensionsSearchBar extends ReactWidget {
                 defaultValue={this.searchModel.query}
                 spellCheck={false}
                 className='theia-input'
-                placeholder={nls.localize('theia/vsx-registry/searchPlaceholder', 'Search Extensions in {0}', 'Open VSX Registry')}
+                placeholder={nls.localize('theia/vsx-registry/searchPlaceholder', 'Search Open VSX Registry')}
                 onChange={this.updateQuery}>
             </input>
             {this.renderOptionContainer()}
@@ -98,10 +102,13 @@ export class VSXExtensionsSearchBar extends ReactWidget {
         if ([...this.extensionsContributions.getContributions()].length < 2) {
             return undefined;
         }
-        const active = this.searchModel.enabledTypes !== undefined;
+        // Icon lights up whenever the query carries a real subset of type tokens; the indicator
+        // intentionally tracks the type filter only, since the mode tokens are already visible in
+        // the input text itself.
+        const active = this.searchModel.parseQuery().typeTokens.size > 0;
         return <span
             className={`${codicon(active ? 'filter-filled' : 'filter')} option action-label ${active ? 'enabled' : ''}`}
-            title={nls.localize('theia/vsx-registry/filterByType', 'Filter by Type')}
+            title={nls.localizeByDefault('Filter Extensions...')}
             onClick={this.handleFilterByTypeClick}>
         </span>;
     }

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-model.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-model.spec.ts
@@ -1,0 +1,167 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { Emitter } from '@theia/core';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { ExtensionsSourceContribution } from './extensions-source-contribution';
+import { VSXExtensionsSearchModel, VSXSearchMode } from './vsx-extensions-search-model';
+
+class StubContribution implements ExtensionsSourceContribution {
+    readonly onDidChange = new Emitter<void>().event;
+    constructor(readonly type: string, readonly displayName: string, readonly searchToken: string, readonly priority = 0) { }
+}
+
+function buildModel(contributions: ExtensionsSourceContribution[] = defaultContributions()): VSXExtensionsSearchModel {
+    const container = new Container();
+    const provider: ContributionProvider<ExtensionsSourceContribution> = { getContributions: () => contributions };
+    container.bind(ContributionProvider).toConstantValue(provider).whenTargetNamed(ExtensionsSourceContribution);
+    container.bind(VSXExtensionsSearchModel).toSelf().inSingletonScope();
+    return container.get(VSXExtensionsSearchModel);
+}
+
+function defaultContributions(): ExtensionsSourceContribution[] {
+    return [
+        new StubContribution('extension', 'Extensions', '@extensions'),
+        new StubContribution('mcp-server', 'MCP Servers', '@mcp'),
+        new StubContribution('skill', 'Skills', '@skills')
+    ];
+}
+
+describe('VSXExtensionsSearchModel.parseQuery', () => {
+
+    it('returns None mode with no tokens for an empty query', () => {
+        const model = buildModel();
+        const parsed = model.parseQuery();
+        expect(parsed.mode).to.equal(VSXSearchMode.None);
+        expect([...parsed.typeTokens]).to.deep.equal([]);
+        expect(parsed.freeText).to.equal('');
+    });
+
+    it('returns Search mode with the original free text when only free text is present', () => {
+        const model = buildModel();
+        model.query = 'hello world';
+        const parsed = model.parseQuery();
+        expect(parsed.mode).to.equal(VSXSearchMode.Search);
+        expect([...parsed.typeTokens]).to.deep.equal([]);
+        expect(parsed.freeText).to.equal('hello world');
+    });
+
+    it('parses a single mode token and yields no free text', () => {
+        const model = buildModel();
+        model.query = '@installed';
+        const parsed = model.parseQuery();
+        expect(parsed.mode).to.equal(VSXSearchMode.Installed);
+        expect([...parsed.typeTokens]).to.deep.equal([]);
+        expect(parsed.freeText).to.equal('');
+    });
+
+    it('extracts type tokens and leaves None mode when there is no free text', () => {
+        const model = buildModel();
+        model.query = '@mcp';
+        const parsed = model.parseQuery();
+        // `@mcp` alone scopes the view (Installed + Recommended + Built-in sections) to MCP,
+        // so there is no Search mode and no free text to send to OVSX.
+        expect(parsed.mode).to.equal(VSXSearchMode.None);
+        expect([...parsed.typeTokens]).to.deep.equal(['@mcp']);
+        expect(parsed.freeText).to.equal('');
+    });
+
+    it('composes mode and type tokens with the remaining free text', () => {
+        const model = buildModel();
+        model.query = '@installed @mcp asana';
+        const parsed = model.parseQuery();
+        expect(parsed.mode).to.equal(VSXSearchMode.Installed);
+        expect([...parsed.typeTokens]).to.deep.equal(['@mcp']);
+        expect(parsed.freeText).to.equal('asana');
+    });
+
+    it('accepts the same token in any order and accumulates type tokens', () => {
+        const model = buildModel();
+        model.query = '@mcp @skills foo';
+        const parsed = model.parseQuery();
+        expect(parsed.mode).to.equal(VSXSearchMode.Search);
+        expect([...parsed.typeTokens].sort()).to.deep.equal(['@mcp', '@skills']);
+        expect(parsed.freeText).to.equal('foo');
+    });
+
+    it('keeps the first of two mode tokens and treats the second as free text', () => {
+        const model = buildModel();
+        model.query = '@installed @builtin';
+        const parsed = model.parseQuery();
+        expect(parsed.mode).to.equal(VSXSearchMode.Installed);
+        // The second mode token survives as free text rather than silently overriding the first;
+        // surfacing it lets the user notice the conflict in the input box.
+        expect(parsed.freeText).to.equal('@builtin');
+    });
+
+    it('treats unknown @-prefixed tokens as free text', () => {
+        const model = buildModel();
+        model.query = '@unknown alpha';
+        const parsed = model.parseQuery();
+        expect(parsed.mode).to.equal(VSXSearchMode.Search);
+        expect([...parsed.typeTokens]).to.deep.equal([]);
+        expect(parsed.freeText).to.equal('@unknown alpha');
+    });
+});
+
+describe('VSXExtensionsSearchModel.isTokenEnabled', () => {
+
+    it('reports every token enabled when no type tokens are present', () => {
+        const model = buildModel();
+        model.query = 'anything';
+        expect(model.isTokenEnabled('@extensions')).to.equal(true);
+        expect(model.isTokenEnabled('@mcp')).to.equal(true);
+        expect(model.isTokenEnabled('@skills')).to.equal(true);
+    });
+
+    it('reports only the tokens present in the query as enabled', () => {
+        const model = buildModel();
+        model.query = '@mcp asana';
+        expect(model.isTokenEnabled('@mcp')).to.equal(true);
+        expect(model.isTokenEnabled('@extensions')).to.equal(false);
+        expect(model.isTokenEnabled('@skills')).to.equal(false);
+    });
+
+    it('reports both tokens enabled when both appear in the query', () => {
+        const model = buildModel();
+        model.query = '@mcp @skills';
+        expect(model.isTokenEnabled('@mcp')).to.equal(true);
+        expect(model.isTokenEnabled('@skills')).to.equal(true);
+        expect(model.isTokenEnabled('@extensions')).to.equal(false);
+    });
+});
+
+describe('VSXExtensionsSearchModel.onDidChangeQuery', () => {
+
+    it('fires when the query value changes', () => {
+        const model = buildModel();
+        let fired = 0;
+        model.onDidChangeQuery(() => fired++);
+        model.query = 'hello';
+        expect(fired).to.equal(1);
+    });
+
+    it('short-circuits when the new value matches the current one', () => {
+        const model = buildModel();
+        model.query = 'same';
+        let fired = 0;
+        model.onDidChangeQuery(() => fired++);
+        model.query = 'same';
+        expect(fired).to.equal(0);
+    });
+});

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
@@ -35,6 +35,11 @@ export class VSXExtensionsSearchModel {
 
     protected readonly onDidChangeQueryEmitter = new Emitter<string>();
     readonly onDidChangeQuery = this.onDidChangeQueryEmitter.event;
+
+    protected readonly onDidChangeFilterEmitter = new Emitter<void>();
+    /** Fires when the contribution-type filter changes (see {@link enabledTypes}). */
+    readonly onDidChangeFilter = this.onDidChangeFilterEmitter.event;
+
     protected readonly specialQueries = new Map<string, VSXSearchMode>([
         [BUILTIN_QUERY, VSXSearchMode.Builtin],
         [INSTALLED_QUERY, VSXSearchMode.Installed],
@@ -51,6 +56,25 @@ export class VSXExtensionsSearchModel {
     }
     get query(): string {
         return this._query;
+    }
+
+    /**
+     * The set of enabled contribution types (e.g. `extension`, `mcp-server`, `skill`) for search
+     * results. `undefined` means "no filter" - all contribution types are shown.
+     */
+    protected _enabledTypes: ReadonlySet<string> | undefined;
+    set enabledTypes(types: ReadonlySet<string> | undefined) {
+        const normalized = types && types.size > 0 ? types : undefined;
+        this._enabledTypes = normalized;
+        this.onDidChangeFilterEmitter.fire();
+    }
+    get enabledTypes(): ReadonlySet<string> | undefined {
+        return this._enabledTypes;
+    }
+
+    /** True when search results of the given contribution type should be shown. */
+    isTypeEnabled(type: string): boolean {
+        return !this._enabledTypes || this._enabledTypes.has(type);
     }
 
     getModeForQuery(): VSXSearchMode {

--- a/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-search-model.ts
@@ -14,8 +14,10 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { Emitter } from '@theia/core/lib/common/event';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { ExtensionsSourceContribution } from './extensions-source-contribution';
 
 export enum VSXSearchMode {
     Initial,
@@ -30,17 +32,33 @@ export const BUILTIN_QUERY = '@builtin';
 export const INSTALLED_QUERY = '@installed';
 export const RECOMMENDED_QUERY = '@recommended';
 
+/** Mutually-exclusive mode tokens, in the order they are checked when parsing the query. */
+export const MODE_QUERIES: readonly string[] = [INSTALLED_QUERY, BUILTIN_QUERY, RECOMMENDED_QUERY];
+
+/**
+ * Outcome of {@link VSXExtensionsSearchModel.parseQuery}: the query, decomposed into the (single)
+ * search mode driven by `@installed`/`@builtin`/`@recommended`, the per-contribution type tokens
+ * (e.g. `@mcp`), and the free-text remainder used as the actual search term.
+ */
+export interface ParsedQuery {
+    /** Search mode the view container uses to pick which widget is visible. */
+    readonly mode: VSXSearchMode;
+    /** Contribution `searchToken`s present in the query. Empty means "all contributions are enabled". */
+    readonly typeTokens: ReadonlySet<string>;
+    /** Everything in the query that isn't a recognised mode or type token. */
+    readonly freeText: string;
+}
+
 @injectable()
 export class VSXExtensionsSearchModel {
+
+    @inject(ContributionProvider) @named(ExtensionsSourceContribution)
+    protected readonly contributions: ContributionProvider<ExtensionsSourceContribution>;
 
     protected readonly onDidChangeQueryEmitter = new Emitter<string>();
     readonly onDidChangeQuery = this.onDidChangeQueryEmitter.event;
 
-    protected readonly onDidChangeFilterEmitter = new Emitter<void>();
-    /** Fires when the contribution-type filter changes (see {@link enabledTypes}). */
-    readonly onDidChangeFilter = this.onDidChangeFilterEmitter.event;
-
-    protected readonly specialQueries = new Map<string, VSXSearchMode>([
+    protected readonly modeForToken = new Map<string, VSXSearchMode>([
         [BUILTIN_QUERY, VSXSearchMode.Builtin],
         [INSTALLED_QUERY, VSXSearchMode.Installed],
         [RECOMMENDED_QUERY, VSXSearchMode.Recommended],
@@ -59,27 +77,55 @@ export class VSXExtensionsSearchModel {
     }
 
     /**
-     * The set of enabled contribution types (e.g. `extension`, `mcp-server`, `skill`) for search
-     * results. `undefined` means "no filter" - all contribution types are shown.
+     * Parses the current query into its mode, type-token and free-text parts. Both mode and type
+     * tokens compose, so `@installed @mcp asana` parses to `{ mode: Installed, typeTokens: {@mcp},
+     * freeText: 'asana' }`.
      */
-    protected _enabledTypes: ReadonlySet<string> | undefined;
-    set enabledTypes(types: ReadonlySet<string> | undefined) {
-        const normalized = types && types.size > 0 ? types : undefined;
-        this._enabledTypes = normalized;
-        this.onDidChangeFilterEmitter.fire();
-    }
-    get enabledTypes(): ReadonlySet<string> | undefined {
-        return this._enabledTypes;
+    parseQuery(): ParsedQuery {
+        const validTypeTokens = this.getRegisteredTypeTokens();
+        let mode: VSXSearchMode | undefined;
+        const typeTokens = new Set<string>();
+        const freeTextParts: string[] = [];
+        for (const token of this._query.split(/\s+/).filter(Boolean)) {
+            // Mode tokens are mutually exclusive: the first wins. A second mode token in the same
+            // query is treated as free text so users don't end up in an ambiguous state.
+            if (mode === undefined && this.modeForToken.has(token)) {
+                mode = this.modeForToken.get(token);
+                continue;
+            }
+            if (validTypeTokens.has(token)) {
+                typeTokens.add(token);
+                continue;
+            }
+            freeTextParts.push(token);
+        }
+        const freeText = freeTextParts.join(' ');
+        if (mode === undefined) {
+            mode = freeText.length > 0 ? VSXSearchMode.Search : VSXSearchMode.None;
+        }
+        return { mode, typeTokens, freeText };
     }
 
-    /** True when search results of the given contribution type should be shown. */
-    isTypeEnabled(type: string): boolean {
-        return !this._enabledTypes || this._enabledTypes.has(type);
-    }
-
+    /** Convenience for the view container, which only needs the mode. */
     getModeForQuery(): VSXSearchMode {
-        return this.query
-            ? this.specialQueries.get(this.query) ?? VSXSearchMode.Search
-            : VSXSearchMode.None;
+        return this.parseQuery().mode;
+    }
+
+    /**
+     * True when the given contribution `searchToken` should be considered enabled for the current
+     * query. When no type tokens are present, all contributions are enabled.
+     */
+    isTokenEnabled(token: string): boolean {
+        const { typeTokens } = this.parseQuery();
+        return typeTokens.size === 0 || typeTokens.has(token);
+    }
+
+    /** Set of `searchToken`s contributed by the currently registered extensions sources. */
+    getRegisteredTypeTokens(): ReadonlySet<string> {
+        const tokens = new Set<string>();
+        for (const contribution of this.contributions.getContributions()) {
+            tokens.add(contribution.searchToken);
+        }
+        return tokens;
     }
 }

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
@@ -70,6 +70,11 @@ function makeResult(id: string, searchableText: string): SearchResult {
 
 class StubSearchModel {
     query: string = '';
+    enabledTypes: ReadonlySet<string> | undefined;
+    readonly onDidChangeFilter = new Emitter<void>().event;
+    isTypeEnabled(type: string): boolean {
+        return !this.enabledTypes || this.enabledTypes.has(type);
+    }
 }
 
 class StubPreferenceService {

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
@@ -51,6 +51,7 @@ class StubContribution implements ExtensionsSourceContribution {
     constructor(
         readonly type: string,
         readonly displayName: string,
+        readonly searchToken: string,
         private readonly results: SearchResult[],
         readonly priority = 0
     ) { }
@@ -66,15 +67,6 @@ interface TaggedElement extends TreeElement {
 function makeResult(id: string, searchableText: string): SearchResult {
     const element: TaggedElement = { id, render: () => undefined };
     return { element, searchableText };
-}
-
-class StubSearchModel {
-    query: string = '';
-    enabledTypes: ReadonlySet<string> | undefined;
-    readonly onDidChangeFilter = new Emitter<void>().event;
-    isTypeEnabled(type: string): boolean {
-        return !this.enabledTypes || this.enabledTypes.has(type);
-    }
 }
 
 class StubPreferenceService {
@@ -95,19 +87,18 @@ function buildSource(contributions: ExtensionsSourceContribution[], query: strin
     } as unknown as VSXExtensionsModel);
     const provider: ContributionProvider<ExtensionsSourceContribution> = { getContributions: () => contributions };
     container.bind(ContributionProvider).toConstantValue(provider).whenTargetNamed(ExtensionsSourceContribution);
-    const searchModel = new StubSearchModel();
-    searchModel.query = query;
-    container.bind(VSXExtensionsSearchModel).toConstantValue(searchModel as unknown as VSXExtensionsSearchModel);
+    container.bind(VSXExtensionsSearchModel).toSelf().inSingletonScope();
     container.bind(PreferenceService).toConstantValue(new StubPreferenceService() as unknown as PreferenceService);
     container.bind(FuzzySearch).toSelf().inSingletonScope();
     container.bind(VSXExtensionsSource).toSelf().inSingletonScope();
+    container.get(VSXExtensionsSearchModel).query = query;
     return container.get(VSXExtensionsSource);
 }
 
 describe('VSXExtensionsSource.collectSearchResults', () => {
 
     it('passes hits through unranked when the query is empty', async () => {
-        const contribution = new StubContribution('extension', 'Extensions', [
+        const contribution = new StubContribution('extension', 'Extensions', '@extensions', [
             makeResult('a', 'alpha'),
             makeResult('b', 'beta')
         ]);
@@ -119,7 +110,7 @@ describe('VSXExtensionsSource.collectSearchResults', () => {
     });
 
     it('passes hits through unranked when there is only one result, regardless of query', async () => {
-        const contribution = new StubContribution('extension', 'Extensions', [
+        const contribution = new StubContribution('extension', 'Extensions', '@extensions', [
             makeResult('only', 'unrelated text')
         ]);
         const source = buildSource([contribution], 'something');
@@ -133,10 +124,10 @@ describe('VSXExtensionsSource.collectSearchResults', () => {
         // First contribution exposes a weak match for "git"; second contribution exposes
         // a much better match. Without global ranking the weak match would win simply
         // because it came from the earlier contribution.
-        const weak = new StubContribution('extension', 'Extensions', [
+        const weak = new StubContribution('extension', 'Extensions', '@extensions', [
             makeResult('weakly-related', 'configuration tool that integrates with git pipelines')
         ]);
-        const strong = new StubContribution('mcp-server', 'MCP Servers', [
+        const strong = new StubContribution('mcp-server', 'MCP Servers', '@mcp', [
             makeResult('strong-match', 'git')
         ], 100);
         const source = buildSource([weak, strong], 'git');
@@ -147,7 +138,7 @@ describe('VSXExtensionsSource.collectSearchResults', () => {
     });
 
     it('drops hits whose searchableText does not match the query at all', async () => {
-        const contribution = new StubContribution('extension', 'Extensions', [
+        const contribution = new StubContribution('extension', 'Extensions', '@extensions', [
             makeResult('matches', 'git client'),
             makeResult('nope', 'totally unrelated content')
         ]);
@@ -156,5 +147,40 @@ describe('VSXExtensionsSource.collectSearchResults', () => {
         const elements = [...(await source.getElements())] as TaggedElement[];
 
         expect(elements.map(e => e.id)).to.deep.equal(['matches']);
+    });
+
+    it('filters search results down to the contributions whose @-tokens appear in the query, ignoring the tokens themselves as search text', async () => {
+        // `@mcp` in the query restricts results to the MCP contribution; the token itself must
+        // not be treated as search text (otherwise the MCP entry's text wouldn't match it).
+        const extensions = new StubContribution('extension', 'Extensions', '@extensions', [
+            makeResult('ext-1', 'a great extension')
+        ]);
+        const mcp = new StubContribution('mcp-server', 'MCP Servers', '@mcp', [
+            makeResult('mcp-1', 'a useful mcp server')
+        ], 100);
+
+        const source = buildSource([extensions, mcp], '@mcp');
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id)).to.deep.equal(['mcp-1']);
+    });
+
+    it('composes @-tokens, including multiple type tokens', async () => {
+        const extensions = new StubContribution('extension', 'Extensions', '@extensions', [
+            makeResult('ext-1', 'ext alpha')
+        ]);
+        const mcp = new StubContribution('mcp-server', 'MCP Servers', '@mcp', [
+            makeResult('mcp-1', 'mcp alpha')
+        ], 100);
+        const skill = new StubContribution('skill', 'Skills', '@skills', [
+            makeResult('skill-1', 'skill alpha')
+        ], 200);
+
+        const source = buildSource([extensions, mcp, skill], '@mcp @skills');
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id).sort()).to.deep.equal(['mcp-1', 'skill-1']);
     });
 });

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -60,6 +60,8 @@ export class VSXExtensionsSource extends TreeSource {
         for (const contribution of this.contributions.getContributions()) {
             this.toDispose.push(contribution.onDidChange(() => this.scheduleFireDidChange()));
         }
+        // Re-collect search results when the contribution-type filter changes.
+        this.toDispose.push(this.searchModel.onDidChangeFilter(() => this.scheduleFireDidChange()));
     }
 
     protected scheduleFireDidChange = debounce(() => this.fireDidChange(), 100, { leading: false, trailing: true });
@@ -98,7 +100,8 @@ export class VSXExtensionsSource extends TreeSource {
         const ctx: SearchContext = {
             verifiedOnly: this.preferenceService.get<boolean>('extensions.onlyShowVerifiedExtensions', false)
         };
-        const results = await Promise.all(contributions.map(c => c.resolveSearchResults?.(query, ctx) ?? []));
+        const enabled = contributions.filter(c => this.searchModel.isTypeEnabled(c.type));
+        const results = await Promise.all(enabled.map(c => c.resolveSearchResults?.(query, ctx) ?? []));
         const all = results.flatMap(r => [...r]);
         const trimmed = query.trim();
         if (!trimmed || all.length <= 1) {

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -60,8 +60,9 @@ export class VSXExtensionsSource extends TreeSource {
         for (const contribution of this.contributions.getContributions()) {
             this.toDispose.push(contribution.onDidChange(() => this.scheduleFireDidChange()));
         }
-        // Re-collect search results when the contribution-type filter changes.
-        this.toDispose.push(this.searchModel.onDidChangeFilter(() => this.scheduleFireDidChange()));
+        // The query carries both the search text and the per-contribution-type filter (via
+        // `@`-prefixed tokens), so any query change must re-collect the entries.
+        this.toDispose.push(this.searchModel.onDidChangeQuery(() => this.scheduleFireDidChange()));
     }
 
     protected scheduleFireDidChange = debounce(() => this.fireDidChange(), 100, { leading: false, trailing: true });
@@ -73,13 +74,16 @@ export class VSXExtensionsSource extends TreeSource {
     async getElements(): Promise<IterableIterator<TreeElement>> {
         const ordered = [...this.contributions.getContributions()]
             .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+        // Apply the type-token filter to every section, not just search results, so the two
+        // filtering mechanisms compose (e.g. `@installed @mcp` only lists installed MCP servers).
+        const enabled = ordered.filter(c => this.searchModel.isTokenEnabled(c.searchToken));
 
         if (this.options.id === VSXExtensionsSourceOptions.SEARCH_RESULT) {
-            return this.collectSearchResults(ordered);
+            return this.collectSearchResults(enabled);
         }
 
         const entries: TreeElement[] = [];
-        for (const contribution of ordered) {
+        for (const contribution of enabled) {
             const iter = await this.resolveForSection(contribution);
             if (!iter) {
                 continue;
@@ -96,14 +100,16 @@ export class VSXExtensionsSource extends TreeSource {
      * regardless of which contribution produced them.
      */
     protected async collectSearchResults(contributions: ExtensionsSourceContribution[]): Promise<IterableIterator<TreeElement>> {
-        const query = this.searchModel.query;
+        // Contributions only see the free-text portion of the query - the `@`-prefixed mode and
+        // type tokens have already been consumed by `parseQuery` to pick the mode and the
+        // contribution filter, so they would otherwise leak into substring matching.
+        const { freeText } = this.searchModel.parseQuery();
         const ctx: SearchContext = {
             verifiedOnly: this.preferenceService.get<boolean>('extensions.onlyShowVerifiedExtensions', false)
         };
-        const enabled = contributions.filter(c => this.searchModel.isTypeEnabled(c.type));
-        const results = await Promise.all(enabled.map(c => c.resolveSearchResults?.(query, ctx) ?? []));
+        const results = await Promise.all(contributions.map(c => c.resolveSearchResults?.(freeText, ctx) ?? []));
         const all = results.flatMap(r => [...r]);
-        const trimmed = query.trim();
+        const trimmed = freeText.trim();
         if (!trimmed || all.length <= 1) {
             return all.map(r => r.element).values();
         }

--- a/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
+++ b/packages/vsx-registry/src/browser/vsx-registry-frontend-module.ts
@@ -17,12 +17,14 @@
 import '../../src/browser/style/index.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
+import { CommandContribution, MenuContribution } from '@theia/core/lib/common';
 import {
     WidgetFactory, bindViewContribution, FrontendApplicationContribution, ViewContainerIdentifier, OpenHandler, WidgetManager, WebSocketConnectionProvider,
     WidgetStatusBarContribution,
     noopWidgetStatusBarContribution
 } from '@theia/core/lib/browser';
 import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
+import { VSXExtensionsFilterContribution } from './vsx-extensions-filter-contribution';
 import { VSXExtensionsViewContainer } from './vsx-extensions-view-container';
 import { VSXExtensionsContribution } from './vsx-extensions-contribution';
 import { VSXExtensionsSearchBar } from './vsx-extensions-search-bar';
@@ -112,6 +114,10 @@ export default new ContainerModule((bind, unbind, isBound, rebind) => {
     })).inSingletonScope();
 
     bind(VSXExtensionsSearchModel).toSelf().inSingletonScope();
+
+    bind(VSXExtensionsFilterContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(VSXExtensionsFilterContribution);
+    bind(MenuContribution).toService(VSXExtensionsFilterContribution);
 
     rebind(LanguageQuickPickService).to(VSXLanguageQuickPickService).inSingletonScope();
 


### PR DESCRIPTION
#### What it does

Follow-up to #17635 (skill registry support) and the broader AI Registry integration. Addresses review feedback across the Extensions view and the MCP/skill install flows:

- **Registry endpoint move.** Per-tool registry views moved from `<base>/<tool>.json` to `<base>/tools/<tool>.json` (the aggregate `all.json` stays at the root). `RegistryFetchService.buildEndpointUrl` now builds the `tools/` path for any tool other than the default `all`. See eclipsefdn-ai-registry/ai-registry-core#32.
- **"Add local MCP config" toolbar visibility.** The command appeared on every section header of the Extensions view. It is now gated exactly like *Install from VSIX…*, i.e. only on the main Extensions toolbar (the view container's tab-bar delegate), not on the individual sub-views. The check locates the container by walking up from the toolbar's widget and reuses `getTabBarDelegate()` rather than matching part-id prefixes.
- **Skill card icon size.** The skill mortar-board icon rendered at the default codicon size, smaller than the MCP icon. It now uses the same `calc(var(--theia-vsx-extension-icon-size) * 0.65)` sizing as the MCP card.
- **OAuth credentials in the MCP install dialog.** When a registry entry advertises an `oauth` block, the install dialog now prompts for the confidential-client **Client ID** and **Client Secret** and shows the (read-only, copyable) **Redirect URL** to register with the provider — mirroring the existing auth-token field. The registry-fixed parts (scopes, authorization server, resource) are not shown. User-supplied credentials are merged into the entry's `oauth` block on install, replacing the registry placeholders. `MCPInstallEntryConfig` now declares the `oauth` field so this round-trips with a type.
- **Filter by type in the Extensions search bar.** A funnel button next to the search input opens an **anchored popup** (rendered through `ContextMenuRenderer`, not a centered quick input) with a checkmark per result kind — Extensions, MCP Servers, Skills — backed by per-type toggle commands. The button only appears when more than one result kind is registered, and lights up while a strict subset is active.
- **Better MCP / skill search.** Registry descriptions are long, keyword-rich prose, so the shared fuzzy ranker treated nearly every MCP server and skill as a hit for any short query (e.g. `asana` matched every server). A shared relevance pre-filter (`matchesRegistrySearch`, in `@theia/ai-registry/common`) now narrows the candidate set before the shared ranker runs: every query term must hit the meaningful name or identifier as a substring, or be the prefix of a word in the name, identifier or description. Reverse-DNS identifiers are reduced to their last domain label plus path (`meaningfulIdentifier`), so the shared `io.github.*` / `com.*` prefixes no longer match unrelated queries like `git`. Both the MCP and skill contributions use it.

#### How to test

**1 — Registry endpoint / tools move**

1. Open the Extensions view and search for an MCP server or skill keyword; confirm results load.
2. To exercise the per-tool path, rebind `AIRegistryConfiguration.getToolName()` to e.g. `theia-ide` and confirm the request goes to `<base>/tools/theia-ide.json` (the default `all` still hits `<base>/all.json`).

**2 — "Add local MCP config" toolbar visibility**

1. Open the Extensions view and confirm **Add local MCP config…** shows **only** on the main Extensions title toolbar (alongside *Install from VSIX…* / *Refresh*), not on each section header.
2. Type a search query and confirm it still shows on the search-results toolbar.

**3 — Skill icon size**

1. Search for a skill and confirm the mortar-board icon matches the size of the MCP icon.

**4 — OAuth fields in the MCP install dialog**

1. Install an MCP server whose entry uses OAuth with a confidential client (e.g. **Asana**). Confirm the dialog shows **OAuth Client ID**, **OAuth Client Secret**, and a read-only **Redirect URL** with a copy button (scopes / authorization server / resource are not shown).
2. Confirm **Install** is disabled until both client ID and secret are filled.
3. After install, verify `ai-features.mcp.mcpServers.<name>.oauth` contains the entered `clientId`/`clientSecret` alongside the registry-supplied `resource`, with no `<clientId>`/`<clientSecret>` placeholders left.
4. Regression: a server with only a static `serverAuthToken` still shows just the **Auth Token** field; a server with neither shows neither.

**5 — Filter by type**

1. Confirm a funnel icon appears next to the search input.
2. Click it and confirm an **anchored popup** (not a centered overlay) lists **Extensions**, **MCP Servers**, **Skills**, all initially checked.
3. Uncheck **Extensions**, search, and confirm only MCP / skill results appear and the funnel shows its active state.
4. Re-check everything and confirm the filter clears.

**6 — MCP / skill search relevance**

1. Search `asana` → only `com.asana/mcp` (and any genuinely related entry) appears.
2. Search `git` → only genuinely git-related entries appear; the shared `io.github.…` / `com.…` prefix no longer matches (a real GitHub server still does).
3. Search `art` → a small relevant set including e.g. `algorithmic-art`.
4. Search `powerpoint` → entries whose description mentions PowerPoint appear even when the term is not in their name.

#### Follow-ups

> [!IMPORTANT]
> **Merge ordering (must be synchronous).** This PR depends on eclipsefdn-ai-registry/ai-registry-core#32. Before merging here:
> 1. Merge ai-registry-core#32 so the production registry serves the `tools/<tool>.json` layout.
> 2. Check if registry is available via ai.open-vsx.org, if yes, change the base url to that.
> 3. Then merge this PR.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
