### PR TITLE
Track active custom editor in the selection service

### DIFF
--- a/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
+++ b/packages/plugin-ext/src/main/browser/custom-editors/custom-editor-widget.ts
@@ -17,8 +17,9 @@
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import URI from '@theia/core/lib/common/uri';
 import { FileOperation } from '@theia/filesystem/lib/common/files';
-import { ApplicationShell, DelegatingSaveable, NavigatableWidget, Saveable, SaveableSource } from '@theia/core/lib/browser';
+import { ApplicationShell, DelegatingSaveable, Message, NavigatableWidget, Saveable, SaveableSource } from '@theia/core/lib/browser';
 import { SaveableService } from '@theia/core/lib/browser/saveable-service';
+import { Disposable, SelectionService } from '@theia/core/lib/common';
 import { Reference } from '@theia/core/lib/common/reference';
 import { WebviewWidget } from '../webview/webview';
 import { CustomEditorModel } from './custom-editors-main';
@@ -54,6 +55,9 @@ export class CustomEditorWidget extends WebviewWidget implements CustomEditorWid
     @inject(SaveableService)
     protected readonly saveService: SaveableService;
 
+    @inject(SelectionService)
+    protected readonly selectionService: SelectionService;
+
     @postConstruct()
     protected override init(): void {
         super.init();
@@ -63,6 +67,16 @@ export class CustomEditorWidget extends WebviewWidget implements CustomEditorWid
                 this.doMove(e.target.resource);
             }
         }));
+        this.toDispose.push(Disposable.create(() => {
+            if (this.selectionService.selection === this) {
+                this.selectionService.selection = undefined;
+            }
+        }));
+    }
+
+    protected override onActivateRequest(msg: Message): void {
+        super.onActivateRequest(msg);
+        this.selectionService.selection = this;
     }
 
     updateID(): void {


### PR DESCRIPTION
> **Note:** This pull request was drafted with AI assistance. I have reviewed the change and take full responsibility for its correctness and for this submission.

#### What it does

`editor/title` menu contributions whose `when` clause references a resource context key (e.g. `resourceScheme == foo`, `resourceLangId == bar`) never render their toolbar buttons for **custom editors**, even though the same contributions work for text editors. This diverges from VS Code, where such `editor/title` items appear for custom editors too.

Root cause: `CommonFrontendContribution.initResourceContextKeys` derives `resourceScheme`, `resourceLangId`, `resourcePath`, etc. **only** from the current `SelectionService` selection. `EditorWidget` pushes itself into the selection on activation, but `WebviewWidget`/`CustomEditorWidget` never do — so when a custom editor becomes the active tab, the resource context keys keep their stale value and the `when` clauses fail to match.

Fix: mirror `EditorWidget` in `CustomEditorWidget` — set the widget as the active selection on `onActivateRequest` and clear it on dispose. `CustomEditorWidget` is already a `NavigatableWidget`, so the resource context keys resolve from its `getResourceUri()`.

#### How to test

1. Contribute a custom editor from a VS Code extension and an `editor/title` menu item gated on a resource key, e.g. `"when": "resourceScheme == <your-custom-scheme>"` (or `resourceLangId == <lang>`).
2. Open a document in that custom editor.
3. Before: the toolbar button is missing. After: the button appears in the editor title toolbar, matching VS Code. Switching back to a regular text editor still updates the keys correctly.

#### Testing note

No automated test is included. The change mirrors the existing `EditorWidget` selection handling in `packages/editor/src/browser/editor-widget.ts`, which is itself not unit-tested. Covering it in isolation would require the first frontend (jsdom) spec in `plugin-ext` and, for the dispose-clear branch, the full DI graph of `WebviewWidget`/`CustomEditorWidget` — disproportionate to a two-line behavioural change. The behaviour is verifiable via the manual steps above. Happy to add a spec if reviewers would prefer one.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the `nls` service

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
