### PR TITLE
chore: fix some Node 24 deprecation warnings

### DIFF
--- a/dev-packages/application-manager/src/application-process.spec.ts
+++ b/dev-packages/application-manager/src/application-process.spec.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ApplicationProcess } from './application-process';
+import { ApplicationPackage } from '@theia/application-package';
+
+describe('ApplicationProcess', () => {
+
+    function createProcess(): ApplicationProcess {
+        // Only `projectPath` is needed for `spawn`'s working directory.
+        const pck = { projectPath: process.cwd() } as ApplicationPackage;
+        return new ApplicationProcess(pck, '');
+    }
+
+    it('should pass arguments containing spaces and shell metacharacters through intact', async () => {
+        const applicationProcess = createProcess();
+        const testArgs = ['hello world', 'a&b', 'c;d', 'quote"inside'];
+        // Print each received argument on its own line so we can compare with the input.
+        const script = 'process.stdout.write(process.argv.slice(1).join(String.fromCharCode(10)))';
+
+        const child = applicationProcess.spawn(process.execPath, ['-e', script, ...testArgs]);
+        let stdout = '';
+        child.stdout!.on('data', data => stdout += data.toString());
+
+        await new Promise<void>((resolve, reject) => {
+            child.on('error', reject);
+            child.on('close', () => resolve());
+        });
+
+        expect(stdout).to.equal(testArgs.join('\n'));
+    });
+});

