### PR TITLE
feat: surface deferred-tool search as a server tool call

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -722,6 +722,86 @@ describe('AnthropicModel', () => {
             // The raw block from `data` is reconstructed faithfully (not the rendering summary).
             expect((resultBlock as { content: unknown }).content).to.deep.equal(rawBlock);
         });
+
+        it('surfaces the deferred tool search as a running then finished server tool call', async () => {
+            const events = [
+                { type: 'message_start', message: { usage: { input_tokens: 10, output_tokens: 0 } } },
+                { type: 'content_block_start', index: 0, content_block: { type: 'server_tool_use', id: 'ts-1', name: 'tool_search_tool_bm25', input: {} } },
+                { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{"query":"file"}' } },
+                { type: 'content_block_stop', index: 0 },
+                {
+                    type: 'content_block_start', index: 1,
+                    content_block: {
+                        type: 'tool_search_tool_result', tool_use_id: 'ts-1',
+                        content: { type: 'tool_search_tool_search_result', tool_references: [{}, {}] }
+                    }
+                },
+                { type: 'content_block_stop', index: 1 },
+                { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 5 } },
+                { type: 'message_stop' },
+            ];
+
+            const model = new class extends AnthropicModel {
+                protected override initializeAnthropic(): Anthropic {
+                    return buildMockAnthropicStream(events);
+                }
+            }('test-id', 'claude-opus-4-5', { status: 'ready' }, true, false, () => 'test-key', undefined);
+
+            const parts = await collectParts(model, 'do something requiring a deferred tool');
+            const calls = parts.filter(isServerToolCallResponsePart).flatMap(p => p.server_tool_calls);
+
+            // The native `tool_search_tool_bm25` invocation is surfaced under the stable, user-facing name.
+            const running = calls.find(c => !c.finished && c.name === 'tool_search');
+            expect(running).to.not.be.undefined;
+            expect(running!.id).to.equal('ts-1');
+
+            const finished = calls.find(c => c.finished);
+            expect(finished).to.not.be.undefined;
+            expect(finished!.id).to.equal('ts-1');
+            expect(finished!.name).to.equal('tool_search');
+            expect(finished!.arguments).to.equal('{"query":"file"}');
+            expect(finished!.result).to.deep.equal({ content: [{ type: 'text', text: 'Found 2 tools.' }] });
+        });
+
+        it('drops the deferred tool search server tool use message on replay', async () => {
+            let capturedParams: Anthropic.MessageCreateParams | undefined;
+            const model = new class extends AnthropicModel {
+                protected override initializeAnthropic(): Anthropic {
+                    return {
+                        messages: {
+                            stream: (params: Anthropic.MessageCreateParams) => {
+                                capturedParams = params;
+                                async function* iterate(): AsyncGenerator<object> { /* no events */ }
+                                const iter = iterate();
+                                (iter as unknown as Record<string, unknown>).on = () => { /* no-op */ };
+                                (iter as unknown as Record<string, unknown>).abort = () => { /* no-op */ };
+                                return iter;
+                            }
+                        }
+                    } as unknown as Anthropic;
+                }
+            }('test-id', 'claude-opus-4-5', { status: 'ready' }, true, false, () => 'test-key', undefined);
+
+            const request: UserRequest = {
+                messages: [
+                    { actor: 'user', type: 'text', text: 'hi' },
+                    {
+                        actor: 'ai', type: 'server_tool_use', id: 'ts-1', name: 'tool_search',
+                        input: { query: 'file' },
+                        result: { content: [{ type: 'text', text: 'Found 2 tools.' }] }
+                    }
+                ],
+                agentId: 'test', sessionId: 'session', requestId: 'req'
+            };
+            const response = await model.request(request);
+            if ('stream' in response) {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                for await (const _part of response.stream) { /* no-op */ }
+            }
+
+            const allBlocks = (capturedParams?.messages ?? []).flatMap(m => Array.isArray(m.content) ? m.content : []);
+            expect(allBlocks.some(b => b.type === 'server_tool_use')).to.be.false;
+        });
     });
 });
 

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -35,7 +35,7 @@ import {
     ToolInvocationContext,
     UserRequest
 } from '@theia/ai-core';
