### PR TITLE
feat(ai-openai): add native web search support

### DIFF
--- a/packages/ai-openai/src/node/openai-language-model.spec.ts
+++ b/packages/ai-openai/src/node/openai-language-model.spec.ts
@@ -15,9 +15,11 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { LanguageModelMessage, LanguageModelRequest, ReasoningSupport } from '@theia/ai-core';
+import { LanguageModelMessage, LanguageModelRequest, LanguageModelResponse, ReasoningSupport, UserRequest } from '@theia/ai-core';
+import { OpenAI } from 'openai';
 import { OpenAiModel, OpenAiModelUtils } from './openai-language-model';
 import { OpenAiResponseApiUtils } from './openai-response-api-utils';
+import { OPENAI_WEB_SEARCH } from './openai-server-tools';
 
 const GPT5_REASONING_SUPPORT: ReasoningSupport = {
     supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
@@ -30,11 +32,20 @@ const O_SERIES_REASONING_SUPPORT: ReasoningSupport = {
 };
 
 class TestableOpenAiModel extends OpenAiModel {
+    chatCompletionsRequests = 0;
+
     public callGetSettings(request: LanguageModelRequest, forResponseApi: boolean = false): Record<string, unknown> {
         return this.getSettings(request, forResponseApi);
     }
     public callApplyResponseApiCompaction(settings: Record<string, unknown>, request: LanguageModelRequest): Record<string, unknown> {
         return this.applyResponseApiCompaction(settings, request);
+    }
+    public callHandleResponseApiRequest(request: UserRequest): Promise<LanguageModelResponse> {
+        return this.handleResponseApiRequest({} as OpenAI, request);
+    }
+    protected override async handleChatCompletionsRequest(): Promise<LanguageModelResponse> {
+        this.chatCompletionsRequests++;
+        return { text: 'fallback' };
     }
 }
 
@@ -58,7 +69,7 @@ function createCompactionModel(
         () => 'test-key', () => undefined,
         false, undefined, undefined,
         new OpenAiModelUtils(), new OpenAiResponseApiUtils(),
-        'developer', 3, useResponseApi, undefined, undefined, undefined, useResponseApi, serverSideCompactionEnabledByDefault,
+        'developer', 3, useResponseApi, undefined, undefined, undefined, undefined, useResponseApi, serverSideCompactionEnabledByDefault,
         serverSideCompactionTokenThresholdByDefault
     );
 }
@@ -118,6 +129,53 @@ describe('OpenAiModel reasoning translation', () => {
             expect(result.reasoning).to.equal(undefined);
             expect(result.reasoning_effort).to.equal(undefined);
         });
