### PR TITLE
fix(ai-ide): prevent searchInWorkspace tool from hanging

### DIFF
--- a/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import { CancellationTokenSource, PreferenceService } from '@theia/core';
 import { WorkspaceSearchProvider } from './workspace-search-provider';
 import { ToolInvocationContext } from '@theia/ai-core';
@@ -98,6 +99,106 @@ describe('Workspace Search Provider Cancellation Tests', () => {
 
         const jsonResponse = JSON.parse(result as string);
         expect(jsonResponse.error).to.equal('Operation cancelled by user');
+    });
+
+    it('should normalize a string fileExtensions argument into an include array without hanging', async () => {
+        let capturedOptions: SearchInWorkspaceOptions | undefined;
+        // Rebind the search service so it records the options and immediately completes the search.
+        container.rebind(SearchInWorkspaceService).toConstantValue({
+            searchWithCallback: async (
+                query: string,
+                rootUris: string[],
+                callbacks: SearchInWorkspaceCallbacks,
+                options: SearchInWorkspaceOptions
+            ) => {
+                capturedOptions = options;
+                callbacks.onDone?.(1);
+                return 1;
+            },
+            cancel: () => { }
+        } as unknown as SearchInWorkspaceService);
+
+        const searchProvider = container.get(WorkspaceSearchProvider);
+        const handler = searchProvider.getTool().handler;
+        // The model may emit fileExtensions as a bare string instead of an array.
+        const result = await handler(
+            JSON.stringify({ query: 'deleteSession', useRegExp: false, fileExtensions: 'spec.ts' }),
+            mockCtx
+        );
+
+        const jsonResponse = JSON.parse(result as string);
+        expect(jsonResponse.error).to.equal(undefined);
+        expect(capturedOptions?.include).to.deep.equal(['**/*.spec.ts']);
+    });
+
+    it('should time out instead of hanging when the search never reports completion', async () => {
+        // Reproduces the original hang: the backend returns a search id but onDone is never called,
+        // and previously the search could also never report an id at all.
+        container.rebind(SearchInWorkspaceService).toConstantValue({
+            searchWithCallback: () => new Promise<number>(() => { /* never resolves: no id, no onDone */ }),
+            cancel: () => { }
+        } as unknown as SearchInWorkspaceService);
+
+        const searchProvider = container.get(WorkspaceSearchProvider);
+        const handler = searchProvider.getTool().handler;
+
+        const clock = sinon.useFakeTimers();
+        try {
+            const resultPromise = handler(
+                JSON.stringify({ query: 'deleteSession', useRegExp: false }),
+                mockCtx
+            );
+            await clock.tickAsync(30000);
+            const jsonResponse = JSON.parse(await resultPromise as string);
+            expect(jsonResponse.error).to.equal('Search timed out after 30 seconds');
+        } finally {
+            clock.restore();
+        }
+    });
+
+    it('should return an error (not hang) when search setup fails', async () => {
+        // An empty workspace makes determineSearchRoots throw; the error must surface as a result.
+        container.rebind(WorkspaceFunctionScope).toConstantValue({
+            getRootMapping: () => new Map()
+        } as unknown as WorkspaceFunctionScope);
+
+        const searchProvider = container.get(WorkspaceSearchProvider);
+        const handler = searchProvider.getTool().handler;
+        const result = await handler(
+            JSON.stringify({ query: 'deleteSession', useRegExp: false }),
+            mockCtx
+        );
+
+        const jsonResponse = JSON.parse(result as string);
+        expect(jsonResponse.error).to.equal('No workspace has been opened yet');
+    });
+
+    it('should accept an array fileExtensions argument', async () => {
+        let capturedOptions: SearchInWorkspaceOptions | undefined;
+        container.rebind(SearchInWorkspaceService).toConstantValue({
+            searchWithCallback: async (
+                query: string,
+                rootUris: string[],
+                callbacks: SearchInWorkspaceCallbacks,
+                options: SearchInWorkspaceOptions
+            ) => {
+                capturedOptions = options;
+                callbacks.onDone?.(1);
+                return 1;
+            },
+            cancel: () => { }
+        } as unknown as SearchInWorkspaceService);
+
+        const searchProvider = container.get(WorkspaceSearchProvider);
+        const handler = searchProvider.getTool().handler;
+        const result = await handler(
+            JSON.stringify({ query: 'deleteSession', useRegExp: false, fileExtensions: ['ts', 'js'] }),
+            mockCtx
+        );
+
+        const jsonResponse = JSON.parse(result as string);
+        expect(jsonResponse.error).to.equal(undefined);
+        expect(capturedOptions?.include).to.deep.equal(['**/*.ts', '**/*.js']);
     });
 
 });

