### PR TITLE
Issues/283 perspective

### DIFF
--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -1,0 +1,39 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { PerspectiveContribution, PerspectiveService } from '@theia/core/lib/browser/perspective-service';
+import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
+
+const CHAT_VIEW_WIDGET_ID = 'chat-view-widget';
+const EXPLORER_VIEW_CONTAINER_ID = 'explorer-view-container';
+const SCM_VIEW_CONTAINER_ID = 'scm-view-container';
+
+@injectable()
+export class AIFirstPerspectiveContribution implements PerspectiveContribution {
+
+    registerPerspectives(service: PerspectiveService): void {
+        service.registerPerspective({
+            id: 'ai-first',
+            label: 'AI First',
+            viewPlacements: new Map<string, ApplicationShell.Area>([
+                [CHAT_VIEW_WIDGET_ID, 'main'],
+                [EXPLORER_VIEW_CONTAINER_ID, 'right'],
+                [SCM_VIEW_CONTAINER_ID, 'right']
+            ])
+        });
+    }
+}

--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { injectable } from '@theia/core/shared/inversify';
+import { nls } from '@theia/core';
 import { PerspectiveContribution, PerspectiveService } from '@theia/core/lib/browser/perspective-service';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 
@@ -28,7 +29,7 @@ export class AIFirstPerspectiveContribution implements PerspectiveContribution {
     registerPerspectives(service: PerspectiveService): void {
         service.registerPerspective({
             id: 'ai-first',
-            label: 'AI First',
+            label: nls.localize('theia/ai-ide/perspective/aiFirst', 'AI First'),
             viewPlacements: new Map<string, ApplicationShell.Area>([
                 [CHAT_VIEW_WIDGET_ID, 'main'],
                 [EXPLORER_VIEW_CONTAINER_ID, 'right'],

--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -16,7 +16,7 @@
 
 import { injectable } from '@theia/core/shared/inversify';
 import { nls } from '@theia/core';
-import { PerspectiveContribution, PerspectiveService } from '@theia/core/lib/browser/perspective-service';
+import { PerspectiveContribution, PerspectiveChromeOptions, PerspectiveService } from '@theia/core/lib/browser/perspective-service';
 import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
 
 const CHAT_VIEW_WIDGET_ID = 'chat-view-widget';
@@ -27,6 +27,11 @@ const SCM_VIEW_CONTAINER_ID = 'scm-view-container';
 export class AIFirstPerspectiveContribution implements PerspectiveContribution {
 
     registerPerspectives(service: PerspectiveService): void {
+        const chromeOptions: PerspectiveChromeOptions = {
+            hideMenuBar: true,
+            hideStatusBar: true,
+            collapseAreas: ['left', 'bottom']
+        };
         service.registerPerspective({
             id: 'ai-first',
             label: nls.localize('theia/ai-ide/perspective/aiFirst', 'AI First'),
@@ -34,7 +39,8 @@ export class AIFirstPerspectiveContribution implements PerspectiveContribution {
                 [CHAT_VIEW_WIDGET_ID, 'main'],
                 [EXPLORER_VIEW_CONTAINER_ID, 'right'],
                 [SCM_VIEW_CONTAINER_ID, 'right']
-            ])
+            ]),
+            chromeOptions
         });
     }
 }

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -125,6 +125,8 @@ import { CodeReviewerAgent } from './code-reviewer-agent';
 import { CodeReviewCapabilityContribution } from './code-review-capability-contribution';
 import { PRReviewAgent } from './review/pr-review-agent';
 import { PRReviewCapabilityContribution } from './review/pr-review-capability-contribution';
+import { PerspectiveContribution } from '@theia/core/lib/browser/perspective-service';
+import { AIFirstPerspectiveContribution } from './ai-first-perspective-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: aiIdePreferenceSchema });
@@ -350,4 +352,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(FrontendApplicationContribution).to(CodeReviewCapabilityContribution);
     bind(FrontendApplicationContribution).to(PRReviewCapabilityContribution);
+
+    bind(AIFirstPerspectiveContribution).toSelf().inSingletonScope();
+    bind(PerspectiveContribution).toService(AIFirstPerspectiveContribution);
 });

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -146,6 +146,7 @@ import { WidgetStatusBarContribution, WidgetStatusBarService } from './widget-st
 import { SymbolIconColorContribution } from './symbol-icon-color-contribution';
 import { CorePreferences, bindCorePreferences } from '../common/core-preferences';
 import { bindBadgeDecoration } from './badges';
+import { PerspectiveContribution, PerspectiveService } from './perspective-service';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -482,6 +483,11 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bindRootContributionProvider(bind, UndoRedoHandler);
     bind(DomInputUndoRedoHandler).toSelf().inSingletonScope();
     bind(UndoRedoHandler).toService(DomInputUndoRedoHandler);
+
+    bind(PerspectiveService).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(PerspectiveService);
+    bind(CommandContribution).toService(PerspectiveService);
+    bindRootContributionProvider(bind, PerspectiveContribution);
 
     bind(WidgetStatusBarService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(WidgetStatusBarService);

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -55,3 +55,4 @@ export * from './markdown-rendering/markdown-renderer';
 export * from './markdown-rendering/markdown';
 export * from './markdown-rendering/markdown-link-handler';
 export * from './components';
+export * from './perspective-service';

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -32,6 +32,8 @@ describe('PerspectiveService', () => {
     let getTabBarForStub: sinon.SinonStub;
     let getAreaForStub: sinon.SinonStub;
     let getOrCreateWidgetStub: sinon.SinonStub;
+    let getLayoutDataStub: sinon.SinonStub;
+    let setLayoutDataStub: sinon.SinonStub;
     let testWidget: Widget;
     let toTearDown: () => void;
 
@@ -46,12 +48,16 @@ describe('PerspectiveService', () => {
         getTabBarForStub = sinon.stub().returns(undefined);
         getAreaForStub = sinon.stub().returns(undefined);
         getOrCreateWidgetStub = sinon.stub().resolves(testWidget);
+        getLayoutDataStub = sinon.stub().returns({ mainPanel: {}, bottomPanel: {} });
+        setLayoutDataStub = sinon.stub().resolves();
 
         const mockShell = {
             addWidget: addWidgetStub,
             activateWidget: activateWidgetStub,
             getTabBarFor: getTabBarForStub,
-            getAreaFor: getAreaForStub
+            getAreaFor: getAreaForStub,
+            getLayoutData: getLayoutDataStub,
+            setLayoutData: setLayoutDataStub
         };
 
         const mockWidgetManager = {
@@ -254,5 +260,218 @@ describe('PerspectiveService', () => {
         (service as unknown as Record<string, unknown>)['contributions'] = undefined;
 
         expect(() => service.initialize()).to.not.throw();
+    });
+
+    // --- New tests for no-op guard, layout save/restore, and default perspective ---
+
+    it('should register the default "Theia IDE" perspective on initialize', () => {
+        service.initialize();
+
+        const perspectives = service.getRegisteredPerspectives();
+        const defaultPerspective = perspectives.find(p => p.id === PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        expect(defaultPerspective).to.not.be.undefined;
+        expect(defaultPerspective!.label).to.equal('Theia IDE');
+        expect(defaultPerspective!.viewPlacements.size).to.equal(0);
+    });
+
+    it('should set the default perspective as the initial active perspective', () => {
+        service.initialize();
+
+        const active = service.getActivePerspective();
+        expect(active).to.not.be.undefined;
+        expect(active!.id).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+    });
+
+    it('should not re-apply when switching to the already-active perspective', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]]),
+            onActivate: sinon.spy(),
+            onDeactivate: sinon.spy()
+        });
+
+        await service.switchPerspective('test');
+
+        // Reset all stubs
+        addWidgetStub.resetHistory();
+        setLayoutDataStub.resetHistory();
+        getOrCreateWidgetStub.resetHistory();
+        getLayoutDataStub.resetHistory();
+        const eventSpy = sinon.spy();
+        service.onDidChangePerspective(eventSpy);
+
+        const descriptor = service.getActivePerspective()!;
+        const onActivateSpy = descriptor.onActivate as sinon.SinonSpy;
+        const onDeactivateSpy = descriptor.onDeactivate as sinon.SinonSpy;
+        onActivateSpy.resetHistory();
+        onDeactivateSpy.resetHistory();
+
+        // Switch to the same perspective again
+        await service.switchPerspective('test');
+
+        expect(addWidgetStub.called).to.be.false;
+        expect(setLayoutDataStub.called).to.be.false;
+        expect(getOrCreateWidgetStub.called).to.be.false;
+        expect(getLayoutDataStub.called).to.be.false;
+        expect(eventSpy.called).to.be.false;
+        expect(onActivateSpy.called).to.be.false;
+        expect(onDeactivateSpy.called).to.be.false;
+    });
+
+    it('should save layout when switching away from a perspective', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('perspA');
+
+        const layoutA = { mainPanel: { widgets: ['editor1'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutA);
+
+        // Switch to B — should save A's layout
+        await service.switchPerspective('perspB');
+
+        expect(getLayoutDataStub.called).to.be.true;
+
+        const layoutB = { mainPanel: { widgets: ['something-else'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutB);
+        setLayoutDataStub.resetHistory();
+
+        // Switch back to A — should restore A's saved layout
+        await service.switchPerspective('perspA');
+
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(layoutA)).to.be.true;
+    });
+
+    it('should restore saved layout when switching back to a perspective', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map([['test-widget', 'left' as ApplicationShell.Area]])
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        // Activate A (first time — applies viewPlacements)
+        await service.switchPerspective('perspA');
+
+        const layoutA = { mainPanel: { widgets: ['editor-customized'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutA);
+
+        // Switch to B (saves A's layout)
+        await service.switchPerspective('perspB');
+
+        const layoutB = { mainPanel: { widgets: ['something-else'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutB);
+
+        setLayoutDataStub.resetHistory();
+        getOrCreateWidgetStub.resetHistory();
+        addWidgetStub.resetHistory();
+
+        // Switch back to A — should restore saved layout, NOT apply viewPlacements
+        await service.switchPerspective('perspA');
+
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(layoutA)).to.be.true;
+        expect(getOrCreateWidgetStub.called).to.be.false;
+        expect(addWidgetStub.called).to.be.false;
+    });
+
+    it('should apply viewPlacements on first activation (no saved layout)', async () => {
+        service.registerPerspective({
+            id: 'fresh',
+            label: 'Fresh',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('fresh');
+
+        expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
+        expect(addWidgetStub.calledOnce).to.be.true;
+        expect(addWidgetStub.calledWith(testWidget, sinon.match({ area: 'main' }))).to.be.true;
+        expect(setLayoutDataStub.called).to.be.false;
+    });
+
+    it('should not apply viewPlacements when a saved layout exists', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map([['test-widget', 'left' as ApplicationShell.Area]])
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        // First activation of A — viewPlacements applied
+        await service.switchPerspective('perspA');
+        expect(getOrCreateWidgetStub.called).to.be.true;
+
+        // Switch to B (saves A's layout)
+        await service.switchPerspective('perspB');
+
+        getOrCreateWidgetStub.resetHistory();
+        addWidgetStub.resetHistory();
+
+        // Switch back to A — should restore layout, NOT use viewPlacements
+        await service.switchPerspective('perspA');
+
+        expect(getOrCreateWidgetStub.called).to.be.false;
+        expect(addWidgetStub.called).to.be.false;
+        expect(setLayoutDataStub.called).to.be.true;
+    });
+
+    it('should allow full round-trip: default → custom → default', async () => {
+        service.initialize();
+
+        service.registerPerspective({
+            id: 'ai-first',
+            label: 'AI First',
+            viewPlacements: new Map([['test-widget', 'left' as ApplicationShell.Area]])
+        });
+
+        // Start in theia-ide (set by initialize)
+        expect(service.getActivePerspective()?.id).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+
+        const defaultLayout = { mainPanel: { widgets: ['default-editor'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(defaultLayout);
+
+        // Switch to ai-first (saves default layout)
+        await service.switchPerspective('ai-first');
+        expect(service.getActivePerspective()?.id).to.equal('ai-first');
+        expect(getLayoutDataStub.called).to.be.true;
+        expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
+
+        const aiLayout = { mainPanel: { widgets: ['ai-stuff'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(aiLayout);
+
+        setLayoutDataStub.resetHistory();
+
+        // Switch back to default (saves ai-first layout, restores default layout)
+        await service.switchPerspective(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        expect(service.getActivePerspective()?.id).to.equal(PerspectiveService.DEFAULT_PERSPECTIVE_ID);
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(defaultLayout)).to.be.true;
+
+        setLayoutDataStub.resetHistory();
+
+        // Switch back to ai-first (saves default layout again, restores ai-first layout)
+        await service.switchPerspective('ai-first');
+        expect(service.getActivePerspective()?.id).to.equal('ai-first');
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(aiLayout)).to.be.true;
     });
 });

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -1,0 +1,258 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from './test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { PerspectiveService, PerspectiveDescriptor } from './perspective-service';
+import { ApplicationShell } from './shell/application-shell';
+import { Widget } from '@lumino/widgets';
+
+disableJSDOM();
+
+describe('PerspectiveService', () => {
+    let service: PerspectiveService;
+    let addWidgetStub: sinon.SinonStub;
+    let activateWidgetStub: sinon.SinonStub;
+    let getTabBarForStub: sinon.SinonStub;
+    let getAreaForStub: sinon.SinonStub;
+    let getOrCreateWidgetStub: sinon.SinonStub;
+    let testWidget: Widget;
+    let toTearDown: () => void;
+
+    beforeEach(() => {
+        toTearDown = enableJSDOM();
+        service = new PerspectiveService();
+        testWidget = new Widget();
+        testWidget.id = 'test-widget';
+
+        addWidgetStub = sinon.stub().resolves();
+        activateWidgetStub = sinon.stub().resolves(undefined);
+        getTabBarForStub = sinon.stub().returns(undefined);
+        getAreaForStub = sinon.stub().returns(undefined);
+        getOrCreateWidgetStub = sinon.stub().resolves(testWidget);
+
+        const mockShell = {
+            addWidget: addWidgetStub,
+            activateWidget: activateWidgetStub,
+            getTabBarFor: getTabBarForStub,
+            getAreaFor: getAreaForStub
+        };
+
+        const mockWidgetManager = {
+            getOrCreateWidget: getOrCreateWidgetStub
+        };
+
+        // Assign mocks via property access since we can't use DI in tests
+        (service as unknown as Record<string, unknown>)['shell'] = mockShell;
+        (service as unknown as Record<string, unknown>)['widgetManager'] = mockWidgetManager;
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        toTearDown();
+    });
+
+    it('should register a perspective', () => {
+        const descriptor: PerspectiveDescriptor = {
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        };
+
+        service.registerPerspective(descriptor);
+
+        const perspectives = service.getRegisteredPerspectives();
+        expect(perspectives).to.have.lengthOf(1);
+        expect(perspectives[0].id).to.equal('test');
+        expect(perspectives[0].label).to.equal('Test');
+    });
+
+    it('should register multiple perspectives', () => {
+        service.registerPerspective({
+            id: 'perspective-1',
+            label: 'Perspective 1',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspective-2',
+            label: 'Perspective 2',
+            viewPlacements: new Map()
+        });
+
+        expect(service.getRegisteredPerspectives()).to.have.lengthOf(2);
+    });
+
+    it('should return undefined for active perspective when none is set', () => {
+        expect(service.getActivePerspective()).to.be.undefined;
+    });
+
+    it('should return undefined from getAreaForView when no perspective is active', () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        });
+
+        expect(service.getAreaForView('widget-a')).to.be.undefined;
+    });
+
+    it('should return the override area when a perspective is active', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(service.getAreaForView('widget-a')).to.equal('main');
+    });
+
+    it('should return undefined for views not in the perspective placement map', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(service.getAreaForView('widget-b')).to.be.undefined;
+    });
+
+    it('should switch perspectives and update the active perspective', async () => {
+        service.registerPerspective({
+            id: 'first',
+            label: 'First',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'second',
+            label: 'Second',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('first');
+        expect(service.getActivePerspective()?.id).to.equal('first');
+
+        await service.switchPerspective('second');
+        expect(service.getActivePerspective()?.id).to.equal('second');
+    });
+
+    it('should fire onDidChangePerspective event when switching', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map()
+        });
+
+        const spy = sinon.spy();
+        service.onDidChangePerspective(spy);
+
+        await service.switchPerspective('test');
+
+        expect(spy.calledOnce).to.be.true;
+        expect(spy.calledWith('test')).to.be.true;
+    });
+
+    it('should not switch to a non-existent perspective', async () => {
+        const spy = sinon.spy();
+        service.onDidChangePerspective(spy);
+
+        await service.switchPerspective('nonexistent');
+
+        expect(spy.called).to.be.false;
+        expect(service.getActivePerspective()).to.be.undefined;
+    });
+
+    it('should call onDeactivate on old perspective and onActivate on new perspective', async () => {
+        const onDeactivate = sinon.spy();
+        const onActivate = sinon.spy();
+
+        service.registerPerspective({
+            id: 'old',
+            label: 'Old',
+            viewPlacements: new Map(),
+            onDeactivate
+        });
+        service.registerPerspective({
+            id: 'new',
+            label: 'New',
+            viewPlacements: new Map(),
+            onActivate
+        });
+
+        await service.switchPerspective('old');
+        await service.switchPerspective('new');
+
+        expect(onDeactivate.calledOnce).to.be.true;
+        expect(onActivate.calledOnce).to.be.true;
+        expect(onDeactivate.calledBefore(onActivate)).to.be.true;
+    });
+
+    it('should add widgets to the target area during switch', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
+        expect(addWidgetStub.calledOnce).to.be.true;
+        expect(addWidgetStub.calledWith(testWidget, sinon.match({ area: 'main' }))).to.be.true;
+    });
+
+    it('should skip adding widget if already in the correct area', async () => {
+        getTabBarForStub.returns({});
+        getAreaForStub.returns('main');
+
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(addWidgetStub.called).to.be.false;
+    });
+
+    it('should call initialize and register contributions', () => {
+        const mockContribution = {
+            registerPerspectives: sinon.spy()
+        };
+
+        (service as unknown as Record<string, unknown>)['contributions'] = {
+            getContributions: () => [mockContribution]
+        };
+
+        service.initialize();
+
+        expect(mockContribution.registerPerspectives.calledOnce).to.be.true;
+        expect(mockContribution.registerPerspectives.calledWith(service)).to.be.true;
+    });
+
+    it('should handle initialize with no contributions', () => {
+        (service as unknown as Record<string, unknown>)['contributions'] = undefined;
+
+        expect(() => service.initialize()).to.not.throw();
+    });
+});

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -22,6 +22,7 @@ import * as sinon from 'sinon';
 import { PerspectiveService, PerspectiveDescriptor } from './perspective-service';
 import { ApplicationShell } from './shell/application-shell';
 import { Widget } from '@lumino/widgets';
+import { Emitter } from '../common/event';
 
 disableJSDOM();
 
@@ -34,8 +35,13 @@ describe('PerspectiveService', () => {
     let getOrCreateWidgetStub: sinon.SinonStub;
     let getLayoutDataStub: sinon.SinonStub;
     let setLayoutDataStub: sinon.SinonStub;
+    let collapsePanelStub: sinon.SinonStub;
+    let topPanelSetHiddenStub: sinon.SinonStub;
+    let statusBarSetHiddenStub: sinon.SinonStub;
     let testWidget: Widget;
     let toTearDown: () => void;
+    let mockCorePreferences: Record<string, unknown> & { onPreferenceChanged: sinon.SinonStub };
+    let mockPreferenceService: { get: sinon.SinonStub };
 
     beforeEach(() => {
         toTearDown = enableJSDOM();
@@ -50,6 +56,9 @@ describe('PerspectiveService', () => {
         getOrCreateWidgetStub = sinon.stub().resolves(testWidget);
         getLayoutDataStub = sinon.stub().returns({ mainPanel: {}, bottomPanel: {} });
         setLayoutDataStub = sinon.stub().resolves();
+        collapsePanelStub = sinon.stub().resolves();
+        topPanelSetHiddenStub = sinon.stub();
+        statusBarSetHiddenStub = sinon.stub();
 
         const mockShell = {
             addWidget: addWidgetStub,
@@ -57,16 +66,34 @@ describe('PerspectiveService', () => {
             getTabBarFor: getTabBarForStub,
             getAreaFor: getAreaForStub,
             getLayoutData: getLayoutDataStub,
-            setLayoutData: setLayoutDataStub
+            setLayoutData: setLayoutDataStub,
+            collapsePanel: collapsePanelStub,
+            topPanel: { setHidden: topPanelSetHiddenStub }
+        };
+
+        const mockStatusBar = {
+            setHidden: statusBarSetHiddenStub
         };
 
         const mockWidgetManager = {
             getOrCreateWidget: getOrCreateWidgetStub
         };
 
+        mockCorePreferences = {
+            'window.menuBarVisibility': 'classic',
+            onPreferenceChanged: sinon.stub().returns({ dispose: () => { } })
+        };
+
+        mockPreferenceService = {
+            get: sinon.stub().returns(true)
+        };
+
         // Assign mocks via property access since we can't use DI in tests
         (service as unknown as Record<string, unknown>)['shell'] = mockShell;
         (service as unknown as Record<string, unknown>)['widgetManager'] = mockWidgetManager;
+        (service as unknown as Record<string, unknown>)['corePreferences'] = mockCorePreferences;
+        (service as unknown as Record<string, unknown>)['preferenceService'] = mockPreferenceService;
+        (service as unknown as Record<string, unknown>)['statusBar'] = mockStatusBar;
     });
 
     afterEach(() => {
@@ -473,5 +500,207 @@ describe('PerspectiveService', () => {
         expect(service.getActivePerspective()?.id).to.equal('ai-first');
         expect(setLayoutDataStub.calledOnce).to.be.true;
         expect(setLayoutDataStub.calledWith(aiLayout)).to.be.true;
+    });
+
+    // --- Chrome control options tests ---
+
+    it('should hide menu bar when perspective has hideMenuBar', async () => {
+        service.registerPerspective({
+            id: 'chrome-test',
+            label: 'Chrome Test',
+            viewPlacements: new Map(),
+            chromeOptions: { hideMenuBar: true }
+        });
+
+        await service.switchPerspective('chrome-test');
+
+        expect(topPanelSetHiddenStub.calledWith(true)).to.be.true;
+    });
+
+    it('should show menu bar when perspective does not hide it and preference allows', async () => {
+        mockCorePreferences['window.menuBarVisibility'] = 'classic';
+
+        service.registerPerspective({
+            id: 'no-chrome',
+            label: 'No Chrome',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('no-chrome');
+
+        expect(topPanelSetHiddenStub.calledWith(false)).to.be.true;
+    });
+
+    it('should keep menu bar hidden when preference hides it even if perspective does not', async () => {
+        mockCorePreferences['window.menuBarVisibility'] = 'hidden';
+
+        service.registerPerspective({
+            id: 'no-chrome',
+            label: 'No Chrome',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('no-chrome');
+
+        expect(topPanelSetHiddenStub.calledWith(true)).to.be.true;
+    });
+
+    it('should hide status bar when perspective has hideStatusBar', async () => {
+        service.registerPerspective({
+            id: 'chrome-test',
+            label: 'Chrome Test',
+            viewPlacements: new Map(),
+            chromeOptions: { hideStatusBar: true }
+        });
+
+        await service.switchPerspective('chrome-test');
+
+        expect(statusBarSetHiddenStub.calledWith(true)).to.be.true;
+    });
+
+    it('should restore status bar based on preference when perspective does not hide it', async () => {
+        mockPreferenceService.get.returns(true);
+
+        service.registerPerspective({
+            id: 'no-chrome',
+            label: 'No Chrome',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('no-chrome');
+
+        expect(statusBarSetHiddenStub.calledWith(false)).to.be.true;
+    });
+
+    it('should collapse areas on first activation only', async () => {
+        service.registerPerspective({
+            id: 'collapse-test',
+            label: 'Collapse Test',
+            viewPlacements: new Map(),
+            chromeOptions: { collapseAreas: ['left'] }
+        });
+        service.registerPerspective({
+            id: 'other',
+            label: 'Other',
+            viewPlacements: new Map()
+        });
+
+        // First activation — should collapse
+        await service.switchPerspective('collapse-test');
+        expect(collapsePanelStub.calledOnce).to.be.true;
+        expect(collapsePanelStub.calledWith('left')).to.be.true;
+
+        collapsePanelStub.resetHistory();
+
+        // Switch away (saves layout)
+        await service.switchPerspective('other');
+
+        collapsePanelStub.resetHistory();
+
+        // Switch back — should restore saved layout, NOT collapse again
+        await service.switchPerspective('collapse-test');
+        expect(collapsePanelStub.called).to.be.false;
+    });
+
+    it('should apply chrome options even when restoring saved layout', async () => {
+        service.registerPerspective({
+            id: 'chrome-test',
+            label: 'Chrome Test',
+            viewPlacements: new Map(),
+            chromeOptions: { hideMenuBar: true, hideStatusBar: true }
+        });
+        service.registerPerspective({
+            id: 'other',
+            label: 'Other',
+            viewPlacements: new Map()
+        });
+
+        // First activation
+        await service.switchPerspective('chrome-test');
+        expect(topPanelSetHiddenStub.calledWith(true)).to.be.true;
+        expect(statusBarSetHiddenStub.calledWith(true)).to.be.true;
+
+        topPanelSetHiddenStub.resetHistory();
+        statusBarSetHiddenStub.resetHistory();
+
+        // Switch away (saves layout)
+        await service.switchPerspective('other');
+
+        topPanelSetHiddenStub.resetHistory();
+        statusBarSetHiddenStub.resetHistory();
+
+        // Switch back (restores saved layout) — chrome should still be applied
+        await service.switchPerspective('chrome-test');
+        expect(topPanelSetHiddenStub.calledWith(true)).to.be.true;
+        expect(statusBarSetHiddenStub.calledWith(true)).to.be.true;
+    });
+
+    it('should re-evaluate chrome when preference changes', () => {
+        const prefEmitter = new Emitter<{ preferenceName: string }>();
+        mockCorePreferences.onPreferenceChanged = sinon.stub().callsFake(
+            (listener: (e: { preferenceName: string }) => void) => prefEmitter.event(listener)
+        );
+
+        service.registerPerspective({
+            id: 'chrome-test',
+            label: 'Chrome Test',
+            viewPlacements: new Map(),
+            chromeOptions: { hideMenuBar: true }
+        });
+
+        service.initialize();
+
+        // Manually set active perspective
+        (service as unknown as Record<string, unknown>)['activePerspectiveId'] = 'chrome-test';
+
+        topPanelSetHiddenStub.resetHistory();
+        statusBarSetHiddenStub.resetHistory();
+
+        // Fire a preference change
+        prefEmitter.fire({ preferenceName: 'window.menuBarVisibility' });
+
+        expect(topPanelSetHiddenStub.called).to.be.true;
+        expect(topPanelSetHiddenStub.calledWith(true)).to.be.true;
+    });
+
+    it('should keep status bar hidden when preference hides it even if perspective does not', async () => {
+        mockPreferenceService.get.returns(false);
+
+        service.registerPerspective({
+            id: 'no-chrome',
+            label: 'No Chrome',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('no-chrome');
+
+        expect(statusBarSetHiddenStub.calledWith(true)).to.be.true;
+    });
+
+    it('should collapse multiple areas on first activation', async () => {
+        service.registerPerspective({
+            id: 'multi-collapse',
+            label: 'Multi Collapse',
+            viewPlacements: new Map(),
+            chromeOptions: { collapseAreas: ['left', 'bottom'] }
+        });
+
+        await service.switchPerspective('multi-collapse');
+
+        expect(collapsePanelStub.calledTwice).to.be.true;
+        expect(collapsePanelStub.calledWith('left')).to.be.true;
+        expect(collapsePanelStub.calledWith('bottom')).to.be.true;
+    });
+
+    it('should not collapse areas when perspective has no collapseAreas', async () => {
+        service.registerPerspective({
+            id: 'no-collapse',
+            label: 'No Collapse',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('no-collapse');
+
+        expect(collapsePanelStub.called).to.be.false;
     });
 });

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -46,7 +46,7 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
     static readonly SWITCH_PERSPECTIVE_COMMAND = {
         id: 'perspective.switch',
         category: nls.localizeByDefault('View'),
-        label: 'Switch Perspective'
+        label: nls.localize('theia/core/perspective/switchPerspective', 'Switch Perspective')
     };
 
     @inject(ApplicationShell)
@@ -61,13 +61,23 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
     @inject(QuickInputService) @optional()
     protected readonly quickInputService: QuickInputService | undefined;
 
+    static readonly DEFAULT_PERSPECTIVE_ID = 'theia-ide';
+
     protected readonly perspectives = new Map<string, PerspectiveDescriptor>();
     protected activePerspectiveId: string | undefined;
+    protected readonly savedLayouts = new Map<string, ApplicationShell.LayoutData>();
 
     protected readonly onDidChangePerspectiveEmitter = new Emitter<string>();
     readonly onDidChangePerspective: Event<string> = this.onDidChangePerspectiveEmitter.event;
 
     initialize(): void {
+        this.registerPerspective({
+            id: PerspectiveService.DEFAULT_PERSPECTIVE_ID,
+            label: nls.localize('theia/core/perspective/theiaIde', 'Theia IDE'),
+            viewPlacements: new Map()
+        });
+        this.activePerspectiveId = PerspectiveService.DEFAULT_PERSPECTIVE_ID;
+
         if (this.contributions) {
             for (const contribution of this.contributions.getContributions()) {
                 contribution.registerPerspectives(this);
@@ -80,6 +90,10 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
     }
 
     async switchPerspective(id: string): Promise<void> {
+        if (id === this.activePerspectiveId) {
+            return;
+        }
+
         const descriptor = this.perspectives.get(id);
         if (!descriptor) {
             return;
@@ -90,29 +104,38 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
             oldPerspective.onDeactivate(this.shell);
         }
 
-        this.activePerspectiveId = id;
-
-        for (const [viewId, area] of descriptor.viewPlacements) {
-            try {
-                const widget = await this.widgetManager.getOrCreateWidget(viewId);
-                const currentTabBar = this.shell.getTabBarFor(widget);
-                if (currentTabBar) {
-                    const currentArea = this.shell.getAreaFor(widget);
-                    if (currentArea === area) {
-                        continue;
-                    }
-                }
-                await this.shell.addWidget(widget, { area });
-            } catch {
-                // Widget factory may not be registered — skip silently
-            }
+        if (this.activePerspectiveId) {
+            this.savedLayouts.set(this.activePerspectiveId, this.shell.getLayoutData());
         }
 
-        for (const [viewId] of descriptor.viewPlacements) {
-            try {
-                await this.shell.activateWidget(viewId);
-            } catch {
-                // Ignore activation errors
+        this.activePerspectiveId = id;
+
+        const savedLayout = this.savedLayouts.get(id);
+        if (savedLayout) {
+            await this.shell.setLayoutData(savedLayout);
+        } else {
+            for (const [viewId, area] of descriptor.viewPlacements) {
+                try {
+                    const widget = await this.widgetManager.getOrCreateWidget(viewId);
+                    const currentTabBar = this.shell.getTabBarFor(widget);
+                    if (currentTabBar) {
+                        const currentArea = this.shell.getAreaFor(widget);
+                        if (currentArea === area) {
+                            continue;
+                        }
+                    }
+                    await this.shell.addWidget(widget, { area });
+                } catch {
+                    // Widget factory may not be registered — skip silently
+                }
+            }
+
+            for (const [viewId] of descriptor.viewPlacements) {
+                try {
+                    await this.shell.activateWidget(viewId);
+                } catch {
+                    // Ignore activation errors
+                }
             }
         }
 
@@ -161,7 +184,7 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
         }));
 
         const selected = await this.quickInputService.showQuickPick(items, {
-            placeholder: 'Select a perspective'
+            placeholder: nls.localize('theia/core/perspective/selectPerspective', 'Select a perspective')
         });
 
         if (selected?.id) {

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -23,12 +23,26 @@ import { CommandContribution, CommandRegistry } from '../common/command';
 import { Emitter, Event } from '../common/event';
 import { QuickInputService, QuickPickItem } from '../common/quick-pick-service';
 import { nls } from '../common/nls';
+import { CorePreferences } from '../common/core-preferences';
+import { PreferenceService } from '../common/preferences';
+import { StatusBarImpl } from './status-bar/status-bar';
+
+export interface PerspectiveChromeOptions {
+    /** Hide the top menu bar. Default: false. */
+    hideMenuBar?: boolean;
+    /** Hide the status bar. Default: false. */
+    hideStatusBar?: boolean;
+    /** Areas to collapse on first activation. User can re-expand freely. */
+    collapseAreas?: ('left' | 'right' | 'bottom')[];
+}
 
 export interface PerspectiveDescriptor {
     id: string;
     label: string;
     /** Widget/view-container ID → target shell area */
     viewPlacements: Map<string, ApplicationShell.Area>;
+    /** Chrome control options for this perspective */
+    chromeOptions?: PerspectiveChromeOptions;
     /** Called when perspective is activated */
     onActivate?(shell: ApplicationShell): void;
     /** Called when switching away */
@@ -61,6 +75,15 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
     @inject(QuickInputService) @optional()
     protected readonly quickInputService: QuickInputService | undefined;
 
+    @inject(CorePreferences)
+    protected readonly corePreferences: CorePreferences;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(StatusBarImpl)
+    protected readonly statusBar: StatusBarImpl;
+
     static readonly DEFAULT_PERSPECTIVE_ID = 'theia-ide';
 
     protected readonly perspectives = new Map<string, PerspectiveDescriptor>();
@@ -83,6 +106,16 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
                 contribution.registerPerspectives(this);
             }
         }
+
+        this.corePreferences.onPreferenceChanged(pref => {
+            if (pref.preferenceName === 'window.menuBarVisibility'
+                || pref.preferenceName === 'workbench.statusBar.visible') {
+                const active = this.getActivePerspective();
+                if (active) {
+                    this.applyChrome(active);
+                }
+            }
+        });
     }
 
     registerPerspective(descriptor: PerspectiveDescriptor): void {
@@ -137,13 +170,35 @@ export class PerspectiveService implements FrontendApplicationContribution, Comm
                     // Ignore activation errors
                 }
             }
+
+            if (descriptor.chromeOptions?.collapseAreas) {
+                for (const area of descriptor.chromeOptions.collapseAreas) {
+                    await this.shell.collapsePanel(area);
+                }
+            }
         }
 
         if (descriptor.onActivate) {
             descriptor.onActivate(this.shell);
         }
 
+        this.applyChrome(descriptor);
+
         this.onDidChangePerspectiveEmitter.fire(id);
+    }
+
+    protected applyChrome(descriptor: PerspectiveDescriptor): void {
+        const perspectiveHidesMenu = descriptor.chromeOptions?.hideMenuBar ?? false;
+        const prefHidesMenu = ['compact', 'hidden'].includes(
+            this.corePreferences['window.menuBarVisibility']
+        );
+        this.shell.topPanel.setHidden(perspectiveHidesMenu || prefHidesMenu);
+
+        const perspectiveHidesStatus = descriptor.chromeOptions?.hideStatusBar ?? false;
+        const prefHidesStatus = !this.preferenceService.get<boolean>(
+            'workbench.statusBar.visible', true
+        );
+        this.statusBar.setHidden(perspectiveHidesStatus || prefHidesStatus);
     }
 
     getActivePerspective(): PerspectiveDescriptor | undefined {

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -1,0 +1,171 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, named, optional } from 'inversify';
+import { ApplicationShell } from './shell/application-shell';
+import { FrontendApplicationContribution } from './frontend-application-contribution';
+import { WidgetManager } from './widget-manager';
+import { ContributionProvider } from '../common/contribution-provider';
+import { CommandContribution, CommandRegistry } from '../common/command';
+import { Emitter, Event } from '../common/event';
+import { QuickInputService, QuickPickItem } from '../common/quick-pick-service';
+import { nls } from '../common/nls';
+
+export interface PerspectiveDescriptor {
+    id: string;
+    label: string;
+    /** Widget/view-container ID → target shell area */
+    viewPlacements: Map<string, ApplicationShell.Area>;
+    /** Called when perspective is activated */
+    onActivate?(shell: ApplicationShell): void;
+    /** Called when switching away */
+    onDeactivate?(shell: ApplicationShell): void;
+}
+
+export const PerspectiveContribution = Symbol('PerspectiveContribution');
+export interface PerspectiveContribution {
+    registerPerspectives(service: PerspectiveService): void;
+}
+
+@injectable()
+export class PerspectiveService implements FrontendApplicationContribution, CommandContribution {
+
+    static readonly SWITCH_PERSPECTIVE_COMMAND = {
+        id: 'perspective.switch',
+        category: nls.localizeByDefault('View'),
+        label: 'Switch Perspective'
+    };
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(WidgetManager)
+    protected readonly widgetManager: WidgetManager;
+
+    @inject(ContributionProvider) @named(PerspectiveContribution) @optional()
+    protected readonly contributions: ContributionProvider<PerspectiveContribution> | undefined;
+
+    @inject(QuickInputService) @optional()
+    protected readonly quickInputService: QuickInputService | undefined;
+
+    protected readonly perspectives = new Map<string, PerspectiveDescriptor>();
+    protected activePerspectiveId: string | undefined;
+
+    protected readonly onDidChangePerspectiveEmitter = new Emitter<string>();
+    readonly onDidChangePerspective: Event<string> = this.onDidChangePerspectiveEmitter.event;
+
+    initialize(): void {
+        if (this.contributions) {
+            for (const contribution of this.contributions.getContributions()) {
+                contribution.registerPerspectives(this);
+            }
+        }
+    }
+
+    registerPerspective(descriptor: PerspectiveDescriptor): void {
+        this.perspectives.set(descriptor.id, descriptor);
+    }
+
+    async switchPerspective(id: string): Promise<void> {
+        const descriptor = this.perspectives.get(id);
+        if (!descriptor) {
+            return;
+        }
+
+        const oldPerspective = this.getActivePerspective();
+        if (oldPerspective?.onDeactivate) {
+            oldPerspective.onDeactivate(this.shell);
+        }
+
+        this.activePerspectiveId = id;
+
+        for (const [viewId, area] of descriptor.viewPlacements) {
+            try {
+                const widget = await this.widgetManager.getOrCreateWidget(viewId);
+                const currentTabBar = this.shell.getTabBarFor(widget);
+                if (currentTabBar) {
+                    const currentArea = this.shell.getAreaFor(widget);
+                    if (currentArea === area) {
+                        continue;
+                    }
+                }
+                await this.shell.addWidget(widget, { area });
+            } catch {
+                // Widget factory may not be registered — skip silently
+            }
+        }
+
+        for (const [viewId] of descriptor.viewPlacements) {
+            try {
+                await this.shell.activateWidget(viewId);
+            } catch {
+                // Ignore activation errors
+            }
+        }
+
+        if (descriptor.onActivate) {
+            descriptor.onActivate(this.shell);
+        }
+
+        this.onDidChangePerspectiveEmitter.fire(id);
+    }
+
+    getActivePerspective(): PerspectiveDescriptor | undefined {
+        if (this.activePerspectiveId) {
+            return this.perspectives.get(this.activePerspectiveId);
+        }
+        return undefined;
+    }
+
+    getAreaForView(viewId: string): ApplicationShell.Area | undefined {
+        const active = this.getActivePerspective();
+        if (active) {
+            return active.viewPlacements.get(viewId);
+        }
+        return undefined;
+    }
+
+    getRegisteredPerspectives(): PerspectiveDescriptor[] {
+        return Array.from(this.perspectives.values());
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(PerspectiveService.SWITCH_PERSPECTIVE_COMMAND, {
+            execute: () => this.showPerspectivePicker(),
+            isEnabled: () => this.perspectives.size > 0
+        });
+    }
+
+    protected async showPerspectivePicker(): Promise<void> {
+        if (!this.quickInputService) {
+            return;
+        }
+
+        const items: QuickPickItem[] = this.getRegisteredPerspectives().map(p => ({
+            label: p.label,
+            id: p.id,
+            description: this.activePerspectiveId === p.id ? nls.localizeByDefault('Active') : undefined
+        }));
+
+        const selected = await this.quickInputService.showQuickPick(items, {
+            placeholder: 'Select a perspective'
+        });
+
+        if (selected?.id) {
+            await this.switchPerspective(selected.id);
+        }
+    }
+}

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -25,6 +25,7 @@ import { WidgetManager } from '../widget-manager';
 import { CommonMenus } from '../common-menus';
 import { ApplicationShell } from './application-shell';
 import { QuickViewService } from '../quick-input';
+import { PerspectiveService } from '../perspective-service';
 
 export interface OpenViewArguments extends ApplicationShell.WidgetOptions {
     toggle?: boolean
@@ -60,6 +61,9 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
 
     @inject(QuickViewService) @optional()
     protected readonly quickView: QuickViewService;
+
+    @inject(PerspectiveService) @optional()
+    protected readonly perspectiveService: PerspectiveService;
 
     readonly toggleCommand?: Command;
 
@@ -102,8 +106,10 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         const area = shell.getAreaFor(widget);
         if (!tabBar) {
             // The widget is not attached yet, so add it to the shell
+            const perspectiveArea = this.perspectiveService?.getAreaForView(this.options.viewContainerId || this.viewId);
             const widgetArgs: OpenViewArguments = {
                 ...this.defaultViewOptions,
+                ...perspectiveArea ? { area: perspectiveArea } : {},
                 ...args
             };
             await shell.addWidget(widget, widgetArgs);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Add a new Perspective Service with a Command to switch perspectives
- Add two perspectives: Theia IDE (Default) and AI First
- The default perspectives simply shows whichever views are configured to open when no layout data is available
- The AI First perspective includes the AI Chat in the main area, and Explorer/SCM on the right (left side is reserved for future new views, e.g. AI Sessions)
- Perspective can optionally hide chrome: menu bars, status bar, collapse areas, ...
- When a Perspective defines a default area for a view, that is different from the view's default area, the Perspective "wins" (So a perspective can move an existing view to a different location).
- By default, perspective are pretty open: they define a default layout with a set of views, but users are still free to reorder them however they like (move views around, close/open views, ...)

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- F1 > Switch Perspective...
- Select AI First
- The new layout should be applied
  - At the moment, open views and editors are never closed; they are only rearranged (follow-up required)
  - New views may be opened if they are not open already
- F1 > Switch Perspective > AI First (Active)
  - Nothing happens: this is already the active perspective
- F1 > Switch Perspective > Theia IDE
  - The default perspective is restored in its latest known state

#### Follow-ups

- Perspective Contribution improvements: https://github.com/eclipsesource/theia/issues/284
- Perspective Layout persistence: https://github.com/eclipsesource/theia/issues/285
- Handle Hide/Close views: views that are not part of the target perspective should be either closed or hidden/disabled
  - This is a potentially complex issue as we don't want to lose "Transient state". Switching back and forth between perspective should restore the initial state as much as possible (so closing/reopening the view might not be a good solution)
- Handle disabling areas: currently, perspectives can indicate that an area (left/right/bottom) should be collapsed by default, but they can't prevent users from re-opening them. This is probably related to the Hide/Close views, as this mechanism is only interesting for perspectives that want to really strictly control what should be shown to the user, and how it should be shown (locked-down mode). 
- Handle secondary windows: currently, secondary windows are kept outside of the perspective mechanism. They remain open where they are when switching perspectives. When closing Theia, they are attached back to their preferred location and then persisted in the Layout Data

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
