### PR TITLE
Remove strict schema conversion for OpenAI Response API

### DIFF
--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -53,9 +53,8 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             default: false,
             title: AI_CORE_PREFERENCES_TITLE,
             markdownDescription: nls.localize('theia/ai/openai/useResponseApi/mdDescription',
-                'Use the newer OpenAI Response API instead of the Chat Completion API for official OpenAI models.\
-                \
-                This setting only applies to official OpenAI models - custom providers must configure this individually.')
+                'Use the newer OpenAI Response API instead of the Chat Completion API for official OpenAI models. ' +
+                'This setting only applies to official OpenAI models - custom providers must configure this individually.')
         },
         [SERVER_SIDE_COMPACTION_PREF]: {
             type: 'string',

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -54,11 +54,8 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             title: AI_CORE_PREFERENCES_TITLE,
             markdownDescription: nls.localize('theia/ai/openai/useResponseApi/mdDescription',
                 'Use the newer OpenAI Response API instead of the Chat Completion API for official OpenAI models.\
-\
-This setting only applies to official OpenAI models - custom providers must configure this individually.\
-\
-Note that for the response API, tool call definitions must satisfy Open AI\'s [strict schema definition](https://platform.openai.com/docs/guides/function-calling#strict-mode).\
-Best effort is made to convert non-conformant schemas, but errors are still possible.')
+                \
+                This setting only applies to official OpenAI models - custom providers must configure this individually.')
         },
         [SERVER_SIDE_COMPACTION_PREF]: {
             type: 'string',

--- a/packages/ai-openai/src/node/openai-model-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-model-utils.spec.ts
@@ -16,8 +16,7 @@
 import { expect } from 'chai';
 import { OpenAiModelUtils } from './openai-language-model';
 import { LanguageModelMessage } from '@theia/ai-core';
-import { OpenAiResponseApiUtils, recursiveStrictJSONSchema } from './openai-response-api-utils';
-import type { JSONSchema, JSONSchemaDefinition } from 'openai/lib/jsonschema';
+import { OpenAiResponseApiUtils } from './openai-response-api-utils';
 
 const utils = new OpenAiModelUtils();
 const responseUtils = new OpenAiResponseApiUtils();
@@ -492,107 +491,6 @@ describe('OpenAiModelUtils - processMessagesForResponseApi', () => {
             const messages = [invalidMessage] as unknown as LanguageModelMessage[];
             expect(() => responseUtils.processMessages(messages, 'developer', 'gpt-4'))
                 .to.throw('unhandled case');
-        });
-    });
-
-    describe('recursiveStrictJSONSchema', () => {
-        it('should return the same object and not modify it when schema has no properties to strictify', () => {
-            const schema: JSONSchema = { type: 'string', description: 'Simple string' };
-            const originalJson = JSON.stringify(schema);
-
-            const result = recursiveStrictJSONSchema(schema);
-
-            expect(result).to.equal(schema);
-            expect(JSON.stringify(schema)).to.equal(originalJson);
-            const resultObj = result as JSONSchema;
-            expect(resultObj).to.not.have.property('additionalProperties');
-            expect(resultObj).to.not.have.property('required');
-        });
-
-        it('should not mutate original but return a new strictified schema when branching applies (properties/items)', () => {
-            const original: JSONSchema = {
-                type: 'object',
-                properties: {
-                    path: { type: 'string' },
-                    data: {
-                        type: 'array',
-                        items: {
-                            type: 'object',
-                            properties: {
-                                a: { type: 'string' }
-                            }
-                        }
-                    }
-                }
-            };
-            const originalClone = JSON.parse(JSON.stringify(original));
-
-            const resultDef = recursiveStrictJSONSchema(original);
-            const result = resultDef as JSONSchema;
-
-            expect(result).to.not.equal(original);
-            expect(original).to.deep.equal(originalClone);
-
-            expect(result.additionalProperties).to.equal(false);
-            expect(result.required).to.have.members(['path', 'data']);
-
-            const itemsDef = (result.properties?.data as JSONSchema).items as JSONSchemaDefinition;
-            expect(itemsDef).to.be.ok;
-            const itemsObj = itemsDef as JSONSchema;
-            expect(itemsObj.additionalProperties).to.equal(false);
-            expect(itemsObj.required).to.have.members(['a']);
-
-            const originalItems = ((original.properties!.data as JSONSchema).items) as JSONSchema;
-            expect(originalItems).to.not.have.property('additionalProperties');
-            expect(originalItems).to.not.have.property('required');
-        });
-
-        it('should strictify nested parameters schema and not mutate the original', () => {
-            const replacementProperties: Record<string, JSONSchema> = {
-                oldContent: { type: 'string', description: 'The exact content to be replaced. Must match exactly, including whitespace, comments, etc.' },
-                newContent: { type: 'string', description: 'The new content to insert in place of matched old content.' },
-                multiple: { type: 'boolean', description: 'Set to true if multiple occurrences of the oldContent are expected to be replaced.' }
-            };
-
-            const parameters: JSONSchema = {
-                type: 'object',
-                properties: {
-                    path: { type: 'string', description: 'The path of the file where content will be replaced.' },
-                    replacements: {
-                        type: 'array',
-                        items: {
-                            type: 'object',
-                            properties: replacementProperties,
-                            required: ['oldContent', 'newContent']
-                        },
-                        description: 'An array of replacement objects, each containing oldContent and newContent strings.'
-                    },
-                    reset: {
-                        type: 'boolean',
-                        description: 'Set to true to clear any existing pending changes for this file and start fresh. Default is false, which merges with existing changes.'
-                    }
-                },
-                required: ['path', 'replacements']
-            };
-
-            const originalClone = JSON.parse(JSON.stringify(parameters));
-
-            const strictifiedDef = recursiveStrictJSONSchema(parameters);
-            const strictified = strictifiedDef as JSONSchema;
-
-            expect(strictified).to.not.equal(parameters);
-            expect(parameters).to.deep.equal(originalClone);
-
-            expect(strictified.additionalProperties).to.equal(false);
-            expect(strictified.required).to.have.members(['path', 'replacements', 'reset']);
-
-            const items = (strictified.properties!.replacements as JSONSchema).items as JSONSchema;
-            expect(items.additionalProperties).to.equal(false);
-            expect(items.required).to.have.members(['oldContent', 'newContent', 'multiple']);
-
-            const origItems = ((parameters.properties!.replacements as JSONSchema).items) as JSONSchema;
-            expect(origItems.required).to.deep.equal(['oldContent', 'newContent']);
-            expect(origItems).to.not.have.property('additionalProperties');
         });
     });
 