--- a/dev-packages/application-manager/src/application-process.ts
+++ b/dev-packages/application-manager/src/application-process.ts
@@ -32,10 +32,26 @@ export class ApplicationProcess {
     ) { }
 
     spawn(command: string, args?: string[], options?: cp.SpawnOptions): cp.ChildProcess {
-        return cp.spawn(command, args || [], Object.assign({}, this.defaultOptions, {
+        // Build a single quoted command line rather than passing an args array together with `shell: true`.
+        // Node.js 24 deprecates the latter (DEP0190) because it does not escape the arguments.
+        const commandLine = this.buildCommandLine(command, args || []);
+        return cp.spawn(commandLine, [], Object.assign({}, this.defaultOptions, {
             ...options,
             shell: true
         }));
+    }
+
+    protected buildCommandLine(command: string, args: string[]): string {
+        return [command, ...args].map(arg => this.quoteArg(arg)).join(' ');
+    }
+
+    protected quoteArg(arg: string): string {
+        if (process.platform === 'win32') {
+            // cmd.exe: wrap in double quotes and escape embedded double quotes by doubling them.
+            return `"${arg.replace(/"/g, '""')}"`;
+        }
+        // POSIX shell: single-quote and escape embedded single quotes (' becomes '\'').
+        return `'${arg.replace(/'/g, '\'\\\'\'')}'`;
     }
 
     fork(modulePath: string, args?: string[], options?: cp.ForkOptions): cp.ChildProcess {
@@ -57,10 +73,7 @@ export class ApplicationProcess {
         if (!binPath) {
             throw new Error(`Could not resolve ${command} relative to ${this.binProjectPath}`);
         }
-        return this.spawn(binPath, args, {
-            ...options,
-            shell: true
-        });
+        return this.spawn(binPath, args, options);
     }
 
     protected resolveBin(rootPath: string, command: string): string | undefined {

--- a/packages/filesystem/src/node/download/file-download-endpoint.ts
+++ b/packages/filesystem/src/node/download/file-download-endpoint.ts
@@ -16,7 +16,6 @@
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import * as url from 'url';
 import { injectable, inject, named } from '@theia/core/shared/inversify';
 import { json } from 'body-parser';
 import { Application, Router } from '@theia/core/shared/express';
@@ -50,7 +49,7 @@ export class FileDownloadEndpoint implements BackendApplicationContribution {
         app.use(json());
         app.use(FileDownloadEndpoint.PATH, router);
         app.get('/file', (request, response) => {
-            const uri = url.parse(request.url).query;
+            const uri = new URL(request.url, 'http://localhost').search.slice(1);
             if (!uri) {
                 response.status(400).send('invalid uri');
                 return;

--- a/packages/mini-browser/src/node/mini-browser-ws-validator.spec.ts
+++ b/packages/mini-browser/src/node/mini-browser-ws-validator.spec.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as http from 'http';
+import { MiniBrowserWsRequestValidator } from './mini-browser-ws-validator';
+
+describe('MiniBrowserWsRequestValidator', () => {
+
+    function createValidator(): MiniBrowserWsRequestValidator {
+        const validator = new MiniBrowserWsRequestValidator();
+        // Uses the default host pattern '{{uuid}}.mini-browser.{{hostname}}'.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (validator as any)['init']();
+        return validator;
+    }
+
+    function createRequest(origin?: string): http.IncomingMessage {
+        const request = {
+            headers: {} as http.IncomingHttpHeaders
+        } as http.IncomingMessage;
+        if (origin !== undefined) {
+            request.headers.origin = origin;
+        }
+        return request;
+    }
+
+    it('should refuse WebSocket upgrades from the mini-browser virtual host', async () => {
+        const validator = createValidator();
+        expect(await validator.allowWsUpgrade(
+            createRequest('http://abc.mini-browser.localhost:3000')
+        )).to.be.false;
+    });
+
+    it('should allow WebSocket upgrades from other origins', async () => {
+        const validator = createValidator();
+        expect(await validator.allowWsUpgrade(
+            createRequest('http://localhost:3000')
+        )).to.be.true;
+    });
+
+    it('should allow requests with no Origin header', async () => {
+        const validator = createValidator();
+        expect(await validator.allowWsUpgrade(createRequest())).to.be.true;
+    });
+
+    it('should not throw and should allow when the Origin header is malformed', async () => {
+        const validator = createValidator();
+        expect(await validator.allowWsUpgrade(
+            createRequest('not-a-valid-url')
+        )).to.be.true;
+    });
+});

--- a/packages/mini-browser/src/node/mini-browser-ws-validator.ts
+++ b/packages/mini-browser/src/node/mini-browser-ws-validator.ts
@@ -17,7 +17,6 @@
 import { WsRequestValidatorContribution } from '@theia/core/lib/node/ws-request-validators';
 import * as http from 'http';
 import { injectable, postConstruct } from '@theia/core/shared/inversify';
-import * as url from 'url';
 import { MiniBrowserEndpoint } from '../common/mini-browser-endpoint';
 
 /**
@@ -45,8 +44,13 @@ export class MiniBrowserWsRequestValidator implements WsRequestValidatorContribu
 
     async allowWsUpgrade(request: http.IncomingMessage): Promise<boolean> {
         if (request.headers.origin && !this.serveSameOrigin) {
-            const origin = url.parse(request.headers.origin);
-            if (origin.host && this.miniBrowserHostRe.test(origin.host)) {
+            let host: string | undefined;
+            try {
+                host = new URL(request.headers.origin).host;
+            } catch {
+                host = undefined;
+            }
+            if (host && this.miniBrowserHostRe.test(host)) {
                 // If the origin comes from the WebViews, refuse:
                 return false;
             }

--- a/packages/plugin-ext/src/main/node/plugin-http-resolver.spec.ts
+++ b/packages/plugin-ext/src/main/node/plugin-http-resolver.spec.ts
@@ -1,0 +1,41 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { HttpPluginDeployerResolver } from './plugin-http-resolver';
+import { PluginDeployerResolverContext } from '../../common';
+
+describe('HttpPluginDeployerResolver', () => {
+
+    function createContext(originId: string): PluginDeployerResolverContext {
+        return {
+            getOriginId: () => originId
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any as PluginDeployerResolverContext;
+    }
+
+    it('should reject a malformed link URI', async () => {
+        const resolver = new HttpPluginDeployerResolver();
+        let error: Error | undefined;
+        try {
+            await resolver.resolve(createContext(':::not a url'));
+        } catch (e) {
+            error = e as Error;
+        }
+        expect(error).to.be.an.instanceOf(Error);
+        expect(error!.message).to.contain('invalid link URI');
+    });
+});

--- a/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
+++ b/packages/plugin-ext/src/main/node/plugin-http-resolver.ts
@@ -19,7 +19,6 @@ import { inject, injectable } from '@theia/core/shared/inversify';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { promises as fs } from 'fs';
 import * as path from 'path';
-import * as url from 'url';
 import { PluginDeployerResolver, PluginDeployerResolverContext } from '../../common';
 import { getTempDirPathAsync } from './temp-dir-util';
 
@@ -56,8 +55,10 @@ export class HttpPluginDeployerResolver implements PluginDeployerResolver {
         // download the file
         // keep filename of the url
         const urlPath = pluginResolverContext.getOriginId();
-        const link = url.parse(urlPath);
-        if (!link.pathname) {
+        let link: URL;
+        try {
+            link = new URL(urlPath);
+        } catch {
             throw new Error('invalid link URI' + urlPath);
         }
 

--- a/packages/plugin-ext/src/main/node/plugin-service.ts
+++ b/packages/plugin-ext/src/main/node/plugin-service.ts
@@ -16,7 +16,6 @@
 
 import * as http from 'http';
 import * as path from 'path';
-import * as url from 'url';
 const vhost = require('vhost');
 import * as express from '@theia/core/shared/express';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
@@ -63,8 +62,13 @@ export class PluginApiContribution implements BackendApplicationContribution, Ws
 
     allowWsUpgrade(request: http.IncomingMessage): MaybePromise<boolean> {
         if (request.headers.origin && !this.serveSameOrigin) {
-            const origin = url.parse(request.headers.origin);
-            if (origin.host && this.webviewExternalEndpointRegExp.test(origin.host)) {
+            let host: string | undefined;
+            try {
+                host = new URL(request.headers.origin).host;
+            } catch {
+                host = undefined;
+            }
+            if (host && this.webviewExternalEndpointRegExp.test(host)) {
                 // If the origin comes from the WebViews, refuse:
                 return false;
             }


### PR DESCRIPTION
#### What it does

Fixes #17756.

- **DEP0190** (`theia build` / `theia rebuild`): `ApplicationProcess` passed an args array together with `shell: true`, which Node 24 deprecates because the arguments are concatenated rather than escaped. `spawn` now builds a single, per-platform quoted command line (POSIX single-quoting, Windows `cmd.exe` double-quoting) and passes an empty args array, matching the pattern already used in `rebuild.ts`. This keeps `shell: true` (still required for resolving Windows `.cmd` shims) while keeping arguments safely quoted. The now-redundant `shell: true` in `spawnBin` is removed.
- **DEP0169** (backend startup): migrates the remaining backend `url.parse()` call sites to the WHATWG `new URL()` API, following the pattern already adopted for `ws-origin-validator.ts` in #17701:
    - `mini-browser/src/node/mini-browser-ws-validator.ts`
    - `plugin-ext/src/main/node/plugin-service.ts`
    - `plugin-ext/src/main/node/plugin-http-resolver.ts`
    - `filesystem/src/node/download/file-download-endpoint.ts`

    Each change is preserves the existing behaviour: the WS-origin validators additionally treat an unparseable `Origin` as "no host" (allow), matching the prior `url.parse` behavior.

#### How to test

Prerequisite: use **Node.js 24.x**, and build with `npm run build:browser`.

DEP0190 (`--trace-deprecation` locates the source):

1. With Node 24 active, run `NODE_OPTIONS=--trace-deprecation npm run build:browser`. Confirm there is no `[DEP0190]` warning and the browser example bundles successfully. (Optionally repeat with a webpack-configured example to exercise the `run('webpack', …)` path, and with `theia rebuild` for an Electron example.)

DEP0169 is emitted once per process and all four sites are in the backend, so the check is simply that no `[DEP0169]` warning appears in the backend console during normal use:

2. Start the browser example with tracing: `NODE_OPTIONS=--trace-deprecation npm run start:browser`, then open http://localhost:3000.  The two WebSocket-origin validators (`mini-browser-ws-validator.ts`, `plugin-service.ts`) run on every WS upgrade, so the frontend's own connection at page load already exercises them.
3. Optionally, to exercise the remaining sites and confirm the app still behaves:
    - open the Mini Browser and a webview (e.g. a Markdown preview). They should render normally
    - (optional) deploy a plugin from an `http(s)://…` URL to exercise the HTTP plugin resolver
4. Confirm there are no `[DEP0169]` warnings in the backend console throughout.

The PR also includes some unit test coverage.

#### Follow-ups

- **DEP0040 (`punycode` deprecation)** Running on Node 24 also emits `[DEP0040]`, originating from a third-party transitive chain bundled into the backend: `@theia/scanoss → scanoss@0.15.7 → node-fetch@2.7.0 → whatwg-url@5.0.0 → tr46@0.0.3`, where the last two do a bare `require("punycode")` (which always resolves to Node's deprecated built-in). `node-fetch@2` loads `whatwg-url` unconditionally even though it uses the native `URL` on modern Node, so merely loading it triggers the warning.

  A scoped npm `override` (`"scanoss": { "node-fetch": { "whatwg-url": "^12" } }`) fixes it (dedupes onto the `whatwg-url@12`/`tr46@4` already in the tree, which use the userland `punycode/`). I left it out of this PR because no incremental npm command applies it to the existing lockfile: `whatwg-url@5` still satisfies `node-fetch`'s declared `^5` range, so `npm install`/`npm dedupe`/`--package-lock-only` all keep it. Only a full `rm -rf node_modules package-lock.json && npm install` re-resolves that dependency, and that brings in ca. 207 unrelated dependency upgrades. This should be handled on its own, ideally alongside a general lockfile refresh, or once `scanoss` updates its `node-fetch` dependency upstream.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
