### PR TITLE
fix(core): always resolve the logger promise

### DIFF
--- a/packages/core/src/common/logger.spec.ts
+++ b/packages/core/src/common/logger.spec.ts
@@ -16,7 +16,7 @@
 
 import { expect } from 'chai';
 import { MockLogger } from './test/mock-logger';
-import { setRootLogger, unsetRootLogger, Logger } from './logger';
+import { setRootLogger, unsetRootLogger, Logger, LogLevel, Log } from './logger';
 import { DefaultLoggerSanitizer, LoggerSanitizer } from './logger-sanitizer';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -39,6 +39,24 @@ class TestableLogger extends Logger {
     public testSanitize(message: string): string {
         return this.sanitize(message);
     }
+
+    public testGetLog(logLevel: LogLevel): Promise<Log> {
+        return this.getLog(logLevel);
+    }
+
+    /** Configure the logger to behave as if the backend reported the given current log level. */
+    public configureLogLevel(level: LogLevel): void {
+        (this as any).created = Promise.resolve();
+        (this as any)._logLevel = Promise.resolve(level);
+        (this as any).server = {
+            log: (...args: any[]) => {
+                this.loggedMessages.push(args);
+                return Promise.resolve();
+            }
+        };
+    }
+
+    public readonly loggedMessages: any[][] = [];
 }
 
 describe('logger', () => {
@@ -64,6 +82,49 @@ describe('logger', () => {
             }
         }
         ).to.not.throw(ReferenceError);
+    });
+
+    describe('log level gating', () => {
+        it('resolves debug() when the debug level is not enabled', async function (): Promise<void> {
+            this.timeout(1000);
+            const logger = new TestableLogger();
+            logger.configureLogLevel(LogLevel.INFO); // DEBUG is below INFO, so it is disabled
+
+            await logger.debug('this should not hang');
+
+            expect(logger.loggedMessages).to.have.lengthOf(0);
+        });
+
+        it('resolves debug() and logs when the debug level is enabled', async () => {
+            const logger = new TestableLogger();
+            logger.configureLogLevel(LogLevel.DEBUG);
+
+            await logger.debug('hello');
+
+            expect(logger.loggedMessages).to.have.lengthOf(1);
+        });
+
+        it('does not invoke a loggable when the level is not enabled', async function (): Promise<void> {
+            this.timeout(1000);
+            const logger = new TestableLogger();
+            logger.configureLogLevel(LogLevel.INFO);
+            let invoked = false;
+
+            await logger.debug(() => { invoked = true; });
+
+            expect(invoked).to.equal(false);
+        });
+
+        it('getLog() resolves to a no-op when the level is not enabled', async function (): Promise<void> {
+            this.timeout(1000);
+            const logger = new TestableLogger();
+            logger.configureLogLevel(LogLevel.INFO);
+
+            const log = await logger.testGetLog(LogLevel.DEBUG);
+            log('this should be ignored');
+
+            expect(logger.loggedMessages).to.have.lengthOf(0);
+        });
     });
 
     describe('Logger sanitization', () => {

--- a/packages/core/src/common/logger.ts
+++ b/packages/core/src/common/logger.ts
@@ -56,6 +56,9 @@ export function setRootLogger(aLogger: ILogger): void {
 export type Log = (message: any, ...params: any[]) => void;
 export type Loggable = (log: Log) => void;
 
+/** Shared no-op {@link Log} returned for a disabled level so that callers neither block nor emit. */
+const nullLogger: Log = () => { };
+
 export const LoggerFactory = Symbol('LoggerFactory');
 export type LoggerFactory = (name: string) => ILogger;
 
@@ -304,6 +307,9 @@ export class Logger implements ILogger {
     }
     log(logLevel: number, arg2: any | Loggable, ...params: any[]): Promise<void> {
         return this.getLog(logLevel).then(log => {
+            if (log === nullLogger) {
+                return;
+            }
             if (typeof arg2 === 'function') {
                 const loggable = arg2;
                 loggable(log);
@@ -313,12 +319,15 @@ export class Logger implements ILogger {
         });
     }
     protected getLog(logLevel: number): Promise<Log> {
-        return this.ifEnabled(logLevel).then(() =>
-            this.created.then(() =>
+        return this.isEnabled(logLevel).then(enabled => {
+            if (!enabled) {
+                return nullLogger;
+            }
+            return this.created.then(() =>
                 (message: any, ...params: any[]) =>
                     this.server.log(this.name, logLevel, this.format(message), params.map(p => this.format(p)))
-            )
-        );
+            );
+        });
     }
     protected format(value: any): any {
         switch (typeof value) {


### PR DESCRIPTION
#### What it does

Fixes #17729.

A log call for a disabled level now resolves as a no-op instead of hanging:

- `getLog()` returns a shared no-op `Log` when the level is disabled (previously it chained on `ifEnabled()`, whose promise never resolves while disabled). Its `Promise<Log>` signature is unchanged.
- `log()` short-cuts on that no-op, so a `Loggable` callback is still **not** invoked when the level is disabled — expensive deferred message construction (e.g. `JSON.stringify` in a `trace` callback) stays deferred.

The `ifEnabled` / `ifDebug` / … gating primitives are intentionally left unchanged; they still resolve only when the level is enabled.

#### How to test

1. Write an asynchronous function that awaits an `ILogger::debug` call.
2. Build and run a Theia example app with default log level.
3. Watch your asynchronous function complete, not hang.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of STMicroelectronics.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
