### PR TITLE
fix(ai-registry): route registry fetch through the backend

### DIFF
--- a/packages/ai-registry/src/common/registry-fetch-service.spec.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.spec.ts
@@ -16,7 +16,7 @@
 
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
-import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
+import { BackendRequestService, RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
 import { AIRegistryConfiguration } from './ai-registry-configuration';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from './mcp/mcp-registry-entry-resolver';
 import { SkillRegistryEntryResolver, SkillRegistryEntryResolverImpl } from './skill/skill-registry-entry-resolver';
@@ -84,7 +84,7 @@ describe('RegistryFetchService', () => {
 
     function buildContainer(requestService: RequestService, config: AIRegistryConfiguration): Container {
         const container = new Container();
-        container.bind(RequestService).toConstantValue(requestService);
+        container.bind(BackendRequestService).toConstantValue(requestService);
         container.bind(AIRegistryConfiguration).toConstantValue(config);
         container.bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
         container.bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);

--- a/packages/ai-registry/src/common/registry-fetch-service.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.ts
@@ -16,7 +16,7 @@
 
 import { Emitter, Event } from '@theia/core';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { RequestContext, RequestService } from '@theia/core/shared/@theia/request';
+import { BackendRequestService, RequestContext, RequestService } from '@theia/core/shared/@theia/request';
 import { AIRegistryConfiguration } from './ai-registry-configuration';
 import { MCPRegistryEntryResolver } from './mcp/mcp-registry-entry-resolver';
 import { RegistryMCPServer, ResolvedRegistryEntry } from './mcp/mcp-registry-types';
@@ -41,7 +41,11 @@ export interface RegistryFetchService {
 @injectable()
 export class RegistryFetchServiceImpl implements RegistryFetchService {
 
-    @inject(RequestService)
+    // Use the backend request service rather than the generic (XHR-first) browser RequestService:
+    // the AI registry host does not send CORS headers, so a direct browser XHR is always blocked
+    // and logs an unsuppressable console error before falling back to the backend. Routing
+    // straight through the backend avoids that noise, matching how VSXRegistryService fetches.
+    @inject(BackendRequestService)
     protected readonly requestService: RequestService;
 
     @inject(AIRegistryConfiguration)


### PR DESCRIPTION
#### What it does

Closes #17735.

`RegistryFetchServiceImpl` injected the generic browser `RequestService`, which is XHR-first. Since `ai.open-vsx.org` sends no `Access-Control-Allow-Origin` header (unlike `open-vsx.org`), the direct browser XHR is always blocked by CORS and logs an unsuppressable `net::ERR_FAILED` console error before falling back to the backend — on every startup with the Extensions view open.

This injects `BackendRequestService` instead, so the fetch goes straight through the backend, matching how `VSXRegistryService` fetches. `RequestContext.asJson()` already decompresses the backend response, so no other change is needed.

#### How to test

1. Start the browser example and open the Extensions view.
2. Before: the browser console shows CORS / `net::ERR_FAILED` errors for `https://ai.open-vsx.org/api/v1/all.json` on each startup.
3. After: those errors are gone, and the MCP Servers / Skills sections still populate.

#### Follow-ups

The root cause is that `ai.open-vsx.org` does not send CORS headers, whereas `open-vsx.org` does (see eclipse/openvsx#306). Configuring CORS on the registry host would also resolve it; this change makes the client robust regardless.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the `nls` service (no user-facing text is added by this change)