-import { CancellationToken, isArray } from '@theia/core';
+import { CancellationToken, isArray, nls } from '@theia/core';
 import { Anthropic } from '@anthropic-ai/sdk';
 import type { Base64ImageSource, ImageBlockParam, Message, MessageParam, TextBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources';
 import { createProxyFetch } from '@theia/ai-core/lib/node';
@@ -443,9 +443,12 @@ export class AnthropicModel implements LanguageModel {
                                 let result: ToolCallContent;
                                 if (searchContent.type === 'tool_search_tool_search_result') {
                                     const found = searchContent.tool_references.length;
-                                    result = { content: [{ type: 'text', text: `Found ${found} tool${found === 1 ? '' : 's'}.` }] };
+                                    const text = found === 1
+                                        ? nls.localize('theia/ai/anthropic/toolSearch/foundOne', 'Found 1 tool.')
+                                        : nls.localize('theia/ai/anthropic/toolSearch/found', 'Found {0} tools.', found);
+                                    result = { content: [{ type: 'text', text }] };
                                 } else {
-                                    result = createToolCallError(`Tool search failed: ${searchContent.error_code}`);
+                                    result = createToolCallError(nls.localize('theia/ai/anthropic/toolSearch/failed', 'Tool search failed: {0}', searchContent.error_code));
                                 }
                                 yield buildServerToolResultPart(serverToolCalls, contentBlock.tool_use_id, ANTHROPIC_TOOL_SEARCH, result, searchContent);
                             }

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -40,7 +40,7 @@ import { Anthropic } from '@anthropic-ai/sdk';
 import type { Base64ImageSource, ImageBlockParam, Message, MessageParam, TextBlockParam, ToolResultBlockParam } from '@anthropic-ai/sdk/resources';
 import { createProxyFetch } from '@theia/ai-core/lib/node';
 import { anthropicReasoningFor } from './anthropic-reasoning';
-import { ANTHROPIC_WEB_FETCH, ANTHROPIC_WEB_SEARCH } from './anthropic-server-tools';
+import { ANTHROPIC_TOOL_SEARCH, ANTHROPIC_TOOL_SEARCH_NATIVE, ANTHROPIC_WEB_FETCH, ANTHROPIC_WEB_SEARCH } from './anthropic-server-tools';
 
 export const DEFAULT_MAX_TOKENS = 4096;
 
@@ -149,6 +149,9 @@ function transformToAnthropicParams(
 
     const convertedMessages = messages
         .filter(message => message.actor !== 'system')
+        // The deferred-tool search is surfaced to the UI (see stream handling) but is executed by Anthropic
+        // internally; it must not be echoed back as history, so drop it before replay.
+        .filter(message => !(LanguageModelMessage.isServerToolUseMessage(message) && message.name === ANTHROPIC_TOOL_SEARCH))
         .map(message => ({
             role: toAnthropicRole(message),
             content: createMessageContent(message)
@@ -407,14 +410,12 @@ export class AnthropicModel implements LanguageModel {
                                 yield { tool_calls: [{ finished: false, id: toolCall.id, function: { name: toolCall.name, arguments: toolCall.args } }] };
                             }
                             if (contentBlock.type === 'server_tool_use') {
-                                // The deferred-tool search invocation also arrives as `server_tool_use`; it is handled by Anthropic
-                                // internally and must not be surfaced to the UI as a server tool call.
-                                if (contentBlock.name === 'tool_search_tool_bm25') {
-                                    console.debug('Anthropic: received deferred tool stream block:', contentBlock);
-                                } else {
-                                    serverToolCall = { name: contentBlock.name, args: '', id: contentBlock.id, index: event.index };
-                                    yield { server_tool_calls: [{ id: serverToolCall.id, name: serverToolCall.name, arguments: '', finished: false }] };
-                                }
+                                // The deferred-tool search invocation also arrives as `server_tool_use` (native name
+                                // `tool_search_tool_bm25`); surface it under a stable, user-facing name so the UI shows the
+                                // search running. Anthropic executes it on its own infrastructure, like other server tools.
+                                const name = contentBlock.name === ANTHROPIC_TOOL_SEARCH_NATIVE ? ANTHROPIC_TOOL_SEARCH : contentBlock.name;
+                                serverToolCall = { name, args: '', id: contentBlock.id, index: event.index };
+                                yield { server_tool_calls: [{ id: serverToolCall.id, name: serverToolCall.name, arguments: '', finished: false }] };
                             }
                             if (contentBlock.type === 'web_fetch_tool_result') {
                                 // Result blocks are delivered complete (not streamed). Surface them as a finished server tool call.
@@ -435,8 +436,18 @@ export class AnthropicModel implements LanguageModel {
                                 }
                                 yield buildServerToolResultPart(serverToolCalls, contentBlock.tool_use_id, ANTHROPIC_WEB_SEARCH, result, searchContent);
                             }
-                            if ((contentBlock.type as string) === 'tool_search_tool_result') {
-                                console.debug('Anthropic: received deferred tool stream block:', contentBlock);
+                            if (contentBlock.type === 'tool_search_tool_result') {
+                                // Result blocks are delivered complete (not streamed). Finish the search server tool call so
+                                // the UI replaces the spinner with a summary.
+                                const searchContent = contentBlock.content;
+                                let result: ToolCallContent;
+                                if (searchContent.type === 'tool_search_tool_search_result') {
+                                    const found = searchContent.tool_references.length;
+                                    result = { content: [{ type: 'text', text: `Found ${found} tool${found === 1 ? '' : 's'}.` }] };
+                                } else {
+                                    result = createToolCallError(`Tool search failed: ${searchContent.error_code}`);
+                                }
+                                yield buildServerToolResultPart(serverToolCalls, contentBlock.tool_use_id, ANTHROPIC_TOOL_SEARCH, result, searchContent);
                             }
                         } else if (event.type === 'content_block_delta') {
                             const delta = event.delta;
@@ -558,8 +569,8 @@ export class AnthropicModel implements LanguageModel {
         } as Anthropic.Messages.Tool));
         if (deferred.size > 0) {
             tools.push({
-                type: 'tool_search_tool_bm25',
-                name: 'tool_search_tool_bm25'
+                type: ANTHROPIC_TOOL_SEARCH_NATIVE,
+                name: ANTHROPIC_TOOL_SEARCH_NATIVE
             });
         }
         // Cache the client tools as before; server tools are appended afterwards.

--- a/packages/ai-anthropic/src/node/anthropic-server-tools.ts
+++ b/packages/ai-anthropic/src/node/anthropic-server-tools.ts
@@ -20,6 +20,11 @@ import { ServerToolDescriptor } from '@theia/ai-core';
 export const ANTHROPIC_WEB_FETCH = 'web_fetch';
 export const ANTHROPIC_WEB_SEARCH = 'web_search';
 
+/** Native Anthropic name for the deferred-tool search server tool (used when converting tools for the API). */
+export const ANTHROPIC_TOOL_SEARCH_NATIVE = 'tool_search_tool_bm25';
+/** Stable, user-facing name under which the deferred-tool search is surfaced as a server tool call. */
+export const ANTHROPIC_TOOL_SEARCH = 'tool_search';
+
 /**
  * Server tools offered by the Anthropic provider. These are executed by Anthropic's infrastructure
  * (not by Theia) and are attached to each model's metadata so the chat UI can offer them.

--- a/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { isUsageResponsePart, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core';
+import { isServerToolCallResponsePart, isUsageResponsePart, LanguageModelStreamResponsePart, UserRequest } from '@theia/ai-core';
 import { OpenAiModelUtils } from './openai-language-model';
 import { OpenAiResponseApiUtils } from './openai-response-api-utils';
 
@@ -105,5 +105,77 @@ describe('OpenAiResponseApiUtils', () => {
             { input_tokens: 100, output_tokens: 10 },
             { input_tokens: 200, output_tokens: 20 }
         ]);
+    });
+
+    it('surfaces the deferred-tool search as a running then finished server tool call', async () => {
+        const utils = new OpenAiResponseApiUtils();
+        const streams = [
+            [
+                {
+                    type: 'response.output_item.added',
+                    item: { id: 'ts-item-1', call_id: 'ts-1', type: 'tool_search_call', execution: 'server', status: 'in_progress', arguments: { query: 'file' } }
+                },
+                {
+                    type: 'response.output_item.done',
+                    item: { id: 'ts-out-1', call_id: 'ts-1', type: 'tool_search_output', execution: 'server', status: 'completed', tools: [{}, {}] }
+                },
+                {
+                    type: 'response.output_item.added',
+                    item: { id: 'item-1', call_id: 'call-1', type: 'function_call', name: 'lookup', arguments: '{"query":"test"}' }
+                },
+                { type: 'response.completed', response: { usage: { input_tokens: 100, output_tokens: 10 } } }
+            ],
+            [
+                { type: 'response.output_text.delta', delta: 'done' },
+                { type: 'response.completed', response: { usage: { input_tokens: 200, output_tokens: 20 } } }
+            ]
+        ];
+        const openai = {
+            responses: {
+                stream: () => toStream(streams.shift() ?? [])
+            }
+        };
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: [{ actor: 'user', type: 'text', text: 'hello' }],
+            deferredToolIds: ['lookup'],
+            tools: [{
+                id: 'lookup',
+                name: 'lookup',
+                parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                handler: async () => 'result'
+            }]
+        };
+
+        const response = await utils.handleRequest(
+            openai as never,
+            request,
+            {},
+            'gpt-5',
+            new OpenAiModelUtils(),
+            'developer',
+            { maxChatCompletions: 3 },
+            'openai/gpt-5',
+            true
+        );
+        const parts: LanguageModelStreamResponsePart[] = [];
+        if ('stream' in response) {
+            for await (const part of response.stream) {
+                parts.push(part);
+            }
+        }
+
+        const calls = parts.filter(isServerToolCallResponsePart).flatMap(p => p.server_tool_calls);
+        const running = calls.find(c => !c.finished);
+        expect(running).to.not.be.undefined;
+        expect(running!.id).to.equal('ts-1');
+        expect(running!.name).to.equal('tool_search');
+
+        const finished = calls.find(c => c.finished);
+        expect(finished).to.not.be.undefined;
+        expect(finished!.id).to.equal('ts-1');
+        expect(finished!.name).to.equal('tool_search');
+        expect(finished!.result).to.deep.equal({ content: [{ type: 'text', text: 'Found 2 tools.' }] });
     });
 });

--- a/packages/ai-openai/src/node/openai-response-api-utils.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.ts
@@ -38,11 +38,19 @@ import type {
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCall,
     ResponseInputItem,
-    ResponseStreamEvent
+    ResponseStreamEvent,
+    ResponseToolSearchCall,
+    ResponseToolSearchOutputItem
 } from 'openai/resources/responses/responses';
 import type { ResponsesModel } from 'openai/resources/shared';
 import { DeveloperMessageSettings, OpenAiModelUtils } from './openai-language-model';
 import { JSONSchema, JSONSchemaDefinition } from 'openai/lib/jsonschema';
+
+/**
+ * User-facing name under which the provider's built-in deferred-tool search is surfaced in the chat UI.
+ * Matches the native Response API tool type (`tool_search`), which OpenAI executes on its own infrastructure.
+ */
+export const OPENAI_TOOL_SEARCH = 'tool_search';
 
 interface ToolCall {
     id: string;
@@ -328,6 +336,8 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
     // Current iteration state
     protected currentInput: ResponseInputItem[];
     protected currentToolCalls = new Map<string, ToolCall>();
+    // Id under which the current deferred-tool search is surfaced, so the running and finished parts merge in the UI.
+    protected toolSearchCallId: string | undefined;
     protected iteration = 0;
     protected readonly maxIterations: number;
     protected readonly tools: Tool[] | undefined;
@@ -465,6 +475,20 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             this.handleIncoming({ content: this.currentResponseText });
         }
 
+        // Surface any deferred-tool search OpenAI executed while producing this response (see handleToolSearchOutput).
+        const toolSearchOutputs = response.output?.filter((item): item is ResponseToolSearchOutputItem => item.type === 'tool_search_output') || [];
+        for (const output of toolSearchOutputs) {
+            const found = output.tools?.length ?? 0;
+            this.handleIncoming({
+                server_tool_calls: [{
+                    id: output.call_id ?? output.id,
+                    name: OPENAI_TOOL_SEARCH,
+                    finished: true,
+                    result: { content: [{ type: 'text', text: `Found ${found} tool${found === 1 ? '' : 's'}.` }] }
+                }]
+            });
+        }
+
         // Find function calls in the response
         const functionCalls = response.output?.filter((item): item is ResponseFunctionToolCall => item.type === 'function_call') || [];
 
@@ -506,6 +530,8 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             case 'response.output_item.added':
                 if (event.item?.type === 'function_call') {
                     this.handleFunctionCallAdded(event.item);
+                } else if (event.item?.type === 'tool_search_call') {
+                    this.handleToolSearchCall(event.item);
                 }
                 break;
 
@@ -520,6 +546,8 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             case 'response.output_item.done':
                 if (event.item?.type === 'function_call') {
                     this.handleFunctionCallDone(event.item);
+                } else if (event.item?.type === 'tool_search_output') {
+                    this.handleToolSearchOutput(event.item);
                 }
                 break;
 
@@ -611,6 +639,36 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             toolCall.name = event.name || toolCall.name;
             toolCall.arguments = event.arguments || toolCall.arguments;
         }
+    }
+
+    /**
+     * The deferred-tool search runs on OpenAI's infrastructure and is reported as `tool_search_call` /
+     * `tool_search_output` output items. Surface it as a server tool call so the chat UI shows the search
+     * running and, once finished, how many tools were loaded. It is never executed by a client handler.
+     */
+    protected handleToolSearchCall(item: ResponseToolSearchCall): void {
+        this.toolSearchCallId = item.call_id ?? item.id;
+        this.handleIncoming({
+            server_tool_calls: [{
+                id: this.toolSearchCallId,
+                name: OPENAI_TOOL_SEARCH,
+                arguments: typeof item.arguments === 'string' ? item.arguments : JSON.stringify(item.arguments ?? ''),
+                finished: false
+            }]
+        });
+    }
+
+    protected handleToolSearchOutput(item: ResponseToolSearchOutputItem): void {
+        const found = item.tools?.length ?? 0;
+        this.handleIncoming({
+            server_tool_calls: [{
+                id: this.toolSearchCallId ?? item.call_id ?? item.id,
+                name: OPENAI_TOOL_SEARCH,
+                finished: true,
+                result: { content: [{ type: 'text', text: `Found ${found} tool${found === 1 ? '' : 's'}.` }] }
+            }]
+        });
+        this.toolSearchCallId = undefined;
     }
 
     protected handleFunctionCallDone(functionCall: ResponseFunctionToolCall): void {

--- a/packages/ai-openai/src/node/openai-response-api-utils.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.ts
@@ -26,7 +26,7 @@ import {
     ToolRequestParameters,
     UserRequest
 } from '@theia/ai-core';
-import { CancellationToken, unreachable } from '@theia/core';
+import { CancellationToken, nls, unreachable } from '@theia/core';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { injectable } from '@theia/core/shared/inversify';
 import { OpenAI } from 'openai';
@@ -51,6 +51,12 @@ import { JSONSchema, JSONSchemaDefinition } from 'openai/lib/jsonschema';
  * Matches the native Response API tool type (`tool_search`), which OpenAI executes on its own infrastructure.
  */
 export const OPENAI_TOOL_SEARCH = 'tool_search';
+
+function openAiToolSearchFoundText(found: number): string {
+    return found === 1
+        ? nls.localize('theia/ai/openai/toolSearch/foundOne', 'Found 1 tool.')
+        : nls.localize('theia/ai/openai/toolSearch/found', 'Found {0} tools.', found);
+}
 
 interface ToolCall {
     id: string;
@@ -484,7 +490,7 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
                     id: output.call_id ?? output.id,
                     name: OPENAI_TOOL_SEARCH,
                     finished: true,
-                    result: { content: [{ type: 'text', text: `Found ${found} tool${found === 1 ? '' : 's'}.` }] }
+                    result: { content: [{ type: 'text', text: openAiToolSearchFoundText(found) }] }
                 }]
             });
         }
@@ -665,7 +671,7 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
                 id: this.toolSearchCallId ?? item.call_id ?? item.id,
                 name: OPENAI_TOOL_SEARCH,
                 finished: true,
-                result: { content: [{ type: 'text', text: `Found ${found} tool${found === 1 ? '' : 's'}.` }] }
+                result: { content: [{ type: 'text', text: openAiToolSearchFoundText(found) }] }
             }]
         });
         this.toolSearchCallId = undefined;


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
The deferred-tool search runs on the provider's own infrastructure and was previously only logged and hidden from the UI. Surface it as a server tool call in both the Anthropic and OpenAI Response API providers, so the chat UI shows the search running and, once finished, how many tools were loaded.

- Anthropic: map the native `tool_search_tool_bm25` invocation onto a stable, user-facing `tool_search` name, and drop it from history on replay.
- OpenAI: handle `tool_search_call` / `tool_search_output` output items.

Includes tests for the running/finished lifecycle and history replay.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Use a deffered tool and see that a search entry pop ups in the chat.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
