### PR TITLE
fix(terminal): stop the file link provider throwing on printed URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 1.74.0 - tbd
 
+- [terminal] fixed the file link provider logging a `UriError` when a printed URL (e.g. `https://example.com/path`) was matched as a local file candidate; such `//host/path` candidates are now skipped and left to the URL link provider [#17767](https://github.com/eclipse-theia/theia/pull/17767)
 - [ai-anthropic, ai-chat, ai-chat-ui, ai-core, ai-openai] added provider-native server-side compaction for chat sessions, modeled as a model capability (`LanguageModelMetaData.serverSideCompactionSupport`) plus layered activation: a global preference (`ai-features.chat.serverSideCompaction`, default on), a per-provider override, and a per-session override (in the session settings dialog) that wins over both. Honored by the Anthropic Messages API (beta) and the OpenAI Responses API; the compaction marker is persisted in the session, replayed on subsequent requests, surfaced as an inline chat marker, and reflected in the token-usage tooltip (cumulative usage and a "compacted Nx" count). Providers/models without the capability ignore it [#17636](https://github.com/eclipse-theia/theia/issues/17636)
 
 ## 1.73.0 - 6/25/2026

--- a/packages/terminal/src/browser/terminal-file-link-provider.spec.ts
+++ b/packages/terminal/src/browser/terminal-file-link-provider.spec.ts
@@ -1,0 +1,95 @@
+// *****************************************************************************
+// Copyright (C) 2026 JuliaHub, Inc. and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+// Importing the provider pulls in xterm, which probes a canvas 2d context on load; JSDOM has no
+// canvas backend, so stub it out to keep this spec runnable without the native `canvas` package.
+(HTMLCanvasElement.prototype as unknown as { getContext: () => unknown }).getContext = () => undefined;
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import * as chai from 'chai';
+import { ILogger } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
+import { TerminalWidget } from './base/terminal-widget';
+import { FileLinkProvider } from './terminal-file-link-provider';
+
+disableJSDOM();
+
+const expect = chai.expect;
+
+class TestFileLinkProvider extends FileLinkProvider {
+    readonly loggedErrors: string[] = [];
+
+    constructor() {
+        super();
+        (this as unknown as { logger: ILogger }).logger = {
+            error: (message: unknown) => { this.loggedErrors.push(String(message)); }
+        } as unknown as ILogger;
+    }
+
+    exposeToURI(match: string, cwd: URI): Promise<URI | undefined> {
+        return this.toURI(match, cwd);
+    }
+}
+
+function terminalWithCwd(cwd: URI): TerminalWidget {
+    return { lastCwd: cwd } as unknown as TerminalWidget;
+}
+
+describe('FileLinkProvider', () => {
+
+    const cwd = new URI('file:///home/user/project');
+
+    describe('#toURI', () => {
+
+        it('should skip a URL authority path beginning with "//" instead of throwing', async () => {
+            const provider = new TestFileLinkProvider();
+            // The '//host/path' the file-path regex matches from a printed URL (its ':' is excluded).
+            expect(await provider.exposeToURI('//juliahub.com/products/dyad', cwd)).to.equal(undefined);
+            expect(await provider.exposeToURI('//github.com/DyadLang/DyadIssues', cwd)).to.equal(undefined);
+        });
+
+        it('should still resolve a genuine absolute local path', async () => {
+            const provider = new TestFileLinkProvider();
+            const uri = await provider.exposeToURI('/home/user/project/file.ts', cwd);
+            expect(uri).to.not.equal(undefined);
+            expect(uri!.path.toString()).to.equal('/home/user/project/file.ts');
+        });
+    });
+
+    describe('#provideLinks', () => {
+
+        it('should not produce a file link or log an error for a printed URL', async () => {
+            const provider = new TestFileLinkProvider();
+            const links = await provider.provideLinks('see https://juliahub.com/products/dyad for details', terminalWithCwd(cwd));
+            expect(links).to.deep.equal([]);
+            expect(provider.loggedErrors).to.deep.equal([]);
+        });
+
+        it('should not throw or log for a printed file:// URL', async () => {
+            const provider = new TestFileLinkProvider();
+            // ':' is excluded, so a file:// URL survives as a '///path' candidate the guard skips;
+            // it is not linkified here today. Documents the no-throw behavior — making file:// links
+            // clickable would be a separate feature.
+            const links = await provider.provideLinks('open file:///home/user/project/file.ts now', terminalWithCwd(cwd));
+            expect(links).to.deep.equal([]);
+            expect(provider.loggedErrors).to.deep.equal([]);
+        });
+    });
+});

--- a/packages/terminal/src/browser/terminal-file-link-provider.ts
+++ b/packages/terminal/src/browser/terminal-file-link-provider.ts
@@ -84,6 +84,14 @@ export class FileLinkProvider implements TerminalLinkProvider {
         if (!path) {
             return;
         }
+        // A '//'-leading match is a URL authority, not a local file: the path regex excludes ':'
+        // but not '/', so a printed URL matches from its '//host/path' remainder. Such a path
+        // cannot form a file URI (no authority component) and is already linkified by the URL link
+        // provider, so skip it rather than let `withPath` throw. The Windows path regex splits the
+        // leading '//' into a single slash during extraction, so the raw match is checked too.
+        if (match.startsWith('//') || path.startsWith('//')) {
+            return;
+        }
         const pathObj = new Path(path);
         return pathObj.isAbsolute ? cwd.withPath(path) : cwd.resolve(path);
     }


### PR DESCRIPTION
> **Disclosure:** this change was drafted with AI assistance (Claude Code) and reviewed and verified by me.

#### What it does

`FileLinkProvider` logs an error on every printed URL:

```
terminal:FileLinkProvider ERROR Error validating //example.com/path
  [UriError]: If a URI does not contain an authority component, then the path cannot begin with two slash characters ("//")
```

`FileLinkProvider` runs over each terminal line with a file-path regex whose `excludedPathCharactersClause` excludes `:` (a line/column separator, as in `file:336`) but not `/`. A printed URL is therefore matched from its `//host/path` remainder, and `toURI` calls `cwd.withPath('//host/path')`, which `vscode-uri` rejects because a `//`-leading path implies an authority a `file:` URI (empty authority) doesn't have. The throw is caught in `isValidFile` and logged at error level for every URL. This affects any `scheme://authority/path`, not just http/https. The URL itself is unaffected — `UrlLinkProvider` still linkifies http/https URLs.

The fix guards `toURI` to return `undefined` for a `//`-leading candidate: such a string can never be a valid single-authority `file:` URI, so it is never a local-file link regardless of scheme, and it is left to the URL link provider. `isValidFile` then yields `false` without reaching the throwing `withPath` — no error log, no false link, URL linkification unchanged. This is a root-cause guard at the URI-construction boundary (matching how the method already returns `undefined` for non-file candidates), not a blanket error swallow; it also covers the same latent throw in `open()`. The Windows path regex splits the leading `//` into a single slash during extraction, so the raw match is checked in addition to the extracted path.

#### How to test

1. Open a terminal and print a URL, e.g. `echo "see https://example.com/path for details"`.
2. Before the fix: `terminal:FileLinkProvider ERROR Error validating //example.com/path` appears in the browser console (and backend log). After the fix: no error is logged, and the http/https URL is still clickable via the URL link provider.
3. Confirm a genuine local path (e.g. `echo /path/to/existing-file.ts`) is still linkified.

The added `terminal-file-link-provider.spec.ts` covers the no-throw behavior for both `scheme://` and `file://` URLs and that genuine absolute local paths still resolve.

#### Follow-ups

A `file://` URL printed in the terminal is not linkified today: `UrlLinkProvider`'s regex only matches `https?://` (plus a localhost pattern), and `FileLinkProvider` skips the `///path` remainder that this guard now (correctly) rejects. Making `file://` links clickable (parse `file://[authority]/path`, resolve, and open) is a separate, self-contained enhancement — agreed with the reviewer to keep it out of this bug fix.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of JuliaHub, Inc.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