--- a/packages/ai-ide/src/browser/workspace-search-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.ts
@@ -117,7 +117,12 @@ export class WorkspaceSearchProvider implements ToolProvider {
 
     private async handleSearch(argString: string, cancellationToken?: CancellationToken): Promise<string> {
         try {
-            const args: { query: string, useRegExp: boolean, fileExtensions?: string[], subDirectoryPath?: string } = JSON.parse(argString);
+            const args: { query: string, useRegExp: boolean, fileExtensions?: string[] | string, subDirectoryPath?: string } = JSON.parse(argString);
+
+            if (cancellationToken?.isCancellationRequested) {
+                return JSON.stringify({ error: 'Operation cancelled by user' });
+            }
+
             const results: SearchInWorkspaceResult[] = [];
             let expectedSearchId: number | undefined;
             let searchCompleted = false;
@@ -128,11 +133,28 @@ export class WorkspaceSearchProvider implements ToolProvider {
                     searchCompleted = true;
                 }
             });
-            if (cancellationToken?.isCancellationRequested) {
-                return JSON.stringify({ error: 'Operation cancelled by user' });
+
+            // Use one more than our actual maximum. this way we can determine if we have more results than our maximum and warn the user
+            const maxResultsForTheiaAPI = this.preferenceService.get<number>(SEARCH_IN_WORKSPACE_MAX_RESULTS_PREF, 30) + 1;
+            const options: SearchInWorkspaceOptions = {
+                useRegExp: args.useRegExp,
+                matchCase: false,
+                matchWholeWord: false,
+                maxResults: maxResultsForTheiaAPI,
+            };
+
+            // The model may supply fileExtensions as a single string instead of an array; normalize to an array so that `.map` never throws.
+            const fileExtensions = args.fileExtensions === undefined ? undefined
+                : Array.isArray(args.fileExtensions) ? args.fileExtensions
+                    : [args.fileExtensions];
+            if (fileExtensions && fileExtensions.length > 0) {
+                options.include = fileExtensions.map(ext => `**/*.${ext}`);
             }
 
-            const searchPromise = new Promise<SearchInWorkspaceResult[]>(async (resolve, reject) => {
+            // Resolve the search roots before starting the search so that any error is reported through the outer try/catch.
+            const rootUris = await this.determineSearchRoots(args.subDirectoryPath);
+
+            const searchPromise = new Promise<SearchInWorkspaceResult[]>((resolve, reject) => {
                 const callbacks: SearchInWorkspaceCallbacks = {
                     onResult: (id, result) => {
                         if (expectedSearchId !== undefined && id !== expectedSearchId) {
@@ -163,26 +185,13 @@ export class WorkspaceSearchProvider implements ToolProvider {
                     }
                 };
 
-                // Use one more than our actual maximum. this way we can determine if we have more results than our maximum and warn the user
-                const maxResultsForTheiaAPI = this.preferenceService.get<number>(SEARCH_IN_WORKSPACE_MAX_RESULTS_PREF, 30) + 1;
-                const options: SearchInWorkspaceOptions = {
-                    useRegExp: args.useRegExp,
-                    matchCase: false,
-                    matchWholeWord: false,
-                    maxResults: maxResultsForTheiaAPI,
-                };
-
-                if (args.fileExtensions && args.fileExtensions.length > 0) {
-                    options.include = args.fileExtensions.map(ext => `**/*.${ext}`);
-                }
-
-                await this.determineSearchRoots(args.subDirectoryPath)
-                    .then(rootUris => this.searchService.searchWithCallback(args.query, rootUris, callbacks, options))
+                this.searchService.searchWithCallback(args.query, rootUris, callbacks, options)
                     .then(id => {
                         expectedSearchId = id;
-                        cancellationToken?.onCancellationRequested(() => {
+                        // Handle cancellation that was requested before the search id became available.
+                        if (cancellationToken?.isCancellationRequested && !searchCompleted) {
                             this.searchService.cancel(id);
-                        });
+                        }
                     })
                     .catch(err => {
                         searchCompleted = true;
@@ -192,8 +201,10 @@ export class WorkspaceSearchProvider implements ToolProvider {
 
             const timeoutPromise = new Promise<SearchInWorkspaceResult[]>((_, reject) => {
                 setTimeout(() => {
-                    if (expectedSearchId !== undefined && !searchCompleted) {
-                        this.searchService.cancel(expectedSearchId);
+                    if (!searchCompleted) {
+                        if (expectedSearchId !== undefined) {
+                            this.searchService.cancel(expectedSearchId);
+                        }
                         searchCompleted = true;
                         reject(new Error('Search timed out after 30 seconds'));
                     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Normalize the `fileExtensions` argument when the model supplies a single string instead of an array, avoiding a "fileExtensions.map is not a function" error that left the tool hanging and blocking the agent
- Move search-root resolution and option setup out of the Promise executor and drop the async executor, so setup errors are returned through the outer try/catch instead of becoming an orphaned unhandled rejection that never settles the search promise
- Make the 30s timeout a real backstop by no longer gating it on the search id being known, so a search that never reports an id can no longer hang forever
- Add tests for string and array fileExtensions, the timeout path, and search-setup failures

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

  1. Open an AI chat with an agent that can call tools (e.g. Coder).
  2. Ask it to search the workspace in a way that makes the model pass fileExtensions as a single
  string, e.g. "search for deleteSession in .spec.ts files under packages/ai-ide".
  3. Before the fix: the tool call hangs indefinitely and the console shows TypeError:
  fileExtensions.map is not a function. After the fix: the search returns results normally.
  4. Unit tests: npx lerna run test --scope @theia/ai-ide (covers string/array fileExtensions, the
  30s timeout backstop, and setup-failure paths).

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
