### PR TITLE
fix(ai-registry): correct search query for MCP "From registry" link

### DIFF
--- a/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.spec.ts
@@ -1,0 +1,98 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// The view contribution import chain pulls in browser-side modules, so a DOM is required at import time.
+const disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { Emitter } from '@theia/core';
+import { VSXExtensionsContribution } from '@theia/vsx-registry/lib/browser/vsx-extensions-contribution';
+import { VSXExtensionsSearchModel } from '@theia/vsx-registry/lib/browser/vsx-extensions-search-model';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { RegistrySearchFilter } from '../../common/registry-search-filter';
+import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { MCPRegistryUiBridgeImpl } from './mcp-registry-ui-bridge-impl';
+
+after(() => disableJSDOM());
+
+class StubRegistryFetchService {
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+    constructor(public entries: ResolvedRegistryEntry[] = []) { }
+    async getEntries(): Promise<ResolvedRegistryEntry[]> {
+        return this.entries;
+    }
+}
+
+const exampleRegistryEntry: ResolvedRegistryEntry = {
+    serverId: 'io.github.ChromeDevTools/chrome-devtools-mcp',
+    name: 'chrome-devtools',
+    description: 'Chrome DevTools MCP server.',
+    localName: 'chrome-devtools',
+    config: { command: 'npx', args: ['-y', 'chrome-devtools-mcp@latest'] },
+    version: '^1.0.0',
+    configHash: 'hash-v1',
+    mcpRegistryVerified: true
+};
+
+function buildBridge(searchModel: { query: string }, entries: ResolvedRegistryEntry[]): MCPRegistryUiBridgeImpl {
+    const container = new Container();
+    container.bind(RegistryFetchService).toConstantValue(new StubRegistryFetchService(entries) as unknown as RegistryFetchService);
+    container.bind(VSXExtensionsContribution).toConstantValue({ openView: async () => undefined } as unknown as VSXExtensionsContribution);
+    container.bind(VSXExtensionsSearchModel).toConstantValue(searchModel as unknown as VSXExtensionsSearchModel);
+    container.bind(MCPRegistryUiBridgeImpl).toSelf().inSingletonScope();
+    return container.get(MCPRegistryUiBridgeImpl);
+}
+
+describe('MCPRegistryUiBridgeImpl.openRegistry', () => {
+
+    it('searches by the raw server id, which the filter surfaces to the linked entry', async () => {
+        const searchModel = { query: '' };
+        const bridge = buildBridge(searchModel, [exampleRegistryEntry]);
+        await bridge.ready();
+
+        await bridge.openRegistry(exampleRegistryEntry.serverId);
+
+        const filter = new RegistrySearchFilter();
+        const searchEntry = {
+            name: exampleRegistryEntry.name,
+            identifier: exampleRegistryEntry.serverId,
+            description: exampleRegistryEntry.description
+        };
+        // The bridge fills the search box with the clean, user-recognizable server id...
+        expect(searchModel.query).to.equal(exampleRegistryEntry.serverId);
+        // ...and the filter reduces that id so it surfaces the linked entry.
+        expect(filter.matches(searchEntry, searchModel.query)).to.equal(true);
+    });
+
+    it('leaves the query untouched for an unknown server id', async () => {
+        const searchModel = { query: 'unchanged' };
+        const bridge = buildBridge(searchModel, [exampleRegistryEntry]);
+        await bridge.ready();
+
+        await bridge.openRegistry('io.github.unknown/not-installed');
+
+        expect(searchModel.query).to.equal('unchanged');
+    });
+});

