### PR TITLE
fix(test): keep specs compatible with React 19

### DIFF
--- a/packages/ai-mcp/src/browser/mcp-configuration-widget.spec.tsx
+++ b/packages/ai-mcp/src/browser/mcp-configuration-widget.spec.tsx
@@ -28,7 +28,8 @@ try {
 
 import { expect } from 'chai';
 import * as React from '@theia/core/shared/react';
-import * as ReactDOM from '@theia/core/shared/react-dom';
+import { createRoot, Root } from '@theia/core/shared/react-dom/client';
+import { flushSync } from '@theia/core/shared/react-dom';
 import { Emitter, Event, MessageService, PreferenceScope, PreferenceService } from '@theia/core';
 import {
     LocalMCPServerDescription,
@@ -70,6 +71,7 @@ class TestAIMCPConfigurationWidget extends AIMCPConfigurationWidget {
 
 describe('AIMCPConfigurationWidget MCP OAuth support', () => {
     let host: HTMLElement;
+    let root: Root | undefined;
 
     before(() => {
         disableJSDOM = enableJSDOM();
@@ -85,7 +87,8 @@ describe('AIMCPConfigurationWidget MCP OAuth support', () => {
     });
 
     afterEach(() => {
-        ReactDOM.unmountComponentAtNode(host);
+        root?.unmount();
+        root = undefined;
         host.remove();
     });
 
@@ -134,7 +137,9 @@ describe('AIMCPConfigurationWidget MCP OAuth support', () => {
     }
 
     function renderWidget(widget: TestAIMCPConfigurationWidget): void {
-        ReactDOM.render(widget.testRender() as React.ReactElement, host);
+        root ??= createRoot(host);
+        // root.render is async; flushSync keeps the tests' immediate assertions valid.
+        flushSync(() => root!.render(widget.testRender() as React.ReactElement));
     }
 
     const oauthServer: RemoteMCPServerDescription = {

--- a/packages/core/src/browser/tree/tree-view-welcome-widget.spec.ts
+++ b/packages/core/src/browser/tree/tree-view-welcome-widget.spec.ts
@@ -21,7 +21,7 @@ const disableJSDOM = enableJSDOM();
 
 import { Container } from 'inversify';
 import { expect } from 'chai';
-import { ReactElement } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import { CommandService } from '../../common';
 import { LabelParser } from '../label-parser';
 import { codicon } from '../widgets';
@@ -44,11 +44,13 @@ before(() => {
 
 describe('TreeViewWelcomeWidget#renderLabelWithIcons', () => {
 
+    type SpanElement = ReactElement<{ className?: string; children?: ReactNode }>;
+
     // Exercise the protected helper without standing up the full TreeWidget DI graph.
-    function render(label: string): ReactElement[] {
+    function render(label: string): SpanElement[] {
         const widget = Object.create(TreeViewWelcomeWidget.prototype) as {
             labelParser: LabelParser;
-            renderLabelWithIcons(label: string): ReactElement[];
+            renderLabelWithIcons(label: string): SpanElement[];
         };
         widget.labelParser = labelParser;
         return widget.renderLabelWithIcons(label);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Narrow `ReactElement` props in `tree-view-welcome-widget.spec.ts` so React 19's stricter default props type (`unknown` instead of `any`) still allows `.props` access.
- Replace removed `ReactDOM.render` / `unmountComponentAtNode` in `mcp-configuration-widget.spec.tsx` with `createRoot` + `root.unmount()`, wrapped in `flushSync` to keep render synchronous for the existing assertions.

Both specs were added after #17567 and used patterns that no longer compile under React 19. The new patterns also work on React 18, so the peer range `^18.3.1 || ^19.0.0` is preserved.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Apply the React 19 test setup from [#17567](https://github.com/eclipse-theia/theia/pull/17567) (the script under "How to test" that flips `devDependencies` in root and `packages/core` to `^19.0.0`), then:

```bash
npm install
npm run compile
npx lerna run test --scope @theia/core --scope @theia/ai-mcp
```

Both specs compile under React 19, and they continue to compile and pass under React 18 (default repo state).

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
