### PR TITLE
Rely on Virtuoso's onAtBottomStateChange for scroll locking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@
 ## 1.74.0 - tbd
 
 - [ai-anthropic, ai-chat, ai-chat-ui, ai-core, ai-openai] added provider-native server-side compaction for chat sessions, modeled as a model capability (`LanguageModelMetaData.serverSideCompactionSupport`) plus layered activation: a global preference (`ai-features.chat.serverSideCompaction`, default on), a per-provider override, and a per-session override (in the session settings dialog) that wins over both. Honored by the Anthropic Messages API (beta) and the OpenAI Responses API; the compaction marker is persisted in the session, replayed on subsequent requests, surfaced as an inline chat marker, and reflected in the token-usage tooltip (cumulative usage and a "compacted Nx" count). Providers/models without the capability ignore it [#17636](https://github.com/eclipse-theia/theia/issues/17636)
+- [ai-chat-ui] replaced scroll-direction heuristics in `ChatViewTreeWidget` with Virtuoso's `atBottomStateChange` for reliable auto-scroll during streaming [#17728](https://github.com/eclipse-theia/theia/pull/17728)
+
+<a name="breaking_changes_1.74.0">[Breaking Changes:](#breaking_changes_1.74.0)</a>
+
+- [ai-chat-ui] `ChatViewTreeWidget` scroll-lock is now driven by Virtuoso's `atBottomStateChange` callback instead of scroll-direction heuristics; the following `protected` members have been removed: `handleScrollEvent()`, `getCurrentScrollTop()`, `isAtAbsoluteBottom()`, `updateScrollToBottomButtonState()`, `lastScrollTop`, `_scrollButtonDebounceTimer`, `SCROLL_BUTTON_GRACE_PERIOD`, and the `updateScrollToRow()` override. Subclasses that override any of these should use the new `handleAtBottomStateChange(isAtBottom: boolean)` method instead [#17728](https://github.com/eclipse-theia/theia/pull/17728)
+- [core] removed `TreeWidget.onScroll`, `TreeWidget.onScrollEmitter`, `TreeWidget.getVirtualizedScrollState()`, `TreeWidget.isScrolledToBottom()`, the `TreeScrollEvent` interface, and the `TreeScrollState` interface. Use `TreeWidget.onAtBottomStateChange` to react to bottom-state changes instead [#17728](https://github.com/eclipse-theia/theia/pull/17728)
 
 ## 1.73.0 - 6/25/2026
 

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -163,23 +163,11 @@ export class ChatViewTreeWidget extends TreeWidget {
     /** Tracks if we are at the bottom for showing the scroll-to-bottom button. */
     protected atBottom = true;
     /**
-     * Track the visibility of the scroll button with debounce logic. Used to prevent flickering when streaming tokens.
+     * Track the visibility of the scroll button.
      */
     protected _showScrollButton = false;
-    /**
-     * Timer for debouncing the scroll button activation (prevents flicker on auto-scroll).
-     * If user scrolls up, this delays showing the button in case auto-scroll-to-bottom kicks in.
-     */
-    protected _scrollButtonDebounceTimer?: number;
-    /**
-     * Debounce period in ms before showing scroll-to-bottom button after scrolling up.
-     * Avoids flickering of the button during LLM token streaming.
-     */
-    protected static readonly SCROLL_BUTTON_GRACE_PERIOD = 100;
 
     onScrollLockChange?: (temporaryLocked: boolean) => void;
-
-    protected lastScrollTop = 0;
 
     set shouldScrollToEnd(shouldScrollToEnd: boolean) {
         this._shouldScrollToEnd = shouldScrollToEnd;
@@ -230,8 +218,8 @@ export class ChatViewTreeWidget extends TreeWidget {
                 });
                 this.update();
             }),
-            this.onScroll(scrollEvent => {
-                this.handleScrollEvent(scrollEvent);
+            this.onAtBottomStateChange(atBottom => {
+                this.handleAtBottomStateChange(atBottom);
             })
         ]);
 
@@ -245,8 +233,6 @@ export class ChatViewTreeWidget extends TreeWidget {
             }
         }
 
-        // Initialize lastScrollTop with current scroll position
-        this.lastScrollTop = this.getCurrentScrollTop(undefined);
     }
 
     public setEnabled(enabled: boolean): void {
@@ -254,54 +240,20 @@ export class ChatViewTreeWidget extends TreeWidget {
         this.update();
     }
 
-    protected handleScrollEvent(scrollEvent: unknown): void {
-        const currentScrollTop = this.getCurrentScrollTop(scrollEvent);
-        const isScrollingUp = currentScrollTop < this.lastScrollTop;
-        const isScrollingDown = currentScrollTop > this.lastScrollTop;
-        const isAtBottom = this.isScrolledToBottom();
-        const isAtAbsoluteBottom = this.isAtAbsoluteBottom();
-
-        // Asymmetric threshold logic to prevent jitter:
-        if (this.shouldScrollToEnd && isScrollingUp) {
-            if (!isAtAbsoluteBottom) {
+    /** Toggles auto-scroll and the scroll-to-bottom button based on whether the viewport includes the bottom of the list. */
+    protected handleAtBottomStateChange(isAtBottom: boolean): void {
+        if (isAtBottom !== this.atBottom) {
+            this.atBottom = isAtBottom;
+            if (isAtBottom) {
+                // Arrived at bottom — re-enable auto-scroll and hide the button
+                this._showScrollButton = false;
+                this.setTemporaryScrollLock(false);
+            } else {
+                // Left the bottom — lock auto-scroll and show the button
+                this._showScrollButton = true;
                 this.setTemporaryScrollLock(true);
             }
-        } else if (!this.shouldScrollToEnd && isAtBottom && isScrollingDown) {
-            this.setTemporaryScrollLock(false);
-        }
-
-        this.updateScrollToBottomButtonState(isAtBottom);
-
-        this.lastScrollTop = currentScrollTop;
-    }
-
-    /** Updates the scroll-to-bottom button state and handles debounce. */
-    protected updateScrollToBottomButtonState(isAtBottom: boolean): void {
-        const atBottomNow = isAtBottom; // Use isScrolledToBottom for threshold
-        if (atBottomNow !== this.atBottom) {
-            this.atBottom = atBottomNow;
-            if (this.atBottom) {
-                // We're at the bottom, hide the button immediately and clear any debounce timer.
-                this._showScrollButton = false;
-                if (this._scrollButtonDebounceTimer !== undefined) {
-                    clearTimeout(this._scrollButtonDebounceTimer);
-                    this._scrollButtonDebounceTimer = undefined;
-                }
-                this.update();
-            } else {
-                // User scrolled up; delay showing the scroll-to-bottom button.
-                if (this._scrollButtonDebounceTimer !== undefined) {
-                    clearTimeout(this._scrollButtonDebounceTimer);
-                }
-                this._scrollButtonDebounceTimer = window.setTimeout(() => {
-                    // Re-check: only show if we're still not at bottom
-                    if (!this.atBottom) {
-                        this._showScrollButton = true;
-                        this.update();
-                    }
-                    this._scrollButtonDebounceTimer = undefined;
-                }, ChatViewTreeWidget.SCROLL_BUTTON_GRACE_PERIOD);
-            }
+            this.update();
         }
     }
 
@@ -310,58 +262,6 @@ export class ChatViewTreeWidget extends TreeWidget {
         this.onScrollLockChange?.(enabled);
         // Update cached scrollToRow so that outdated values do not cause unwanted scrolling on update()
         this.updateScrollToRow();
-    }
-
-    protected getCurrentScrollTop(scrollEvent: unknown): number {
-        // For virtualized trees, use the virtualized view's scroll state (most reliable)
-        if (this.props.virtualized !== false && this.view) {
-            const scrollState = this.getVirtualizedScrollState();
-            if (scrollState !== undefined) {
-                return scrollState.scrollTop;
-            }
-        }
-
-        // Try to extract scroll position from the scroll event
-        if (scrollEvent && typeof scrollEvent === 'object' && 'scrollTop' in scrollEvent) {
-            const scrollEventWithScrollTop = scrollEvent as { scrollTop: unknown };
-            const scrollTop = scrollEventWithScrollTop.scrollTop;
-            if (typeof scrollTop === 'number' && !isNaN(scrollTop)) {
-                return scrollTop;
-            }
-        }
-
-        // Last resort: use DOM scroll position
-        if (this.node && typeof this.node.scrollTop === 'number') {
-            return this.node.scrollTop;
-        }
-
-        return 0;
-    }
-
-    /**
-     * Returns true if the scroll position is at the absolute (1px tolerance) bottom of the scroll container.
-     * Handles both virtualized and non-virtualized scroll containers.
-     * Allows for a tiny floating point epsilon (1px).
-     */
-    protected isAtAbsoluteBottom(): boolean {
-        let scrollTop: number = 0;
-        let scrollHeight: number = 0;
-        let clientHeight: number = 0;
-        const EPSILON = 1; // px
-        if (this.props.virtualized !== false && this.view) {
-            const state = this.getVirtualizedScrollState();
-            if (state) {
-                scrollTop = state.scrollTop;
-                scrollHeight = state.scrollHeight ?? 0;
-                clientHeight = state.clientHeight ?? 0;
-            }
-        } else if (this.node) {
-            scrollTop = this.node.scrollTop;
-            scrollHeight = this.node.scrollHeight;
-            clientHeight = this.node.clientHeight;
-        }
-        const diff = Math.abs(scrollTop + clientHeight - scrollHeight);
-        return diff <= EPSILON;
     }
 
     protected override renderTree(model: TreeModel): React.ReactNode {
@@ -397,10 +297,7 @@ export class ChatViewTreeWidget extends TreeWidget {
         this.scrollToRow = this.rows.size;
         this.atBottom = true;
         this._showScrollButton = false;
-        if (this._scrollButtonDebounceTimer !== undefined) {
-            clearTimeout(this._scrollButtonDebounceTimer);
-            this._scrollButtonDebounceTimer = undefined;
-        }
+        this.setTemporaryScrollLock(false);
         this.update();
     }
 
@@ -809,16 +706,6 @@ export class ChatViewTreeWidget extends TreeWidget {
         // Otherwise, the space key will never be handled by the monaco editor
         return false;
     }
-
-    /**
-     * Ensure atBottom state is correct when content grows (e.g., LLM streaming while scroll lock is enabled).
-     */
-    protected override updateScrollToRow(): void {
-        super.updateScrollToRow();
-        const isAtBottom = this.isScrolledToBottom();
-        this.updateScrollToBottomButtonState(isAtBottom);
-    }
-
 }
 
 interface WidgetContainerProps {

--- a/packages/core/src/browser/tree/tree-widget.tsx
+++ b/packages/core/src/browser/tree/tree-widget.tsx
@@ -64,27 +64,9 @@ export const TREE_NODE_CAPTION_CLASS = 'theia-TreeNodeCaption';
 export const TREE_NODE_INDENT_GUIDE_CLASS = 'theia-tree-node-indent';
 
 /**
- * Threshold in pixels to consider the view as being scrolled to the bottom
+ * Threshold in pixels to consider the view as being scrolled to the bottom.
  */
 export const SCROLL_BOTTOM_THRESHOLD = 30;
-
-/**
- * Tree scroll event data.
- */
-export interface TreeScrollEvent {
-    readonly scrollTop: number;
-    readonly scrollLeft: number;
-}
-
-/**
- * Tree scroll state data.
- */
-export interface TreeScrollState {
-    readonly scrollTop: number;
-    readonly isAtBottom: boolean;
-    readonly scrollHeight?: number;
-    readonly clientHeight?: number;
-}
 
 export const TreeProps = Symbol('TreeProps');
 
@@ -189,8 +171,8 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
     protected searchBox: SearchBox;
     protected searchHighlights: Map<string, TreeDecoration.CaptionHighlight>;
 
-    protected readonly onScrollEmitter = new Emitter<TreeScrollEvent>();
-    readonly onScroll: TheiaEvent<TreeScrollEvent> = this.onScrollEmitter.event;
+    protected readonly onAtBottomStateChangeEmitter = new Emitter<boolean>();
+    readonly onAtBottomStateChange: TheiaEvent<boolean> = this.onAtBottomStateChangeEmitter.event;
 
     @inject(TreeDecoratorService)
     protected readonly decoratorService: TreeDecoratorService;
@@ -285,7 +267,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         this.node.addEventListener('mouseup', this.handleMiddleClickEvent.bind(this));
         this.node.addEventListener('auxclick', this.handleMiddleClickEvent.bind(this));
         this.toDispose.pushAll([
-            this.onScrollEmitter,
+            this.onAtBottomStateChangeEmitter,
             this.model,
             this.model.onChanged(() => this.updateRows()),
             this.model.onSelectionChanged(() => this.scheduleUpdateScrollToRow({ resize: false })),
@@ -551,7 +533,7 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
                 rows={rows}
                 renderNodeRow={this.renderNodeRow}
                 scrollToRow={this.scrollToRow}
-                onScrollEmitter={this.onScrollEmitter}
+                onAtBottomStateChangeEmitter={this.onAtBottomStateChangeEmitter}
                 {...this.props.viewProps}
             />;
         }
@@ -1201,39 +1183,6 @@ export class TreeWidget extends ReactWidget implements StatefulWidget {
         return this.node;
     }
 
-    /**
-     * Get the current scroll state from the virtualized view.
-     * This should be used instead of accessing the DOM scroll properties directly
-     * when the tree is virtualized.
-     */
-    protected getVirtualizedScrollState(): TreeScrollState | undefined {
-        return this.view?.getScrollState();
-    }
-
-    /**
-     * Check if the tree is scrolled to the bottom.
-     * Works with both virtualized and non-virtualized trees.
-     */
-    isScrolledToBottom(): boolean {
-        if (this.props.virtualized !== false && this.view) {
-            // Use virtualized scroll state
-            const scrollState = this.getVirtualizedScrollState();
-            return scrollState?.isAtBottom ?? true;
-        } else {
-            // Fallback to DOM-based calculation for non-virtualized trees
-            const scrollContainer = this.node;
-            const scrollHeight = scrollContainer.scrollHeight;
-            const scrollTop = scrollContainer.scrollTop;
-            const clientHeight = scrollContainer.clientHeight;
-
-            if (scrollHeight <= clientHeight) {
-                return true;
-            }
-
-            return scrollHeight - scrollTop - clientHeight <= SCROLL_BOTTOM_THRESHOLD;
-        }
-    }
-
     protected override onAfterAttach(msg: Message): void {
         const up = [
             Key.ARROW_UP,
@@ -1658,11 +1607,14 @@ export namespace TreeWidget {
         /**
          * Optional scroll event emitter.
          */
-        onScrollEmitter?: Emitter<TreeScrollEvent>
+        /**
+         * Optional emitter fired when the at-bottom state changes.
+         */
+        onAtBottomStateChangeEmitter?: Emitter<boolean>
     }
     export class View extends React.Component<ViewProps> {
         list: VirtuosoHandle | undefined;
-        private lastScrollState: TreeScrollState = { scrollTop: 0, isAtBottom: true, scrollHeight: 0, clientHeight: 0 };
+
         /**
          * Ensure the selected row is scrolled into view when virtualization finishes updating.
          */
@@ -1687,28 +1639,14 @@ export namespace TreeWidget {
         }
 
         override render(): React.ReactNode {
-            const { rows, width, height, scrollToRow, renderNodeRow, onScrollEmitter, ...other } = this.props;
+            const { rows, width, height, scrollToRow, renderNodeRow, onAtBottomStateChangeEmitter, ...other } = this.props;
             return <Virtuoso
                 ref={(list: VirtuosoHandle | null) => {
                     this.list = (list || undefined);
                     this.scrollIntoViewIfNeeded();
                 }}
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                onScroll={(e: any) => {
-                    const scrollTop = e.target.scrollTop;
-                    const scrollHeight = e.target.scrollHeight;
-                    const clientHeight = e.target.clientHeight;
-                    const isAtBottom = scrollHeight - scrollTop - clientHeight <= SCROLL_BOTTOM_THRESHOLD;
-
-                    // Store scroll state before firing the event to prevent jitter during inference and scrolling
-                    this.lastScrollState = { scrollTop, isAtBottom, scrollHeight, clientHeight };
-                    onScrollEmitter?.fire({ scrollTop, scrollLeft: e.target.scrollLeft || 0 });
-                }}
                 atBottomStateChange={(atBottom: boolean) => {
-                    this.lastScrollState = {
-                        ...this.lastScrollState,
-                        isAtBottom: atBottom
-                    };
+                    onAtBottomStateChangeEmitter?.fire(atBottom);
                 }}
                 atBottomThreshold={SCROLL_BOTTOM_THRESHOLD}
                 totalCount={rows.length}
@@ -1720,10 +1658,6 @@ export namespace TreeWidget {
                 overscan={800}
                 {...other}
             />;
-        }
-
-        getScrollState(): TreeScrollState {
-            return { ...this.lastScrollState };
         }
     }
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Simplifies the scroll lock mechanisms implemented for the AI chat view to depend on Virtuoso's own `onAtBottomStateChanged` callback mechanism. In testing, this seems to reduce scroll jiggle and be more reliable than the current implementation.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test

1. In a chat with some content...
2. Scrolling to the bottom of the chat should make the 'scroll to bottom' button disappear.
3. Scrolling more than 30px from the bottom should make the 'scroll to bottom' appear.
4. Adding content (user messages, agent responses) while at the bottom should result in the content at bottom being visible - i.e. scroll is locked to bottom.
5. Adding content when _not_ at the bottom should result in no scrolling - the visible content should be unchanged.
6. Neither adding content while at bottom nor scrolling near the bottom should produce jiggles in scroll position.

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
