### PR TITLE
fix(vsx-registry): deploy Open VSX extensions under the versioned id

### DIFF
--- a/packages/vsx-registry/src/node/vsx-extension-resolver.ts
+++ b/packages/vsx-registry/src/node/vsx-extension-resolver.ts
@@ -75,7 +75,11 @@ export class VSXExtensionResolver implements PluginDeployerResolver {
         if (extension.error) {
             throw new Error(extension.error);
         }
-        const resolvedId = id.id + '-' + extension.version;
+        const resolvedId = PluginIdentifiers.componentsToVersionedId({
+            publisher: extension.namespace,
+            name: extension.name,
+            version: extension.version
+        });
         const downloadUrl = extension.files.download;
         console.log(`[${id.id}]: resolved to '${resolvedId}'`);
 


### PR DESCRIPTION
#### What it does

Makes `VSXExtensionResolver` deploy Open VSX extensions under their versioned id `publisher.name@version`, matching `LocalVSIXFilePluginDeployerResolver`.

Previously Open VSX installs were deployed under `publisher.name-version` (dash), while the in-memory plugin registry, uninstall logic, and the local-`.vsix` resolver all key plugins by `publisher.name@version`. Because the forms diverge only for Open VSX, mixing install sources for the same extension+version left a stale `@`-keyed registration pointing at a deleted directory, producing `ENOENT .../publisher.name@version/extension/package.json` on plugin-host init. This completes the convergence started for the local `.vsix` resolver in #16845.

Fixes #17733.

#### How to test

1. Run the browser example (long-lived backend).
2. Install an extension from a VSIX file, then uninstall it (keep the backend running).
3. Install the same extension from Open VSX, then reload the window.
4. Before this change the plugin fails to load with `ENOENT .../@<version>/extension/package.json`; after, it loads and only the single `@`-form deployment directory exists.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no user-facing text in this change)

#### Reminder for reviewers
