### PR TITLE
Improve support for accessing Open Editors in AI Agents

### DIFF
--- a/packages/ai-ide/src/browser/architect-prompt-template.ts
+++ b/packages/ai-ide/src/browser/architect-prompt-template.ts
@@ -19,6 +19,7 @@ import {
   GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SEARCH_IN_WORKSPACE_FUNCTION_ID, FIND_FILES_BY_PATTERN_FUNCTION_ID
 } from '../common/workspace-functions';
 import { CONTEXT_FILES_VARIABLE_ID, TASK_CONTEXT_SUMMARY_VARIABLE_ID } from '../common/context-variables';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
 import {
   CREATE_TASK_CONTEXT_FUNCTION_ID,
   GET_TASK_CONTEXT_FUNCTION_ID,
@@ -194,6 +195,8 @@ When a diagram clarifies an architectural concept or how something is implemente
 
 {{prompt:project-info}}
 
+{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
+
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 `
   },
@@ -231,6 +234,8 @@ Always look at the relevant files to understand your task using the function ~{$
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
+
+{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 `
     },
     {
@@ -463,6 +468,8 @@ When a diagram clarifies an architectural concept or how something is implemente
 {{${CONTEXT_FILES_VARIABLE_ID}}}
 
 {{prompt:project-info}}
+
+{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 `

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -124,7 +124,7 @@ import { AppTesterCapabilityContribution } from './apptester-capability-contribu
 import { GitHubCapabilityContribution } from './github-capability-contribution';
 import { ShellExecutionCapabilityContribution } from './shell-execution-capability-contribution';
 import { MemoryCapabilityContribution } from './memory-capability-contribution';
-import { OpenEditorsHintContribution } from './open-editors-prompt-fragment';
+import { OpenEditorsHintContribution } from './open-editors-hint-contribution';
 import { AgentModeConfirmationService, AgentModeConfirmationServiceImpl } from './agent-mode-confirmation-service';
 import { ExploreAgent } from './explore-agent';
 import { CodeReviewerAgent } from './code-reviewer-agent';

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -124,6 +124,7 @@ import { AppTesterCapabilityContribution } from './apptester-capability-contribu
 import { GitHubCapabilityContribution } from './github-capability-contribution';
 import { ShellExecutionCapabilityContribution } from './shell-execution-capability-contribution';
 import { MemoryCapabilityContribution } from './memory-capability-contribution';
+import { OpenEditorsHintContribution } from './open-editors-prompt-fragment';
 import { AgentModeConfirmationService, AgentModeConfirmationServiceImpl } from './agent-mode-confirmation-service';
 import { ExploreAgent } from './explore-agent';
 import { CodeReviewerAgent } from './code-reviewer-agent';
@@ -366,6 +367,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(FrontendApplicationContribution).to(GitHubCapabilityContribution);
     bind(FrontendApplicationContribution).to(ShellExecutionCapabilityContribution);
     bind(FrontendApplicationContribution).to(MemoryCapabilityContribution);
+    bind(FrontendApplicationContribution).to(OpenEditorsHintContribution);
 
     bind(FrontendApplicationContribution).to(CodeReviewCapabilityContribution);
     bind(FrontendApplicationContribution).to(PRReviewCapabilityContribution);

--- a/packages/ai-ide/src/browser/open-editors-hint-contribution.ts
+++ b/packages/ai-ide/src/browser/open-editors-hint-contribution.ts
@@ -19,8 +19,6 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { PromptService } from '@theia/ai-core/lib/common';
 import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
 
-export { OPEN_EDITORS_HINT_FRAGMENT_ID };
-
 @injectable()
 export class OpenEditorsHintContribution implements FrontendApplicationContribution {
 

--- a/packages/ai-ide/src/browser/open-editors-prompt-fragment.ts
+++ b/packages/ai-ide/src/browser/open-editors-prompt-fragment.ts
@@ -1,0 +1,40 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PromptService } from '@theia/ai-core/lib/common';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from '../common/open-editors-hint-fragment-id';
+
+export { OPEN_EDITORS_HINT_FRAGMENT_ID };
+
+@injectable()
+export class OpenEditorsHintContribution implements FrontendApplicationContribution {
+
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
+
+    onStart(): void {
+        this.promptService.addBuiltInPromptFragment({
+            id: OPEN_EDITORS_HINT_FRAGMENT_ID,
+            template: `## Open Editors
+The following files are currently open in the user's editor. This is provided as contextual information only \
+— these files may or may not be relevant to the current request. Do not assume they are related unless the user explicitly refers to them.
+
+{{openEditors}}`
+        });
+    }
+}

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -36,6 +36,7 @@ import {
 } from './file-changeset-function-ids';
 import { GET_TASK_CONTEXT_FUNCTION_ID } from './task-context-function-ids';
 import { ArchitectAgentId, ExploreAgentId } from './agent-ids';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from './open-editors-hint-fragment-id';
 
 export const CODER_SYSTEM_PROMPT_ID = 'coder-system';
 
@@ -258,6 +259,8 @@ Always retrieve relevant files using ~{${FILE_CONTENT_FUNCTION_ID}} to understan
 
 ## Project Info
 {{prompt:project-info}}
+
+{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 
@@ -547,6 +550,8 @@ Always retrieve relevant files using ~{${FILE_CONTENT_FUNCTION_ID}} to understan
 ## Project Info
 {{prompt:project-info}}
 
+{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
+
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 
 # Final Instruction
@@ -636,6 +641,8 @@ You have previously proposed changes for the following files. Some suggestions m
 {{${CHANGE_SET_SUMMARY_VARIABLE_ID}}}
 
 {{prompt:project-info}}
+
+{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 
 {{${TASK_CONTEXT_SUMMARY_VARIABLE_ID}}}
 

--- a/packages/ai-ide/src/common/open-editors-hint-fragment-id.ts
+++ b/packages/ai-ide/src/common/open-editors-hint-fragment-id.ts
@@ -1,0 +1,17 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export const OPEN_EDITORS_HINT_FRAGMENT_ID = 'open-editors-hint';

--- a/packages/ai-ide/src/common/universal-prompt-template.ts
+++ b/packages/ai-ide/src/common/universal-prompt-template.ts
@@ -11,6 +11,7 @@
 
 import { BasePromptFragment } from '@theia/ai-core/lib/common';
 import { CHAT_CONTEXT_DETAILS_VARIABLE_ID } from '@theia/ai-chat';
+import { OPEN_EDITORS_HINT_FRAGMENT_ID } from './open-editors-hint-fragment-id';
 
 export const universalTemplate: BasePromptFragment = {
    id: 'universal-system-default',
@@ -23,6 +24,8 @@ You are an assistant integrated into {{productName}}, designed to assist softwar
 ## Current Context
 Some files and other pieces of data may have been added by the user to the context of the chat. If any have, the details can be found below.
 {{${CHAT_CONTEXT_DETAILS_VARIABLE_ID}}}
+
+{{prompt:${OPEN_EDITORS_HINT_FRAGMENT_ID}}}
 `
 };
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Add two distinct mechanisms to support "Open Editors":
  - A prompt fragment (currently enabled by default in Universal, Architect and Coder) that references the existing variable "openEditors" (or `#_ff`)
    - automatic integration of the `#_ff` variable
    - can be added or removed from any agent via prompt customization
  - A contribution that automatically adds open editors to the current context, guarded by a user preference (enabled by default)
    - works for any agent
    - immediate user feedback via the context files
    - user can remove individual files

Both mechanisms are currently overlapping, as they are both enabled by default. I added both so we can more easily compare, but we might want to choose one (or keep both but only enable one or the other by default).

Closes #17326

#### How to test

- Default prompt behavior:
  - Open the AI Chat
  - Open some files in Theia
  - Remove them from context (or disable the preference `Auto Add Open Editors`)
  - Ask Architect, Coder or Universal about open files: they should at least be able to list them
- Auto Add to Context:
  - Open the AI Chat
  - Open some files in Theia: they should automatically be added to the context (and can then be manually removed by the user)
  - Talk to any agent other than Architect, Coder and Universal: they should be able to reference these files

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
