### PR TITLE
fix(core): improve SelectComponent keyboard navigation

### DIFF
--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -91,7 +91,11 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         return selected;
     }
 
-    override componentDidUpdate(prevProps: SelectComponentProps): void {
+    override componentDidUpdate(prevProps: SelectComponentProps, prevState: SelectComponentState): void {
+        if (prevState.selected !== this.state.selected && this.state.dimensions) {
+            const el = this.dropdownRef?.current?.querySelector(`[data-option-index="${this.state.selected}"]`);
+            el?.scrollIntoView({ block: 'nearest' });
+        }
         if (prevProps.defaultValue !== this.props.defaultValue || prevProps.options !== this.props.options) {
             const selected = this.getInitialSelectedIndex(this.props);
             this.setState({
@@ -404,6 +408,7 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         return (
             <div
                 key={index}
+                data-option-index={index}
                 className={`theia-select-component-option${index === selected ? ' selected' : ''}`}
                 onMouseOver={() => {
                     this.setState({

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -93,8 +93,17 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
 
     override componentDidUpdate(prevProps: SelectComponentProps, prevState: SelectComponentState): void {
         if (prevState.selected !== this.state.selected && this.state.dimensions) {
-            const el = this.dropdownRef?.current?.querySelector(`[data-option-index="${this.state.selected}"]`);
-            el?.scrollIntoView({ block: 'nearest' });
+            const container = this.dropdownRef?.current;
+            const el = container?.querySelector(`[data-option-index="${this.state.selected}"]`) as HTMLElement | undefined;
+            if (container && el) {
+                const elBottom = el.offsetTop + el.offsetHeight;
+                const containerBottom = container.scrollTop + container.clientHeight;
+                if (elBottom > containerBottom) {
+                    container.scrollTop = elBottom - container.clientHeight;
+                } else if (el.offsetTop < container.scrollTop) {
+                    container.scrollTop = el.offsetTop;
+                }
+            }
         }
         if (prevProps.defaultValue !== this.props.defaultValue || prevProps.options !== this.props.options) {
             const selected = this.getInitialSelectedIndex(this.props);

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -93,15 +93,15 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
 
     override componentDidUpdate(prevProps: SelectComponentProps, prevState: SelectComponentState): void {
         if (prevState.selected !== this.state.selected && this.state.dimensions) {
-            const container = this.dropdownRef?.current;
-            const el = container?.querySelector(`[data-option-index="${this.state.selected}"]`) as HTMLElement | undefined;
-            if (container && el) {
-                const elBottom = el.offsetTop + el.offsetHeight;
-                const containerBottom = container.scrollTop + container.clientHeight;
-                if (elBottom > containerBottom) {
-                    container.scrollTop = elBottom - container.clientHeight;
-                } else if (el.offsetTop < container.scrollTop) {
-                    container.scrollTop = el.offsetTop;
+            const dropdownContainer = this.dropdownRef?.current;
+            const selectedOption = dropdownContainer?.querySelector(`[data-option-index="${this.state.selected}"]`) as HTMLElement | undefined;
+            if (dropdownContainer && selectedOption) {
+                const optionBottom = selectedOption.offsetTop + selectedOption.offsetHeight;
+                const visibleBottom = dropdownContainer.scrollTop + dropdownContainer.clientHeight;
+                if (optionBottom > visibleBottom) {
+                    dropdownContainer.scrollTop = optionBottom - dropdownContainer.clientHeight;
+                } else if (selectedOption.offsetTop < dropdownContainer.scrollTop) {
+                    dropdownContainer.scrollTop = selectedOption.offsetTop;
                 }
             }
         }

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -258,11 +258,11 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         </>;
     }
 
-    protected nextNotSeparator(direction: 'forwards' | 'backwards'): number {
+    protected nextNotSeparator(direction: 'forwards' | 'backwards', startFrom?: number): number {
         const { options } = this.props;
         const step = direction === 'forwards' ? 1 : -1;
         const length = this.props.options.length;
-        let selected = this.state.selected;
+        let selected = startFrom ?? this.state.selected;
         let count = 0;
         do {
             selected = (selected + step) % length;
@@ -280,14 +280,14 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             return;
         }
         if (ev.key === 'ArrowUp') {
-            const selected = this.nextNotSeparator('backwards');
+            const selected = this.nextNotSeparator('backwards', this.state.hover);
             this.setState({
                 selected,
                 hover: selected
             });
         } else if (ev.key === 'ArrowDown') {
             if (this.state.dimensions) {
-                const selected = this.nextNotSeparator('forwards');
+                const selected = this.nextNotSeparator('forwards', this.state.hover);
                 this.setState({
                     selected,
                     hover: selected


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Fixes two keyboard navigation issues in `SelectComponent`:

1. When the dropdown is open and has enough options to scroll, navigating with arrow keys did not scroll the selected option into view. Fixed by manually setting `scrollTop` on the dropdown container in `componentDidUpdate` when the selected index changes.

2. When hovering over an option with the mouse and then pressing arrow keys, navigation started from the original selected option rather than the hovered one. Fixed by passing the current `hover` index as the starting point to `nextNotSeparator`.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open the Output panel (View -> Output)
2. Open the channel dropdown. It needs enough options to show a scrollbar. I temporarily added dummy options to make the list longer.
3. With the dropdown open, press Arrow Down or Arrow Up key repeatedly — the selected option should stay visible as it scrolls through the list
4. With the dropdown open, hover the mouse over an option partway down the list, move the mouse away, then press Arrow Down. Navigation should continue from the hovered option, not the originally selected one.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of Texas Instruments

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