+    });
+});
+
+describe('OpenAiModel Response API fallback', () => {
+    function createFailingModel(): TestableOpenAiModel {
+        const responseApiUtils = {
+            handleRequest: async () => { throw new Error('Response API unavailable'); }
+        } as unknown as OpenAiResponseApiUtils;
+        return new TestableOpenAiModel(
+            'test-id', 'gpt-5', { status: 'ready' }, true,
+            () => 'test-key', () => undefined,
+            false, undefined, undefined,
+            new OpenAiModelUtils(), responseApiUtils,
+            'developer', 3, true
+        );
+    }
+
+    it('does not fall back to Chat Completions when a server tool is selected', async () => {
+        const model = createFailingModel();
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: [],
+            serverTools: [OPENAI_WEB_SEARCH]
+        };
+
+        let error: unknown;
+        try {
+            await model.callHandleResponseApiRequest(request);
+        } catch (caught) {
+            error = caught;
+        }
+
+        expect(error).to.be.instanceOf(Error).with.property('message', 'Response API unavailable');
+        expect(model.chatCompletionsRequests).to.equal(0);
+    });
+
+    it('retains Chat Completions fallback when no server tool is selected', async () => {
+        const model = createFailingModel();
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: []
+        };
+
+        expect(await model.callHandleResponseApiRequest(request)).to.deep.equal({ text: 'fallback' });
+        expect(model.chatCompletionsRequests).to.equal(1);
     });
 });
 

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -26,7 +26,8 @@ import {
     LanguageModelStatus,
     ReasoningSupport,
     resolveCompactionTokenThreshold,
-    resolveServerSideCompaction
+    resolveServerSideCompaction,
+    ServerToolDescriptor
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
 import { injectable } from '@theia/core/shared/inversify';
@@ -71,6 +72,8 @@ export type DeveloperMessageSettings = 'user' | 'system' | 'developer' | 'mergeW
 
 export class OpenAiModel implements LanguageModel {
 
+    readonly vendor = 'openai';
+
     /**
      * The options for the OpenAI runner.
      */
@@ -112,6 +115,7 @@ export class OpenAiModel implements LanguageModel {
         public proxy?: string,
         public reasoningSupport?: ReasoningSupport,
         public maxInputTokens?: number,
+        public serverTools?: ServerToolDescriptor[],
         public serverSideCompactionSupport: boolean = false,
         public serverSideCompactionEnabledByDefault: boolean = false,
         public serverSideCompactionTokenThresholdByDefault?: number
@@ -291,8 +295,8 @@ export class OpenAiModel implements LanguageModel {
                 cancellationToken
             );
         } catch (error) {
-            // If Response API fails, fall back to Chat Completions API
-            if (error instanceof Error) {
+            // Chat Completions cannot execute Response API server tools.
+            if (error instanceof Error && !request.serverTools?.length) {
                 console.warn(`Response API failed for model ${this.id}, falling back to Chat Completions API:`, error.message);
                 return this.handleChatCompletionsRequest(openai, request, cancellationToken);
             }

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.spec.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.spec.ts
@@ -1,0 +1,57 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { OpenAiModelDescription } from '../common';
+import { OpenAiLanguageModelsManagerImpl } from './openai-language-models-manager-impl';
+import { OPENAI_SERVER_TOOLS, OPENAI_WEB_SEARCH } from './openai-server-tools';
+
+class TestableOpenAiLanguageModelsManagerImpl extends OpenAiLanguageModelsManagerImpl {
+    resolveServerToolsForTest(description: OpenAiModelDescription): typeof OPENAI_SERVER_TOOLS | undefined {
+        return this.resolveServerTools(description);
+    }
+}
+
+function modelDescription(overrides: Partial<OpenAiModelDescription> = {}): OpenAiModelDescription {
+    return {
+        id: 'openai/gpt-5',
+        model: 'gpt-5',
+        apiKey: true,
+        apiVersion: undefined,
+        maxRetries: 3,
+        ...overrides
+    };
+}
+
+describe('OpenAiLanguageModelsManagerImpl server tools', () => {
+    const manager = new TestableOpenAiLanguageModelsManagerImpl();
+
+    it('offers native web search for Response API models using the OpenAI endpoint', () => {
+        const serverTools = manager.resolveServerToolsForTest(modelDescription({ useResponseApi: true }));
+        expect(serverTools?.some(tool => tool.id === OPENAI_WEB_SEARCH)).to.equal(true);
+    });
+
+    it('does not offer native web search for custom endpoints', () => {
+        expect(manager.resolveServerToolsForTest(modelDescription({
+            useResponseApi: true,
+            url: 'https://example.com/v1'
+        }))).to.equal(undefined);
+    });
+
+    it('does not offer native web search without the Response API', () => {
+        expect(manager.resolveServerToolsForTest(modelDescription())).to.equal(undefined);
+    });
+});

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -21,6 +21,7 @@ import { DeveloperMessageSettings, OpenAiModel, OpenAiModelUtils } from './opena
 import { OpenAiResponseApiUtils } from './openai-response-api-utils';
 import { getOpenAiModelDefaults } from './openai-model-defaults';
 import { OpenAiLanguageModelsManager, OpenAiModelDescription } from '../common';
+import { OPENAI_SERVER_TOOLS } from './openai-server-tools';
 
 interface ResolvedModelMetadata {
     maxInputTokens?: number;
@@ -92,6 +93,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
 
             const status = this.calculateStatus(modelDescription, apiKeyProvider());
             const metadata = this.resolveMetadata(modelDescription);
+            const serverTools = this.resolveServerTools(modelDescription);
 
             if (model) {
                 if (!(model instanceof OpenAiModel)) {
@@ -113,6 +115,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                     proxy: proxyUrl,
                     reasoningSupport: metadata.reasoningSupport,
                     maxInputTokens: metadata.maxInputTokens,
+                    serverTools,
                     serverSideCompactionSupport: metadata.serverSideCompactionSupport,
                     serverSideCompactionEnabledByDefault: modelDescription.serverSideCompactionEnabledByDefault ?? false,
                     serverSideCompactionTokenThresholdByDefault: modelDescription.serverSideCompactionTokenThresholdByDefault
@@ -137,6 +140,7 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         proxyUrl,
                         metadata.reasoningSupport,
                         metadata.maxInputTokens,
+                        serverTools,
                         metadata.serverSideCompactionSupport,
                         modelDescription.serverSideCompactionEnabledByDefault ?? false,
                         modelDescription.serverSideCompactionTokenThresholdByDefault
@@ -144,6 +148,10 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                 ]);
             }
         }
+    }
+
+    protected resolveServerTools(description: OpenAiModelDescription): typeof OPENAI_SERVER_TOOLS | undefined {
+        return description.useResponseApi && !description.url ? OPENAI_SERVER_TOOLS : undefined;
     }
 
     /**

--- a/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.spec.ts
@@ -19,7 +19,8 @@ import {
     CompactionMessage, isCompactionResponsePart, isServerToolCallResponsePart, isUsageResponsePart, LanguageModelMessage, LanguageModelStreamResponsePart, UserRequest
 } from '@theia/ai-core';
 import { OpenAiModelUtils } from './openai-language-model';
-import { OpenAiResponseApiUtils } from './openai-response-api-utils';
+import { OPENAI_FUNCTION_CALL_REASONING_DATA_KEY, OpenAiResponseApiUtils } from './openai-response-api-utils';
+import { OPENAI_WEB_SEARCH, OPENAI_WEB_SEARCH_REPLAY_DATA_KEY } from './openai-server-tools';
 
 async function* toStream(events: unknown[]): AsyncIterable<unknown> {
     for (const event of events) {
@@ -59,6 +60,27 @@ describe('OpenAiResponseApiUtils', () => {
             throw new Error('Expected a function tool');
         }
         expect(convertedTool.parameters).to.equal(parameters);
+    });
+
+    it('adds native web search without requiring client tools', () => {
+        const utils = new OpenAiResponseApiUtils();
+
+        expect(utils.convertToolsForResponseApi(undefined, undefined, [OPENAI_WEB_SEARCH])).to.deep.equal([
+            { type: 'web_search' }
+        ]);
+        expect(utils.convertToolsForResponseApi()).to.equal(undefined);
+    });
+
+    it('combines native web search with function and deferred-tool search tools', () => {
+        const utils = new OpenAiResponseApiUtils();
+        const tools = utils.convertToolsForResponseApi([{
+            id: 'lookup',
+            name: 'lookup',
+            parameters: { type: 'object', properties: {} },
+            handler: async () => 'result'
+        }], ['lookup'], [OPENAI_WEB_SEARCH]);
+
+        expect(tools?.map(tool => tool.type)).to.deep.equal(['function', 'tool_search', 'web_search']);
     });
 
     it('emits per-iteration usage for Response API tool calls instead of accumulated usage', async () => {
@@ -101,15 +123,20 @@ describe('OpenAiResponseApiUtils', () => {
                 }
             ]
         ];
+        const streamRequests: Record<string, unknown>[] = [];
         const openai = {
             responses: {
-                stream: () => toStream(streams.shift() ?? [])
+                stream: (responseRequest: Record<string, unknown>) => {
+                    streamRequests.push(responseRequest);
+                    return toStream(streams.shift() ?? []);
+                }
             }
         };
         const request: UserRequest = {
             sessionId: 'session-1',
             requestId: 'request-1',
             messages: [{ actor: 'user', type: 'text', text: 'hello' }],
+            serverTools: [OPENAI_WEB_SEARCH],
             tools: [{
                 id: 'lookup',
                 name: 'lookup',
@@ -140,6 +167,71 @@ describe('OpenAiResponseApiUtils', () => {
             { input_tokens: 100, output_tokens: 10 },
             { input_tokens: 200, output_tokens: 20 }
         ]);
+        expect(streamRequests).to.have.length(2);
+        expect(streamRequests.every(streamRequest =>
+            JSON.stringify(streamRequest.include) === JSON.stringify(['web_search_call.action.sources', 'reasoning.encrypted_content'])
+        )).to.equal(true);
+    });
+
+    it('preserves reasoning and web search items for the next function-tool iteration', async () => {
+        const utils = new OpenAiResponseApiUtils();
+        const reasoningItem = { id: 'rs-1', type: 'reasoning', summary: [], encrypted_content: 'encrypted-reasoning' };
+        const searchCall = {
+            id: 'ws-1',
+            type: 'web_search_call',
+            status: 'completed',
+            action: { type: 'search', query: 'news' }
+        };
+        const streams = [
+            [
+                { type: 'response.output_item.done', item: reasoningItem },
+                { type: 'response.output_item.done', item: searchCall },
+                {
+                    type: 'response.output_item.added',
+                    item: { id: 'item-1', call_id: 'call-1', type: 'function_call', name: 'lookup', arguments: '{"query":"test"}' }
+                }
+            ],
+            [{ type: 'response.output_text.delta', delta: 'done' }]
+        ];
+        const streamRequests: Record<string, unknown>[] = [];
+        const openai = {
+            responses: {
+                stream: (responseRequest: Record<string, unknown>) => {
+                    streamRequests.push(responseRequest);
+                    return toStream(streams.shift() ?? []);
+                }
+            }
+        };
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: [{ actor: 'user', type: 'text', text: 'hello' }],
+            serverTools: [OPENAI_WEB_SEARCH],
+            tools: [{
+                id: 'lookup',
+                name: 'lookup',
+                parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                handler: async () => 'result'
+            }]
+        };
+
+        const response = await utils.handleRequest(
+            openai as never, request, {}, 'gpt-5', new OpenAiModelUtils(), 'developer',
+            { maxChatCompletions: 3 }, 'openai/gpt-5', true
+        );
+        const parts: LanguageModelStreamResponsePart[] = [];
+        if ('stream' in response) {
+            for await (const part of response.stream) {
+                parts.push(part);
+            }
+        }
+
+        expect(parts).to.not.be.empty;
+
+        expect(streamRequests).to.have.length(2);
+        expect(streamRequests[1].input).to.deep.include.members([reasoningItem, searchCall]);
+        const input = streamRequests[1].input as unknown[];
+        expect(input.indexOf(reasoningItem)).to.be.lessThan(input.indexOf(searchCall));
     });
 
     it('yields a compaction part when the stream contains a response.output_item.done compaction event', async () => {
@@ -263,6 +355,203 @@ describe('OpenAiResponseApiUtils', () => {
         expect(finished!.id).to.equal('ts-1');
         expect(finished!.name).to.equal('tool_search');
         expect(finished!.result).to.deep.equal({ content: [{ type: 'text', text: 'Found 2 tools.' }] });
+    });
+
+    it('surfaces web search as a running then finished server tool call', async () => {
+        const utils = new OpenAiResponseApiUtils();
+        const reasoningItem = {
+            id: 'rs-1',
+            type: 'reasoning',
+            summary: [],
+            encrypted_content: 'encrypted-reasoning'
+        };
+        const searchCall = {
+            id: 'ws-1',
+            type: 'web_search_call',
+            status: 'failed',
+            action: { type: 'search', query: 'latest AI news' }
+        };
+        const openai = {
+            responses: {
+                stream: () => toStream([
+                    { type: 'response.output_item.done', item: reasoningItem },
+                    { type: 'response.output_item.added', item: { ...searchCall, status: 'in_progress' } },
+                    { type: 'response.output_item.done', item: searchCall },
+                    { type: 'response.output_text.delta', delta: 'Latest news.' },
+                    { type: 'response.completed', response: { usage: { input_tokens: 10, output_tokens: 5 } } }
+                ])
+            }
+        };
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: [{ actor: 'user', type: 'text', text: 'What is new?' }],
+            serverTools: [OPENAI_WEB_SEARCH]
+        };
+
+        const response = await utils.handleRequest(
+            openai as never, request, {}, 'gpt-5', new OpenAiModelUtils(), 'developer',
+            { maxChatCompletions: 3 }, 'openai/gpt-5', true
+        );
+        const parts: LanguageModelStreamResponsePart[] = [];
+        if ('stream' in response) {
+            for await (const part of response.stream) {
+                parts.push(part);
+            }
+        }
+
+        const calls = parts.filter(isServerToolCallResponsePart).flatMap(part => part.server_tool_calls);
+        expect(calls).to.have.length(2);
+        expect(calls[0]).to.deep.include({ id: 'ws-1', name: OPENAI_WEB_SEARCH, finished: false });
+        expect(calls[1]).to.deep.include({ id: 'ws-1', name: OPENAI_WEB_SEARCH, finished: true });
+        expect(calls[1].result).to.deep.equal({ content: [{ type: 'text', text: 'Web search failed.' }] });
+        expect(calls[1].data).to.deep.equal({
+            [OPENAI_WEB_SEARCH_REPLAY_DATA_KEY]: JSON.stringify([reasoningItem, searchCall])
+        });
+    });
+
+    it('surfaces web search from a non-streaming response and requests sources', async () => {
+        const utils = new OpenAiResponseApiUtils();
+        let createRequest: Record<string, unknown> | undefined;
+        const openai = {
+            responses: {
+                create: async (responseRequest: Record<string, unknown>) => {
+                    createRequest = responseRequest;
+                    return {
+                        output_text: 'Answer',
+                        output: [{ id: 'ws-1', type: 'web_search_call', status: 'completed', action: { type: 'search', query: 'news' } }]
+                    };
+                }
+            }
+        };
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: [{ actor: 'user', type: 'text', text: 'Search' }],
+            serverTools: [OPENAI_WEB_SEARCH]
+        };
+
+        const response = await utils.handleRequest(
+            openai as never, request, { include: ['file_search_call.results', 'web_search_call.action.sources'] },
+            'gpt-5', new OpenAiModelUtils(), 'developer', { maxChatCompletions: 3 }, 'openai/gpt-5', false
+        );
+        const parts: LanguageModelStreamResponsePart[] = [];
+        if ('stream' in response) {
+            for await (const part of response.stream) {
+                parts.push(part);
+            }
+        }
+
+        const calls = parts.filter(isServerToolCallResponsePart).flatMap(part => part.server_tool_calls);
+        expect(calls).to.have.length(1);
+        expect(calls[0]).to.deep.include({ id: 'ws-1', name: OPENAI_WEB_SEARCH, finished: true });
+        expect(createRequest?.include).to.deep.equal(['file_search_call.results', 'web_search_call.action.sources', 'reasoning.encrypted_content']);
+    });
+
+    it('replays persisted OpenAI reasoning before its web search call', () => {
+        const utils = new OpenAiResponseApiUtils();
+        const reasoningItem = {
+            id: 'rs-1',
+            type: 'reasoning',
+            summary: [],
+            encrypted_content: 'encrypted-reasoning'
+        };
+        const searchCall = {
+            id: 'ws-1',
+            type: 'web_search_call',
+            status: 'completed',
+            action: {
+                type: 'search',
+                query: 'news',
+                sources: [{ type: 'url', url: 'https://example.com', title: 'Example' }]
+            }
+        };
+        const messages: LanguageModelMessage[] = [{
+            actor: 'ai',
+            type: 'server_tool_use',
+            id: 'ws-1',
+            name: OPENAI_WEB_SEARCH,
+            input: searchCall.action,
+            result: { content: [{ type: 'text', text: 'Web search completed.' }] },
+            data: {
+                [OPENAI_WEB_SEARCH_REPLAY_DATA_KEY]: JSON.stringify([reasoningItem, searchCall])
+            }
+        }];
+
+        const { input } = utils.processMessages(messages, 'developer', 'gpt-5');
+
+        expect(input).to.deep.equal([reasoningItem, searchCall]);
+    });
+
+    it('persists and replays reasoning before a function call', async () => {
+        const utils = new OpenAiResponseApiUtils();
+        const reasoningItem = { id: 'rs-1', type: 'reasoning', summary: [], encrypted_content: 'encrypted-reasoning' };
+        const functionCall = {
+            id: 'fc-1', call_id: 'call-1', type: 'function_call', name: 'lookup', arguments: '{"query":"test"}'
+        };
+        const requests: Record<string, unknown>[] = [];
+        const streams = [
+            [
+                { type: 'response.output_item.done', item: reasoningItem },
+                { type: 'response.output_item.added', item: functionCall }
+            ],
+            [{ type: 'response.output_text.delta', delta: 'done' }]
+        ];
+        const openai = {
+            responses: {
+                stream: (responseRequest: Record<string, unknown>) => {
+                    requests.push(responseRequest);
+                    return toStream(streams.shift() ?? []);
+                }
+            }
+        };
+        const request: UserRequest = {
+            sessionId: 'session-1',
+            requestId: 'request-1',
+            messages: [{ actor: 'user', type: 'text', text: 'hello' }],
+            tools: [{
+                id: 'lookup',
+                name: 'lookup',
+                parameters: { type: 'object', properties: { query: { type: 'string' } } },
+                handler: async () => 'result'
+            }]
+        };
+
+        const response = await utils.handleRequest(
+            openai as never, request, {}, 'gpt-5', new OpenAiModelUtils(), 'developer',
+            { maxChatCompletions: 3 }, 'openai/gpt-5', true
+        );
+        const parts: LanguageModelStreamResponsePart[] = [];
+        if ('stream' in response) {
+            for await (const part of response.stream) {
+                parts.push(part);
+            }
+        }
+
+        expect(requests[0].include).to.deep.equal(['reasoning.encrypted_content']);
+        const completedCall = parts.flatMap(part => 'tool_calls' in part ? part.tool_calls : []).find(call => call.finished);
+        expect(completedCall?.data).to.deep.equal({
+            [OPENAI_FUNCTION_CALL_REASONING_DATA_KEY]: JSON.stringify([reasoningItem])
+        });
+        expect(requests[1].input).to.deep.include.members([reasoningItem]);
+        const nextInput = requests[1].input as unknown[];
+        const replayedCall = nextInput.find(item => (item as { type?: string }).type === 'function_call');
+        expect(nextInput.indexOf(reasoningItem)).to.be.lessThan(nextInput.indexOf(replayedCall));
+
+        const { input } = utils.processMessages([{
+            actor: 'ai',
+            type: 'tool_use',
+            id: 'call-1',
+            name: 'lookup',
+            input: { query: 'test' },
+            data: completedCall?.data
+        }], 'developer', 'gpt-5');
+        expect(input).to.deep.equal([reasoningItem, {
+            type: 'function_call',
+            call_id: 'call-1',
+            name: 'lookup',
+            arguments: '{"query":"test"}'
+        }]);
     });
 
     describe('processMessages server-side compaction replay', () => {

--- a/packages/ai-openai/src/node/openai-response-api-utils.ts
+++ b/packages/ai-openai/src/node/openai-response-api-utils.ts
@@ -21,6 +21,7 @@ import {
     LanguageModelResponse,
     LanguageModelStreamResponsePart,
     TextMessage,
+    ToolCallResult,
     ToolInvocationContext,
     ToolRequest,
     UserRequest
@@ -36,6 +37,7 @@ import type {
     ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent,
     ResponseFunctionToolCall,
+    ResponseFunctionWebSearch,
     ResponseInputItem,
     ResponseStreamEvent,
     ResponseToolSearchCall,
@@ -43,6 +45,9 @@ import type {
 } from 'openai/resources/responses/responses';
 import type { ResponsesModel } from 'openai/resources/shared';
 import { DeveloperMessageSettings, OpenAiModelUtils } from './openai-language-model';
+import { OPENAI_WEB_SEARCH, OPENAI_WEB_SEARCH_REPLAY_DATA_KEY } from './openai-server-tools';
+
+export const OPENAI_FUNCTION_CALL_REASONING_DATA_KEY = 'openAiFunctionCallReasoning';
 
 /**
  * User-facing name under which the provider's built-in deferred-tool search is surfaced in the chat UI.
@@ -61,9 +66,10 @@ interface ToolCall {
     call_id?: string;
     name: string;
     arguments: string;
-    result?: unknown;
+    result?: ToolCallResult;
     error?: Error;
     executed: boolean;
+    reasoningItems?: ResponseInputItem[];
 }
 
 /**
@@ -96,7 +102,13 @@ export class OpenAiResponseApiUtils {
         }
 
         const { instructions, input } = this.processMessages(request.messages, developerMessageSettings, model);
-        const tools = this.convertToolsForResponseApi(request.tools, request.deferredToolIds);
+        const tools = this.convertToolsForResponseApi(request.tools, request.deferredToolIds, request.serverTools);
+        const include = [...new Set([
+            ...(Array.isArray(settings.include) ? settings.include : []),
+            ...(request.serverTools?.includes(OPENAI_WEB_SEARCH) ? ['web_search_call.action.sources'] : []),
+            ...(request.tools?.length || request.serverTools?.includes(OPENAI_WEB_SEARCH) ? ['reasoning.encrypted_content'] : [])
+        ])];
+        const effectiveSettings = include.length > 0 ? { ...settings, include } : settings;
 
         // If no tools are provided, use simple response handling
         if (!tools || tools.length === 0) {
@@ -105,7 +117,7 @@ export class OpenAiResponseApiUtils {
                     model: model as ResponsesModel,
                     instructions,
                     input,
-                    ...settings
+                    ...effectiveSettings
                 });
                 return { stream: this.createSimpleResponseApiStreamIterator(stream, cancellationToken) };
             } else {
@@ -113,7 +125,7 @@ export class OpenAiResponseApiUtils {
                     model: model as ResponsesModel,
                     instructions,
                     input,
-                    ...settings
+                    ...effectiveSettings
                 });
 
                 return {
@@ -130,7 +142,7 @@ export class OpenAiResponseApiUtils {
         const iterator = new ResponseApiToolCallIterator(
             openai,
             request,
-            settings,
+            effectiveSettings,
             model,
             modelUtils,
             developerMessageSettings,
@@ -147,13 +159,9 @@ export class OpenAiResponseApiUtils {
     /**
      * Converts ToolRequest objects to the format expected by the Response API.
      */
-    convertToolsForResponseApi(tools?: ToolRequest[], deferredToolIds?: string[]): Tool[] | undefined {
-        if (!tools || tools.length === 0) {
-            return undefined;
-        }
-
+    convertToolsForResponseApi(tools?: ToolRequest[], deferredToolIds?: string[], serverTools?: string[]): Tool[] | undefined {
         const deferred = new Set(deferredToolIds ?? []);
-        const converted: Tool[] = tools.map(tool => ({
+        const converted: Tool[] = (tools ?? []).map(tool => ({
             type: 'function' as const,
             name: tool.name,
             description: tool.description || '',
@@ -167,7 +175,13 @@ export class OpenAiResponseApiUtils {
         if (deferred.size > 0) {
             converted.push({ type: 'tool_search', execution: 'server' });
         }
-        console.debug(`Converted ${tools.length} tools for Response API:`, converted.map(t => t.type === 'function' ? t.name : t.type));
+        if (serverTools?.includes(OPENAI_WEB_SEARCH)) {
+            converted.push({ type: 'web_search' });
+        }
+        if (converted.length === 0) {
+            return undefined;
+        }
+        console.debug(`Converted ${(tools ?? []).length} tools for Response API:`, converted.map(t => t.type === 'function' ? t.name : t.type));
         return converted;
     }
 
@@ -305,6 +319,14 @@ export class OpenAiResponseApiUtils {
                     });
                 }
             } else if (LanguageModelMessage.isToolUseMessage(message)) {
+                const rawReasoning = message.data?.[OPENAI_FUNCTION_CALL_REASONING_DATA_KEY];
+                if (rawReasoning) {
+                    try {
+                        input.push(...JSON.parse(rawReasoning) as ResponseInputItem[]);
+                    } catch {
+                        // Skip malformed provider data.
+                    }
+                }
                 input.push({
                     type: 'function_call',
                     call_id: message.id,
@@ -333,8 +355,14 @@ export class OpenAiResponseApiUtils {
             } else if (LanguageModelMessage.isThinkingMessage(message)) {
                 // Pass
             } else if (LanguageModelMessage.isServerToolUseMessage(message)) {
-                // 'server_tool_use' replay messages can appear when switching providers within a
-                // session; OpenAI has no equivalent, so they are skipped.
+                const rawReplay = message.data?.[OPENAI_WEB_SEARCH_REPLAY_DATA_KEY];
+                if (message.name === OPENAI_WEB_SEARCH && rawReplay) {
+                    try {
+                        input.push(...JSON.parse(rawReplay) as ResponseInputItem[]);
+                    } catch {
+                        // Skip malformed provider data.
+                    }
+                }
             } else {
                 unreachable(message);
             }
@@ -371,6 +399,8 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
     protected readonly tools: Tool[] | undefined;
     protected readonly instructions?: string;
     protected currentResponseText = '';
+    protected pendingReasoningItems: ResponseInputItem[] = [];
+    protected currentWebSearchReplayItems: ResponseInputItem[] = [];
 
     constructor(
         protected readonly openai: OpenAI,
@@ -388,7 +418,7 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
         const { instructions, input } = utils.processMessages(request.messages, developerMessageSettings, model);
         this.instructions = instructions;
         this.currentInput = input;
-        this.tools = utils.convertToolsForResponseApi(request.tools, request.deferredToolIds);
+        this.tools = utils.convertToolsForResponseApi(request.tools, request.deferredToolIds, request.serverTools);
         this.maxIterations = runnerOptions.maxChatCompletions || 100;
 
         // Start the first iteration
@@ -457,6 +487,8 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
     protected async processStream(): Promise<void> {
         this.currentToolCalls.clear();
         this.currentResponseText = '';
+        this.pendingReasoningItems = [];
+        this.currentWebSearchReplayItems = [];
 
         if (this.isStreaming) {
             // Use streaming API
@@ -503,6 +535,21 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             this.handleIncoming({ content: this.currentResponseText });
         }
 
+        const pendingReasoningItems: ResponseInputItem[] = [];
+        for (const item of response.output ?? []) {
+            if (item.type === 'reasoning') {
+                pendingReasoningItems.push(item);
+            } else if (item.type === 'web_search_call') {
+                this.handleWebSearchCall(item, true, [...pendingReasoningItems, item]);
+                pendingReasoningItems.length = 0;
+            } else if (item.type === 'function_call' && item.id) {
+                const toolCall = this.createToolCall(item, item.id);
+                toolCall.reasoningItems = pendingReasoningItems.splice(0);
+                this.currentToolCalls.set(item.id, toolCall);
+                this.handleFunctionCall(toolCall, false);
+            }
+        }
+
         // Surface any deferred-tool search OpenAI executed while producing this response (see handleToolSearchOutput).
         const toolSearchOutputs = response.output?.filter((item): item is ResponseToolSearchOutputItem => item.type === 'tool_search_output') || [];
         for (const output of toolSearchOutputs) {
@@ -517,35 +564,6 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             });
         }
 
-        // Find function calls in the response
-        const functionCalls = response.output?.filter((item): item is ResponseFunctionToolCall => item.type === 'function_call') || [];
-
-        // Process each function call
-        for (const functionCall of functionCalls) {
-            if (functionCall.id && functionCall.name) {
-                const toolCall: ToolCall = {
-                    id: functionCall.id,
-                    call_id: functionCall.call_id || functionCall.id,
-                    name: functionCall.name,
-                    arguments: functionCall.arguments || '',
-                    executed: false
-                };
-
-                this.currentToolCalls.set(functionCall.id, toolCall);
-
-                // Yield the tool call initiation
-                this.handleIncoming({
-                    tool_calls: [{
-                        id: functionCall.id,
-                        finished: false,
-                        function: {
-                            name: functionCall.name,
-                            arguments: functionCall.arguments || ''
-                        }
-                    }]
-                });
-            }
-        }
     }
 
     protected async handleStreamEvent(event: ResponseStreamEvent): Promise<void> {
@@ -560,6 +578,8 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
                     this.handleFunctionCallAdded(event.item);
                 } else if (event.item?.type === 'tool_search_call') {
                     this.handleToolSearchCall(event.item);
+                } else if (event.item?.type === 'web_search_call') {
+                    this.handleWebSearchCall(event.item, false);
                 }
                 break;
 
@@ -583,6 +603,11 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
                     });
                 } else if (event.item?.type === 'tool_search_output') {
                     this.handleToolSearchOutput(event.item);
+                } else if (event.item?.type === 'reasoning') {
+                    this.pendingReasoningItems.push(event.item);
+                } else if (event.item?.type === 'web_search_call') {
+                    this.handleWebSearchCall(event.item, true, [...this.pendingReasoningItems, event.item]);
+                    this.pendingReasoningItems = [];
                 }
                 break;
 
@@ -605,27 +630,38 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
         if (functionCall.id && functionCall.call_id) {
             console.debug(`Function call added: ${functionCall.name} with id ${functionCall.id} and call_id ${functionCall.call_id}`);
 
-            const toolCall: ToolCall = {
-                id: functionCall.id,
-                call_id: functionCall.call_id,
-                name: functionCall.name || '',
-                arguments: functionCall.arguments || '',
-                executed: false
-            };
-
+            const toolCall = this.createToolCall(functionCall, functionCall.id);
+            toolCall.reasoningItems = this.pendingReasoningItems.splice(0);
             this.currentToolCalls.set(functionCall.id, toolCall);
-
-            this.handleIncoming({
-                tool_calls: [{
-                    id: functionCall.id,
-                    finished: false,
-                    function: {
-                        name: functionCall.name || '',
-                        arguments: functionCall.arguments || ''
-                    }
-                }]
-            });
+            this.handleFunctionCall(toolCall, false);
         }
+    }
+
+    protected createToolCall(functionCall: ResponseFunctionToolCall, id: string): ToolCall {
+        return {
+            id,
+            call_id: functionCall.call_id || functionCall.id,
+            name: functionCall.name || '',
+            arguments: functionCall.arguments || '',
+            executed: false
+        };
+    }
+
+    protected handleFunctionCall(toolCall: ToolCall, finished: boolean, result?: ToolCallResult): void {
+        this.handleIncoming({
+            tool_calls: [{
+                id: toolCall.id,
+                finished,
+                function: {
+                    name: toolCall.name,
+                    arguments: toolCall.arguments
+                },
+                result,
+                data: finished && toolCall.reasoningItems?.length ? {
+                    [OPENAI_FUNCTION_CALL_REASONING_DATA_KEY]: JSON.stringify(toolCall.reasoningItems)
+                } : undefined
+            }]
+        });
     }
 
     protected handleFunctionCallArgsDelta(event: ResponseFunctionCallArgumentsDeltaEvent): void {
@@ -655,7 +691,8 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
                 id: event.item_id,
                 name: event.name || '',
                 arguments: event.arguments || '',
-                executed: false
+                executed: false,
+                reasoningItems: this.pendingReasoningItems.splice(0)
             };
             this.currentToolCalls.set(event.item_id, toolCall);
 
@@ -674,6 +711,32 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             toolCall.name = event.name || toolCall.name;
             toolCall.arguments = event.arguments || toolCall.arguments;
         }
+    }
+
+    protected handleWebSearchCall(item: ResponseFunctionWebSearch, finished: boolean, replayItems?: ResponseInputItem[]): void {
+        if (finished && replayItems) {
+            this.currentWebSearchReplayItems.push(...replayItems);
+        }
+        const action = JSON.stringify(item.action);
+        this.handleIncoming({
+            server_tool_calls: [{
+                id: item.id,
+                name: OPENAI_WEB_SEARCH,
+                arguments: action,
+                finished,
+                result: finished ? {
+                    content: [{
+                        type: 'text',
+                        text: item.status === 'failed'
+                            ? nls.localize('theia/ai/openai/webSearch/failed', 'Web search failed.')
+                            : nls.localize('theia/ai/openai/webSearch/completed', 'Web search completed.')
+                    }]
+                } : undefined,
+                data: finished && replayItems ? {
+                    [OPENAI_WEB_SEARCH_REPLAY_DATA_KEY]: JSON.stringify(replayItems)
+                } : undefined
+            }]
+        });
     }
 
     /**
@@ -727,50 +790,25 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
                     toolCall.result = result;
 
                     // Yield the tool call completion
-                    this.handleIncoming({
-                        tool_calls: [{
-                            id: itemId,
-                            finished: true,
-                            function: {
-                                name: toolCall.name,
-                                arguments: toolCall.arguments
-                            },
-                            result
-                        }]
-                    });
+                    this.handleFunctionCall(toolCall, true, result);
                 } catch (error) {
                     console.error(`Error executing tool ${toolCall.name}:`, error);
                     toolCall.error = error instanceof Error ? error : new Error(String(error));
 
                     // Yield the tool call error
-                    this.handleIncoming({
-                        tool_calls: [{
-                            id: itemId,
-                            finished: true,
-                            function: {
-                                name: toolCall.name,
-                                arguments: toolCall.arguments
-                            },
-                            result: createToolCallError(error instanceof Error ? error.message : String(error))
-                        }]
-                    });
+                    this.handleFunctionCall(toolCall, true, createToolCallError(error instanceof Error ? error.message : String(error)));
+
                 }
             } else {
                 console.warn(`Tool ${toolCall.name} not found in request tools`);
                 toolCall.error = new Error(`Tool ${toolCall.name} not found`);
 
                 // Yield the tool call error
-                this.handleIncoming({
-                    tool_calls: [{
-                        id: itemId,
-                        finished: true,
-                        function: {
-                            name: toolCall.name,
-                            arguments: toolCall.arguments
-                        },
-                        result: createToolCallError(`Tool '${toolCall.name}' not found in the available tools for this request.`, 'tool-not-available')
-                    }]
-                });
+                this.handleFunctionCall(
+                    toolCall,
+                    true,
+                    createToolCallError(`Tool '${toolCall.name}' not found in the available tools for this request.`, 'tool-not-available')
+                );
             }
 
             toolCall.executed = true;
@@ -787,7 +825,7 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
         // Add the function calls that were made by the assistant
         const functionCalls: ResponseInputItem[] = [];
         for (const [itemId, toolCall] of this.currentToolCalls) {
-            functionCalls.push({
+            functionCalls.push(...toolCall.reasoningItems ?? [], {
                 type: 'function_call',
                 call_id: toolCall.call_id || itemId,
                 name: toolCall.name,
@@ -816,7 +854,7 @@ class ResponseApiToolCallIterator implements AsyncIterableIterator<LanguageModel
             }
         }
 
-        this.currentInput = [...this.currentInput, assistantMessage, ...functionCalls, ...toolResults];
+        this.currentInput = [...this.currentInput, ...this.currentWebSearchReplayItems, assistantMessage, ...functionCalls, ...toolResults];
     }
 
     protected handleIncoming(message: LanguageModelStreamResponsePart): void {

--- a/packages/ai-openai/src/node/openai-server-tools.ts
+++ b/packages/ai-openai/src/node/openai-server-tools.ts
@@ -1,0 +1,26 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ServerToolDescriptor } from '@theia/ai-core';
+
+export const OPENAI_WEB_SEARCH = 'web_search';
+export const OPENAI_WEB_SEARCH_REPLAY_DATA_KEY = 'openAiWebSearchReplay';
+
+export const OPENAI_SERVER_TOOLS: ServerToolDescriptor[] = [{
+    id: OPENAI_WEB_SEARCH,
+    name: 'Web Search',
+    description: 'Lets the model search the web on OpenAI\'s infrastructure.'
+}];


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
- Expose Web Search as a selectable server tool for OpenAI models using the Responses API
- Add the native `web_search` tool to requests when enabled
- Surface streaming and non-streaming `web_search_call` output as running and completed server tool calls in the chat UI
- Preserve completed web search calls for subsequent conversation turns
- Add tests for tool conversion, event handling, and history replay

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
Use an openai model, activate response api, ask the agent to research something.
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