--- a/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-registry-ui-bridge-impl.ts
@@ -82,6 +82,9 @@ export class MCPRegistryUiBridgeImpl implements MCPRegistryUiBridge {
         // (with a warning + Unlink / Uninstall); jumping to an empty search hides it, so
         // we just show the view and let the user see the warning in Installed.
         if (serverId && this.hasServer(serverId)) {
+            // Search by the raw server id: it's the clean, user-recognizable string (the same one
+            // shown on the registry website) and `RegistrySearchFilter` reduces it to surface the
+            // linked entry. See `RegistrySearchFilter.reduceQuery`.
             this.searchModel.query = serverId;
         }
         await this.viewContribution.openView({ activate: true });

--- a/packages/ai-registry/src/common/registry-search-filter.spec.ts
+++ b/packages/ai-registry/src/common/registry-search-filter.spec.ts
@@ -19,9 +19,12 @@ import { RegistrySearchFilter } from './registry-search-filter';
 
 describe('RegistrySearchFilter.meaningfulIdentifier', () => {
     const filter = new RegistrySearchFilter();
-    it('reduces a reverse-DNS id to its last domain label plus path', () => {
+    it('drops the reverse-DNS TLD and hosting namespace, keeping the owner label plus path', () => {
         expect(filter.meaningfulIdentifier('com.asana/mcp')).to.equal('asana mcp');
         expect(filter.meaningfulIdentifier('io.github.anthropics/algorithmic-art')).to.equal('anthropics algorithmic-art');
+    });
+    it('keeps a distinctive intermediate domain label instead of only the last one', () => {
+        expect(filter.meaningfulIdentifier('com.cloudflare.mcp/mcp')).to.equal('cloudflare mcp mcp');
     });
     it('leaves a plain string unchanged', () => {
         expect(filter.meaningfulIdentifier('Hugging Face')).to.equal('Hugging Face');
@@ -49,6 +52,17 @@ describe('RegistrySearchFilter.matches', () => {
         expect(filter.matches(art, 'git')).to.equal(false);
         // ...but a genuine GitHub entry still matches.
         expect(filter.matches(github, 'git')).to.equal(true);
+    });
+
+    it('finds an entry by its full reverse-DNS server id (e.g. copied from the registry website)', () => {
+        expect(filter.matches(asana, 'com.asana/mcp')).to.equal(true);
+        expect(filter.matches(grafana, 'io.github.grafana/mcp-grafana')).to.equal(true);
+        expect(filter.matches(github, 'io.github.github/github-mcp-server')).to.equal(true);
+    });
+
+    it('pinpoints the entry when searching a full server id, excluding unrelated ones', () => {
+        expect(filter.matches(grafana, 'com.asana/mcp')).to.equal(false);
+        expect(filter.matches(asana, 'io.github.grafana/mcp-grafana')).to.equal(false);
     });
 
     it('matches a substring of the kebab-case name', () => {

--- a/packages/ai-registry/src/common/registry-search-filter.ts
+++ b/packages/ai-registry/src/common/registry-search-filter.ts
@@ -18,6 +18,13 @@ import { injectable } from '@theia/core/shared/inversify';
 
 const SEGMENT_SEPARATOR = /[\p{P}\s]+/u;
 
+/**
+ * Reverse-DNS labels that host third-party owners rather than identifying one (e.g. the `github`
+ * in `io.github.<owner>`). They are dropped along with the leading TLD so the owner label becomes
+ * the meaningful part, while a query like `git` still can't match every `io.github.*` entry.
+ */
+const HOSTING_NAMESPACES = new Set(['github', 'gitlab', 'gitee', 'bitbucket']);
+
 export interface RegistrySearchEntry {
     name: string;
     identifier: string;
@@ -45,7 +52,7 @@ export interface RegistrySearchEntry {
 export class RegistrySearchFilter {
 
     matches(entry: RegistrySearchEntry, query: string): boolean {
-        const terms = this.tokenize(query);
+        const terms = this.tokenize(this.reduceQuery(query));
         if (terms.length === 0) {
             return true;
         }
@@ -63,16 +70,44 @@ export class RegistrySearchFilter {
      * Reduces a registry identifier to its human-meaningful part for search matching.
      *
      * Registry identifiers are reverse-DNS ids with a path, e.g. `com.asana/mcp` or
-     * `io.github.anthropics/algorithmic-art`. The leading domain labels (`com`, `io`, `github`, ...)
-     * are shared boilerplate that would otherwise let a query like `git` match every `io.github.*`
-     * entry. This keeps only the last domain label plus the path: `asana mcp`, `anthropics algorithmic-art`.
+     * `io.github.anthropics/algorithmic-art`. The leading TLD (`com`, `io`, ...) and any hosting
+     * namespace (`github` in `io.github.<owner>`) are shared boilerplate that would otherwise let a
+     * query like `git` match every `io.github.*` entry, so they are dropped. The remaining owner
+     * labels plus the path are kept: `asana mcp`, `anthropics algorithmic-art`, `cloudflare mcp mcp`.
      *
      * Plain strings without a domain or path are returned unchanged.
      */
     meaningfulIdentifier(identifier: string): string {
         const [domain, ...rest] = identifier.split('/');
-        const lastLabel = domain.split('.').pop() || domain;
-        return [lastLabel, ...rest].join(' ');
+        return [...this.meaningfulDomainLabels(domain), ...rest].join(' ');
+    }
+
+    /**
+     * Drops the boilerplate leading labels of a reverse-DNS domain, keeping the owner label(s).
+     * A single-label string (no reverse-DNS structure) is returned as-is.
+     */
+    protected meaningfulDomainLabels(domain: string): string[] {
+        const labels = domain.split('.');
+        if (labels.length <= 1) {
+            return labels;
+        }
+        labels.shift(); // drop the leading TLD label (io, com, app, ai, ...)
+        // Drop a hosting namespace like `github` in `io.github.<owner>`, but only when an owner
+        // label still follows it - otherwise the owner itself would be discarded (e.g. `com.gitlab`).
+        if (labels.length > 1 && HOSTING_NAMESPACES.has(labels[0].toLowerCase())) {
+            labels.shift();
+        }
+        return labels;
+    }
+
+    /**
+     * Reduces a query shaped like a registry id (reverse-DNS domain with a `/` path) the same way
+     * entry identifiers are reduced, so the full id - e.g. copied from the registry website or set
+     * by the "From registry" link - finds the server instead of being rejected by the stripped
+     * boilerplate labels it would otherwise require as terms. Plain-text queries are left untouched.
+     */
+    protected reduceQuery(query: string): string {
+        return query.includes('/') ? this.meaningfulIdentifier(query) : query;
     }
 
     protected tokenize(text: string): string[] {


### PR DESCRIPTION
#### What it does

Fixes #17739.

The MCP **"From registry"** link pre-filled the Extensions search with the raw registry serverId (e.g. `io.github.ChromeDevTools/chrome-devtools-mcp`). `RegistrySearchFilter` strips the reverse-DNS domain labels (`io`, `github`) from entry ids while still requiring *every* query term to match, so those stripped labels could never match and the linked server was filtered out — the search showed no results.

The bridge now sets the query via `RegistrySearchFilter.meaningfulIdentifier(serverId)`, the same reduction the filter matches against, so the linked server is reliably surfaced.

#### How to test

1. Add an MCP server from the AI registry (e.g. chrome-devtools).
2. In **AI Configuration → MCP Servers**, click **"From registry"** next to the server.
3. The Extensions view opens and shows the server (previously the search box was filled but empty).

Or run the added unit test:

```
npx mocha ./packages/ai-registry/lib/browser/mcp/mcp-registry-ui-bridge-impl.spec.js
```

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the `nls` service (no user-facing text changed)
