### PR TITLE
feat: --session-preference CLI overrides and AI Allow-All Mode banner

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-frontend-module.ts
@@ -58,6 +58,8 @@ import { ChatViewMenuContribution } from './chat-view-contribution';
 import { ChatViewLanguageContribution } from './chat-view-language-contribution';
 import { bindChatViewPreferences } from './chat-view-preferences';
 import { ChatViewWidget } from './chat-view-widget';
+import { ChatBannerProvider } from './chat-banner-provider';
+import { ChatBannerWidget } from './chat-banner-widget';
 import { ChatViewWidgetToolbarContribution } from './chat-view-widget-toolbar-contribution';
 import { ContextVariablePicker } from './context-variable-picker';
 import { ChangeSetActionRenderer, ChangeSetActionService } from './change-set-actions/change-set-action-service';
@@ -122,6 +124,8 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bindRootContributionProvider(bind, ChatResponsePartRenderer);
     bindRootContributionProvider(bind, ChatWelcomeMessageProvider);
+    bindRootContributionProvider(bind, ChatBannerProvider);
+    bind(ChatBannerWidget).toSelf();
 
     bindChatViewWidget(bind);
 

--- a/packages/ai-chat-ui/src/browser/chat-banner-provider.ts
+++ b/packages/ai-chat-ui/src/browser/chat-banner-provider.ts
@@ -1,0 +1,36 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { Event } from '@theia/core';
+
+/**
+ * Contribution point for compact, persistent banners shown above the chat view
+ * content (between the tab title and the message list). Unlike {@link ChatWelcomeMessageProvider},
+ * these banners stay visible while the user is actively chatting.
+ *
+ * Implementations should return `undefined` from {@link renderBanner} when there
+ * is nothing to show, so the host can collapse to zero height.
+ */
+export const ChatBannerProvider = Symbol('ChatBannerProvider');
+export interface ChatBannerProvider {
+    /** Optional priority for rendering order. Higher values render first. Default: 0. */
+    readonly priority?: number;
+    /** Fired when the banner content (or visibility) may have changed. */
+    readonly onDidChange?: Event<void>;
+    /** Render the banner, or `undefined` to hide it. */
+    renderBanner(): React.ReactNode | undefined;
+}

