### PR TITLE
fix(ai-mcp): preserve cursor when editing MCP server fields

### DIFF
--- a/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
@@ -132,7 +132,16 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
 
     protected handleFormChange = (field: keyof MCPServerFormData, value: string | boolean): void => {
         this.formData = { ...this.formData, [field]: value };
-        this.update();
+        if (field === 'serverType') {
+            // serverType toggles which fields are shown - needs a re-render.
+            this.update();
+        } else {
+            // Inputs are uncontrolled (defaultValue/defaultChecked) so the DOM keeps the typed
+            // value without a React re-render. Skipping the re-render on every keystroke avoids
+            // the cursor-jump caused by Lumino's async update path with controlled inputs
+            // (GH-17414); we only refresh validation + accept-button state.
+            this.validate();
+        }
     };
 
     protected render(): React.ReactNode {
@@ -143,7 +152,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                     <input
                         type="text"
                         className="theia-input"
-                        value={this.formData.name}
+                        defaultValue={this.formData.name}
                         onChange={e => this.handleFormChange('name', e.target.value)}
                         placeholder={nls.localize('theia/ai/mcpConfiguration/form/serverNamePlaceholder', 'e.g., my-mcp-server')}
                         disabled={this.isEditing}
@@ -172,7 +181,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                         <input
                             type="checkbox"
                             className='theia-input'
-                            checked={this.formData.autostart}
+                            defaultChecked={this.formData.autostart}
                             onChange={e => this.handleFormChange('autostart', e.target.checked)}
                         />
                         {nls.localize('theia/ai/mcpConfiguration/form/autostart', 'Autostart')}
@@ -183,7 +192,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                         <input
                             type="checkbox"
                             className='theia-input'
-                            checked={this.formData.deferLoading}
+                            defaultChecked={this.formData.deferLoading}
                             onChange={e => this.handleFormChange('deferLoading', e.target.checked)}
                         />
                         {nls.localize('theia/ai/mcpConfiguration/form/deferLoading', 'Defer tool loading (discover tools on demand via the provider tool search)')}
@@ -201,7 +210,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                     <input
                         type="text"
                         className="theia-input"
-                        value={this.formData.command}
+                        defaultValue={this.formData.command}
                         onChange={e => this.handleFormChange('command', e.target.value)}
                         placeholder={nls.localize('theia/ai/mcpConfiguration/form/commandPlaceholder', 'e.g., npx or uvx')}
                         spellCheck={false}
@@ -213,7 +222,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                     <input
                         type="text"
                         className="theia-input"
-                        value={this.formData.args}
+                        defaultValue={this.formData.args}
                         onChange={e => this.handleFormChange('args', e.target.value)}
                         placeholder={nls.localize('theia/ai/mcpConfiguration/form/argsPlaceholder', 'Space-separated, e.g., -y @modelcontextprotocol/server-brave-search')}
                         spellCheck={false}
@@ -224,7 +233,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                     <label>{nls.localize('theia/ai/mcpConfiguration/environmentVariables', 'Environment Variables')}:</label>
                     <textarea
                         className="theia-input"
-                        value={this.formData.env}
+                        defaultValue={this.formData.env}
                         onChange={e => this.handleFormChange('env', e.target.value)}
                         placeholder={nls.localize('theia/ai/mcpConfiguration/form/envPlaceholder', 'KEY=value (one per line)')}
                         rows={3}
@@ -278,7 +287,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                     <input
                         type="text"
                         className="theia-input"
-                        value={this.formData.serverUrl}
+                        defaultValue={this.formData.serverUrl}
                         onChange={e => this.handleFormChange('serverUrl', e.target.value)}
                         placeholder={nls.localize('theia/ai/mcpConfiguration/form/serverUrlPlaceholder', 'e.g., https://mcp.example.com')}
                         spellCheck={false}
@@ -292,7 +301,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                             <input
                                 type="password"
                                 className="theia-input"
-                                value={this.formData.serverAuthToken}
+                                defaultValue={this.formData.serverAuthToken}
                                 onChange={e => this.handleFormChange('serverAuthToken', e.target.value)}
                                 placeholder={nls.localize('theia/ai/mcpConfiguration/form/authTokenPlaceholder', 'Optional authentication token')}
                                 spellCheck={false}
@@ -304,7 +313,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                             <input
                                 type="text"
                                 className="theia-input"
-                                value={this.formData.serverAuthTokenHeader}
+                                defaultValue={this.formData.serverAuthTokenHeader}
                                 onChange={e => this.handleFormChange('serverAuthTokenHeader', e.target.value)}
                                 placeholder={nls.localize('theia/ai/mcpConfiguration/form/authHeaderPlaceholder', 'Default: Authorization with Bearer')}
                                 spellCheck={false}
@@ -317,7 +326,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                     <label>{nls.localize('theia/ai/mcpConfiguration/headers', 'Headers')}:</label>
                     <textarea
                         className="theia-input"
-                        value={this.formData.headers}
+                        defaultValue={this.formData.headers}
                         onChange={e => this.handleFormChange('headers', e.target.value)}
                         placeholder={nls.localize('theia/ai/mcpConfiguration/form/headersPlaceholder', 'Header-Name=value (one per line)')}
                         rows={3}
@@ -366,7 +375,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                             <input
                                 type="text"
                                 className="theia-input"
-                                value={this.formData.oauthClientId}
+                                defaultValue={this.formData.oauthClientId}
                                 onChange={e => this.handleFormChange('oauthClientId', e.target.value)}
                                 placeholder={nls.localize('theia/ai/mcpConfiguration/form/oauthClientIdPlaceholder', 'Optional static client ID')}
                                 spellCheck={false}
@@ -378,7 +387,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                             <input
                                 type="password"
                                 className="theia-input"
-                                value={this.formData.oauthClientSecret}
+                                defaultValue={this.formData.oauthClientSecret}
                                 onChange={e => this.handleFormChange('oauthClientSecret', e.target.value)}
                                 placeholder={nls.localize('theia/ai/mcpConfiguration/form/oauthClientSecretPlaceholder',
                                     'Only for servers requiring a confidential client')}
@@ -391,7 +400,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                             <input
                                 type="text"
                                 className="theia-input"
-                                value={this.formData.oauthScopes}
+                                defaultValue={this.formData.oauthScopes}
                                 onChange={e => this.handleFormChange('oauthScopes', e.target.value)}
                                 placeholder={nls.localize('theia/ai/mcpConfiguration/form/oauthScopesPlaceholder', 'Space-separated scopes')}
                                 spellCheck={false}
@@ -403,7 +412,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                             <input
                                 type="text"
                                 className="theia-input"
-                                value={this.formData.oauthAuthorizationServer}
+                                defaultValue={this.formData.oauthAuthorizationServer}
                                 onChange={e => this.handleFormChange('oauthAuthorizationServer', e.target.value)}
                                 placeholder={nls.localize('theia/ai/mcpConfiguration/form/oauthAuthorizationServerPlaceholder', 'Optional authorization server URL')}
                                 spellCheck={false}
@@ -415,7 +424,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                             <input
                                 type="text"
                                 className="theia-input"
-                                value={this.formData.oauthResource}
+                                defaultValue={this.formData.oauthResource}
                                 onChange={e => this.handleFormChange('oauthResource', e.target.value)}
                                 placeholder={nls.localize('theia/ai/mcpConfiguration/form/oauthResourcePlaceholder', 'Optional resource URI')}
                                 spellCheck={false}


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Resolves GH-17414

- Switch the edit dialog's inputs to uncontrolled (defaultValue / defaultChecked) so the DOM holds the typed value
- With Lumino's async update path, controlled inputs would either snap the cursor to the end or revert the value after each keystroke
- handleFormChange still mirrors to formData and refreshes validation; only a serverType change triggers a re-render, since that toggles which fields are shown

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open the AI Configuration View and switch to the MCP Servers Tab
- Add and edit MCP server entries and verify the editing of values in the input fields now works as expected within the dialog

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
