### PR TITLE
[vscode] API bump and nls update to 1.125.0 and implement MultiDocumentHighlightProvider for hover verbosity

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,7 +18,7 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.121.0';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.125.0';
 
 /**
  * The default supported monaco editor version the framework supports.

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -2643,7 +2643,7 @@ interface ReasoningSelectorProps {
 const reasoningLevelLabel = (level: ReasoningLevel): string => {
     switch (level) {
         case 'off': return nls.localizeByDefault('Off');
-        case 'minimal': return nls.localize('theia/ai/chat-ui/reasoning/minimal', 'Minimal');
+        case 'minimal': return nls.localizeByDefault('Minimal');
         case 'low': return nls.localizeByDefault('Low');
         case 'medium': return nls.localizeByDefault('Medium');
         case 'high': return nls.localizeByDefault('High');

--- a/packages/ai-claude-code/src/browser/renderers/ls-tool-renderer.tsx
+++ b/packages/ai-claude-code/src/browser/renderers/ls-tool-renderer.tsx
@@ -129,7 +129,7 @@ const LSToolComponent: React.FC<{
     const expandedContent = (
         <div className="claude-code-tool details">
             <div className="claude-code-tool detail-row">
-                <span className="claude-code-tool detail-label">{nls.localize('theia/ai/claude-code/directory', 'Directory')}</span>
+                <span className="claude-code-tool detail-label">{nls.localizeByDefault('Directory')}</span>
                 <code className="claude-code-tool detail-value">{input.path}</code>
             </div>
             {input.ignore && input.ignore.length > 0 && (

--- a/packages/ai-claude-code/src/browser/renderers/web-fetch-tool-renderer.tsx
+++ b/packages/ai-claude-code/src/browser/renderers/web-fetch-tool-renderer.tsx
@@ -90,7 +90,7 @@ const WebFetchToolComponent: React.FC<{
                 <code className="claude-code-tool detail-value">{input.url}</code>
             </div>
             <div className="claude-code-tool detail-row">
-                <span className="claude-code-tool detail-label">{nls.localize('theia/ai/claude-code/domain', 'Domain')}</span>
+                <span className="claude-code-tool detail-label">{nls.localizeByDefault('Domain')}</span>
                 <span className="claude-code-tool detail-value">{getDomain(input.url)}</span>
             </div>
             <div className="claude-code-tool detail-row">

--- a/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/agent-configuration-widget.tsx
@@ -312,7 +312,7 @@ export class AIAgentConfigurationWidget extends AIListDetailConfigurationWidget<
                             <tr>
                                 <th>{nls.localize('theia/ai/core/agentConfiguration/templateName', 'Template')}</th>
                                 <th>{nls.localize('theia/ai/core/agentConfiguration/variant', 'Variant')}</th>
-                                <th className="template-actions-header">{nls.localize('theia/ai/core/agentConfiguration/actions', 'Actions')}</th>
+                                <th className="template-actions-header">{nls.localizeByDefault('Actions')}</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -882,7 +882,7 @@ const AgentGenericCapabilitiesSettings = ({ agentId, savedSelections, aiSettings
                 <tr>
                     <th>{nls.localizeByDefault('Type')}</th>
                     <th>{nls.localize('theia/ai/ide/agentConfiguration/selections', 'Selections')}</th>
-                    <th className="template-actions-header">{nls.localize('theia/ai/core/agentConfiguration/actions', 'Actions')}</th>
+                    <th className="template-actions-header">{nls.localizeByDefault('Actions')}</th>
                 </tr>
             </thead>
             <tbody>

--- a/packages/ai-ide/src/browser/ai-configuration/token-usage-configuration-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/token-usage-configuration-widget.tsx
@@ -188,7 +188,7 @@ export class AITokenUsageConfigurationWidget extends AITableConfigurationWidget<
                 <table className="ai-configuration-table">
                     <tfoot>
                         <tr className="ai-configuration-footer-total-row">
-                            <td className="token-usage-model-column">{nls.localize('theia/ai/tokenUsage/total', 'Total')}</td>
+                            <td className="token-usage-model-column">{nls.localizeByDefault('Total')}</td>
                             <td className="token-usage-column">{this.formatNumber(totalInputTokens)}</td>
                             {showCacheColumns && (
                                 <>

--- a/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
@@ -225,7 +225,7 @@ const UserInteractionComponent: React.FC<UserInteractionComponentProps> = ({
     }
 
     const activeState = stepStates[currentStep];
-    const stepLabel = nls.localize('theia/ai-ide/userInteractionStepLabel', 'Step {0} of {1}', currentStep + 1, stepCount);
+    const stepLabel = nls.localizeByDefault('Step {0} of {1}', currentStep + 1, stepCount);
     const advanceLabel = isLastStep
         ? nls.localize('theia/ai-ide/userInteractionFinishStep', 'Finish')
         : nls.localizeByDefault('Next');
@@ -259,7 +259,7 @@ const UserInteractionComponent: React.FC<UserInteractionComponentProps> = ({
                         return (
                             <span className='user-interaction-tool status canceled'>
                                 <i className={codicon('close')} />
-                                {nls.localize('theia/ai-ide/userInteractionCanceled', 'Canceled')}
+                                {nls.localizeByDefault('Canceled')}
                             </span>
                         );
                     }

--- a/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
+++ b/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
@@ -248,7 +248,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
         const startingIcon = 'loading';
         const stopIcon = isRemote ? 'debug-disconnect' : 'debug-stop';
         const startLabel = isRemote
-            ? nls.localize('theia/ai/mcpConfiguration/connectServer', 'Connect')
+            ? nls.localizeByDefault('Connect')
             : nls.localizeByDefault('Start Server');
         const startingLabel = isRemote
             ? nls.localize('theia/ai/mcpConfiguration/connectingServer', 'Connecting...')

--- a/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
+++ b/packages/ai-terminal/src/browser/shell-execution-tool-renderer.tsx
@@ -819,7 +819,7 @@ const DeniedUI: React.FC<DeniedUIProps> = ({
 
     const getStatusLabel = (): string => {
         if (confirmationState === 'rejected') {
-            return nls.localize('theia/ai-terminal/executionCanceled', 'Canceled');
+            return nls.localizeByDefault('Canceled');
         }
         return denialReason
             ? nls.localize('theia/ai-terminal/executionDeniedWithReason', 'Denied with reason')
@@ -896,7 +896,7 @@ const CanceledUI: React.FC<CanceledUIProps> = ({
                         <span className="shell-execution-tool duration">{formatDuration(canceledResult.duration)}</span>
                     )}
                     <span className="shell-execution-tool status-label canceled">
-                        {nls.localize('theia/ai-terminal/executionCanceled', 'Canceled')}
+                        {nls.localizeByDefault('Canceled')}
                     </span>
                 </span>
             </div>

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -499,6 +499,8 @@
 			"codeLens",
 			"detectIndentation",
 			"diffAlgorithm.advanced",
+			"diffAlgorithm.advancedExternal",
+			"diffAlgorithm.advancedWasm",
 			"diffAlgorithm.legacy",
 			"editor.experimental.asyncTokenization",
 			"editor.experimental.asyncTokenizationLogging",
@@ -2646,6 +2648,16 @@
 			"selectPrevCodeAction.title",
 			"toggleSectionCodeAction.title"
 		],
+		"vs/platform/agentHost/common/agentHost.config.contribution": [
+			"chat.agentHost.enabled",
+			"chat.agents.copilotCli.hideExtensionHost",
+			"chat.editor.copilotCli.hideExtensionHost",
+			"chat.editor.defaultProvider",
+			"chat.editor.defaultProvider.copilotAh",
+			"chat.editor.defaultProvider.copilotEh",
+			"chat.editor.defaultProvider.local",
+			"chatAgentHostConfigurationTitle"
+		],
 		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
 			"agentHost.config.customizations.description",
 			"agentHost.config.customizations.descriptionField",
@@ -2655,10 +2667,14 @@
 			"agentHost.config.customizations.uri",
 			"agentHost.config.defaultShell.description",
 			"agentHost.config.defaultShell.title",
-			"agentHost.config.disableCustomTerminalTool.description",
-			"agentHost.config.disableCustomTerminalTool.title"
+			"agentHost.config.enableCustomTerminalTool.description",
+			"agentHost.config.enableCustomTerminalTool.title",
+			"agentHost.config.rubberDuck.description",
+			"agentHost.config.rubberDuck.title"
 		],
 		"vs/platform/agentHost/common/agentHostSchema": [
+			"agentHost.config.sessionSyncEnabled.description",
+			"agentHost.config.sessionSyncEnabled.title",
 			"agentHost.config.telemetryLevel.description",
 			"agentHost.config.telemetryLevel.title",
 			"agentHost.sessionConfig.autoApprove",
@@ -2681,6 +2697,31 @@
 			"agentHost.sessionConfig.permissions.toolName",
 			"agentHost.sessionConfig.permissionsDescription"
 		],
+		"vs/platform/agentHost/common/agentHostStarter.config.contribution": [
+			"chat.agentHost.claudeAgent.enabled",
+			"chat.agentHost.codexAgent.binaryArgs",
+			"chat.agentHost.codexAgent.codexHome",
+			"chat.agentHost.codexAgent.enabled",
+			"chat.agentHost.codexAgent.sdkRoot",
+			"chat.agentHost.otel.captureContent",
+			"chat.agentHost.otel.dbSpanExporter.enabled",
+			"chat.agentHost.otel.enabled",
+			"chat.agentHost.otel.exporterType",
+			"chat.agentHost.otel.otlpEndpoint",
+			"chat.agentHost.otel.outfile",
+			"chatAgentHostStarterConfigurationTitle"
+		],
+		"vs/platform/agentHost/common/changesetUri": [
+			"branchChangeset.label",
+			"compareTurnsChangeset.description",
+			"compareTurnsChangeset.label",
+			"sessionChangeset.description",
+			"sessionChangeset.label",
+			"thisTurnChangeset.description",
+			"thisTurnChangeset.label",
+			"uncommittedChangeset.description",
+			"uncommittedChangeset.label"
+		],
 		"vs/platform/agentHost/common/claudeModelConfig": [
 			"claude.modelThinkingLevel.description",
 			"claude.modelThinkingLevel.high",
@@ -2690,11 +2731,67 @@
 			"claude.modelThinkingLevel.title",
 			"claude.modelThinkingLevel.xhigh"
 		],
+		"vs/platform/agentHost/common/sandboxConfigSchema": [
+			"agentHost.config.sandbox.advancedRuntime.title",
+			"agentHost.config.sandbox.allowedDomains.item.title",
+			"agentHost.config.sandbox.allowedDomains.title",
+			"agentHost.config.sandbox.allowUnsandboxedCommands.title",
+			"agentHost.config.sandbox.autoApproveUnsandboxedCommands.title",
+			"agentHost.config.sandbox.deniedDomains.item.title",
+			"agentHost.config.sandbox.deniedDomains.title",
+			"agentHost.config.sandbox.enabled.title",
+			"agentHost.config.sandbox.linuxFileSystem.title",
+			"agentHost.config.sandbox.macFileSystem.title",
+			"agentHost.config.sandbox.title",
+			"agentHost.config.sandbox.windowsEnabled.title",
+			"agentHost.config.sandbox.windowsFileSystem.title"
+		],
 		"vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl": [
 			"sshKbiDefaultPrompt"
 		],
+		"vs/platform/agentHost/electron-browser/wslRemoteAgentHostServiceImpl": [
+			"wslProgressFinalizing",
+			"wslProgressHandshake"
+		],
+		"vs/platform/agentHost/node/agentHostCommitOperationHandler": [
+			"agentHost.changeset.commit.authExpired",
+			"agentHost.changeset.commit.authRequired",
+			"agentHost.changeset.commit.cancelled",
+			"agentHost.changeset.commit.committed",
+			"agentHost.changeset.commit.diffFailed",
+			"agentHost.changeset.commit.emptyMessage",
+			"agentHost.changeset.commit.noChanges"
+		],
+		"vs/platform/agentHost/node/agentHostCommitOperationProvider": [
+			"agentHost.changeset.commit"
+		],
 		"vs/platform/agentHost/node/agentHostMain": [
 			"agentHost"
+		],
+		"vs/platform/agentHost/node/agentHostPullRequestOperationHandler": [
+			"agentHost.changeset.pr.authRequired",
+			"agentHost.changeset.pr.body",
+			"agentHost.changeset.pr.cancelled",
+			"agentHost.changeset.pr.commitMessage",
+			"agentHost.changeset.pr.computeChangesFailed",
+			"agentHost.changeset.pr.created",
+			"agentHost.changeset.pr.createdDraft",
+			"agentHost.changeset.pr.existing",
+			"agentHost.changeset.pr.noChanges"
+		],
+		"vs/platform/agentHost/node/agentHostPullRequestOperationProvider": [
+			"agentHost.changeset.createDraftPR",
+			"agentHost.changeset.createPR"
+		],
+		"vs/platform/agentHost/node/agentHostRenameCommand": [
+			"agentHostSlashCommand.rename.description"
+		],
+		"vs/platform/agentHost/node/agentService": [
+			"agentHost.forkedSessionFallback",
+			"agentHost.forkedTitlePrefix"
+		],
+		"vs/platform/agentHost/node/agentSideEffects": [
+			"agentHostRename.renamed"
 		],
 		"vs/platform/agentHost/node/claude/claudeAgent": [
 			"claude.sessionConfig.permissionMode",
@@ -2743,7 +2840,91 @@
 			"claude.tool.task",
 			"claude.tool.todoWrite",
 			"claude.tool.webFetch",
-			"claude.tool.write"
+			"claude.tool.write",
+			"claude.toolComplete.bash",
+			"claude.toolComplete.bashCmd",
+			"claude.toolComplete.bashOutput",
+			"claude.toolComplete.edit",
+			"claude.toolComplete.editFile",
+			"claude.toolComplete.failed",
+			"claude.toolComplete.generic",
+			"claude.toolComplete.glob",
+			"claude.toolComplete.globPattern",
+			"claude.toolComplete.grep",
+			"claude.toolComplete.grepPattern",
+			"claude.toolComplete.killBash",
+			"claude.toolComplete.ls",
+			"claude.toolComplete.lsPath",
+			"claude.toolComplete.read",
+			"claude.toolComplete.readFile",
+			"claude.toolComplete.task",
+			"claude.toolComplete.todoWrite",
+			"claude.toolComplete.webFetch",
+			"claude.toolComplete.webFetchGeneric",
+			"claude.toolInvoke.bash",
+			"claude.toolInvoke.bashCmd",
+			"claude.toolInvoke.bashOutput",
+			"claude.toolInvoke.edit",
+			"claude.toolInvoke.editFile",
+			"claude.toolInvoke.glob",
+			"claude.toolInvoke.globPattern",
+			"claude.toolInvoke.grep",
+			"claude.toolInvoke.grepPattern",
+			"claude.toolInvoke.killBash",
+			"claude.toolInvoke.ls",
+			"claude.toolInvoke.lsPath",
+			"claude.toolInvoke.read",
+			"claude.toolInvoke.readFile",
+			"claude.toolInvoke.todoWrite",
+			"claude.toolInvoke.webFetch",
+			"claude.toolInvoke.webFetchGeneric"
+		],
+		"vs/platform/agentHost/node/claude/customizations/claudeSdkCustomizationBundler": [
+			"claude.discovered.displayName"
+		],
+		"vs/platform/agentHost/node/codex/codexAgent": [
+			"codex.modelThinkingLevel.description",
+			"codex.modelThinkingLevel.high",
+			"codex.modelThinkingLevel.low",
+			"codex.modelThinkingLevel.medium",
+			"codex.modelThinkingLevel.minimal",
+			"codex.modelThinkingLevel.title",
+			"codex.sessionConfig.additionalDirectories",
+			"codex.sessionConfig.additionalDirectories.item",
+			"codex.sessionConfig.additionalDirectoriesDescription",
+			"codex.sessionConfig.approvalPolicy",
+			"codex.sessionConfig.approvalPolicy.never",
+			"codex.sessionConfig.approvalPolicy.neverDescription",
+			"codex.sessionConfig.approvalPolicy.onFailure",
+			"codex.sessionConfig.approvalPolicy.onFailureDescription",
+			"codex.sessionConfig.approvalPolicy.onRequest",
+			"codex.sessionConfig.approvalPolicy.onRequestDescription",
+			"codex.sessionConfig.approvalPolicy.untrusted",
+			"codex.sessionConfig.approvalPolicy.untrustedDescription",
+			"codex.sessionConfig.approvalPolicyDescription",
+			"codex.sessionConfig.modelReasoningEffort",
+			"codex.sessionConfig.modelReasoningEffort.high",
+			"codex.sessionConfig.modelReasoningEffort.low",
+			"codex.sessionConfig.modelReasoningEffort.medium",
+			"codex.sessionConfig.modelReasoningEffort.minimal",
+			"codex.sessionConfig.modelReasoningEffortDescription",
+			"codex.sessionConfig.networkAccessEnabled",
+			"codex.sessionConfig.networkAccessEnabledDescription",
+			"codex.sessionConfig.sandboxMode",
+			"codex.sessionConfig.sandboxMode.dangerFullAccess",
+			"codex.sessionConfig.sandboxMode.dangerFullAccessDescription",
+			"codex.sessionConfig.sandboxMode.readOnly",
+			"codex.sessionConfig.sandboxMode.readOnlyDescription",
+			"codex.sessionConfig.sandboxMode.workspaceWrite",
+			"codex.sessionConfig.sandboxMode.workspaceWriteDescription",
+			"codex.sessionConfig.sandboxModeDescription",
+			"codex.sessionConfig.webSearchMode",
+			"codex.sessionConfig.webSearchMode.cached",
+			"codex.sessionConfig.webSearchMode.disabled",
+			"codex.sessionConfig.webSearchMode.live",
+			"codex.sessionConfig.webSearchModeDescription",
+			"codexAgent.description",
+			"codexAgent.displayName"
 		],
 		"vs/platform/agentHost/node/copilot/copilotAgent": [
 			"agentHost.sessionConfig.branch",
@@ -2754,6 +2935,11 @@
 			"agentHost.sessionConfig.isolation.worktree",
 			"agentHost.sessionConfig.isolation.worktreeDescription",
 			"agentHost.sessionConfig.isolationDescription",
+			"copilot.modelContextTier.default",
+			"copilot.modelContextTier.description",
+			"copilot.modelContextTier.longerSessions",
+			"copilot.modelContextTier.longerSessionsNoCompaction",
+			"copilot.modelContextTier.title",
 			"copilot.modelThinkingLevel.description",
 			"copilot.modelThinkingLevel.high",
 			"copilot.modelThinkingLevel.low",
@@ -2775,11 +2961,24 @@
 			"agentHost.planReview.interactive.label",
 			"agentHost.planReview.questionMessage",
 			"agentHost.planReview.title",
-			"agentHost.planReview.viewPlanLink"
+			"agentHost.planReview.viewPlanLink",
+			"agentHost.unsandboxedCommandConfirmation.blockedDomains",
+			"agentHost.unsandboxedCommandConfirmation.generic",
+			"agentHost.unsandboxedCommandConfirmation.reason",
+			"agentHost.unsandboxedCommandConfirmation.title.blockedDomains",
+			"agentHost.unsandboxedCommandConfirmation.title.generic"
 		],
 		"vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider": [
 			"copilotSlashCommand.compact.description",
-			"copilotSlashCommand.plan.description"
+			"copilotSlashCommand.plan.description",
+			"copilotSlashCommand.research.description",
+			"copilotSlashCommand.rubberDuck.description"
+		],
+		"vs/platform/agentHost/node/copilot/copilotSystemNotification": [
+			"agentHost.copilot.systemNotification.agentCompleted",
+			"agentHost.copilot.systemNotification.shellCompleted",
+			"agentHost.copilot.systemNotification.shellDescriptionCompleted",
+			"agentHost.copilot.systemNotification.shellIdCompleted"
 		],
 		"vs/platform/agentHost/node/copilot/copilotToolDisplay": [
 			"copilot.permission.default.message",
@@ -2816,6 +3015,8 @@
 			"toolComplete.viewFileFromLine",
 			"toolComplete.viewFileLine",
 			"toolComplete.viewFileRange",
+			"toolComplete.webFetch",
+			"toolComplete.webFetchGeneric",
 			"toolComplete.writeShell",
 			"toolComplete.writeShellCmd",
 			"toolInvoke.create",
@@ -2842,6 +3043,8 @@
 			"toolInvoke.viewFileFromLine",
 			"toolInvoke.viewFileLine",
 			"toolInvoke.viewFileRange",
+			"toolInvoke.webFetch",
+			"toolInvoke.webFetchGeneric",
 			"toolInvoke.writeShell",
 			"toolInvoke.writeShellCmd",
 			"toolName.applyPatch",
@@ -2896,6 +3099,8 @@
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
 			"ssh.failedToReadPrivateKey",
 			"ssh.keyFileAuthRequiresPath",
+			"sshKeyPassphraseName",
+			"sshKeyPassphrasePrompt",
 			"sshProgressCheckingAgent",
 			"sshProgressConnecting",
 			"sshProgressDownloadingCLI",
@@ -2906,9 +3111,18 @@
 		"vs/platform/agentHost/node/tunnelHostMainService": [
 			"tunnelHost.log"
 		],
+		"vs/platform/agentHost/node/wslRemoteAgentHostService": [
+			"wslProgressConnecting",
+			"wslProgressDetectingPlatform",
+			"wslProgressPreparingCLI",
+			"wslUnsupportedPlatform"
+		],
 		"vs/platform/browserView/common/browserView": [
 			"browserZoomAccessibilityLabel",
 			"browserZoomPercent"
+		],
+		"vs/platform/browserView/electron-main/browserSession": [
+			"browserSession.untrustedFile"
 		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
 			"browser.contextMenu.addElementToChat",
@@ -4024,12 +4238,27 @@
 			"bodyFontSizeSmall",
 			"bodyFontSizeXSmall",
 			"codiconFontSize",
+			"codiconFontSizeCompact",
 			"cornerRadiusCircle",
 			"cornerRadiusLarge",
 			"cornerRadiusMedium",
 			"cornerRadiusSmall",
 			"cornerRadiusXLarge",
 			"cornerRadiusXSmall",
+			"spacingNone",
+			"spacingSize100",
+			"spacingSize120",
+			"spacingSize160",
+			"spacingSize20",
+			"spacingSize200",
+			"spacingSize240",
+			"spacingSize280",
+			"spacingSize320",
+			"spacingSize360",
+			"spacingSize40",
+			"spacingSize400",
+			"spacingSize60",
+			"spacingSize80",
 			"strokeThickness"
 		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
@@ -4369,6 +4598,7 @@
 			"auxiliaryBarAriaLabel"
 		],
 		"vs/sessions/browser/parts/chatCompositeBar": [
+			"chatTabsAriaLabel",
 			"closeChat",
 			"renameChat",
 			"renameChat.prompt"
@@ -4436,12 +4666,22 @@
 		],
 		"vs/sessions/browser/parts/mobile/contributions/mobileDiffView": [
 			"diffView.back",
-			"diffView.backLabel",
 			"diffView.loading",
 			"diffView.nextFile",
 			"diffView.noChanges",
 			"diffView.position",
 			"diffView.prevFile"
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileMultiDiffView": [
+			"multiDiffView.back",
+			"multiDiffView.file",
+			"multiDiffView.fileCount",
+			"multiDiffView.fileFallback",
+			"multiDiffView.files",
+			"multiDiffView.loadError",
+			"multiDiffView.loading",
+			"multiDiffView.noChanges",
+			"multiDiffView.toggleFile"
 		],
 		"vs/sessions/browser/parts/mobile/mobilePickerSheet": [
 			"mobilePickerSheet.done",
@@ -4470,9 +4710,17 @@
 			"mobileTopBar.changes",
 			"mobileTopBar.changesTooltip",
 			"mobileTopBar.closeSessions",
+			"mobileTopBar.filesChangedCount",
+			"mobileTopBar.filesChangedTooltip",
 			"mobileTopBar.newSession",
 			"mobileTopBar.newSessionAria",
-			"mobileTopBar.openSessions"
+			"mobileTopBar.openSessions",
+			"mobileTopBar.singleFileChanged",
+			"mobileTopBar.singleFileChangedTooltip"
+		],
+		"vs/sessions/browser/parts/sessionHeader": [
+			"agentSessions.newSession",
+			"renameSession.aria"
 		],
 		"vs/sessions/browser/sessionsSetUpService": [
 			"loading",
@@ -4503,23 +4751,31 @@
 			"agents"
 		],
 		"vs/sessions/common/contextkeys": [
-			"activeChatBar",
 			"activeSessionHasGitRepository",
 			"activeSessionHasGitSyncActionRunning",
 			"activeSessionProviderId",
+			"activeSessions",
 			"activeSessionType",
+			"activeSessionUsesCombinedConfigPicker",
 			"activeSessionWorkspaceIsVirtual",
-			"chatBarFocus",
-			"chatBarVisible",
 			"chatSessionProviderId",
+			"chatSessionType",
 			"editorMaximized",
 			"isActiveSessionArchived",
-			"isNewChatInSession",
+			"multipleSessionsVisible",
+			"sessionIsArchived",
+			"sessionIsCreated",
+			"sessionIsMaximized",
+			"sessionIsRead",
+			"sessionIsSticky",
 			"sessionsAquariumActive",
 			"sessionsCanGoBack",
 			"sessionsCanGoForward",
+			"sessionsFocus",
 			"sessionsIsPhoneLayout",
 			"sessionsKeyboardVisible",
+			"sessionSupportsMultipleChats",
+			"sessionsVisible",
 			"sessionsWelcomeVisible",
 			"sessionWorkspacePickerGroup"
 		],
@@ -4532,12 +4788,12 @@
 			"agents.fontSize.label1",
 			"agents.fontSize.label2",
 			"agents.fontSize.label3",
-			"agents.fontSize.label4",
-			"agents.fontWeight.medium",
 			"agents.fontWeight.regular",
 			"agents.fontWeight.semiBold"
 		],
 		"vs/sessions/common/theme": [
+			"activeSessionView.background",
+			"activeSessionView.foreground",
 			"agentFeedbackInputWidget.border",
 			"agents.background",
 			"agentsBadge.background",
@@ -4558,7 +4814,9 @@
 			"agentsUnreadBadge.background",
 			"agentsUnreadBadge.foreground",
 			"agentsUpdateButton.downloadedBackground",
-			"agentsUpdateButton.downloadingBackground"
+			"agentsUpdateButton.downloadingBackground",
+			"inactiveSessionView.background",
+			"inactiveSessionView.foreground"
 		],
 		"vs/sessions/contrib/accountMenu/browser/account.contribution": [
 			"accountAvatarAlt",
@@ -4603,6 +4861,7 @@
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution": [
 			"agentFeedback.add",
 			"agentFeedback.addAndSubmit",
+			"agentFeedback.addComment",
 			"agentFeedback.addFeedback",
 			"altEnter",
 			"enter"
@@ -4612,19 +4871,19 @@
 			"zero"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution": [
+			"acceptComment",
+			"addReplyPlaceholder",
+			"addToComment",
+			"agentReviewComment",
 			"collapse",
 			"convertComment",
 			"editComment",
 			"expand",
-			"feedbackComment",
-			"feedbackSuggestion",
 			"lineNumber",
 			"lineRange",
 			"nComments",
 			"prReviewComment",
 			"removeComment",
-			"reviewComment",
-			"reviewSuggestion",
 			"suggestedChangeLine",
 			"suggestedChangeLines"
 		],
@@ -4694,7 +4953,8 @@
 				"comment": [
 					"&& denotes a mnemonic"
 				]
-			}
+			},
+			"sessions.changes.openSingleFileDiff"
 		],
 		"vs/sessions/contrib/changes/browser/changesTitleBarWidget": [
 			"agentSecondarySidebarToggleClosedIcon",
@@ -4741,6 +5001,7 @@
 			"commitToRepoFailed",
 			"deleteFromRepoFailed",
 			"skillUI.actOnFeedback",
+			"skillUI.codeReview",
 			"skillUI.commit",
 			"skillUI.createDraftPr",
 			"skillUI.createPr",
@@ -4753,11 +5014,9 @@
 			"branchChatSessionTooltip"
 		],
 		"vs/sessions/contrib/chat/browser/chat.contribution": [
-			"chat.newEdits.label",
-			"chat.viewContainer.label",
-			"chatViewIcon",
-			"sessions.newChat.view",
-			"sessions.newChatInSession.view"
+			"chat.agentHost.runWorktreeCreatedTasks",
+			"chat.agentSessions.scopedInputHistory",
+			"chat.newEdits.label"
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
 			"mobileSessionTypePicker.title"
@@ -4768,6 +5027,9 @@
 			"mobileWorkspacePicker.noFolders",
 			"mobileWorkspacePicker.searchFolders",
 			"mobileWorkspacePicker.title"
+		],
+		"vs/sessions/contrib/chat/browser/modelPicker": [
+			"sessionsModelPicker"
 		],
 		"vs/sessions/contrib/chat/browser/newChatContextAttachments": [
 			"attachAsContext",
@@ -4785,6 +5047,7 @@
 			"chatInput.accessibilityHelpNoKb",
 			"loading",
 			"send",
+			"sendWithBackgroundHint",
 			"sessionsChatInput.placeholder.describeTheOutcome",
 			"sessionsChatInput.placeholder.describeWhatYouWantToBuild",
 			"sessionsChatInput.placeholder.describeYourMission",
@@ -4801,13 +5064,13 @@
 			"sessionsChatInput.placeholder.whatWillYouShipToday",
 			"sessionsChatInput.placeholder.whatWouldYouLikeToAutomate"
 		],
-		"vs/sessions/contrib/chat/browser/newChatInSessionViewPane": [
+		"vs/sessions/contrib/chat/browser/newChatInSessionWidget": [
 			"newChatInSessionPlaceholder",
 			"subSessionTip.ariaLabel",
 			"subSessionTip.dismiss",
 			"subSessionTip.message"
 		],
-		"vs/sessions/contrib/chat/browser/newChatViewPane": [
+		"vs/sessions/contrib/chat/browser/newChatWidget": [
 			"newSessionChooseWorkspace",
 			"newSessionIn",
 			"newSessionWith",
@@ -4900,7 +5163,10 @@
 			"sessionsChat.filesView",
 			"sessionsChat.history",
 			"sessionsChat.input",
+			"sessionsChat.inputBackground",
 			"sessionsChat.mobileConfig",
+			"sessionsChat.navigateNextSession",
+			"sessionsChat.navigatePreviousSession",
 			"sessionsChat.overview",
 			"sessionsChat.sessionsView",
 			"sessionsChat.workspace"
@@ -4910,11 +5176,12 @@
 			"sessionTypePicker.triggerAriaLabel"
 		],
 		"vs/sessions/contrib/chat/browser/sessionWorkspacePicker": [
-			"pickLocalProvider",
 			"pickWorkspace",
 			"workspacePicker.ariaLabel",
 			"workspacePicker.browseSelectAction",
 			"workspacePicker.browseSelectLocal",
+			"workspacePicker.connectingRemoteAgentHost",
+			"workspacePicker.connectRemoteAgentHostFailed",
 			"workspacePicker.experimental",
 			"workspacePicker.filter",
 			"workspacePicker.pickAriaLabel",
@@ -4924,6 +5191,7 @@
 			"slashCommand.agents",
 			"slashCommand.hooks",
 			"slashCommand.instructions",
+			"slashCommand.models",
 			"slashCommand.skills"
 		],
 		"vs/sessions/contrib/chat/browser/variableCompletions": [
@@ -4938,23 +5206,17 @@
 			"sessionsChatDebugViewIcon"
 		],
 		"vs/sessions/contrib/codeReview/browser/codeReview.contributions": [
-			"sessions.canRunCodeReview",
 			"sessions.runCodeReview",
-			"sessions.runCodeReview.noChanges",
-			"sessions.runCodeReview.noSession",
-			"sessions.runCodeReview.tooltip.default",
-			"sessions.runCodeReview.tooltip.limitReached",
-			"sessions.runCodeReview.tooltip.loading",
-			"sessions.runCodeReview.tooltip.manyUnresolved",
-			"sessions.runCodeReview.tooltip.noCommentsRunAgain",
-			"sessions.runCodeReview.tooltip.oneUnresolved",
-			"sessions.runCodeReview.tooltip.runAgain"
+			"sessions.runCodeReview.tooltip"
 		],
 		"vs/sessions/contrib/editor/browser/editor.contribution": [
+			"addFileAsContext",
 			"closeMainEditorPart",
 			"maximizeMainEditorPart",
 			"openEditorInModal",
 			"openModalEditorInEditor",
+			"pullEditorLeft",
+			"pushEditorRight",
 			"restoreMainEditorPart"
 		],
 		"vs/sessions/contrib/files/browser/files.contribution": [
@@ -4989,13 +5251,13 @@
 			"policyBlocked.openVSCode",
 			"policyBlocked.title"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker": [
+			"agentHostAgentPicker"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker": [
 			"agentHostClaudePermissionModePicker.ariaLabel",
 			"agentHostClaudePermissionModePicker.triggerAriaLabel",
 			"permissions.learnMore"
-		],
-		"vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker": [
-			"agentHostModelPicker"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
 			"agentHostModePicker.ariaLabel",
@@ -5003,6 +5265,10 @@
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
 			"copySessionBranchName"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets": [
+			"lastTurnChanges",
+			"lastTurnChangesDescription"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker": [
 			"agentHostAutoApprove.autopilot.warning.detail",
@@ -5018,6 +5284,10 @@
 			"agentHostRunningSessionModePicker",
 			"agentHostRunningSessionPermissionModePicker",
 			"agentHostSessionConfig.ariaLabel",
+			"agentHostSessionConfig.boolean.false",
+			"agentHostSessionConfig.boolean.offLabel",
+			"agentHostSessionConfig.boolean.onLabel",
+			"agentHostSessionConfig.boolean.true",
 			"agentHostSessionConfig.filter",
 			"agentHostSessionConfig.triggerAria",
 			"agentHostSessionConfig.triggerAriaReadOnly",
@@ -5058,15 +5328,18 @@
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider": [
 			"copilotCLI",
+			"new session",
 			"noAgents",
 			"notConnectedSend"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
 			"exportAgentHostDebugLogs"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution": [
+			"sessions.chat.agentHost.defaultSessionsProvider"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider": [
-			"localAgentHostLabel",
-			"localAgentHostSessionTypeLocation"
+			"localAgentHostLabel"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
 			"openSessionEventsFile"
@@ -5082,6 +5355,8 @@
 			"claude.permissionMode.acceptEdits.description",
 			"claude.permissionMode.auto",
 			"claude.permissionMode.auto.description",
+			"claude.permissionMode.bypass",
+			"claude.permissionMode.bypass.description",
 			"claude.permissionMode.default",
 			"claude.permissionMode.default.description",
 			"claude.permissionMode.plan",
@@ -5091,16 +5366,13 @@
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution": [
 			"sessions.chat.claudeAgent.enabled",
-			"sessions.chat.localAgent.enabled",
 			"sessions.github.copilot.multiChatSessions"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
 			"branchPicker",
 			"claudePermissionModePicker",
-			"cloudModelPicker",
 			"deleteSession",
 			"isolationPicker",
-			"localModelPicker",
 			"modePicker",
 			"permissionPicker"
 		],
@@ -5126,7 +5398,6 @@
 			"deleteSession.delete",
 			"deleteSession.detail",
 			"deleteSession.detailMultiple",
-			"localSession",
 			"new chat",
 			"new session",
 			"repositories",
@@ -5148,12 +5419,6 @@
 			"permissions.default.subtext",
 			"permissions.learnMore"
 		],
-		"vs/sessions/contrib/providers/copilotChatSessions/browser/modelPicker": [
-			"modelPicker.ariaLabel",
-			"modelPicker.auto",
-			"modelPicker.filter",
-			"modelPicker.triggerAriaLabel"
-		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker": [
 			"configureCustomAgents",
 			"modePicker.ariaLabel",
@@ -5166,12 +5431,25 @@
 			"permissions.autoApprove.label",
 			"permissions.autoApprove.subtext",
 			"permissions.autopilot",
+			"permissions.autopilot.description",
 			"permissions.autopilot.label",
 			"permissions.autopilot.subtext",
 			"permissions.default",
 			"permissions.default.label",
 			"permissions.default.subtext",
 			"permissions.learnMore"
+		],
+		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution": [
+			"sessions.chat.localAgent.enabled"
+		],
+		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider": [
+			"deleteChat.confirm",
+			"deleteChat.delete",
+			"deleteChat.detail",
+			"localChatSessionsProvider",
+			"localSession",
+			"newChat",
+			"newSession"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/manageRemoteAgentHosts": [
 			"manageHosts.actionsHeader",
@@ -5193,7 +5471,8 @@
 			"chat.remoteAgentHosts.enabled",
 			"chat.remoteAgentHosts.name",
 			"chat.remoteAgentTunnels",
-			"chat.sshRemoteAgentHostCommand"
+			"chat.sshRemoteAgentHostCommand",
+			"remoteAgentHost.removeConfiguredPlugin"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions": [
 			"addNewSSHHost",
@@ -5208,6 +5487,8 @@
 			"connectViaSSHShort",
 			"connectViaTunnel",
 			"connectViaTunnelShort",
+			"connectViaWSL",
+			"connectViaWSLShort",
 			"nameRemotePlaceholder",
 			"nameRemotePrompt",
 			"nameRemoteTitle",
@@ -5256,13 +5537,23 @@
 			"tunnelListFailed",
 			"tunnelNoneFound",
 			"tunnelPickPlaceholder",
-			"tunnelPickTitle"
+			"tunnelPickTitle",
+			"wslConnectFailed",
+			"wslConnecting",
+			"wslDistroDefault",
+			"wslDistroRunning",
+			"wslDistroStopped",
+			"wslInstallDocsAction",
+			"wslListFailed",
+			"wslNoDistros",
+			"wslNotInstalled",
+			"wslPickPlaceholder",
+			"wslPickTitle"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostCustomizationHarness": [
 			"remoteAgentHost.addPlugin",
 			"remoteAgentHost.addPluginTooltip",
 			"remoteAgentHost.pluginAlreadyConfigured",
-			"remoteAgentHost.removeConfiguredPlugin",
 			"remoteAgentHost.selectPluginFolder"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider": [
@@ -5273,9 +5564,6 @@
 			"notConnectedSend",
 			"notConnectedSession",
 			"selectRemoteFolder"
-		],
-		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.contribution": [
-			"agentHostTerminal.channelRemote"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteHostOptions": [
 			"agentHostIncompatibleNotification",
@@ -5296,7 +5584,6 @@
 			"workspacePicker.reconnect",
 			"workspacePicker.remoteOptionsTitle",
 			"workspacePicker.removeRemote",
-			"workspacePicker.showOutput",
 			"workspacePicker.statusConnecting",
 			"workspacePicker.statusIncompatible",
 			"workspacePicker.statusOffline",
@@ -5340,8 +5627,14 @@
 			"skills"
 		],
 		"vs/sessions/contrib/sessions/browser/mobile/mobileOverlayContribution": [
+			"mobileChangesNotAvailable",
 			"mobileOpenFileDiff",
 			"mobileOpenSessionChanges"
+		],
+		"vs/sessions/contrib/sessions/browser/sessionHoverContent": [
+			"agentSessions.fileChanged",
+			"agentSessions.filesChanged",
+			"agentSessions.newSession"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"agentSessions.view.label",
@@ -5354,6 +5647,19 @@
 			}
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsActions": [
+			"chatCompositeBar.addChat",
+			"chatCompositeBar.close",
+			"chatCompositeBar.maximize",
+			"chatCompositeBar.pin",
+			"chatCompositeBar.pinView",
+			"chatCompositeBar.unmaximize",
+			"chatCompositeBar.unpin",
+			"chatCompositeBar.unpinView",
+			"closeAllSessions",
+			"closeEditorArea",
+			"focusActiveSession",
+			"focusLastSessionInGrid",
+			"focusSessionInGrid",
 			{
 				"key": "miSessionsBack",
 				"comment": [
@@ -5367,17 +5673,21 @@
 				]
 			},
 			"newSession",
-			"recentSessions",
+			"otherSessions",
+			"recentlyOpened",
+			"renameSessionHeader",
 			"searchSessions",
 			"sessionsGoBack",
+			"sessionsGoBackTooltip",
 			"sessionsGoForward",
+			"sessionsGoForwardTooltip",
 			"showSessionsPicker",
 			"untitledSession"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget": [
-			"agentSessions.newSession",
 			"agentSessionsControl",
 			"agentSessionsShowSessions",
+			"newSession",
 			"showSessions"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
@@ -5391,6 +5701,7 @@
 			"pinned",
 			"secondsDuration",
 			"sessionItemAria",
+			"sessions.dragLabel",
 			"sessionsList",
 			"showLessAria",
 			"showLessCompact",
@@ -5398,6 +5709,8 @@
 			"showLessWorkspacesCompact",
 			"showMoreAria",
 			"showMoreCompact",
+			"showMoreWorkspaceAria",
+			"showMoreWorkspaceCompact",
 			"showMoreWorkspacesAria",
 			"showMoreWorkspacesCompact",
 			"today",
@@ -5428,7 +5741,6 @@
 			"statusNeedsInput"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
-			"addChat",
 			"archivePinnedSectionSessions.confirm",
 			"archivePinnedSectionSessions.confirmSingle",
 			"archiveSection",
@@ -5450,8 +5762,12 @@
 			"markAsDone",
 			"markRead",
 			"markUnread",
+			"navigateNextSession",
+			"navigateNextSession.mnemonic",
+			"navigatePreviousSession",
+			"navigatePreviousSession.mnemonic",
 			"newSessionForWorkspace",
-			"openInNewWindow",
+			"openToTheSide",
 			"pinSession",
 			"refresh",
 			"renameSession",
@@ -5467,6 +5783,9 @@
 			"unarchiveSectionSessions.unarchive",
 			"unarchiveSession",
 			"unpinSession"
+		],
+		"vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner": [
+			"agentHostSessionTaskTerminalName"
 		],
 		"vs/sessions/contrib/terminal/browser/sessionsTerminalContribution": [
 			"dumpTerminalTracking",
@@ -5543,6 +5862,9 @@
 			"learnMore",
 			"loginWith",
 			"no",
+			"xaaResourceSecretPlaceholder",
+			"xaaResourceSecretPrompt",
+			"xaaResourceSecretTitle",
 			"yes"
 		],
 		"vs/workbench/api/browser/mainThreadChatSessions": [
@@ -5642,6 +5964,11 @@
 			"incorrectAccountDetail",
 			"keep",
 			"loginWith",
+			"mcp.enterpriseManaged.issuerInvalid",
+			"mcp.enterpriseManaged.issuerMissing",
+			"mcp.enterpriseManaged.issuerNotHttp",
+			"mcp.enterpriseManaged.missingAS",
+			"mcp.enterpriseManaged.missingResource",
 			"mcpAuthSessionRemoved"
 		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
@@ -6551,6 +6878,7 @@
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
 			"breadcrumbsActive",
+			"breadcrumbsHasSymbols",
 			"breadcrumbsPossible",
 			"breadcrumbsVisible",
 			"cmd.copyPath",
@@ -7640,6 +7968,11 @@
 			"command-error",
 			"no-dataprovider",
 			"refresh",
+			"treeActionBarAriaLabel",
+			"treeActionBarAriaLabelNoName",
+			"treeAriaLabelHasActions",
+			"treeAriaLabelHasActionsSuffix",
+			"treeAriaLabelHasActionsTooltip",
 			"treeView.enableCollapseAll",
 			"treeView.enableRefresh",
 			"treeView.toggleCollapseAll"
@@ -8155,6 +8488,7 @@
 			"auxiliaryBarVisible",
 			"bannerFocused",
 			"dirtyWorkingCopies",
+			"editorAreaFocus",
 			"editorIsOpen",
 			"editorPartEditorGroupMaximized",
 			"editorPartModal",
@@ -8628,6 +8962,110 @@
 		"vs/workbench/contrib/accessibilitySignals/browser/openDiffEditorAnnouncement": [
 			"openDiffEditorAnnouncement"
 		],
+		"vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution": [
+			"agents.voice.alwaysOnTop",
+			"agents.voice.backendUrl",
+			"agents.voice.enabled",
+			"agents.voice.textToSpeech",
+			"agentsVoiceConfigurationTitle",
+			"agentsVoicePushToTalk",
+			"resetAgentsVoiceOnboarding",
+			"toggleAgentsVoiceWindow"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget": [
+			"agentsVoice.feedbackError"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidgetBinding": [
+			"agentsVoice.chat",
+			"agentsVoice.otherSessions",
+			"agentsVoice.untitledSession"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/confirmationComponent": [
+			"agentsVoice.approve",
+			"agentsVoice.deny",
+			"agentsVoice.openInVSCode"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/feedbackDialog": [
+			"agentsVoice.cancel",
+			"agentsVoice.feedbackConsent",
+			"agentsVoice.feedbackError",
+			"agentsVoice.feedbackPlaceholder",
+			"agentsVoice.feedbackThanks",
+			"agentsVoice.sendFeedback",
+			"agentsVoice.submit",
+			"agentsVoice.submitting"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/headerComponent": [
+			"agentsVoice.configureKeybinding",
+			"agentsVoice.disconnect",
+			"agentsVoice.minimize",
+			"agentsVoice.openMiniView",
+			"agentsVoice.pushToTalkSpace",
+			"agentsVoice.sendFeedback"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/onboardingComponent": [
+			"agentsVoice.changeHotkeySuffix",
+			"agentsVoice.changePttKey",
+			"agentsVoice.configureHotkey",
+			"agentsVoice.connecting",
+			"agentsVoice.feedbackDesc",
+			"agentsVoice.getStarted",
+			"agentsVoice.miniViewSuffix",
+			"agentsVoice.openMiniView",
+			"agentsVoice.pttDesc",
+			"agentsVoice.pttHoldDesc",
+			"agentsVoice.welcomeDesc",
+			"agentsVoice.welcomeTitle"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/sessionListComponent": [
+			"agentsVoice.approve",
+			"agentsVoice.deny",
+			"agentsVoice.newSession",
+			"agentsVoice.noActiveSessions",
+			"agentsVoice.openInVSCode",
+			"agentsVoice.openSessionAction",
+			"agentsVoice.sendTo",
+			"agentsVoice.sendToActive",
+			"agentsVoice.stop",
+			"agentsVoice.stopSessionAction"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/statusRowsComponent": [
+			"agentsVoice.done",
+			"agentsVoice.needsInput",
+			"agentsVoice.noActiveSessions",
+			"agentsVoice.working"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscripts.contribution": [
+			"agentsVoice.showTranscripts",
+			"agentsVoice.showTranscripts.menu",
+			"agentsVoiceCategory",
+			"voiceTranscripts.archiveAll",
+			"voiceTranscripts.deleteAll",
+			"voiceTranscripts.deleteAllConfirm",
+			"voiceTranscripts.deleteAllConfirmButton",
+			"voiceTranscripts.deleteAllDetail",
+			"voiceTranscripts.focus",
+			"voiceTranscripts.refresh",
+			"voiceTranscriptsContainer",
+			"voiceTranscriptsView",
+			"voiceTranscriptsViewIcon"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscriptsView": [
+			"voiceTranscripts.archivedNote",
+			"voiceTranscripts.earlierMonth",
+			"voiceTranscripts.earlierWeek",
+			"voiceTranscripts.empty",
+			"voiceTranscripts.older",
+			"voiceTranscripts.today",
+			"voiceTranscripts.yesterday"
+		],
+		"vs/workbench/contrib/agentsVoice/common/agentsVoiceColors": [
+			"agentsVoice.speakingBackground",
+			"agentsVoice.speakingForeground"
+		],
+		"vs/workbench/contrib/agentsVoice/common/voiceTranscriptStore": [
+			"join.voiceTranscriptStore"
+		],
 		"vs/workbench/contrib/authentication/browser/actions/manageAccountPreferencesForExtensionAction": [
 			"accounts",
 			"currentAccount",
@@ -8735,6 +9173,12 @@
 		"vs/workbench/contrib/browserView/common/browserEditorInput": [
 			"browser.editorLabel"
 		],
+		"vs/workbench/contrib/browserView/common/browserSearch": [
+			"browser.search.engine.bing",
+			"browser.search.engine.duckduckgo",
+			"browser.search.engine.google",
+			"browser.search.engine.yahoo"
+		],
 		"vs/workbench/contrib/browserView/common/browserView": [
 			"browserView.shareBlocked.title",
 			"browserView.shareWithAgent.allow",
@@ -8745,44 +9189,13 @@
 			"browserView.shareWithAgent.title"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/browserEditor": [
-			"browser.canGoBack",
-			"browser.canGoForward",
-			"browser.certCloseTab",
-			"browser.certDetailsHeading",
-			"browser.certError",
-			"browser.certErrorDescription",
-			"browser.certErrorExtraWarning",
-			"browser.certErrorLabel",
-			"browser.certFingerprint",
-			"browser.certGoBack",
-			"browser.certIssuer",
-			"browser.certProceed",
-			"browser.certSubject",
-			"browser.certValid",
 			"browser.editorFocused",
-			"browser.errorUrlLabel",
 			"browser.hasError",
 			"browser.hasUrl",
-			"browser.loadErrorLabel",
-			"browser.overlayPauseDetail.notification",
-			"browser.overlayPauseHeading.notification",
-			"browser.urlPlaceholder",
-			"browser.welcomeSubtitle",
-			"browser.welcomeSubtitleChat",
-			"browser.welcomeTitle"
+			"browserCategory"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/browserView.contribution": [
 			"browser.editorLabel"
-		],
-		"vs/workbench/contrib/browserView/electron-browser/browserViewActions": [
-			"browser.focusUrlInputAction",
-			"browser.goBackAction",
-			"browser.goForwardAction",
-			"browser.hardReloadAction",
-			"browser.openExternalAction",
-			"browser.openSettingsAction",
-			"browser.reloadAction",
-			"browserCategory"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserDataStorageFeatures": [
 			"browser.clearEphemeralStorageAction",
@@ -8793,6 +9206,12 @@
 					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
 				],
 				"key": "browser.dataStorage"
+			},
+			{
+				"comment": [
+					"This is the description for a setting. Values surrounded by single quotes are not to be translated."
+				],
+				"key": "browser.dataStorage.default"
 			},
 			{
 				"comment": [
@@ -8819,20 +9238,85 @@
 			"browser.toggleDevToolsAction"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures": [
+			"browser.addAreaScreenshotToChatAction",
 			"browser.addConsoleLogsToChatAction",
 			"browser.addElementToChatAction",
+			"browser.addFullPageScreenshotToChatAction",
+			"browser.addScreenshotToChatAction",
 			"browser.agentSharingContentWarning.detail",
 			"browser.agentSharingContentWarning.dontShowAgain",
 			"browser.agentSharingContentWarning.message",
 			"browser.agentSharingContentWarning.ok",
+			"browser.areaSelectionActive",
+			"browser.chatActionsSubmenu",
 			"browser.elementSelectionActive",
 			"browser.enableChatTools",
+			{
+				"comment": [
+					"This is the description for a setting."
+				],
+				"key": "browser.experimentalUserTools.enabled"
+			},
 			"browser.shareWithAgent",
 			"browser.sharingWithAgent",
 			"browser.unshareWithAgent",
+			"browserAreaScreenshot",
 			"browserCategory",
+			"browserFullPageScreenshot",
+			"browserScreenshot",
 			"consoleLogs",
 			"workbench.browser.agentHostChatToolsEnabled"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorEmulationFeatures": [
+			"browser.device.dimensionsLabel",
+			"browser.device.dprAriaLabel",
+			"browser.device.dprLabel",
+			"browser.device.dprTitle",
+			"browser.device.heightAriaLabel",
+			"browser.device.inputPlaceholderAuto",
+			"browser.device.scaleLabel",
+			"browser.device.swapDimensionsTitle",
+			"browser.device.widthAriaLabel",
+			"browser.device.zoomAriaLabel",
+			"browser.device.zoomAuto",
+			"browser.devicePresets.mobileTag",
+			"browser.devicePresets.placeholder",
+			"browser.emulationHasUserAgent",
+			"browser.emulationIsMobile",
+			"browser.emulationToolbar.close",
+			"browser.emulationToolbar.mobile",
+			"browser.emulationToolbar.presets",
+			"browser.emulationToolbar.reset",
+			"browser.emulationToolbar.userAgent",
+			"browser.emulationToolbarVisible",
+			"browser.pickDevicePreset",
+			"browser.resetEmulation",
+			"browser.setUserAgent",
+			"browser.toggleDeviceEmulation",
+			"browser.toggleMobileEmulation",
+			"browser.userAgent.prompt"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorErrorFeatures": [
+			"browser.certCloseTab",
+			"browser.certDetailsHeading",
+			"browser.certError",
+			"browser.certErrorDescription",
+			"browser.certErrorExtraWarning",
+			"browser.certErrorLabel",
+			"browser.certFingerprint",
+			"browser.certGoBack",
+			"browser.certHoverDetail1",
+			"browser.certHoverDetail2",
+			"browser.certHoverHeading",
+			"browser.certIssuer",
+			"browser.certProceed",
+			"browser.certRevoke",
+			"browser.certSubject",
+			"browser.certValid",
+			"browser.errorUrlLabel",
+			"browser.loadErrorLabel",
+			"browser.notSecure",
+			"browser.remoteErrorExtraWarning"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorFindFeature": [
 			"browser.findNextAction",
@@ -8861,6 +9345,57 @@
 			"browser.zoomInAction",
 			"browser.zoomOutAction"
 		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserFavoritesFeature": [
+			"browser.addFavorite",
+			"browser.addFavoriteAction",
+			"browser.favorites",
+			"browser.removeFavorite",
+			"browser.removeFavoriteWithKb",
+			"browser.urlIsFavorited"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserHistoryFeature": [
+			"browser.history",
+			"browser.history.clearAll",
+			"browser.history.clearDay",
+			"browser.history.placeholder",
+			"browser.history.title",
+			"browser.history.today",
+			"browser.history.yesterday",
+			"browser.maxHistoryEntries",
+			"browser.recents",
+			"browser.removeFromHistory",
+			"browser.showHistory"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserNavigationFeatures": [
+			"browser.canGoBack",
+			"browser.canGoForward",
+			"browser.configureSearchEngine",
+			"browser.focusUrlInputAction",
+			"browser.goBackAction",
+			"browser.goForwardAction",
+			"browser.hardReloadAction",
+			"browser.openExternalAction",
+			"browser.openSettingsAction",
+			"browser.reloadAction",
+			"browser.searchFor",
+			{
+				"key": "browser.urlOrSearchPlaceholder",
+				"comment": [
+					"Placeholder text shown in the integrated browser's address (URL) bar when it is empty. The user can either type a search query to search the web, or type a URL to navigate to it."
+				]
+			},
+			"browser.urlPlaceholder"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserRemoteFeatures": [
+			"browser.connectedLocally.file",
+			"browser.connectedLocally.generic",
+			"browser.connectedRemotely",
+			"browser.enableRemoteProxy"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserSearchFeatures": [
+			"browser.search.engine.none",
+			"browser.searchEngine"
+		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures": [
 			"browser.backgroundGroup",
 			"browser.closeAll",
@@ -8885,6 +9420,8 @@
 			},
 			"browser.openNewTab",
 			"browser.openOrListAction",
+			"browser.openTabs",
+			"browser.openTabsDescription",
 			"browser.quickOpenAction",
 			"browser.quickOpenPlaceholder",
 			{
@@ -8921,12 +9458,14 @@
 			"toggle.browser",
 			"toggle.browserDescription"
 		],
-		"vs/workbench/contrib/browserView/electron-browser/siteInfoWidget": [
-			"browser.certHoverDetail1",
-			"browser.certHoverDetail2",
-			"browser.certHoverHeading",
-			"browser.certRevoke",
-			"browser.notSecure"
+		"vs/workbench/contrib/browserView/electron-browser/features/browserWelcomeFeature": [
+			"browser.welcomeSubtitle",
+			"browser.welcomeSubtitleChat",
+			"browser.welcomeTitle"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/webContentsViewRendererFeature": [
+			"browser.overlayPauseDetail.notification",
+			"browser.overlayPauseHeading.notification"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers": [
 			"browser.blockedByPolicy",
@@ -9050,8 +9589,16 @@
 			"browser.type.invocation.element",
 			"browser.type.past",
 			"browser.type.past.element",
+			"browser.typeAndSubmit.invocation",
+			"browser.typeAndSubmit.invocation.element",
+			"browser.typeAndSubmit.past",
+			"browser.typeAndSubmit.past.element",
 			"typeBrowserTool.displayName",
 			"typeBrowserTool.userDescription"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/widgets/browserUrlBarWidget": [
+			"browser.goTo",
+			"browser.urlPlaceholder"
 		],
 		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
 			"areYouSureQuiteBulkEdit.detail",
@@ -9248,6 +9795,7 @@
 			"workbench.action.chat.newChat",
 			"workbench.action.chat.nextCodeBlock",
 			"workbench.action.chat.nextUserPrompt",
+			"workbench.action.chat.openAgentHostFolderPicker",
 			"workbench.action.chat.previousUserPrompt",
 			"workbench.action.chat.restoreLastCheckpoint",
 			"workbench.action.chat.undoEdits",
@@ -9376,6 +9924,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatDeveloperActions": [
 			"workbench.action.chat.clearRecentlyUsedLanguageModels.label",
+			"workbench.action.chat.inspectAgentHostSubscriptions.label",
 			"workbench.action.chat.inspectChatModel.label",
 			"workbench.action.chat.inspectChatModelReferences.label",
 			"workbench.action.chat.logChatIndex.label",
@@ -9486,12 +10035,14 @@
 		"vs/workbench/contrib/chat/browser/actions/chatPluginActions": [
 			"installPluginFromSource",
 			"localMarketplace",
+			"managedMarketplace",
 			"managePluginMarketplaces",
 			"noMarketplaces",
 			"openMarketplaceDirectory",
 			"plugins",
 			"pluginSourcePlaceholder",
 			"pluginSourcePrompt",
+			"removeManagedMarketplace",
 			"removeMarketplace",
 			"selectMarketplace",
 			"selectMarketplaceAction",
@@ -9621,6 +10172,7 @@
 			"install",
 			"openPluginFolder",
 			"openReadme",
+			"pluginPolicyBlocked",
 			"uninstall"
 		],
 		"vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor": [
@@ -9658,6 +10210,10 @@
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
 			"agentHostChatInputPicker.ariaLabel",
+			"agentHostChatInputPicker.boolean.false",
+			"agentHostChatInputPicker.boolean.offLabel",
+			"agentHostChatInputPicker.boolean.onLabel",
+			"agentHostChatInputPicker.boolean.true",
 			"agentHostChatInputPicker.filter",
 			"agentHostChatInputPicker.learnMorePermissions",
 			"agentHostChatInputPicker.triggerAria",
@@ -9666,13 +10222,12 @@
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution": [
 			"agentHost.autoApprovePicker",
-			"agentHost.branchPicker",
-			"agentHost.isolationPicker",
+			"agentHost.folderPicker",
 			"agentHost.modePicker",
 			"agentHost.permissionModePicker"
 		],
-		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostEditingSession": [
-			"multiDiffEditorInput.name"
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem": [
+			"agentHost.selectFolder"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution": [
 			"agentHost.permission.allow",
@@ -9689,13 +10244,12 @@
 			"agentHost.elicit.url.instruction",
 			"agentHost.elicit.url.open",
 			"agentHost.elicit.url.title",
+			"agentHost.forkedSessionLabel",
 			"agentHost.responseDetails.credit",
 			"agentHost.responseDetails.credits",
-			"chat.forked.fallbackTitle",
-			"chat.forked.title"
+			"agentHost.turnError"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
-			"agentHostTerminal.channelLocal",
 			"agentHostTerminal.local"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter": [
@@ -9720,6 +10274,7 @@
 			"chat.session.providerDescription.codex",
 			"chat.session.providerDescription.growth",
 			"chat.session.providerDescription.local",
+			"chat.session.providerLabel.agentHostCopilot",
 			"chat.session.providerLabel.background",
 			"chat.session.providerLabel.cloud",
 			"chat.session.providerLabel.local"
@@ -9763,6 +10318,7 @@
 			"deleteSession.confirm",
 			"deleteSession.delete",
 			"deleteSession.detail",
+			"deleteSession.error",
 			"deleteSessions.confirm",
 			"doNotAskAgain",
 			"find",
@@ -9926,6 +10482,13 @@
 			"showAgentSessionsQuickAccess",
 			"showCommandsQuickAccess",
 			"showFilesQuickAccess"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability": [
+			"chat.sessionType.noModels",
+			"chat.sessionType.noModelsHover",
+			"chat.sessionType.upgradeHover",
+			"chat.sessionType.upgradeLink",
+			"chat.sessionType.upgradeMobile"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons": [
 			"aiCustomizationAddIcon",
@@ -10092,7 +10655,6 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor": [
 			"agents",
 			"agentsDesc",
-			"aiCustomizationManagementSashBorder",
 			"backToList",
 			"backToListTooltip",
 			"backToMcpList",
@@ -10111,18 +10673,19 @@
 			"editorViewRawButtonLabel",
 			"editorViewRawButtonTooltip",
 			"homeButton",
+			"homeButtonLabel",
 			"homeButtonTooltip",
 			"hooks",
 			"hooksDesc",
 			"instructions",
 			"instructionsDesc",
 			"learnMoreModels",
+			"localHarnessLabel",
 			"mcpServers",
 			"mcpServersDesc",
 			"models",
 			"modelsDesc",
 			"modelsDescription",
-			"overview",
 			"plugins",
 			"pluginsDesc",
 			"previewFieldHelpAriaLabel",
@@ -10150,7 +10713,8 @@
 			"workspaceSaveTarget"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput": [
-			"aiCustomizationManagementEditorName"
+			"aiCustomizationManagementEditorName",
+			"aiCustomizationManagementEditorNameWithHarness"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers": [
 			"agents",
@@ -10172,7 +10736,7 @@
 			"sentToChat",
 			"skills",
 			"skillsDesc",
-			"welcomeHeading",
+			"welcomeHeadingWithHarness",
 			"welcomeSubtitle",
 			"workflowInputAriaLabel",
 			"workflowInputPlaceholder",
@@ -10201,6 +10765,7 @@
 			"addMcpServer",
 			"addServer",
 			"addServerTooltip",
+			"backToInstalled",
 			"browseMarketplace",
 			"builtInGroup",
 			"builtInGroupDescription",
@@ -10224,6 +10789,7 @@
 			"mcpAccessDisabledBySettingPrefix",
 			"mcpAccessDisabledSettingLink",
 			"mcpAccessDisabledTitle",
+			"mcpBrowseBack",
 			"mcpGroupAriaLabel",
 			"mcpServers",
 			"mcpServersDescription",
@@ -10314,6 +10880,10 @@
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets": [
 			"chat.attachment",
 			"chat.attachment.clearButton",
+			"chat.attachment.saveFileButton",
+			"chat.attachment.saveFileError",
+			"chat.attachment.saveImageButton",
+			"chat.attachment.saveImageError",
 			"chat.attachment.withDeleteHint",
 			"chat.browserToolsDisabled",
 			"chat.browserToolsDisabled.aria",
@@ -10408,18 +10978,14 @@
 			"chat.agent.thinkingMode.fixedScrolling",
 			"chat.agent.thinkingStyle",
 			"chat.agentHost.ahpJsonlLogging",
-			"chat.agentHost.claudeAgent.path",
 			"chat.agentHost.clientTools",
 			"chat.agentHost.customTerminalTool.enabled",
-			"chat.agentHost.enabled",
-			"chat.agentHost.ipcLogging",
-			"chat.agentHost.otel.captureContent",
-			"chat.agentHost.otel.dbSpanExporter.enabled",
-			"chat.agentHost.otel.enabled",
-			"chat.agentHost.otel.exporterType",
-			"chat.agentHost.otel.otlpEndpoint",
-			"chat.agentHost.otel.outfile",
+			"chat.agentHost.sdkSandbox.enabled",
+			"chat.agentHost.sdkSandbox.enabled.allowNetwork",
+			"chat.agentHost.sdkSandbox.enabled.off",
+			"chat.agentHost.sdkSandbox.enabled.on",
 			"chat.agentLocations.invalidPath",
+			"chat.agents.claude.preferAgentHost",
 			"chat.agents.config.locations.description",
 			"chat.agents.config.locations.title",
 			"chat.agentsControl.badge",
@@ -10427,6 +10993,10 @@
 			"chat.agentsControl.enabled",
 			"chat.agentsControl.hidden",
 			"chat.agentSessionProjection.enabled",
+			"chat.agentsHandoffTip.mode",
+			"chat.agentsHandoffTip.mode.custom",
+			"chat.agentsHandoffTip.mode.default",
+			"chat.agentsHandoffTip.mode.hidden",
 			"chat.agentSkillsLocations.description",
 			"chat.agentSkillsLocations.invalidPath",
 			"chat.agentSkillsLocations.title",
@@ -10443,7 +11013,7 @@
 			"chat.artifacts.rules.byMimeType",
 			"chat.artifacts.rules.groupName",
 			"chat.artifacts.rules.onlyShowGroup",
-			"chat.autopilot.enabled",
+			"chat.autopilot.advanced.enabled",
 			"chat.autoReply.description",
 			"chat.checkpoints.enabled",
 			"chat.checkpoints.showFileChanges",
@@ -10451,15 +11021,16 @@
 			"chat.contextUsage.enabled",
 			"chat.customizations.harnessSelector.enabled",
 			"chat.customizations.structuredPreview.enabled",
-			"chat.customizations.useChatSessionCustomizationsForCustomAgents",
 			"chat.detectParticipant.enabled",
 			"chat.disableAIFeatures",
 			"chat.editing.autoAcceptDelay",
 			"chat.editing.confirmEditRequestRemoval",
 			"chat.editing.confirmEditRequestRetry",
 			"chat.editing.explainChanges.enabled",
+			"chat.editing.openChangedFileInDiffEditor",
 			"chat.editing.revealNextChangeOnResolve",
 			"chat.editMode.hidden",
+			"chat.editor.claude.preferAgentHost",
 			"chat.editorAssociations",
 			"chat.editRequests",
 			"chat.exitAfterDelegation",
@@ -10536,7 +11107,6 @@
 			"chat.notifyWindowOnResponseReceived.always",
 			"chat.notifyWindowOnResponseReceived.off",
 			"chat.notifyWindowOnResponseReceived.windowNotFocused",
-			"chat.offlineByok",
 			"chat.permissions.default.autoApprove.description",
 			"chat.permissions.default.autoApprove.label",
 			"chat.permissions.default.autopilot.description",
@@ -10549,7 +11119,13 @@
 			"chat.planReview.inlineEditor.enabled",
 			"chat.pluginLocations",
 			"chat.plugins.enabled",
+			"chat.plugins.enabledPlugins",
+			"chat.plugins.enabledPlugins.policy",
+			"chat.plugins.extraMarketplaces",
+			"chat.plugins.extraMarketplaces.policy",
 			"chat.plugins.marketplaces",
+			"chat.plugins.strictMarketplaces",
+			"chat.plugins.strictMarketplaces.policy",
 			"chat.progressBorder.enabled",
 			"chat.promptFileLocations.invalidPath",
 			"chat.promptFilesRecommendations.description",
@@ -10567,6 +11143,7 @@
 			"chat.subagents.allowInvocationsFromSubagents",
 			"chat.subagents.allowInvocationsFromSubagents.md",
 			"chat.tips.enabled",
+			"chat.titleBar.openInAgentsWindow.enabled",
 			"chat.titleBar.signIn.enabled",
 			"chat.toolReferenceName.description",
 			"chat.tools.autoApprove.edits",
@@ -10618,6 +11195,11 @@
 			"interactiveSession.editor.wordWrap",
 			"interactiveSessionConfigurationTitle",
 			"mcp.discovery.enabled",
+			"mcp.enterpriseManagedAuth.idp",
+			"mcp.enterpriseManagedAuth.idp.clientId",
+			"mcp.enterpriseManagedAuth.idp.clientSecret",
+			"mcp.enterpriseManagedAuth.idp.issuer",
+			"mcp.enterpriseManagedAuth.idp.policy",
 			"mcp.gallery.serviceUrl",
 			"mcp.list"
 		],
@@ -10656,62 +11238,67 @@
 			"chatDebug.unknown"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView": [
+			"chatDebug.cache.agentItem",
 			"chatDebug.cache.allComponentsIdentical",
 			"chatDebug.cache.badge.contentDrift",
 			"chatDebug.cache.badge.identical",
 			"chatDebug.cache.badge.lengthChange",
 			"chatDebug.cache.badge.onlyA",
 			"chatDebug.cache.badge.onlyB",
-			"chatDebug.cache.breakAt",
 			"chatDebug.cache.breakLineTooltip",
 			"chatDebug.cache.cachedTok",
 			"chatDebug.cache.cacheHit",
+			"chatDebug.cache.changeNote",
 			"chatDebug.cache.charsTotal",
+			"chatDebug.cache.chunkBreakdown",
+			"chatDebug.cache.chunkCol",
+			"chatDebug.cache.chunkIdxCol",
 			"chatDebug.cache.componentsHeading",
 			"chatDebug.cache.componentSizes",
 			"chatDebug.cache.continuationComponentsNote",
-			"chatDebug.cache.continuationDeltaAlsoChanged",
-			"chatDebug.cache.continuationDeltaBreak",
-			"chatDebug.cache.continuationNoDeltaBreak",
+			"chatDebug.cache.currCol",
 			"chatDebug.cache.diffSideA",
 			"chatDebug.cache.diffSideB",
 			"chatDebug.cache.diffSummary",
 			"chatDebug.cache.driftLegend",
 			"chatDebug.cache.duration",
+			"chatDebug.cache.effortNotSent",
 			"chatDebug.cache.endTime",
-			"chatDebug.cache.expirationHeadline",
-			"chatDebug.cache.expirationNote",
-			"chatDebug.cache.firstMessage",
+			"chatDebug.cache.filterAgentsLabel",
+			"chatDebug.cache.filterAll",
+			"chatDebug.cache.filterSome",
+			"chatDebug.cache.findingJump",
+			"chatDebug.cache.findings",
 			"chatDebug.cache.firstRequest",
 			"chatDebug.cache.firstRequestNote",
+			"chatDebug.cache.groupLegend",
 			"chatDebug.cache.hitChip",
 			"chatDebug.cache.hitHeadline",
+			"chatDebug.cache.hitHeadlineVerdict",
+			"chatDebug.cache.identicalNote",
 			"chatDebug.cache.inputTok",
-			"chatDebug.cache.kind.added",
-			"chatDebug.cache.kind.addedNoSize",
-			"chatDebug.cache.kind.contentDrift",
-			"chatDebug.cache.kind.contentDriftNoSize",
-			"chatDebug.cache.kind.dropped",
-			"chatDebug.cache.kind.lengthChange",
-			"chatDebug.cache.kind.lengthChangeNoSize",
 			"chatDebug.cache.laneCurrent",
 			"chatDebug.cache.lanePrevious",
 			"chatDebug.cache.legend.tools",
 			"chatDebug.cache.legend.toolSearch",
-			"chatDebug.cache.lossLine",
 			"chatDebug.cache.model",
 			"chatDebug.cache.modelTurn",
 			"chatDebug.cache.msChip",
-			"chatDebug.cache.noBreak",
+			"chatDebug.cache.noFindings",
 			"chatDebug.cache.notPresent",
 			"chatDebug.cache.noTurns",
+			"chatDebug.cache.noTurnsForAgents",
 			"chatDebug.cache.optionsBanner",
-			"chatDebug.cache.optionsBroke",
 			"chatDebug.cache.optionsCurr",
 			"chatDebug.cache.optionsKey",
 			"chatDebug.cache.optionsPrev",
+			"chatDebug.cache.pctCol",
+			"chatDebug.cache.pctValue",
 			"chatDebug.cache.performance",
+			"chatDebug.cache.prevCol",
 			"chatDebug.cache.previousRequest",
+			"chatDebug.cache.railGap",
+			"chatDebug.cache.recomputedTooltip",
 			"chatDebug.cache.requestId",
 			"chatDebug.cache.requestIdTooltip",
 			"chatDebug.cache.requestOptionsHeading",
@@ -10727,6 +11314,21 @@
 			"chatDebug.cache.requestShape.toolSearchRequest",
 			"chatDebug.cache.requestShape.toolSearchRequestDescription",
 			"chatDebug.cache.requestTitle",
+			"chatDebug.cache.reusedTooltip",
+			"chatDebug.cache.reuseLane",
+			"chatDebug.cache.reusePct",
+			"chatDebug.cache.segDriftTooltip",
+			"chatDebug.cache.segGroupTooltip",
+			"chatDebug.cache.segSizeChars",
+			"chatDebug.cache.segSizeTokens",
+			"chatDebug.cache.segTooltip",
+			"chatDebug.cache.selectAllAgents",
+			"chatDebug.cache.sessionHealth",
+			"chatDebug.cache.sessionHealthChip",
+			"chatDebug.cache.sessionHealthStats",
+			"chatDebug.cache.sessionHealthStatsLost",
+			"chatDebug.cache.sessionOverallHit",
+			"chatDebug.cache.sessionOverallSub",
 			"chatDebug.cache.signatureHeading",
 			"chatDebug.cache.signatureSummaryBreakComponent",
 			"chatDebug.cache.signatureSummaryClean",
@@ -10735,12 +11337,13 @@
 			"chatDebug.cache.summaryChanged",
 			"chatDebug.cache.summaryDropped",
 			"chatDebug.cache.summaryIdentical",
-			"chatDebug.cache.systemBroke",
 			"chatDebug.cache.systemComponent",
 			"chatDebug.cache.toggleGroup",
+			"chatDebug.cache.tokCol",
 			"chatDebug.cache.tokensReused",
-			"chatDebug.cache.toolsBroke",
+			"chatDebug.cache.tokensReusedLost",
 			"chatDebug.cache.toolsComponent",
+			"chatDebug.cache.totalRow",
 			"chatDebug.cache.truncatedBoth",
 			"chatDebug.cache.truncatedOne",
 			"chatDebug.cache.truncatedSideCurr",
@@ -10748,17 +11351,89 @@
 			"chatDebug.cache.ttft",
 			"chatDebug.cache.turnAria",
 			"chatDebug.cache.turnHelp",
-			"chatDebug.cache.uncachedLine",
 			"chatDebug.cache.unknownPrompt",
+			"chatDebug.cache.unnamedAgent",
 			"chatDebug.cache.visibleSignatureHeading",
 			"chatDebug.cache.visibleSignatureNote",
 			"chatDebug.cache.visibleSignatureSummaryBreak",
 			"chatDebug.cache.visibleSignatureSummaryClean",
-			"chatDebug.cache.visibleWireInput",
-			"chatDebug.cache.whereBroke",
 			"chatDebug.cacheExplorer",
 			"chatDebug.cacheExplorer.title",
 			"chatDebug.title"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheInsights": [
+			"chatDebug.cache.category.expiration",
+			"chatDebug.cache.category.healthy",
+			"chatDebug.cache.category.history",
+			"chatDebug.cache.category.model",
+			"chatDebug.cache.category.options",
+			"chatDebug.cache.category.system",
+			"chatDebug.cache.category.tools",
+			"chatDebug.cache.category.unknown",
+			"chatDebug.cache.div.appended",
+			"chatDebug.cache.div.innerEdit",
+			"chatDebug.cache.div.leadingRemoved",
+			"chatDebug.cache.div.prepended",
+			"chatDebug.cache.div.truncated",
+			"chatDebug.cache.insight.afterBreak.detail",
+			"chatDebug.cache.insight.afterBreak.title",
+			"chatDebug.cache.insight.append.detail",
+			"chatDebug.cache.insight.append.title",
+			"chatDebug.cache.insight.continuation.detail",
+			"chatDebug.cache.insight.continuation.title",
+			"chatDebug.cache.insight.drift.hint",
+			"chatDebug.cache.insight.drift.sizes",
+			"chatDebug.cache.insight.drift.title",
+			"chatDebug.cache.insight.drift.volatileHint",
+			"chatDebug.cache.insight.expired.detail",
+			"chatDebug.cache.insight.expired.gap",
+			"chatDebug.cache.insight.expired.hint",
+			"chatDebug.cache.insight.expired.title",
+			"chatDebug.cache.insight.lookback.detail",
+			"chatDebug.cache.insight.lookback.hint",
+			"chatDebug.cache.insight.lookback.title",
+			"chatDebug.cache.insight.model.detail",
+			"chatDebug.cache.insight.model.hint",
+			"chatDebug.cache.insight.model.title",
+			"chatDebug.cache.insight.options.hint",
+			"chatDebug.cache.insight.options.title",
+			"chatDebug.cache.insight.prevContinuation.detail",
+			"chatDebug.cache.insight.prevContinuation.title",
+			"chatDebug.cache.insight.stable.detail",
+			"chatDebug.cache.insight.stable.title",
+			"chatDebug.cache.insight.system.detail",
+			"chatDebug.cache.insight.system.hint",
+			"chatDebug.cache.insight.system.title",
+			"chatDebug.cache.insight.system.volatileHint",
+			"chatDebug.cache.insight.tools.hint",
+			"chatDebug.cache.insight.tools.title",
+			"chatDebug.cache.insight.toolsAdded",
+			"chatDebug.cache.insight.toolsDef.detail",
+			"chatDebug.cache.insight.toolsDef.hint",
+			"chatDebug.cache.insight.toolsDef.title",
+			"chatDebug.cache.insight.toolsModified",
+			"chatDebug.cache.insight.toolsRemoved",
+			"chatDebug.cache.insight.toolsReorder.detail",
+			"chatDebug.cache.insight.toolsReorder.hint",
+			"chatDebug.cache.insight.toolsReorder.title",
+			"chatDebug.cache.insight.toolsSet.hint",
+			"chatDebug.cache.insight.toolsSet.title",
+			"chatDebug.cache.insight.tooSmall.detail",
+			"chatDebug.cache.insight.tooSmall.hint",
+			"chatDebug.cache.insight.tooSmall.title",
+			"chatDebug.cache.insight.truncated.detail",
+			"chatDebug.cache.insight.truncated.hint",
+			"chatDebug.cache.insight.truncated.title",
+			"chatDebug.cache.session.allHealthy.detail",
+			"chatDebug.cache.session.allHealthy.title",
+			"chatDebug.cache.session.expiration.detail",
+			"chatDebug.cache.session.expiration.hint",
+			"chatDebug.cache.session.expiration.title",
+			"chatDebug.cache.session.recurring.detail",
+			"chatDebug.cache.session.recurring.title",
+			"chatDebug.cache.volatile.counter",
+			"chatDebug.cache.volatile.timestamp",
+			"chatDebug.cache.volatile.uuid"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugDetailPanel": [
 			"chatDebug.closeDetail",
@@ -11140,29 +11815,46 @@
 			"model.capabilities",
 			"model.contextSize.totalTokens",
 			"model.name",
+			"model.name.hidden",
 			"modelName",
+			"models.addModel",
 			"models.agentMode",
 			"models.cacheCost.plural",
 			"models.cacheCost.singular",
 			"models.capabilities",
-			"models.configure",
-			"models.configureContextMenu",
 			"models.configureModel",
 			"models.contextSize",
 			"models.deleteAction",
 			"models.deleteConfirmation",
 			"models.enableModelProvider",
+			"models.goToSettings",
+			"models.hideGroup",
+			"models.hideModel",
+			"models.hideModelsPlural",
 			"models.inputCost.plural",
 			"models.inputCost.singular",
+			"models.installProviderExtensions",
+			"models.longContextCacheCost.plural",
+			"models.longContextCacheCost.singular",
+			"models.longContextInputCost.plural",
+			"models.longContextInputCost.singular",
+			"models.longContextOutputCost.plural",
+			"models.longContextOutputCost.singular",
+			"models.longContextPricing",
 			"models.managedByOrganization",
 			"models.manageProvider",
 			"models.outputCost.plural",
 			"models.outputCost.singular",
 			"models.pinModel",
 			"models.pricing",
+			"models.renameGroup",
+			"models.showGroup",
+			"models.showModel",
+			"models.showModelsPlural",
 			"models.toolCalling",
 			"models.tools",
 			"models.unpinModel",
+			"models.updateApiKey",
 			"models.vision",
 			"modelsTable.ariaLabel",
 			"outputCost.ariaLabel.plural",
@@ -11174,6 +11866,7 @@
 			"status.ariaLabel",
 			"tokenLimits",
 			"vendor.ariaLabel",
+			"vendor.hidden.ariaLabel",
 			"visible.ariaLabel"
 		],
 		"vs/workbench/contrib/chat/browser/chatOutputItemRenderer": [
@@ -11220,6 +11913,32 @@
 			"showExtension",
 			"vscode.extension.contributes.chatParticipant"
 		],
+		"vs/workbench/contrib/chat/browser/chatQuotaNotification": [
+			"manageBudget",
+			"manageBudget2",
+			"manageBudget3",
+			"quota.approaching.default",
+			"quota.approaching.free",
+			"quota.approaching.managed",
+			"quota.approaching.overageEnabled",
+			"quota.approaching.title",
+			"quota.blocked.managed",
+			"quota.blocked.managed.title",
+			"quota.exhausted.anonymous",
+			"quota.exhausted.default",
+			"quota.exhausted.free",
+			"quota.exhausted.hadOverage",
+			"quota.exhausted.managed",
+			"quota.exhausted.title",
+			"quota.overage.desc",
+			"quota.overage.title",
+			"rateLimit.resets",
+			"rateLimit.session",
+			"rateLimit.weekly",
+			"signIn",
+			"upgrade",
+			"upgrade2"
+		],
 		"vs/workbench/contrib/chat/browser/chatRepoInfo": [
 			"chat.repoInfo.enabled",
 			"chatRepoInfoConfigurationTitle"
@@ -11252,6 +11971,7 @@
 			"chatSessionsExtPoint.name",
 			"chatSessionsExtPoint.order",
 			"chatSessionsExtPoint.requiresCustomModels",
+			"chatSessionsExtPoint.supportsAutoModel",
 			"chatSessionsExtPoint.supportsFileAttachments",
 			"chatSessionsExtPoint.supportsHandOffs",
 			"chatSessionsExtPoint.supportsImageAttachments",
@@ -11296,7 +12016,9 @@
 			"toggle.chatSignIn",
 			"toggle.chatSignInDescription",
 			"triggerChatSetup",
-			"triggerChatSetupFromAccounts"
+			"triggerChatSetupFromAccounts",
+			"upgradeSuccess",
+			"upgradeSuccessDescription"
 		],
 		"vs/workbench/contrib/chat/browser/chatSetup/chatSetupController": [
 			"enterpriseInstance",
@@ -11397,6 +12119,7 @@
 					"{Locked=\"]({3})\"}"
 				]
 			},
+			"additionalBudgetLabel",
 			"cancelSnooze",
 			"chatsLabel",
 			"completions.plus5min",
@@ -11427,9 +12150,12 @@
 			"premiumLimitReached",
 			"premiumLimitReachedCompact",
 			"quotaAdditionalUsageActive",
+			"quotaAdditionalUsageActiveEnterprise",
 			"quotaAdditionalUsageApproaching",
+			"quotaAdditionalUsageApproachingEnterprise",
 			"quotaBudgetActive",
 			"quotaBudgetApproaching",
+			"quotaBudgetExceededEnterprise",
 			"quotaCreditsDisplay",
 			"quotaDisplay",
 			"quotaLabel",
@@ -11468,7 +12194,7 @@
 			"signIn"
 		],
 		"vs/workbench/contrib/chat/browser/chatTipCatalog": [
-			"tip.agenticBrowser",
+			"tip.agentsWindow",
 			"tip.attachFiles",
 			"tip.autoAcceptDelay",
 			"tip.codeActions",
@@ -11609,6 +12335,7 @@
 			"confirmAddMarketplaceDetail",
 			"confirmInstallPlugin",
 			"confirmInstallPluginDetail",
+			"confirmInstallTargetedPlugin",
 			{
 				"key": "installButton",
 				"comment": [
@@ -11883,6 +12610,8 @@
 					"{Locked='[`chat.autoReply`](command:workbench.action.openSettings?%5B%22chat.autoReply%22%5D)'}"
 				]
 			},
+			"autopilotRiskSkipFallback",
+			"autopilotRiskSkipped",
 			"copilot.toolSet.agent.description",
 			"copilot.toolSet.execute.description",
 			"copilot.toolSet.read.description",
@@ -11942,6 +12671,19 @@
 			"chatViewsWelcome.when",
 			"vscode.extension.contributes.chatViewsWelcome"
 		],
+		"vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService": [
+			"agentsVoice.action.approve",
+			"agentsVoice.action.autoApprove",
+			"agentsVoice.action.focusSession",
+			"agentsVoice.action.getSessionChanges",
+			"agentsVoice.action.getSessionInfo",
+			"agentsVoice.action.getSessionThread",
+			"agentsVoice.action.newSessions",
+			"agentsVoice.action.reject",
+			"agentsVoice.action.revokeAutoApprove",
+			"agentsVoice.action.sendToChat",
+			"agentsVoice.action.working"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatAgentHover": [
 			"reservedName",
 			"viewExtensionLabel"
@@ -11989,6 +12731,17 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExtensionsContentPart": [
 			"chat.extensions.loading"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExternalEditContentPart": [
+			"chat.codeblock.deletions",
+			"chat.codeblock.deletions.one",
+			"chat.codeblock.edited",
+			"chat.codeblock.insertions",
+			"chat.codeblock.insertions.one",
+			"chat.externalEdit.created",
+			"chat.externalEdit.deleted",
+			"chat.externalEdit.renamed",
+			"summary"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatHookContentPart": [
 			"hook.title.stopped",
@@ -12143,8 +12896,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart": [
 			"clickToContinue",
-			"configureBudget",
-			"enableAdditionalUsage",
+			"manageBudget",
 			"upgradeToCopilotPro",
 			"waitWarning"
 		],
@@ -12195,6 +12947,8 @@
 			"editsSummary"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart": [
+			"chat.thinking.createdFile",
+			"chat.thinking.deletedFile",
 			"chat.thinking.deletions",
 			"chat.thinking.deletions.one",
 			"chat.thinking.editedFile",
@@ -12209,6 +12963,7 @@
 			"chat.thinking.insertions",
 			"chat.thinking.insertions.one",
 			"chat.thinking.label",
+			"chat.thinking.renamedFile",
 			"chat.thinking.shimmer",
 			"chat.thinking.started",
 			"chat.thinking.terminal.1",
@@ -12229,6 +12984,7 @@
 			"chat.working.fun.1",
 			"chat.working.fun.2",
 			"chat.working.fun.3",
+			"chat.working.fun.4",
 			"chat.working.fun.minecraft.1",
 			"chat.working.fun.ms.1"
 		],
@@ -12302,10 +13058,6 @@
 			"mcpAppError",
 			"retry"
 		],
-		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMissingSandboxDepsConfirmationSubPart": [
-			"missingDeps.cancel",
-			"missingDeps.install"
-		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatModifiedFilesConfirmationSubPart": [
 			"manyFilesChanged",
 			"modifiedFilesAllChangesTitle",
@@ -12314,14 +13066,21 @@
 			"oneFileChanged",
 			"viewAllChanges"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatSandboxPrerequisiteConfirmationSubPart": [
+			"missingDeps.install",
+			"sandboxPrerequisite.applyFix",
+			"sandboxPrerequisite.cancel"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart": [
 			"autoApprove.button.enable",
 			"autoApprove.enable",
 			"autoApprove.markdown",
 			"autoApprove.markdown2",
 			"autoApprove.title",
+			"chat.terminal.allowNetwork.defaultReason",
 			"chat.terminal.detail.approvalNeeded",
 			"chat.terminal.detail.sandboxInsufficient",
+			"chat.terminal.detail.unrestrictedNetwork",
 			"chat.terminal.unsandboxedExecution.defaultReason",
 			"newRule.session",
 			"newRule.session.plural",
@@ -12482,6 +13241,11 @@
 		"vs/workbench/contrib/chat/browser/widget/input/chatFollowups": [
 			"followUpAriaLabel"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatGoalBannerWidget": [
+			"chat.goalBanner.dismiss",
+			"chat.goalBanner.label",
+			"chat.goalBanner.loading"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget": [
 			"dismissNotification"
 		],
@@ -12499,6 +13263,10 @@
 			"chatInput.mode.edit",
 			"chatInput.model"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatInputStatusActionViewItem": [
+			"chat.inputStatus.otel.manageSettings",
+			"chat.inputStatus.otel.title"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatModelPicker": [
 			"chat.effort.costHint",
 			"chat.effort.header",
@@ -12513,6 +13281,7 @@
 			"chat.modelPicker.downloadUpdateHover",
 			"chat.modelPicker.effortAriaLabel",
 			"chat.modelPicker.effortTooltip",
+			"chat.modelPicker.noModels",
 			"chat.modelPicker.otherModels",
 			"chat.modelPicker.pin",
 			"chat.modelPicker.pinned",
@@ -12528,6 +13297,7 @@
 			"chat.priceCategory.high",
 			"chat.priceCategory.low",
 			"chat.priceCategory.medium",
+			"chat.priceCategory.unknown",
 			"chat.priceCategory.veryHigh",
 			"chat.tokens.costHint",
 			"chat.tokens.header",
@@ -12539,10 +13309,10 @@
 			"models.costValueSingular",
 			"models.effortDefault",
 			"models.inputCostLabel",
+			"models.longContextPriceTitle",
 			"models.outputCostLabel",
 			"models.priceCategoryTitle",
-			"models.priceTitle",
-			"models.tokensDefault"
+			"models.priceTitle"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter": [
 			"chatPhoneInput.autoLabel",
@@ -12589,7 +13359,8 @@
 			"pastedCodeAttachment",
 			"pastedImageAttachment",
 			"pastedImageName",
-			"pastedSymbolReference"
+			"pastedSymbolReference",
+			"pasteHtmlAsMarkdown"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem": [
 			"chat.modelPicker.label"
@@ -12669,6 +13440,7 @@
 			"contextUsagePercentageLabel"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane": [
+			"agentsVoice.voiceChatTitle",
 			"chat.loadSessionFailed",
 			"newSession",
 			"sessionInProgress",
@@ -12756,6 +13528,7 @@
 			"inInteractiveInput",
 			"inQuickChat",
 			"interactiveInputHasFocus",
+			"interactiveInputHasSendableContent",
 			"interactiveInputHasText",
 			"interactiveSessionCurrentlyEditing",
 			"interactiveSessionCurrentlyEditingInput",
@@ -12769,7 +13542,170 @@
 		],
 		"vs/workbench/contrib/chat/common/attachments/chatVariableEntries": [
 			"chat.attachment.problems.all",
-			"chat.attachment.problems.inFile"
+			"chat.attachment.problems.inFile",
+			"chat.attachmentSummary.file.many",
+			"chat.attachmentSummary.file.one",
+			"chat.attachmentSummary.image.many",
+			"chat.attachmentSummary.image.one"
+		],
+		"vs/workbench/contrib/chat/common/chatErrorMessages": [
+			"chatError.aMoment",
+			"chatError.canceled",
+			"chatError.duration.hours",
+			"chatError.duration.hoursMinutes",
+			"chatError.duration.minutes",
+			"chatError.duration.seconds",
+			"chatError.extensionBlocked",
+			"chatError.failed",
+			"chatError.failedWithServerId",
+			"chatError.filtered.copyright",
+			{
+				"key": "chatError.filtered.copyrightMd",
+				"comment": [
+					"{Locked='](https://aka.ms/copilot-chat-filtered-docs)'}"
+				]
+			},
+			"chatError.filtered.default",
+			{
+				"key": "chatError.filtered.defaultMd",
+				"comment": [
+					"{Locked='](https://aka.ms/copilot-chat-filtered-docs)'}"
+				]
+			},
+			"chatError.filtered.prompt",
+			{
+				"key": "chatError.filtered.promptMd",
+				"comment": [
+					"{Locked='](https://aka.ms/copilot-chat-filtered-docs)'}"
+				]
+			},
+			"chatError.invalidStatefulMarker",
+			"chatError.length",
+			"chatError.network",
+			"chatError.notFound",
+			"chatError.offTopic",
+			"chatError.quota.additionalSpend",
+			"chatError.quota.business",
+			"chatError.quota.default",
+			"chatError.quota.free",
+			"chatError.quota.generic",
+			"chatError.quota.individual",
+			{
+				"key": "chatError.quota.overage",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			"chatError.quota.pro",
+			"chatError.quota.server",
+			"chatError.quota.ubb.business",
+			"chatError.quota.ubb.businessDate",
+			"chatError.quota.ubb.default",
+			"chatError.quota.ubb.defaultDate",
+			"chatError.quota.ubb.free",
+			"chatError.quota.ubb.freeDate",
+			"chatError.quota.ubb.individual",
+			"chatError.quota.ubb.individualDate",
+			"chatError.quota.ubb.pro",
+			"chatError.quota.ubb.proDate",
+			{
+				"key": "chatError.rateLimit.agentMode",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.generic",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.genericAuto",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.integration",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.model",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.modelAuto",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.overloaded",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.overloadedAuto",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.server",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.serverAuto",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.session",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.sessionUpgrade",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.weekly",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.weeklyAuto",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.weeklyDate",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			{
+				"key": "chatError.rateLimit.weeklyDateAuto",
+				"comment": [
+					"{Locked=']({'}"
+				]
+			},
+			"chatError.somethingWrong",
+			"chatError.unknown"
 		],
 		"vs/workbench/contrib/chat/common/chatImageExtraction": [
 			"chatImageExtraction.defaultTitle",
@@ -13439,9 +14375,21 @@
 			"workbench.action.speech.stopReadAloud"
 		],
 		"vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions": [
+			"chat.agentsHandoff.tip.action",
+			"chat.agentsHandoff.tip.action.custom",
+			"chat.agentsHandoff.tip.action.default",
+			"chat.agentsHandoff.tip.description",
+			"chat.agentsHandoff.tip.description.copilot",
+			"chat.agentsHandoff.tip.emptyWorkspace.description",
+			"chat.agentsHandoff.tip.emptyWorkspace.message",
+			"chat.agentsHandoff.tip.message",
+			"chat.agentsHandoff.tip.mute",
 			"openAgentsWindow",
 			"openInAgentsHover",
-			"openWorkspaceInAgentsWindow"
+			"openSessionInAgentsWindow",
+			"openWorkspaceInAgentsWindow",
+			"toggle.openInAgentsWindow",
+			"toggle.openInAgentsWindowDescription"
 		],
 		"vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool": [
 			"fetchWebPage.binaryNotSupported",
@@ -13824,7 +14772,13 @@
 			"schema.folding",
 			"schema.folding.markers",
 			"schema.folding.markers.end",
+			"schema.folding.markers.end.errorMessage",
+			"schema.folding.markers.end.flags",
+			"schema.folding.markers.end.pattern",
 			"schema.folding.markers.start",
+			"schema.folding.markers.start.errorMessage",
+			"schema.folding.markers.start.flags",
+			"schema.folding.markers.start.pattern",
 			"schema.folding.offSide",
 			"schema.indentationRules",
 			"schema.indentationRules.decreaseIndentPattern",
@@ -14639,6 +15593,8 @@
 			"commentLabelWithKeybinding",
 			"commentLabelWithKeybindingNoKeybinding",
 			"debugLaunchConfigurations",
+			"debugLaunchConfigurations.search",
+			"debugLaunchConfigurationsAriaLabel",
 			"debugSession",
 			"noConfigurations"
 		],
@@ -15189,6 +16145,7 @@
 		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
 			"addWatchExpression",
 			"collapse",
+			"copyAllWatchExpressions",
 			"copyWatchExpression",
 			"removeAllWatchExpressions",
 			"typeNewValue",
@@ -15703,7 +16660,6 @@
 			}
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
-			"all",
 			"autoRestart",
 			"builtin",
 			"builtin filter",
@@ -15720,7 +16676,6 @@
 			"enableAll",
 			"enableAllWorkspace",
 			"enableAutoUpdate",
-			"enabled",
 			"enabled filter",
 			"enablePreRleaseLabel",
 			"extension",
@@ -15735,9 +16690,9 @@
 			"extensions.affinity",
 			"extensions.allowOpenInModalEditor",
 			"extensions.autoUpdate",
-			"extensions.autoUpdate.enabled",
-			"extensions.autoUpdate.false",
-			"extensions.autoUpdate.true",
+			"extensions.autoUpdate.off",
+			"extensions.autoUpdate.on",
+			"extensions.autoUpdateDelay",
 			"extensions.gallery.serviceUrl",
 			"extensions.supportAgentsWindow",
 			"extensions.supportUntrustedWorkspaces",
@@ -15815,10 +16770,11 @@
 			},
 			"most popular filter",
 			"most popular recommended",
-			"none",
 			"notFound",
 			"notInstalled",
 			"noUpdatesAvailable",
+			"off",
+			"on",
 			"recently published filter",
 			"recentlyPublishedExtensions",
 			"refreshExtension",
@@ -15863,7 +16819,6 @@
 			"workbench.extensions.action.undoIgnoredRecommendation",
 			"workbench.extensions.installExtension.arg.decription",
 			"workbench.extensions.installExtension.description",
-			"workbench.extensions.installExtension.option.context",
 			"workbench.extensions.installExtension.option.donotSync",
 			"workbench.extensions.installExtension.option.enable",
 			"workbench.extensions.installExtension.option.installOnlyNewlyAddedFromExtensionPackVSIX",
@@ -15877,6 +16832,7 @@
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"auto update message",
+			"autoUpdateDelayed",
 			"cancel",
 			"Cannot be enabled",
 			"cannot be installed",
@@ -16128,6 +17084,7 @@
 			"deprecated",
 			"disabled",
 			"disabledExtensions",
+			"dismiss notification",
 			"enabled",
 			"enabledExtensions",
 			"extensionFound",
@@ -16289,6 +17246,7 @@
 			"postUpdateTooltip",
 			"postUpdateUpdateTooltip",
 			"pre-release",
+			"privateMarketplace",
 			"reload",
 			"reload window",
 			"report issue",
@@ -17208,6 +18166,9 @@
 			"imageCarousel.thumbnailLabelVideo",
 			"imageCarousel.thumbnails"
 		],
+		"vs/workbench/contrib/imageCarousel/browser/imageCarouselEditorInput": [
+			"imageCarouselEditorLabelIcon"
+		],
 		"vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty": [
 			"description",
 			"isReadingLineWithInlayHints",
@@ -17373,8 +18334,12 @@
 			"vscodePlaceholder"
 		],
 		"vs/workbench/contrib/issue/browser/issueFormService": [
+			"additionalIssueData",
 			"cancel",
 			"confirmCloseIssueReporter",
+			"issueData",
+			"issueReporter.attachmentsHeading",
+			"issueReporter.attachmentsUploadFailed",
 			"issueReporterWriteToClipboard",
 			{
 				"key": "ok",
@@ -17382,6 +18347,7 @@
 					"&& denotes a mnemonic"
 				]
 			},
+			"pasteData",
 			{
 				"key": "yes",
 				"comment": [
@@ -17393,6 +18359,128 @@
 			"contributedIssuePage",
 			"extensions",
 			"reportExtensionMarketplace"
+		],
+		"vs/workbench/contrib/issue/browser/issueReporterEditorInput": [
+			"discard",
+			"discardIssue",
+			"discardIssueDetail",
+			"issueReporterEditorInputName",
+			"issueReporterIcon"
+		],
+		"vs/workbench/contrib/issue/browser/issueReporterEditorPane": [
+			"noData",
+			"noExperiments",
+			"openSystemSettings",
+			"recordingTooLarge",
+			"screenRecordingPermissionDenied",
+			"screenRecordingPermissionDeniedGeneric"
+		],
+		"vs/workbench/contrib/issue/browser/issueReporterOverlay": [
+			"abExperiments",
+			"additionalInformation",
+			"additionalPerformanceData",
+			"additionalPerformanceDataDescription",
+			"attachments",
+			"back",
+			"bug",
+			"bugGuidance",
+			"captureOptions",
+			"category",
+			"categoryRequired",
+			"closeTab",
+			"composeMessage",
+			"defaultGuidance",
+			"deleteRecording",
+			"deleteScreenshot",
+			"describeHeading",
+			"description",
+			"descriptionPlaceholder",
+			"descriptionRequired",
+			"editScreenshot",
+			"excludeAllExtraAttachments",
+			"excludeAllExtraAttachmentsAria",
+			"expand",
+			"extension",
+			"extensionData",
+			"extensionExternalIssueUrl",
+			"extensionNoIssueUrl",
+			"extensionPlaceholder",
+			"extensionRequired",
+			"extensions",
+			"extensionSource",
+			"featureGuidance",
+			"featureRequest",
+			"feedbackCategory",
+			"fiveSeconds",
+			"generateTitle",
+			"generateTitleBtn",
+			"generatingTitle",
+			"hideToolbarInScreenshots",
+			"includeAllExtraAttachments",
+			"includeAllExtraAttachmentsAria",
+			"includeInIssue",
+			"issueTargetRepo",
+			"issueTitle",
+			"issueTitlePlaceholder",
+			"loadingDiagnostics",
+			"loadingExtensionData",
+			"loadingProcessInfo",
+			"loadingSystemInfo",
+			"loadingWorkspaceInfo",
+			"markdownSupported",
+			"marketplace",
+			"marketplacePlaceholder",
+			"maxAttachmentsReached",
+			"minimize",
+			"next",
+			"noDelay",
+			"noDescription",
+			"noSimilarIssues",
+			"noTitle",
+			"openExternalIssueReporter",
+			"or",
+			"perfGuidance",
+			"performanceIssue",
+			"previewOnGitHub",
+			"recordingActive",
+			"recordingThumbnailAlt",
+			"recordVideo",
+			"refresh",
+			"refreshPerformanceData",
+			"reportIssue",
+			"reviewSubmit",
+			"runningProcesses",
+			"screenshot",
+			"screenshotAlt",
+			"screenshots",
+			"screenshotsHeading",
+			"screenshotsSubtitle",
+			"searchingSimilarIssues",
+			"selectExtension",
+			"shortcutHintIntro",
+			"similarIssues",
+			"similarIssuesNeedsTitle",
+			"similarIssuesSearchFailed",
+			"skip",
+			"stepOf",
+			"stopRecording",
+			"submit",
+			"systemInformation",
+			"target",
+			"targetRequired",
+			"tenSeconds",
+			"threeSeconds",
+			"titleRequired",
+			"toCapture",
+			"toRecord",
+			"unknown",
+			"unknownSource",
+			"updateAvailable",
+			"uploading",
+			"vscode",
+			"vscodePlaceholder",
+			"waitingForDiagnostics",
+			"workspaceMetadata"
 		],
 		"vs/workbench/contrib/issue/browser/issueReporterPage": [
 			"acknowledgements",
@@ -17459,6 +18547,40 @@
 			"troubleshootIssue",
 			"use insiders"
 		],
+		"vs/workbench/contrib/issue/browser/screenshotAnnotation": [
+			"annotationHint",
+			"apply",
+			"arrow",
+			"cancel",
+			"colorValue",
+			"crop",
+			"discard",
+			"ellipse",
+			"eraser",
+			"fillColor",
+			"freehand",
+			"opacity",
+			"pan",
+			"rectangle",
+			"redo",
+			"save",
+			"select",
+			"setFillColor",
+			"setOpacity",
+			"setStrokeColor",
+			"setStrokeWidth",
+			"setTextSize",
+			"strokeColor",
+			"strokeWidth",
+			"text",
+			"textBackgroundColor",
+			"textColor",
+			"textSize",
+			"toolOptions",
+			"transparentColor",
+			"typeText",
+			"undo"
+		],
 		"vs/workbench/contrib/issue/common/issue.contribution": [
 			{
 				"key": "miReportIssue",
@@ -17475,6 +18597,10 @@
 			}
 		],
 		"vs/workbench/contrib/issue/electron-browser/issue.contribution": [
+			"issueReporter.wizard.enabled",
+			"issueReporter.wizard.fullWorkspaceScan",
+			"issueReporterConfigurationTitle",
+			"issueReporterEditorPaneTitle",
 			"openIssueReporter",
 			{
 				"key": "reportPerformanceIssue",
@@ -17855,6 +18981,17 @@
 			"mcp.addConfiguration.description",
 			"mcp.addServer",
 			"mcp.addServer.description",
+			"mcp.agentHost.disable",
+			"mcp.agentHost.enable",
+			"mcp.agentHost.noServers",
+			"mcp.agentHost.noServers.description",
+			"mcp.agentHost.showLocal",
+			"mcp.agentHost.status.authRequired",
+			"mcp.agentHost.status.error",
+			"mcp.agentHost.status.ready",
+			"mcp.agentHost.status.starting",
+			"mcp.agentHost.status.stopped",
+			"mcp.agentHostOptions",
 			"mcp.autoStart",
 			"mcp.browseResources",
 			"mcp.command.browse",
@@ -17895,9 +19032,19 @@
 			"mcp.samplingLog.description",
 			"mcp.samplingLog.title",
 			"mcp.selectAction",
+			"mcp.selectAgentHostServer",
 			"mcp.selectServer",
 			"mcp.server.options.tooltip",
 			"mcp.servers",
+			"mcp.setOAuthClientSecret",
+			"mcp.setOAuthClientSecret.delete",
+			"mcp.setOAuthClientSecret.hide",
+			"mcp.setOAuthClientSecret.placeholder.replace",
+			"mcp.setOAuthClientSecret.placeholder.set",
+			"mcp.setOAuthClientSecret.prompt",
+			"mcp.setOAuthClientSecret.reveal",
+			"mcp.setOAuthClientSecret.title.replace",
+			"mcp.setOAuthClientSecret.title.set",
 			"mcp.showOutput",
 			"mcp.showOutput.description",
 			"mcp.signOut",
@@ -18015,8 +19162,10 @@
 			"edit",
 			"edit.savedValue.tooltip",
 			"mcp.debug",
+			"mcp.replaceClientSecret",
 			"mcp.restart",
 			"mcp.server.more",
+			"mcp.setClientSecret",
 			"mcp.start",
 			"mcp.stop",
 			"mcp.variableNotFound",
@@ -18198,6 +19347,7 @@
 			"app.mcp.json.headers",
 			"app.mcp.json.oauth",
 			"app.mcp.json.oauth.clientId",
+			"app.mcp.json.oauth.enterpriseManaged",
 			"app.mcp.json.sandbox",
 			"app.mcp.json.sandbox.filesystem",
 			"app.mcp.json.sandbox.filesystem.allowWrite",
@@ -18355,6 +19505,8 @@
 		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
 			"diffAlgorithm.advanced",
+			"diffAlgorithm.advancedExternal",
+			"diffAlgorithm.advancedWasm",
 			"diffAlgorithm.legacy",
 			"name"
 		],
@@ -19097,6 +20249,11 @@
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"fail.noEditor",
 			"fail.noEditor.extensionMissing",
+			"notebook.webHost.confirm",
+			"notebook.webHost.declined",
+			"notebook.webHost.detail",
+			"notebook.webHost.open",
+			"notebook.webHost.remember",
 			"notebookOpenAsText",
 			"notebookOpenEnableMissingViewType",
 			"notebookOpenInstallMissingViewType",
@@ -20709,6 +21866,7 @@
 		],
 		"vs/workbench/contrib/search/browser/patternInputWidget": [
 			"defaultLabel",
+			"onlySearchInChangedFiles",
 			"onlySearchInOpenEditors",
 			"useExcludesAndIgnoreFilesDescription"
 		],
@@ -22586,17 +23744,39 @@
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool": [
 			"allow",
 			"runInTerminal",
+			"runInTerminal.allowNetwork",
+			"runInTerminal.allowNetwork.autoRetry",
+			"runInTerminal.allowNetwork.autoRetry.confirmationMessage",
+			"runInTerminal.allowNetwork.autoRetry.domain",
+			"runInTerminal.allowNetwork.autoRetry.invocation",
+			"runInTerminal.allowNetwork.autoRetry.reason",
+			"runInTerminal.allowNetwork.confirmationMessage",
+			"runInTerminal.allowNetwork.confirmationMessage.defaultReason",
+			"runInTerminal.allowNetwork.disabled.invocation",
+			"runInTerminal.allowNetwork.disabled.result",
+			"runInTerminal.bubblewrap.applyFix",
+			"runInTerminal.bubblewrap.cancel",
+			"runInTerminal.bubblewrap.cancelled",
+			"runInTerminal.bubblewrap.message",
+			"runInTerminal.bubblewrap.repairFailed",
+			"runInTerminal.bubblewrap.repairUnknown",
+			"runInTerminal.bubblewrap.stillUnavailable",
+			"runInTerminal.bubblewrap.title",
+			"runInTerminal.bubblewrap.unusable",
 			"runInTerminal.confirmationMessage",
 			"runInTerminal.defaultExplanation",
 			"runInTerminal.defaultGoal",
 			"runInTerminal.inDirectory",
 			"runInTerminal.invocation",
 			"runInTerminal.invocation.sandbox",
+			"runInTerminal.missingDeps.bubblewrapFailed",
+			"runInTerminal.missingDeps.bubblewrapFailedNoRepair",
 			"runInTerminal.missingDeps.cancel",
 			"runInTerminal.missingDeps.cancelled",
 			"runInTerminal.missingDeps.failed",
 			"runInTerminal.missingDeps.install",
 			"runInTerminal.missingDeps.message",
+			"runInTerminal.missingDeps.recheckFailed",
 			"runInTerminal.missingDeps.title",
 			"runInTerminal.missingDeps.unknown",
 			"runInTerminal.presentationOverride",
@@ -22712,7 +23892,15 @@
 			"agentSandbox.macFileSystemSetting.allowWrite",
 			"agentSandbox.macFileSystemSetting.denyRead",
 			"agentSandbox.macFileSystemSetting.denyWrite",
+			"agentSandbox.retryWithAllowNetworkRequests",
 			"agentSandbox.runtimeSetting",
+			"agentSandbox.windowsEnabledSetting",
+			"agentSandbox.windowsEnabledSetting.allowNetworkDescription",
+			"agentSandbox.windowsEnabledSetting.offDescription",
+			"agentSandbox.windowsFileSystemSetting",
+			"agentSandbox.windowsFileSystemSetting.allowRead",
+			"agentSandbox.windowsFileSystemSetting.allowWrite",
+			"agentSandbox.windowsFileSystemSetting.denyRead",
 			"autoApprove.defaults",
 			"autoApprove.deprecated",
 			"autoApprove.description.commandLine",
@@ -24714,6 +25902,7 @@
 			"onboarding.aiPref.selected.alert",
 			"onboarding.back",
 			"onboarding.close",
+			"onboarding.continue",
 			"onboarding.continueWithoutSignIn",
 			"onboarding.getStarted",
 			"onboarding.keymap.installError",
@@ -24758,9 +25947,11 @@
 			"onboarding.signIn.disclaimer.settingsPrefix",
 			"onboarding.signIn.disclaimer.suffix",
 			"onboarding.signIn.disclaimer.terms",
+			"onboarding.signIn.enterprise.continue",
 			"onboarding.signIn.enterprise.error",
 			"onboarding.signIn.enterprise.invalid",
 			"onboarding.signIn.enterprise.placeholder",
+			"onboarding.signIn.enterprise.progress",
 			"onboarding.signIn.enterprise.prompt",
 			"onboarding.signIn.enterprise.resolve",
 			"onboarding.signIn.error",
@@ -24771,6 +25962,7 @@
 			"onboarding.signIn.google",
 			"onboarding.signIn.heroSubtitle",
 			"onboarding.signIn.heroTitle",
+			"onboarding.signIn.signedIn",
 			"onboarding.step.agentSessions.subtitle.before",
 			"onboarding.step.aria",
 			"onboarding.stepOf",
@@ -25341,9 +26533,11 @@
 			"menus.chatEditingSessionChangesToolbar",
 			"menus.chatEditingSessionTitleToolbar",
 			"menus.chatEditorInlineGutter",
+			"menus.chatInputStatus",
 			"menus.chatMultiDiffContext",
 			"menus.chatNewSession",
 			"menus.chatSessions",
+			"menus.chatSessionsItemContext",
 			"menus.chatSessionsNewSession",
 			"menus.chatTextEditor",
 			"menus.commandPalette",
@@ -25719,6 +26913,7 @@
 			"openLocalFolder",
 			"remoteFileDialog.badPath",
 			"remoteFileDialog.cancel",
+			"remoteFileDialog.createFolderFailed",
 			"remoteFileDialog.hideDotFiles",
 			"remoteFileDialog.invalidPath",
 			"remoteFileDialog.local",
@@ -25727,6 +26922,7 @@
 			"remoteFileDialog.showDotFiles",
 			"remoteFileDialog.validateBadFilename",
 			"remoteFileDialog.validateCreateDirectory",
+			"remoteFileDialog.validateCreateDirectoryOpen",
 			"remoteFileDialog.validateExisting",
 			"remoteFileDialog.validateFileOnly",
 			"remoteFileDialog.validateFolder",
@@ -26101,6 +27297,10 @@
 			"installResolver",
 			"learnMore",
 			"relaunch",
+			"remoteConnectionConfirm",
+			"remoteConnectionConfirmButton",
+			"remoteConnectionConfirmDetail",
+			"remoteConnectionRejected",
 			"resolverExtensionNotFound",
 			"restart",
 			"restartExtensionHost",
@@ -27444,6 +28644,8 @@
 			"Controls whether the editor shows CodeLens.",
 			"Controls whether {0} and {1} will be automatically detected when a file is opened based on the file contents.",
 			"Uses the advanced diffing algorithm.",
+			"Uses the advanced diffing algorithm from the external `@vscode/diff` package (pure JavaScript).",
+			"Uses the advanced diffing algorithm from the external `@vscode/diff` package (WebAssembly).",
 			"Uses the legacy diffing algorithm.",
 			"Controls whether the tokenization should happen asynchronously on a web worker.",
 			"Controls whether async tokenization should be logged. For debugging only.",
@@ -28463,7 +29665,7 @@
 			"Error",
 			"Hint",
 			"Info",
-			"{0} at {1}. ",
+			"{0}: {1} at {2}. ",
 			"{0} of {1} problems",
 			"Warning"
 		],
@@ -29251,6 +30453,16 @@
 			"Select previous action",
 			"Toggle section"
 		],
+		"vs/platform/agentHost/common/agentHost.config.contribution": [
+			"When enabled, some agents run in a separate agent host process.",
+			"When enabled, hides the Extension Host Copilot CLI entry from the Agents window picker.",
+			"When enabled, hides the Extension Host Copilot CLI entry from the editor window chat picker.",
+			"Controls which provider is used as the default for new editor chat sessions.",
+			"Use the Agent Host Copilot CLI",
+			"Use the Extension Host Copilot CLI",
+			"Use the built-in VS Code local chat harness",
+			"Chat Agent Host"
+		],
 		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
 			"Plugins configured on this agent host and available to remote sessions.",
 			"Description",
@@ -29260,10 +30472,14 @@
 			"Plugin URI",
 			"Absolute path to the shell executable used by host-managed terminals. Normally pushed by the connected VS Code client from `terminal.integrated.agentHostProfile.<os>` (falling back to `terminal.integrated.defaultProfile.<os>`); when unset, the agent host falls back to the system shell. Only the path is supported; `args` and `env` from the workbench profile are not piped through yet. The workbench only pushes this for the local agent host — remote agent host operators should set this directly in the remote machine's `agent-host-config.json`.",
 			"Default Shell",
-			"When enabled, Copilot SDK sessions use the SDK's default terminal behavior instead of Agent Host's terminal tool override.",
-			"Use SDK Terminal Tool"
+			"When enabled, Copilot SDK sessions use Agent Host's terminal tool override instead of the SDK's default terminal behavior.",
+			"Use Agent Host Terminal Tool",
+			"When enabled, the coding agent uses a rubber duck critic subagent to review code changes using a complementary model.",
+			"Rubber Duck Agent"
 		],
 		"vs/platform/agentHost/common/agentHostSchema": [
+			"Whether remote session sync is enabled for the copilot-sdk CLI.",
+			"Session Sync",
 			"Most restrictive telemetry level requested by connected clients.",
 			"Telemetry Level",
 			"Approvals",
@@ -29276,15 +30492,40 @@
 			"Tool approval behavior for this session",
 			"Agent Mode",
 			"Interactive",
-			"Ask for input and approval for each action",
+			"Step-by-step collaboration",
 			"Plan",
-			"Generate a plan first, then choose how to execute it",
+			"Plan first, execute when ready",
 			"How the agent should approach this turn",
 			"Permissions",
 			"Allowed tools",
 			"Denied tools",
 			"Tool name",
 			"Per-tool session permissions. Updated automatically when approving a tool \"in this Session\"."
+		],
+		"vs/platform/agentHost/common/agentHostStarter.config.contribution": [
+			"When enabled, the agent host registers the Claude provider (subject to the Claude SDK being reachable). Independent of `#chat.agents.claude.preferAgentHost#` and `#chat.editor.claude.preferAgentHost#`, which choose which integration surfaces Claude. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
+			"Additional command-line arguments passed to `codex app-server`. Primarily useful for debugging (for example, `--log-level=debug`).",
+			"Optional override for `$CODEX_HOME`. Controls where the codex binary reads config and writes rollouts. When empty, codex uses its default (`~/.codex`).",
+			"When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
+			"Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@openai/codex`. When set, the agent host spawns the Codex binary from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
+			"When enabled, includes prompt and response content in OTel span attributes. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks.",
+			"When enabled, the agent host persists every emitted OTel span to a local SQLite database. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink.",
+			"When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally.",
+			"Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime.",
+			"OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process.",
+			"Output path for span JSON lines when exporter type is `file`. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`.",
+			"Chat Agent Host Starter"
+		],
+		"vs/platform/agentHost/common/changesetUri": [
+			"Branch Changes",
+			"Show changes made between different turns",
+			"Compare Turns",
+			"Show all changes made in this session",
+			"All Changes",
+			"Show changes made in this turn",
+			"This Turn",
+			"Show uncommitted changes in this session",
+			"Uncommitted Changes"
 		],
 		"vs/platform/agentHost/common/claudeModelConfig": [
 			"Controls how much reasoning effort Claude uses.",
@@ -29295,11 +30536,67 @@
 			"Thinking Level",
 			"Extra High"
 		],
+		"vs/platform/agentHost/common/sandboxConfigSchema": [
+			"Advanced Sandbox Runtime",
+			"Domain",
+			"Allowed Network Domains",
+			"Allow Unsandboxed Commands",
+			"Auto-Approve Unsandboxed Commands",
+			"Domain",
+			"Denied Network Domains",
+			"Sandbox Enabled",
+			"Linux Sandbox Filesystem",
+			"macOS Sandbox Filesystem",
+			"Agent Sandbox",
+			"Sandbox Enabled (Windows)",
+			"Windows Sandbox Filesystem"
+		],
 		"vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl": [
 			"Authentication required for {0}@{1}"
 		],
+		"vs/platform/agentHost/electron-browser/wslRemoteAgentHostServiceImpl": [
+			"Provisioning agent host in {0}...",
+			"Establishing connection to {0}..."
+		],
+		"vs/platform/agentHost/node/agentHostCommitOperationHandler": [
+			"Authentication is required to generate a commit message. Please sign in to GitHub Copilot and try again.",
+			"Sign in to GitHub Copilot to generate a commit message.",
+			"Commit operation was cancelled.",
+			"Committed changes with message: `{0}`",
+			"Could not compute uncommitted changes to generate a commit message.",
+			"Generated commit message was empty.",
+			"No uncommitted changes to commit."
+		],
+		"vs/platform/agentHost/node/agentHostCommitOperationProvider": [
+			"Commit"
+		],
 		"vs/platform/agentHost/node/agentHostMain": [
 			"Agent Host"
+		],
+		"vs/platform/agentHost/node/agentHostPullRequestOperationHandler": [
+			"Sign in to GitHub with repository access to create a pull request.",
+			"Created from `{0}` targeting `{1}`.",
+			"Pull request operation was cancelled.",
+			"Agent Host changes for {0}",
+			"Could not compute branch changes to create a pull request.",
+			"Created pull request [#{0}]({1}).",
+			"Created draft pull request [#{0}]({1}).",
+			"Pull request [#{0}]({1}) already exists.",
+			"There are no branch changes to create a pull request for."
+		],
+		"vs/platform/agentHost/node/agentHostPullRequestOperationProvider": [
+			"Create Draft Pull Request",
+			"Create Pull Request"
+		],
+		"vs/platform/agentHost/node/agentHostRenameCommand": [
+			"Rename this chat"
+		],
+		"vs/platform/agentHost/node/agentService": [
+			"Forked Session",
+			"Forked: "
+		],
+		"vs/platform/agentHost/node/agentSideEffects": [
+			"Renamed: {0}"
 		],
 		"vs/platform/agentHost/node/claude/claudeAgent": [
 			"Approvals",
@@ -29348,7 +30645,91 @@
 			"Run subagent task",
 			"Update todo list",
 			"Fetch URL",
-			"Write file"
+			"Write file",
+			"Ran shell command",
+			"Ran {0}",
+			"Read shell output",
+			"Edited file",
+			"Edited {0}",
+			"\"{0}\" failed",
+			"Used \"{0}\"",
+			"Found files",
+			"Found files matching {0}",
+			"Searched files",
+			"Searched for {0}",
+			"Killed shell command",
+			"Listed directory",
+			"Listed {0}",
+			"Read file",
+			"Read {0}",
+			"Ran subagent",
+			"Updated todo list",
+			"Fetched {0}",
+			"Fetched URL",
+			"Running shell command",
+			"Running {0}",
+			"Reading shell output",
+			"Editing file",
+			"Editing {0}",
+			"Finding files",
+			"Finding files matching {0}",
+			"Searching files",
+			"Searching for {0}",
+			"Killing shell command",
+			"Listing directory",
+			"Listing {0}",
+			"Reading file",
+			"Reading {0}",
+			"Updating todo list",
+			"Fetching {0}",
+			"Fetching URL"
+		],
+		"vs/platform/agentHost/node/claude/customizations/claudeSdkCustomizationBundler": [
+			"Discovered in Claude"
+		],
+		"vs/platform/agentHost/node/codex/codexAgent": [
+			"Controls how much reasoning effort Codex uses.",
+			"High",
+			"Low",
+			"Medium",
+			"Minimal",
+			"Thinking Level",
+			"Additional Writable Directories",
+			"Directory",
+			"Absolute paths the sandbox is allowed to write to, in addition to the workspace. Only applies when Sandbox is Workspace Write.",
+			"Approvals",
+			"No Escalations",
+			"Never ask for elevated permission; commands that cannot run in the sandbox are rejected.",
+			"Ask on Failure",
+			"Try commands in the sandbox first, then ask to retry with elevated permission if the sandbox blocks them.",
+			"Ask When Needed",
+			"Ask only when Codex determines a command needs elevated permission.",
+			"Ask More Often",
+			"Ask before more command categories so you can review actions more closely.",
+			"How Codex requests approval for tool calls.",
+			"Reasoning Effort",
+			"High",
+			"Low",
+			"Medium",
+			"Minimal",
+			"Controls how much reasoning effort Codex uses.",
+			"Network",
+			"Allow sandboxed tool calls to make outbound network requests. Only applies when Sandbox is Workspace Write.",
+			"Sandbox",
+			"Full Access (Dangerous)",
+			"Tool calls have unrestricted disk and network access.",
+			"Read-Only",
+			"Tool calls can read the workspace but cannot modify files.",
+			"Workspace Write",
+			"Tool calls can read and write within the workspace; network is controlled separately.",
+			"Filesystem and network restrictions applied to tool calls.",
+			"Web Search",
+			"Cached Only",
+			"Disabled",
+			"Live",
+			"Web-search tool availability for the model.",
+			"Codex agent backed by the OpenAI Codex app-server",
+			"Codex"
 		],
 		"vs/platform/agentHost/node/copilot/copilotAgent": [
 			"Branch",
@@ -29359,6 +30740,11 @@
 			"Worktree",
 			"Create a Git worktree for isolation",
 			"Where the agent should make changes",
+			"Default",
+			"Selects the context window size for this model.",
+			"Longer sessions",
+			"Longer sessions without compaction",
+			"Context Size",
 			"Controls how much reasoning effort the model uses.",
 			"High",
 			"Low",
@@ -29380,11 +30766,24 @@
 			"Implement Plan",
 			"How would you like to proceed?",
 			"Review Plan",
-			"View full plan"
+			"View full plan",
+			"This command needs to access blocked network domain(s): {0}.",
+			"This command needs to run outside the sandbox.",
+			"Reason for leaving the sandbox: {0}",
+			"Run Command Outside the Sandbox to Access {0}?",
+			"Run Command Outside the Sandbox?"
 		],
 		"vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider": [
 			"Free up context by compacting the conversation history",
-			"Create an implementation plan before coding"
+			"Create an implementation plan before coding",
+			"Run deep research on a topic using search and web sources",
+			"Get an independent critique of the current approach"
+		],
+		"vs/platform/agentHost/node/copilot/copilotSystemNotification": [
+			"Background agent completed",
+			"Shell completed",
+			"`{0}` completed",
+			"Shell `{0}` completed"
 		],
 		"vs/platform/agentHost/node/copilot/copilotToolDisplay": [
 			"Allow the model to call {0}?",
@@ -29421,6 +30820,8 @@
 			"Read {0}, line {1} to the end",
 			"Read {0}, line {1}",
 			"Read {0}, lines {1} to {2}",
+			"Fetched {0}",
+			"Fetched URL",
 			"Sent input to shell",
 			"Sent {0} to shell",
 			"Creating file",
@@ -29447,6 +30848,8 @@
 			"Reading {0}, line {1} to the end",
 			"Reading {0}, line {1}",
 			"Reading {0}, lines {1} to {2}",
+			"Fetching {0}",
+			"Fetching URL",
 			"Sending input to shell",
 			"Sending {0} to shell",
 			"Apply Patch",
@@ -29501,6 +30904,8 @@
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
 			"Failed to read private key file: {0}",
 			"Key file authentication requires a private key path.",
+			"SSH Key Passphrase",
+			"Enter passphrase for SSH key {0}.",
 			"Checking for existing agent host...",
 			"Establishing SSH connection...",
 			"Installing VS Code CLI on remote...",
@@ -29511,9 +30916,18 @@
 		"vs/platform/agentHost/node/tunnelHostMainService": [
 			"Remote Connections"
 		],
+		"vs/platform/agentHost/node/wslRemoteAgentHostService": [
+			"Connecting to agent host in {0}...",
+			"Detecting platform in {0}...",
+			"Preparing CLI in {0}...",
+			"Unsupported WSL distro platform: {0}"
+		],
 		"vs/platform/browserView/common/browserView": [
 			"Page Zoom: {0}%",
 			"{0}%"
+		],
+		"vs/platform/browserView/electron-main/browserSession": [
+			"Forbidden. File does not reside within a trusted folder."
 		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
 			"Add Element to Chat",
@@ -30477,12 +31891,27 @@
 			"Small font size for secondary content.",
 			"Extra small font size for less prominent content.",
 			"Base font size for codicons.",
+			"Compact font size for codicons.",
 			"Circular corner radius for fully rounded UI elements.",
 			"Large corner radius for prominent UI elements.",
 			"Base corner radius for UI elements.",
 			"Small corner radius for compact UI elements.",
 			"Extra large corner radius for very prominent UI elements.",
 			"Extra small corner radius for very compact UI elements.",
+			"No spacing (0px).",
+			"Spacing of 10px.",
+			"Spacing of 12px.",
+			"Spacing of 16px.",
+			"Spacing of 2px.",
+			"Spacing of 20px.",
+			"Spacing of 24px.",
+			"Spacing of 28px.",
+			"Spacing of 32px.",
+			"Spacing of 36px.",
+			"Spacing of 4px.",
+			"Spacing of 40px.",
+			"Spacing of 6px.",
+			"Spacing of 8px.",
 			"Base stroke thickness for borders and outlines."
 		],
 		"vs/platform/theme/common/tokenClassificationRegistry": [
@@ -30687,6 +32116,7 @@
 			"Session Details"
 		],
 		"vs/sessions/browser/parts/chatCompositeBar": [
+			"Chats",
 			"Close",
 			"Rename",
 			"Rename Chat"
@@ -30719,12 +32149,22 @@
 		],
 		"vs/sessions/browser/parts/mobile/contributions/mobileDiffView": [
 			"Back",
-			"Back",
 			"Loading…",
 			"Next file",
 			"No changes in this file.",
 			"{0} / {1}",
 			"Previous file"
+		],
+		"vs/sessions/browser/parts/mobile/contributions/mobileMultiDiffView": [
+			"Back",
+			"file",
+			"{0} {1}",
+			"file",
+			"files",
+			"Unable to load changes in this file.",
+			"Loading…",
+			"No changes in this file.",
+			"Toggle {0}"
 		],
 		"vs/sessions/browser/parts/mobile/mobilePickerSheet": [
 			"Done",
@@ -30753,9 +32193,17 @@
 			"View changes",
 			"{0} files changed (+{1} -{2})",
 			"Close sessions",
+			"{0} files",
+			"{0} files changed",
 			"New Session",
 			"New session",
-			"Open sessions"
+			"Open sessions",
+			"1 file",
+			"1 file changed"
+		],
+		"vs/sessions/browser/parts/sessionHeader": [
+			"New Session",
+			"Rename session"
 		],
 		"vs/sessions/browser/sessionsSetUpService": [
 			"Loading",
@@ -30777,23 +32225,31 @@
 			"Agents"
 		],
 		"vs/sessions/common/contextkeys": [
-			"The identifier of the active chat bar panel",
 			"Whether the active session has an associated git repository",
 			"Whether the active session has a git sync action currently running",
 			"The provider ID of the active session",
+			"The identifier of the active sessions panel",
 			"The session type of the active session",
+			"Whether the active session's provider offers a combined mode and model configuration picker (used on phone layouts in place of the standalone pickers)",
 			"Whether the active session's workspace is virtual",
-			"Whether the chat bar has keyboard focus",
-			"Whether the chat bar is visible",
 			"The provider ID of a session in context menu overlays",
+			"The session type of a session in context menu overlays",
 			"Whether the editor area is maximized",
 			"Whether the active session is archived (marked as done)",
-			"Whether the user is composing a new chat within the active session",
+			"Whether more than one session is visible in the sessions part's grid",
+			"Whether the session is archived (marked as done)",
+			"Whether the session view's session has been created (chat view shown, not new-session view)",
+			"Whether the session view is currently maximized in the sessions part's grid",
+			"Whether the session has been marked as read",
+			"Whether the session view's session is sticky in the grid",
 			"Whether the sessions aquarium overlay is active",
 			"Whether there is a previous session in the navigation history",
 			"Whether there is a next session in the navigation history",
+			"Whether the sessions part has keyboard focus",
 			"Whether the current layout is the phone layout",
 			"Whether the virtual keyboard is visible",
+			"Whether the session view's session supports multiple chats",
+			"Whether the sessions part is visible",
 			"Whether the sessions welcome overlay is visible",
 			"The currently active group tab in the session workspace picker"
 		],
@@ -30803,15 +32259,15 @@
 			"Heading 1 font size for the agents window (welcome screen title).",
 			"Heading 2 font size for the agents window (title).",
 			"Heading 3 font size for the agents window (subtitle).",
-			"Label 1 font size for the agents window (interactive tabs).",
-			"Label 2 font size for the agents window (metadata emphasis).",
-			"Label 3 font size for the agents window (metadata primary).",
-			"Label 4 font size for the agents window (badge).",
-			"Medium font weight (500) for the agents window.",
+			"Label 1 font size for the agents window (section title, tabs).",
+			"Label 2 font size for the agents window (metadata).",
+			"Label 3 font size for the agents window (badge).",
 			"Regular font weight (400) for the agents window.",
 			"SemiBold font weight (600) for the agents window."
 		],
 		"vs/sessions/common/theme": [
+			"Background color of an active session view in the agent sessions window.",
+			"Foreground color of an active session view in the agent sessions window.",
 			"Border color of the agent feedback input widget shown in the editor.",
 			"Background color of the agent sessions window shell and gradient base.",
 			"Background color of badges in the agent sessions window.",
@@ -30832,7 +32288,9 @@
 			"Background color of the unread sessions count badge on the sidebar toggle.",
 			"Foreground color of the unread sessions count badge on the sidebar toggle.",
 			"Background color of the update button when download is complete in the agent sessions window.",
-			"Background color of the update button to show download progress in the agent sessions window."
+			"Background color of the update button to show download progress in the agent sessions window.",
+			"Background color of an inactive session view in the agent sessions window.",
+			"Foreground color of an inactive session view in the agent sessions window."
 		],
 		"vs/sessions/contrib/accountMenu/browser/account.contribution": [
 			"GitHub profile image for {0}",
@@ -30870,8 +32328,9 @@
 			"Navigation Status"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution": [
-			"Add Feedback (Enter)",
-			"Add Feedback and Submit (Alt+Enter)",
+			"Add Feedback",
+			"Add Feedback and Submit",
+			"Add Comment",
 			"Add Feedback",
 			"Alt+Enter",
 			"Enter"
@@ -30881,19 +32340,19 @@
 			"0/0"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution": [
+			"Accept",
+			"Add a comment…",
+			"Add to Comment",
+			"Agent Review",
 			"Collapse",
 			"Convert to Agent Feedback",
 			"Edit",
 			"Expand",
-			"Feedback",
-			"Feedback Suggestion",
 			"Line {0}",
 			"Lines {0}-{1}",
 			"{0} comments",
 			"PR Review",
 			"Remove",
-			"Review",
-			"Review Suggestion",
 			"Suggested Change • Line {0}",
 			"Suggested Change • Lines {0}-{1}"
 		],
@@ -30958,7 +32417,8 @@
 		"vs/sessions/contrib/changes/browser/changes.contribution": [
 			"Changes",
 			"View icon for the Changes view.",
-			"Chan&&ges"
+			"Chan&&ges",
+			"Controls whether clicking a file in the Changes view opens a single file diff editor instead of the multi file diff editor."
 		],
 		"vs/sessions/contrib/changes/browser/changesTitleBarWidget": [
 			"Icon for the sessions secondary sidebar when closed.",
@@ -31005,6 +32465,7 @@
 			"Your customization was saved to this session's worktree, but we couldn't apply it to the default branch. You may need to apply it manually.",
 			"Your customization was removed from this session's worktree, but we couldn't apply the change to the default branch. You may need to remove it manually.",
 			"Used by the Submit Feedback button in the Changes toolbar",
+			"Used by the Run Code Review button in the Changes view",
 			"Used by the Commit button in the Changes toolbar",
 			"Used by the Create Draft Pull Request button in the Changes toolbar",
 			"Used by the Create Pull Request button in the Changes toolbar",
@@ -31017,10 +32478,8 @@
 			"Branch to new session"
 		],
 		"vs/sessions/contrib/chat/browser/chat.contribution": [
-			"New Chat",
-			"Chat",
-			"View icon of the chat view.",
-			"New Session",
+			"Whether to automatically run tasks tagged with `\"runOptions\": { \"runOn\": \"worktreeCreated\" }` when a new agent host session worktree is created. Manual `Run Task` invocations are unaffected.",
+			"Controls whether chat input history in the Agents Window is scoped to the current session. Disable this to use shared input history across sessions.",
 			"New Chat"
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
@@ -31032,6 +32491,9 @@
 			"No folders match",
 			"Search folders…",
 			"Choose Workspace"
+		],
+		"vs/sessions/contrib/chat/browser/modelPicker": [
+			"Model"
 		],
 		"vs/sessions/contrib/chat/browser/newChatContextAttachments": [
 			"Attach as Context",
@@ -31049,6 +32511,7 @@
 			"Chat input. Press Enter to send out the request. Use the Chat Accessibility Help command for more information.",
 			"Loading...",
 			"Send",
+			"Send (Alt-click to start in the background)",
 			"Describe the outcome you want",
 			"Describe what you want to build",
 			"Describe your mission",
@@ -31065,13 +32528,13 @@
 			"What will you ship today?",
 			"What would you like to automate?"
 		],
-		"vs/sessions/contrib/chat/browser/newChatInSessionViewPane": [
+		"vs/sessions/contrib/chat/browser/newChatInSessionWidget": [
 			"Ask a follow-up question or start a new topic within this session...",
 			"Sub-session tip",
 			"Dismiss tip",
 			"This is a sub-session, a new chat in the same workspace. Use it to ask questions, run tasks, or explore ideas with fresh context."
 		],
-		"vs/sessions/contrib/chat/browser/newChatViewPane": [
+		"vs/sessions/contrib/chat/browser/newChatWidget": [
 			"Start by picking a",
 			"New session in",
 			"with",
@@ -31164,7 +32627,10 @@
 			"Focus the Files Explorer view{0}.",
 			"Use up and down arrows to navigate your request history in the input box.",
 			"You are in the chat input. Type a message and press Enter to send it.",
+			"Press Alt+Enter to start the session in the background without navigating into it. The started session appears in the Chat Sessions view.",
 			"On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection.",
+			"Navigate to the next session in the list{0}.",
+			"Navigate to the previous session in the list{0}.",
 			"You are in the Agents window. The Agents window is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options.",
 			"Focus the Chat Sessions view{0}.",
 			"Shift+Tab to navigate to the workspace picker and choose a workspace for your session."
@@ -31174,11 +32640,12 @@
 			"Pick Session Type, {0}"
 		],
 		"vs/sessions/contrib/chat/browser/sessionWorkspacePicker": [
-			"Select a provider",
 			"workspace",
 			"Workspace Picker",
 			"Select...",
 			"Select...",
+			"Connecting to {0}...",
+			"Failed to connect to {0}.",
 			"Experimental",
 			"Search Workspaces...",
 			"Start by picking a workspace",
@@ -31188,6 +32655,7 @@
 			"View and manage custom agents",
 			"View and manage hooks",
 			"View and manage instructions",
+			"Open the model picker",
 			"View and manage skills"
 		],
 		"vs/sessions/contrib/chat/browser/variableCompletions": [
@@ -31202,23 +32670,17 @@
 			"View icon of the chat debug view in the sessions window."
 		],
 		"vs/sessions/contrib/codeReview/browser/codeReview.contributions": [
-			"True when a new code review can be started for the active session version.",
 			"Run Code Review",
-			"No changes available for code review.",
-			"No active session available for code review.",
-			"Run Code Review",
-			"Maximum of {0} code reviews reached for this session version.",
-			"Creating code review...",
-			"{0} review comments unresolved.",
-			"Previous code review produced no comments. Run code review again.",
-			"1 review comment unresolved.",
-			"Run another code review."
+			"Run Code Review"
 		],
 		"vs/sessions/contrib/editor/browser/editor.contribution": [
+			"Add File as Context",
 			"Close Editor Area",
 			"Maximize Editor Area",
 			"Open in Modal Editor",
 			"Open in Editor Area",
+			"Show Secondary Side Bar",
+			"Push Editor Right",
 			"Restore Editor Area"
 		],
 		"vs/sessions/contrib/files/browser/files.contribution": [
@@ -31248,13 +32710,13 @@
 			"Open VS Code",
 			"Agents Disabled"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker": [
+			"Agent"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostClaudePermissionModePicker": [
 			"Approvals Picker",
 			"Pick Approvals, {0}",
 			"Learn more about permissions"
-		],
-		"vs/sessions/contrib/providers/agentHost/browser/agentHostModelPicker": [
-			"Model"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
 			"Agent Mode Picker",
@@ -31262,6 +32724,10 @@
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
 			"Copy Session Branch Name"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionChangesets": [
+			"Last Turn Changes",
+			"Show only changes made in the last turn"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker": [
 			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.",
@@ -31277,6 +32743,10 @@
 			"Agent Mode",
 			"Approvals",
 			"{0} Picker",
+			"Off",
+			"Off",
+			"On",
+			"On",
 			"Filter options...",
 			"{0}: {1}",
 			"{0}: {1}, Read-Only",
@@ -31317,15 +32787,18 @@
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider": [
 			"Copilot CLI",
+			"New Session",
 			"Agent host has not advertised any agents yet.",
 			"Cannot send request: not connected to agent host."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
 			"Export Agent Host Debug Logs..."
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution": [
+			"When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#{0}#`."
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider": [
-			"Local Agent Host",
-			"Local"
+			"Local Agent Host"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
 			"Open Copilot CLI State File"
@@ -31341,6 +32814,8 @@
 			"Claude edits files without asking",
 			"Auto",
 			"A model classifier approves or denies tool operations automatically",
+			"Bypass Permissions",
+			"All tools run without any confirmation",
 			"Ask Before Edits",
 			"Claude asks for approval before making changes",
 			"Plan Mode",
@@ -31350,16 +32825,13 @@
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution": [
 			"Enable Claude Agent sessions in the Agents window. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly. Uses your existing Copilot subscription.",
-			"Enable Local VS Code chat sessions in the Agents Window.",
 			"Whether to enable multiple chats within a single session in the Copilot Chat sessions provider."
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
 			"Branch",
 			"Permission Mode",
-			"Model",
 			"Delete...",
 			"Isolation Mode",
-			"Model",
 			"Mode",
 			"Permissions"
 		],
@@ -31385,7 +32857,6 @@
 			"Delete",
 			"This action cannot be undone.",
 			"This will delete all {0} chats in this session. This action cannot be undone.",
-			"Local",
 			"New Chat",
 			"New Session",
 			"Repositories",
@@ -31407,12 +32878,6 @@
 			"Copilot uses your configured settings",
 			"Learn more about permissions"
 		],
-		"vs/sessions/contrib/providers/copilotChatSessions/browser/modelPicker": [
-			"Model Picker",
-			"Auto",
-			"Filter models...",
-			"Pick Model, {0}"
-		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker": [
 			"Configure Custom Agents...",
 			"Mode Picker",
@@ -31425,12 +32890,25 @@
 			"Bypass Approvals",
 			"All tool calls are auto-approved",
 			"Autopilot (Preview)",
+			"Auto-approve all tool calls and continue until the task is done. Autopilot may increase costs.",
 			"Autopilot (Preview)",
 			"Autonomously iterates from start to finish",
 			"Default Approvals",
 			"Default Approvals",
 			"Copilot uses your configured settings",
 			"Learn more about permissions"
+		],
+		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution": [
+			"Enable Local VS Code chat sessions in the Agents Window. Reload the window for changes to take effect."
+		],
+		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider": [
+			"Are you sure you want to delete this chat?",
+			"Delete",
+			"This action cannot be undone.",
+			"Local Chat",
+			"Local",
+			"New Chat",
+			"New Session"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/manageRemoteAgentHosts": [
 			"Add or Manage",
@@ -31452,7 +32930,8 @@
 			"Enable connecting to remote agent hosts.",
 			"A display name for this remote agent host.",
 			"Additional dev tunnel names to look for when connecting to remote agent hosts. These are looked up in addition to tunnels automatically enumerated from your account.",
-			"For development: Override the command used to start the remote agent host over SSH. When set, skips automatic CLI installation and runs this command instead. The command must print a WebSocket URL matching ws://127.0.0.1:PORT (optionally with ?tkn=TOKEN) to stdout or stderr./"
+			"For development: Override the command used to start the remote agent host over SSH. When set, skips automatic CLI installation and runs this command instead. The command must print a WebSocket URL matching ws://127.0.0.1:PORT (optionally with ?tkn=TOKEN) to stdout or stderr./",
+			"Remove from Remote Host"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostActions": [
 			"Add New SSH Host...",
@@ -31467,6 +32946,8 @@
 			"SSH...",
 			"Connect to Remote Agent Host via Dev Tunnel",
 			"Tunnels...",
+			"Connect to Remote Agent Host via WSL",
+			"WSL...",
 			"My Remote",
 			"Enter a display name for this remote agent host.",
 			"Name Remote Agent Host",
@@ -31515,13 +32996,23 @@
 			"Failed to list dev tunnels: {0}",
 			"No dev tunnels with agent host support were found. Start a tunnel with 'code tunnel' on another machine.",
 			"Select a dev tunnel to connect to",
-			"Connect via Dev Tunnel"
+			"Connect via Dev Tunnel",
+			"Failed to connect to WSL distribution '{0}': {1}",
+			"Connecting to WSL distribution '{0}'...",
+			"Default distribution",
+			"Running",
+			"Stopped",
+			"Install WSL",
+			"Failed to list WSL distributions: {0}",
+			"No WSL 2 distributions are installed.",
+			"Windows Subsystem for Linux is not installed or not enabled.",
+			"Select a WSL distribution to connect to",
+			"Connect via WSL"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostCustomizationHarness": [
 			"Add Remote Plugin",
 			"Add a plugin folder that already exists on this remote agent host.",
 			"'{0}' is already configured on {1}.",
-			"Remove from Remote Host",
 			"Select Plugin Folder on {0}"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostSessionsProvider": [
@@ -31532,9 +33023,6 @@
 			"Cannot send request: not connected to remote agent host '{0}'.",
 			"Cannot create session: not connected to remote agent host '{0}'.",
 			"Select Folder on {0}"
-		],
-		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHostTerminal.contribution": [
-			"Agent Host Terminal ({0})"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteHostOptions": [
 			"Cannot connect to {0}: {1}",
@@ -31555,7 +33043,6 @@
 			"Reconnect",
 			"Options for {0}",
 			"Remove Remote",
-			"Show Output",
 			"Connecting",
 			"Incompatible",
 			"Offline",
@@ -31594,8 +33081,14 @@
 			"Skills"
 		],
 		"vs/sessions/contrib/sessions/browser/mobile/mobileOverlayContribution": [
+			"File-level changes are not available for this session yet.",
 			"Open File Diff",
 			"Open Session Changes"
+		],
+		"vs/sessions/contrib/sessions/browser/sessionHoverContent": [
+			"1 file changed",
+			"{0} files changed",
+			"New Session"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"Sessions",
@@ -31603,20 +33096,37 @@
 			"&&Sessions"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsActions": [
+			"New Chat",
+			"Close",
+			"Maximize Session",
+			"Pin Session",
+			"Pin View",
+			"Restore Session",
+			"Unpin Session",
+			"Unpin View",
+			"Close All Sessions",
+			"Close Editor Area",
+			"Focus Active Session",
+			"Focus Last Session in Grid",
+			"Focus Session {0} in Grid",
 			"&&Back",
 			"&&Forward",
 			"New Session",
-			"Recent Sessions",
-			"Search sessions by name",
+			"other sessions",
+			"recently opened",
+			"Rename...",
+			"Search sessions by name or folder",
 			"Go Back",
+			"Go Back One Session",
 			"Go Forward",
+			"Go Forward One Session",
 			"Show Sessions Picker",
 			"New Session"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget": [
-			"New Session",
 			"Agent Sessions",
 			"Show Sessions",
+			"New Session",
 			"Show Sessions"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
@@ -31630,6 +33140,7 @@
 			"Pinned",
 			"now",
 			"{0}, created {1}",
+			"{0} sessions",
 			"Sessions",
 			"Show fewer sessions",
 			"Show less",
@@ -31637,6 +33148,8 @@
 			"Show fewer workspaces",
 			"Show {0} more sessions",
 			"+{0} more",
+			"Show {0} more workspace",
+			"+{0} more workspace",
 			"Show {0} more workspaces",
 			"+{0} more workspaces",
 			"Today",
@@ -31667,7 +33180,6 @@
 			"Input Needed"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
-			"New Sub-Session",
 			"Are you sure you want to mark {0} pinned sessions as done?",
 			"Are you sure you want to mark 1 pinned session as done?",
 			"Mark All as Done",
@@ -31689,8 +33201,12 @@
 			"Mark as Done",
 			"Mark as Read",
 			"Mark as Unread",
+			"Go to Next Session",
+			"&&Next Session",
+			"Go to Previous Session",
+			"&&Previous Session",
 			"New Session",
-			"Open in New Window",
+			"Open to the Side",
 			"Pin",
 			"Refresh Sessions",
 			"Rename...",
@@ -31706,6 +33222,9 @@
 			"Restore All",
 			"Restore",
 			"Unpin"
+		],
+		"vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner": [
+			"Task: {0}"
 		],
 		"vs/sessions/contrib/terminal/browser/sessionsTerminalContribution": [
 			"Dump Terminal Tracking",
@@ -31777,6 +33296,9 @@
 			"Learn more",
 			"Login with {0}",
 			"No",
+			"Resource client secret",
+			"The resource at '{0}' uses a per-resource client identifier '{1}'. Enter the matching client secret (leave blank if none). The value is saved in OS secret storage; manage it later via the 'Set Client Secret' code lens in mcp.json.",
+			"Resource Client Secret Required",
 			"Yes"
 		],
 		"vs/workbench/api/browser/mainThreadChatSessions": [
@@ -31841,6 +33363,11 @@
 			"The chosen account, {0}, does not match the requested account, {1}.",
 			"Keep {0}",
 			"Login with {0}",
+			"Enterprise-managed MCP authentication requires `mcp.enterpriseManagedAuth.idp.issuer` to be a valid URL; got '{0}'.",
+			"Enterprise-managed MCP authentication requires `mcp.enterpriseManagedAuth.idp.issuer` to be configured. Set it via enterprise policy (Windows Group Policy / macOS managed preferences / Linux `/etc/vscode/policy.json`) or, for local testing, by hand-editing `settings.json`.",
+			"Enterprise-managed MCP authentication requires `mcp.enterpriseManagedAuth.idp.issuer` to use the `https` or `http` scheme; got '{0}'.",
+			"The enterprise-managed MCP server '{0}' did not advertise an `authorization_servers` entry in its protected-resource metadata.",
+			"The enterprise-managed MCP server '{0}' did not advertise a protected-resource metadata document with a 'resource' identifier.",
 			"Authentication session for {0} removed, stopping server"
 		],
 		"vs/workbench/api/browser/mainThreadMessageService": [
@@ -32525,6 +34052,7 @@
 		],
 		"vs/workbench/browser/parts/editor/breadcrumbsControl": [
 			"Whether breadcrumbs have focus",
+			"Whether breadcrumbs contain symbol items",
 			"Whether the editor can show breadcrumbs",
 			"Whether breadcrumbs are currently visible",
 			"Copy Breadcrumbs Path",
@@ -33249,6 +34777,11 @@
 			"Error running command {1}: {0}. This is likely caused by the extension that contributes {1}.",
 			"There is no data provider registered that can provide view data.",
 			"Refresh",
+			"Actions for {0}",
+			"Actions",
+			"has actions",
+			"{0}, has actions",
+			"{0}, has actions",
 			"Whether the tree view with id {0} enables collapse all.",
 			"Whether the tree view with id {0} enables refresh.",
 			"Whether collapse all is toggled for the tree view with id {0}."
@@ -33599,6 +35132,7 @@
 			"Whether the auxiliary bar is visible",
 			"Whether the banner has keyboard focus",
 			"Whether there are any working copies with unsaved changes",
+			"Whether the editor area (any editor part) has keyboard focus",
 			"Whether an editor is open",
 			"Editor Part has a maximized group",
 			"Whether focus is in a modal editor part",
@@ -34072,6 +35606,110 @@
 		"vs/workbench/contrib/accessibilitySignals/browser/openDiffEditorAnnouncement": [
 			"Diff editor"
 		],
+		"vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution": [
+			"Keep the Voice Mode window always on top of other windows.",
+			"Voice backend WebSocket URL. Leave empty to use the default hosted backend. Set to e.g. `ws://localhost:8000/api/v1/realtime/voice` to point at a backend running on your machine.",
+			"Enable the Voice Mode panel in the chat view for voice-driven coding conversations.",
+			"When enabled, the assistant reads responses aloud. When disabled, responses appear as text transcripts only.",
+			"Voice Mode",
+			"Voice Mode: Push to Talk",
+			"Voice: Reset Onboarding",
+			"Voice Mode"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget": [
+			"Failed to submit"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidgetBinding": [
+			"Chat",
+			"Other",
+			"Untitled session"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/confirmationComponent": [
+			"Approve",
+			"Deny",
+			"Open in VS Code"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/feedbackDialog": [
+			"Cancel",
+			"By submitting, you agree that your session logs and transcript history will be included with your feedback.",
+			"Failed to submit feedback",
+			"What could we improve?",
+			"Thank you for your feedback!",
+			"Send Feedback",
+			"Submit",
+			"Submitting..."
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/headerComponent": [
+			"Configure keybinding",
+			"Disconnect",
+			"Minimize",
+			"Open mini-view",
+			"Push to talk (Space)",
+			"Send feedback"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/onboardingComponent": [
+			"to use it from any app.",
+			"Change push-to-talk key",
+			"Configure a keybinding",
+			"Connecting…",
+			"Use the feedback icon to help us improve your experience.",
+			"Get Started",
+			"to multitask while VS Code is not in the foreground.",
+			"Open the mini-view",
+			"Push-to-talk",
+			"— hold the key while speaking, release when done.",
+			"Speak to an assistant that controls multiple coding agents at once. Get notified when work is done or input is needed.",
+			"Welcome to Voice Chat"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/sessionListComponent": [
+			"Approve",
+			"Deny",
+			"New session",
+			"No active sessions",
+			"Open in VS Code",
+			"Open session",
+			"Send to",
+			"Send to (active)",
+			"Stop",
+			"Stop session"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/components/statusRowsComponent": [
+			"done",
+			"needs input",
+			"No active sessions",
+			"working"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscripts.contribution": [
+			"Show Voice Transcripts",
+			"Show Voice Transcripts",
+			"Agents Voice",
+			"Archive All",
+			"Delete All",
+			"Delete all voice transcripts?",
+			"Delete",
+			"This permanently deletes the local transcript file for your user. There is no server-side copy.",
+			"Focus Voice Transcripts View",
+			"Refresh",
+			"Voice Transcripts",
+			"Voice Transcripts",
+			"View icon of the Voice Transcripts view."
+		],
+		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscriptsView": [
+			"{0} archived turn{1} hidden.",
+			"Earlier this month",
+			"Earlier this week",
+			"No transcripts yet. Start a voice conversation to populate this view.",
+			"Older",
+			"Today",
+			"Yesterday"
+		],
+		"vs/workbench/contrib/agentsVoice/common/agentsVoiceColors": [
+			"Background color for the speaking voice state row highlight",
+			"Color for the speaking/active voice state indicator"
+		],
+		"vs/workbench/contrib/agentsVoice/common/voiceTranscriptStore": [
+			"Saving voice transcript"
+		],
 		"vs/workbench/contrib/authentication/browser/actions/manageAccountPreferencesForExtensionAction": [
 			"Accounts",
 			"Current account",
@@ -34164,6 +35802,12 @@
 		"vs/workbench/contrib/browserView/common/browserEditorInput": [
 			"Browser"
 		],
+		"vs/workbench/contrib/browserView/common/browserSearch": [
+			"Bing",
+			"DuckDuckGo",
+			"Google",
+			"Yahoo!"
+		],
 		"vs/workbench/contrib/browserView/common/browserView": [
 			"Cannot Share with Agent",
 			"&&Allow",
@@ -34174,8 +35818,84 @@
 			"Share with Agent?"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/browserEditor": [
-			"Whether the browser can go back",
-			"Whether the browser can go forward",
+			"Whether the browser editor is focused",
+			"Whether the browser has a load error",
+			"Whether the browser has a URL loaded",
+			"Browser"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/browserView.contribution": [
+			"Browser"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserDataStorageFeatures": [
+			"Clear Storage (Ephemeral)",
+			"Clear Storage (Global)",
+			"Clear Storage (Workspace)",
+			"Controls how browser data (cookies, cache, storage) is shared between browser views.\n\n**Note**: In untrusted workspaces, this setting is ignored and `ephemeral` storage is always used.",
+			"`global` for local workspaces, `workspace` for remote workspaces.",
+			"Each browser view has its own session that is cleaned up when closed.",
+			"All browser views share a single persistent session across all workspaces. Incompatible with remote sessions.",
+			"Browser views within the same workspace share a persistent session. If no workspace is opened, `ephemeral` storage is used.",
+			"The storage scope of the current browser view"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserDevToolsFeature": [
+			"Whether developer tools are open for the current browser view",
+			"Developer Tools"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures": [
+			"Add Area Screenshot to Chat",
+			"Add Console Logs to Chat",
+			"Add Element to Chat",
+			"Add Full Page Screenshot to Chat (Experimental)",
+			"Add Screenshot to Chat",
+			"Pages may contain hidden prompts that can influence agent behavior. Double-check the attached contents before sending.",
+			"Don't show again",
+			"Use caution when attaching content from untrusted sources.",
+			"&&OK",
+			"Whether area selection is currently active",
+			"Add to Chat",
+			"Whether element selection is currently active",
+			"When enabled, chat agents can use browser tools to open and interact with pages in the Integrated Browser.",
+			"When enabled, experimental user-facing tools are available in the Integrated Browser's Add to Chat menu.",
+			"Share with Agent",
+			"Sharing with Agent",
+			"Stop Sharing with Agent",
+			"Browser Area Screenshot",
+			"Browser",
+			"Browser Full Page Screenshot",
+			"Browser Screenshot",
+			"Console Logs",
+			"When enabled, integrated browser tools are exposed as client-provided tools to agent host sessions in the Sessions window. Requires {0} and {1}."
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorEmulationFeatures": [
+			"Dimensions:",
+			"Device pixel ratio",
+			"DPR:",
+			"Device pixel ratio (blank = system default)",
+			"Viewport height",
+			"auto",
+			"Scale:",
+			"Swap Dimensions",
+			"Viewport width",
+			"Zoom factor",
+			"Auto ({0}%)",
+			"mobile",
+			"Select a device preset",
+			"Whether the browser emulation has a custom user agent",
+			"Whether the browser emulation is in mobile mode",
+			"Close",
+			"Mobile Emulation",
+			"Apply Preset...",
+			"Reset",
+			"Set User Agent...",
+			"Whether the browser emulation toolbar is visible",
+			"Emulate Device...",
+			"Reset Emulation",
+			"Emulate User Agent...",
+			"Device Emulation",
+			"Toggle Mobile Emulation",
+			"User agent string (leave empty for VS Code default)"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorErrorFeatures": [
 			"Close Tab",
 			"Certificate Details",
 			"Error",
@@ -34184,64 +35904,18 @@
 			"Certificate Error",
 			"Fingerprint",
 			"Go Back",
+			"Your connection to this site is not secure.",
+			"You previously chose to proceed to '{0}' despite a certificate error ({1}).",
+			"Certificate Not Trusted",
 			"Issuer",
 			"Proceed anyway (unsafe)",
+			"Revoke and Close",
 			"Subject",
 			"Valid",
-			"Whether the browser editor is focused",
 			"URL:",
-			"Whether the browser has a load error",
-			"Whether the browser has a URL loaded",
 			"Failed to Load Page",
-			"Dismiss the notification to continue using the browser.",
-			"Paused due to Notification",
-			"Enter a URL",
-			"Enter a URL above to get started.",
-			"Use Add Element to Chat to reference UI elements in chat prompts.",
-			"Browser"
-		],
-		"vs/workbench/contrib/browserView/electron-browser/browserView.contribution": [
-			"Browser"
-		],
-		"vs/workbench/contrib/browserView/electron-browser/browserViewActions": [
-			"Focus URL Input",
-			"Go Back",
-			"Go Forward",
-			"Hard Reload",
-			"Open in External Browser",
-			"Open Browser Settings",
-			"Reload",
-			"Browser"
-		],
-		"vs/workbench/contrib/browserView/electron-browser/features/browserDataStorageFeatures": [
-			"Clear Storage (Ephemeral)",
-			"Clear Storage (Global)",
-			"Clear Storage (Workspace)",
-			"Controls how browser data (cookies, cache, storage) is shared between browser views.\n\n**Note**: In untrusted workspaces, this setting is ignored and `ephemeral` storage is always used.",
-			"Each browser view has its own session that is cleaned up when closed.",
-			"All browser views share a single persistent session across all workspaces.",
-			"Browser views within the same workspace share a persistent session. If no workspace is opened, `ephemeral` storage is used.",
-			"The storage scope of the current browser view"
-		],
-		"vs/workbench/contrib/browserView/electron-browser/features/browserDevToolsFeature": [
-			"Whether developer tools are open for the current browser view",
-			"Toggle Developer Tools"
-		],
-		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures": [
-			"Add Console Logs to Chat",
-			"Add Element to Chat",
-			"Pages may contain hidden prompts that can influence agent behavior. Double-check the attached contents before sending.",
-			"Don't show again",
-			"Use caution when attaching content from untrusted sources.",
-			"&&OK",
-			"Whether element selection is currently active",
-			"When enabled, chat agents can use browser tools to open and interact with pages in the Integrated Browser.",
-			"Share with Agent",
-			"Sharing with Agent",
-			"Stop Sharing with Agent",
-			"Browser",
-			"Console Logs",
-			"When enabled, integrated browser tools are exposed as client-provided tools to agent host sessions in the Sessions window. Requires {0} and {1}."
+			"Not Secure",
+			"This usually means the host is not available or could not be reached from the remote."
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorFindFeature": [
 			"Find Next",
@@ -34259,6 +35933,52 @@
 			"Reset Zoom",
 			"Zoom In",
 			"Zoom Out"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserFavoritesFeature": [
+			"Add to Favorites",
+			"Add to Favorites",
+			"Favorites",
+			"Remove from Favorites",
+			"Remove from Favorites ({0})",
+			"Whether the current browser URL is a favorite"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserHistoryFeature": [
+			"History",
+			"Clear All History",
+			"Clear Entries for This Day",
+			"Filter browser history",
+			"Browser History",
+			"Today",
+			"Yesterday",
+			"Maximum number of history items kept per session scope. Older entries are evicted first.",
+			"Recents",
+			"Remove from History",
+			"History"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserNavigationFeatures": [
+			"Whether the browser can go back",
+			"Whether the browser can go forward",
+			"Configure Search Engine",
+			"Focus URL Input",
+			"Go Back",
+			"Go Forward",
+			"Hard Reload",
+			"Open in External Browser",
+			"Browser Settings",
+			"Reload",
+			"{0} - {1} Search",
+			"Search or enter URL",
+			"Enter a URL"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserRemoteFeatures": [
+			"File URLs are served locally, not over the remote connection.",
+			"Connected locally",
+			"Connected via remote",
+			"When enabled, browser requests in remote workspaces are proxied through the remote connection. This allows web pages to access resources available on the remote host."
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserSearchFeatures": [
+			"None",
+			"Controls the search engine used to search the web from the address bar of the integrated browser. Select 'None' to disable search."
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserTabManagementFeatures": [
 			"Background",
@@ -34279,6 +35999,8 @@
 			"When enabled, localhost links (`localhost`, `127.0.0.1`, `[::1]`) and all-interfaces links (`0.0.0.0`, `[0:0:0:0:0:0:0:0]`, `[::]`) from the terminal, chat, and other sources will open in the Integrated Browser instead of the system browser.",
 			"New Integrated Browser Tab",
 			"Browser",
+			"Open Tabs",
+			"Select a tab to switch",
 			"Quick Open Browser Tab...",
 			"Select a browser tab",
 			"Controls whether the Integrated Browser button is shown in the title bar.",
@@ -34290,12 +36012,14 @@
 			"Integrated Browser",
 			"Toggle visibility of the Integrated Browser button in title bar"
 		],
-		"vs/workbench/contrib/browserView/electron-browser/siteInfoWidget": [
-			"Your connection to this site is not secure.",
-			"You previously chose to proceed to '{0}' despite a certificate error ({1}).",
-			"Certificate Not Trusted",
-			"Revoke and Close",
-			"Not Secure"
+		"vs/workbench/contrib/browserView/electron-browser/features/browserWelcomeFeature": [
+			"Enter a URL above to get started.",
+			"Use Add Element to Chat to reference UI elements in chat prompts.",
+			"Browser"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/webContentsViewRendererFeature": [
+			"Dismiss the notification to continue using the browser.",
+			"Paused due to Notification"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/tools/browserToolHelpers": [
 			"Blocked by network domain policy",
@@ -34407,8 +36131,16 @@
 			"Typing text in {0} in {1}",
 			"Typed text in {0}",
 			"Typed text in {0} in {1}",
+			"Typing text in {0} and pressing Enter",
+			"Typing text in {0} in {1} and pressing Enter",
+			"Typed text in {0} and pressed Enter",
+			"Typed text in {0} in {1} and pressed Enter",
 			"Type in Page",
 			"Type text or press keys in a browser page"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/widgets/browserUrlBarWidget": [
+			"Go to {0}",
+			"Enter a URL"
 		],
 		"vs/workbench/contrib/bulkEdit/browser/bulkEditService": [
 			"'{0}' is in progress.",
@@ -34600,6 +36332,7 @@
 			"To create a new chat session, invoke the New Chat command{0}.",
 			"To focus the next code block within a response, invoke the Chat: Next Code Block command{0}.",
 			"To navigate to the next user prompt in the conversation, invoke the Next User Prompt command{0}.",
+			"When starting an agent session in a multi-root workspace, you can choose which root folder it runs in by invoking the Folder command{0}, then selecting a folder from the list.",
 			"To navigate to the previous user prompt in the conversation, invoke the Previous User Prompt command{0}.",
 			"- Restore to Last Checkpoint{0}.",
 			"- Undo Edits{0}.",
@@ -34728,6 +36461,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatDeveloperActions": [
 			"Clear Recently Used Language Models",
+			"Inspect Agent Host Subscriptions",
 			"Inspect Chat Model",
 			"Inspect Chat Model References",
 			"Log Chat Index",
@@ -34838,12 +36572,14 @@
 		"vs/workbench/contrib/chat/browser/actions/chatPluginActions": [
 			"Install Plugin from Source",
 			"Local",
+			"{0} (managed by enterprise policy)",
 			"Manage Plugin Marketplaces",
 			"No plugin marketplaces configured",
 			"Open Folder",
 			"Plugins",
 			"owner/repo or git clone URL",
 			"Enter a GitHub repository or git URL to install a plugin from",
+			"Enterprise policy manages '{0}', so it can't be removed here.",
 			"Remove Marketplace",
 			"Select a plugin marketplace",
 			"Select an action for '{0}'",
@@ -34973,6 +36709,7 @@
 			"Install",
 			"Open Plugin Folder",
 			"Open README",
+			"The plugin \"{0}\" has been disabled by your organization and cannot be enabled.",
 			"Uninstall"
 		],
 		"vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor": [
@@ -35006,10 +36743,14 @@
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution": [
 			"{0} - Agent Host",
-			"{0} [Local]"
+			"{0} [Agent Host]"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
 			"{0} Picker",
+			"Off",
+			"Off",
+			"On",
+			"On",
 			"Filter...",
 			"Learn more about permissions",
 			"{0}: {1}",
@@ -35018,13 +36759,12 @@
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution": [
 			"Auto-Approve",
-			"Branch",
-			"Isolation",
+			"Folder",
 			"Agent Mode",
 			"Approvals"
 		],
-		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostEditingSession": [
-			"Suggested Edits"
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem": [
+			"Folder"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution": [
 			"Allow",
@@ -35041,13 +36781,12 @@
 			"Open this URL?",
 			"Open {0}",
 			"Authorization Required",
+			"Forked Session",
 			"{0} credit",
 			"{0} credits",
-			"Forked Session",
-			"Forked: {0}"
+			"Error: ({0}) {1}"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
-			"Agent Host Terminal (Local)",
 			"Local"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter": [
@@ -35072,6 +36811,7 @@
 			"Opens a new Codex session in the editor. Codex sessions can be managed from the chat sessions view.",
 			"Learn about Copilot features.",
 			"Run tasks within VS Code chat. The agent iterates via chat and works interactively to implement changes on your main workspace.",
+			"Copilot CLI [Agent Host]",
 			"Copilot CLI",
 			"Cloud",
 			"Local"
@@ -35115,6 +36855,7 @@
 			"Are you sure you want to delete this chat session?",
 			"Delete",
 			"This action cannot be undone.",
+			"Failed to delete chat session: {0}",
 			"Are you sure you want to delete {0} chat sessions?",
 			"Do not ask me again",
 			"Find Agent Session",
@@ -35278,6 +37019,13 @@
 			"Show Agent Sessions",
 			"Show Commands (Unified)",
 			"Show Files (Unified)"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability": [
+			"No models available",
+			"No models are available for this agent.",
+			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan) to use this agent.",
+			"[Upgrade](command:workbench.action.chat.upgradePlan)",
+			"Requires GitHub Copilot Pro"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons": [
 			"Icon for adding new items.",
@@ -35444,7 +37192,6 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor": [
 			"Agents",
 			"Define custom agents with specialized personas, tool access, and instructions for specific tasks.",
-			"The color of the Agent Customizations editor splitview sash border.",
 			"Back to list",
 			"Back to list",
 			"Back to MCP servers",
@@ -35463,18 +37210,19 @@
 			"View Raw",
 			"Show the raw markdown file",
 			"Overview",
+			"Overview",
 			"Back to overview",
 			"Hooks",
 			"Configure automated actions triggered by events like saving files or running tasks.",
 			"Instructions",
 			"Set always-on instructions that guide AI behavior across your workspace or user profile.",
 			"Learn more about language models",
+			"Local",
 			"MCP Servers",
 			"Connect external tool servers that extend AI capabilities with custom tools and data sources.",
 			"Models",
 			"Configure and manage language models available for use.",
 			"Browse and manage language models from different providers. Select models for use in chat, code completion, and other AI features.",
-			"Overview",
 			"Plugins",
 			"Install and manage agent plugins that add additional tools, skills, and integrations.",
 			"Show help for '{0}'",
@@ -35502,7 +37250,8 @@
 			"Workspace"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditorInput": [
-			"Agent Customizations"
+			"Agent Customizations",
+			"Agent Customizations for {0}"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationWelcomePagePromptLaunchers": [
 			"Agents",
@@ -35524,7 +37273,7 @@
 			"Sent to chat ✓",
 			"Skills",
 			"Create reusable skill files that provide domain-specific knowledge and workflows.",
-			"Agent Customizations",
+			"Agent Customizations for {0}",
 			"Tailor how agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.",
 			"Describe your preferences to customize your agent",
 			"Prefer concise commits, thorough reviews, and tested code...",
@@ -35553,6 +37302,7 @@
 			"Add an MCP server configuration to get started",
 			"Add Server",
 			"Add Server",
+			"Back to installed servers",
 			"Browse Marketplace",
 			"Built-in",
 			"MCP servers built into VS Code. These are available automatically.",
@@ -35576,6 +37326,7 @@
 			"MCP servers are disabled in settings. ",
 			"Configure in settings.",
 			"MCP servers are disabled",
+			"Back",
 			"{0}, {1} items, {2}",
 			"MCP Servers",
 			"An open standard that lets AI use external tools and services. MCP servers provide tools for file operations, databases, APIs, and more.",
@@ -35666,6 +37417,10 @@
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets": [
 			"Attached context, {0}",
 			"Remove from context",
+			"Save As...",
+			"Failed to save file: {0}",
+			"Save Image As...",
+			"Failed to save image: {0}",
 			"{0} (Delete)",
 			"Browser tools are not enabled.",
 			"Browser tools are not enabled, {0}",
@@ -35760,18 +37515,14 @@
 			"Show thinking in a fixed-height streaming panel that auto-scrolls; click header to expand to full height.",
 			"Controls how thinking is rendered.",
 			"When enabled, logs all AHP transport messages for agent host connections to JSONL files under the window's log directory.",
-			"Experimental, for local testing only. Absolute path to a locally-installed `@anthropic-ai/claude-agent-sdk` package. When set, the Claude agent provider is registered inside the agent host and the SDK is loaded from this path. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect. This setting will be removed once the SDK is delivered through the Extension Marketplace.",
 			"Tool reference names to expose as client-provided tools in agent host sessions.",
 			"When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior.",
-			"When enabled, some agents run in a separate agent host process.",
-			"When enabled, logs all IPC traffic for each agent host to a dedicated output channel.",
-			"When enabled, includes prompt and response content in OTel span attributes. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks.",
-			"When enabled, the agent host persists every emitted OTel span to a local SQLite database. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink.",
-			"When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally.",
-			"Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime.",
-			"OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process.",
-			"Output path for span JSON lines when exporter type is `file`. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`.",
+			"Sandbox mode for the Copilot SDK's built-in shell tool. Only takes effect when `#chat.agentHost.customTerminalTool.enabled#` is `false`; when the Agent Host's own terminal tool is enabled, the engine sandbox is controlled by `#chat.agent.sandbox.enabled#`.",
+			"The SDK's built-in shell tool runs inside a sandbox with unrestricted outbound network access.",
+			"No sandbox policy is forwarded for the SDK's built-in shell tool — commands run unsandboxed.",
+			"The SDK's built-in shell tool runs inside a sandbox using the configured filesystem policy and host-list-restricted network.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
+			"When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window.",
 			"Specify location(s) of custom agent files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
 			"Agent File Locations",
 			"Shows the agent status as a badge next to the command center.",
@@ -35779,6 +37530,10 @@
 			"Controls how the 'Agent Status' indicator appears in the title bar command center. When set to `hidden`, the indicator is not shown. Other values show the indicator and automatically enable {0}. The unread and in-progress session indicators require {1} to be enabled.",
 			"The agent status indicator is hidden from the title bar.",
 			"Controls whether Agent Session Projection mode is enabled for reviewing agent sessions in a focused workspace.",
+			"Controls the tip shown above the chat input offering to continue eligible agent sessions in the Agents Window.",
+			"Show the handoff tip with an alternate description.",
+			"Show the handoff tip with the default description.",
+			"Never show the handoff tip.",
 			"Specify location(s) of agent skills (`{0}`) that can be used in Chat Sessions. [Learn More]({1}).\n\nEach path should contain skill subfolders with SKILL.md files (e.g., add `my-skills` if you have `my-skills/skillA/SKILL.md`). Relative paths are resolved from the root folder(s) of your workspace.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
 			"Agent Skills Locations",
@@ -35795,7 +37550,7 @@
 			"Rules for extracting artifacts from tool results by MIME type. Maps MIME type patterns (e.g. 'image/*') to group configuration.",
 			"Display name for the artifact group.",
 			"When true, show only the group header instead of individual items.",
-			"Controls whether the Autopilot mode is available in the permissions picker. When enabled, Autopilot auto-approves all tool calls and continues until the task is done.",
+			"Enables **Advanced Autopilot**, a single switch that turns on all advanced Autopilot behaviors that delegate more of the loop to the agent. Currently, after each Autopilot turn a small, fast model evaluates whether your original request is complete; if not, Autopilot keeps working using that evaluation as guidance for the next turn, instead of relying on the agent to signal completion itself.",
 			"Automatically skip question carousels by telling the agent that the user is not available and to use its best judgment. This is an advanced setting and can lead to unintended choices or actions based on incomplete context.",
 			"Enables checkpoints in chat. Checkpoints allow you to restore the chat to a previous state.",
 			"Controls whether to show chat checkpoint file changes.",
@@ -35803,15 +37558,16 @@
 			"Show the context window usage indicator in the chat input.",
 			"Controls whether the harness selector is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering.",
 			"Controls whether the Chat Customizations editor shows a structured preview for markdown customization files (agents, skills, instructions, prompts). When disabled, the editor always opens the raw markdown in the embedded code editor.",
-			"When enabled, custom agents shown in the chat mode picker are sourced from the customization harness service (scoped per session type) instead of the prompts service.",
 			"Enables chat participant autodetection for panel chat.",
 			"Disable and hide built-in AI features provided by GitHub Copilot, including chat and inline suggestions.",
 			"Delay after which changes made by chat are automatically accepted. Values are in seconds, `0` means disabled and `100` seconds is the maximum.",
 			"Whether to show a confirmation before removing a request and its associated edits.",
 			"Whether to show a confirmation before retrying a request and its associated edits.",
 			"Controls whether the Explain button in the Chat panel and the Explain Changes context menu in the SCM view are shown. This is an experimental feature.",
+			"Controls whether selecting a file in the changed files list of a chat response opens it in a diff editor showing the changes made by chat, or in a regular editor. Holding `kbstyle(Alt)` while selecting the file opens it with the opposite behavior.",
 			"Controls whether the editor automatically reveals the next change after keeping or undoing a chat edit.",
 			"When enabled, hides the Edit mode from the chat mode picker.",
+			"When enabled, Claude sessions opened from the regular workbench (sidebar chat) run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window.",
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for opening files from chat (for example `\"*.md\": \"vscode.markdown.preview.editor\"`).",
 			"Enables editing of requests in the chat. This allows you to change the request content and resubmit it to the model.",
 			"Controls whether the chat panel automatically exits after delegating a request to another session.",
@@ -35888,7 +37644,6 @@
 			"Always show OS notifications for responses, even when the window is focused.",
 			"Never show OS notifications for responses.",
 			"Show OS notifications for responses when the window is not focused.",
-			"Experimental: enable BYOK chat features without GitHub sign-in.",
 			"Start new chat sessions in Bypass Approvals mode.",
 			"Bypass Approvals",
 			"Start new chat sessions in Autopilot mode.",
@@ -35901,7 +37656,13 @@
 			"When enabled, the plan review widget mounts an editor inline, as opposed to in a separate editor tab.",
 			"Plugin directories to discover. Each key is a path that points directly to a plugin folder, and the value enables (`true`) or disables (`false`) it. Paths can be absolute, relative to the workspace root, or start with `~/` for the user's home directory.",
 			"Enable agent plugin integration in chat.",
-			"Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated.",
+			"Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form (resolved to Copilot CLI install paths); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, also restricts which marketplace-discovered plugins are allowed to load (only IDs mapped to `true` here pass the gate).",
+			"Plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin.",
+			"Enterprise-managed additional plugin marketplaces. Unioned with {0}.",
+			"Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`).",
+			"Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo` or `owner/repo#ref`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`, each optionally suffixed with `#ref`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated.",
+			"When enabled, only marketplaces supplied via enterprise policy are trusted. Plugins from any other marketplace will not load.",
+			"Only trust marketplaces supplied via enterprise policy; plugins from any other marketplace will not load.",
 			"Show an animated gradient border around the chat input while the agent is working or thinking. When enabled and reduced motion is not enabled, this overrides {0} to be off. Has no effect when reduced motion is enabled.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported. Glob patterns are deprecated and will be removed in future versions.",
 			"Configure which prompt files to recommend in the chat welcome view. Each key is a prompt file name, and the value can be `true` to always recommend, `false` to never recommend, or a [when clause](https://aka.ms/vscode-when-clause) expression like `resourceExtname == .js` or `resourceLangId == markdown`.",
@@ -35919,6 +37680,7 @@
 			"Allow subagents to invoke subagents.",
 			"Controls whether subagents can invoke other subagents. When enabled, nesting is limited to a maximum depth of 5.",
 			"Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features.",
+			"Controls whether the Open in Agents Window button is shown in the title bar.",
 			"Controls whether the Copilot Sign In button is shown in the title bar when signed out. When disabled, the Sign In affordance falls back to the status bar.",
 			"{0} - {1}",
 			"Controls whether edits made by the agent are automatically approved. The default is to approve all edits except those made to certain files which have the potential to cause immediate unintended side-effects, such as `**/.vscode/*.json`.\n\nSet to `true` to automatically approve edits to matching files, `false` to always require explicit approval. The last pattern matching a given file will determine whether the edit is automatically approved.",
@@ -35927,7 +37689,7 @@
 			"When enabled, multiple tool confirmations are batched into a carousel above the input.",
 			"Controls which tools are eligible for automatic approval. Tools set to 'false' will always present a confirmation and will never offer the option to auto-approve. The default behavior (or setting a tool to 'true') may result in the tool offering auto-approval options.",
 			"Controls which URLs are automatically approved when requested by chat tools. Keys are URL patterns and values can be `true` to approve both requests and responses, `false` to deny, or an object with `approveRequest` and `approveResponse` properties for granular control.\n\nExamples:\n- `\"https://example.com\": true` - Approve all requests to example.com\n- `\"https://*.example.com\": true` - Approve all requests to any subdomain of example.com\n- `\"https://example.com/api/*\": { \"approveRequest\": true, \"approveResponse\": false }` - Approve requests but not responses for example.com/api paths",
-			"When enabled, terminal tool confirmations show an LLM-generated risk level (Safe / Caution / Review carefully) and a short explanation.",
+			"When enabled, tool confirmations show an LLM-generated risk level (Safe / Caution / Review carefully) and a short explanation.",
 			"The language model id used to generate tool risk assessments. Should be a small, fast model.",
 			"When enabled, terminal tool calls are always displayed in a collapsible container with a simplified view.",
 			"Controls whether to show the todo list widget above the chat input. When enabled, the widget displays todo items created by the agent and updates as progress is made.",
@@ -35955,8 +37717,8 @@
 			"Use nested AGENTS.md files",
 			"Controls whether a stronger skill adherence prompt is used that encourages the model to immediately invoke skills when relevant rather than just announcing them.",
 			"Use Skill Adherence Prompt",
-			"Override the language model used by built-in utility flows (titles, summaries, fallback responses, etc.). Leave empty to use the default model.",
-			"Override the language model used by built-in small/fast utility flows (commit messages, intent detection, inline-chat progress, etc.). A fast and inexpensive model is recommended. Leave empty to use the default model.",
+			"Override the language model used by built-in utility flows. Leave empty to use the default model.",
+			"Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the default model.",
 			"Show a progress badge on the chat view when an agent session is in progress that is opened in that view.",
 			"Show chat agent sessions when chat is empty or to the side when chat view is wide enough.",
 			"Controls the orientation of the chat agent sessions view when it is shown alongside the chat.",
@@ -35970,6 +37732,11 @@
 			"Controls whether lines should wrap in chat codeblocks.",
 			"Chat",
 			"Configures discovery of Model Context Protocol servers from configuration from various other applications.",
+			"(Preview) The OAuth/OIDC IdP configuration used for enterprise-managed Model Context Protocol (MCP) servers. Typically delivered via enterprise policy (Windows Group Policy / macOS managed preferences / Linux `/etc/vscode/policy.json`); developers may hand-edit `settings.json` for local testing. Properties: `issuer` (HTTPS URL), `clientId`, `clientSecret`.",
+			"The OAuth client ID registered with the SSO issuer for this device.",
+			"The OAuth client secret paired with `clientId`. Intended for local development only.",
+			"The OAuth/OIDC issuer URL of the SSO authorization server. Must be an `https://` URL.",
+			"The OAuth/OIDC IdP configuration used for enterprise-managed Model Context Protocol (MCP) server authentication. Delivered through enterprise policy (Windows Group Policy, macOS managed preferences, Linux `/etc/vscode/policy.json`).",
 			"Configure the MCP Gallery service URL to connect to",
 			"List Servers"
 		],
@@ -36008,62 +37775,67 @@
 			"unknown"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheExplorerView": [
+			"{0} ({1})",
 			"All components are identical between A and B.",
 			"content drift",
 			"identical",
 			"length change",
 			"only in A",
 			"only in B",
-			"At {0} — {1}",
 			"Cache break at messages[{0}]",
 			"cached tok",
 			"cache hit",
+			"What changed: {0}",
 			"{0} chars",
+			"Chunk breakdown",
+			"Chunk",
+			"#",
 			"Components",
 			"{0} → {1} chars",
 			"This request uses previous_response_id, so input messages are not positionally diffed against the previous request. Components below show cache-key shape changes; the current continuation delta is shown separately.",
-			"The visible wire delta also changed at {0}. That is expected when comparing consecutive continuation requests of different kinds, such as tool_search_output followed by a new user input.",
-			"The captured wire delta changed at {0} — {1}. This is a delta-to-delta comparison between consecutive Responses API requests, not the full reconstructed prompt prefix.",
-			"No divergence detected in the captured wire delta. The full reconstructed prompt prefix is provider-side for this continuation request.",
+			"Current",
 			"Previous · {0} chars",
 			"Current · {0} chars",
 			"Diff summary",
 			"drift",
 			"duration",
+			"(not sent — provider default)",
 			"endTime",
-			"{0}% cache hit — likely cache expiration",
-			"The prompt prefix matches but the model still treated this as a fresh request. Most likely the cached entry expired between requests.",
-			"the first message",
+			"Agent",
+			"All agents ({0})",
+			"{0} of {1} agents",
+			"Reveal {0} in Components",
+			"Findings",
 			"First request in session",
 			"OTel-reported cache hit. Nothing earlier in this session to diff against — the system prompt and tools may still match a previous session's cache.",
+			"small messages (grouped)",
 			"[cache {0}%]",
 			"{0}% cache hit",
+			"{0}% cache hit — {1}",
+			"{0} identical message(s) not shown — they extend the shared, cache-servable prefix.",
 			"input tok",
-			"added {0} message ({1} chars)",
-			"added {0} message",
-			"{0} message body changed ({1} chars)",
-			"{0} message body changed",
-			"previous {0} message dropped",
-			"{0} message resized to {1} chars",
-			"{0} message size changed",
 			"Current",
 			"Previous",
 			"tools (catalog)",
 			"tool search",
-			"Lost: {0} tokens ({1}% of this request)",
 			"model",
 			"Model Turn",
 			"[{0}ms]",
-			"No prefix divergence detected.",
+			"No findings for this request pair.",
 			"(not present)",
 			"No model turns recorded for this session yet.",
+			"No model turns match the selected agent filter.",
 			"Options changed: {0}",
-			"Request options changed — the cache was invalidated even though the message prefix matches.",
 			"Current",
 			"Option",
 			"Previous",
+			"% of current",
+			"{0}%",
 			"Cache performance",
+			"Previous",
 			"Previous request",
+			"{0} min idle · cache likely expired",
+			"Diverges from the previous request: {0} chars are recomputed",
 			"requestId",
 			"Request id: {0}",
 			"Request Options",
@@ -36079,6 +37851,21 @@
 			"tool_search_output request",
 			"This request contains a Responses API tool_search_output item. No previous-response continuation marker was captured, so the displayed input may be a full or history-sliced request rather than only a continuation delta.",
 			"Request",
+			"Byte-identical to the previous request: {0} chars can be served from cache",
+			"Match",
+			"{0}% match",
+			"{0} ({1}): {2} — drifted. Click to inspect.",
+			"{0} … {1}: {2} small messages, {3}",
+			"{0} chars",
+			"{0} chars (≈ {1} tok)",
+			"{0} ({1}): {2}",
+			"Show All Agents",
+			"Session cache health",
+			"{0} ×{1} · {2} tok",
+			"{0} of {1} request pairs healthy",
+			"{0} of {1} request pairs healthy · ~{2} tokens recomputed avoidably",
+			"{0}% overall cache hit",
+			"{0} of {1} input tokens served from cache across {2} requests (token-weighted)",
 			"Prompt Signature",
 			"{0} of {1} chars reused · break at {2}",
 			"{0} of {1} chars reused · no divergence detected",
@@ -36087,12 +37874,13 @@
 			"{0} in-place changed",
 			"{0} dropped from previous",
 			"{0} identical",
-			"System instructions changed — the cache was invalidated even though the message prefix matches.",
 			"system",
 			"Toggle group",
+			"≈ tok",
 			"{0} of {1} input tokens reused",
-			"Tool definitions changed — the catalog of available tools differs between requests, which invalidates the cache even though the message prefix matches.",
+			"{0} of {1} input tokens reused · {2} uncached ({3}%)",
 			"tools catalog",
+			"Total",
 			"Both sides truncated by the OTel attribute cap (originals were {0} and {1} chars) — diff may be partial.",
 			"{0} side truncated by the OTel attribute cap (original was {1} chars) — diff may be partial.",
 			"Current",
@@ -36100,17 +37888,89 @@
 			"timeToFirstToken",
 			"Turn {0}: {1}",
 			"Click to compare this request against the previous one",
-			"Uncached in this request: {0} tokens ({1}% of this request)",
 			"(no prompt captured)",
+			"(unnamed)",
 			"Visible Request Signature",
 			"For Responses API continuations, this shows the captured request inputs: system instructions, tools sent on this request, and the visible input delta. Earlier conversation state is referenced by previous response id and is not expanded here.",
 			"{0} of {1} captured request chars match before first captured drift: {2}",
 			"{0} of {1} captured request chars match · no captured divergence detected",
-			"Visible wire input",
-			"Where the cache broke",
 			"Cache Explorer",
 			"Cache Explorer — Prefix Diff",
 			"Agent Debug Logs"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugCacheInsights": [
+			"expiration / not cacheable",
+			"healthy growth",
+			"history rewritten",
+			"model changed",
+			"request options changed",
+			"system prompt changed",
+			"tool catalog changed",
+			"not classified",
+			"{0} chars appended — the previous content survives as a shared prefix",
+			"edited in place — first difference at char {0} ({1} leading and {2} trailing chars unchanged)",
+			"first {0} chars removed — this block no longer starts with the same bytes",
+			"{0} chars prepended — this block no longer starts with the same bytes",
+			"last {0} chars removed — the remaining content still matches the previous bytes",
+			"Once the prefix breaks at messages[{0}], everything after it is recomputed regardless — fix the first break first.",
+			"{0} more changed position(s) after the break",
+			"{0} new message(s) after {1} unchanged — the shared prefix was extended, not broken. The uncached tokens are the new suffix being written to the cache for the next request.",
+			"New messages appended — expected growth",
+			"Only the wire delta is captured for this request; prior context is referenced by previous_response_id and reconstructed provider-side. Analysis is limited to system, tools, and request options.",
+			"Responses API continuation",
+			"Conversation history must be byte-identical between requests to reuse the cached prefix. A re-serialized {0} turn — trimmed whitespace, dropped reasoning or preamble text, reformatted tool calls — silently invalidates everything after it.",
+			"{0} message, {1} → {2} chars",
+			"History rewritten at messages[{0}]",
+			"The changed region looks like a {0} — a volatile value re-rendered into the conversation history breaks the prefix on every request.",
+			"The prompt is byte-identical to the previous request but only {0}% was served from cache.{1}",
+			" {0} minute(s) elapsed since the previous request.",
+			"Provider prompt caches expire after a few minutes of inactivity (typically ~{0} min). Long gaps between requests recompute the full prompt even when nothing changed.",
+			"Likely cache expiration",
+			"Providers typically look back ~{0} content blocks for a prior cache entry; a turn that appends more can silently miss it even though the prefix matches.",
+			"During long tool loops, place intermediate cache breakpoints every ~15 blocks so the next request can still find a cache entry.",
+			"{0} blocks appended — beyond the typical cache lookback window",
+			"{0} → {1}",
+			"Prompt caches are scoped to a model — switching models recomputes the entire prompt. Route sub-tasks that need a different model through a separate request chain so the main loop keeps its cache.",
+			"Model changed",
+			"Options are part of the cache key on most providers. Keep per-request options stable when cache reuse matters.",
+			"Request options changed",
+			"The previous request was a Responses API continuation (delta-only wire input); positionally diffing this full request against it would be misleading.",
+			"Message comparison suppressed",
+			"No divergence detected — {0}% of input tokens were served from cache.",
+			"Prompt prefix fully stable",
+			"{0} → {1} chars · {2}",
+			"A system prompt change invalidates everything after the tools block. Keep the system prompt byte-stable for the life of a session and inject per-turn context into the newest message instead.",
+			"System prompt changed",
+			"The changed region looks like a {0} — volatile values interpolated into the system prompt break the cache on every request. Move dynamic content after the conversation history or drop it.",
+			"The tool catalog is the first block of the prompt — any byte change here invalidates the entire cache.",
+			"Tool catalog changed",
+			"added: {0}",
+			"changed: {0}",
+			"A changed tool description or schema rewrites the prompt from the tools block onward. Check for dynamic content (counts, paths, timestamps) inside tool descriptions.",
+			"Tool definitions modified",
+			"modified: {0}",
+			"removed: {0}",
+			"Same {0} tools with identical definitions, sent in a different order.",
+			"Tools render at the very start of the prompt — a pure reorder still changes the bytes and invalidates the entire cache. Serialize the tool list deterministically (e.g. sort by name).",
+			"Tool definitions reordered",
+			"Tool definitions render before everything else, so adding or removing a tool mid-session invalidates the whole prompt. Keep the tool set stable for the life of a session, or use deferred/appended tool loading instead of swapping the catalog.",
+			"Tool catalog changed ({0} → {1} tools)",
+			"{0} input tokens — providers only cache prompts above a minimum prefix size (roughly 1,024-4,096 tokens depending on model), and smaller prompts silently never cache.",
+			"Small utility requests (titles, summaries) often sit below the threshold; a 0% hit on them is normal and not worth optimizing.",
+			"Prompt may be below the minimum cacheable size",
+			"{0} message(s) present in the previous request are missing from this one.",
+			"History slicing or compaction shortens the prefix — the cache can only match up to the cut, and everything after it is recomputed.",
+			"History truncated at messages[{0}]",
+			"Every request either appended new messages or matched the previous prompt exactly — no avoidable cache breaks in this session.",
+			"All request pairs grew the prefix cleanly",
+			"~{0} tokens recomputed after idle gaps or on prompts below the cacheable minimum.",
+			"If long gaps are inherent to the workflow, consider a longer-TTL cache or pre-warming before the user returns.",
+			"Cache likely expired {0} times",
+			"~{0} tokens recomputed across those requests. A break that repeats is systemic — look for the same root cause on every occurrence.",
+			"Recurring invalidator: {0} in {1} of {2} request pairs",
+			"large changing number",
+			"timestamp",
+			"unique id (UUID)"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugDetailPanel": [
 			"Close",
@@ -36492,29 +38352,46 @@
 			"Capabilities: {0}",
 			"Context size: {0} tokens",
 			"{0} from {1}",
+			"{0} from {1} (hidden)",
 			"Name",
+			"Add Model",
 			"Agent Mode",
 			"Cache Cost: {0} credits per 1M tokens",
 			"Cache Cost: {0} credit per 1M tokens",
 			"Capabilities",
 			"Configure...",
-			"Configure",
-			"Configure...",
 			"Context Size",
 			"Delete",
 			"Would you like to delete {0}?",
-			"Add Models...",
+			"Add Models",
+			"Open in Language Models (JSON)",
+			"Hide All Models",
+			"Hide Model",
+			"Hide Models",
 			"Input Cost: {0} credits per 1M tokens",
 			"Input Cost: {0} credit per 1M tokens",
+			"Install Model Providers",
+			"Cache Cost: {0} credits per 1M tokens",
+			"Cache Cost: {0} credit per 1M tokens",
+			"Input Cost: {0} credits per 1M tokens",
+			"Input Cost: {0} credit per 1M tokens",
+			"Output Cost: {0} credits per 1M tokens",
+			"Output Cost: {0} credit per 1M tokens",
+			"Long Context Pricing",
 			"Adding models is managed by your organization",
 			"Manage {0}...",
 			"Output Cost: {0} credits per 1M tokens",
 			"Output Cost: {0} credit per 1M tokens",
 			"Pin Model",
 			"Pricing",
+			"Rename Group",
+			"Show All Models",
+			"Show Model",
+			"Show Models",
 			"Tools",
 			"Tools",
 			"Unpin Model",
+			"Update API Key",
 			"Vision",
 			"Language Models",
 			"Output cost: {0} credits per 1M tokens",
@@ -36526,6 +38403,7 @@
 			"Status: {0}",
 			"Context Size",
 			"{0} Models",
+			"{0} Models (hidden)",
 			"Visible Models"
 		],
 		"vs/workbench/contrib/chat/browser/chatOutputItemRenderer": [
@@ -36567,6 +38445,32 @@
 			"Show Extension",
 			"Contributes a chat participant"
 		],
+		"vs/workbench/contrib/chat/browser/chatQuotaNotification": [
+			"Manage Budget",
+			"Manage Budget",
+			"Manage Budget",
+			"Set additional budget to cover extra usage.",
+			"Upgrade to continue past the limit.",
+			"Contact your admin to increase your limits.",
+			"Additional budget is enabled to cover extra usage.",
+			"Credits at {0}%",
+			"Your organization or enterprise has exceeded its Copilot budget. Contact your admin to resume usage.",
+			"Usage Blocked",
+			"Sign in to keep going.",
+			"Manage your budget to keep building.",
+			"Upgrade to keep going.",
+			"Increase your budget to keep building.",
+			"Contact your admin to increase your limits.",
+			"Credit Limit Reached",
+			"Additional budget is now covering extra usage.",
+			"Credit Limit Reached",
+			"Resets on {0}.",
+			"You've used {0}% of your session rate limit.",
+			"You've used {0}% of your weekly rate limit.",
+			"Sign In",
+			"Upgrade",
+			"Upgrade"
+		],
 		"vs/workbench/contrib/chat/browser/chatRepoInfo": [
 			"Controls whether lightweight repository metadata (branch, commit, remotes) is captured when a chat request is submitted for internal diagnostics.",
 			"Chat Repository Info"
@@ -36599,6 +38503,7 @@
 			"Name of the dynamically registered chat participant (eg: @agent). Must not contain whitespace.",
 			"Order in which this item should be displayed.",
 			"When set, the chat session will show a filtered model picker that prefers custom models. This enables the use of standard model picker with contributed sessions.",
+			"Whether the chat session supports the synthetic \"Auto\" model fallback. Defaults to false. When true and no models are available, the picker shows \"Auto\" instead of a \"No models available\" state.",
 			"Whether this chat session supports attaching files or file references.",
 			"Whether this chat session supports hand-off prompts.",
 			"Whether this chat session supports attaching images.",
@@ -36630,7 +38535,7 @@
 			"Chat",
 			"Explain",
 			"Fix",
-			"Sign in to use AI features",
+			"Sign in to use GitHub Copilot",
 			"Learn How to Hide AI Features",
 			"Manage GitHub Copilot Budget",
 			"Upgrade to GitHub Copilot Pro",
@@ -36643,7 +38548,9 @@
 			"Copilot Sign In",
 			"Toggle visibility of the Copilot Sign In button in title bar",
 			"Use AI Features with Copilot for free...",
-			"Sign in to use AI features..."
+			"Sign in to use GitHub Copilot...",
+			"Upgrade Successful",
+			"Please wait up to 10 minutes for your new plan to apply."
 		],
 		"vs/workbench/contrib/chat/browser/chatSetup/chatSetupController": [
 			"What is your {0} instance?",
@@ -36695,7 +38602,7 @@
 			"By continuing, you agree to {0}'s [Terms]({1}) and [Privacy Statement]({2}). {3} Copilot may show [public code]({4}) suggestions and use your data to improve the product. You can change these [settings]({5}) anytime.",
 			"By continuing, you agree to {0}'s [Terms]({1}) and [Privacy Statement]({2}).",
 			"Use AI Features",
-			"Sign in to use AI Features",
+			"Sign in to use GitHub Copilot",
 			"Start using AI Features"
 		],
 		"vs/workbench/contrib/chat/browser/chatSlashCommands": [
@@ -36722,6 +38629,7 @@
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard": [
 			"Set up Copilot to use AI features.",
 			"By continuing with {0} Copilot, you agree to {1}'s [Terms]({2}) and [Privacy Statement]({3})",
+			"Additional Budget",
 			"Cancel Snooze",
 			"Chat messages",
 			"+5 min",
@@ -36752,9 +38660,12 @@
 			"Organization limit reached.",
 			"{0} limit reached.",
 			"Additional budget is configured. Usage will continue until limits reset.",
+			"Copilot has paused because your limits are reached. Please contact your admin to increase your limits.",
 			"Once the limit is reached, additional budget will be used.",
+			"Copilot will pause when your limits are reached. Please contact your admin to increase your limits.",
 			"Premium request budget is configured. Usage will continue until limits reset.",
 			"Once the limit is reached, premium request budget will be used.",
+			"Your organization or enterprise has exceeded its Copilot budget. Contact your admin to resume usage.",
 			"{0} / {1}",
 			"{0}%",
 			"Manage Copilot Settings",
@@ -36775,8 +38686,8 @@
 			"Next edit suggestions",
 			"(overridden)",
 			"Snooze",
-			"Sign in to use Copilot AI features.",
-			"Sign in to use AI Features",
+			"Sign in to use GitHub Copilot AI features.",
+			"Sign in to use GitHub Copilot",
 			"Upgrade"
 		],
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry": [
@@ -36787,13 +38698,13 @@
 			"Copilot Status",
 			"Copilot status",
 			"Inline suggestions disabled",
-			"Inline suggestions quota reached",
+			"Inline suggestions limit reached",
 			"Inline suggestions snoozed",
 			"Copilot disabled",
 			"Sign In"
 		],
 		"vs/workbench/contrib/chat/browser/chatTipCatalog": [
-			"Enable [{0}](command:workbench.action.openSettings?%5B%22workbench.browser.enableChatTools%22%5D \"Open Settings\") to let the agent open and interact with pages in the Integrated Browser.",
+			"Work across multiple projects at once in the [Agents window](command:{0} \"Open Agents Window\").",
 			"Reference files or folders with # to give the agent more context about the task.",
 			"Configure [{0}](command:workbench.action.openSettings?%5B%22chat.editing.autoAcceptDelay%22%5D \"Open Settings\") to automatically accept changes from the agent after a short countdown.",
 			"Select a code block in the editor and right-click to access more AI actions.",
@@ -36919,6 +38830,7 @@
 			"An external application wants to add a plugin marketplace. Plugins from this marketplace will appear in the plugin catalog and can be installed.\n\nSource: {0}",
 			"Install Plugin from '{0}'?",
 			"An external application wants to install a plugin from this source. Plugins can run code on your machine. Only install plugins from sources you trust.\n\nSource: {0}",
+			"Install Plugin '{0}' from '{1}'?",
 			"&&Install"
 		],
 		"vs/workbench/contrib/chat/browser/promptsDebugContribution": [
@@ -37174,6 +39086,8 @@
 			"Enable",
 			"Enable global auto approve?",
 			"Global auto approve also known as \"YOLO mode\" disables manual approval completely for _all tools in all workspaces_, allowing the agent to act fully autonomously. This is extremely dangerous and is *never* recommended, even containerized environments like [Codespaces](https://github.com/features/codespaces) and [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) have user keys forwarded into the container that could be compromised.\n\n**This feature disables [critical security protections](https://code.visualstudio.com/docs/copilot/security) and makes it much easier for an attacker to compromise the machine.**\n\nNote: This setting only controls tool approval and does not prevent the agent from asking questions. To automatically answer agent questions, use the [`chat.autoReply`](command:workbench.action.openSettings?%5B%22chat.autoReply%22%5D) setting.",
+			"The action was assessed as potentially destructive or irreversible.",
+			"Autopilot skipped \"{0}\" because it was assessed as high-risk: {1}",
 			"Delegate tasks to other agents",
 			"Execute code and applications on your machine",
 			"Read files in your workspace",
@@ -37233,6 +39147,19 @@
 			"Condition when the welcome message is shown.",
 			"Contributes a welcome message to a chat view"
 		],
+		"vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService": [
+			"Approving...",
+			"Auto-approving session...",
+			"Focusing session...",
+			"Checking changes...",
+			"Checking sessions...",
+			"Checking conversation...",
+			"Starting new sessions...",
+			"Rejecting...",
+			"Revoking auto-approve...",
+			"Sending to chat...",
+			"Working..."
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatAgentHover": [
 			"This chat extension is using a reserved name.",
 			"View Extension"
@@ -37280,6 +39207,17 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExtensionsContentPart": [
 			"Loading extensions..."
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatExternalEditContentPart": [
+			"{0} deletions",
+			"1 deletion",
+			"Edited",
+			"{0} insertions",
+			"1 insertion",
+			"Created",
+			"Deleted",
+			"Renamed",
+			"Edited {0}, {1}, {2}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatHookContentPart": [
 			"Blocked by {0} hook",
@@ -37414,8 +39352,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart": [
 			"Click to Retry",
-			"Configure Budget",
-			"Configure Budget",
+			"Manage Budget",
 			"Upgrade to GitHub Copilot Pro",
 			"Changes may take a few minutes to take effect."
 		],
@@ -37466,6 +39403,8 @@
 			"Made changes."
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart": [
+			"Created {0}",
+			"Deleted {0}",
 			"{0} deletions",
 			"1 deletion",
 			"Edited {0}",
@@ -37480,6 +39419,7 @@
 			"{0} insertions",
 			"1 insertion",
 			"{0}: {1}",
+			"Renamed {0}",
 			"{0}: ",
 			"Thinking",
 			"Executing",
@@ -37500,6 +39440,7 @@
 			"Bribing the hamster",
 			"Reticulating splines",
 			"Untangling the spaghetti",
+			"Communing with the codebase",
 			"Mining diamonds",
 			"Summoning Clippy"
 		],
@@ -37573,10 +39514,6 @@
 			"Error loading MCP App: {0}",
 			"Retry"
 		],
-		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatMissingSandboxDepsConfirmationSubPart": [
-			"Cancel",
-			"Install"
-		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatModifiedFilesConfirmationSubPart": [
 			"{0} files changed",
 			"All Changes",
@@ -37585,14 +39522,21 @@
 			"1 file changed",
 			"View All Changes"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatSandboxPrerequisiteConfirmationSubPart": [
+			"Install",
+			"Apply Fix and Retry",
+			"Cancel"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatTerminalToolConfirmationSubPart": [
 			"Enable",
 			"Enable Auto Approve...",
 			"This will enable a configurable subset of commands to run in the terminal autonomously. It provides *best effort protections* and assumes the agent is not acting maliciously.",
 			"Learn more about the potential risks and how to avoid them.",
 			"Enable terminal auto approve?",
+			"The model did not provide a reason for requesting unrestricted network access in the sandbox.",
 			"Approval needed:",
 			"Sandbox insufficient:",
+			"Unrestricted network access:",
 			"The model did not provide a reason for requesting unsandboxed execution.",
 			"Session auto approve rule {0} added",
 			"Session auto approve rules {0} added",
@@ -37747,6 +39691,11 @@
 		"vs/workbench/contrib/chat/browser/widget/input/chatFollowups": [
 			"Follow up question: {0}"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatGoalBannerWidget": [
+			"Dismiss",
+			"Goal",
+			"Determining goal…"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget": [
 			"Dismiss notification"
 		],
@@ -37764,6 +39713,10 @@
 			"(Edit), edit files in your workspace.",
 			", {0}. "
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatInputStatusActionViewItem": [
+			"Manage Settings",
+			"Agent being monitored via [OpenTelemetry]({0})"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatModelPicker": [
 			"Higher levels of thinking may increase costs",
 			"Thinking Effort",
@@ -37778,6 +39731,7 @@
 			"This model requires a newer version of VS Code. [Download Update](command:update.downloadUpdate) to access it.",
 			"Thinking Effort: {0}",
 			"Set Thinking Effort",
+			"No models available",
 			"Other Models",
 			"Pin Model",
 			"Pinned",
@@ -37793,8 +39747,9 @@
 			"High cost",
 			"Low cost",
 			"Medium cost",
+			"{0} cost",
 			"Very high cost",
-			"Larger size may increase cost in longer sessions",
+			"Larger context may increase cost",
 			"Context Size",
 			"Cached input",
 			"Configurable:",
@@ -37804,10 +39759,10 @@
 			"{0} credit",
 			"{0} (default)",
 			"Input",
+			"Long context cost (per 1M tokens)",
 			"Output",
 			"Cost",
-			"Cost (per 1M tokens)",
-			"{0} (default)"
+			"Cost (per 1M tokens)"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter": [
 			"Auto",
@@ -37854,7 +39809,8 @@
 			"Pasted Code Attachment",
 			"Pasted Image Attachment",
 			"Pasted Image",
-			"Pasted Symbol Reference"
+			"Pasted Symbol Reference",
+			"Paste as Markdown"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem": [
 			"Pick Model"
@@ -37875,7 +39831,7 @@
 			"Disabled by enterprise policy",
 			"All tool calls are auto-approved",
 			"Autopilot (Preview)",
-			"Auto-approve all tool calls and continue until the task is done",
+			"Auto-approve all tool calls and continue until the task is done. Autopilot may increase costs.",
 			"Autopilot (Preview)",
 			"Disabled by enterprise policy",
 			"Disabled by enterprise policy",
@@ -37928,6 +39884,7 @@
 			"Context window usage: {0}%"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane": [
+			"Voice Mode",
 			"Failed to open chat session: {0}",
 			"New Session",
 			"Agent Session in Progress",
@@ -38015,6 +39972,7 @@
 			"True when focus is in the chat input, false otherwise.",
 			"True when the quick chat UI has focus, false otherwise.",
 			"True when the chat input has focus.",
+			"True when the chat input has text or file attachments that can be sent.",
 			"True when the chat input has text.",
 			"True when the current request is being edited.",
 			"True when the current request input at the bottom is being edited.",
@@ -38028,7 +39986,70 @@
 		],
 		"vs/workbench/contrib/chat/common/attachments/chatVariableEntries": [
 			"All Problems",
-			"Problems in {0}"
+			"Problems in {0}",
+			"Attached {0} files",
+			"Attached 1 file",
+			"Attached {0} images",
+			"Attached 1 image"
+		],
+		"vs/workbench/contrib/chat/common/chatErrorMessages": [
+			"a moment",
+			"Canceled",
+			"{0} hours",
+			"{0} hours {1} minutes",
+			"{0} minutes",
+			"{0} seconds",
+			"Sorry, something went wrong.",
+			"Sorry, your request failed. Please try again.\n\nClient Request Id: {0}\n\nReason: {1}",
+			"Sorry, your request failed. Please try again.\n\nClient Request Id: {0}\n\nGH Request Id: {1}\n\nReason: {2}",
+			"Sorry, the response matched public code so it was blocked. Please rephrase your prompt.",
+			"Sorry, the response matched public code so it was blocked. Please rephrase your prompt. [Learn more]({0}).",
+			"Sorry, the response was filtered by the Responsible AI Service. Please rephrase your prompt and try again.",
+			"Sorry, the response was filtered by the Responsible AI Service. Please rephrase your prompt and try again. [Learn more]({0}).",
+			"Sorry, your prompt was filtered by the Responsible AI Service. Please rephrase your prompt and try again.",
+			"Sorry, your prompt was filtered by the Responsible AI Service. Please rephrase your prompt and try again. [Learn more]({0}).",
+			"Your chat session state is invalid, please start a new chat.",
+			"Sorry, the response hit the length limit. Please rephrase your prompt.",
+			"Sorry, there was a network error. Please try again later. Request id: {0}\n\nReason: {1}",
+			"Sorry, the resource was not found.",
+			"Sorry, but I can only assist with programming related questions.",
+			"You've reached your additional usage limit for your plan. Upgrade your plan to keep going.",
+			"You've exhausted your credits. To continue working, please contact your organization's Copilot admin or wait for your allowance to renew.",
+			"You've exhausted your premium model quota. To continue working, switch to Auto. For additional paid premium requests, please reach out to your organization's Copilot admin or wait for your allowance to renew.",
+			"You've reached your monthly chat messages quota. Upgrade to Copilot Pro or wait for your allowance to renew.",
+			"Quota Exceeded",
+			"You've exhausted your premium model quota. Please enable additional paid premium requests, upgrade to Copilot Pro+, or wait for your allowance to renew.",
+			"You cannot accrue additional premium requests at this time. Please contact [GitHub Support]({0}) to continue using Copilot.",
+			"You've exhausted your premium model quota. Please enable additional paid premium requests or wait for your allowance to renew.",
+			"Quota Exceeded\n\nServer Error: {0}\nError Code: {1}",
+			"You've reached your credit limit. To continue working, please contact your organization's Copilot admin or wait for your credits to reset.",
+			"You've reached your credit limit. To continue working, please contact your organization's Copilot admin or wait until your credits reset on {0}.",
+			"You've reached your credit limit. To continue working, switch to Auto. For additional paid credits, please reach out to your organization's Copilot admin or wait for your credits to reset.",
+			"You've reached your credit limit. To continue working, switch to Auto. For additional paid credits, please reach out to your organization's Copilot admin or wait until your credits reset on {0}.",
+			"You've reached your monthly credit limit. Upgrade to Copilot Pro or wait for your credits to reset.",
+			"You've reached your monthly credit limit. Upgrade to Copilot Pro or wait until your credits reset on {0}.",
+			"You've reached your monthly credit limit. Please enable additional paid credits, upgrade to Copilot Pro+, or wait for your credits to reset.",
+			"You've reached your monthly credit limit. Please enable additional paid credits, upgrade to Copilot Pro+, or wait until your credits reset on {0}.",
+			"You've reached your monthly credit limit. Please enable additional paid credits or wait for your credits to reset.",
+			"You've reached your monthly credit limit. Please enable additional paid credits or wait until your credits reset on {0}.",
+			"Sorry, you have exceeded the agent mode rate limit. Please switch to ask mode and try again in {0}. [Learn More]({1})",
+			"Sorry, your request was rate-limited. Please wait {0} before trying again or consider switching to Auto. [Learn More]({1})",
+			"Sorry, your request was rate-limited. Please wait {0} before trying again. [Learn More]({1})",
+			"Sorry, GitHub Copilot Chat is currently experiencing high demand. Please try again in {0}. [Learn More]({1})",
+			"You've hit the rate limit for this model. Please try switching to Auto or try again in {0}. [Learn More]({1})",
+			"You've hit the rate limit for this model. Please try again in {0}. [Learn More]({1})",
+			"Sorry, the upstream model provider is currently experiencing high demand. Please try again in {0} or consider switching to Auto. [Learn More]({1})",
+			"Sorry, the upstream model provider is currently experiencing high demand. Please try again in {0}. [Learn More]({1})",
+			"Sorry, you have been rate-limited. Please wait {0} before trying again or consider switching to Auto. [Learn More]({1})\n\nServer Error: {2}\nError Code: {3}",
+			"Sorry, you have been rate-limited. Please wait {0} before trying again. [Learn More]({1})\n\nServer Error: {2}\nError Code: {3}",
+			"You've hit your session rate limit. Please wait {0} for your limit to reset. [Learn More]({1})",
+			"You've hit your session rate limit. Please upgrade your plan or wait {0} for your limit to reset. [Learn More]({1})",
+			"You've reached your weekly rate limit. Please switch to the Auto model to continue working or wait {0} for your limit to reset. [Learn More]({1})",
+			"You've reached your weekly rate limit. Please wait {0} for your limit to reset. [Learn More]({1})",
+			"You've reached your weekly rate limit. Please switch to the Auto model to continue working or wait for your limit to reset on {0}. [Learn More]({1})",
+			"You've reached your weekly rate limit. Please wait for your limit to reset on {0}. [Learn More]({1})",
+			"Sorry, something went wrong.",
+			"Sorry, no response was returned."
 		],
 		"vs/workbench/contrib/chat/common/chatImageExtraction": [
 			"Images",
@@ -38698,9 +40719,21 @@
 			"Stop Reading Aloud"
 		],
 		"vs/workbench/contrib/chat/electron-browser/agentSessions/agentSessionsActions": [
+			"Open in Agents Window",
+			"Give your agent more room?",
+			"Continue in Agents Window",
+			"Get a dedicated, multi-pane view alongside your workspace.",
+			"Free with your Copilot plan — get a dedicated, multi-pane view alongside your workspace.",
+			"Open the Agents Window to start a Copilot CLI session.",
+			"Copilot CLI [Agent Host] isn't available without an open folder",
+			"Continue this session in the Agents Window",
+			"Don't Show Again",
 			"Open Agents Window",
 			"Open in Agents Window",
-			"Open in Agents"
+			"Open in Agents Window",
+			"Open in Agents",
+			"Open in Agents Window",
+			"Toggle visibility of the Open in Agents Window button in title bar"
 		],
 		"vs/workbench/contrib/chat/electron-browser/builtInTools/fetchPageTool": [
 			"Binary files are not supported at the moment.",
@@ -39016,7 +41049,13 @@
 			"The language's folding settings.",
 			"Language specific folding markers such as '#region' and '#endregion'. The start and end regexes will be tested against the contents of all lines and must be designed efficiently",
 			"The RegExp pattern for the end marker. The regexp must start with '^'.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"The RegExp flags for the end marker.",
+			"The RegExp pattern for the end marker.",
 			"The RegExp pattern for the start marker. The regexp must start with '^'.",
+			"Must match the pattern `/^([gimuy]+)$/`.",
+			"The RegExp flags for the start marker.",
+			"The RegExp pattern for the start marker.",
 			"A language adheres to the off-side rule if blocks in that language are expressed by their indentation. If set, empty lines belong to the subsequent block.",
 			"The language's indentation settings.",
 			"If a line matches this pattern, then all the lines after it should be unindented once (until another rule matches).",
@@ -39567,6 +41606,8 @@
 			"{0}, use ({1}) for accessibility help",
 			"{0}, run the command Open Accessibility Help which is currently not triggerable via keybinding.",
 			"Debug Launch Configurations",
+			"Search configurations",
+			"Debug Launch Configurations: {0}",
 			"Debug Session",
 			"No Configurations"
 		],
@@ -39981,6 +42022,7 @@
 		"vs/workbench/contrib/debug/browser/watchExpressionsView": [
 			"Add Expression",
 			"Collapse All",
+			"Copy All",
 			"Copy Expression",
 			"Remove All Expressions",
 			"Type new value",
@@ -40401,7 +42443,6 @@
 			"this repository"
 		],
 		"vs/workbench/contrib/extensions/browser/extensions.contribution": [
-			"All Extensions",
 			"If activated, extensions will automatically restart following an update if the window is not in focus. There can be a data loss if you have open Notebooks or Custom Editors.",
 			"Extension '{0}' is a Built-in extension and cannot be uninstalled",
 			"Built-in",
@@ -40409,7 +42450,7 @@
 			"Clear Extensions Search Results",
 			"Disable All Installed Extensions",
 			"Disable All Installed Extensions for this Workspace",
-			"Disable Auto Update for All Extensions",
+			"Disable Auto Update for Extensions",
 			"Disabled",
 			"Switch to Release Version",
 			"Download Pre-Release VSIX",
@@ -40417,8 +42458,7 @@
 			"Download VSIX",
 			"Enable All Extensions",
 			"Enable All Extensions for this Workspace",
-			"Enable Auto Update for All Extensions",
-			"Only Enabled Extensions",
+			"Enable Auto Update for Extensions",
 			"Enabled",
 			"Switch to Pre-Release Version",
 			"Extension",
@@ -40433,9 +42473,9 @@
 			"Configure an extension to execute in a different extension host process.",
 			"Controls whether extensions and MCP servers open in a modal editor overlay.",
 			"Controls the automatic update behavior of extensions. The updates are fetched from a Microsoft online service.",
-			"Download and install updates automatically only for enabled extensions.",
 			"Extensions are not automatically updated.",
-			"Download and install updates automatically for all extensions.",
+			"Download and install updates automatically only for enabled extensions.",
+			"Controls the delay in hours after an extension update is published before it is automatically installed. Only applies when `#extensions.autoUpdate#` is set to `on`. This delay helps avoid installing potentially problematic updates immediately after release.",
 			"Configure the Marketplace service URL to connect to",
 			"Override the Agents window support of an extension. Extensions using `true` will be enabled in the Agents window even when they would otherwise be disabled.",
 			"Override the untrusted workspace support of an extension. Extensions using `true` will always be enabled. Extensions using `limited` will always be enabled, and the extension will hide functionality that requires trust. Extensions using `false` will only be enabled only when the workspace is trusted.",
@@ -40498,10 +42538,11 @@
 			"E&&xtensions",
 			"Most Popular",
 			"Recommended",
-			"None",
 			"Extension '{0}' not found.",
 			"Extension '{0}' is not installed. Make sure you use the full extension ID, including the publisher, e.g.: ms-dotnettools.csharp.",
 			"All extensions are up to date.",
+			"Off",
+			"On",
 			"Recently Published",
 			"Show Recently Published Extensions",
 			"Refresh",
@@ -40546,7 +42587,6 @@
 			"Undo Ignored Recommendation",
 			"Extension id or VSIX resource uri",
 			"Install the given extension",
-			"Context for the installation. This is a JSON object that can be used to pass any information to the installation handlers. i.e. `{skipWalkthrough: true}` will skip opening the walkthrough upon install.",
 			"When enabled, VS Code do not sync this extension when Settings Sync is on.",
 			"When enabled, the extension will be enabled if it is installed but disabled. If the extension is already enabled, this has no effect.",
 			"When enabled, VS Code installs only newly added extensions from the extension pack VSIX. This option is considered only while installing a VSIX.",
@@ -40560,6 +42600,7 @@
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"Please [review the extension]({0}) and update it manually.",
+			"This extension is not updated yet because new versions are auto updated 2 hours after they are published. It will be auto updated {0}.",
 			"Cancel",
 			"This extension is disabled because it is not supported in {0} for the Web.",
 			"The '{0}' extension is not available in {1}. Click 'More Information' to learn more.",
@@ -40791,6 +42832,7 @@
 			"Deprecated",
 			"Disabled",
 			"Disabled",
+			"Dismiss",
 			"Enabled",
 			"Enabled",
 			"1 extension found.",
@@ -40871,8 +42913,8 @@
 		"vs/workbench/contrib/extensions/browser/extensionsWorkbenchService": [
 			"All Platforms",
 			"Cannot install the '{0}' extension because it is not available in this setup.",
-			"Do you want to disable auto update for all extensions?",
-			"Do you want to enable auto update for all extensions?",
+			"Do you want to disable auto update for extensions?",
+			"Do you want to enable auto update for extensions?",
 			"Auto Update Extensions",
 			"This will reset any auto update settings you have set for individual extensions.",
 			"The update for {0} extension introduces executable code, which is not present in the currently installed version.",
@@ -40895,8 +42937,8 @@
 			"Would you like to enable '{0}' extension?",
 			"Enable Extension",
 			"Extension '{0}' not found.",
-			"Extensions require a window reload to take effect.",
-			"Extensions require a restart to take effect.",
+			"Extensions require a window reload to apply updates.",
+			"All extensions require a restart to apply updates.",
 			"Extensions were auto restarted to enable updates.",
 			"Can't install '{0}' extension because it is not compatible.",
 			"Some extensions are disabled due to version incompatibility. Review and update them.",
@@ -40927,6 +42969,7 @@
 			"Please {0} to enable the updated extension.",
 			"Please update {0} to enable the updated extension.",
 			"pre-release",
+			"This window is connected to a [private extension marketplace]({0}) managed by your organization.",
 			"reload window",
 			"Reload Window",
 			"If this issue persists, please report it at {0}",
@@ -41556,6 +43599,9 @@
 			"Video {0} of {1}",
 			"Image thumbnails"
 		],
+		"vs/workbench/contrib/imageCarousel/browser/imageCarouselEditorInput": [
+			"Icon of the image carousel editor label."
+		],
 		"vs/workbench/contrib/inlayHints/browser/inlayHintsAccessibilty": [
 			"Code with Inlay Hint Information",
 			"Whether the current line and its inlay hints are currently focused",
@@ -41715,16 +43761,143 @@
 			"E.g Workbench is missing problems panel"
 		],
 		"vs/workbench/contrib/issue/browser/issueFormService": [
+			"Additional Issue Data",
 			"Cancel",
 			"Your input will not be saved. Are you sure you want to close this window?",
+			"Issue Data",
+			"Attachments",
+			"Upload failed. Please drag and drop attachments manually.",
 			"There is too much data to send to GitHub directly. The data will be copied to the clipboard, please paste it into the GitHub issue page that is opened.",
 			"&&OK",
+			"We have written the needed data into your clipboard because it was too large to send. Please paste.",
 			"&&Yes"
 		],
 		"vs/workbench/contrib/issue/browser/issueQuickAccess": [
 			"Open Extension Page",
 			"Extensions",
 			"Extension Marketplace"
+		],
+		"vs/workbench/contrib/issue/browser/issueReporterEditorInput": [
+			"Discard",
+			"Discard issue report?",
+			"Your issue report has unsaved changes that will be lost.",
+			"Report Issue",
+			"Icon for the issue reporter editor."
+		],
+		"vs/workbench/contrib/issue/browser/issueReporterEditorPane": [
+			"No issue reporter data available.",
+			"No current experiments.",
+			"Open System Settings",
+			"Recording stopped automatically: the 100 MB upload limit was reached.",
+			"{0} needs Screen Recording permission to record videos. Grant access in System Settings, then click Record again.",
+			"Screen recording permission was denied. Allow {0} to record the screen and try again."
+		],
+		"vs/workbench/contrib/issue/browser/issueReporterOverlay": [
+			"A/B Experiments",
+			"Additional Information",
+			"Additional Performance Data",
+			"Optionally include currently running processes and workspace metadata to help diagnose performance issues.",
+			"Attachments ({0})",
+			"Back",
+			"Bug",
+			"Describe what happened, the steps to reproduce, what you expected, and what you observed instead.",
+			"Capture options",
+			"Category",
+			"Select a category to continue.",
+			"Close",
+			"Describe",
+			"Select a category above, then describe your feedback in detail.",
+			"Remove recording",
+			"Delete screenshot",
+			"Describe your feedback",
+			"Description",
+			"Describe the issue in detail...",
+			"Enter a description to continue.",
+			"Click to edit screenshot",
+			"Exclude All",
+			"Exclude all additional issue data from this issue",
+			"Expand",
+			"Extension",
+			"Extension Data",
+			"This extension uses an external issue reporter. Preview will open that issue reporter.",
+			"This extension does not provide an issue reporting URL.",
+			"E.g. Missing alt text on extension readme image",
+			"Select an extension to continue.",
+			"Extensions ({0})",
+			"A VS Code extension",
+			"Describe the feature you'd like to see, what problem it would solve, and any alternatives you've considered.",
+			"Feature Request",
+			"Category",
+			"5 seconds",
+			"Generate title from description",
+			"Generate from description",
+			"Generating...",
+			"Hide Toolbar in Screenshots",
+			"Include All",
+			"Include all additional issue data in this issue",
+			"Include in issue",
+			"Issue will be created in {0}/{1}.",
+			"Title",
+			"Brief summary of the issue",
+			"Loading diagnostics...",
+			"Loading extension issue data...",
+			"Loading currently running processes...",
+			"Loading system information...",
+			"Loading workspace metadata...",
+			"Markdown formatting is supported.",
+			"Extensions Marketplace",
+			"E.g. Cannot disable installed extension",
+			"Max attachments reached",
+			"Minimize",
+			"Next",
+			"No delay",
+			"(no description)",
+			"No similar issues found.",
+			"(no title)",
+			"Open External Issue Reporter",
+			"or",
+			"Describe what is slow, when it happens, whether it's consistent or intermittent, and any patterns you've noticed.",
+			"Performance Issue",
+			"Preview on GitHub",
+			"Recording active",
+			"Recording {0}",
+			"Record video",
+			"Refresh",
+			"Reload running processes and workspace metadata",
+			"Report Issue",
+			"Review and submit",
+			"Running Processes",
+			"Screenshot",
+			"Screenshot {0}",
+			"Attachments",
+			"Add attachments for better context",
+			"You can add up to {0} screenshots or videos. Navigate VS Code and choose when to capture.",
+			"Searching similar issues...",
+			"Select extension",
+			"Use the floating capture bar, or press",
+			"Similar Issues",
+			"Enter a title to search for similar issues.",
+			"Unable to search for similar issues.",
+			"Skip",
+			"Step {0} of {1}",
+			"Stop recording",
+			"Review",
+			"System Information",
+			"Target",
+			"Select a target to continue.",
+			"10 seconds",
+			"3 seconds",
+			"Enter a title to continue.",
+			"to capture a screenshot",
+			"to start or stop recording",
+			"Unknown",
+			"Don't know",
+			"A new version of {0} is available.",
+			"Uploading...",
+			"Visual Studio Code",
+			"E.g. Workbench is missing problems panel",
+			"Waiting for performance diagnostics to finish loading",
+			"Workspace Metadata"
 		],
 		"vs/workbench/contrib/issue/browser/issueReporterPage": [
 			"I acknowledge that my VS Code version is not updated and this issue may be closed.",
@@ -41780,11 +43953,49 @@
 			"Troubleshoot Issue...",
 			"This likely means that the issue has been addressed already and will be available in an upcoming release. You can safely use {0} insiders until the new stable version is available."
 		],
+		"vs/workbench/contrib/issue/browser/screenshotAnnotation": [
+			"Edit screenshot to highlight the problem",
+			"Apply",
+			"Arrow",
+			"Cancel",
+			"{0}: {1}",
+			"Crop",
+			"Discard",
+			"Ellipse",
+			"Eraser",
+			"Fill Color",
+			"Draw",
+			"Opacity",
+			"Pan",
+			"Rectangle",
+			"Redo",
+			"Save",
+			"Select / Move",
+			"Set Fill Color",
+			"Set Opacity",
+			"Set Stroke Color",
+			"Set Stroke Width to {0}px",
+			"Set Text Size to {0}px",
+			"Stroke Color",
+			"Stroke Width",
+			"Text",
+			"Background Color",
+			"Text Color",
+			"Text Size",
+			"Tool Options",
+			"{0}: Transparent",
+			"Type text",
+			"Undo"
+		],
 		"vs/workbench/contrib/issue/common/issue.contribution": [
 			"Report &&Issue",
 			"Report Issue..."
 		],
 		"vs/workbench/contrib/issue/electron-browser/issue.contribution": [
+			"Enable the new issue reporter wizard instead of the classic issue reporter.",
+			"When auto-collecting performance diagnostics for the issue reporter wizard, walk the full workspace instead of stopping at the default 20,000-file cap. Set to false on very large workspaces if the scan slows the initial wizard render.",
+			"Issue Reporter",
+			"Issue Reporter",
 			"Open Issue Reporter",
 			"Report Performance Issue...",
 			"Type the name of an extension to report on."
@@ -42140,6 +44351,17 @@
 			"Installs a new Model Context protocol to the mcp.json settings",
 			"Add Server",
 			"Add a new server configuration",
+			"Disable Server",
+			"Enable Server",
+			"No MCP servers",
+			"This session does not expose any MCP servers",
+			"Show locally configured servers...",
+			"Authentication required",
+			"Error",
+			"Running",
+			"Starting",
+			"Stopped",
+			"Agent Host Server Options",
 			"Automatically start MCP servers when sending a chat message",
 			"Browse Resources...",
 			"MCP Servers",
@@ -42180,9 +44402,19 @@
 			"Show the sampling requests for this server",
 			"MCP Sampling: {0}",
 			"Select action for '{0}'",
+			"Select an MCP Server for this session",
 			"Select an MCP Server",
 			"Show server options for {0}",
 			"MCP Servers",
+			"Set OAuth Client Secret",
+			"Delete stored client secret",
+			"Hide client secret",
+			"Enter a new client secret to replace the stored value",
+			"Enter client secret",
+			"Enter the client secret for OAuth client '{0}'.",
+			"Show client secret",
+			"Replace Client Secret for {0}",
+			"Set Client Secret for {0}",
 			"Show Output",
 			"Set the models the server can use via MCP sampling",
 			"Sign Out",
@@ -42295,8 +44527,10 @@
 			"Edit",
 			"Edit saved value",
 			"Debug",
+			"Replace Client Secret",
 			"Restart",
 			"More...",
+			"Set Client Secret",
 			"Start",
 			"Stop",
 			"Variable `{0}` not found, did you mean ${{1}}?",
@@ -42477,7 +44711,8 @@
 			"The working directory for the server command. Defaults to the workspace folder when run in a workspace.",
 			"Additional headers sent to the server.",
 			"OAuth configuration for authenticating with the server.",
-			"The OAuth client ID to use when authenticating with the server.",
+			"The OAuth client ID to use when authenticating with the server. When `enterpriseManaged` is `true`, this is the **resource** authorization server's client ID (the client trusted by the protected resource), not the IdP's. To set the matching client secret, use the *Set Client Secret* code lens above this field — secrets are stored in the OS secret store, not in this file.",
+			"(Preview) When set to `true`, this MCP server authenticates through the SSO issuer configured by `#mcp.enterpriseManagedAuth.idp#` using OAuth Identity Assertion Authorization Grant (ID-JAG). After a one-time sign-in, subsequent enterprise-managed servers connect silently. The IdP issuer and client credentials are read from the `#mcp.enterpriseManagedAuth.idp#` setting; the `clientId` on this server entry is passed to the resource authorization server.",
 			"Sandbox config that determines file system and network access. Sandboxing is enabled when sandboxEnabled property is set at the server level on Mac OS and Linux only.",
 			"Filesystem access settings for the sandboxed server. Glob patterns are supported for Mac OS only.",
 			"List of file paths that the server is allowed to write to. e.g. `~/src/`.",
@@ -42630,6 +44865,8 @@
 		],
 		"vs/workbench/contrib/mergeEditor/browser/mergeEditor.contribution": [
 			"Uses the advanced diffing algorithm.",
+			"Uses the advanced diffing algorithm from the external `@vscode/diff` package (pure JavaScript).",
+			"Uses the advanced diffing algorithm from the external `@vscode/diff` package (WebAssembly).",
 			"Uses the legacy diffing algorithm.",
 			"Merge Editor"
 		],
@@ -43281,6 +45518,11 @@
 		"vs/workbench/contrib/notebook/browser/notebookEditor": [
 			"Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed and enabled.",
 			"Cannot open resource with notebook editor type '{0}', please check if you have the right extension installed and enabled.",
+			"Do you trust the authors of this notebook?",
+			"The notebook was not opened because its authors are not trusted.",
+			"Notebooks can run code that has access to your browser session, including any signed-in accounts. Only open notebooks from authors you trust.",
+			"Open Notebook",
+			"Don't ask me again",
 			"Open As Text",
 			"Enable extension for '{0}'",
 			"Install extension for '{0}'",
@@ -44666,6 +46908,7 @@
 		],
 		"vs/workbench/contrib/search/browser/patternInputWidget": [
 			"input",
+			"Search only in Changed Files (Source Control)",
 			"Search only in Open Editors",
 			"Use Exclude Settings and Ignore Files"
 		],
@@ -46358,17 +48601,39 @@
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool": [
 			"Allow",
 			"Run `{0}` command?",
+			"Allow the sandbox to run `{0}` command with unrestricted network access.",
+			"Retry `{0}` command in the sandbox by allowing network access?",
+			"`{0}`",
+			"Retry `{0}` command in the sandbox by allowing network access to {1}?",
+			"Running `{0}` in the sandbox with unrestricted network access",
+			"The sandboxed execution output indicated the sandbox blocked required network access.",
+			"Explanation: {0}\n\nGoal: {1}\n\nReason for allowing unrestricted network access in the sandbox: {2}",
+			"The model indicated that this sandboxed command needs unrestricted network access.",
+			"Not running `{0}` because unrestricted network access in the sandbox is disabled",
+			"The command was not executed because it requested unrestricted network access in the terminal sandbox, but per-command network access is disabled by chat.agent.sandbox.retryWithAllowNetworkRequests. Run the command with restricted network access instead, or enable the setting to allow network access requests.",
+			"Apply Fix and Retry",
+			"Cancel",
+			"Bubblewrap sandbox repair was cancelled by the user.",
+			"Bubblewrap cannot create the sandbox environment.",
+			"Bubblewrap repair failed (exit code {0}). The command was not executed.",
+			"Could not determine whether the bubblewrap repair succeeded. The command was not executed.",
+			"Bubblewrap still cannot create the required sandbox namespace after remediation. The command was not executed.",
+			"Repair Bubblewrap Sandbox",
+			"Bubblewrap is installed but cannot create the required sandbox namespace on this system. The command was not executed.",
 			"Explanation: {0}\n\nGoal: {1}",
 			"No explanation provided",
 			"No goal provided",
 			"Run `{0}` command within `{1}`?",
 			"Running `{0}`",
 			"Running `{0}` in sandbox",
+			"Sandbox dependencies were installed, but bubblewrap cannot create the required sandbox namespace. Run the command again to choose an available repair option.",
+			"Sandbox dependencies were installed, but bubblewrap cannot create the required sandbox namespace on this system. The command was not executed.",
 			"Cancel",
 			"Sandbox dependency installation was cancelled by the user.",
 			"Sandbox dependency installation failed (exit code {0}). The command was not executed.",
 			"Install",
 			"The following dependencies required for sandboxed execution are not installed: {0}. Would you like to install them?",
+			"Sandbox prerequisites are still not satisfied after installation. The command was not executed.",
 			"Missing Sandbox Dependencies",
 			"Could not determine whether sandbox dependency installation succeeded. The command was not executed.",
 			"Run `{0}` command in `{1}`?",
@@ -46406,9 +48671,9 @@
 			"Run in Terminal",
 			"Run commands in the terminal",
 			"Skip",
-			"`{0}` may need input",
-			"`{0}` completed",
-			"`{0}` terminal exited"
+			"{0} may need input",
+			"{0} completed",
+			"{0} terminal exited"
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/sendToTerminalTool": [
 			"Focus Terminal",
@@ -46484,7 +48749,15 @@
 			"Array of additional paths to allow write access. Leave empty to disallow writes outside the workspace folders, workspace storage folder, and sandbox temp directory.",
 			"Array of paths to deny read access. Leave empty to allow reading all paths.",
 			"Array of paths to deny write access within allowed paths (takes precedence over allowWrite).",
+			"Controls whether agent mode terminal commands can retry in the sandbox with unrestricted network access after user confirmation. This applies only when {0} is set to `on` and preserves file system sandboxing while relaxing network restrictions for an approved command.",
 			"Note: this setting is applicable only when {0} is enabled. Key/value pairs are passed through to the root of the sandbox runtime configuration.",
+			"Controls whether agent mode uses sandboxing on Windows.",
+			"Enable sandboxing for agent mode tools on Windows and allow all network domains.",
+			"Disable sandboxing for agent mode tools on Windows.",
+			"Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on Windows. Paths do not support glob patterns, only literal paths (ex: C:\\src, C:\\Users\\me\\.ssh, .env).",
+			"Array of additional paths to allow read-only access. Takes precedence over denyRead.",
+			"Array of additional paths to allow read/write access. Leave empty to disallow writes outside the workspace folders, workspace storage folder, and sandbox temp directory.",
+			"Array of paths to deny access. Leave empty to allow reading all paths.",
 			"Note that there's a default set of rules to allow and also deny commands. Consider setting {0} to {1} to ignore all default rules to ensure there are no conflicts with your own rules. Do this at your own risk, the default denial rules are designed to protect you against running dangerous commands.",
 			"Use {0} instead",
 			"An object can be used to match against the full command line instead of matching sub-commands and inline commands, for example {0}. In order to be auto approved _both_ the sub-command and command line must not be explicitly denied, then _either_ all sub-commands or command line needs to be approved.",
@@ -46542,7 +48815,7 @@
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalSandboxService": [
 			"Delete Files in Sandbox Temp Dir",
 			"Focus Terminal",
-			"Installing missing sandbox dependencies may prompt for your sudo password. Select Focus Terminal to type it in the terminal.",
+			"Applying sandbox prerequisites may prompt for your sudo password. Select Focus Terminal to type it in the terminal.",
 			"The terminal is awaiting input."
 		],
 		"vs/workbench/contrib/terminalContrib/clipboard/browser/terminal.clipboard.contribution": [
@@ -48236,6 +50509,7 @@
 			"{0} selected",
 			"Back",
 			"Close",
+			"Continue",
 			"Continue without Signing In",
 			"Get Started",
 			"Could not install {0} keymap. You can install it later from Extensions.",
@@ -48257,13 +50531,13 @@
 			"Agents tutorial",
 			"Customize Your Agents",
 			"Tailor Copilot to your project with custom instructions and agents, skills, reusable prompts, and MCP servers that connect to the tools and context you rely on.",
-			"Choose Your Agent",
-			"Agents That Work Your Way",
+			"Agents made for the task",
+			"Agents that work your way",
 			"Plan",
-			"Produce a structured implementation plan before any code changes, then hand it off to an implementation agent to execute.",
+			"Produce a structured implementation plan before any code changes, then hand it off to an agent to execute.",
 			"Run Agents Anywhere",
 			"Run agents locally for interactive work, in the background with Copilot CLI, or in the cloud with cloud agents that open a pull request your team can review.",
-			"Sign in for AI Powered Features",
+			"Sign in to use GitHub Copilot",
 			"Continue with Apple",
 			". {0} Copilot may show ",
 			" suggestions and use your data to improve the product.",
@@ -48275,9 +50549,11 @@
 			"You can change these ",
 			" anytime.",
 			"Terms",
+			"Continue",
 			"GitHub Enterprise sign-in failed. Check your instance URL and try again.",
 			"You must enter a valid {0} instance (i.e. \"octocat\" or \"https://octocat.ghe.com\")",
 			"i.e. \"octocat\" or \"https://octocat.ghe.com\"...",
+			"Waiting for {0} sign-in to complete...",
 			"What is your {0} instance?",
 			"Will resolve to {0}",
 			"Sign-in failed. You can try again later from the Accounts menu.",
@@ -48286,8 +50562,9 @@
 			"Continue with GitHub",
 			"Continue with GitHub",
 			"Continue with Google",
-			"Sign in to continue with AI-powered development.",
+			"Sign in to use GitHub Copilot.",
 			"Welcome to VS Code",
+			"You're signed in. You can continue to the next step.",
 			"Open Chat anytime with ",
 			"Step {0} of {1}: {2}",
 			"{0} of {1}",
@@ -48712,9 +50989,11 @@
 			"The Chat Editing widget toolbar menu for session changes.",
 			"The Chat Editing widget toolbar menu for session title.",
 			"The inline gutter menu in the chat editor.",
+			"The status indicator area at the rightmost end of the toolbar shown beneath the chat input",
 			"The Chat Multi-Diff context menu.",
 			"The Chat new session menu.",
 			"The Chat Sessions menu.",
+			"The context menu for items in the Sessions window's session list.",
 			"Menu for new chat sessions.",
 			"The Chat submenu in the text editor context menu.",
 			"The Command Palette",
@@ -49005,6 +51284,7 @@
 			"Open Local Folder...",
 			"The path does not exist. Use ~ to go to your home directory.",
 			"Cancel",
+			"Could not create folder: {0}",
 			"Hide dot files",
 			"Please enter a valid path.",
 			"Show Local",
@@ -49012,6 +51292,7 @@
 			"Folder path",
 			"Show dot files",
 			"Please enter a valid file name.",
+			"The folder {0} does not exist. Would you like to create it?",
 			"The folder {0} does not exist. Would you like to create it?",
 			"{0} already exists. Are you sure you want to overwrite it?",
 			"Please select a file.",
@@ -49301,6 +51582,10 @@
 			"Extension '{0}' is required to open the remote window.\nDo you want to install the extension?",
 			"Learn More",
 			"Relaunch VS Code",
+			"Allow connecting to the remote server '{0}:{1}'?",
+			"Connect",
+			"Code is about to connect to '{0}:{1}' to host a remote extension host. Only continue if you trust this server, as it will be able to run code and access files on your behalf.",
+			"Connection to '{0}:{1}' was not allowed.",
 			"`{0}` not found on marketplace",
 			"Restart Extension Host",
 			"Restart Extension Host",

--- a/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc-model.ts
@@ -343,6 +343,11 @@ export interface DocumentHighlightProvider {
     provideDocumentHighlights(model: monaco.editor.ITextModel, position: monaco.Position, token: monaco.CancellationToken): DocumentHighlight[] | undefined;
 }
 
+export interface MultiDocumentHighlightDto {
+    uri: UriComponents;
+    highlights: DocumentHighlight[];
+}
+
 export interface FormattingOptions {
     tabSize: number;
     insertSpaces: boolean;

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -46,6 +46,7 @@ import {
     InlineValue,
     InlineValueContext,
     DocumentHighlight,
+    MultiDocumentHighlightDto,
     FormattingOptions,
     ChainedCacheId,
     Definition,
@@ -1824,6 +1825,8 @@ export interface LanguagesExt {
     $provideEvaluatableExpression(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<EvaluatableExpression | undefined>;
     $provideInlineValues(handle: number, resource: UriComponents, range: Range, context: InlineValueContext, token: CancellationToken): Promise<InlineValue[] | undefined>;
     $provideDocumentHighlights(handle: number, resource: UriComponents, position: Position, token: CancellationToken): Promise<DocumentHighlight[] | undefined>;
+    $provideMultiDocumentHighlights(handle: number, resource: UriComponents, position: Position, otherResources: UriComponents[], token: CancellationToken):
+        Promise<MultiDocumentHighlightDto[] | undefined>;
     $provideDocumentFormattingEdits(handle: number, resource: UriComponents,
         options: FormattingOptions, token: CancellationToken): Promise<TextEdit[] | undefined>;
     $provideDocumentRangeFormattingEdits(handle: number, resource: UriComponents, range: Range,
@@ -1919,6 +1922,7 @@ export interface LanguagesMain {
     $registerInlineValuesProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $emitInlineValuesEvent(eventHandle: number, event?: any): void;
     $registerDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
+    $registerMultiDocumentHighlightProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void;
     $registerQuickFixProvider(handle: number, pluginInfo: PluginInfo, selector: SerializedDocumentFilter[], codeActionKinds?: string[], documentation?: CodeActionProviderDocumentation): void;
     $clearDiagnostics(id: string): void;
     $changeDiagnostics(id: string, delta: [string, MarkerData[]][]): void;

--- a/packages/plugin-ext/src/main/browser/languages-main.ts
+++ b/packages/plugin-ext/src/main/browser/languages-main.ts
@@ -80,7 +80,8 @@ import {
     EvaluatableExpressionProvider,
     InlineValue,
     InlineValueContext,
-    InlineValuesProvider
+    InlineValuesProvider,
+    MultiDocumentHighlightProvider
 } from '@theia/monaco-editor-core/esm/vs/editor/common/languages';
 import { ITextModel } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
 import { CodeActionTriggerKind } from '../../plugin/types-impl';
@@ -353,7 +354,8 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
 
     protected createHoverProvider(handle: number): monaco.languages.HoverProvider {
         return {
-            provideHover: (model, position, token) => this.provideHover(handle, model, position, token)
+            provideHover: (model, position, token, context) =>
+                this.provideHover(handle, model, position, token, context as monaco.languages.HoverContext<HoverWithId> | undefined)
         };
     }
 
@@ -446,6 +448,45 @@ export class LanguagesMainImpl implements LanguagesMain, Disposable {
             }
 
             return undefined;
+        });
+    }
+
+    $registerMultiDocumentHighlightProvider(handle: number, _pluginInfo: PluginInfo, selector: SerializedDocumentFilter[]): void {
+        const languageSelector = this.toLanguageSelector(selector);
+        const multiDocumentHighlightProvider = this.createMultiDocumentHighlightProvider(handle, languageSelector);
+        this.register(handle,
+            StandaloneServices.get(ILanguageFeaturesService).multiDocumentHighlightProvider.register(languageSelector, multiDocumentHighlightProvider));
+    }
+
+    protected createMultiDocumentHighlightProvider(handle: number, selector: LanguageSelector): MultiDocumentHighlightProvider {
+        return {
+            selector,
+            provideMultiDocumentHighlights: (model, position, otherModels, token) =>
+                // @monaco-uplift: cast due to ITextModel enum incompatibility between internal and standalone API types
+                this.provideMultiDocumentHighlights(handle, model as unknown as monaco.editor.ITextModel, position,
+                    otherModels as unknown as monaco.editor.ITextModel[], token)
+        };
+    }
+
+    protected provideMultiDocumentHighlights(
+        handle: number, model: monaco.editor.ITextModel, position: monaco.Position,
+        otherModels: monaco.editor.ITextModel[], token: monaco.CancellationToken
+    ): monaco.languages.ProviderResult<Map<monaco.Uri, monaco.languages.DocumentHighlight[]>> {
+        const otherResources = otherModels.map(m => m.uri);
+        return this.proxy.$provideMultiDocumentHighlights(handle, model.uri, position, otherResources, token).then(result => {
+            if (!result) {
+                return undefined;
+            }
+            const map = new Map<monaco.Uri, monaco.languages.DocumentHighlight[]>();
+            for (const entry of result) {
+                const uri = monaco.Uri.revive(entry.uri);
+                const highlights: monaco.languages.DocumentHighlight[] = entry.highlights.map(item => ({
+                    ...item,
+                    kind: item.kind ?? monaco.languages.DocumentHighlightKind.Text
+                }));
+                map.set(uri, highlights);
+            }
+            return map;
         });
     }
 

--- a/packages/plugin-ext/src/plugin/languages.ts
+++ b/packages/plugin-ext/src/plugin/languages.ts
@@ -44,6 +44,7 @@ import {
     SerializedDocumentFilter,
     SignatureHelp,
     DocumentHighlight,
+    MultiDocumentHighlightDto,
     Range,
     TextEdit,
     FormattingOptions,
@@ -81,6 +82,7 @@ import { HoverAdapter } from './languages/hover';
 import { EvaluatableExpressionAdapter } from './languages/evaluatable-expression';
 import { InlineValuesAdapter } from './languages/inline-values';
 import { DocumentHighlightAdapter } from './languages/document-highlight';
+import { MultiDocumentHighlightAdapter } from './languages/multi-document-highlight';
 import { DocumentFormattingAdapter } from './languages/document-formatting';
 import { RangeFormattingAdapter } from './languages/range-formatting';
 import { OnTypeFormattingAdapter } from './languages/on-type-formatting';
@@ -122,6 +124,7 @@ type Adapter = CompletionAdapter |
     EvaluatableExpressionAdapter |
     InlineValuesAdapter |
     DocumentHighlightAdapter |
+    MultiDocumentHighlightAdapter |
     DocumentFormattingAdapter |
     RangeFormattingAdapter |
     OnTypeFormattingAdapter |
@@ -465,6 +468,23 @@ export class LanguagesExtImpl implements LanguagesExt {
         return this.withAdapter(handle, DocumentHighlightAdapter, adapter => adapter.provideDocumentHighlights(URI.revive(resource), position, token), undefined);
     }
     // ### Document Highlight Provider end
+
+    // ### Multi Document Highlight Provider begin
+    registerMultiDocumentHighlightProvider(
+        selector: theia.DocumentSelector, provider: theia.MultiDocumentHighlightProvider, pluginInfo: PluginInfo
+    ): theia.Disposable {
+        const callId = this.addNewAdapter(new MultiDocumentHighlightAdapter(provider, this.documents));
+        this.proxy.$registerMultiDocumentHighlightProvider(callId, pluginInfo, this.transformDocumentSelector(selector));
+        return this.createDisposable(callId);
+    }
+
+    $provideMultiDocumentHighlights(
+        handle: number, resource: UriComponents, position: Position, otherResources: UriComponents[], token: theia.CancellationToken
+    ): Promise<MultiDocumentHighlightDto[] | undefined> {
+        return this.withAdapter(handle, MultiDocumentHighlightAdapter,
+            adapter => adapter.provideMultiDocumentHighlights(URI.revive(resource), position, otherResources, token), undefined);
+    }
+    // ### Multi Document Highlight Provider end
 
     // ### WorkspaceSymbol Provider begin
     registerWorkspaceSymbolProvider(provider: theia.WorkspaceSymbolProvider, pluginInfo: PluginInfo): theia.Disposable {

--- a/packages/plugin-ext/src/plugin/languages/multi-document-highlight.ts
+++ b/packages/plugin-ext/src/plugin/languages/multi-document-highlight.ts
@@ -1,0 +1,75 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { URI } from '@theia/core/shared/vscode-uri';
+import * as theia from '@theia/plugin';
+import { DocumentsExtImpl } from '../documents';
+import * as types from '../types-impl';
+import * as Converter from '../type-converters';
+import { Position } from '../../common/plugin-api-rpc';
+import { MultiDocumentHighlightDto } from '../../common/plugin-api-rpc-model';
+import { UriComponents } from '../../common/uri-components';
+
+export class MultiDocumentHighlightAdapter {
+
+    constructor(
+        private readonly provider: theia.MultiDocumentHighlightProvider,
+        private readonly documents: DocumentsExtImpl) {
+    }
+
+    provideMultiDocumentHighlights(
+        resource: URI,
+        position: Position,
+        otherResources: UriComponents[],
+        token: theia.CancellationToken
+    ): Promise<MultiDocumentHighlightDto[] | undefined> {
+        const documentData = this.documents.getDocumentData(resource);
+        if (!documentData) {
+            return Promise.reject(new Error(`There is no document for ${resource}`));
+        }
+
+        const document = documentData.document;
+        const zeroBasedPosition = Converter.toPosition(position);
+
+        const otherDocuments: theia.TextDocument[] = [];
+        for (const otherResource of otherResources) {
+            const otherUri = URI.revive(otherResource);
+            const otherDocData = this.documents.getDocumentData(otherUri);
+            if (otherDocData) {
+                otherDocuments.push(otherDocData.document);
+            }
+        }
+
+        return Promise.resolve(this.provider.provideMultiDocumentHighlights(document, zeroBasedPosition, otherDocuments, token)).then(result => {
+            if (!result) {
+                return undefined;
+            }
+
+            if (!this.isMultiDocumentHighlightArray(result)) {
+                return undefined;
+            }
+
+            return result.map(multiHighlight => ({
+                uri: multiHighlight.uri,
+                highlights: multiHighlight.highlights.map(h => Converter.fromDocumentHighlight(h))
+            }));
+        });
+    }
+
+    private isMultiDocumentHighlightArray(array: unknown): array is types.MultiDocumentHighlight[] {
+        return Array.isArray(array) && array.length > 0 && array[0] instanceof types.MultiDocumentHighlight;
+    }
+}

--- a/packages/plugin-ext/src/plugin/plugin-context.ts
+++ b/packages/plugin-ext/src/plugin/plugin-context.ts
@@ -1061,12 +1061,8 @@ export function createAPIFactory(
             registerDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.DocumentHighlightProvider): theia.Disposable {
                 return languagesExt.registerDocumentHighlightProvider(selector, provider, pluginToPluginInfo(plugin));
             },
-            /**
-             * @stubbed
-             * @monaco-uplift: wait until API is available in Monaco (1.85.0+)
-             */
             registerMultiDocumentHighlightProvider(selector: theia.DocumentSelector, provider: theia.MultiDocumentHighlightProvider): theia.Disposable {
-                return Disposable.NULL;
+                return languagesExt.registerMultiDocumentHighlightProvider(selector, provider, pluginToPluginInfo(plugin));
             },
             registerWorkspaceSymbolProvider(provider: theia.WorkspaceSymbolProvider): theia.Disposable {
                 return languagesExt.registerWorkspaceSymbolProvider(provider, pluginToPluginInfo(plugin));

--- a/packages/plugin/src/theia.proposed.multiDocumentHighlightProvider.d.ts
+++ b/packages/plugin/src/theia.proposed.multiDocumentHighlightProvider.d.ts
@@ -74,7 +74,6 @@ export module '@theia/plugin' {
          * @param selector A selector that defines the documents this provider is applicable to.
          * @param provider A multi-document highlight provider.
          * @returns A {@link Disposable} that unregisters this provider when being disposed.
-         * @stubbed
          */
         export function registerMultiDocumentHighlightProvider(selector: DocumentSelector, provider: MultiDocumentHighlightProvider): Disposable;
     }

--- a/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
+++ b/packages/property-view/src/browser/resource-property-view/resource-property-view-tree-widget.tsx
@@ -98,7 +98,7 @@ export class ResourcePropertyViewTreeWidget extends TreeWidget implements Proper
             const infoNode = this.createCategoryNode('info', nls.localizeByDefault('Info'));
             this.propertiesTree.set('info', infoNode);
 
-            infoNode.children.push(this.createResultLineNode('isDirectory', nls.localize('theia/property-view/directory', 'Directory'), fileStatObject.isDirectory, infoNode));
+            infoNode.children.push(this.createResultLineNode('isDirectory', nls.localizeByDefault('Directory'), fileStatObject.isDirectory, infoNode));
             infoNode.children.push(this.createResultLineNode('isFile', nls.localizeByDefault('File'), fileStatObject.isFile, infoNode));
             infoNode.children.push(this.createResultLineNode('isSymbolicLink', nls.localize('theia/property-view/symbolicLink', 'Symbolic link'),
                 fileStatObject.isSymbolicLink, infoNode));

--- a/packages/scm-extra/src/browser/history/scm-history-constants.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-constants.ts
@@ -19,7 +19,7 @@ import { OpenViewArguments } from '@theia/core/lib/browser';
 import { ScmFileChangeNode, ScmHistoryCommit } from '../scm-file-change-node';
 
 export const SCM_HISTORY_ID = 'scm-history';
-export const SCM_HISTORY_LABEL = nls.localize('theia/scm/history', 'History');
+export const SCM_HISTORY_LABEL = nls.localizeByDefault('History');
 export const SCM_HISTORY_TOGGLE_KEYBINDING = 'alt+h';
 export const SCM_HISTORY_MAX_COUNT = 100;
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- implement stubbed MultiDocumentHighlightProvider for hover verbosity 
- Bump API compatibility to 1.125.0
  - The bump unblocks extensions targeting 1.125.0
- Update nls.metadata for vscode API 1.125.0
  - Fix suggestions to use `nls.localizeByDefault` or replace removed defaults

No public API changes: `src/vscode-dts/vscode.d.ts` is unchanged between 1.121.1 and 1.125.0, so no `theia.d.ts` updates are required this cycle.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Check the filtered [vscode-theia-comparator/status](https://eclipse-theia.github.io/vscode-theia-comparator/status.html) with the current Theia master and VS Code 1.125.0
- Regarding nls update: CI Lint step is successful and no localization related warnings are shown on startup
- for the hover verbosity: hover a symbol in a ts file for example, e.g. the function definition `requestHover` in `packages/core/src/browser/status-bar/status-bar.tsx#L141`, and verify the verbosity of the hover content can be in/decreased via +/-

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