--- a/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
@@ -28,6 +28,39 @@ async function* toStream(events: unknown[]): AsyncIterable<unknown> {
 }
 
 describe('OpenAiResponseApiUtils', () => {
+    it('passes tool parameters through unchanged in non-strict mode', () => {
+        const utils = new OpenAiResponseApiUtils();
+        const parameters = {
+            type: 'object' as const,
+            properties: {
+                metadata: {
+                    type: 'object' as const,
+                    additionalProperties: { type: 'string' }
+                }
+            }
+        };
+
+        const converted = utils.convertToolsForResponseApi([{
+            id: 'lookup',
+            name: 'lookup',
+            parameters,
+            handler: async () => 'result'
+        }]);
+
+        expect(converted).to.have.lengthOf(1);
+        const convertedTool = converted?.[0];
+        expect(convertedTool).to.include({
+            type: 'function',
+            name: 'lookup',
+            parameters,
+            strict: false
+        });
+        if (convertedTool?.type !== 'function') {
+            throw new Error('Expected a function tool');
+        }
+        expect(convertedTool.parameters).to.equal(parameters);
+    });
+
     it('emits per-iteration usage for Response API tool calls instead of accumulated usage', async () => {
         const utils = new OpenAiResponseApiUtils();
         const streams = [

--- a/packages/ai-openai/src/node/openai-response-api-utils.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.ts
@@ -23,7 +23,6 @@ import {
     TextMessage,
     ToolInvocationContext,
     ToolRequest,
-    ToolRequestParameters,
     UserRequest
 } from '@theia/ai-core';
 import { CancellationToken, nls, unreachable } from '@theia/core';
@@ -44,7 +43,6 @@ import type {
 } from 'openai/resources/responses/responses';
 import type { ResponsesModel } from 'openai/resources/shared';
 import { DeveloperMessageSettings, OpenAiModelUtils } from './openai-language-model';
-import { JSONSchema, JSONSchemaDefinition } from 'openai/lib/jsonschema';
 
 /**
  * User-facing name under which the provider's built-in deferred-tool search is surfaced in the chat UI.
@@ -159,11 +157,11 @@ export class OpenAiResponseApiUtils {
             type: 'function' as const,
             name: tool.name,
             description: tool.description || '',
-            // The Response API is very strict re: JSON schema: all properties must be listed as required,
-            // and additional properties must be disallowed.
-            // https://platform.openai.com/docs/guides/function-calling#strict-mode
-            parameters: this.recursiveStrictToolCallParameters(tool.parameters),
-            strict: true,
+            // Tool schemas are passed through as-is (non-strict). Strict mode (`strict: true`) is opt-in and
+            // only supports a JSON-schema subset (all properties required, `additionalProperties: false`
+            // everywhere), which cannot express the open-ended maps common in MCP tool schemas.
+            parameters: tool.parameters as unknown as FunctionTool['parameters'],
+            strict: false,
             defer_loading: deferred.has(tool.id) ? true : undefined
         }));
         if (deferred.size > 0) {
@@ -171,10 +169,6 @@ export class OpenAiResponseApiUtils {
         }
         console.debug(`Converted ${tools.length} tools for Response API:`, converted.map(t => t.type === 'function' ? t.name : t.type));
         return converted;
-    }
-
-    recursiveStrictToolCallParameters(schema: ToolRequestParameters): FunctionTool['parameters'] {
-        return recursiveStrictJSONSchema(schema) as FunctionTool['parameters'];
     }
 
     protected createSimpleResponseApiStreamIterator(
@@ -882,51 +876,4 @@ export function processSystemMessages(
         return updated;
     }
     return messages;
-}
-
-export function recursiveStrictJSONSchema(schema: JSONSchemaDefinition): JSONSchemaDefinition {
-    if (typeof schema === 'boolean') { return schema; }
-    let result: JSONSchema | undefined = undefined;
-    if (schema.properties) {
-        result ??= { ...schema };
-        result.additionalProperties = false;
-        result.required = Object.keys(schema.properties);
-        result.properties = Object.fromEntries(Object.entries(schema.properties).map(([key, props]) => [key, recursiveStrictJSONSchema(props)]));
-    }
-    if (schema.items) {
-        result ??= { ...schema };
-        result.items = Array.isArray(schema.items)
-            ? schema.items.map(recursiveStrictJSONSchema)
-            : recursiveStrictJSONSchema(schema.items);
-    }
-    if (schema.oneOf) {
-        result ??= { ...schema };
-        result.oneOf = schema.oneOf.map(recursiveStrictJSONSchema);
-    }
-    if (schema.anyOf) {
-        result ??= { ...schema };
-        result.anyOf = schema.anyOf.map(recursiveStrictJSONSchema);
-    }
-    if (schema.allOf) {
-        result ??= { ...schema };
-        result.allOf = schema.allOf.map(recursiveStrictJSONSchema);
-    }
-    if (schema.if) {
-        result ??= { ...schema };
-        result.if = recursiveStrictJSONSchema(schema.if);
-    }
-    if (schema.then) {
-        result ??= { ...schema };
-        result.then = recursiveStrictJSONSchema(schema.then);
-    }
-    if (schema.else) {
-        result ??= { ...schema };
-        result.else = recursiveStrictJSONSchema(schema.else);
-    }
-    if (schema.not) {
-        result ??= { ...schema };
-        result.not = recursiveStrictJSONSchema(schema.not);
-    }
-
-    return result ?? schema;
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Drop the recursiveStrictJSONSchema transform and strict:true flag when converting tools for the Response API, passing tool parameters through unchanged. Strict mode is opt-in and was self-imposed, causing repeated 400 errors on MCP tools with open-ended maps (e.g. additionalProperties). Also removes the related preference note and strictify unit tests.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Use a mcp service with a normal jsonschema but which cannot be used in openai strict mode. the asana mcp has such an example.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
