### PR TITLE
fix(plugin-ext): defer plugin view initialization until layout restore completes

### DIFF
--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -277,9 +277,20 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
     }
 
     protected override async afterLoadContributions(toDisconnect: DisposableCollection): Promise<void> {
-        await this.viewRegistry.initWidgets();
-        // remove restored plugin widgets which were not registered by contributions
-        this.viewRegistry.removeStaleWidgets();
+        // Defer view initialization until the layout has been restored: initWidgets/removeStaleWidgets
+        // must not run while the ShellLayoutRestorer still holds restored plugin view widgets, otherwise
+        // removeStaleWidgets can dispose a restored view container mid-restore and abort the whole
+        // layout restoration (see https://github.com/eclipse-theia/theia/issues/17770).
+        // Deliberately not awaited: startPlugins runs after this hook and may register file system
+        // providers the layout restoration depends on (see beforeLoadContributions).
+        this.appState.reachedState('initialized_layout').then(async () => {
+            if (toDisconnect.disposed) {
+                return;
+            }
+            await this.viewRegistry.initWidgets();
+            // remove restored plugin widgets which were not registered by contributions
+            this.viewRegistry.removeStaleWidgets();
+        });
         this.workspaceTrustService.refreshRestrictedModeIndicator();
     }
 

--- a/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/browser/hosted-plugin.ts
@@ -290,7 +290,7 @@ export class HostedPluginSupport extends AbstractHostedPluginSupport<PluginManag
             await this.viewRegistry.initWidgets();
             // remove restored plugin widgets which were not registered by contributions
             this.viewRegistry.removeStaleWidgets();
-        });
+        }).catch(console.error);
         this.workspaceTrustService.refreshRestrictedModeIndicator();
     }
 


### PR DESCRIPTION
#### What it does

Fixes #17770 — since 1.71.0, plugin contributions load after `attached_shell` (not `initialized_layout`), so `afterLoadContributions` → `PluginViewRegistry.initWidgets()`/`removeStaleWidgets()` run concurrently with `ShellLayoutRestorer.restoreLayout()`. If the saved layout contains a `plugin-view-container` whose plugin has not registered its contributions yet (late deployment, failed install), `removeStaleWidgets()` disposes the restored widget while the restorer still holds it. `setLayoutData` then throws `Error: view container is disposed`, the whole layout restore is aborted, and the disposed title left in the `SideTabBar` breaks rendering of all activity bar tabs.

This PR defers `initWidgets()`/`removeStaleWidgets()` behind `appState.reachedState('initialized_layout')`, restoring the pre-1.71 guarantee that plugin view widgets are never disposed while the layout restorer references them. The deferral is deliberately **not awaited**: `startPlugins` runs after this hook and may register file system providers the restore depends on — blocking here would reintroduce the deadlock that the 1.71 change fixed (see the comment in `beforeLoadContributions`). If the connection is disposed before the layout initializes, the deferred work is skipped.

#### How to test

1. Open a workspace and open a plugin-contributed view container in the left panel, so it is stored in the layout.
2. Make that plugin register late or fail to deploy on the next start (e.g. a user-installed extension that is no longer resolvable at startup).
3. Reload repeatedly. Without this fix, layout restore intermittently fails with `view container is disposed` / `Could not restore layout` and the left activity bar renders no icons. With the fix, the layout is restored and the stale container is removed after `initialized_layout`, as before 1.71.

#### Follow-ups

Possible defense-in-depth (separate PR): tolerate disposed widgets in `ApplicationShell.setLayoutData`/side panel restore, and guard `TabBarRenderer`/`TabBarBadgeDecorator` so a single disposed widget cannot abort rendering of the entire tab bar.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
