### PR TITLE
feat(ai-ide): render delegated sessions as children in session list

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -447,10 +447,34 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
 
     protected async askForChatSession(): Promise<QuickPickItem | undefined> {
         const getItems = async (): Promise<(QuickPickItem | QuickPickSeparator)[]> => {
-            const activeSessions = this.chatService.getSessions()
+            const allActiveSessions = this.chatService.getSessions();
+
+            // Try to load persisted sessions, but don't fail if it doesn't work
+            interface PersistedSessionPickItem {
+                isActive: false;
+                isChild: boolean;
+                id: string;
+                title: string;
+                lastDate: number;
+                firstRequestText: undefined;
+                agentIconClass: string | undefined;
+                agentName: string | undefined;
+            }
+            let persistedIndex: Record<string, ChatSessionMetadata> = {};
+            try {
+                persistedIndex = await this.chatService.getPersistedSessions();
+            } catch (error) {
+                this.logger.error('Failed to load persisted sessions, showing only active sessions', error);
+                // Continue with just active sessions
+            }
+
+            // Show every session here, including delegated child sessions, so all are reachable. Child
+            // sessions are flagged so the picker can mark them rather than nesting them like the home view.
+            const activeSessions = allActiveSessions
                 .filter(session => session.title)
                 .map(session => ({
                     isActive: true as const,
+                    isChild: !!session.rootSessionId,
                     id: session.id,
                     title: session.title!,
                     lastDate: session.lastInteraction ? session.lastInteraction.getTime() : 0,
@@ -460,42 +484,27 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                 }))
                 .sort((a, b) => b.lastDate - a.lastDate);
 
-            // Try to load persisted sessions, but don't fail if it doesn't work
-            interface PersistedSessionPickItem {
-                isActive: false;
-                id: string;
-                title: string;
-                lastDate: number;
-                firstRequestText: undefined;
-                agentIconClass: string | undefined;
-                agentName: string | undefined;
-            }
-            let persistedSessions: PersistedSessionPickItem[] = [];
-            try {
-                const persistedIndex = await this.chatService.getPersistedSessions();
-                const activeIds = new Set(activeSessions.map(s => s.id));
-                persistedSessions = Object.values(persistedIndex)
-                    .filter(metadata => !activeIds.has(metadata.sessionId))
-                    .map(metadata => {
-                        const agent = metadata.pinnedAgentId ? this.chatAgentService.getAgent(metadata.pinnedAgentId) : undefined;
-                        return {
-                            isActive: false as const,
-                            id: metadata.sessionId,
-                            title: metadata.title,
-                            lastDate: metadata.saveDate,
-                            firstRequestText: undefined,
-                            agentIconClass: agent?.iconClass,
-                            agentName: agent?.name
-                        };
-                    })
-                    .sort((a, b) => b.lastDate - a.lastDate);
-            } catch (error) {
-                this.logger.error('Failed to load persisted sessions, showing only active sessions', error);
-                // Continue with just active sessions
-            }
+            const activeIds = new Set(activeSessions.map(s => s.id));
+            const persistedSessions: PersistedSessionPickItem[] = Object.values(persistedIndex)
+                .filter(metadata => !activeIds.has(metadata.sessionId))
+                .map(metadata => {
+                    const agent = metadata.pinnedAgentId ? this.chatAgentService.getAgent(metadata.pinnedAgentId) : undefined;
+                    return {
+                        isActive: false as const,
+                        isChild: !!metadata.rootSessionId,
+                        id: metadata.sessionId,
+                        title: metadata.title,
+                        lastDate: metadata.saveDate,
+                        firstRequestText: undefined,
+                        agentIconClass: agent?.iconClass,
+                        agentName: agent?.name
+                    };
+                })
+                .sort((a, b) => b.lastDate - a.lastDate);
 
             interface SessionPickItem {
                 isActive: boolean;
+                isChild: boolean;
                 id: string;
                 title: string;
                 lastDate: number;
@@ -515,9 +524,13 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
                     icon = '$(archive) ';
                 }
                 const label = `${icon}${session.title}`;
-                // Mirror the home-view item subtitle: "@Agent · time ago"
+                // Mirror the home-view item subtitle: "@Agent · time ago". Child sessions are shown
+                // flat here (the home view nests them), so tag them as delegated to keep them distinct.
                 const timeAgo = formatTimeAgo(session.lastDate);
-                const description = session.agentName ? `@${session.agentName} · ${timeAgo}` : timeAgo;
+                const subtitle = session.agentName ? `@${session.agentName} · ${timeAgo}` : timeAgo;
+                const description = session.isChild
+                    ? `${subtitle} · ${nls.localize('theia/ai/chat-ui/delegatedSession', 'Delegated')}`
+                    : subtitle;
                 return {
                     label,
                     description,

--- a/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
@@ -248,4 +248,20 @@ describe('AgentDelegationTool', () => {
             expect(result).to.equal('');
         });
     });
+
+    describe('delegateToAgent() — session persistence', () => {
+        it('does not delete the delegated session after completion', async () => {
+            const newSession = makeNewSession();
+            const agentService = makeChatAgentService();
+            const chatService = makeChatService(newSession);
+            const tool = makeAgentDelegationTool(agentService, chatService);
+            const ctx = makeChatContext();
+
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
+            await tool.getTool().handler(argString, ctx);
+
+            // deleteSession should never have been called for the delegated session
+            expect((chatService.deleteSession as sinon.SinonStub).called).to.be.false;
+        });
+    });
 });

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -124,8 +124,6 @@ export class AgentDelegationTool implements ToolProvider {
             let newSession;
             let childModelDisposable: Disposable | undefined;
             try {
-                // FIXME: this creates a new conversation visible in the UI (Panel), which we don't want
-                // It is not possible to start a session without specifying a location (default=Panel)
                 const chatService = this.getChatService();
 
                 // Store the current active session to restore it after delegation
@@ -142,6 +140,12 @@ export class AgentDelegationTool implements ToolProvider {
                 const rootId = ctx.rootSessionId || ctx.request.session.id;
                 newSession.rootSessionId = rootId;
                 newSession.model.rootSessionId = rootId;
+
+                // Track the immediate parent (the delegating session) so the UI can render the full
+                // delegation hierarchy, not just a flat list under the root.
+                const parentId = ctx.request.session.id;
+                newSession.parentSessionId = parentId;
+                newSession.model.parentSessionId = parentId;
 
                 if (taskContextId) {
                     newSession.model.context.addVariables({
@@ -222,12 +226,8 @@ export class AgentDelegationTool implements ToolProvider {
                         .filter((text): text is string => text !== undefined && text !== '')
                         .join('\n\n');
 
-                    // Clean up the session and parent-child link after completion
+                    // Clean up the parent-child link after completion (event bubbling is no longer needed)
                     childModelDisposable?.dispose();
-                    const chatService = this.getChatService();
-                    chatService.deleteSession(newSession.id).catch(error => {
-                        this.logger.error('Failed to delete delegated session', error);
-                    });
 
                     // Return the raw text to the top-level Agent, as a tool result
                     return stringResult;

--- a/packages/ai-chat/src/browser/chat-session-store-impl.spec.ts
+++ b/packages/ai-chat/src/browser/chat-session-store-impl.spec.ts
@@ -63,12 +63,13 @@ describe('ChatSessionStoreImpl', () => {
     const GLOBAL_CONFIG_DIR = 'file:///__test__/mock-config';
     const DEFAULT_STORAGE_SCOPE: SessionStorageScope = 'workspace';
 
-    function createMockSessionMetadata(id: string, saveDate: number): ChatSessionMetadata {
+    function createMockSessionMetadata(id: string, saveDate: number, rootSessionId?: string): ChatSessionMetadata {
         return {
             sessionId: id,
             title: `Session ${id}`,
             saveDate,
-            location: ChatAgentLocation.Panel
+            location: ChatAgentLocation.Panel,
+            rootSessionId
         };
     }
 
@@ -699,6 +700,65 @@ describe('ChatSessionStoreImpl', () => {
 
             // readFile should have been called twice
             expect(mockFileService.readFile.callCount).to.equal(2);
+        });
+    });
+
+    describe('rootSessionId persistence', () => {
+        const mockModel = (id: string) => ({
+            id,
+            isEmpty: () => false,
+            location: ChatAgentLocation.Panel,
+            toSerializable: () => ({
+                location: ChatAgentLocation.Panel,
+                requests: [],
+                responses: [],
+                hierarchy: { rootBranchId: '', branches: {} }
+            })
+        });
+
+        it('should include rootSessionId in the session index when updating', async () => {
+            mockPreferenceService.get.withArgs(PERSISTED_SESSION_LIMIT_PREF, 25).returns(25);
+
+            const sessions = [
+                { model: mockModel('parent-session') as never, title: 'Parent Session', saveDate: 1000, pinnedAgentId: undefined, rootSessionId: undefined },
+                { model: mockModel('child-session') as never, title: 'Child Session', saveDate: 2000, pinnedAgentId: undefined, rootSessionId: 'parent-session' }
+            ] as never[];
+
+            // Setup index file response
+            const index = { 'parent-session': { sessionId: 'parent-session', title: 'Parent Session', saveDate: 1000, location: 'panel' } };
+            mockFileService.readFile.resolves({
+                value: BinaryBuffer.fromString(JSON.stringify(index))
+            } as never);
+
+            // Access protected method via any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (chatSessionStore as any).updateIndex(sessions);
+
+            const savedIndexCall = mockFileService.writeFile.lastCall;
+            const savedIndex = JSON.parse(savedIndexCall.args[1].toString());
+            expect(savedIndex['child-session']).to.not.be.undefined;
+            expect(savedIndex['child-session'].rootSessionId).to.equal('parent-session');
+        });
+
+        it('should handle sessions without rootSessionId', async () => {
+            mockPreferenceService.get.withArgs(PERSISTED_SESSION_LIMIT_PREF, 25).returns(25);
+
+            const sessions = [
+                { model: mockModel('standalone-session') as never, title: 'Standalone Session', saveDate: 1000, pinnedAgentId: undefined, rootSessionId: undefined }
+            ] as never[];
+
+            const index = { 'standalone-session': { sessionId: 'standalone-session', title: 'Standalone Session', saveDate: 1000, location: 'panel' } };
+            mockFileService.readFile.resolves({
+                value: BinaryBuffer.fromString(JSON.stringify(index))
+            } as never);
+
+            // Access protected method via any
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            await (chatSessionStore as any).updateIndex(sessions);
+
+            const savedIndexCall = mockFileService.writeFile.lastCall;
+            const savedIndex = JSON.parse(savedIndexCall.args[1].toString());
+            expect(savedIndex['standalone-session'].rootSessionId).to.be.undefined;
         });
     });
 

--- a/packages/ai-chat/src/browser/chat-session-store-impl.ts
+++ b/packages/ai-chat/src/browser/chat-session-store-impl.ts
@@ -116,6 +116,8 @@ export class ChatSessionStoreImpl implements ChatSessionStore {
                     title: session.title,
                     pinnedAgentId: session.pinnedAgentId,
                     saveDate: session.saveDate,
+                    rootSessionId: session.rootSessionId,
+                    parentSessionId: session.parentSessionId,
                     model: modelData
                 };
                 this.logger.debug('Writing session to file', {

--- a/packages/ai-chat/src/common/chat-model-serialization.ts
+++ b/packages/ai-chat/src/common/chat-model-serialization.ts
@@ -201,6 +201,10 @@ export interface SerializedChatData {
     title?: string;
     model: SerializedChatModel;
     saveDate: number;
+    /** ID of the root session in the delegation chain. */
+    rootSessionId?: string;
+    /** ID of the immediate parent session that delegated this one. */
+    parentSessionId?: string;
 }
 
 export interface SerializableChatsData {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -334,6 +334,8 @@ export interface ChatModel {
     readonly status: ChatSessionStatus;
     /** ID of the root session in the delegation chain. For delegated sessions, this points to the topmost session where task contexts are stored. */
     rootSessionId?: string;
+    /** ID of the immediate parent session that delegated this one. Undefined for top-level sessions. */
+    parentSessionId?: string;
     getRequests(): ChatRequestModel[];
     getBranches(): ChatHierarchyBranch<ChatRequestModel>[];
     isEmpty(): boolean;
@@ -1135,6 +1137,7 @@ export class MutableChatModel implements ChatModel, Disposable {
     protected _location: ChatAgentLocation;
     protected _status: ChatSessionStatus = 'idle';
     rootSessionId?: string;
+    parentSessionId?: string;
 
     get location(): ChatAgentLocation {
         return this._location;

--- a/packages/ai-chat/src/common/chat-service-deletion.spec.ts
+++ b/packages/ai-chat/src/common/chat-service-deletion.spec.ts
@@ -267,6 +267,58 @@ describe('ChatService Session Deletion', () => {
             expect(sessionStore.deletedSessions).to.include(persistedSessionId);
         });
 
+        it('should cascade-delete descendants when deleting an intermediate session (A -> B -> C, in memory)', async () => {
+            // Delegation chain A -> B -> C, all loaded in memory. C's rootSessionId points at A (the
+            // root of the chain), but its immediate parent is B, so deleting B must still remove C.
+            const a = chatService.createSession(ChatAgentLocation.Panel);
+            const b = chatService.createSession(ChatAgentLocation.Panel);
+            const c = chatService.createSession(ChatAgentLocation.Panel);
+            const internal = b as unknown as { rootSessionId?: string; parentSessionId?: string };
+            internal.rootSessionId = a.id;
+            internal.parentSessionId = a.id;
+            const cInternal = c as unknown as { rootSessionId?: string; parentSessionId?: string };
+            cInternal.rootSessionId = a.id;
+            cInternal.parentSessionId = b.id;
+
+            await chatService.deleteSession(b.id);
+
+            const remaining = chatService.getSessions().map(s => s.id);
+            expect(remaining).to.include(a.id);
+            expect(remaining).to.not.include(b.id);
+            expect(remaining).to.not.include(c.id);
+            expect(sessionStore.deletedSessions).to.include(b.id);
+            expect(sessionStore.deletedSessions).to.include(c.id);
+        });
+
+        it('should cascade-delete persisted-only descendants of an intermediate session', async () => {
+            // The whole chain lives only in the persisted index (e.g. after a reload). Deleting the
+            // intermediate B must reach C via its parentSessionId even though C's rootSessionId is A.
+            sessionStore.getSessionIndex = async (): Promise<ChatSessionIndex> => ({
+                A: { sessionId: 'A', title: 'A', saveDate: 0, location: ChatAgentLocation.Panel },
+                B: { sessionId: 'B', title: 'B', saveDate: 0, location: ChatAgentLocation.Panel, rootSessionId: 'A', parentSessionId: 'A' },
+                C: { sessionId: 'C', title: 'C', saveDate: 0, location: ChatAgentLocation.Panel, rootSessionId: 'A', parentSessionId: 'B' }
+            });
+
+            await chatService.deleteSession('B');
+
+            expect(sessionStore.deletedSessions).to.include('B');
+            expect(sessionStore.deletedSessions).to.include('C');
+            expect(sessionStore.deletedSessions).to.not.include('A');
+        });
+
+        it('should not loop forever on a cyclic parent reference', async () => {
+            // Defensive: a corrupted index where two sessions reference each other must still terminate.
+            sessionStore.getSessionIndex = async (): Promise<ChatSessionIndex> => ({
+                X: { sessionId: 'X', title: 'X', saveDate: 0, location: ChatAgentLocation.Panel, parentSessionId: 'Y' },
+                Y: { sessionId: 'Y', title: 'Y', saveDate: 0, location: ChatAgentLocation.Panel, parentSessionId: 'X' }
+            });
+
+            await chatService.deleteSession('X');
+
+            expect(sessionStore.deletedSessions).to.include('X');
+            expect(sessionStore.deletedSessions).to.include('Y');
+        });
+
         it('should fire SessionDeletedEvent for persisted-only sessions', async () => {
             // When deleting a persisted-only session (not in memory),
             // we still fire the event so consumers (e.g. the Welcome view's chat cards)

--- a/packages/ai-chat/src/common/chat-service.spec.ts
+++ b/packages/ai-chat/src/common/chat-service.spec.ts
@@ -1,0 +1,211 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Container } from '@theia/core/shared/inversify';
+import { ChatServiceImpl } from './chat-service';
+import { ChatAgentService } from './chat-agent-service';
+import { ChatSessionStore } from './chat-session-store';
+import { ChatContentDeserializerRegistry } from './chat-content-deserializer';
+import { ChangeSetElementDeserializerRegistry } from './change-set-element-deserializer';
+import { ToolInvocationRegistry, AIVariableService } from '@theia/ai-core';
+import { ILogger } from '@theia/core';
+import { ChatRequestParser } from './chat-request-parser';
+
+disableJSDOM();
+
+describe('ChatServiceImpl', () => {
+    let sandbox: sinon.SinonSandbox;
+    let chatService: ChatServiceImpl;
+    let mockSessionStore: sinon.SinonStubbedInstance<ChatSessionStore>;
+    let mockAgentService: sinon.SinonStubbedInstance<ChatAgentService>;
+    let mockDeserRegistry: sinon.SinonStubbedInstance<ChatContentDeserializerRegistry>;
+    let mockChangeSetDeserRegistry: sinon.SinonStubbedInstance<ChangeSetElementDeserializerRegistry>;
+    let mockToolInvocationRegistry: sinon.SinonStubbedInstance<ToolInvocationRegistry>;
+    let mockVariableService: sinon.SinonStubbedInstance<AIVariableService>;
+    let mockRequestParser: sinon.SinonStubbedInstance<ChatRequestParser>;
+    let mockLogger: sinon.SinonStubbedInstance<ILogger>;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+
+        mockSessionStore = {
+            storeSessions: sandbox.stub().resolves(),
+            readSession: sandbox.stub().resolves(undefined) as never,
+            deleteSession: sandbox.stub().resolves() as never,
+            clearAllSessions: sandbox.stub().resolves() as never,
+            getSessionIndex: sandbox.stub().resolves({}) as never,
+            hasPersistedSessions: sandbox.stub().resolves(false) as never
+        };
+
+        mockAgentService = {
+            getAgent: sandbox.stub().returns(undefined),
+            getAgents: sandbox.stub().returns([]),
+            resolveAgent: sandbox.stub().returns(undefined)
+        } as sinon.SinonStubbedInstance<ChatAgentService>;
+
+        mockDeserRegistry = {
+            deserialize: sandbox.stub().resolves([])
+        } as sinon.SinonStubbedInstance<ChatContentDeserializerRegistry>;
+
+        mockChangeSetDeserRegistry = {
+            deserialize: sandbox.stub().resolves([])
+        } as sinon.SinonStubbedInstance<ChangeSetElementDeserializerRegistry>;
+
+        mockToolInvocationRegistry = {
+            getFunction: sandbox.stub().returns(undefined)
+        } as sinon.SinonStubbedInstance<ToolInvocationRegistry>;
+
+        mockVariableService = {
+            resolveVariable: sandbox.stub().resolves(undefined)
+        } as sinon.SinonStubbedInstance<AIVariableService>;
+
+        mockRequestParser = {
+            parseChatRequest: sandbox.stub().resolves({ parts: [], toolRequests: [], variables: [] })
+        } as sinon.SinonStubbedInstance<ChatRequestParser>;
+
+        mockLogger = {
+            debug: sandbox.stub(),
+            info: sandbox.stub(),
+            warn: sandbox.stub(),
+            error: sandbox.stub()
+        } as sinon.SinonStubbedInstance<ILogger>;
+
+        const container = new Container();
+        container.bind(ChatServiceImpl).toSelf().inSingletonScope();
+        container.bind(ChatAgentService).toConstantValue(mockAgentService);
+        container.bind(ChatSessionStore).toConstantValue(mockSessionStore);
+        container.bind(ChatContentDeserializerRegistry).toConstantValue(mockDeserRegistry);
+        container.bind(ChangeSetElementDeserializerRegistry).toConstantValue(mockChangeSetDeserRegistry);
+        container.bind(ToolInvocationRegistry).toConstantValue(mockToolInvocationRegistry);
+        container.bind(ChatRequestParser).toConstantValue(mockRequestParser);
+        container.bind(AIVariableService).toConstantValue(mockVariableService);
+        container.bind(ILogger).toConstantValue(mockLogger);
+
+        chatService = container.get(ChatServiceImpl);
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('deleteSession', () => {
+        it('should delete child sessions when deleting a parent session', async () => {
+            // Create a parent session
+            const parentSession = chatService.createSession();
+
+            // Create a child session by directly setting rootSessionId
+            const childSession = chatService.createSession();
+            childSession.rootSessionId = parentSession.id;
+
+            // Delete the parent session
+            await chatService.deleteSession(parentSession.id);
+
+            // Verify parent session was deleted
+            expect(chatService.getSession(parentSession.id)).to.be.undefined;
+
+            // Verify child session was also deleted (cascade delete)
+            expect(chatService.getSession(childSession.id)).to.be.undefined;
+
+            // Verify deleteSession was called for both sessions
+            expect(mockSessionStore.deleteSession.callCount).to.equal(2);
+            expect(mockSessionStore.deleteSession.calledWith(parentSession.id)).to.be.true;
+            expect(mockSessionStore.deleteSession.calledWith(childSession.id)).to.be.true;
+        });
+
+        it('should handle multiple child sessions', async () => {
+            // Create a parent session
+            const parentSession = chatService.createSession();
+
+            // Create multiple child sessions
+            const child1 = chatService.createSession();
+            child1.rootSessionId = parentSession.id;
+            const child2 = chatService.createSession();
+            child2.rootSessionId = parentSession.id;
+            const child3 = chatService.createSession();
+            child3.rootSessionId = parentSession.id;
+
+            // Delete the parent session
+            await chatService.deleteSession(parentSession.id);
+
+            // Verify all sessions were deleted
+            expect(chatService.getSession(parentSession.id)).to.be.undefined;
+            expect(chatService.getSession(child1.id)).to.be.undefined;
+            expect(chatService.getSession(child2.id)).to.be.undefined;
+            expect(chatService.getSession(child3.id)).to.be.undefined;
+
+            // Verify deleteSession was called for all sessions
+            expect(mockSessionStore.deleteSession.callCount).to.equal(4);
+        });
+
+        it('should not delete sessions without rootSessionId', async () => {
+            // Create a standalone session
+            const standaloneSession = chatService.createSession();
+
+            // Delete it
+            await chatService.deleteSession(standaloneSession.id);
+
+            // Verify only that session was deleted
+            expect(chatService.getSession(standaloneSession.id)).to.be.undefined;
+            expect(mockSessionStore.deleteSession.callCount).to.equal(1);
+        });
+
+        it('should delete persisted-only child sessions that are not loaded in memory', async () => {
+            // Parent is in memory; the child exists only in the persisted index (e.g. after a reload).
+            const parentSession = chatService.createSession();
+            const persistedChildId = 'persisted-child-id';
+            mockSessionStore.getSessionIndex.resolves({
+                [persistedChildId]: {
+                    sessionId: persistedChildId,
+                    title: 'Persisted child',
+                    saveDate: 0,
+                    location: parentSession.model.location,
+                    rootSessionId: parentSession.id
+                }
+            });
+
+            await chatService.deleteSession(parentSession.id);
+
+            // Both the in-memory parent and the persisted-only child are removed from storage.
+            expect(mockSessionStore.deleteSession.calledWith(parentSession.id)).to.be.true;
+            expect(mockSessionStore.deleteSession.calledWith(persistedChildId)).to.be.true;
+        });
+
+        it('should not delete sessions with different rootSessionId', async () => {
+            // Create two independent sessions
+            const session1 = chatService.createSession();
+            const session2 = chatService.createSession();
+
+            // Set session2 as a child of a non-existent session
+            session2.rootSessionId = 'non-existent-session-id';
+
+            // Delete session1
+            await chatService.deleteSession(session1.id);
+
+            // Verify only session1 was deleted
+            expect(chatService.getSession(session1.id)).to.be.undefined;
+            expect(chatService.getSession(session2.id)).to.not.be.undefined;
+            expect(mockSessionStore.deleteSession.callCount).to.equal(1);
+            expect(mockSessionStore.deleteSession.calledWith(session1.id)).to.be.true;
+        });
+    });
+});

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -226,12 +226,24 @@ export class ChatServiceImpl implements ChatService {
     }
 
     async deleteSession(sessionId: string): Promise<void> {
-        // Delete children (sessions whose rootSessionId points to this session) first. Children may
-        // live only in memory, only in persisted storage (e.g. after a reload, not yet restored),
-        // or both, so collect ids from both sources to avoid orphaning persisted-only children.
+        await this.deleteSessionAndChildren(sessionId, new Set<string>());
+    }
+
+    protected async deleteSessionAndChildren(sessionId: string, visited: Set<string>): Promise<void> {
+        if (visited.has(sessionId)) {
+            return;
+        }
+        visited.add(sessionId);
+
+        // Delete children first. A child is any session whose immediate parent (parentSessionId) or root
+        // (rootSessionId) points to this session. Matching parentSessionId is what lets us cascade through
+        // intermediate levels: deleting B in A -> B -> C reaches C via its parentSessionId even though C's
+        // rootSessionId still points at A. Children may live only in memory, only in persisted storage
+        // (e.g. after a reload, not yet restored), or both, so collect ids from both sources. The visited
+        // set guards against cycles and re-deleting a child reachable from more than one ancestor.
         const childIds = new Set<string>();
         for (const s of this._sessions) {
-            if (s.rootSessionId === sessionId) {
+            if (s.parentSessionId === sessionId || s.rootSessionId === sessionId) {
                 childIds.add(s.id);
             }
         }
@@ -239,7 +251,7 @@ export class ChatServiceImpl implements ChatService {
             try {
                 const index = await this.sessionStore.getSessionIndex();
                 for (const metadata of Object.values(index)) {
-                    if (metadata.rootSessionId === sessionId) {
+                    if (metadata.parentSessionId === sessionId || metadata.rootSessionId === sessionId) {
                         childIds.add(metadata.sessionId);
                     }
                 }
@@ -248,7 +260,7 @@ export class ChatServiceImpl implements ChatService {
             }
         }
         for (const childId of childIds) {
-            await this.deleteSession(childId);
+            await this.deleteSessionAndChildren(childId, visited);
         }
 
         const sessionIndex = this._sessions.findIndex(candidate => candidate.id === sessionId);

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -73,6 +73,8 @@ export interface ChatSession {
     pinnedAgent?: ChatAgent;
     /** ID of the root session in the delegation chain. For delegated sessions, this points to the topmost session where task contexts are stored. */
     rootSessionId?: string;
+    /** ID of the immediate parent session that delegated this one. Undefined for top-level sessions. */
+    parentSessionId?: string;
 }
 
 export interface ActiveSessionChangedEvent {
@@ -224,6 +226,31 @@ export class ChatServiceImpl implements ChatService {
     }
 
     async deleteSession(sessionId: string): Promise<void> {
+        // Delete children (sessions whose rootSessionId points to this session) first. Children may
+        // live only in memory, only in persisted storage (e.g. after a reload, not yet restored),
+        // or both, so collect ids from both sources to avoid orphaning persisted-only children.
+        const childIds = new Set<string>();
+        for (const s of this._sessions) {
+            if (s.rootSessionId === sessionId) {
+                childIds.add(s.id);
+            }
+        }
+        if (this.sessionStore) {
+            try {
+                const index = await this.sessionStore.getSessionIndex();
+                for (const metadata of Object.values(index)) {
+                    if (metadata.rootSessionId === sessionId) {
+                        childIds.add(metadata.sessionId);
+                    }
+                }
+            } catch (error) {
+                this.logger.error('Failed to read session index for cascade delete', { sessionId, error });
+            }
+        }
+        for (const childId of childIds) {
+            await this.deleteSession(childId);
+        }
+
         const sessionIndex = this._sessions.findIndex(candidate => candidate.id === sessionId);
 
         // If session is in memory, remove it
@@ -458,9 +485,15 @@ export class ChatServiceImpl implements ChatService {
         // Store session with title, pinned agent info, last interaction timestamp, and error state
         const lastRequest = session.model.getRequests().at(-1);
         const hasError = lastRequest?.response.isComplete === true && lastRequest?.response.isError === true;
-        return this.sessionStore.storeSessions(
-            { model: session.model, title: session.title, pinnedAgentId: session.pinnedAgent?.id, lastInteraction: session.lastInteraction?.getTime(), hasError }
-        ).catch(error => {
+        return this.sessionStore.storeSessions({
+            model: session.model,
+            title: session.title,
+            pinnedAgentId: session.pinnedAgent?.id,
+            lastInteraction: session.lastInteraction?.getTime(),
+            hasError,
+            rootSessionId: session.rootSessionId,
+            parentSessionId: session.parentSessionId
+        }).catch(error => {
             this.logger.error('Failed to store chat sessions', error);
         });
     }
@@ -517,8 +550,12 @@ export class ChatServiceImpl implements ChatService {
             lastInteraction: new Date(serialized.saveDate),
             model,
             isActive: false,
-            pinnedAgent
+            pinnedAgent,
+            rootSessionId: serialized.rootSessionId,
+            parentSessionId: serialized.parentSessionId
         };
+        session.model.rootSessionId = serialized.rootSessionId;
+        session.model.parentSessionId = serialized.parentSessionId;
         this._sessions.push(session);
         this.setupAutoSaveForSession(session);
         this.onSessionEventEmitter.fire({ type: 'created', sessionId: session.id });

--- a/packages/ai-chat/src/common/chat-session-store.ts
+++ b/packages/ai-chat/src/common/chat-session-store.ts
@@ -28,6 +28,10 @@ export interface ChatModelWithMetadata {
     lastInteraction?: number;
     /** Whether the last request ended with an error. */
     hasError?: boolean;
+    /** ID of the root session in the delegation chain. */
+    rootSessionId?: string;
+    /** ID of the immediate parent session that delegated this one. */
+    parentSessionId?: string;
 }
 
 export interface ChatSessionStore {
@@ -75,4 +79,8 @@ export interface ChatSessionMetadata {
     pinnedAgentId?: string;
     /** Whether the last request ended with an error. */
     hasError?: boolean;
+    /** ID of the root session in the delegation chain. */
+    rootSessionId?: string;
+    /** ID of the immediate parent session that delegated this one. */
+    parentSessionId?: string;
 }

--- a/packages/ai-ide/src/browser/chat-session-item.tsx
+++ b/packages/ai-ide/src/browser/chat-session-item.tsx
@@ -45,6 +45,21 @@ export interface ChatSessionItemProps {
     actions?: ChatSessionItemAction[];
     /** Invoked when an action is triggered, with the action and this item's session. */
     onAction?: (action: ChatSessionItemAction, session: ChatSessionMetadata) => void;
+    /**
+     * Whether this session has child sessions. The children themselves are rendered separately by
+     * the parent list; this only drives the expand/collapse toggle.
+     */
+    hasChildSessions?: boolean;
+    /** Whether this item is a child of a parent session. */
+    isChildSession?: boolean;
+    /** Depth level for indentation. */
+    depth?: number;
+    /** Whether the parent session is expanded. */
+    isExpanded?: boolean;
+    /** Whether any descendant session needs user action; shows a warning badge on this row. */
+    descendantNeedsAttention?: boolean;
+    /** Called when the user toggles the expand/collapse state. */
+    onToggleExpand?: () => void;
 }
 
 /** Subscribes the component to the unread flag for one session. */
@@ -92,7 +107,12 @@ export interface ChatSessionItemComponentProps extends ChatSessionItemProps {
 }
 
 export function ChatSessionItem(props: ChatSessionItemComponentProps): React.ReactElement {
-    const { session, isRestored, chatService, chatAgentService, hoverService, markdownRenderer, unreadState, onClick, actions, onAction, formatTimeAgo } = props;
+    const {
+        session, isRestored, chatService, chatAgentService, hoverService, markdownRenderer, unreadState,
+        onClick, actions, onAction, formatTimeAgo, hasChildSessions, isChildSession, depth, isExpanded,
+        descendantNeedsAttention, onToggleExpand
+    } = props;
+    const currentDepth = depth ?? 0;
 
     // eslint-disable-next-line no-null/no-null
     const itemRef = React.useRef<HTMLDivElement | null>(null);
@@ -155,13 +175,13 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
         // once the session is actually opened.
         const loadedSession = chatService.getSession(session.sessionId);
         const tooltip = loadedSession
-            ? buildSessionTooltip(loadedSession, session, chatAgentService, markdownRenderer, hasUnread)
-            : buildRestoredSessionTooltip(session, chatAgentService);
+            ? buildSessionTooltip(loadedSession, session, chatAgentService, markdownRenderer, hasUnread, descendantNeedsAttention)
+            : buildRestoredSessionTooltip(session, chatAgentService, descendantNeedsAttention);
         // The tooltip may hold a markdown render result; dispose it once the hover is torn down
         // (or right away if we no longer intend to show it).
         if (!hoverActiveRef.current) { tooltip.dispose(); return; }
         hoverService.requestHover({ content: tooltip.element, target, position: 'left', onHide: () => tooltip.dispose() });
-    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread]);
+    }, [session, chatService, chatAgentService, hoverService, markdownRenderer, hasUnread, descendantNeedsAttention]);
 
     React.useEffect(() => () => { hoverActiveRef.current = false; }, []);
 
@@ -188,14 +208,20 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
     // so the waiting state takes precedence over the generic working spinner: it signals that the
     // user, not the agent, needs to act.
     const isWorking = status !== undefined && ChatSessionStatus.isInProgress(status);
-    const isWaitingForInput = status !== undefined && ChatSessionStatus.requiresUserAction(status);
+    const ownWaitingForInput = status !== undefined && ChatSessionStatus.requiresUserAction(status);
+    // A row whose (possibly nested) delegated child needs action shows the same bell + dot as a row
+    // that needs action itself, so the signal is consistent and stands out even when collapsed.
+    const isWaitingForInput = ownWaitingForInput || descendantNeedsAttention === true;
     const showWorking = isWorking && !isWaitingForInput;
-    const showUnread = hasUnread && !isWorking && !hasError;
-    const attentionLabel = status === 'awaitingApproval'
-        ? nls.localize('theia/ai/ide/requiresApproval', 'Requires your approval')
-        : nls.localize('theia/ai/ide/waitingForInput', 'Waiting for your input');
+    const showUnread = hasUnread && !isWorking && !hasError && !isWaitingForInput;
+    const attentionLabel = ownWaitingForInput
+        ? (status === 'awaitingApproval'
+            ? nls.localize('theia/ai/ide/requiresApproval', 'Requires your approval')
+            : nls.localize('theia/ai/ide/waitingForInput', 'Waiting for your input'))
+        : nls.localize('theia/ai/ide/childInteractionNeeded', 'A delegated session needs your attention');
     const itemClasses = [
         'theia-chat-session-item',
+        isChildSession && 'theia-chat-session-item-child',
         isWaitingForInput && 'theia-chat-session-item-attention',
         showWorking && 'theia-chat-session-item-working',
         hasError && !isWorking && 'theia-chat-session-item-error',
@@ -213,26 +239,55 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
             className={itemClasses}
             role="button"
             tabIndex={0}
+            style={{ '--tree-indent': `${currentDepth * 12}px` } as React.CSSProperties}
             onClick={onClick}
             onKeyDown={handleKeyDown}
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
             onMouseOver={handleMouseOver}>
             <div className="theia-chat-session-item-icon-col">
-                {isRestored ? (
-                    <span className={`${codicon('archive')} theia-chat-session-item-archive-icon`}
-                        title={nls.localize('theia/ai/ide/restoredSession', 'Restored session')} />
+                {hasChildSessions ? (
+                    <span className="theia-chat-session-item-expand-icon"
+                        onClick={e => {
+                            e.stopPropagation();
+                            onToggleExpand?.();
+                        }}
+                        onKeyDown={e => {
+                            if (isActivationKey(e)) {
+                                e.preventDefault();
+                                e.stopPropagation();
+                                onToggleExpand?.();
+                            }
+                        }}
+                        onMouseDown={e => e.preventDefault()}
+                        role="button"
+                        tabIndex={0}
+                        aria-expanded={isExpanded}
+                        aria-label={isExpanded
+                            ? nls.localize('theia/ai/ide/collapseSession', 'Collapse {0}', title)
+                            : nls.localize('theia/ai/ide/expandSession', 'Expand {0}', title)}>
+                        <span className={`codicon ${isExpanded ? 'codicon-chevron-down' : 'codicon-chevron-right'}`} />
+                    </span>
                 ) : (
-                    <span className={`theia-chat-session-item-agent-icon ${iconClass}`} />
+                    <span className="theia-chat-session-item-expand-icon theia-chat-session-item-expand-placeholder" aria-hidden="true" />
                 )}
-                {showUnread && (
-                    <span className="theia-chat-session-item-unread-dot"
-                        aria-label={nls.localize('theia/ai/ide/tooltip/unread', 'Unread')} />
-                )}
-                {isWaitingForInput && (
-                    <span className="theia-chat-session-item-attention-dot"
-                        aria-label={attentionLabel} />
-                )}
+                <span className="theia-chat-session-item-status-icon">
+                    {isRestored && !isWaitingForInput ? (
+                        <span className={`${codicon('archive')} theia-chat-session-item-archive-icon`}
+                            title={nls.localize('theia/ai/ide/restoredSession', 'Restored session')} />
+                    ) : (
+                        <span className={`theia-chat-session-item-agent-icon ${iconClass}`}
+                            title={isWaitingForInput ? attentionLabel : undefined} />
+                    )}
+                    {showUnread && (
+                        <span className="theia-chat-session-item-unread-dot"
+                            aria-label={nls.localize('theia/ai/ide/tooltip/unread', 'Unread')} />
+                    )}
+                    {isWaitingForInput && (
+                        <span className="theia-chat-session-item-attention-dot"
+                            aria-label={attentionLabel} />
+                    )}
+                </span>
             </div>
             <div className="theia-chat-session-item-content">
                 <div className="theia-chat-session-item-title-line">

--- a/packages/ai-ide/src/browser/chat-session-tooltip.ts
+++ b/packages/ai-ide/src/browser/chat-session-tooltip.ts
@@ -89,7 +89,7 @@ function addDefinitionEntry(definitionList: HTMLDListElement, term: string, deta
 export function buildSessionTooltip(
     session: ChatSession, metadata: ChatSessionMetadata,
     agentService: ChatAgentService, markdownRenderer: MarkdownRenderer,
-    isUnread: boolean
+    isUnread: boolean, descendantNeedsAttention: boolean = false
 ): SessionTooltip {
     const toDispose = new DisposableCollection();
     const requests = session.model.getRequests();
@@ -110,6 +110,13 @@ export function buildSessionTooltip(
         const badge = document.createElement('div');
         badge.className = 'theia-chat-session-badge-attention-tooltip';
         badge.textContent = nls.localize('theia/ai/ide/waitingForInput', 'Waiting for your input');
+        container.appendChild(badge);
+    } else if (descendantNeedsAttention) {
+        // The session itself is not awaiting the user, but one of its delegated children is;
+        // surface that instead of the generic running badge so the reason is clear.
+        const badge = document.createElement('div');
+        badge.className = 'theia-chat-session-badge-attention-tooltip';
+        badge.textContent = nls.localize('theia/ai/ide/childInteractionNeeded', 'A delegated session needs your attention');
         container.appendChild(badge);
     } else if (ChatSessionStatus.isInProgress(status)) {
         const badge = document.createElement('div');
@@ -196,14 +203,20 @@ export function buildSessionTooltip(
  * shown on the home view). Avoids any restore I/O so hover does not promote the item to Active.
  */
 export function buildRestoredSessionTooltip(
-    metadata: ChatSessionMetadata, agentService: ChatAgentService
+    metadata: ChatSessionMetadata, agentService: ChatAgentService, descendantNeedsAttention: boolean = false
 ): SessionTooltip {
     const container = document.createElement('div');
     container.className = 'theia-chat-session-tooltip';
 
     const badge = document.createElement('div');
-    badge.className = 'theia-chat-session-badge-restored-tooltip';
-    badge.textContent = nls.localize('theia/ai/ide/restoredSession', 'Restored session');
+    if (descendantNeedsAttention) {
+        // A persisted parent whose delegated child needs the user; show that rather than "Restored".
+        badge.className = 'theia-chat-session-badge-attention-tooltip';
+        badge.textContent = nls.localize('theia/ai/ide/childInteractionNeeded', 'A delegated session needs your attention');
+    } else {
+        badge.className = 'theia-chat-session-badge-restored-tooltip';
+        badge.textContent = nls.localize('theia/ai/ide/restoredSession', 'Restored session');
+    }
     container.appendChild(badge);
 
     const definitionList = document.createElement('dl');

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
@@ -23,7 +23,7 @@ import { Emitter } from '@theia/core';
 import { ChatAgentLocation, ChatService, ChatSession, ChatSessionMetadata, ChatSessionStatus } from '@theia/ai-chat';
 import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
 import { ApplicationShell, Widget } from '@theia/core/lib/browser';
-import { ChatSessionsWelcomeMessageProvider, SectionedSessions, computeVisibleSessionSlots } from './chat-sessions-welcome-message-provider';
+import { ChatSessionsWelcomeMessageProvider, SectionedSessions, SessionRow, computeVisibleSessionSlots } from './chat-sessions-welcome-message-provider';
 disableJSDOM();
 
 /**
@@ -322,6 +322,110 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
             ], []);
             expect(sections.active[0].pinnedAgentId).to.equal('Coder');
             expect(sections.active[0].location).to.equal(ChatAgentLocation.Panel);
+        });
+    });
+
+    describe('session hierarchy', () => {
+
+        class HierarchyTestProvider extends ChatSessionsWelcomeMessageProvider {
+            constructor(chatService: ChatService, persistedSessions: ChatSessionMetadata[] = []) {
+                super();
+                (this as unknown as { chatService: ChatService }).chatService = chatService;
+                this._persistedSessions = persistedSessions;
+            }
+            rows(sections: SectionedSessions): SessionRow[] {
+                return this.buildRows(sections);
+            }
+            subtreeRequiresAction(row: SessionRow): boolean {
+                return this.descendantRequiresAction(row);
+            }
+            expand(session: ChatSession): void {
+                this.expandAncestors(session);
+            }
+            get expanded(): Set<string> {
+                return this.expandedRoots;
+            }
+        }
+
+        function meta(sessionId: string, opts?: { rootSessionId?: string; parentSessionId?: string }): ChatSessionMetadata {
+            return {
+                sessionId,
+                title: sessionId,
+                saveDate: 0,
+                location: ChatAgentLocation.Panel,
+                rootSessionId: opts?.rootSessionId,
+                parentSessionId: opts?.parentSessionId
+            };
+        }
+
+        function loadedSession(id: string, status: ChatSessionStatus, opts?: { rootSessionId?: string; parentSessionId?: string }): ChatSession {
+            return {
+                id,
+                rootSessionId: opts?.rootSessionId,
+                parentSessionId: opts?.parentSessionId,
+                model: { status }
+            } as unknown as ChatSession;
+        }
+
+        function findRow(rows: SessionRow[], sessionId: string): SessionRow {
+            const row = rows.find(r => r.session.sessionId === sessionId);
+            expect(row, `row ${sessionId}`).to.not.be.undefined;
+            return row!;
+        }
+
+        it('nests a restored A -> B hierarchy with an active C under the root', () => {
+            const provider = new HierarchyTestProvider({ getSession: () => undefined } as unknown as ChatService);
+            const sections: SectionedSessions = {
+                active: [meta('C', { rootSessionId: 'A', parentSessionId: 'B' })],
+                restored: [meta('A'), meta('B', { rootSessionId: 'A', parentSessionId: 'A' })]
+            };
+
+            const rows = provider.rows(sections);
+            const rowA = findRow(rows, 'A');
+            expect(rowA.isRestored).to.equal(true);
+            expect(rowA.childSessions.map(c => c.session.sessionId)).to.deep.equal(['B']);
+            const rowB = rowA.childSessions[0];
+            expect(rowB.isRestored).to.equal(true);
+            expect(rowB.childSessions.map(c => c.session.sessionId)).to.deep.equal(['C']);
+            expect(rowB.childSessions[0].isRestored).to.equal(false);
+        });
+
+        it('propagates a deep descendant needing action up the tree', () => {
+            // Only the leaf C awaits input; both B and the root A must report a descendant needing action.
+            const chatService = {
+                getSession: (id: string) => id === 'C' ? loadedSession('C', 'awaitingInput') : loadedSession(id, 'idle')
+            } as unknown as ChatService;
+            const provider = new HierarchyTestProvider(chatService);
+            const sections: SectionedSessions = {
+                active: [meta('C', { rootSessionId: 'A', parentSessionId: 'B' })],
+                restored: [meta('A'), meta('B', { rootSessionId: 'A', parentSessionId: 'A' })]
+            };
+
+            const rows = provider.rows(sections);
+            const rowA = findRow(rows, 'A');
+            const rowB = rowA.childSessions[0];
+            const rowC = rowB.childSessions[0];
+            expect(provider.subtreeRequiresAction(rowA)).to.equal(true);
+            expect(provider.subtreeRequiresAction(rowB)).to.equal(true);
+            expect(provider.subtreeRequiresAction(rowC)).to.equal(false);
+        });
+
+        it('expands every ancestor of a session that needs action, falling back to persisted-only ancestors', () => {
+            // C is loaded and awaiting input; its ancestors B and A exist only in the persisted index
+            // (e.g. C was opened directly from "Browse all chats"). The walk must reach the root A, not
+            // stop at the first ancestor `getSession` cannot resolve.
+            const c = loadedSession('C', 'awaitingInput', { rootSessionId: 'A', parentSessionId: 'B' });
+            const chatService = {
+                getSession: (id: string) => id === 'C' ? c : undefined
+            } as unknown as ChatService;
+            const provider = new HierarchyTestProvider(chatService, [
+                meta('A'),
+                meta('B', { rootSessionId: 'A', parentSessionId: 'A' })
+            ]);
+
+            provider.expand(c);
+
+            expect([...provider.expanded].sort()).to.deep.equal(['A', 'B']);
         });
     });
 });

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -17,7 +17,7 @@
 import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
 import {
-    ChatAgentService, ChatService, ChatSession, ChatSessionMetadata
+    ChatAgentService, ChatService, ChatSession, ChatSessionMetadata, ChatSessionStatus
 } from '@theia/ai-chat';
 import { BYPASS_MODEL_REQUIREMENT_PREF, PERSISTED_SESSION_LIMIT_PREF, SESSION_STORAGE_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
 import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
@@ -38,6 +38,22 @@ const RESTORED_MIN_RESERVATION = 5;
 export interface SectionedSessions {
     active: ChatSessionMetadata[];
     restored: ChatSessionMetadata[];
+}
+
+/** A session row with its optional child sessions. */
+export interface SessionRow {
+    session: ChatSessionMetadata;
+    isRestored: boolean;
+    childSessions: SessionRow[];
+}
+
+/**
+ * The id of a session's immediate parent for tree building. Falls back to the root session id for
+ * sessions persisted before immediate-parent tracking existed, so their hierarchy still renders
+ * (flat under the root, as before).
+ */
+function parentIdOf(session: ChatSessionMetadata): string | undefined {
+    return session.parentSessionId ?? session.rootSessionId;
 }
 
 export interface VisibleSessionSlots {
@@ -69,19 +85,31 @@ export function computeVisibleSessionSlots(activeTotal: number, restoredTotal: n
 }
 
 interface SessionsListProps {
-    sections: SectionedSessions;
+    rows: SessionRow[];
     /** Total cap on items shown on the home view; overflow surfaces via the Browse all link. */
     maxSessions: number;
-    renderItem: (session: ChatSessionMetadata, isRestored: boolean) => React.ReactNode;
+    renderRow: (row: SessionRow) => React.ReactNode;
     onBrowseAll: () => void;
 }
 
-function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: SessionsListProps): React.ReactElement {
-    const total = sections.active.length + sections.restored.length;
-    const { activeCount, restoredCount } = computeVisibleSessionSlots(sections.active.length, sections.restored.length, maxSessions);
-    const activeVisible = sections.active.slice(0, activeCount);
-    const restoredVisible = sections.restored.slice(0, restoredCount);
-    const hiddenCount = total - activeVisible.length - restoredVisible.length;
+function SessionsList({ rows, maxSessions, renderRow, onBrowseAll }: SessionsListProps): React.ReactElement {
+    // Children are rendered inline by their parent row, so only top-level rows appear in the
+    // sections. A child whose parent session is not in the list falls back to top-level (orphan).
+    const topLevelRows = rows.filter(row => {
+        const parentId = parentIdOf(row.session);
+        if (!parentId) {
+            return true;
+        }
+        return !rows.some(r => r.session.sessionId === parentId);
+    });
+
+    const activeRows = topLevelRows.filter(row => !row.isRestored);
+    const restoredRows = topLevelRows.filter(row => row.isRestored);
+
+    const { activeCount, restoredCount } = computeVisibleSessionSlots(activeRows.length, restoredRows.length, maxSessions);
+    const activeVisible = activeRows.slice(0, activeCount);
+    const restoredVisible = restoredRows.slice(0, restoredCount);
+    const hiddenCount = topLevelRows.length - activeVisible.length - restoredVisible.length;
 
     return (
         <div className="theia-WelcomeMessage-SessionsList">
@@ -90,7 +118,7 @@ function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: Sessio
                     <div className="theia-WelcomeMessage-SessionsHeader">
                         {nls.localizeByDefault('Active')}
                     </div>
-                    {activeVisible.map(s => renderItem(s, false))}
+                    {activeVisible.map(row => renderRow(row))}
                 </div>
             )}
             {restoredVisible.length > 0 && (
@@ -98,7 +126,7 @@ function SessionsList({ sections, maxSessions, renderItem, onBrowseAll }: Sessio
                     <div className="theia-WelcomeMessage-SessionsHeader">
                         {nls.localize('theia/ai/ide/sectionRestored', 'Restored')}
                     </div>
-                    {restoredVisible.map(s => renderItem(s, true))}
+                    {restoredVisible.map(row => renderRow(row))}
                 </div>
             )}
             {hiddenCount > 0 && (
@@ -154,7 +182,7 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     protected _inputEnabled = false;
 
-    private readonly unreadSessions = new Map<string, { unread: boolean; seenRequests: number; seenCompleted: number; listener: DisposableCollection }>();
+    private readonly unreadSessions = new Map<string, { unread: boolean; requiresAction: boolean; seenRequests: number; seenCompleted: number; listener: DisposableCollection }>();
     private readonly onUnreadChangedEmitter = new Emitter<string>();
     readonly onUnreadChanged: Event<string> = this.onUnreadChangedEmitter.event;
 
@@ -168,6 +196,9 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     /** Persisted sessions index sorted newest first. May include duplicates of active sessions. */
     protected _persistedSessions: ChatSessionMetadata[] = [];
+
+    /** Expanded root session IDs (default collapsed). */
+    protected expandedRoots = new Set<string>();
 
     protected readonly onStateChangedEmitter = new Emitter<void>();
     readonly onStateChanged: Event<void> = this.onStateChangedEmitter.event;
@@ -264,6 +295,7 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         const reqs = session.model.getRequests();
         const state = {
             unread: false,
+            requiresAction: ChatSessionStatus.requiresUserAction(session.model.status),
             seenRequests: reqs.length,
             seenCompleted: this.countCompleted(reqs),
             listener: new DisposableCollection()
@@ -271,6 +303,16 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         this.unreadSessions.set(session.id, state);
 
         session.model.onDidChange(() => {
+            const requiresAction = ChatSessionStatus.requiresUserAction(session.model.status);
+            if (requiresAction !== state.requiresAction) {
+                state.requiresAction = requiresAction;
+                // When a delegated child starts needing action, auto-expand its ancestors so the whole
+                // subtree is revealed naturally. Don't auto-collapse afterwards: leave that to the user.
+                if (requiresAction) {
+                    this.expandAncestors(session);
+                }
+                this.onStateChangedEmitter.fire();
+            }
             const current = session.model.getRequests();
             if (current.length > state.seenRequests || this.countCompleted(current) > state.seenCompleted) {
                 // Only silently update the seen counts (instead of flashing the unread badge)
@@ -335,7 +377,9 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
                 saveDate: session.lastInteraction?.getTime() ?? Date.now(),
                 location: session.model.location,
                 pinnedAgentId: session.pinnedAgent?.id,
-                hasError: session.model.status === 'failed'
+                hasError: session.model.status === 'failed',
+                rootSessionId: session.rootSessionId,
+                parentSessionId: session.parentSessionId
             }));
         const restored = this._persistedSessions.filter(metadata => !activeIds.has(metadata.sessionId));
         return { active, restored };
@@ -356,13 +400,33 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
     protected renderSessionsSection(sections: SectionedSessions): React.ReactNode {
         const maxSessions = this.preferenceService.get<number>(WELCOME_SCREEN_SESSIONS_PREF, 20);
+        // Build one row per session (carrying its own restored flag), then nest each child row under
+        // its immediate parent's row to reconstruct the full delegation hierarchy. Children keep their
+        // row so the restored flag and actions are computed once here rather than recomputed per child.
+        const allSessions = [...sections.active, ...sections.restored];
+        const activeIds = new Set(sections.active.map(s => s.sessionId));
+        // Two passes on purpose: the first pass creates a row for every session so the second pass can
+        // link each child to its parent. Sessions are ordered by recency, not parent-first, so a child
+        // may precede its parent here; linking in a single pass would miss parents not yet created.
+        const rowsById = new Map<string, SessionRow>();
+        for (const session of allSessions) {
+            rowsById.set(session.sessionId, { session, isRestored: !activeIds.has(session.sessionId), childSessions: [] });
+        }
+        for (const session of allSessions) {
+            const parentId = parentIdOf(session);
+            if (parentId) {
+                rowsById.get(parentId)?.childSessions.push(rowsById.get(session.sessionId)!);
+            }
+        }
+        const rows = [...rowsById.values()];
+
         return (
             <div className="theia-WelcomeMessage" key="sessions-section">
                 <div className="theia-WelcomeMessage-SessionsSection">
                     <SessionsList
-                        sections={sections}
+                        rows={rows}
                         maxSessions={maxSessions}
-                        renderItem={this.renderSessionItem}
+                        renderRow={this.renderSessionRow}
                         onBrowseAll={this.handleBrowseAllChats}
                     />
                 </div>
@@ -370,27 +434,83 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         );
     }
 
-    protected renderSessionItem = (session: ChatSessionMetadata, isRestored: boolean): React.ReactNode => {
-        const actions = this.chatSessionItemActionContributions
+    protected toggleExpand = (sessionId: string): void => {
+        this.expandedRoots = new Set(this.expandedRoots);
+        if (this.expandedRoots.has(sessionId)) {
+            this.expandedRoots.delete(sessionId);
+        } else {
+            this.expandedRoots.add(sessionId);
+        }
+        this.onStateChangedEmitter.fire();
+    };
+
+    /** Whether a loaded session currently needs user action (approval or input). */
+    protected sessionRequiresAction(sessionId: string): boolean {
+        const session = this.chatService.getSession(sessionId);
+        return session !== undefined && ChatSessionStatus.requiresUserAction(session.model.status);
+    }
+
+    /** Whether any descendant (at any depth) of the given row currently needs user action. */
+    protected descendantRequiresAction(row: SessionRow): boolean {
+        return row.childSessions.some(child =>
+            this.sessionRequiresAction(child.session.sessionId) || this.descendantRequiresAction(child));
+    }
+
+    /**
+     * Expands every ancestor of the given session (walking the immediate-parent chain) so a deeply
+     * delegated session becomes visible. The caller is responsible for triggering a re-render.
+     */
+    protected expandAncestors(session: ChatSession): void {
+        const visited = new Set<string>();
+        let parentId = session.parentSessionId ?? session.rootSessionId;
+        while (parentId && !visited.has(parentId)) {
+            visited.add(parentId);
+            this.expandedRoots.add(parentId);
+            const parent = this.chatService.getSession(parentId);
+            parentId = parent?.parentSessionId ?? parent?.rootSessionId;
+        }
+    }
+
+    /** Collects the enabled session-item actions for a session, sorted by priority. */
+    protected getSessionActions(session: ChatSessionMetadata): ChatSessionItemAction[] {
+        return this.chatSessionItemActionContributions
             .getContributions()
             .flatMap(c => c.getActions(session))
             .filter(action => this.commandRegistry.isEnabled(action.commandId, session))
             .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0));
+    }
+
+    protected renderSessionRow = (row: SessionRow): React.ReactNode => this.renderSessionRowAtDepth(row, 0);
+
+    /** Renders a session row and, when expanded, its child rows recursively so nested delegations show. */
+    protected renderSessionRowAtDepth(row: SessionRow, depth: number): React.ReactNode {
+        const hasChildSessions = row.childSessions.length > 0;
+        const isExpanded = hasChildSessions && this.expandedRoots.has(row.session.sessionId);
+        const descendantNeedsAttention = this.descendantRequiresAction(row);
+
         return (
-            <ChatSessionItem
-                key={session.sessionId}
-                session={session}
-                isRestored={isRestored}
-                chatService={this.chatService}
-                chatAgentService={this.chatAgentService}
-                hoverService={this.hoverService}
-                markdownRenderer={this.markdownRenderer}
-                unreadState={this}
-                onClick={() => this.handleSessionItemClick(session.sessionId)}
-                actions={actions}
-                onAction={this.handleSessionItemAction}
-                formatTimeAgo={date => formatTimeAgo(date)}
-            />
+            <React.Fragment key={row.session.sessionId}>
+                <ChatSessionItem
+                    session={row.session}
+                    isRestored={row.isRestored}
+                    chatService={this.chatService}
+                    chatAgentService={this.chatAgentService}
+                    hoverService={this.hoverService}
+                    markdownRenderer={this.markdownRenderer}
+                    unreadState={this}
+                    onClick={() => this.handleSessionItemClick(row.session.sessionId)}
+                    actions={this.getSessionActions(row.session)}
+                    onAction={this.handleSessionItemAction}
+                    formatTimeAgo={date => formatTimeAgo(date)}
+                    hasChildSessions={hasChildSessions}
+                    isChildSession={depth > 0}
+                    depth={depth}
+                    isExpanded={isExpanded}
+                    descendantNeedsAttention={descendantNeedsAttention}
+                    onToggleExpand={hasChildSessions ? () => this.toggleExpand(row.session.sessionId) : undefined}
+                />
+                {isExpanded && row.childSessions.map(child => this.renderSessionRowAtDepth(child, depth + 1))}
+            </React.Fragment>
         );
     };
 

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -304,6 +304,8 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
 
         session.model.onDidChange(() => {
             const requiresAction = ChatSessionStatus.requiresUserAction(session.model.status);
+            // Only react to a change in whether this session needs user action (approval/input) - i.e. a
+            // transition into or out of that state - not to every model change while the state is stable.
             if (requiresAction !== state.requiresAction) {
                 state.requiresAction = requiresAction;
                 // When a delegated child starts needing action, auto-expand its ancestors so the whole
@@ -398,16 +400,16 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         return this.renderSessionsSection(sections);
     }
 
-    protected renderSessionsSection(sections: SectionedSessions): React.ReactNode {
-        const maxSessions = this.preferenceService.get<number>(WELCOME_SCREEN_SESSIONS_PREF, 20);
-        // Build one row per session (carrying its own restored flag), then nest each child row under
-        // its immediate parent's row to reconstruct the full delegation hierarchy. Children keep their
-        // row so the restored flag and actions are computed once here rather than recomputed per child.
+    /**
+     * Builds one {@link SessionRow} per session (carrying its own restored flag), then nests each child
+     * row under its immediate parent's row to reconstruct the full (multi-level) delegation hierarchy.
+     * Two passes on purpose: the first creates a row for every session so the second can link each child
+     * to its parent. Sessions are ordered by recency, not parent-first, so a child may precede its parent
+     * here; linking in a single pass would miss parents not yet created.
+     */
+    protected buildRows(sections: SectionedSessions): SessionRow[] {
         const allSessions = [...sections.active, ...sections.restored];
         const activeIds = new Set(sections.active.map(s => s.sessionId));
-        // Two passes on purpose: the first pass creates a row for every session so the second pass can
-        // link each child to its parent. Sessions are ordered by recency, not parent-first, so a child
-        // may precede its parent here; linking in a single pass would miss parents not yet created.
         const rowsById = new Map<string, SessionRow>();
         for (const session of allSessions) {
             rowsById.set(session.sessionId, { session, isRestored: !activeIds.has(session.sessionId), childSessions: [] });
@@ -418,7 +420,12 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
                 rowsById.get(parentId)?.childSessions.push(rowsById.get(session.sessionId)!);
             }
         }
-        const rows = [...rowsById.values()];
+        return [...rowsById.values()];
+    }
+
+    protected renderSessionsSection(sections: SectionedSessions): React.ReactNode {
+        const maxSessions = this.preferenceService.get<number>(WELCOME_SCREEN_SESSIONS_PREF, 20);
+        const rows = this.buildRows(sections);
 
         return (
             <div className="theia-WelcomeMessage" key="sessions-section">
@@ -461,13 +468,25 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
      * delegated session becomes visible. The caller is responsible for triggering a re-render.
      */
     protected expandAncestors(session: ChatSession): void {
+        // Resolve the next ancestor for a given session id. Prefer the loaded session, but fall back to
+        // the persisted index: an ancestor may not be loaded in memory (e.g. a child opened directly via
+        // "Browse all chats"). Without the fallback the walk stops at the first persisted-only ancestor,
+        // leaving the child hidden under a still-collapsed root.
+        const persistedById = new Map(this._persistedSessions.map(metadata => [metadata.sessionId, metadata]));
+        const parentIdFor = (id: string): string | undefined => {
+            const loaded = this.chatService.getSession(id);
+            if (loaded) {
+                return loaded.parentSessionId ?? loaded.rootSessionId;
+            }
+            const metadata = persistedById.get(id);
+            return metadata && parentIdOf(metadata);
+        };
         const visited = new Set<string>();
         let parentId = session.parentSessionId ?? session.rootSessionId;
         while (parentId && !visited.has(parentId)) {
             visited.add(parentId);
             this.expandedRoots.add(parentId);
-            const parent = this.chatService.getSession(parentId);
-            parentId = parent?.parentSessionId ?? parent?.rootSessionId;
+            parentId = parentIdFor(parentId);
         }
     }
 

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -1169,7 +1169,7 @@
   display: flex;
   align-items: center;
   gap: var(--theia-ui-padding);
-  padding: var(--theia-ui-padding) calc(var(--theia-ui-padding) * 2);
+  padding: var(--theia-ui-padding);
   border-radius: 3px;
   cursor: pointer;
   outline: none;
@@ -1187,11 +1187,18 @@
 }
 
 .theia-chat-session-item-icon-col {
-  position: relative;
   display: inline-flex;
   align-items: center;
   gap: calc(var(--theia-ui-padding) / 2);
   flex-shrink: 0;
+}
+
+/* Positioning context for the unread/attention badges so they anchor to the status icon itself
+   rather than to the whole column (which now also holds the expand toggle to the left). */
+.theia-chat-session-item-status-icon {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
 }
 
 .theia-chat-session-item-unread-dot,
@@ -1244,9 +1251,55 @@
    foreground so they stay readable on the highlighted background. */
 .theia-chat-session-item:focus .theia-chat-session-item-agent-icon,
 .theia-chat-session-item:focus .theia-chat-session-item-archive-icon,
+.theia-chat-session-item:focus .theia-chat-session-item-expand-icon,
 .theia-chat-session-item:focus-within .theia-chat-session-item-agent-icon,
-.theia-chat-session-item:focus-within .theia-chat-session-item-archive-icon {
+.theia-chat-session-item:focus-within .theia-chat-session-item-archive-icon,
+.theia-chat-session-item:focus-within .theia-chat-session-item-expand-icon {
   color: inherit;
+}
+
+/* Expand/collapse toggle shown next to the agent icon on parent sessions.
+   Non-parent rows render a same-sized placeholder so agent icons stay aligned. */
+.theia-chat-session-item-expand-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  box-sizing: content-box;
+  width: var(--theia-ui-font-size0);
+  padding: calc(var(--theia-ui-padding) / 2);
+  border-radius: 3px;
+  color: var(--theia-descriptionForeground);
+  font-size: var(--theia-ui-font-size0);
+  outline: none;
+}
+
+.theia-chat-session-item-expand-icon:not(.theia-chat-session-item-expand-placeholder) {
+  cursor: pointer;
+}
+
+.theia-chat-session-item-expand-icon:not(.theia-chat-session-item-expand-placeholder):hover {
+  color: var(--theia-icon-foreground);
+  background-color: var(--theia-toolbar-hoverBackground, var(--theia-list-hoverBackground));
+}
+
+/* Only show a focus ring for keyboard focus, not on pointer clicks. */
+.theia-chat-session-item-expand-icon:focus-visible {
+  outline: 1px solid var(--theia-focusBorder);
+}
+
+/* The placeholder only reserves layout space and must not be interactive. */
+.theia-chat-session-item-expand-placeholder {
+  visibility: hidden;
+  pointer-events: none;
+}
+
+/* Child session indentation */
+.theia-chat-session-item-child {
+  padding-left: calc(var(--tree-indent, 0px) + var(--theia-ui-padding) * 3);
+}
+
+.theia-chat-session-item-child .theia-chat-session-item-content {
+  font-size: calc(var(--theia-ui-font-size1) * 0.95);
 }
 
 .theia-chat-session-item-content {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Group delegated chat sessions under their parent session in the welcome screen session list, as a collapsible multi-level hierarchy.

- Track each session's root and immediate parent on chat sessions and thread them through serialization, the chat service, and the session store so the welcome view can reconstruct the full delegation hierarchy.
- Render parent sessions with a collapsible expand/collapse toggle shown next to the agent icon; childless rows reserve an equal-sized placeholder so agent icons stay aligned across all rows.
- Indent child sessions per depth and give the expand toggle a larger hit area, a keyboard-only focus ring, selection-aware coloring, and an accessible label that names the session.
- Keep the Active and Restored sections in the welcome list, splitting top-level rows by section while children render nested under their parent.
- Auto-expand a session's ancestors when one of its delegated descendants starts awaiting user action, so it is revealed.
- Mark every ancestor of an awaiting session with the same bell icon, attention dot, and hover tooltip as the awaiting session — visible even on collapsed or not-yet-opened (restored) parents.
- Show delegated child sessions in the 'Browse all chats' quick input too (tagged as delegated), so every session stays reachable; the welcome list still nests them under their parent.
- Cascade session deletion to children, covering both in-memory and persisted-only children so a deleted parent never leaves orphans.

Note: I did a first few round with an AI review here: https://github.com/eclipsesource/theia/pull/323

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Build (npm run build:browser) and start the browser app; create a delegated chat so a
  parent session gets child sessions.
2. In the welcome session list, confirm parents show the agent icon plus an expand chevron
  (childless rows keep icons aligned via a placeholder), and toggling shows/hides indented
  children.
3. Focus a parent row: the chevron stays visible on the selection background, and clicking it
  shows no focus ring.
4. Confirm both Active and Restored sections render; child sessions appear nested under their
  parent in the list, and also in the "Browse all chats" quick input tagged as *Delegated*.
5. Create a multi-level delegation (e.g. Coder → Architect → Explore) and confirm it nests
  recursively. When a nested session needs approval/input, confirm its ancestors auto-expand
  and show the bell icon plus attention dot, with a tooltip explaining a delegated session
  needs your attention.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