--- a/packages/ai-chat-ui/src/browser/chat-banner-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-banner-widget.tsx
@@ -1,0 +1,69 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { ContributionProvider } from '@theia/core';
+import { ReactWidget } from '@theia/core/lib/browser';
+import { ChatBannerProvider } from './chat-banner-provider';
+
+/**
+ * Host widget rendered above the chat content. Collects all {@link ChatBannerProvider}
+ * contributions, sorts them by priority (descending), and renders the non-`undefined`
+ * banners. Subscribes to each provider's `onDidChange` event for live updates.
+ *
+ * The widget's outer node has the `chat-banner-host` class. It exposes a CSS hook
+ * for hosts to style the banner area; the widget itself ships with no layout
+ * opinion beyond stacking entries vertically.
+ */
+@injectable()
+export class ChatBannerWidget extends ReactWidget {
+
+    static readonly ID = 'chat-banner-widget';
+
+    @inject(ContributionProvider) @named(ChatBannerProvider)
+    protected readonly bannerProviders: ContributionProvider<ChatBannerProvider>;
+
+    @postConstruct()
+    protected init(): void {
+        this.id = ChatBannerWidget.ID;
+        this.addClass('chat-banner-host');
+        for (const provider of this.bannerProviders.getContributions()) {
+            if (provider.onDidChange) {
+                this.toDispose.push(provider.onDidChange(() => this.update()));
+            }
+        }
+        this.update();
+    }
+
+    protected render(): React.ReactNode {
+        const providers = this.bannerProviders.getContributions()
+            .toSorted((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+        const nodes = providers
+            .map((p, idx) => {
+                const banner = p.renderBanner();
+                if (banner === undefined) {
+                    return undefined;
+                }
+                return <React.Fragment key={idx}>{banner}</React.Fragment>;
+            })
+            .filter((node): node is React.ReactElement => node !== undefined);
+        if (nodes.length === 0) {
+            return undefined;
+        }
+        return <>{nodes}</>;
+    }
+}

--- a/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-view-widget.tsx
@@ -23,6 +23,7 @@ import { ApplicationShell, BaseWidget, codicon, ExtractableWidget, Message, Pane
 import { nls } from '@theia/core/lib/common/nls';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { AIChatInputWidget } from './chat-input-widget';
+import { ChatBannerWidget } from './chat-banner-widget';
 import { ChatViewTreeWidget, ChatWelcomeMessageProvider } from './chat-tree-view/chat-view-tree-widget';
 import { AIActivationService } from '@theia/ai-core/lib/browser/ai-activation-service';
 import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
@@ -78,7 +79,9 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         @inject(ChatViewTreeWidget)
         readonly treeWidget: ChatViewTreeWidget,
         @inject(AIChatInputWidget)
-        readonly inputWidget: AIChatInputWidget
+        readonly inputWidget: AIChatInputWidget,
+        @inject(ChatBannerWidget)
+        readonly bannerWidget: ChatBannerWidget
     ) {
         super();
         this.id = ChatViewWidget.ID;
@@ -95,6 +98,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         this.toDispose.pushAll([
             this.treeWidget,
             this.inputWidget,
+            this.bannerWidget,
             this.onStateChanged(newState => {
                 const shouldScrollToEnd = !newState.locked && !newState.temporaryLocked;
                 this.treeWidget.shouldScrollToEnd = shouldScrollToEnd;
@@ -103,6 +107,7 @@ export class ChatViewWidget extends BaseWidget implements ExtractableWidget, Sta
         ]);
         const layout = this.layout = new PanelLayout();
 
+        layout.addWidget(this.bannerWidget);
         this.treeWidget.node.classList.add('chat-tree-view-widget');
         layout.addWidget(this.treeWidget);
         this.inputWidget.node.classList.add('chat-input-widget');

--- a/packages/ai-ide/src/browser/ai-allow-all-mode-chat-banner.spec.ts
+++ b/packages/ai-ide/src/browser/ai-allow-all-mode-chat-banner.spec.ts
@@ -1,0 +1,205 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+import { expect } from 'chai';
+import { Emitter } from '@theia/core';
+import { PreferenceChange } from '@theia/core/lib/common/preferences';
+import {
+    DEFAULT_TOOL_CONFIRMATION_PREFERENCE,
+    TOOL_CONFIRMATION_PREFERENCE,
+    ToolConfirmationMode
+} from '@theia/ai-chat/lib/common/chat-tool-preferences';
+import { AiAllowAllModeChatBanner } from './ai-allow-all-mode-chat-banner';
+disableJSDOM();
+
+/**
+ * Test double for the subset of `PreferenceService` the banner actually uses.
+ * A backing map keyed by preference name provides the session value seen by
+ * `inspect(...)`, and a public emitter drives the banner's change listener.
+ */
+class FakePreferenceService {
+    readonly sessionValues = new Map<string, unknown>();
+    readonly changeEmitter = new Emitter<PreferenceChange>();
+    readonly onPreferenceChanged = this.changeEmitter.event;
+
+    inspect(key: string): { sessionValue: unknown } | undefined {
+        if (!this.sessionValues.has(key)) {
+            return undefined;
+        }
+        return { sessionValue: this.sessionValues.get(key) };
+    }
+
+    setSession(key: string, value: unknown): void {
+        if (value === undefined) {
+            this.sessionValues.delete(key);
+        } else {
+            this.sessionValues.set(key, value);
+        }
+        // The banner only ever inspects `preferenceName`, so a minimal change payload is enough.
+        this.changeEmitter.fire({ preferenceName: key } as unknown as PreferenceChange);
+    }
+}
+
+describe('AiAllowAllModeChatBanner', () => {
+
+    type Probe = AiAllowAllModeChatBanner & {
+        isBypassValue(key: string, value: unknown): boolean;
+        collectOverrides(): ReadonlyArray<{ label: string; bypass: boolean }>;
+        dismissed: boolean;
+        dismissedSignature: string | undefined;
+    };
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+    after(() => {
+        disableJSDOM();
+    });
+
+    function createBanner(prefService?: FakePreferenceService): { banner: Probe; prefs: FakePreferenceService } {
+        const prefs = prefService ?? new FakePreferenceService();
+        const banner = new AiAllowAllModeChatBanner() as Probe;
+        // Wire the fake preference service into the private inject site, then run the
+        // `@postConstruct` init manually. Doing this without a full DI container keeps the
+        // test focused on the banner's own logic.
+        (banner as unknown as { preferenceService: FakePreferenceService }).preferenceService = prefs;
+        (banner as unknown as { init(): void }).init();
+        return { banner, prefs };
+    }
+
+    describe('isBypassValue', () => {
+
+        it('flags Allow-All only when the global default is forced to ALWAYS_ALLOW', () => {
+            const { banner } = createBanner();
+            expect(banner.isBypassValue(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, ToolConfirmationMode.ALWAYS_ALLOW)).to.be.true;
+            expect(banner.isBypassValue(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, ToolConfirmationMode.CONFIRM)).to.be.false;
+            expect(banner.isBypassValue(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, ToolConfirmationMode.DISABLED)).to.be.false;
+        });
+
+        it('does not flag Allow-All for per-tool ALWAYS_ALLOW entries', () => {
+            // Per-tool overrides are scoped exceptions and stay informational rather than
+            // escalating the strip to the red Allow-All treatment.
+            const { banner } = createBanner();
+            expect(banner.isBypassValue(TOOL_CONFIRMATION_PREFERENCE, { shellExecute: ToolConfirmationMode.ALWAYS_ALLOW })).to.be.false;
+            expect(banner.isBypassValue(TOOL_CONFIRMATION_PREFERENCE, {
+                shellExecute: ToolConfirmationMode.ALWAYS_ALLOW,
+                writeFile: ToolConfirmationMode.CONFIRM
+            })).to.be.false;
+            expect(banner.isBypassValue(TOOL_CONFIRMATION_PREFERENCE, {})).to.be.false;
+        });
+
+        it('returns false for unrelated keys', () => {
+            const { banner } = createBanner();
+            expect(banner.isBypassValue('ai-features.AiEnable.enableAI', true)).to.be.false;
+            expect(banner.isBypassValue('ai-features.agentMode.enabled', true)).to.be.false;
+            expect(banner.isBypassValue('ai-features.chat.defaultChatAgent', 'Coder')).to.be.false;
+        });
+    });
+
+    describe('collectOverrides', () => {
+
+        it('is empty when no watched preference has a session value', () => {
+            const { banner } = createBanner();
+            expect(banner.collectOverrides()).to.deep.equal([]);
+        });
+
+        it('reports the default tool confirmation with bypass=true when forced to ALWAYS_ALLOW', () => {
+            const { banner, prefs } = createBanner();
+            prefs.setSession(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, ToolConfirmationMode.ALWAYS_ALLOW);
+            const overrides = banner.collectOverrides();
+            expect(overrides).to.have.lengthOf(1);
+            expect(overrides[0].bypass).to.be.true;
+            expect(overrides[0].label).to.contain(ToolConfirmationMode.ALWAYS_ALLOW);
+        });
+
+        it('reports per-tool entries with bypass=false', () => {
+            const { banner, prefs } = createBanner();
+            prefs.setSession(TOOL_CONFIRMATION_PREFERENCE, { shellExecute: ToolConfirmationMode.ALWAYS_ALLOW });
+            const overrides = banner.collectOverrides();
+            expect(overrides).to.have.lengthOf(1);
+            expect(overrides[0].bypass).to.be.false;
+            expect(overrides[0].label).to.contain('shellExecute');
+        });
+    });
+
+    describe('renderBanner', () => {
+
+        it('returns undefined when there are no overrides', () => {
+            const { banner } = createBanner();
+            expect(banner.renderBanner()).to.equal(undefined);
+        });
+
+        it('returns undefined once the strip has been dismissed', () => {
+            const { banner, prefs } = createBanner();
+            prefs.setSession(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, ToolConfirmationMode.ALWAYS_ALLOW);
+            expect(banner.renderBanner()).to.not.equal(undefined);
+            banner.dismissed = true;
+            expect(banner.renderBanner()).to.equal(undefined);
+        });
+
+        it('returns a rendered node when at least one override is active', () => {
+            const { banner, prefs } = createBanner();
+            prefs.setSession(TOOL_CONFIRMATION_PREFERENCE, { shellExecute: ToolConfirmationMode.ALWAYS_ALLOW });
+            expect(banner.renderBanner()).to.not.equal(undefined);
+        });
+    });
+
+    describe('dismissal reset', () => {
+
+        it('un-dismisses the strip when the override set escalates into a bypass state', () => {
+            const { banner, prefs } = createBanner();
+            prefs.setSession(TOOL_CONFIRMATION_PREFERENCE, { shellExecute: ToolConfirmationMode.ALWAYS_ALLOW });
+            banner.dismissed = true;
+            banner.dismissedSignature = (banner as unknown as { overrideSignature(): string }).overrideSignature();
+
+            prefs.setSession(DEFAULT_TOOL_CONFIRMATION_PREFERENCE, ToolConfirmationMode.ALWAYS_ALLOW);
+
+            expect(banner.dismissed).to.be.false;
+            expect(banner.dismissedSignature).to.equal(undefined);
+        });
+
+        it('un-dismisses the strip when a new override is added while the strip was dismissed', () => {
+            const { banner, prefs } = createBanner();
+            prefs.setSession(TOOL_CONFIRMATION_PREFERENCE, { shellExecute: ToolConfirmationMode.ALWAYS_ALLOW });
+            banner.dismissed = true;
+            banner.dismissedSignature = (banner as unknown as { overrideSignature(): string }).overrideSignature();
+
+            // Broaden the per-tool override set. Same key, added tool entry; the signature must differ.
+            prefs.setSession(TOOL_CONFIRMATION_PREFERENCE, {
+                shellExecute: ToolConfirmationMode.ALWAYS_ALLOW,
+                writeFile: ToolConfirmationMode.ALWAYS_ALLOW
+            });
+
+            expect(banner.dismissed).to.be.false;
+        });
+
+        it('leaves the dismissal alone when a change event fires with the same override set', () => {
+            const { banner, prefs } = createBanner();
+            prefs.setSession(TOOL_CONFIRMATION_PREFERENCE, { shellExecute: ToolConfirmationMode.ALWAYS_ALLOW });
+            banner.dismissed = true;
+            banner.dismissedSignature = (banner as unknown as { overrideSignature(): string }).overrideSignature();
+
+            // Fire a change event without actually changing the underlying value.
+            prefs.changeEmitter.fire({ preferenceName: TOOL_CONFIRMATION_PREFERENCE } as unknown as PreferenceChange);
+
+            expect(banner.dismissed).to.be.true;
+        });
+    });
+});

--- a/packages/ai-ide/src/browser/ai-allow-all-mode-chat-banner.tsx
+++ b/packages/ai-ide/src/browser/ai-allow-all-mode-chat-banner.tsx
@@ -1,0 +1,217 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { codicon } from '@theia/core/lib/browser';
+import { DisposableCollection, Emitter, Event } from '@theia/core';
+import { nls } from '@theia/core/lib/common/nls';
+import { PreferenceService } from '@theia/core/lib/common';
+import { ChatBannerProvider } from '@theia/ai-chat-ui/lib/browser/chat-banner-provider';
+import {
+    DEFAULT_TOOL_CONFIRMATION_PREFERENCE,
+    TOOL_CONFIRMATION_PREFERENCE,
+    ToolConfirmationMode
+} from '@theia/ai-chat/lib/common/chat-tool-preferences';
+
+interface AiSessionOverride {
+    /** Human-readable label, e.g. "Default tool confirmation: always_allow". */
+    label: string;
+    /** Whether this override bypasses AI tool confirmations globally. */
+    bypass: boolean;
+}
+
+/**
+ * Persistent strip rendered above the chat content whenever an AI tool confirmation
+ * preference (`ai-features.chat.defaultToolConfirmation` or `ai-features.chat.toolConfirmation`)
+ * is active in the session scope (typically set via `--session-preference`). When the
+ * global default is forced to "Allow All" the strip is shown in error styling as the
+ * Theia AI Allow-All Mode banner; per-tool confirmation overrides use warning styling.
+ *
+ * Other AI-namespaced session overrides (e.g. forced-on AI features, default chat agent)
+ * are reported by the generic Session Preferences status bar item and intentionally not
+ * duplicated here.
+ */
+@injectable()
+export class AiAllowAllModeChatBanner implements ChatBannerProvider {
+
+    readonly priority = 1000;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    /**
+     * Only tool confirmation preferences are watched here. Other AI session overrides
+     * (enable AI, agent mode, default chat agent, etc.) are surfaced in the generic
+     * Session Preferences status bar item to keep the banner from duplicating the list.
+     */
+    protected readonly watchedKeys: ReadonlyArray<string> = [
+        DEFAULT_TOOL_CONFIRMATION_PREFERENCE,
+        TOOL_CONFIRMATION_PREFERENCE
+    ];
+
+    /**
+     * Process-lifetime dismissal flag. Reset on the next launch so the user is
+     * always reminded once per process. Also automatically cleared when the override
+     * set changes in any way after a dismissal (see {@link init}), so a previously
+     * dismissed strip cannot silently hide new or escalated overrides.
+     */
+    protected dismissed = false;
+
+    /**
+     * Signature of the override set at the moment the user dismissed the strip.
+     * `undefined` while the strip is not dismissed.
+     */
+    protected dismissedSignature: string | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        const watched = new Set(this.watchedKeys);
+        this.toDispose.push(this.preferenceService.onPreferenceChanged(e => {
+            if (!watched.has(e.preferenceName)) {
+                return;
+            }
+            if (this.dismissed && this.overrideSignature() !== this.dismissedSignature) {
+                // The override set has changed since the user dismissed the strip
+                // (new override added, existing value changed, escalation into a bypass, ...).
+                // Re-surface the strip so the change cannot hide behind the earlier dismissal.
+                this.dismissed = false;
+                this.dismissedSignature = undefined;
+            }
+            this.onDidChangeEmitter.fire();
+        }));
+    }
+
+    /**
+     * Stable snapshot of the watched preferences' current session values. Used to
+     * detect changes to the override set for the dismissal-reset logic; not for
+     * anything user-visible so the format is intentionally simple.
+     */
+    protected overrideSignature(): string {
+        return this.watchedKeys
+            .map(key => `${key}=${JSON.stringify(this.preferenceService.inspect(key)?.sessionValue ?? undefined)}`)
+            .join('|');
+    }
+
+    renderBanner(): React.ReactNode | undefined {
+        if (this.dismissed) {
+            return undefined;
+        }
+        const overrides = this.collectOverrides();
+        if (overrides.length === 0) {
+            return undefined;
+        }
+        const isAllowAll = overrides.some(override => override.bypass);
+        const className = `theia-ai-allow-all-mode-strip ${isAllowAll ? 'is-allow-all' : 'is-overrides'}`;
+        const title = isAllowAll
+            ? nls.localize('theia/ai/ide/allowAllMode/title', 'Theia AI Allow-All Mode')
+            : nls.localize('theia/ai/ide/toolConfirmationOverrides/title', 'AI Tool Confirmation Overrides');
+        const tooltipLines = [
+            isAllowAll
+                ? nls.localize('theia/ai/ide/allowAllMode/stripTooltip',
+                    'AI tool calls run without confirmation in this session. Only enable in environments you trust.')
+                : nls.localize('theia/ai/ide/toolConfirmationOverrides/stripTooltip',
+                    'One or more AI tools are auto-approved for this session via command-line flags.'),
+            '',
+            ...overrides.map(override => `• ${override.label}`),
+            '',
+            nls.localize('theia/ai/ide/allowAllMode/stripTooltipFooter',
+                'Set via --session-preference. Restart without the flag to restore your saved settings.')
+        ];
+        return <div
+            className={className}
+            title={tooltipLines.join('\n')}
+            role='status'
+            aria-live='polite'>
+            <span className={`theia-ai-allow-all-mode-strip-icon ${codicon('warning')}`}></span>
+            <span className='theia-ai-allow-all-mode-strip-title'>{title}</span>
+            <button
+                type='button'
+                className={`theia-ai-allow-all-mode-strip-dismiss ${codicon('close')}`}
+                title={nls.localize('theia/ai/ide/allowAllMode/dismiss', 'Hide for this session')}
+                aria-label={nls.localize('theia/ai/ide/allowAllMode/dismiss', 'Hide for this session')}
+                onClick={this.handleDismiss}
+            />
+        </div>;
+    }
+
+    /** AI-relevant preferences currently coming from the session scope. */
+    protected collectOverrides(): AiSessionOverride[] {
+        const overrides: AiSessionOverride[] = [];
+        for (const key of this.watchedKeys) {
+            const sessionValue = this.preferenceService.inspect(key)?.sessionValue;
+            if (sessionValue === undefined) {
+                continue;
+            }
+            overrides.push({
+                label: this.describe(key, sessionValue),
+                bypass: this.isBypassValue(key, sessionValue)
+            });
+        }
+        return overrides;
+    }
+
+    /**
+     * Returns `true` only when the global default is forced to Allow-All. Per-tool
+     * `always_allow` entries via `TOOL_CONFIRMATION_PREFERENCE` are scoped exceptions
+     * and remain in the banner as informational (warning) entries rather than escalating
+     * the whole strip to the red "Allow-All Mode" treatment.
+     */
+    protected isBypassValue(key: string, value: unknown): boolean {
+        if (key === DEFAULT_TOOL_CONFIRMATION_PREFERENCE) {
+            return value === ToolConfirmationMode.ALWAYS_ALLOW;
+        }
+        return false;
+    }
+
+    protected describe(key: string, value: unknown): string {
+        switch (key) {
+            case DEFAULT_TOOL_CONFIRMATION_PREFERENCE:
+                return nls.localize('theia/ai/ide/sessionOverride/defaultToolConfirmation',
+                    'Default tool confirmation: {0}', String(value));
+            case TOOL_CONFIRMATION_PREFERENCE: {
+                if (value && typeof value === 'object') {
+                    const entries = Object.entries(value as Record<string, unknown>)
+                        .map(([tool, mode]) => `${tool}=${mode}`)
+                        .join(', ');
+                    return nls.localize('theia/ai/ide/sessionOverride/toolConfirmation',
+                        'Per-tool confirmation overrides: {0}', entries);
+                }
+                return nls.localize('theia/ai/ide/sessionOverride/toolConfirmationGeneric',
+                    'Per-tool confirmation overrides set');
+            }
+            default:
+                return `${key} = ${JSON.stringify(value)}`;
+        }
+    }
+
+    protected handleDismiss = (e: React.MouseEvent<HTMLButtonElement>) => {
+        e.stopPropagation();
+        this.dismissed = true;
+        // Snapshot the signature so a subsequent change to the override set is detected
+        // in the preference-change listener and un-dismisses the strip automatically.
+        this.dismissedSignature = this.overrideSignature();
+        this.onDidChangeEmitter.fire();
+    };
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+}

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -80,6 +80,8 @@ import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-t
 import { IdeChatWelcomeMessageProvider } from './ide-chat-welcome-message-provider';
 import { ChatSessionsWelcomeMessageProvider } from './chat-sessions-welcome-message-provider';
 import { ChatSessionItemActionContribution, DefaultChatSessionItemActionContribution } from './chat-session-item-action-contribution';
+import { AiAllowAllModeChatBanner } from './ai-allow-all-mode-chat-banner';
+import { ChatBannerProvider } from '@theia/ai-chat-ui/lib/browser/chat-banner-provider';
 import { DefaultChatAgentRecommendationService } from './default-chat-agent-recommendation-service';
 import { AITokenUsageConfigurationWidget } from './ai-configuration/token-usage-configuration-widget';
 import { AISkillsConfigurationWidget } from './ai-configuration/skills-configuration-widget';
@@ -194,6 +196,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(ChatWelcomeMessageProvider).to(IdeChatWelcomeMessageProvider).inSingletonScope();
     bind(ChatWelcomeMessageProvider).to(ChatSessionsWelcomeMessageProvider).inSingletonScope();
+    bind(ChatBannerProvider).to(AiAllowAllModeChatBanner).inSingletonScope();
     bindRootContributionProvider(bind, ChatSessionItemActionContribution);
     bind(DefaultChatSessionItemActionContribution).toSelf().inSingletonScope();
     bind(ChatSessionItemActionContribution).toService(DefaultChatSessionItemActionContribution);

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -2170,3 +2170,70 @@
   outline: 2px solid var(--theia-focusBorder);
   outline-offset: -2px;
 }
+
+/* Persistent banner strip rendered above the AI chat content when an AI session
+ * override (e.g. --session-preference) is active. */
+.chat-banner-host {
+  flex: none;
+  width: 100%;
+}
+
+.chat-banner-host:empty {
+  display: none;
+}
+
+.theia-ai-allow-all-mode-strip {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: calc(var(--theia-ui-padding) * 0.75);
+  padding: calc(var(--theia-ui-padding) * 0.6) calc(var(--theia-ui-padding) * 1.5);
+  background-color: var(--theia-inputValidation-warningBackground);
+  font-size: var(--theia-ui-font-size1);
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  cursor: default;
+}
+
+.theia-ai-allow-all-mode-strip.is-allow-all {
+  background-color: var(--theia-inputValidation-errorBackground);
+}
+
+.theia-ai-allow-all-mode-strip-icon {
+  flex: none;
+}
+
+.theia-ai-allow-all-mode-strip.is-allow-all .theia-ai-allow-all-mode-strip-icon {
+  color: var(--theia-errorForeground);
+}
+
+.theia-ai-allow-all-mode-strip-title {
+  font-weight: 600;
+}
+
+.theia-ai-allow-all-mode-strip-dismiss {
+  flex: none;
+  margin-left: calc(var(--theia-ui-padding) * 0.5);
+  padding: 2px;
+  background: transparent;
+  border: none;
+  border-radius: 3px;
+  color: inherit;
+  opacity: 0.7;
+  font: inherit;
+  line-height: 1;
+  cursor: pointer;
+}
+
+.theia-ai-allow-all-mode-strip-dismiss:hover {
+  opacity: 1;
+  background-color: var(--theia-toolbar-hoverBackground);
+}
+
+.theia-ai-allow-all-mode-strip-dismiss:focus {
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: -1px;
+}
+

--- a/packages/core/src/browser/preferences/preference-contribution.ts
+++ b/packages/core/src/browser/preferences/preference-contribution.ts
@@ -22,16 +22,24 @@ import { isObject } from '../../common/types';
 import { PreferenceSchemaServiceImpl } from '../../common/preferences/preference-schema-service';
 import { PreferenceContribution, PreferenceSchemaService } from '../../common/preferences/preference-schema';
 import { DefaultsPreferenceProvider } from '../../common/preferences/defaults-preference-provider';
+import { SessionPreferenceProvider } from '../../common/preferences/session-preference-provider';
 import { PreferenceLanguageOverrideService } from '../../common/preferences/preference-language-override-service';
 import { FrontendConfigPreferenceContribution } from './frontend-config-preference-contributions';
 import { bindPreferenceConfigurations } from '../../common/preferences/preference-configurations';
 
 export function bindPreferenceSchemaProvider(bind: interfaces.Bind): void {
     bindPreferenceConfigurations(bind);
-    bind(ValidPreferenceScopes).toConstantValue([PreferenceScope.Default, PreferenceScope.User, PreferenceScope.Workspace, PreferenceScope.Folder]);
+    bind(ValidPreferenceScopes).toConstantValue([
+        PreferenceScope.Default,
+        PreferenceScope.User,
+        PreferenceScope.Workspace,
+        PreferenceScope.Folder,
+        PreferenceScope.Session
+    ]);
     bind(PreferenceSchemaServiceImpl).toSelf().inSingletonScope();
     bind(PreferenceSchemaService).toService(PreferenceSchemaServiceImpl);
     bind(PreferenceProvider).to(DefaultsPreferenceProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Default);
+    bind(PreferenceProvider).to(SessionPreferenceProvider).inSingletonScope().whenTargetNamed(PreferenceScope.Session);
     bind(PreferenceLanguageOverrideService).toSelf().inSingletonScope();
     bindRootContributionProvider(bind, PreferenceContribution);
     bind(PreferenceContribution).to(FrontendConfigPreferenceContribution).inSingletonScope();

--- a/packages/core/src/browser/preferences/preference-service.spec.ts
+++ b/packages/core/src/browser/preferences/preference-service.spec.ts
@@ -262,6 +262,7 @@ describe('Preference Service', () => {
                 globalValue,
                 workspaceValue,
                 workspaceFolderValue,
+                sessionValue: undefined,
                 value,
             };
             const inspection = preferences.inspect(TAB_SIZE, DUMMY_URI);
@@ -374,6 +375,7 @@ describe('Preference Service', () => {
                 globalValue: undefined,
                 workspaceValue: undefined,
                 workspaceFolderValue: undefined,
+                sessionValue: undefined,
                 value: 4,
             };
             assert.deepStrictEqual(expected, preferences.inspect('editor.tabSize'));
@@ -397,6 +399,7 @@ describe('Preference Service', () => {
                 globalValue: 2,
                 workspaceValue: undefined,
                 workspaceFolderValue: undefined,
+                sessionValue: undefined,
                 value: 2
             };
             preferences.set('editor.tabSize', 2, PreferenceScope.User);
@@ -422,6 +425,7 @@ describe('Preference Service', () => {
                 globalValue: undefined,
                 workspaceValue: undefined,
                 workspaceFolderValue: undefined,
+                sessionValue: undefined,
                 value: 4
             };
             assert.deepStrictEqual(expected, preferences.inspect('editor.tabSize'));
@@ -534,6 +538,74 @@ describe('Preference Service', () => {
             assert.strictEqual(false, preferences.get('[go].editor.insertSpaces'));
             assert.strictEqual(false, preferences.get('editor.formatOnSave'));
             assert.strictEqual(true, preferences.get('[go].editor.formatOnSave'));
+        });
+    });
+
+    describe('session-scope overrides', () => {
+        function getSessionProvider(): PreferenceProvider {
+            return testContainer.getNamed<PreferenceProvider>(PreferenceProvider, PreferenceScope.Session);
+        }
+
+        beforeEach(() => {
+            prefSchema.addSchema({
+                scope: PreferenceScope.Folder,
+                properties: {
+                    'test.session': { type: 'number' }
+                }
+            });
+        });
+
+        it('takes precedence over the user scope', async () => {
+            getProvider(PreferenceScope.User).setPreference('test.session', 1);
+            await prefService.set('test.session', 99, PreferenceScope.Session);
+            expect(prefService.get('test.session')).equals(99);
+        });
+
+        it('is dropped when the same key is written to a persistent scope', async () => {
+            const sessionProvider = getSessionProvider();
+            getProvider(PreferenceScope.User).setPreference('test.session', 1);
+            await prefService.set('test.session', 99, PreferenceScope.Session);
+            expect(prefService.get('test.session')).equals(99);
+
+            // An explicit user edit must win over the session override and clear it.
+            await prefService.set('test.session', 2, PreferenceScope.User);
+            expect(sessionProvider.get('test.session')).to.equal(undefined);
+            expect(prefService.get('test.session')).equals(2);
+        });
+
+        it('is reported via inspect().sessionValue', async () => {
+            await prefService.set('test.session', 42, PreferenceScope.Session);
+            expect(prefService.inspect('test.session')?.sessionValue).equals(42);
+        });
+
+        it('emits a Session-scope change event when evicted by a persistent write', async () => {
+            // Status bar listeners rely on this: an eviction must surface as an
+            // onPreferenceChanged event whose `scope` is Session, otherwise the
+            // status bar would never clear after the override is dropped.
+            await prefService.set('test.session', 99, PreferenceScope.Session);
+
+            const sessionScopeEvents: PreferenceScope[] = [];
+            const listener = prefService.onPreferenceChanged(e => {
+                if (e.preferenceName === 'test.session') {
+                    sessionScopeEvents.push(e.scope);
+                }
+            });
+            try {
+                await prefService.set('test.session', 2, PreferenceScope.User);
+            } finally {
+                listener.dispose();
+            }
+
+            expect(sessionScopeEvents).to.include(PreferenceScope.Session);
+        });
+
+        it('is left alone when writing to the Session scope itself', async () => {
+            const sessionProvider = getSessionProvider();
+            await prefService.set('test.session', 7, PreferenceScope.Session);
+            expect(sessionProvider.get('test.session')).to.equal(7);
+            // A second write to Session must not trigger eviction of itself.
+            await prefService.set('test.session', 8, PreferenceScope.Session);
+            expect(sessionProvider.get('test.session')).to.equal(8);
         });
     });
 

--- a/packages/core/src/browser/style/status-bar.css
+++ b/packages/core/src/browser/style/status-bar.css
@@ -63,7 +63,7 @@ body.theia-no-open-workspace #theia-statusBar {
   padding-inline: var(--theia-ui-padding);
 }
 
-#theia-statusBar .area.left .element.has-background {
+#theia-statusBar .area.left .element.has-background:not(#session-preference-status) {
   margin-left: calc(-1 * var(--theia-ui-padding));
 }
 

--- a/packages/core/src/common/preferences/index.ts
+++ b/packages/core/src/common/preferences/index.ts
@@ -16,6 +16,7 @@
 
 export * from './defaults-preference-provider';
 export * from './preference-language-override-service';
+export * from './session-preference-provider';
 export * from './preference-provider-impl';
 export * from './preference-provider';
 export * from './preference-schema-service';

--- a/packages/core/src/common/preferences/preference-scope.spec.ts
+++ b/packages/core/src/common/preferences/preference-scope.spec.ts
@@ -20,11 +20,11 @@ import { PreferenceScope } from './preference-scope';
 describe('PreferenceScope', () => {
 
     it('getScopes() should return numbers from broadest to narrowest', () => {
-        expect(PreferenceScope.getScopes()).deep.equal([0, 1, 2, 3]);
+        expect(PreferenceScope.getScopes()).deep.equal([0, 1, 2, 3, 4]);
     });
 
     it('getReversedScopes() should return numbers from narrowest to broadest', () => {
-        expect(PreferenceScope.getReversedScopes()).deep.equal([3, 2, 1, 0]);
+        expect(PreferenceScope.getReversedScopes()).deep.equal([4, 3, 2, 1, 0]);
     });
 
     it('getScopeNames() should return the names of scopes broader than the current one', () => {
@@ -36,11 +36,13 @@ describe('PreferenceScope', () => {
         expect(PreferenceScope.is(PreferenceScope.User)).to.be.true;
         expect(PreferenceScope.is(PreferenceScope.Workspace)).to.be.true;
         expect(PreferenceScope.is(PreferenceScope.Folder)).to.be.true;
+        expect(PreferenceScope.is(PreferenceScope.Session)).to.be.true;
         expect(PreferenceScope.is(0)).to.be.true;
         expect(PreferenceScope.is(1)).to.be.true;
         expect(PreferenceScope.is(2)).to.be.true;
         expect(PreferenceScope.is(3)).to.be.true;
-        expect(PreferenceScope.is(4)).to.be.false;
+        expect(PreferenceScope.is(4)).to.be.true;
+        expect(PreferenceScope.is(5)).to.be.false;
         expect(PreferenceScope.is(-1)).to.be.false;
         expect(PreferenceScope.is({})).to.be.false;
         expect(PreferenceScope.is('Default')).to.be.false;

--- a/packages/core/src/common/preferences/preference-scope.ts
+++ b/packages/core/src/common/preferences/preference-scope.ts
@@ -23,7 +23,12 @@ export enum PreferenceScope {
     Default,
     User,
     Workspace,
-    Folder
+    Folder,
+    /**
+     * Process-lifetime, in-memory scope used by `--session-preference` CLI overrides.
+     * Has the highest precedence and is never persisted to disk.
+     */
+    Session
 }
 
 export namespace PreferenceScope {

--- a/packages/core/src/common/preferences/preference-service.ts
+++ b/packages/core/src/common/preferences/preference-service.ts
@@ -255,6 +255,10 @@ export interface PreferenceInspection<T = JSONValue> {
      */
     workspaceFolderValue: T | undefined,
     /**
+     * Value in session scope (in-memory, set via `--session-preference`).
+     */
+    sessionValue?: T | undefined,
+    /**
      * The value that is active, i.e. the value set in the lowest scope available.
      */
     value: T | undefined;
@@ -453,9 +457,35 @@ export class PreferenceServiceImpl implements PreferenceService {
         }
         const provider = this.getProvider(resolvedScope);
         if (provider && await provider.setPreference(preferenceName, value, resourceUri)) {
+            await this.evictSessionOverride(preferenceName, resolvedScope);
             return;
         }
         throw new Error(`Unable to write to ${PreferenceScope[resolvedScope]} Settings.`);
+    }
+
+    /**
+     * When a preference is written to a persistent scope, drop any in-memory session
+     * override (set via `--session-preference`) for the same key so that the explicit
+     * change takes effect for the remainder of the session. Without this, the session
+     * scope would keep shadowing the user's change because it has higher precedence.
+     *
+     * Note: this fires for any write to a persistent scope, including programmatic
+     * writes from extensions. Extensions that race with startup CLI overrides will
+     * therefore clear them. This is intentional: a programmatic write is "explicit"
+     * from the preference system's point of view, but consumers should be aware.
+     *
+     * Session preferences are global (no per-resource scoping), so `resourceUri` is
+     * not threaded through.
+     */
+    protected async evictSessionOverride(preferenceName: string, writtenScope: PreferenceScope): Promise<void> {
+        if (writtenScope === PreferenceScope.Session || writtenScope === PreferenceScope.Default) {
+            return;
+        }
+        const sessionProvider = this.getProvider(PreferenceScope.Session);
+        if (sessionProvider && sessionProvider.get(preferenceName) !== undefined) {
+            // Passing `undefined` clears the value in the session provider.
+            await sessionProvider.setPreference(preferenceName, undefined as unknown as JSONValue);
+        }
     }
 
     getBoolean(preferenceName: string): boolean | undefined;
@@ -499,10 +529,11 @@ export class PreferenceServiceImpl implements PreferenceService {
         const globalValue = this.inspectInScope<T>(preferenceName, PreferenceScope.User, resourceUri, forceLanguageOverride);
         const workspaceValue = this.inspectInScope<T>(preferenceName, PreferenceScope.Workspace, resourceUri, forceLanguageOverride);
         const workspaceFolderValue = this.inspectInScope<T>(preferenceName, PreferenceScope.Folder, resourceUri, forceLanguageOverride);
+        const sessionValue = this.inspectInScope<T>(preferenceName, PreferenceScope.Session, resourceUri, forceLanguageOverride);
 
-        const valueApplied = workspaceFolderValue ?? workspaceValue ?? globalValue ?? defaultValue;
+        const valueApplied = sessionValue ?? workspaceFolderValue ?? workspaceValue ?? globalValue ?? defaultValue;
 
-        return { preferenceName, defaultValue, globalValue, workspaceValue, workspaceFolderValue, value: valueApplied };
+        return { preferenceName, defaultValue, globalValue, workspaceValue, workspaceFolderValue, sessionValue, value: valueApplied };
     }
 
     inspectInScope<T extends JSONValue>(preferenceName: string, scope: PreferenceScope, resourceUri?: string, forceLanguageOverride?: boolean): T | undefined {
@@ -526,6 +557,8 @@ export class PreferenceServiceImpl implements PreferenceService {
                 return inspection.workspaceValue;
             case PreferenceScope.Folder:
                 return inspection.workspaceFolderValue;
+            case PreferenceScope.Session:
+                return inspection.sessionValue;
         }
         unreachable(scope, 'Not all PreferenceScope enum variants handled.');
     }
@@ -551,9 +584,10 @@ export class PreferenceServiceImpl implements PreferenceService {
         }
 
         // Scopes in ascending order of scope breadth.
-        const allScopes = [...this.schemaService.validScopes].reverse();
-        // Get rid of Default scope. We can't set anything there.
-        allScopes.pop();
+        const allScopes = [...this.schemaService.validScopes].reverse()
+            // Default is read-only, and Session is populated only by `--session-preference`,
+            // so neither is a valid target for a regular user edit.
+            .filter(scope => scope !== PreferenceScope.Default && scope !== PreferenceScope.Session);
 
         const isScopeDefined = (scope: PreferenceScope) => this.getScopedValueFromInspection(inspection, scope) !== undefined;
 

--- a/packages/core/src/common/preferences/session-preference-provider.spec.ts
+++ b/packages/core/src/common/preferences/session-preference-provider.spec.ts
@@ -1,0 +1,78 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { SessionPreferenceProvider } from './session-preference-provider';
+import { PreferenceScope } from './preference-scope';
+
+describe('SessionPreferenceProvider', () => {
+
+    let provider: SessionPreferenceProvider;
+
+    beforeEach(() => {
+        provider = new SessionPreferenceProvider();
+        // PostConstruct emulation
+        (provider as unknown as { init(): void }).init();
+    });
+
+    it('claims only the Session scope', () => {
+        expect(provider.canHandleScope(PreferenceScope.Session)).to.be.true;
+        expect(provider.canHandleScope(PreferenceScope.User)).to.be.false;
+        expect(provider.canHandleScope(PreferenceScope.Workspace)).to.be.false;
+        expect(provider.canHandleScope(PreferenceScope.Folder)).to.be.false;
+        expect(provider.canHandleScope(PreferenceScope.Default)).to.be.false;
+    });
+
+    it('starts empty', () => {
+        expect(provider.getPreferences()).to.deep.equal({});
+    });
+
+    it('stores set values in memory and exposes them via get/resolve', async () => {
+        const ok = await provider.setPreference('editor.fontSize', 18);
+        expect(ok).to.be.true;
+        expect(provider.get('editor.fontSize')).to.equal(18);
+        expect(provider.resolve('editor.fontSize').value).to.equal(18);
+        expect(provider.getPreferences()).to.deep.equal({ 'editor.fontSize': 18 });
+    });
+
+    it('emits a change event on set', async () => {
+        let received: { name: string; newValue: unknown; oldValue: unknown; scope: PreferenceScope } | undefined;
+        provider.onDidPreferencesChanged(changes => {
+            const key = Object.keys(changes)[0];
+            received = {
+                name: changes[key].preferenceName,
+                newValue: changes[key].newValue,
+                oldValue: changes[key].oldValue,
+                scope: changes[key].scope
+            };
+        });
+        await provider.setPreference('foo', 'bar');
+        expect(received).to.deep.equal({ name: 'foo', newValue: 'bar', oldValue: undefined, scope: PreferenceScope.Session });
+    });
+
+    it('removes a value when set to undefined', async () => {
+        await provider.setPreference('foo', 'bar');
+        const removed = await provider.setPreference('foo', undefined as never);
+        expect(removed).to.be.true;
+        expect(provider.get('foo')).to.equal(undefined);
+        expect(provider.getPreferences()).to.deep.equal({});
+    });
+
+    it('returns false when removing a key that was never set', async () => {
+        const removed = await provider.setPreference('missing', undefined as never);
+        expect(removed).to.be.false;
+    });
+});

--- a/packages/core/src/common/preferences/session-preference-provider.ts
+++ b/packages/core/src/common/preferences/session-preference-provider.ts
@@ -1,0 +1,69 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { JSONObject, JSONValue } from '@lumino/coreutils';
+import { injectable, postConstruct } from 'inversify';
+import { PreferenceProvider, PreferenceProviderDataChange } from './preference-provider';
+import { PreferenceProviderImpl } from './preference-provider-impl';
+import { PreferenceScope } from './preference-scope';
+
+/**
+ * In-memory preference provider used for process-lifetime overrides such as those
+ * supplied via the `--session-preference` CLI option. Values live in memory only
+ * and are dropped when the process exits.
+ */
+@injectable()
+export class SessionPreferenceProvider extends PreferenceProviderImpl implements PreferenceProvider {
+
+    protected readonly preferences = new Map<string, JSONValue>();
+
+    @postConstruct()
+    protected init(): void {
+        this._ready.resolve();
+    }
+
+    override canHandleScope(scope: PreferenceScope): boolean {
+        return scope === PreferenceScope.Session;
+    }
+
+    getPreferences(): JSONObject {
+        const result: JSONObject = {};
+        for (const [name, value] of this.preferences) {
+            result[name] = value;
+        }
+        return result;
+    }
+
+    async setPreference(key: string, value: JSONValue | undefined): Promise<boolean> {
+        const oldValue = this.preferences.get(key);
+        if (value === undefined) {
+            if (!this.preferences.has(key)) {
+                return false;
+            }
+            this.preferences.delete(key);
+        } else {
+            this.preferences.set(key, value);
+        }
+        const change: PreferenceProviderDataChange = {
+            preferenceName: key,
+            newValue: value,
+            oldValue,
+            scope: PreferenceScope.Session
+        };
+        await this.emitPreferencesChangedEvent([change]);
+        return true;
+    }
+}

--- a/packages/monaco/src/browser/monaco-frontend-module.ts
+++ b/packages/monaco/src/browser/monaco-frontend-module.ts
@@ -259,6 +259,7 @@ export function createMonacoConfigurationService(container: interfaces.Container
             case PreferenceScope.User: return ConfigurationTarget.USER;
             case PreferenceScope.Workspace: return ConfigurationTarget.WORKSPACE;
             case PreferenceScope.Folder: return ConfigurationTarget.WORKSPACE_FOLDER;
+            case PreferenceScope.Session: return ConfigurationTarget.MEMORY;
         }
     };
 

--- a/packages/plugin-ext/src/main/browser/preference-registry-main.ts
+++ b/packages/plugin-ext/src/main/browser/preference-registry-main.ts
@@ -36,8 +36,16 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 
 export function getPreferences(preferenceProviderProvider: PreferenceProviderProvider, rootFolders: FileStat[]): PreferenceData {
     const folders = rootFolders.map(root => root.resource.toString());
+    // Session-scoped values are process-lifetime CLI overrides (see PreferenceScope.Session).
+    // The plugin-side `parse()` in `preference-registry.ts` only reads up to Folder, so
+    // shipping session data across would leak potentially security-sensitive overrides
+    // (e.g. AI tool auto-approval) into the plugin host without any consumer on the other
+    // side. Exclude the scope explicitly until plugins can opt in to session values.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return PreferenceScope.getScopes().reduce((result: { [key: number]: any }, scope: PreferenceScope) => {
+        if (scope === PreferenceScope.Session) {
+            return result;
+        }
         result[scope] = {};
         const provider = preferenceProviderProvider(scope);
         if (provider) {

--- a/packages/preferences/src/browser/preference-frontend-contribution.ts
+++ b/packages/preferences/src/browser/preference-frontend-contribution.ts
@@ -28,11 +28,56 @@ export class PreferenceFrontendContribution implements FrontendApplicationContri
     protected readonly preferenceService: PreferenceService;
 
     onStart(): void {
-        this.CliPreferences.getPreferences().then(async preferences => {
-            await this.preferenceService.ready;
-            for (const [key, value] of preferences) {
-                this.preferenceService.set(key, value, PreferenceScope.User);
+        this.applyCliPreferences();
+    }
+
+    protected async applyCliPreferences(): Promise<void> {
+        // Fetch both buckets in parallel; both are RPC hops to the same backend and
+        // can overlap with the preference service initialising its providers.
+        const [session, persistent] = await Promise.all([
+            this.CliPreferences.getSessionPreferences().catch(e => {
+                console.warn('Failed to fetch --session-preference values:', e);
+                return [] as [string, unknown][];
+            }),
+            this.CliPreferences.getPreferences().catch(e => {
+                console.warn('Failed to fetch --set-preference values:', e);
+                return [] as [string, unknown][];
+            })
+        ]);
+
+        // `preferenceService.set()` needs the target provider registered in the providers
+        // map, which only happens once `initializeProviders()` has walked every scope and
+        // resolved `ready`. Writing before that returns `undefined` from `getProvider()`
+        // and the call throws "Unable to write to ... Settings".
+        await this.preferenceService.ready;
+
+        // Session writes go first and are awaited sequentially so that when the same key
+        // appears in both `--session-preference` and `--set-preference`, the persistent
+        // write in the next block sees a settled session provider (and correctly triggers
+        // `evictSessionOverride`) rather than racing with the session write.
+        await this.applyAll(session, PreferenceScope.Session);
+        if (session.length > 0) {
+            // Log keys only. Values may carry overrides for security-sensitive prefs
+            // (e.g. AI tool auto-approval) and should not leak into screenshots or support bundles.
+            console.info(`Applied ${session.length} --session-preference value(s):`,
+                session.map(([k]) => k).join(', '));
+        }
+
+        await this.applyAll(persistent, PreferenceScope.User);
+    }
+
+    /**
+     * Applies a batch of CLI-provided preferences sequentially. A rejection from an
+     * individual write (bad key, invalid scope, etc.) is logged and does not abort the
+     * remaining writes, and it is not left as an unhandled promise rejection.
+     */
+    protected async applyAll(entries: ReadonlyArray<[string, unknown]>, scope: PreferenceScope): Promise<void> {
+        for (const [key, value] of entries) {
+            try {
+                await this.preferenceService.set(key, value, scope);
+            } catch (e) {
+                console.warn(`Failed to apply CLI preference "${key}" to ${PreferenceScope[scope]} scope:`, e);
             }
-        });
+        }
     }
 }

--- a/packages/preferences/src/browser/preference-frontend-module.ts
+++ b/packages/preferences/src/browser/preference-frontend-module.ts
@@ -32,6 +32,7 @@ import { PreferenceOpenHandler } from './preference-open-handler';
 import { CliPreferences, CliPreferencesPath } from '../common/cli-preferences';
 import { ServiceConnectionProvider } from '@theia/core/lib/browser/messaging/service-connection-provider';
 import { PreferenceFrontendContribution } from './preference-frontend-contribution';
+import { SessionPreferenceStatusBarContribution } from './session-preference-status-bar-contribution';
 import { PreferenceLayoutProvider } from './util/preference-layout';
 import { PreferencesWidget } from './views/preference-widget';
 import { PreferenceStorageFactory } from '../common/abstract-resource-preference-provider';
@@ -70,6 +71,8 @@ export function bindPreferences(bind: interfaces.Bind, unbind: interfaces.Unbind
     bind(CliPreferences).toDynamicValue(ctx => ServiceConnectionProvider.createProxy<CliPreferences>(ctx.container, CliPreferencesPath)).inSingletonScope();
     bind(PreferenceFrontendContribution).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(PreferenceFrontendContribution);
+    bind(SessionPreferenceStatusBarContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(SessionPreferenceStatusBarContribution);
 
     bind(WidgetStatusBarContribution).toConstantValue(noopWidgetStatusBarContribution(PreferencesWidget));
 }

--- a/packages/preferences/src/browser/session-preference-status-bar-contribution.ts
+++ b/packages/preferences/src/browser/session-preference-status-bar-contribution.ts
@@ -1,0 +1,157 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { CommonCommands, FrontendApplicationContribution, StatusBar, StatusBarAlignment } from '@theia/core/lib/browser';
+import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import { PreferenceProviderProvider, PreferenceScope, PreferenceService } from '@theia/core/lib/common/preferences';
+import { DisposableCollection, nls } from '@theia/core';
+
+export const SESSION_PREFERENCE_STATUS_BAR_ID = 'session-preference-status';
+
+/**
+ * Status bar item that reports preferences whose effective value comes from the
+ * in-memory session scope (typically set via `--session-preference`). Each active
+ * override is listed in the tooltip with a link that opens the Settings UI filtered
+ * to that preference, so the user can read its description there.
+ */
+@injectable()
+export class SessionPreferenceStatusBarContribution implements FrontendApplicationContribution {
+
+    @inject(StatusBar)
+    protected readonly statusBar: StatusBar;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(PreferenceProviderProvider)
+    protected readonly providerProvider: PreferenceProviderProvider;
+
+    protected readonly toDispose = new DisposableCollection();
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(
+            this.preferenceService.onPreferenceChanged(e => {
+                // React to both additions and removals of session overrides.
+                // Filtering by `isInSessionScope(key)` would miss removals because by the time
+                // the event fires, the session value is already gone.
+                if (e.scope === PreferenceScope.Session) {
+                    this.refresh();
+                }
+            })
+        );
+    }
+
+    onStart(): void {
+        this.preferenceService.ready.then(() => this.refresh());
+    }
+
+    protected refresh(): void {
+        const entries = this.collectActive();
+        if (entries.length === 0) {
+            this.statusBar.removeElement(SESSION_PREFERENCE_STATUS_BAR_ID);
+            return;
+        }
+        const label = nls.localize('theia/preferences/sessionPreferences/statusBar',
+            'Session Preferences ({0})', entries.length);
+        this.statusBar.setElement(SESSION_PREFERENCE_STATUS_BAR_ID, {
+            alignment: StatusBarAlignment.LEFT,
+            text: `$(warning) ${label}`,
+            tooltip: this.buildTooltip(entries),
+            // Lower priority sits further right on the left area, so this entry stays
+            // to the right of higher-priority entries (workspace, git, problems).
+            priority: 1,
+            backgroundColor: 'var(--theia-statusBarItem-prominentBackground)',
+            color: 'var(--theia-statusBarItem-prominentForeground)'
+        });
+    }
+
+    protected collectActive(): ReadonlyArray<[string, unknown]> {
+        // Read directly from the session provider rather than walking schema properties,
+        // so overrides for keys that aren't registered as schema properties (e.g. a stray
+        // `--session-preference foo.bar=1`) still show up here and in the tooltip.
+        const sessionProvider = this.providerProvider(PreferenceScope.Session);
+        const preferences = sessionProvider?.getPreferences() ?? {};
+        const result: [string, unknown][] = Object.entries(preferences);
+        // Stable order: alphabetical by key.
+        result.sort(([a], [b]) => a.localeCompare(b));
+        return result;
+    }
+
+    protected buildTooltip(entries: ReadonlyArray<[string, unknown]>): MarkdownStringImpl {
+        // `isTrusted` is restricted to the single command we actually emit links for, so
+        // a stray `command:` link in any preference key (extremely unlikely) can't execute.
+        const md = new MarkdownStringImpl('', {
+            supportThemeIcons: true,
+            isTrusted: { enabledCommands: [CommonCommands.OPEN_PREFERENCES.id] }
+        });
+        md.appendMarkdown(`**${nls.localize('theia/preferences/sessionPreferences/tooltipHeader',
+            'These settings are overridden for this session')}**\n\n`);
+        md.appendMarkdown(nls.localize('theia/preferences/sessionPreferences/tooltipBody',
+            'They were passed in via --session-preference and only live in memory. Click a setting name to jump to it in the Settings view.'));
+        md.appendMarkdown('\n\n');
+        for (const [key, value] of entries) {
+            // The setting name is a plain markdown link to the Settings view; the value
+            // follows as plain text after a colon. No code-block styling on either side.
+            md.appendMarkdown(`[${this.escapeLinkText(key)}](${this.buildOpenSettingsUri(key)}): ${this.formatDisplayValue(value)}\n\n`);
+        }
+        md.appendMarkdown(nls.localize('theia/preferences/sessionPreferences/tooltipChangeNote',
+            'Editing any of these clears its session override for this run. To use the saved values from the next launch on, restart without the --session-preference arguments.'));
+        return md;
+    }
+
+    protected buildOpenSettingsUri(preferenceKey: string): string {
+        // The Settings UI uses its search term, so a plain key string filters the view
+        // to that single preference.
+        const args = encodeURIComponent(JSON.stringify([preferenceKey]));
+        return `command:${CommonCommands.OPEN_PREFERENCES.id}?${args}`;
+    }
+
+    /**
+     * Produces a readable, no-code-formatting representation of a preference value:
+     * strings without surrounding JSON quotes, booleans as on/off, primitives as-is,
+     * objects/arrays as compact JSON. The result is shown as plain text in the tooltip.
+     */
+    protected formatDisplayValue(value: unknown): string {
+        if (typeof value === 'string') {
+            return value.length === 0 ? '(empty)' : value;
+        }
+        if (typeof value === 'boolean') {
+            return value
+                ? nls.localize('theia/preferences/sessionPreferences/valueOn', 'on')
+                : nls.localize('theia/preferences/sessionPreferences/valueOff', 'off');
+        }
+        if (value === undefined) {
+            return '(unset)';
+        }
+        try {
+            return JSON.stringify(value);
+        } catch {
+            return String(value);
+        }
+    }
+
+    /** Escape `]` so it can't terminate the markdown link early. */
+    protected escapeLinkText(text: string): string {
+        return text.replace(/\]/g, '\\]');
+    }
+
+    onStop(): void {
+        this.toDispose.dispose();
+        this.statusBar.removeElement(SESSION_PREFERENCE_STATUS_BAR_ID);
+    }
+}

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -349,11 +349,38 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
             headlineWrapper.removeChild(currentFirstChild);
         }
 
-        const currentLastChild = headlineWrapper.lastChild as HTMLElement;
-        if (currentLastChild.classList.contains('preference-leaf-headline-suffix')) {
-            this.compareOtherModifiedScopes(headlineWrapper, currentLastChild);
+        const existingModifiedScopes = headlineWrapper.querySelector('.preference-modified-scopes-suffix') as HTMLElement | null;
+        if (existingModifiedScopes) {
+            this.compareOtherModifiedScopes(headlineWrapper, existingModifiedScopes);
         } else {
             this.createOtherModifiedScopes(headlineWrapper);
+        }
+        this.updateSessionOverrideState();
+    }
+
+    /**
+     * Adds (or removes) a subtle "Overridden by session" suffix in the headline when a
+     * session override (set via `--session-preference`) is active for this preference.
+     * Styled like the existing "Modified in:" suffix so it reads as a hint, not a warning.
+     * Editing remains enabled; writing a new value clears the session override via
+     * `PreferenceServiceImpl.evictSessionOverride`.
+     */
+    protected updateSessionOverrideState(): void {
+        const { headlineWrapper } = this;
+        // Defensive: remove any leftover marker from earlier prominent styling.
+        headlineWrapper.querySelector('.preference-session-override-marker')?.remove();
+
+        const hasSessionOverride = this.inspection?.sessionValue !== undefined;
+        const existingSuffix = headlineWrapper.querySelector('.preference-session-suffix') as HTMLElement | null;
+        if (hasSessionOverride && !existingSuffix) {
+            const suffix = document.createElement('i');
+            suffix.classList.add('preference-leaf-headline-suffix', 'preference-session-suffix');
+            suffix.textContent = nls.localize('theia/preferences/sessionOverride/suffix', 'Overridden by session');
+            suffix.title = nls.localize('theia/preferences/sessionOverride/suffixTooltip',
+                'This preference has a session value set via --session-preference. Editing it here clears the session override for the rest of this session.');
+            headlineWrapper.appendChild(suffix);
+        } else if (!hasSessionOverride && existingSuffix) {
+            existingSuffix.remove();
         }
     }
 
@@ -389,8 +416,14 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
         const modifiedScopes = this.getModifiedScopesAsStrings();
         if (modifiedScopes.length !== 0) {
             const wrapper = document.createElement('i');
-            wrapper.classList.add('preference-leaf-headline-suffix');
-            headlineWrapper.appendChild(wrapper);
+            wrapper.classList.add('preference-leaf-headline-suffix', 'preference-modified-scopes-suffix');
+            // The session suffix, if present, is always inserted after the modified-scopes suffix.
+            const sessionSuffix = headlineWrapper.querySelector('.preference-session-suffix');
+            if (sessionSuffix) {
+                headlineWrapper.insertBefore(wrapper, sessionSuffix);
+            } else {
+                headlineWrapper.appendChild(wrapper);
+            }
 
             const messagePrefix = this.getModifiedMessagePrefix();
             const messageWrapper = document.createElement('span');

--- a/packages/preferences/src/common/cli-preferences.ts
+++ b/packages/preferences/src/common/cli-preferences.ts
@@ -19,4 +19,5 @@ export const CliPreferencesPath = '/services/cli-preferences';
 
 export interface CliPreferences {
     getPreferences(): Promise<[string, unknown][]>;
+    getSessionPreferences(): Promise<[string, unknown][]>;
 }

--- a/packages/preferences/src/node/preference-backend-module.ts
+++ b/packages/preferences/src/node/preference-backend-module.ts
@@ -16,6 +16,7 @@
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { CliContribution } from '@theia/core/lib/node/cli';
+import { RemoteCliContribution } from '@theia/core/lib/node/remote/remote-cli-contribution';
 import { PreferenceCliContribution } from './preference-cli-contribution';
 import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
 import { CliPreferences, CliPreferencesPath } from '../common/cli-preferences';
@@ -35,6 +36,7 @@ export default new ContainerModule(bind => {
     bind(PreferenceCliContribution).toSelf().inSingletonScope();
     bind(CliPreferences).toService(PreferenceCliContribution);
     bind(CliContribution).toService(PreferenceCliContribution);
+    bind(RemoteCliContribution).toService(PreferenceCliContribution);
     bind(JSONCEditor).toSelf().inSingletonScope();
 
     bind(PreferenceStorageFactory).toFactory(({ container }) => (uri: URI, scope: PreferenceScope) => new BackendPreferenceStorage(

--- a/packages/preferences/src/node/preference-cli-contribution.spec.ts
+++ b/packages/preferences/src/node/preference-cli-contribution.spec.ts
@@ -1,0 +1,171 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { OS } from '@theia/core/lib/common/os';
+import { RemoteCliContext } from '@theia/core/lib/node/remote/remote-cli-contribution';
+import { PreferenceCliContribution } from './preference-cli-contribution';
+
+const REMOTE_CLI_CONTEXT: RemoteCliContext = {
+    platform: { os: OS.Type.Linux, arch: 'x64' },
+    directory: '/'
+};
+
+describe('PreferenceCliContribution', () => {
+
+    let contribution: PreferenceCliContribution;
+
+    beforeEach(() => {
+        contribution = new PreferenceCliContribution();
+    });
+
+    describe('--set-preference', () => {
+        it('parses a single key=value entry as JSON', async () => {
+            contribution.setArguments({ setPreference: 'editor.fontSize=14' });
+            expect(await contribution.getPreferences()).to.deep.equal([['editor.fontSize', 14]]);
+            expect(await contribution.getSessionPreferences()).to.deep.equal([]);
+        });
+
+        it('parses string values quoted as JSON strings', async () => {
+            contribution.setArguments({ setPreference: 'workbench.colorTheme="Dark+"' });
+            expect(await contribution.getPreferences()).to.deep.equal([['workbench.colorTheme', 'Dark+']]);
+        });
+
+        it('parses object values', async () => {
+            contribution.setArguments({ setPreference: 'ai-features.chat.toolConfirmation={"shellExecute":"always_allow"}' });
+            expect(await contribution.getPreferences()).to.deep.equal([
+                ['ai-features.chat.toolConfirmation', { shellExecute: 'always_allow' }]
+            ]);
+        });
+
+        it('accepts an array of entries', async () => {
+            contribution.setArguments({ setPreference: ['editor.fontSize=12', 'editor.tabSize=2'] });
+            expect(await contribution.getPreferences()).to.deep.equal([
+                ['editor.fontSize', 12],
+                ['editor.tabSize', 2]
+            ]);
+        });
+
+        it('decodes base64-prefixed JSON values', async () => {
+            const json = JSON.stringify({ nested: true, n: 1 });
+            const b64 = Buffer.from(json, 'utf-8').toString('base64');
+            contribution.setArguments({ setPreference: `my.pref=base64:${b64}` });
+            expect(await contribution.getPreferences()).to.deep.equal([
+                ['my.pref', { nested: true, n: 1 }]
+            ]);
+        });
+
+        it('preserves "=" characters inside the value', async () => {
+            contribution.setArguments({ setPreference: 'my.pref="a=b=c"' });
+            expect(await contribution.getPreferences()).to.deep.equal([['my.pref', 'a=b=c']]);
+        });
+
+        it('skips entries that do not contain "="', async () => {
+            const originalWarn = console.warn;
+            console.warn = () => { /* silence expected warning */ };
+            try {
+                contribution.setArguments({ setPreference: ['justAKey', 'editor.fontSize=14'] });
+            } finally {
+                console.warn = originalWarn;
+            }
+            expect(await contribution.getPreferences()).to.deep.equal([['editor.fontSize', 14]]);
+        });
+
+        it('skips entries whose value is not valid JSON', async () => {
+            const originalWarn = console.warn;
+            console.warn = () => { /* silence expected warning */ };
+            try {
+                contribution.setArguments({ setPreference: ['my.pref=notJson', 'editor.fontSize=14'] });
+            } finally {
+                console.warn = originalWarn;
+            }
+            expect(await contribution.getPreferences()).to.deep.equal([['editor.fontSize', 14]]);
+        });
+    });
+
+    describe('--session-preference', () => {
+        it('routes entries into the session preferences bucket', async () => {
+            contribution.setArguments({ sessionPreference: 'ai-features.chat.defaultToolConfirmation="always_allow"' });
+            expect(await contribution.getSessionPreferences()).to.deep.equal([
+                ['ai-features.chat.defaultToolConfirmation', 'always_allow']
+            ]);
+            expect(await contribution.getPreferences()).to.deep.equal([]);
+        });
+
+        it('supports multiple session entries and base64', async () => {
+            const b64 = Buffer.from('{"shellExecute":"always_allow"}', 'utf-8').toString('base64');
+            contribution.setArguments({
+                sessionPreference: [
+                    'ai-features.chat.defaultToolConfirmation="always_allow"',
+                    `ai-features.chat.toolConfirmation=base64:${b64}`
+                ]
+            });
+            expect(await contribution.getSessionPreferences()).to.deep.equal([
+                ['ai-features.chat.defaultToolConfirmation', 'always_allow'],
+                ['ai-features.chat.toolConfirmation', { shellExecute: 'always_allow' }]
+            ]);
+        });
+
+        it('keeps --set-preference and --session-preference independent', async () => {
+            contribution.setArguments({
+                setPreference: 'editor.fontSize=14',
+                sessionPreference: 'editor.fontSize=20'
+            });
+            expect(await contribution.getPreferences()).to.deep.equal([['editor.fontSize', 14]]);
+            expect(await contribution.getSessionPreferences()).to.deep.equal([['editor.fontSize', 20]]);
+        });
+    });
+
+    describe('enhanceArgs (remote forwarding)', () => {
+        it('returns an empty list when no session prefs are set', () => {
+            expect(contribution.enhanceArgs(REMOTE_CLI_CONTEXT)).to.deep.equal([]);
+        });
+
+        it('emits one base64-encoded --session-preference flag per entry', () => {
+            contribution.setArguments({
+                sessionPreference: [
+                    'ai-features.chat.defaultToolConfirmation="always_allow"',
+                    'ai-features.chat.toolConfirmation={"shellExecute":"always_allow"}'
+                ]
+            });
+            const args = contribution.enhanceArgs(REMOTE_CLI_CONTEXT);
+            expect(args).to.have.lengthOf(2);
+            for (const arg of args) {
+                expect(arg.startsWith('--session-preference=')).to.be.true;
+                const eq = arg.indexOf('=', '--session-preference='.length);
+                const key = arg.substring('--session-preference='.length, eq);
+                const rawValue = arg.substring(eq + 1);
+                expect(rawValue.startsWith('base64:')).to.be.true;
+                const decoded = JSON.parse(Buffer.from(rawValue.substring('base64:'.length), 'base64').toString('utf-8'));
+                if (key === 'ai-features.chat.defaultToolConfirmation') {
+                    expect(decoded).to.equal('always_allow');
+                } else {
+                    expect(decoded).to.deep.equal({ shellExecute: 'always_allow' });
+                }
+            }
+        });
+
+        it('does not forward --set-preference values', () => {
+            contribution.setArguments({
+                setPreference: 'editor.fontSize=14',
+                sessionPreference: 'foo="bar"'
+            });
+            const args = contribution.enhanceArgs(REMOTE_CLI_CONTEXT);
+            expect(args).to.have.lengthOf(1);
+            expect(args[0]).to.match(/^--session-preference=foo=base64:/);
+        });
+    });
+});

--- a/packages/preferences/src/node/preference-cli-contribution.ts
+++ b/packages/preferences/src/node/preference-cli-contribution.ts
@@ -17,36 +17,74 @@
 import { injectable } from '@theia/core/shared/inversify';
 import { Argv } from '@theia/core/shared/yargs';
 import { CliContribution } from '@theia/core/lib/node/cli';
+import { RemoteCliContext, RemoteCliContribution } from '@theia/core/lib/node/remote/remote-cli-contribution';
 import { CliPreferences } from '../common/cli-preferences';
 
 @injectable()
-export class PreferenceCliContribution implements CliContribution, CliPreferences {
+export class PreferenceCliContribution implements CliContribution, CliPreferences, RemoteCliContribution {
 
     protected preferences: [string, unknown][] = [];
+    protected sessionPreferences: [string, unknown][] = [];
 
     configure(conf: Argv<{}>): void {
         conf.option('set-preference', {
             nargs: 1,
-            desc: 'sets the specified preference'
+            desc: 'sets the specified preference (persisted to user settings)'
+        });
+        conf.option('session-preference', {
+            nargs: 1,
+            desc: 'sets the specified preference for this process only (in-memory, not persisted)'
         });
     }
 
     setArguments(args: Record<string, unknown>): void {
         if (args.setPreference) {
-            const preferences: string[] = args.setPreference instanceof Array ? args.setPreference : [args.setPreference];
-            for (const preference of preferences) {
-                const firstEqualIndex = preference.indexOf('=');
-                let rawValue = preference.substring(firstEqualIndex + 1);
-                if (rawValue.startsWith('base64:')) {
-                    rawValue = Buffer.from(rawValue.substring('base64:'.length), 'base64').toString('utf-8');
-                }
-                this.preferences.push([preference.substring(0, firstEqualIndex), JSON.parse(rawValue)]);
+            this.parseInto(args.setPreference, this.preferences);
+        }
+        if (args.sessionPreference) {
+            this.parseInto(args.sessionPreference, this.sessionPreferences);
+        }
+    }
+
+    protected parseInto(raw: unknown, target: [string, unknown][]): void {
+        const entries: string[] = raw instanceof Array ? raw : [raw as string];
+        for (const entry of entries) {
+            const firstEqualIndex = entry.indexOf('=');
+            if (firstEqualIndex <= 0) {
+                console.warn(`Ignoring preference CLI argument "${entry}": expected KEY=JSONVALUE.`);
+                continue;
+            }
+            let rawValue = entry.substring(firstEqualIndex + 1);
+            if (rawValue.startsWith('base64:')) {
+                rawValue = Buffer.from(rawValue.substring('base64:'.length), 'base64').toString('utf-8');
+            }
+            try {
+                target.push([entry.substring(0, firstEqualIndex), JSON.parse(rawValue)]);
+            } catch (e) {
+                const reason = e instanceof Error ? e.message : String(e);
+                console.warn(`Ignoring preference CLI argument "${entry}": value is not valid JSON (${reason}).`);
             }
         }
     }
 
     async getPreferences(): Promise<[string, unknown][]> {
         return this.preferences;
+    }
+
+    async getSessionPreferences(): Promise<[string, unknown][]> {
+        return this.sessionPreferences;
+    }
+
+    /**
+     * Forward `--session-preference` values to the remote backend when attaching
+     * to a remote (e.g. dev container). Values are base64-encoded JSON to survive
+     * shell argument parsing intact.
+     */
+    enhanceArgs(_context: RemoteCliContext): string[] {
+        return this.sessionPreferences.map(([key, value]) => {
+            const encoded = Buffer.from(JSON.stringify(value), 'utf-8').toString('base64');
+            return `--session-preference=${key}=base64:${encoded}`;
+        });
     }
 
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Adds a new in-memory preference scope and a `--session-preference` CLI flag that lets adopters (and dev-container launch configs) pin preferences for the duration of a single process without touching the user's persisted settings. Builds on top of that a small UI surface so users always know which settings are being forced.

Preferences foundation:
- New `PreferenceScope.Session`, a highest-precedence in-memory scope that never persists to disk, backed by `SessionPreferenceProvider`.
- New `--session-preference KEY=JSONVALUE` CLI flag parallel to `--set-preference`. Repeatable, supports a `base64:` value prefix for shell-unfriendly values, and skips malformed entries with a warning instead of throwing.
- Forwarded to remote backends via `RemoteCliContribution.enhanceArgs`, so values reach the remote process after a dev-container attach.
- Writing the same key to a persistent scope drops the session override (`evictSessionOverride`) and emits a Session-scope change event so listeners stay in sync. The session scope is excluded from regular edit-target selection.
- Session scope maps to monaco's `MEMORY` configuration target.
- Session-overridden preferences show a subtle "Overridden by session" suffix in the Settings UI (styled like the existing "Modified in:" treatment) across all scope tabs. Editing the preference clears the session override.
- A dedicated status bar item lists active session overrides in a markdown tooltip; each entry is a link that opens the Settings view filtered to that preference.
- Both CLI buckets (`--set-preference` and `--session-preference`) are fetched in parallel after `preferenceService.ready`. Only preference keys are logged at startup; values are intentionally omitted so security-sensitive overrides (AI auto-approve, etc.) cannot leak into logs or screenshots.

AI surfacing:
- New `ChatBannerProvider` contribution point and `ChatBannerWidget` host in `@theia/ai-chat-ui` for persistent banners above the chat content.
- New `AiAllowAllModeChatBanner` in `@theia/ai-ide`: a dismissible strip that appears above the chat content when an AI tool confirmation preference (`ai-features.chat.defaultToolConfirmation` or `ai-features.chat.toolConfirmation`) is set in the session scope.
  - Red "Theia AI Allow-All Mode" only when the global default is forced to Allow-All.
  - Yellow "AI Tool Confirmation Overrides" for per-tool `always_allow` entries.
- The banner intentionally only watches the two tool confirmation preferences. Other AI session overrides (enable AI, agent mode, default chat agent) are surfaced in the generic Session Preferences status bar item to avoid duplicating the same list in two places.
- Announces changes via `role='status'` + `aria-live='polite'`.

Tests cover the session provider, override eviction (including the Session-scope change event and the no-op when writing to Session itself), CLI parsing including malformed entries, remote-arg forwarding, and the banner's bypass-detection rule.


#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Add a few `--session-preference` entries to the `Launch Electron Backend` (or `Launch Browser Backend`) configuration in `.vscode/launch.json`:

```jsonc
"args": [
    ".",
    // ...existing args...
    "--session-preference=ai-features.AiEnable.enableAI=true",
    "--session-preference=ai-features.agentMode.enabled=true",
    "--session-preference=ai-features.agentSettings={\"Coder\":{\"capabilityOverrides\":{\"shell-execution\":true}}}",
    "--session-preference=ai-features.chat.toolConfirmation={\"shellExecute\":\"always_allow\"}",
    "--session-preference=ai-features.chat.defaultChatAgent=\"Coder\"",
    "--session-preference=ai-features.chat.defaultToolConfirmation=\"always_allow\""
]
```

Note: values must be valid JSON, so bare strings need escaped quotes (`\"Coder\"`) and objects need their inner quotes escaped too. For complex values you can also use `base64:<base64-encoded JSON>` to avoid shell escaping.

Launch the application and check:

1. A "Session Preferences (N)" entry appears on the left side of the status bar. Hovering it shows a tooltip listing each overridden preference as a clickable link that jumps to the Settings view, filtered to that preference.
2. Opening the Settings UI: each overridden preference shows a subtle italic "Overridden by session" suffix in its row title. The input still works; changing the value clears the session override for the rest of the session.
3. Above the chat view: a red "Theia AI Allow-All Mode" strip appears because `defaultToolConfirmation` is forced to Allow-All. Dismiss it with the close button; it stays dismissed for the rest of the process and comes back on the next launch.
4. Remove the `defaultToolConfirmation` line and relaunch: the strip turns yellow ("AI Tool Confirmation Overrides") because `toolConfirmation` still has a per-tool Allow-All entry for `shellExecute`.
5. Remove all `--session-preference` flags and relaunch: the status bar item, the suffix in the Settings UI, and the chat banner all disappear.
6. Remote / dev-container attach: the same `--session-preference` flags are forwarded to the remote backend; the same UI signals should appear there as well.

Test the CLI guards by passing a malformed entry (e.g. `--session-preference=foo` with no `=`, or `--session-preference=foo=notJson`): the application starts normally and logs a warning in the dev tools console; the malformed entry is skipped, valid ones still apply.


#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- **AI configuration view alignment.** The reworked AI configuration view (planned for next week) should apply the same "Overridden by session" indication per control. The simple per-control check is `preferenceService.inspect(key)?.sessionValue !== undefined`. Leaving this out of this PR to avoid double work since the layout is changing.
- **Direct edits to `settings.json` do not evict session overrides.** `evictSessionOverride` only fires from `PreferenceServiceImpl.set()`, so an edit in the JSON file is saved correctly but the session value still wins for the rest of the session. Status bar item remains the discoverable signal. A future improvement could either show a one-shot notification when the JSON is opened while a session override is active, or evict on file-based change events as well.
- **Workspace trust is not checked for CLI overrides.** `applyCliPreferences` applies values unconditionally. Whether to gate security-sensitive overrides (such as AI tool auto-approval) at the CLI-application layer is a policy decision left for a follow-up.
- **Resource-scoped (language) overrides.** `SessionPreferenceProvider` is global and does not honor `resourceUri`; per-language overrides (e.g. `[typescript].editor.tabSize`) are not supported through `--session-preference`. Sufficient for the current use cases (process-level AI configuration); revisit if a real need appears.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
