### PR TITLE
Improve composition check for keybindings

### DIFF
--- a/packages/core/src/browser/keybinding.ts
+++ b/packages/core/src/browser/keybinding.ts
@@ -610,11 +610,10 @@ export class KeybindingRegistry {
     }
 
     registerEventListeners(win: Window): Disposable {
-        /* vvv HOTFIX begin vvv
-        *
-        * This is a hotfix against issues eclipse/theia#6459 and gitpod-io/gitpod#875 .
-        * It should be reverted after Theia was updated to the newer Monaco.
-        */
+        // IME composition tracking for the textarea-based editor input path,
+        // where compositionstart/compositionend bubble through the DOM.
+        // (For the native EditContext path, these events never reach the DOM;
+        // the keydown handler below uses additional checks for that case.)
         let inComposition = false;
         const compositionStart = () => {
             inComposition = true;
@@ -627,9 +626,15 @@ export class KeybindingRegistry {
         win.document.addEventListener('compositionend', compositionEnd);
 
         const keydown = (event: KeyboardEvent) => {
-            if (inComposition !== true) {
-                this.run(event);
+            // Skip IME-related keydowns. `inComposition` covers the textarea input path;
+            // `isComposing` and `keyCode === 229` cover the native EditContext path where
+            // composition events don't reach the DOM. The keyCode check catches keys that
+            // finalize a composition (e.g. arrow keys) where isComposing is already false.
+            // eslint-disable-next-line deprecation/deprecation
+            if (inComposition || event.isComposing || event.keyCode === 229) {
+                return;
             }
+            this.run(event);
         };
         win.document.addEventListener('keydown', keydown, true);
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Fixes a few issues with IME composition that I've observed typing in Korean (on MacOS). The issues were:

- Problems in transition between syllable blocks. Intermittently(?), typing a multi-block word with a forced break would ignore the first letter of the second block.
- Problems transitioning out of composition through other keypresses: e.g. down arrow would insert current block at current position, and also insert it in the current cursor index in the next line, and then move to the second line after the initial input.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. Using a Korean keyboard, type a variety of syllable blocks. (I used two-set Korean, so these sequences should give these outputs: akfrdms 맑은 akfrms 말근 aksen 만두 dhkdwk 왕자)
2. Using a Korean keyboard, in a file with some text (I used packages/ai-mcp-ui/src/browser/mcp-command-contribution.ts), type one of the syllable blocks above on one line, then, before exiting composition (i.e. without typing space or enter), hit down arrow. The text you input should appear on the line on which you input it, and not on the line below. i.e. you should not end up with this:

<img width="316" height="55" alt="image" src="https://github.com/user-attachments/assets/13a4aeae-9896-40b1-ba4f-c7a43b7d5d52" />

3. Try some other IME systems and make sure nothing is broken. I tried locally with Chinese (Zhuyin) input and Japanese.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
