### PR TITLE
fix: force full response when re-issuing the browser connection token

### DIFF
--- a/packages/core/src/node/hosting/browser-connection-token.spec.ts
+++ b/packages/core/src/node/hosting/browser-connection-token.spec.ts
@@ -108,18 +108,23 @@ describe('BrowserConnectionTokenBackendContribution', () => {
         interface MockResponse {
             cookieCalls: CookieCall[];
             nextCalled: boolean;
+            requestHeaders: Record<string, string | undefined>;
         }
 
-        function callMiddleware(cookieValue?: string): MockResponse {
+        function callMiddleware(cookieValue?: string, conditionalHeaders = false): MockResponse {
             const contribution = createContribution();
-            const result: MockResponse = { cookieCalls: [], nextCalled: false };
-
             const req = {
                 headers: {} as Record<string, string | undefined>,
                 socket: { remoteAddress: '127.0.0.1' }
             };
+            const result: MockResponse = { cookieCalls: [], nextCalled: false, requestHeaders: req.headers };
+
             if (cookieValue !== undefined) {
                 req.headers.cookie = `${BROWSER_TOKEN_COOKIE_NAME}=${cookieValue}`;
+            }
+            if (conditionalHeaders) {
+                req.headers['if-none-match'] = 'W/"etag"';
+                req.headers['if-modified-since'] = 'Thu, 01 Jan 2026 00:00:00 GMT';
             }
 
             const res = {
@@ -162,6 +167,28 @@ describe('BrowserConnectionTokenBackendContribution', () => {
             expect(result.nextCalled).to.be.true;
             expect(result.cookieCalls).to.have.length(1);
             expect(result.cookieCalls[0].value).to.equal(token.value);
+        });
+
+        it('should drop conditional request headers when re-issuing the cookie (stale token)', () => {
+            const result = callMiddleware('stale-token-from-old-server', true);
+            expect(result.nextCalled).to.be.true;
+            expect(result.cookieCalls).to.have.length(1);
+            expect(result.requestHeaders['if-none-match']).to.be.undefined;
+            expect(result.requestHeaders['if-modified-since']).to.be.undefined;
+        });
+
+        it('should drop conditional request headers when issuing the cookie (no cookie)', () => {
+            const result = callMiddleware(undefined, true);
+            expect(result.cookieCalls).to.have.length(1);
+            expect(result.requestHeaders['if-none-match']).to.be.undefined;
+            expect(result.requestHeaders['if-modified-since']).to.be.undefined;
+        });
+
+        it('should keep conditional request headers when the cookie is valid', () => {
+            const result = callMiddleware(token.value, true);
+            expect(result.cookieCalls).to.have.length(0);
+            expect(result.requestHeaders['if-none-match']).to.equal('W/"etag"');
+            expect(result.requestHeaders['if-modified-since']).to.equal('Thu, 01 Jan 2026 00:00:00 GMT');
         });
     });
 });

--- a/packages/core/src/node/hosting/browser-connection-token.ts
+++ b/packages/core/src/node/hosting/browser-connection-token.ts
@@ -94,6 +94,13 @@ export class BrowserConnectionTokenBackendContribution implements BackendApplica
                 sameSite: 'strict',
                 path: '/'
             });
+            // The static handlers would answer a revalidation of an unchanged page with a 304,
+            // and reverse proxies commonly drop Set-Cookie from 304 replies or answer the
+            // revalidation from their own cache. The browser would then keep the stale token
+            // and every WebSocket handshake would be rejected, with no way to recover short of
+            // a cache-bypassing hard reload. Force a full 200 so the cookie reaches the browser.
+            delete req.headers['if-none-match'];
+            delete req.headers['if-modified-since'];
         }
         next();
     }


### PR DESCRIPTION
#### What it does

Fixes #17761.

The connection-token middleware re-issues the `theia-connection-token` cookie on page responses, but a revalidation of an unchanged cached page yields a `304` — and reverse proxies commonly drop `Set-Cookie` from 304 replies or answer the revalidation from their own cache. After a backend restart rotates the token, browsers behind such proxies keep the stale cookie and every WebSocket handshake is rejected (403) with no recovery.

This PR drops `If-None-Match`/`If-Modified-Since` when the presented token is missing or stale, so the response is a full 200 that carries the fresh cookie. Requests presenting a valid token are untouched, so caching behavior is unchanged in the steady state.

#### How to test

- Unit tests added in `browser-connection-token.spec.ts` (conditional headers dropped when issuing/re-issuing, kept when the token is valid).
- Manually: load the app, edit the `theia-connection-token` cookie to a bogus value in devtools, reload with the network cache enabled — without this fix the page is served as 304, the stale cookie survives, and the handshake loops on 403; with it the page returns 200 with a fresh cookie and the app connects.

#### Follow-ups

The frontend could recover from rejected handshakes (e.g. one cache-bypassing reload) instead of spinning indefinitely — tracked in #17761.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)