### PR TITLE
fix(vsx-registry): render README for installed extensions

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extension-editor.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension-editor.tsx
@@ -78,13 +78,11 @@ export class VSXExtensionEditor extends ReactWidget {
     };
 
     protected resolveScrollContainer = (element: VSXExtensionEditorComponent | null) => {
-        if (!element) {
-            this.deferredScrollContainer.reject(new Error('element is null'));
-        } else if (!element.scrollContainer) {
-            this.deferredScrollContainer.reject(new Error('element.scrollContainer is undefined'));
-        } else {
-            this.deferredScrollContainer.resolve(element.scrollContainer);
-        }
+        // The dedicated scroll container only exists when the extension has a README to render.
+        // When it is missing (no README, or the component is being unmounted) fall back to the
+        // editor's own node so that scrolling still works and the deferred is never left rejected
+        // without a handler, which would otherwise surface as an uncaught promise rejection.
+        this.deferredScrollContainer.resolve(element?.scrollContainer ?? this.node);
     };
 
     protected render(): React.ReactNode {

--- a/packages/vsx-registry/src/browser/vsx-extension.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extension.tsx
@@ -270,12 +270,18 @@ export class VSXExtension implements VSXExtensionData, TreeElement {
     }
 
     get readmeUrl(): string | undefined {
-        const plugin = this.plugin;
-        const readmeUrl = plugin && plugin.metadata.model.readmeUrl;
-        if (readmeUrl) {
-            return new Endpoint({ path: readmeUrl }).getRestUrl().toString();
-        }
-        return this.data['readmeUrl'];
+        return this.localReadmeUrl ?? this.data['readmeUrl'];
+    }
+
+    /**
+     * The README URL served by the local plugin host for an installed extension, or `undefined`
+     * if the README is not available locally (e.g. for a non-installed extension whose README is
+     * hosted by the remote registry). A local README is same-origin and can be fetched directly by
+     * the frontend, whereas a remote README must be retrieved through the backend `VSXRegistryService`.
+     */
+    get localReadmeUrl(): string | undefined {
+        const readmeUrl = this.plugin?.metadata.model.readmeUrl;
+        return readmeUrl ? new Endpoint({ path: readmeUrl }).getRestUrl().toString() : undefined;
     }
 
     get licenseUrl(): string | undefined {

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -32,6 +32,7 @@ import { VSXAllVersions, VSXExtensionRaw, VSXSearchEntry, VSXSearchOptions, VSXT
 import { OVSXApiFilterProvider } from '@theia/ovsx-client';
 import { ApplicationServer } from '@theia/core/lib/common/application-protocol';
 import { VSXRegistryService } from '../common/vsx-registry-service';
+import { RequestContext, RequestService } from '@theia/core/shared/@theia/request';
 import { HostedPluginServer, PluginIdentifiers, PluginType } from '@theia/plugin-ext';
 import { HostedPluginWatcher } from '@theia/plugin-ext/lib/hosted/browser/hosted-plugin-watcher';
 import { ILogger } from '@theia/core';
@@ -65,6 +66,9 @@ export class VSXExtensionsModel {
 
     @inject(VSXRegistryService)
     protected readonly vsxRegistryService: VSXRegistryService;
+
+    @inject(RequestService)
+    protected readonly request: RequestService;
 
     @inject(HostedPluginSupport)
     protected readonly pluginSupport: HostedPluginSupport;
@@ -184,7 +188,12 @@ export class VSXExtensionsModel {
             }
             if (extension.readme === undefined && extension.readmeUrl) {
                 try {
-                    const rawReadme = await this.vsxRegistryService.fetchReadme(extension.readmeUrl);
+                    // A README served by the local plugin host (installed extensions) is same-origin and can be
+                    // fetched directly by the frontend. A remote registry README must go through the backend
+                    // `VSXRegistryService`, which only allows fetching from configured OVSX registry origins.
+                    const rawReadme = extension.localReadmeUrl
+                        ? RequestContext.asText(await this.request.request({ url: extension.localReadmeUrl }))
+                        : await this.vsxRegistryService.fetchReadme(extension.readmeUrl);
                     if (rawReadme) {
                         const readme = this.compileReadme(rawReadme);
                         extension.update({ readme });


### PR DESCRIPTION
#### What it does

Fixes #17737.

Installed extensions serve their README from the local backend (`hostedPlugin/...`), but the backend `fetchReadme` added in 1.73 only allows the configured OVSX registry origin, so the README was dropped and the editor logged `element.scrollContainer is undefined`.

- Fetch local plugin READMEs directly on the frontend (same-origin); keep remote registry READMEs on the origin-guarded backend.
- Resolve the editor scroll container to the widget node when there is no README, avoiding the unhandled rejection.

#### How to test

1. Open the Extensions view and click an installed extension that ships a README.
2. The README renders and no `element.scrollContainer is undefined` error appears in the console.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- none -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
