### PR TITLE
fix(core): always show the bottom-panel toggle

### DIFF
--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -680,7 +680,6 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
             }
         });
         commandRegistry.registerCommand(CommonCommands.TOGGLE_BOTTOM_PANEL, {
-            isEnabled: () => this.shell.getWidgets('bottom').length > 0,
             execute: () => {
                 if (this.shell.isExpanded('bottom')) {
                     this.shell.collapsePanel('bottom');

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -355,6 +355,7 @@ export class ApplicationShell extends Widget {
                 });
             }
         });
+        this.refreshBottomPanelToggleButton();
         this.initializedDeferred.resolve();
     }
 
@@ -689,14 +690,10 @@ export class ApplicationShell extends Widget {
             spacing: 0
         }, area => this.doToggleMaximized(area));
         dockPanel.id = BOTTOM_AREA_ID;
-        dockPanel.widgetAdded.connect((sender, widget) => {
-            this.refreshBottomPanelToggleButton();
-        });
         dockPanel.widgetRemoved.connect((sender, widget) => {
             if (sender.isEmpty) {
                 this.collapseBottomPanel();
             }
-            this.refreshBottomPanelToggleButton();
         }, this);
         dockPanel.node.addEventListener('lm-dragenter', event => {
             // Make sure that the main panel hides its overlay when the bottom panel is expanded
@@ -887,7 +884,6 @@ export class ApplicationShell extends Widget {
                     }
                 });
             }
-            this.refreshBottomPanelToggleButton();
         }
         // Proceed with the main panel once all others are set up
         await this.bottomPanelState.pendingUpdate;
@@ -1631,24 +1627,20 @@ export class ApplicationShell extends Widget {
      * and refers to the command `core.toggle.bottom.panel`.
      */
     protected refreshBottomPanelToggleButton(): void {
-        if (this.bottomPanel.isEmpty) {
-            this.statusBar.removeElement(BOTTOM_PANEL_TOGGLE_ID);
-        } else {
-            const label = nls.localize('theia/core/common/collapseBottomPanel', 'Toggle Bottom Panel');
-            const element: StatusBarEntry = {
-                name: label,
-                text: '$(codicon-window)',
-                alignment: StatusBarAlignment.RIGHT,
-                tooltip: label,
-                command: 'core.toggle.bottom.panel',
-                accessibilityInformation: {
-                    label: label,
-                    role: 'button'
-                },
-                priority: -1000
-            };
-            this.statusBar.setElement(BOTTOM_PANEL_TOGGLE_ID, element);
-        }
+        const label = nls.localize('theia/core/common/collapseBottomPanel', 'Toggle Bottom Panel');
+        const element: StatusBarEntry = {
+            name: label,
+            text: '$(codicon-window)',
+            alignment: StatusBarAlignment.RIGHT,
+            tooltip: label,
+            command: 'core.toggle.bottom.panel',
+            accessibilityInformation: {
+                label: label,
+                role: 'button'
+            },
+            priority: -1000
+        };
+        this.statusBar.setElement(BOTTOM_PANEL_TOGGLE_ID, element);
     }
 
     /**

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1566,9 +1566,11 @@ export class ApplicationShell extends Widget {
             let size: number | undefined;
             if (bottomPanel.isEmpty) {
                 bottomPanel.node.style.minHeight = '0';
-                size = this.options.bottomPanel.emptySize;
-            } else if (this.bottomPanelState.lastPanelSize) {
+            }
+            if (this.bottomPanelState.lastPanelSize) {
                 size = this.bottomPanelState.lastPanelSize;
+            } else if (bottomPanel.isEmpty) {
+                size = this.options.bottomPanel.emptySize;
             } else {
                 size = this.getDefaultBottomPanelSize();
             }

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -276,6 +276,11 @@
   background: inherit;
 }
 
+/* Ensure the empty bottom panel keeps a top border separating it from the main panel. */
+#theia-bottom-content-panel:not(:has(.lm-TabBar)) {
+  border-top: var(--theia-border-width) solid var(--theia-panel-border);
+}
+
 #theia-bottom-content-panel .lm-TabBar-tab {
   background: inherit;
 }


### PR DESCRIPTION
#### What it does

Fixes [#17679](https://github.com/eclipse-theia/theia/issues/17679).

The status-bar item that toggles the bottom panel was only shown while the bottom panel contained at least one widget. It appeared/disappeared as views were opened/closed, and once the panel was empty the toggle vanished — so the user could no longer expand the panel, even though expanding an empty bottom panel to a blank canvas is perfectly valid (the main area can also be empty).

Changes:

- Always show the `bottom-panel-toggle` status-bar item, even when the bottom panel is empty, so users can expand an empty (blank) panel. The toggle is now created during shell init so it is present at startup regardless of the restored layout.
- Make the `core.toggle.bottom.panel` command always enabled (removed the "has widgets" guard).
- Add a top border to the empty bottom panel so it stays visually distinct from the main panel when no tab bar is present.
- Preserve the bottom panel size across toggling when it is empty: re-expanding now prefers the saved `lastPanelSize` instead of always resetting to the default `emptySize`.

The existing behavior of auto-collapsing the panel when its last widget is closed is kept. The difference is only that the toggle now remains, so the panel can be re-expanded.

#### How to test

1. Start the Browser or Electron example (`npm run start:browser`).
2. Close all widgets in the bottom panel (e.g. Problems/Output). The panel collapses, but the toggle item remains in the status bar (right side, window codicon).
3. Click the toggle (or press `Ctrl+J` / `Cmd+J`). The bottom panel expands as a blank panel; click again to collapse. Verify the toggle works with no widgets present.
4. With the empty panel expanded, confirm there is a top border separating it from the main panel.
5. Resize the empty panel by dragging its upper border, then toggle it closed and open again — it should reopen at the same size (previously it reset to the default size).
6. Open the Output view — the panel behaves as before, the toggle stays present, and there is no double border.
7. Reload with a saved layout that has an empty bottom panel — the toggle is present on startup.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
