### PR TITLE
add copy as text, export, and keybinds

### DIFF
--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -46,6 +46,19 @@ export namespace ProblemsMenu {
     export const PROBLEMS = [...PROBLEMS_CONTEXT_MENU, '2_problems'];
 }
 
+export interface SerializedProblemMarker {
+    resource: string;
+    owner: string;
+    code?: string | number;
+    severity?: number;
+    message: string;
+    source?: string;
+    startLineNumber: number;
+    startColumn: number;
+    endLineNumber: number;
+    endColumn: number;
+}
+
 export namespace ProblemsCommands {
     export const COLLAPSE_ALL: Command = {
         id: 'problems.collapse.all'
@@ -78,7 +91,7 @@ export namespace ProblemsCommands {
         id: 'problems.export',
         category: 'Problems',
         label: 'Export',
-        iconClass: codicon('arrow-circle-up', true)
+        iconClass: codicon('arrow-circle-up')
     }, 'theia/markers/export', nls.getDefaultKey('Problems'));
     export const CLEAR_ALL = Command.toLocalizedCommand({
         id: 'problems.clear.all',
@@ -337,10 +350,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
     protected copy(selections: ProblemSelection | ProblemSelection[]): void {
         const selectionsArray = Array.isArray(selections) ? selections : [selections];
         const serializedProblems = selectionsArray.map(selection => this.serializeMarker(selection.marker as ProblemMarker));
-        const output = selectionsArray.length === 1
-            ? JSON.stringify(serializedProblems[0], undefined, '\t')
-            : JSON.stringify(serializedProblems, undefined, '\t');
-        this.addToClipboard(output);
+        this.addToClipboard(JSON.stringify(serializedProblems, undefined, '\t'));
     }
 
     protected copyMessage(selections: ProblemSelection | ProblemSelection[]): void {
@@ -352,7 +362,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         this.addToClipboard(messages.join('\n'));
     }
 
-    protected serializeMarker(marker: ProblemMarker): object {
+    protected serializeMarker(marker: ProblemMarker): SerializedProblemMarker {
         return {
             resource: marker.uri,
             owner: marker.owner,
@@ -378,43 +388,15 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
     protected collectSelectedLinesInOrder(widget: ProblemWidget, node: TreeNode, selectedSet: Set<TreeNode>, lines: string[]): void {
         if (selectedSet.has(node)) {
             if (MarkerInfoNode.is(node)) {
-                lines.push(this.formatMarkerInfoNode(widget, node));
+                lines.push(widget.formatMarkerFileNodeAsText(node));
             } else if (MarkerNode.is(node)) {
-                lines.push(this.formatMarkerNode(node));
+                lines.push(widget.formatMarkerNodeAsText(node));
             }
         }
         if (CompositeTreeNode.is(node) && node.children) {
             for (const child of node.children) {
                 this.collectSelectedLinesInOrder(widget, child, selectedSet, lines);
             }
-        }
-    }
-
-    protected formatMarkerInfoNode(widget: ProblemWidget, node: MarkerInfoNode): string {
-        const name = widget.toNodeName(node);
-        const description = widget.toNodeDescription(node);
-        return description ? `${name} ${description}` : name;
-    }
-
-    protected formatMarkerNode(node: MarkerNode): string {
-        const marker = node.marker as ProblemMarker;
-        const severity = this.getSeverityLabel(marker.data.severity);
-        const line = marker.data.range.start.line + 1;
-        const column = marker.data.range.start.character + 1;
-        const location = nls.localizeByDefault('Ln {0}, Col {1}', line, column);
-        const source = marker.data.source ? `${marker.data.source}` : '';
-        const code = marker.data.code ? `(${marker.data.code})` : '';
-        const sourceCode = [source, code].filter(s => s).join(' ');
-        const suffix = sourceCode ? ` ${sourceCode}` : '';
-        return `${severity}: ${marker.data.message}${suffix} [${location}]`;
-    }
-
-    protected getSeverityLabel(severity: number | undefined): string {
-        switch (severity) {
-            case 1: return 'error';
-            case 2: return 'warning';
-            case 3: return 'info';
-            default: return 'hint';
         }
     }
 
@@ -432,9 +414,9 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
 
         const filePath = await this.fileDialogService.showSaveDialog({
-            title: 'Export Problems',
-            filters: { 'JSON Files': ['json'] },
-            saveLabel: 'Export'
+            title: nls.localize('theia/markers/exportProblems', 'Export Problems'),
+            filters: { [nls.localize('theia/markers/jsonFiles', 'JSON Files')]: ['json'] },
+            saveLabel: nls.localize('theia/markers/export', 'Export')
         });
 
         if (!filePath) {

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -20,18 +20,24 @@ import {
     FrontendApplication, FrontendApplicationContribution, CompositeTreeNode, SelectableTreeNode, Widget, codicon,
     TreeNode, TreeSelection
 } from '@theia/core/lib/browser';
+import { MessageService } from '@theia/core/lib/common/message-service';
 import { StatusBar, StatusBarAlignment } from '@theia/core/lib/browser/status-bar/status-bar';
 import { AbstractViewContribution } from '@theia/core/lib/browser/shell/view-contribution';
 import { PROBLEM_KIND, ProblemMarker } from '../../common/problem-marker';
 import { ProblemManager, ProblemStat } from './problem-manager';
 import { ProblemWidget, PROBLEMS_WIDGET_ID } from './problem-widget';
 import { ProblemTreeModel } from './problem-tree-model';
-import { MarkerNode } from '../marker-tree';
+import { MarkerNode, MarkerInfoNode } from '../marker-tree';
 import { MenuPath, MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
+import { LabelProvider } from '@theia/core/lib/browser/label-provider';
+import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { ProblemSelection } from './problem-selection';
 import { nls } from '@theia/core/lib/common/nls';
+import { FileDialogService } from '@theia/filesystem/lib/browser';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
 
 export const PROBLEMS_CONTEXT_MENU: MenuPath = [PROBLEM_KIND];
 
@@ -48,15 +54,32 @@ export namespace ProblemsCommands {
         id: 'problems.collapse.all.toolbar',
         iconClass: codicon('collapse-all')
     };
-    export const COPY: Command = {
-        id: 'problems.copy'
-    };
-    export const COPY_MESSAGE: Command = {
+    export const COPY = Command.toDefaultLocalizedCommand({
+        id: 'problems.copy',
+        category: 'Problems',
+        label: 'Copy'
+    });
+    export const COPY_MESSAGE = Command.toDefaultLocalizedCommand({
         id: 'problems.copy.message',
-    };
-    export const SELECT_ALL: Command = {
-        id: 'problems.select.all'
-    };
+        category: 'Problems',
+        label: 'Copy Message'
+    });
+    export const COPY_AS_TEXT = Command.toLocalizedCommand({
+        id: 'problems.copy.as.text',
+        category: 'Problems',
+        label: 'Copy as Text'
+    }, 'theia/markers/copyAsText', nls.getDefaultKey('Problems'));
+    export const SELECT_ALL = Command.toDefaultLocalizedCommand({
+        id: 'problems.select.all',
+        category: 'Problems',
+        label: 'Select All'
+    });
+    export const EXPORT = Command.toLocalizedCommand({
+        id: 'problems.export',
+        category: 'Problems',
+        label: 'Export',
+        iconClass: codicon('arrow-circle-up', true)
+    }, 'theia/markers/export', nls.getDefaultKey('Problems'));
     export const CLEAR_ALL = Command.toLocalizedCommand({
         id: 'problems.clear.all',
         category: 'Problems',
@@ -66,10 +89,15 @@ export namespace ProblemsCommands {
 }
 
 @injectable()
-export class ProblemContribution extends AbstractViewContribution<ProblemWidget> implements FrontendApplicationContribution, TabBarToolbarContribution {
+export class ProblemContribution extends AbstractViewContribution<ProblemWidget> implements FrontendApplicationContribution, TabBarToolbarContribution, KeybindingContribution {
 
     @inject(ProblemManager) protected readonly problemManager: ProblemManager;
     @inject(StatusBar) protected readonly statusBar: StatusBar;
+    @inject(FileDialogService) protected readonly fileDialogService: FileDialogService;
+    @inject(FileService) protected readonly fileService: FileService;
+    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
+    @inject(ContextKeyService) protected readonly contextKeyService: ContextKeyService;
+    @inject(MessageService) protected readonly messageService: MessageService;
 
     constructor() {
         super({
@@ -86,6 +114,12 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
     onStart(app: FrontendApplication): void {
         this.updateStatusBarElement();
         this.problemManager.onDidChangeMarkers(this.updateStatusBarElement);
+        const problemsFocusKey = this.contextKeyService.createKey<boolean>('problemsFocus', false);
+        const updateFocusKey = () => {
+            problemsFocusKey.set(this.shell.activeWidget instanceof ProblemWidget);
+        };
+        updateFocusKey();
+        this.shell.onDidChangeActiveWidget(updateFocusKey);
     }
 
     async initializeLayout(app: FrontendApplication): Promise<void> {
@@ -165,10 +199,27 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
                 }
             })
         });
+        commands.registerCommand(ProblemsCommands.COPY_AS_TEXT, {
+            isEnabled: () => this.withWidget(undefined, () => true),
+            isVisible: () => this.withWidget(undefined, () => true),
+            execute: () => this.withWidget(undefined, widget => {
+                const selectedSet = new Set(widget.model.selectedNodes);
+                if (selectedSet.size > 0) {
+                    this.copyAsText(widget, widget.model.root, selectedSet);
+                }
+            })
+        });
         commands.registerCommand(ProblemsCommands.SELECT_ALL, {
             isEnabled: () => this.withWidget(undefined, () => true),
             isVisible: () => this.withWidget(undefined, () => true),
             execute: () => this.withWidget(undefined, widget => this.selectAllProblems(widget))
+        });
+        commands.registerCommand(ProblemsCommands.EXPORT, {
+            isEnabled: () => this.withWidget(undefined, () => true),
+            isVisible: () => this.withWidget(undefined, () => true),
+            execute: async () => {
+                await this.withWidget(undefined, async widget => await this.exportProblems(widget));
+            }
         });
         commands.registerCommand(ProblemsCommands.CLEAR_ALL, {
             isEnabled: widget => this.withWidget(widget, () => true),
@@ -188,6 +239,14 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             commandId: ProblemsCommands.COPY_MESSAGE.id,
             label: nls.localizeByDefault('Copy Message'),
             order: '1'
+        });
+        menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
+            commandId: ProblemsCommands.COPY_AS_TEXT.id,
+            order: '2'
+        });
+        menus.registerMenuAction(ProblemsMenu.CLIPBOARD, {
+            commandId: ProblemsCommands.EXPORT.id,
+            order: '3'
         });
         menus.registerMenuAction(ProblemsMenu.PROBLEMS, {
             commandId: ProblemsCommands.COLLAPSE_ALL.id,
@@ -216,6 +275,19 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         });
     }
 
+    override registerKeybindings(keybindings: KeybindingRegistry): void {
+        keybindings.registerKeybinding({
+            command: ProblemsCommands.COPY.id,
+            keybinding: 'ctrlcmd+c',
+            when: 'problemsFocus'
+        });
+        keybindings.registerKeybinding({
+            command: ProblemsCommands.SELECT_ALL.id,
+            keybinding: 'ctrlcmd+a',
+            when: 'problemsFocus'
+        });
+    }
+
     protected async collapseAllProblems(): Promise<void> {
         const { model } = await this.widget;
         const root = model.root as CompositeTreeNode;
@@ -226,7 +298,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
     }
 
-    protected async selectAllProblems(widget: ProblemWidget): Promise<void> {
+    protected selectAllProblems(widget: ProblemWidget): void {
         const { model } = widget;
         const root = model.root as CompositeTreeNode;
         if (root) {
@@ -264,22 +336,11 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
 
     protected copy(selections: ProblemSelection | ProblemSelection[]): void {
         const selectionsArray = Array.isArray(selections) ? selections : [selections];
-        const serializedProblems = selectionsArray.map(selection => {
-            const marker = selection.marker as ProblemMarker;
-            return {
-                resource: marker.uri,
-                owner: marker.owner,
-                code: marker.data.code,
-                severity: marker.data.severity,
-                message: marker.data.message,
-                source: marker.data.source,
-                startLineNumber: marker.data.range.start.line,
-                startColumn: marker.data.range.start.character,
-                endLineNumber: marker.data.range.end.line,
-                endColumn: marker.data.range.end.character
-            };
-        });
-        this.addToClipboard(JSON.stringify(serializedProblems, undefined, '\t'));
+        const serializedProblems = selectionsArray.map(selection => this.serializeMarker(selection.marker as ProblemMarker));
+        const output = selectionsArray.length === 1
+            ? JSON.stringify(serializedProblems[0], undefined, '\t')
+            : JSON.stringify(serializedProblems, undefined, '\t');
+        this.addToClipboard(output);
     }
 
     protected copyMessage(selections: ProblemSelection | ProblemSelection[]): void {
@@ -289,6 +350,130 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             return marker.data.message;
         });
         this.addToClipboard(messages.join('\n'));
+    }
+
+    protected serializeMarker(marker: ProblemMarker): object {
+        return {
+            resource: marker.uri,
+            owner: marker.owner,
+            code: marker.data.code,
+            severity: marker.data.severity,
+            message: marker.data.message,
+            source: marker.data.source,
+            startLineNumber: marker.data.range.start.line,
+            startColumn: marker.data.range.start.character,
+            endLineNumber: marker.data.range.end.line,
+            endColumn: marker.data.range.end.character
+        };
+    }
+
+    protected copyAsText(widget: ProblemWidget, root: TreeNode | undefined, selectedSet: Set<TreeNode>): void {
+        const lines: string[] = [];
+        if (root) {
+            this.collectSelectedLinesInOrder(widget, root, selectedSet, lines);
+        }
+        this.addToClipboard(lines.join('\n'));
+    }
+
+    protected collectSelectedLinesInOrder(widget: ProblemWidget, node: TreeNode, selectedSet: Set<TreeNode>, lines: string[]): void {
+        if (selectedSet.has(node)) {
+            if (MarkerInfoNode.is(node)) {
+                lines.push(this.formatMarkerInfoNode(widget, node));
+            } else if (MarkerNode.is(node)) {
+                lines.push(this.formatMarkerNode(node));
+            }
+        }
+        if (CompositeTreeNode.is(node) && node.children) {
+            for (const child of node.children) {
+                this.collectSelectedLinesInOrder(widget, child, selectedSet, lines);
+            }
+        }
+    }
+
+    protected formatMarkerInfoNode(widget: ProblemWidget, node: MarkerInfoNode): string {
+        const name = widget.toNodeName(node);
+        const description = widget.toNodeDescription(node);
+        return description ? `${name} ${description}` : name;
+    }
+
+    protected formatMarkerNode(node: MarkerNode): string {
+        const marker = node.marker as ProblemMarker;
+        const severity = this.getSeverityLabel(marker.data.severity);
+        const line = marker.data.range.start.line + 1;
+        const column = marker.data.range.start.character + 1;
+        const location = nls.localizeByDefault('Ln {0}, Col {1}', line, column);
+        const source = marker.data.source ? `${marker.data.source}` : '';
+        const code = marker.data.code ? `(${marker.data.code})` : '';
+        const sourceCode = [source, code].filter(s => s).join(' ');
+        const suffix = sourceCode ? ` ${sourceCode}` : '';
+        return `${severity}: ${marker.data.message}${suffix} [${location}]`;
+    }
+
+    protected getSeverityLabel(severity: number | undefined): string {
+        switch (severity) {
+            case 1: return 'error';
+            case 2: return 'warning';
+            case 3: return 'info';
+            default: return 'hint';
+        }
+    }
+
+    protected async exportProblems(widget: ProblemWidget): Promise<void> {
+        const selectedNodes = widget.model.selectedNodes;
+
+        if (selectedNodes.length === 0) {
+            return;
+        }
+
+        const markerNodes = this.collectMarkerNodes(selectedNodes);
+
+        if (markerNodes.length === 0) {
+            return;
+        }
+
+        const filePath = await this.fileDialogService.showSaveDialog({
+            title: 'Export Problems',
+            filters: { 'JSON Files': ['json'] },
+            saveLabel: 'Export'
+        });
+
+        if (!filePath) {
+            return;
+        }
+
+        try {
+            const serializedProblems = markerNodes.map(node => this.serializeMarker(node.marker as ProblemMarker));
+            const content = JSON.stringify(serializedProblems, undefined, '\t');
+            await this.fileService.write(filePath, content);
+            this.messageService.info(nls.localize('theia/markers/exportSuccess', 'Problems exported successfully.'));
+        } catch (error) {
+            const errorMessage = error instanceof Error ? error.message : String(error);
+            this.messageService.error(errorMessage);
+        }
+    }
+
+    protected collectMarkerNodes(nodes: readonly TreeNode[]): MarkerNode[] {
+        const seen = new Set<MarkerNode>();
+        for (const node of nodes) {
+            if (MarkerNode.is(node)) {
+                seen.add(node);
+            } else if (CompositeTreeNode.is(node)) {
+                this.collectMarkerNodesRecursive(node, seen);
+            }
+        }
+        return Array.from(seen);
+    }
+
+    protected collectMarkerNodesRecursive(node: CompositeTreeNode, seen: Set<MarkerNode>): void {
+        if (node.children) {
+            for (const child of node.children) {
+                if (MarkerNode.is(child)) {
+                    seen.add(child);
+                } else if (CompositeTreeNode.is(child)) {
+                    this.collectMarkerNodesRecursive(child, seen);
+                }
+            }
+        }
     }
 
     protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), cb: (problems: ProblemWidget) => T): T | false {

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -32,7 +32,6 @@ import { MenuPath, MenuModelRegistry } from '@theia/core/lib/common/menu';
 import { Command, CommandRegistry } from '@theia/core/lib/common/command';
 import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { KeybindingContribution, KeybindingRegistry } from '@theia/core/lib/browser/keybinding';
-import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import { ProblemSelection } from './problem-selection';
 import { nls } from '@theia/core/lib/common/nls';
@@ -108,7 +107,6 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
     @inject(StatusBar) protected readonly statusBar: StatusBar;
     @inject(FileDialogService) protected readonly fileDialogService: FileDialogService;
     @inject(FileService) protected readonly fileService: FileService;
-    @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
     @inject(ContextKeyService) protected readonly contextKeyService: ContextKeyService;
     @inject(MessageService) protected readonly messageService: MessageService;
 
@@ -290,7 +288,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
 
     override registerKeybindings(keybindings: KeybindingRegistry): void {
         keybindings.registerKeybinding({
-            command: ProblemsCommands.COPY.id,
+            command: ProblemsCommands.COPY_AS_TEXT.id,
             keybinding: 'ctrlcmd+c',
             when: 'problemsFocus'
         });
@@ -407,7 +405,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             return;
         }
 
-        const markerNodes = this.collectMarkerNodes(selectedNodes);
+        const markerNodes = this.collectMarkerNodes(selectedNodes, new Set<MarkerNode>());
 
         if (markerNodes.length === 0) {
             return;
@@ -416,7 +414,8 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         const filePath = await this.fileDialogService.showSaveDialog({
             title: nls.localize('theia/markers/exportProblems', 'Export Problems'),
             filters: { [nls.localize('theia/markers/jsonFiles', 'JSON Files')]: ['json'] },
-            saveLabel: nls.localize('theia/markers/export', 'Export')
+            saveLabel: nls.localize('theia/markers/export', 'Export'),
+            inputValue: nls.localizeByDefault('Problem').toLowerCase()
         });
 
         if (!filePath) {
@@ -434,28 +433,15 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
         }
     }
 
-    protected collectMarkerNodes(nodes: readonly TreeNode[]): MarkerNode[] {
-        const seen = new Set<MarkerNode>();
+    protected collectMarkerNodes(nodes: readonly TreeNode[], seen: Set<MarkerNode>): MarkerNode[] {
         for (const node of nodes) {
             if (MarkerNode.is(node)) {
                 seen.add(node);
             } else if (CompositeTreeNode.is(node)) {
-                this.collectMarkerNodesRecursive(node, seen);
+                this.collectMarkerNodes(node.children, seen);
             }
         }
         return Array.from(seen);
-    }
-
-    protected collectMarkerNodesRecursive(node: CompositeTreeNode, seen: Set<MarkerNode>): void {
-        if (node.children) {
-            for (const child of node.children) {
-                if (MarkerNode.is(child)) {
-                    seen.add(child);
-                } else if (CompositeTreeNode.is(child)) {
-                    this.collectMarkerNodesRecursive(child, seen);
-                }
-            }
-        }
     }
 
     protected withWidget<T>(widget: Widget | undefined = this.tryGetWidget(), cb: (problems: ProblemWidget) => T): T | false {

--- a/packages/markers/src/browser/problem/problem-contribution.ts
+++ b/packages/markers/src/browser/problem/problem-contribution.ts
@@ -415,7 +415,7 @@ export class ProblemContribution extends AbstractViewContribution<ProblemWidget>
             title: nls.localize('theia/markers/exportProblems', 'Export Problems'),
             filters: { [nls.localize('theia/markers/jsonFiles', 'JSON Files')]: ['json'] },
             saveLabel: nls.localize('theia/markers/export', 'Export'),
-            inputValue: nls.localizeByDefault('Problem').toLowerCase()
+            inputValue: nls.localizeByDefault('Problems').toLowerCase() + '.json'
         });
 
         if (!filePath) {

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -31,6 +31,17 @@ import { nls } from '@theia/core/lib/common/nls';
 
 export const PROBLEMS_WIDGET_ID = 'problems';
 
+interface MarkerNodeFormatData {
+    severityClass: string;
+    severityLabel: string;
+    message: string;
+    line: number;
+    column: number;
+    location: string;
+    source: string;
+    code: string;
+}
+
 @injectable()
 export class ProblemWidget extends TreeWidget {
 
@@ -175,37 +186,45 @@ export class ProblemWidget extends TreeWidget {
         return <ProblemMarkerRemoveButton model={this.model} node={node} />;
     }
 
-    override toNodeName(node: TreeNode): string {
-        return super.toNodeName(node);
-    }
-
-    override toNodeDescription(node: TreeNode): string {
-        return super.toNodeDescription(node);
+    protected getMarkerNodeFormatData(marker: ProblemMarker): MarkerNodeFormatData {
+        const line = marker.data.range.start.line + 1;
+        const column = marker.data.range.start.character + 1;
+        const location = nls.localizeByDefault('Ln {0}, Col {1}', line, column);
+        const severityClass = marker.data.severity ? this.getSeverityClass(marker.data.severity) : '';
+        const severityLabel = marker.data.severity ? this.getSeverityLabel(marker.data.severity) : '';
+        const source = marker.data.source ? `${marker.data.source}` : '';
+        const code = marker.data.code ? `(${marker.data.code})` : '';
+        return {
+            severityClass,
+            severityLabel,
+            message: marker.data.message,
+            line,
+            column,
+            location,
+            source,
+            code,
+        };
     }
 
     protected decorateMarkerNode(node: MarkerNode): React.ReactNode {
         if (ProblemMarker.is(node.marker)) {
-            let severityClass: string = '';
             const problemMarker = node.marker;
-            if (problemMarker.data.severity) {
-                severityClass = this.getSeverityClass(problemMarker.data.severity);
-            }
-            const location = nls.localizeByDefault('Ln {0}, Col {1}', problemMarker.data.range.start.line + 1, problemMarker.data.range.start.character + 1);
+            const data = this.getMarkerNodeFormatData(problemMarker);
             return <div
                 className='markerNode'
-                title={`${problemMarker.data.message} (${problemMarker.data.range.start.line + 1}, ${problemMarker.data.range.start.character + 1})`}>
+                title={`${data.message} (${data.line}, ${data.column})`}>
                 <div>
-                    <i className={`${severityClass} ${TREE_NODE_INFO_CLASS}`}></i>
+                    <i className={`${data.severityClass} ${TREE_NODE_INFO_CLASS}`}></i>
                 </div>
-                <div className='message'>{problemMarker.data.message}
-                    {(!!problemMarker.data.source || !!problemMarker.data.code) &&
+                <div className='message'>{data.message}
+                    {(!!data.source || !!data.code) &&
                         <span className={'owner ' + TREE_NODE_INFO_CLASS}>
-                            {problemMarker.data.source || ''}
-                            {problemMarker.data.code ? `(${problemMarker.data.code})` : ''}
+                            {data.source || ''}
+                            {data.code || ''}
                         </span>
                     }
                     <span className={'position ' + TREE_NODE_INFO_CLASS}>
-                        {`[${location}]`}
+                        {`[${data.location}]`}
                     </span>
                 </div>
             </div>;
@@ -213,13 +232,36 @@ export class ProblemWidget extends TreeWidget {
         return '';
     }
 
+    formatMarkerNodeAsText(node: MarkerNode): string {
+        const marker = node.marker as ProblemMarker;
+        const data = this.getMarkerNodeFormatData(marker);
+        const sourceCode = [data.source, data.code].filter(s => s).join(' ');
+        const suffix = sourceCode ? ` ${sourceCode}` : '';
+        return `${data.severityLabel}: ${data.message}${suffix} [${data.location}]`;
+    }
+
+    protected getSeverityLabel(severity: DiagnosticSeverity): string {
+        switch (severity) {
+            case DiagnosticSeverity.Error: return nls.localizeByDefault('Error');
+            case DiagnosticSeverity.Warning: return nls.localizeByDefault('Warning');
+            case DiagnosticSeverity.Information: return nls.localizeByDefault('Info');
+            default: return nls.localizeByDefault('Hint');
+        }
+    }
+
     protected getSeverityClass(severity: DiagnosticSeverity): string {
         switch (severity) {
-            case 1: return `${codicon('error')} error`;
-            case 2: return `${codicon('warning')} warning`;
-            case 3: return `${codicon('info')} information`;
+            case DiagnosticSeverity.Error: return `${codicon('error')} error`;
+            case DiagnosticSeverity.Warning: return `${codicon('warning')} warning`;
+            case DiagnosticSeverity.Information: return `${codicon('info')} information`;
             default: return `${codicon('thumbsup')} hint`;
         }
+    }
+
+    formatMarkerFileNodeAsText(node: MarkerInfoNode): string {
+        const name = this.toNodeName(node);
+        const description = this.toNodeDescription(node);
+        return description ? `${name} ${description}` : name;
     }
 
     protected decorateMarkerFileNode(node: MarkerInfoNode): React.ReactNode {

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -175,6 +175,14 @@ export class ProblemWidget extends TreeWidget {
         return <ProblemMarkerRemoveButton model={this.model} node={node} />;
     }
 
+    override toNodeName(node: TreeNode): string {
+        return super.toNodeName(node);
+    }
+
+    override toNodeDescription(node: TreeNode): string {
+        return super.toNodeDescription(node);
+    }
+
     protected decorateMarkerNode(node: MarkerNode): React.ReactNode {
         if (ProblemMarker.is(node.marker)) {
             let severityClass: string = '';

--- a/packages/markers/src/browser/problem/problem-widget.tsx
+++ b/packages/markers/src/browser/problem/problem-widget.tsx
@@ -69,8 +69,6 @@ export class ProblemWidget extends TreeWidget {
         this.title.iconClass = codicon('warning');
         this.title.closable = true;
         this.addClass('theia-marker-container');
-
-        this.addClipboardListener(this.node, 'copy', e => this.handleCopy(e));
     }
 
     @postConstruct()
@@ -133,14 +131,6 @@ export class ProblemWidget extends TreeWidget {
         super.tapNode(node);
         if (MarkerNode.is(node)) {
             this.model.revealNode(node);
-        }
-    }
-
-    protected handleCopy(event: ClipboardEvent): void {
-        const uris = this.model.selectedNodes.filter(MarkerNode.is).map(node => node.uri.toString());
-        if (uris.length > 0 && event.clipboardData) {
-            event.clipboardData.setData('text/plain', uris.join('\n'));
-            event.preventDefault();
         }
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Implements https://github.com/eclipse-theia/theia/issues/17706.
- Add an "export" menu, which will open up a file dialog and write the json object to a user-specified file. Note: Unlike "copy", when only a header is selected, we export all of its children. Also, unlike "copy", the exported json is always a list, even when there is only one problem selected. This would be easier for automated process with the exported file.
- Add a "copy as text" menu. It is to copy message, but will also output the file names, severity level, and other info that are visible and selected. Unlike "copy", this menu works for headers as well (it will just copy the file name as displayed in the selected item).
- Wire up Ctrl+C and Ctrl+A key bindings for copy and select all, respectively.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the Problems view.
2. Create at least two problems.
4. Press Ctrl+a.
5. Observe all nodes are now selected.
6. Press Ctrl+c.
7. Paste the content somewhere, confirm it is the correct list of json object.
8. Select a problem.
9. Right click on any node, see there is a "export" in the context menu.
10. Click "export".
11. Observe a file dialog pops up.
12. Input a file destination, and click OK.
13. Observe the correct list of json objects is exported.
14. Repeat 9~13 on multiple problems.
15. Select a problem header.
16. Repeat 9~12.
17. Observe all of the children of the header are exported. Note that if both header and the problem itself are selected, there should still be only one copy of the corresponding object in the list.
18. Select any number of nodes.
19. . Right click on any node, see there is a "copy as text" in the context menu.
20.  Click "copy as text".
21. Paste the content somewhere, confirm it is the correct text as displayed.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- Now that "copy as text" and "export" works for headers, I'm not sure if it would be better if we make "copy" to work on headesr as well. However, I personally find it does not make too much sense if "copy message" copies all the children for a selected header.
- If we don't want to make "copy" to work on headers, I think Ctrl+c is better wire up with "copy as text" instead, and rename "copy as text" to "copy", while the existing "copy" to "copy as json" or "copy details", since it would be weird if "copy" and "Ctrl+c" is not the more general version. 
- Behavior of "export" is not the same with "copy", since I think it would make more sense this way. I feel that a user should be able to export all of its children problem if they click on a header. We may certainly change this to match "copy" exactly if that is better.
- Also, currently the copy and copy message returns the result in whatever order the nodes are selected. Maybe we want to do the same as what copy as text is doing now, and return in the order displayed in the view?
- In future, it might be good to refactor "copy as text" to allow the users to decide the format themselves, as in VScode: https://github.com/microsoft/vscode/issues/133408#issuecomment-928211672. I don't think it's a priority now, though.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
