### PR TITLE
feat(ai-chat-ui): add per-session model selector and in-thread badge

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -22,7 +22,7 @@ import { ChatAgentService } from '@theia/ai-chat/lib/common/chat-agent-service';
 import { ParsedChatRequest } from '@theia/ai-chat/lib/common/parsed-chat-request';
 import {
     GenericCapabilitySelections, AIVariableResolutionRequest, ParsedCapability,
-    FrontendLanguageModelRegistry, ReasoningLevel, ReasoningSettings, ReasoningSupport,
+    FrontendLanguageModelRegistry, LanguageModel, ReasoningLevel, ReasoningSettings, ReasoningSupport,
     PREFERENCE_NAME_REASONING, ReasoningPreferenceEntry, ServerToolDescriptor
 } from '@theia/ai-core';
 import { mergeReasoningSettings } from '@theia/ai-core/lib/browser/frontend-language-model-service';
@@ -260,6 +260,10 @@ export class AIChatInputWidget extends ReactWidget {
         }
     };
 
+    /** Monotonic token for the latest async {@link updateReasoningSupport} run; older, out-of-order runs discard their results when this changes. */
+    protected reasoningStateGeneration = 0;
+    /** Monotonic token for the latest async {@link updateResolvedDefaultModel} run; older, out-of-order runs discard their results when this changes. */
+    protected resolvedDefaultGeneration = 0;
     /** Reasoning capability of the model the receiving agent would currently use; undefined hides the selector. */
     protected currentReasoningSupport?: ReasoningSupport;
     /** Id (`provider/model`) of the model that backs {@link currentReasoningSupport}; used to resolve preference defaults. */
@@ -335,12 +339,25 @@ export class AIChatInputWidget extends ReactWidget {
     }
 
     protected async updateReasoningSupport(agentId: string | undefined): Promise<void> {
+        // Guard against out-of-order completion: if the model/session changes while the async lookups
+        // below are in flight, a stale run must not overwrite the fields with outdated values.
+        const generation = ++this.reasoningStateGeneration;
         let support: ReasoningSupport | undefined;
         let modelId: string | undefined;
         let maxInputTokens: number | undefined;
         let serverTools: ServerToolDescriptor[] | undefined;
         let vendor: string | undefined;
-        if (agentId) {
+        // A per-session model override drives all model-dependent state (reasoning support, context
+        // size, server tools, vendor) instead of the agent's configured default.
+        const overrideId = this.getSessionModelOverride();
+        const overrideModel = overrideId ? await this.languageModelRegistry.getReadyLanguageModel(overrideId) : undefined;
+        if (overrideModel) {
+            support = overrideModel.reasoningSupport;
+            modelId = overrideModel.id;
+            maxInputTokens = overrideModel.maxInputTokens;
+            serverTools = overrideModel.serverTools;
+            vendor = overrideModel.vendor;
+        } else if (agentId) {
             const agent = this.chatAgentService.getAgent(agentId);
             if (agent) {
                 for (const requirement of agent.languageModelRequirements ?? []) {
@@ -370,6 +387,10 @@ export class AIChatInputWidget extends ReactWidget {
                 }
             }
         }
+        if (generation !== this.reasoningStateGeneration) {
+            // A newer refresh started while we awaited; its results win.
+            return;
+        }
         if (support !== this.currentReasoningSupport
             || modelId !== this.currentLanguageModelId
             || maxInputTokens !== this.currentMaxInputTokens
@@ -382,6 +403,7 @@ export class AIChatInputWidget extends ReactWidget {
             this.currentModelVendor = vendor;
             this.update();
         }
+        this.updateResolvedDefaultModel();
     }
 
     protected handleCapabilityChange = (fragmentId: string, enabled: boolean): void => {
@@ -477,6 +499,87 @@ export class AIChatInputWidget extends ReactWidget {
             delete newCommon.reasoning;
         }
         (session.model as MutableChatModel).setSettings({ ...currentSettings, commonSettings: newCommon });
+    }
+
+    /** Language models available for the per-session model selector; refreshed on registry changes. */
+    protected availableModels: LanguageModel[] = [];
+    /** Concrete model id the agent default currently resolves to (e.g. what `default/code` points at); falls back to the identifier. */
+    protected resolvedDefaultLabel?: string;
+
+    protected async loadAvailableModels(): Promise<void> {
+        this.availableModels = await this.languageModelRegistry.getLanguageModels();
+    }
+
+    /**
+     * Resolves the model a new session would use for this agent, honoring the per-agent override
+     * configured in the AI configuration (via {@link AISettingsService}) and following aliases, so
+     * the selector's "Default" reflects the effective, resolved target.
+     */
+    protected async updateResolvedDefaultModel(): Promise<void> {
+        // Guard against out-of-order completion, mirroring updateReasoningSupport.
+        const generation = ++this.resolvedDefaultGeneration;
+        const agent = this.receivingAgent ? this.chatAgentService.getAgent(this.receivingAgent.agentId) : undefined;
+        const requirement = agent?.languageModelRequirements?.[0];
+        let label: string | undefined;
+        if (agent && requirement) {
+            const agentSettings = await this.aiSettingsService.getAgentSettings(agent.id);
+            const effective = agentSettings?.languageModelRequirements?.find(r => r.purpose === requirement.purpose)?.identifier
+                ?? requirement.identifier;
+            const resolved = await this.languageModelRegistry.selectLanguageModel({ agent: agent.id, ...requirement });
+            const resolvedId = resolved?.id;
+            // Show "alias → resolved" when the effective default is an alias that resolves to a concrete model.
+            label = resolvedId && effective && resolvedId !== effective ? `${effective} → ${resolvedId}` : (resolvedId ?? effective);
+        }
+        if (generation !== this.resolvedDefaultGeneration) {
+            // A newer refresh started while we awaited; its results win.
+            return;
+        }
+        if (label !== this.resolvedDefaultLabel) {
+            this.resolvedDefaultLabel = label;
+            this.update();
+        }
+    }
+
+    /** The per-session model override id for the active session, if any. */
+    protected getSessionModelOverride(): string | undefined {
+        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
+        return session?.model.settings?.commonSettings?.modelId;
+    }
+
+    /** Sets (or clears, with `undefined`) the per-session model override for the active session. */
+    protected handleSessionModelChange = (modelId: string | undefined): void => {
+        const session = this.chatService.getSessions().find(s => s.model.id === this._chatModel?.id);
+        if (!session) {
+            return;
+        }
+        const currentSettings = session.model.settings ?? {};
+        const currentCommon = currentSettings.commonSettings ?? {};
+        if ((currentCommon.modelId ?? undefined) === (modelId ?? undefined)) {
+            return;
+        }
+        const newCommon: typeof currentCommon = { ...currentCommon };
+        if (modelId) {
+            newCommon.modelId = modelId;
+        } else {
+            delete newCommon.modelId;
+        }
+        (session.model as MutableChatModel).setSettings({ ...currentSettings, commonSettings: newCommon });
+        // The override changes the effective model, so refresh all model-dependent state.
+        this.updateReasoningSupport(this.receivingAgent?.agentId);
+        this.update();
+    };
+
+    /** Builds the props for the per-session model selector. */
+    protected getModelSelectorProps(): ModelSelectorWidgetProps {
+        const currentModelId = this.getSessionModelOverride();
+        const defaultLabel = this.resolvedDefaultLabel
+            ?? nls.localize('theia/ai/chat-ui/agentDefaultModel', 'agent default');
+        return {
+            models: this.availableModels,
+            currentModelId,
+            defaultLabel,
+            onModelChange: this.handleSessionModelChange,
+        };
     }
 
     protected async updateAvailableGenericCapabilities(): Promise<void> {
@@ -962,12 +1065,22 @@ export class AIChatInputWidget extends ReactWidget {
             this.refreshCapabilities();
         }));
 
-        // Refresh reasoning capability if the language model registry changes (model added/removed/alias re-resolved).
+        // Refresh reasoning capability and the model selector list if the language model registry
+        // changes (model added/removed/alias re-resolved).
         this.toDispose.push(this.languageModelRegistry.onChange(() => {
+            this.loadAvailableModels().then(() => this.update());
             if (this.receivingAgent) {
                 this.updateReasoningSupport(this.receivingAgent.agentId);
             }
         }));
+        // When the agent's model is changed in the AI configuration, refresh the selector's resolved
+        // default and the model-dependent state (reasoning support, context size, server tools, vendor).
+        this.toDispose.push(this.aiSettingsService.onDidChange(() => {
+            this.updateResolvedDefaultModel();
+            this.updateReasoningSupport(this.receivingAgent?.agentId);
+        }));
+        this.loadAvailableModels().then(() => this.update());
+        this.updateResolvedDefaultModel();
 
         // When the default mode changes externally (e.g. via AI Configuration),
         // sync the mode selector. Deferred via queueMicrotask so the prompt service's
@@ -1382,6 +1495,7 @@ export class AIChatInputWidget extends ReactWidget {
                     currentLevel: this.getCurrentReasoningLevel(),
                     onReasoningChange: this.handleReasoningChange,
                 }}
+                modelSelectorProps={this.getModelSelectorProps()}
                 capabilitiesProps={{
                     capabilities: this.capabilityDefaults,
                     overrides: this.userCapabilityOverrides,
@@ -1669,6 +1783,18 @@ export class AIChatInputWidget extends ReactWidget {
     }
 }
 
+/** Props for the per-session language model selector. */
+interface ModelSelectorWidgetProps {
+    /** Models available to switch to. */
+    models: LanguageModel[];
+    /** The session's current model override id, if any (undefined = use the agent default). */
+    currentModelId?: string;
+    /** Human-readable label of the model/alias new sessions use by default. */
+    defaultLabel: string;
+    /** Set the session override (or clear it with `undefined`). */
+    onModelChange: (modelId: string | undefined) => void;
+}
+
 interface ChatInputProperties {
     branch?: ChatHierarchyBranch;
     onCancel: (requestModel: ChatRequestModel) => void;
@@ -1723,6 +1849,7 @@ interface ChatInputProperties {
         currentLevel?: ReasoningLevel;
         onReasoningChange: (level: ReasoningLevel) => void;
     };
+    modelSelectorProps: ModelSelectorWidgetProps;
     capabilitiesProps: {
         capabilities: ParsedCapability[];
         overrides: Map<string, boolean>;
@@ -2236,6 +2363,7 @@ const ChatInput: React.FunctionComponent<ChatInputProperties> = (props: ChatInpu
                         currentLevel: props.reasoningSelectorProps.currentLevel,
                         onReasoningChange: props.reasoningSelectorProps.onReasoningChange,
                     }}
+                    modelSelectorProps={props.modelSelectorProps}
                     capabilitiesToggle={{
                         show: props.showCapabilities !== false,
                         isOpen: props.capabilitiesProps.isOpen,
@@ -2288,6 +2416,7 @@ interface ChatInputOptionsProps {
         currentLevel?: ReasoningLevel;
         onReasoningChange: (level: ReasoningLevel) => void;
     };
+    modelSelectorProps: ModelSelectorWidgetProps;
     capabilitiesToggle: {
         show: boolean;
         isOpen: boolean;
@@ -2306,6 +2435,7 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({
     tokenUsage,
     modeSelectorProps,
     reasoningSelectorProps,
+    modelSelectorProps,
     capabilitiesToggle
 }) => {
     const capabilitiesLabel = nls.localize('theia/ai/chat-ui/toggleCapabilitiesConfig', 'Toggle Capabilities Configuration');
@@ -2413,6 +2543,16 @@ const ChatInputOptions: React.FunctionComponent<ChatInputOptionsProps> = ({
                         reasoningSupport={reasoningSelectorProps.reasoningSupport}
                         currentLevel={reasoningSelectorProps.currentLevel}
                         onReasoningChange={reasoningSelectorProps.onReasoningChange}
+                        disabled={!isEnabled}
+                        hoverService={hoverService}
+                    />
+                )}
+                {(modelSelectorProps.models.length > 0 || modelSelectorProps.currentModelId) && (
+                    <ChatModelSelector
+                        models={modelSelectorProps.models}
+                        currentModelId={modelSelectorProps.currentModelId}
+                        defaultLabel={modelSelectorProps.defaultLabel}
+                        onModelChange={modelSelectorProps.onModelChange}
                         disabled={!isEnabled}
                         hoverService={hoverService}
                     />
@@ -2570,6 +2710,82 @@ const ChatModeSelector: React.FunctionComponent<ChatModeSelectorProps> = React.m
                 className={`theia-ChatInput-ModeSelector${disabled ? ' disabled' : ''}`}
                 options={options}
                 defaultValue={currentMode ?? modes[0]?.id ?? ''}
+                onChange={handleChange}
+            />
+        </span>
+    );
+});
+
+interface ChatModelSelectorProps {
+    models: LanguageModel[];
+    currentModelId?: string;
+    defaultLabel: string;
+    onModelChange: (modelId: string | undefined) => void;
+    disabled?: boolean;
+    hoverService: HoverService;
+}
+
+/**
+ * Per-session model selector. The first option ("Default") reverts to the agent's configured
+ * model that new sessions use; picking any other model overrides it for the current session only.
+ */
+const ChatModelSelector: React.FunctionComponent<ChatModelSelectorProps> = React.memo(({
+    models, currentModelId, defaultLabel, onModelChange, disabled, hoverService
+}) => {
+    // Sentinel value for the "use the agent default" option (SelectComponent needs a non-empty value).
+    const defaultValueId = '__default__';
+    const isOverridden = !!currentModelId;
+    // The override points at a model that is no longer ready/available. Guard on a loaded model list so
+    // the override is not flagged as unavailable during the initial (still empty) load.
+    const isUnavailable = isOverridden && models.length > 0
+        && !models.some(model => model.id === currentModelId && model.status.status === 'ready');
+    const options: SelectOption[] = React.useMemo(() => {
+        const readyModels = models.filter(model => model.status.status === 'ready')
+            // Stable, predictable order: the registry adds models as their async metadata resolves.
+            .sort((left, right) => left.id.localeCompare(right.id));
+        const opts: SelectOption[] = [
+            {
+                value: defaultValueId,
+                label: nls.localizeByDefault('Default'),
+                detail: defaultLabel
+            },
+            ...readyModels.map(model => ({
+                value: model.id,
+                label: model.id,
+                detail: model.name && model.name !== model.id ? model.name : undefined
+            }))
+        ];
+        // Keep the active override visible even if its model is no longer ready/available, so the
+        // selector reflects the stored modelId instead of silently falling back to "Default". Once we
+        // know it is unavailable, show it as a disabled (struck-through) entry that cannot be reselected.
+        if (currentModelId && !opts.some(option => option.value === currentModelId)) {
+            opts.push({
+                value: currentModelId,
+                label: currentModelId,
+                detail: nls.localize('theia/ai/chat-ui/modelUnavailable', 'unavailable'),
+                disabled: isUnavailable
+            });
+        }
+        return opts;
+    }, [models, defaultLabel, currentModelId, isUnavailable]);
+
+    const handleChange = React.useCallback(
+        (option: SelectOption) => onModelChange(!option.value || option.value === defaultValueId ? undefined : option.value),
+        [onModelChange]
+    );
+
+    const title = isUnavailable
+        ? nls.localize('theia/ai/chat-ui/sessionModelUnavailable', 'Model for this chat is unavailable ({0}); requests use the agent default', currentModelId!)
+        : isOverridden
+            ? nls.localize('theia/ai/chat-ui/sessionModel', 'Model for this chat')
+            : nls.localize('theia/ai/chat-ui/sessionModelDefault', 'Model for this chat ({0})', defaultLabel);
+
+    return (
+        <span className='theia-ChatInput-ModelSelector-container' onMouseEnter={hoverHandler(hoverService, title)}>
+            <SelectComponent
+                className={`theia-ChatInput-ModelSelector${isOverridden ? ' session-override' : ''}${disabled ? ' disabled' : ''}`}
+                options={options}
+                defaultValue={currentModelId ?? defaultValueId}
                 onChange={handleChange}
             />
         </span>

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -65,6 +65,7 @@ import { useMarkdownRendering } from '../chat-response-renderer/markdown-part-re
 import { ProgressMessage } from '../chat-progress-message';
 import { AIChatTreeInputFactory, type AIChatTreeInputWidget } from './chat-view-tree-input-widget';
 import { PromptVariantBadge } from './prompt-variant-badge';
+import { ModelBadge } from './model-badge';
 
 // TODO Instead of directly operating on the ChatRequestModel we could use an intermediate view model
 export interface RequestNode extends TreeNode {
@@ -494,6 +495,7 @@ export class ChatViewTreeWidget extends TreeWidget {
 
         const promptVariantId = isResponseNode(node) ? node.response.promptVariantId : undefined;
         const isPromptVariantEdited = isResponseNode(node) ? !!node.response.isPromptVariantEdited : false;
+        const languageModel = isResponseNode(node) ? node.response.languageModel : undefined;
 
         return <React.Fragment>
             <div className='theia-ChatNodeHeader'>
@@ -532,6 +534,12 @@ export class ChatViewTreeWidget extends TreeWidget {
                     <PromptVariantBadge
                         variantId={promptVariantId}
                         isEdited={isPromptVariantEdited}
+                        hoverService={this.hoverService}
+                    />
+                )}
+                {languageModel && (
+                    <ModelBadge
+                        modelId={languageModel}
                         hoverService={this.hoverService}
                     />
                 )}

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/chat-view-tree-widget.tsx
@@ -545,36 +545,38 @@ export class ChatViewTreeWidget extends TreeWidget {
                 )}
                 {inProgress && !waitingForInput &&
                     <span className='theia-ChatContentInProgress' role='status' aria-live='polite'>
+                        <span className={`${codicon('loading')} codicon-modifier-spin`} aria-hidden={true}></span>
                         {nls.localize('theia/ai/chat-ui/chat-view-tree-widget/generating', 'Generating')}
                     </span>}
                 {inProgress && waitingForInput &&
                     <span className='theia-ChatContentInProgress' role='status' aria-live='polite'>
+                        <span className={`${codicon('loading')} codicon-modifier-spin`} aria-hidden={true}></span>
                         {nls.localize('theia/ai/chat-ui/chat-view-tree-widget/waitingForInput', 'Waiting for input')}
                     </span>}
-                <div className='theia-ChatNodeToolbar'>
-                    {!inProgress &&
-                        toolbarContributions.length > 0 &&
-                        toolbarContributions.map(action =>
-                            <span
-                                key={action.commandId}
-                                className={`theia-ChatNodeToolbarAction ${action.icon}`}
-                                title={action.tooltip}
-                                aria-label={action.tooltip}
-                                tabIndex={0}
-                                onClick={e => {
-                                    e.stopPropagation();
-                                    this.commandRegistry.executeCommand(action.commandId, node);
-                                }}
-                                onKeyDown={e => {
-                                    if (isEnterKey(e)) {
+                {!inProgress &&
+                    <div className='theia-ChatNodeToolbar'>
+                        {toolbarContributions.length > 0 &&
+                            toolbarContributions.map(action =>
+                                <span
+                                    key={action.commandId}
+                                    className={`theia-ChatNodeToolbarAction ${action.icon}`}
+                                    title={action.tooltip}
+                                    aria-label={action.tooltip}
+                                    tabIndex={0}
+                                    onClick={e => {
                                         e.stopPropagation();
                                         this.commandRegistry.executeCommand(action.commandId, node);
-                                    }
-                                }}
-                                role='button'
-                            ></span>
-                        )}
-                </div>
+                                    }}
+                                    onKeyDown={e => {
+                                        if (isEnterKey(e)) {
+                                            e.stopPropagation();
+                                            this.commandRegistry.executeCommand(action.commandId, node);
+                                        }
+                                    }}
+                                    role='button'
+                                ></span>
+                            )}
+                    </div>}
             </div>
         </React.Fragment>;
     }

--- a/packages/ai-chat-ui/src/browser/chat-tree-view/model-badge.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-tree-view/model-badge.tsx
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+
+export interface ModelBadgeProps {
+    /** Identifier of the language model that produced the response. */
+    modelId: string;
+    hoverService: HoverService;
+}
+
+/**
+ * Badge shown next to a chat response indicating which language model produced it. Mirrors the
+ * model badge shown in the AI History view.
+ */
+export const ModelBadge: React.FC<ModelBadgeProps> = ({ modelId, hoverService }) => {
+    // eslint-disable-next-line no-null/no-null
+    const badgeRef = React.useRef<HTMLSpanElement>(null);
+    const tooltip = nls.localize('theia/ai/chat-ui/modelBadgeTooltip', 'Language model used for this response: {0}', modelId);
+
+    return (
+        <span
+            ref={badgeRef}
+            className='theia-ModelBadge'
+            onMouseEnter={() => {
+                if (badgeRef.current) {
+                    hoverService.requestHover({
+                        content: tooltip,
+                        target: badgeRef.current,
+                        position: 'right'
+                    });
+                };
+            }}
+        >
+            {modelId}
+        </span>
+    );
+};

--- a/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
+++ b/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
@@ -212,6 +212,8 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
 
     protected preservedReasoning: CommonChatSessionSettings['reasoning'];
 
+    protected preservedModelId: CommonChatSessionSettings['modelId'];
+
     protected contentRoot: Root;
     protected editorContainerNode: HTMLDivElement;
 
@@ -230,6 +232,9 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
 
         // Reasoning is edited in the chat input; preserve it across this dialog.
         this.preservedReasoning = this.settings.commonSettings?.reasoning;
+
+        // The per-session model override is edited in the chat input; preserve it across this dialog.
+        this.preservedModelId = this.settings.commonSettings?.modelId;
 
         // Read the per-session compaction override (undefined = use global/per-provider setting).
         this.compactionOverride = this.settings.commonSettings?.compaction?.enabled;
@@ -414,6 +419,9 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
         const commonSettings: CommonChatSessionSettings = {};
         if (this.preservedReasoning) {
             commonSettings.reasoning = this.preservedReasoning;
+        }
+        if (this.preservedModelId) {
+            commonSettings.modelId = this.preservedModelId;
         }
         if (this.confirmationTimeoutEnabled && !isNaN(this.confirmationTimeoutSeconds) && this.confirmationTimeoutSeconds > 0) {
             commonSettings.confirmationTimeout = this.confirmationTimeoutSeconds;

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -46,46 +46,30 @@ div:last-child>.theia-ChatNode {
   font-size: 13px;
   font-weight: 600;
   margin: 0;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  /* Keep the agent name for as long as possible: badges shrink first, the name only truncates as a
+     last resort (after the badges), and the status never shrinks. */
+  flex-shrink: 1;
 }
 
 .theia-ChatNodeHeader .theia-ChatContentInProgress {
-  color: var(--theia-disabledForeground);
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding) / 2);
+  /* Always keep the live status visible and anchored to the right, whatever the name/badge length. */
+  margin-left: auto;
+  flex-shrink: 0;
   white-space: nowrap;
+  color: var(--theia-progressBar-background);
 }
 
 .theia-ChatNodeHeader .theia-ChatContentInProgress-Cancel {
   position: absolute;
   z-index: 999;
   right: 20px;
-}
-
-@keyframes dots {
-
-  0%,
-  20% {
-    content: "";
-  }
-
-  40% {
-    content: ".";
-  }
-
-  60% {
-    content: "..";
-  }
-
-  80%,
-  100% {
-    content: "...";
-  }
-}
-
-.theia-ChatNodeHeader .theia-ChatContentInProgress::after {
-  content: "";
-  animation: dots 1s steps(1, end) infinite;
-  display: inline-block;
-  width: 3ch;
-  text-align: left;
 }
 
 .theia-ChatNode .codicon {
@@ -112,6 +96,17 @@ div:last-child>.theia-ChatNode {
   color: var(--theia-editorWarning-foreground);
   background-color: var(--theia-inputValidation-warningBackground);
   border: 1px solid var(--theia-editorWarning-foreground);
+}
+
+/* In the crowded header the badges may be long; let both ellipsize together (with equal priority),
+   before the agent name and without pushing the live status out. The full text stays available via
+   each badge's hover tooltip. */
+.theia-ChatNodeHeader .theia-PromptVariantBadge,
+.theia-ChatNodeHeader .theia-ModelBadge {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex-shrink: 100;
 }
 
 .theia-ChatNode .theia-ChatNodeToolbar {

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -96,11 +96,13 @@ div:last-child>.theia-ChatNode {
   font-weight: 600;
 }
 
-.theia-PromptVariantBadge {
+/* Prompt variant and model badges share a subtle look; only an edited variant is emphasized. */
+.theia-PromptVariantBadge,
+.theia-ModelBadge {
   padding: 0 calc(var(--theia-ui-padding) * 2 / 3);
   font-size: var(--theia-ui-font-size0);
-  color: var(--theia-badge-foreground);
-  background-color: var(--theia-badge-background);
+  color: var(--theia-descriptionForeground);
+  background-color: var(--theia-editor-inactiveSelectionBackground);
   border-radius: calc(var(--theia-ui-padding) * 2 / 3);
   white-space: nowrap;
   user-select: none;
@@ -673,10 +675,14 @@ div:last-child>.theia-ChatNode {
 .theia-ChatInputOptions .theia-ChatInputOptions-left {
   order: -1;
   gap: calc(var(--theia-ui-padding) / 3);
+  /* Let the group shrink so the model selector can give way to the right group. */
+  min-width: 0;
 }
 
 .theia-ChatInputOptions .theia-ChatInputOptions-right {
   margin-right: calc(var(--theia-ui-padding) * 4 / 3);
+  /* Keep the token usage and send/stop button fully visible. */
+  flex-shrink: 0;
 }
 
 .theia-ChatInputOptions .option {
@@ -687,6 +693,8 @@ div:last-child>.theia-ChatNode {
   justify-content: space-between;
   align-items: center;
   gap: calc(var(--theia-ui-padding) / 3);
+  /* Keep icon buttons at their natural size so icon and label never overlap. */
+  flex-shrink: 0;
   box-sizing: border-box;
   user-select: none;
   background-repeat: no-repeat;
@@ -758,6 +766,67 @@ div:last-child>.theia-ChatNode {
 
 .theia-ChatInput-ModeSelector.disabled,
 .theia-ChatInput-ReasoningSelector.disabled {
+  opacity: var(--theia-mod-disabled-opacity);
+  cursor: default;
+  pointer-events: none;
+}
+
+/* Wrapper span is the flex item in the options row, so it (not the inner select) carries the shrink
+   behaviour; otherwise the inner nowrap label keeps it at full width. Sizes to content (so "Default"
+   sits snug to the chevron) up to max-width, then shrinks and ellipsizes the label for long names. */
+.theia-ChatInput-ModelSelector-container {
+  display: flex;
+  flex-shrink: 1;
+  min-width: 0;
+  max-width: 200px;
+}
+
+/* Per-session model selector: shares the compact selector styling. */
+.theia-ChatInput-ModelSelector.theia-select-component {
+  min-width: 0;
+  width: 100%;
+  min-height: unset;
+  overflow: hidden;
+  height: calc(var(--theia-icon-size) + var(--theia-ui-padding) - 1px);
+  padding: 0 calc(var(--theia-ui-padding) * 2 / 3);
+  border: var(--theia-border-width) solid transparent;
+  box-sizing: border-box;
+  background: var(--theia-editor-background);
+  font-family: var(--theia-ui-font-family);
+  font-size: var(--theia-content-font-size);
+  border-radius: calc(var(--theia-ui-padding) * 5 / 6);
+  outline: none;
+}
+
+.theia-ChatInput-ModelSelector .theia-select-component-chevron {
+  font-size: var(--theia-ui-font-size1);
+  margin-left: calc(var(--theia-ui-padding) / 3);
+  /* Keep the arrow visible even when the label is fully ellipsized. */
+  flex-shrink: 0;
+}
+
+.theia-ChatInput-ModelSelector.theia-select-component:hover {
+  background-color: var(--theia-toolbar-hoverBackground);
+}
+
+.theia-ChatInput-ModelSelector.theia-select-component:focus-visible {
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: -1px;
+}
+
+/* Indicate an active per-session model override with accent-colored text rather than a focus-like border. */
+.theia-ChatInput-ModelSelector.session-override .theia-select-component-label {
+  color: var(--theia-textLink-foreground);
+}
+
+/* The shown model is unavailable (a disabled selection): flag it at a glance without opening the
+   dropdown. Keyed off the displayed option, so navigating to a valid model clears it. */
+.theia-ChatInput-ModelSelector.theia-select-component-selection-disabled .theia-select-component-label {
+  color: var(--theia-errorForeground);
+  text-decoration: line-through;
+}
+
+.theia-ChatInput-ModelSelector.disabled {
   opacity: var(--theia-mod-disabled-opacity);
   cursor: default;
   pointer-events: none;

--- a/packages/ai-chat/src/common/chat-agents.spec.ts
+++ b/packages/ai-chat/src/common/chat-agents.spec.ts
@@ -18,8 +18,8 @@ import 'reflect-metadata';
 
 import { expect } from 'chai';
 import {
-    LanguageModel, LanguageModelMessage, LanguageModelRequirement, LanguageModelResponse,
-    LanguageModelService, LanguageModelStreamResponsePart, ServerToolDescriptor, UserRequest
+    LanguageModel, LanguageModelMessage, LanguageModelRegistry, LanguageModelRequirement, LanguageModelResponse,
+    LanguageModelSelector, LanguageModelService, LanguageModelStreamResponsePart, ServerToolDescriptor, UserRequest
 } from '@theia/ai-core';
 import { AbstractChatAgent, AbstractStreamParsingChatAgent, ChatAgentLocation } from './chat-agents';
 import {
@@ -50,6 +50,14 @@ class TestChatAgent extends AbstractChatAgent {
 
     public exposeSendLlmRequest(request: MutableChatRequestModel, languageModel: LanguageModel): Promise<LanguageModelResponse> {
         return this.sendLlmRequest(request, [], [], undefined, languageModel);
+    }
+
+    public exposeGetLanguageModelForRequest(request: MutableChatRequestModel, purpose = 'chat'): Promise<LanguageModel> {
+        return this.getLanguageModelForRequest(request, purpose);
+    }
+
+    public setLanguageModelRegistry(registry: LanguageModelRegistry): void {
+        this.languageModelRegistry = registry;
     }
 }
 
@@ -209,5 +217,78 @@ describe('AbstractChatAgent.parse compaction', () => {
         expect(compaction.provider).to.equal('anthropic');
         expect(compaction.data).to.deep.equal({ b: 1 });
         expect(compaction.summary).to.equal('s');
+    });
+});
+
+describe('AbstractChatAgent.getLanguageModelForRequest', () => {
+
+    const DEFAULT_MODEL = 'default-model';
+    const OVERRIDE_MODEL = 'override-model';
+
+    let agent: TestChatAgent;
+    let requestedIdentifiers: (string | undefined)[];
+
+    function fakeModel(id: string): LanguageModel {
+        return { id } as LanguageModel;
+    }
+
+    beforeEach(() => {
+        agent = new TestChatAgent();
+        agent.languageModelRequirements.push({ purpose: 'chat', identifier: DEFAULT_MODEL });
+        requestedIdentifiers = [];
+        // Resolve any of the known model ids; anything else (e.g. an unavailable override) resolves to undefined.
+        const known = new Set([DEFAULT_MODEL, OVERRIDE_MODEL]);
+        agent.setLanguageModelRegistry({
+            // Settings-aware selection used for the agent default (fallback) path.
+            async selectLanguageModel(request: LanguageModelSelector): Promise<LanguageModel | undefined> {
+                requestedIdentifiers.push(request.identifier);
+                return request.identifier && known.has(request.identifier) ? fakeModel(request.identifier) : undefined;
+            },
+            // Direct resolution used for the per-session override path (bypasses agent settings).
+            async getReadyLanguageModel(idOrAlias: string): Promise<LanguageModel | undefined> {
+                requestedIdentifiers.push(idOrAlias);
+                return known.has(idOrAlias) ? fakeModel(idOrAlias) : undefined;
+            }
+        } as unknown as LanguageModelRegistry);
+    });
+
+    function createRequest(modelOverride?: string): MutableChatRequestModel {
+        const model = new MutableChatModel(ChatAgentLocation.Panel);
+        const request = model.addRequest(createParsedRequest('Hello'));
+        if (modelOverride !== undefined) {
+            model.setSettings({ commonSettings: { modelId: modelOverride } });
+        }
+        return request;
+    }
+
+    it('uses the agent default when no session override is set', async () => {
+        const resolved = await agent.exposeGetLanguageModelForRequest(createRequest());
+        expect(resolved.id).to.equal(DEFAULT_MODEL);
+    });
+
+    it('honors the session model override when it resolves', async () => {
+        const resolved = await agent.exposeGetLanguageModelForRequest(createRequest(OVERRIDE_MODEL));
+        expect(resolved.id).to.equal(OVERRIDE_MODEL);
+        // The override id must be the first thing tried.
+        expect(requestedIdentifiers[0]).to.equal(OVERRIDE_MODEL);
+    });
+
+    it('falls back to the agent default when the session override does not resolve', async () => {
+        const resolved = await agent.exposeGetLanguageModelForRequest(createRequest('no-such-model'));
+        expect(resolved.id).to.equal(DEFAULT_MODEL);
+        // First the unavailable override is attempted, then the agent default.
+        expect(requestedIdentifiers).to.deep.equal(['no-such-model', DEFAULT_MODEL]);
+    });
+
+    it('throws when neither the override nor the default resolves', async () => {
+        agent.languageModelRequirements.length = 0;
+        agent.languageModelRequirements.push({ purpose: 'chat', identifier: 'missing-default' });
+        let error: Error | undefined;
+        try {
+            await agent.exposeGetLanguageModelForRequest(createRequest('also-missing'));
+        } catch (e) {
+            error = e as Error;
+        }
+        expect(error).to.be.an('error');
     });
 });

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -52,6 +52,7 @@ import {
 } from '@theia/ai-core';
 import {
     Agent,
+    FrontendLanguageModelRegistry,
     isLanguageModelParsedResponse,
     isLanguageModelStreamResponse,
     isLanguageModelTextResponse,
@@ -227,10 +228,12 @@ export abstract class AbstractChatAgent implements ChatAgent {
 
     async invoke(request: MutableChatRequestModel): Promise<void> {
         try {
-            const languageModel = await this.getLanguageModel(this.defaultLanguageModelPurpose);
+            const languageModel = await this.getLanguageModelForRequest(request, this.defaultLanguageModelPurpose);
             if (!languageModel) {
                 throw new Error(nls.localize('theia/ai/chat/couldNotFindMatchingLM', 'Couldn\'t find a matching language model. Please check your setup!'));
             }
+            // Record the model that actually handled this request so the chat thread can show it.
+            request.response.setLanguageModel(languageModel.id);
             const context: ChatSessionContext = {
                 model: request.session,
                 request,
@@ -313,6 +316,36 @@ export abstract class AbstractChatAgent implements ChatAgent {
 
     protected async getLanguageModel(languageModelPurpose: string): Promise<LanguageModel> {
         return this.selectLanguageModel(this.getLanguageModelSelector(languageModelPurpose));
+    }
+
+    /**
+     * Resolves the language model for a request, honoring a per-session model override
+     * ({@link CommonChatSessionSettings.modelId}) when set and resolvable, and otherwise falling
+     * back to the agent's configured model for the given purpose.
+     */
+    protected async getLanguageModelForRequest(request: MutableChatRequestModel, languageModelPurpose: string): Promise<LanguageModel> {
+        const overrideId = request.session.settings?.commonSettings?.modelId;
+        if (overrideId) {
+            // Resolve the override directly. We must not go through `selectLanguageModel` here, because
+            // that honors the per-agent model configured in the AI settings, which would take
+            // precedence over and thus ignore the session override.
+            const overridden = await this.resolveModelById(overrideId);
+            if (overridden) {
+                return overridden;
+            }
+        }
+        return this.getLanguageModel(languageModelPurpose);
+    }
+
+    /** Resolves a concrete language model (or alias) id to a ready model, or `undefined` if none is ready. */
+    protected async resolveModelById(modelId: string): Promise<LanguageModel | undefined> {
+        const registry = this.languageModelRegistry as LanguageModelRegistry & Partial<FrontendLanguageModelRegistry>;
+        if (typeof registry.getReadyLanguageModel === 'function') {
+            // Frontend registry: resolves aliases and only returns the model if it is ready.
+            return registry.getReadyLanguageModel(modelId);
+        }
+        const model = await registry.getLanguageModel(modelId);
+        return model?.status.status === 'ready' ? model : undefined;
     }
 
     protected async selectLanguageModel(selector: LanguageModelRequirement): Promise<LanguageModel> {

--- a/packages/ai-chat/src/common/chat-auto-save.spec.ts
+++ b/packages/ai-chat/src/common/chat-auto-save.spec.ts
@@ -25,7 +25,7 @@ import { ILogger } from '@theia/core';
 import { ChatAgentLocation } from './chat-agents';
 import { ChatContentDeserializerRegistry, ChatContentDeserializerRegistryImpl, DefaultChatContentDeserializerContribution } from './chat-content-deserializer';
 import { ChangeSetElementDeserializerRegistry, ChangeSetElementDeserializerRegistryImpl } from './change-set-element-deserializer';
-import { ChatModel } from './chat-model';
+import { ChatModel, MutableChatModel } from './chat-model';
 import { SerializedChatData } from './chat-model-serialization';
 import { ParsedChatRequest, ParsedChatRequestTextPart } from './parsed-chat-request';
 
@@ -239,6 +239,23 @@ describe('Chat Auto-Save Mechanism', () => {
 
             // Verify no auto-save occurred
             expect(sessionStore.saveCount).to.equal(0);
+        });
+    });
+
+    describe('Auto-save on settings changes', () => {
+        it('should auto-save when per-session settings change', async () => {
+            const session = chatService.createSession(ChatAgentLocation.Panel);
+            // Non-empty session so saveSession does not skip it.
+            await chatService.sendRequest(session.id, { text: 'Test request' });
+            sessionStore.reset();
+
+            // A selector-only / dialog-only settings change must trigger persistence.
+            (session.model as MutableChatModel).setSettings({ commonSettings: { modelId: 'test/model' } });
+
+            // Wait for auto-save to complete (debounce is 500ms + execution time)
+            await new Promise(resolve => setTimeout(resolve, 700));
+
+            expect(sessionStore.saveCount).to.be.greaterThan(0);
         });
     });
 

--- a/packages/ai-chat/src/common/chat-model-serialization.spec.ts
+++ b/packages/ai-chat/src/common/chat-model-serialization.spec.ts
@@ -700,4 +700,42 @@ describe('ChatModel Serialization and Restoration', () => {
             expect(restoredPart.resolution?.variable.description).to.equal('File variable');
         });
     });
+
+    describe('Session settings and response model serialization', () => {
+        it('should serialize and restore the per-session model override', () => {
+            const model = new MutableChatModel(ChatAgentLocation.Panel);
+            model.addRequest(createParsedRequest('Hello'));
+            model.setSettings({ commonSettings: { modelId: 'anthropic/claude-opus-4-8' } });
+
+            const serialized = model.toSerializable();
+            expect(serialized.settings?.commonSettings?.modelId).to.equal('anthropic/claude-opus-4-8');
+
+            const restored = new MutableChatModel(serialized);
+            expect(restored.settings?.commonSettings?.modelId).to.equal('anthropic/claude-opus-4-8');
+        });
+
+        it('should leave settings undefined when none were set', () => {
+            const model = new MutableChatModel(ChatAgentLocation.Panel);
+            model.addRequest(createParsedRequest('Hello'));
+
+            const serialized = model.toSerializable();
+            expect(serialized.settings).to.be.undefined;
+
+            const restored = new MutableChatModel(serialized);
+            expect(restored.settings).to.be.undefined;
+        });
+
+        it('should serialize and restore the language model recorded on a response', () => {
+            const model = new MutableChatModel(ChatAgentLocation.Panel);
+            const request = model.addRequest(createParsedRequest('Hello'));
+            request.response.setLanguageModel('anthropic/claude-opus-4-8');
+            request.response.complete();
+
+            const serialized = model.toSerializable();
+            expect(serialized.responses[0].languageModel).to.equal('anthropic/claude-opus-4-8');
+
+            const restored = new MutableChatModel(serialized);
+            expect(restored.getAllRequests()[0].response.languageModel).to.equal('anthropic/claude-opus-4-8');
+        });
+    });
 });

--- a/packages/ai-chat/src/common/chat-model-serialization.ts
+++ b/packages/ai-chat/src/common/chat-model-serialization.ts
@@ -16,7 +16,7 @@
 
 import { GenericCapabilitySelections } from '@theia/ai-core';
 import { ChatAgentLocation } from './chat-agents';
-import { ResponseTokenUsage } from './chat-model';
+import { ChatSessionSettings, ResponseTokenUsage } from './chat-model';
 
 export interface SerializableChangeSetElement {
     kind?: string;
@@ -138,6 +138,8 @@ export interface SerializableChatResponseData {
     errorMessage?: string;
     promptVariantId?: string;
     isPromptVariantEdited?: boolean;
+    /** Identifier of the language model that produced this response, if recorded. */
+    languageModel?: string;
     tokenUsage?: ResponseTokenUsage;
     content: SerializableChatResponseContentData[];
 }
@@ -189,6 +191,11 @@ export interface SerializedChatModel {
     requests: SerializableChatRequestData[];
     /** All responses for the requests */
     responses: SerializableChatResponseData[];
+    /**
+     * Per-session settings (e.g. the per-session model override) so they survive a reload and the
+     * chat input can restore the correct selection.
+     */
+    settings?: ChatSessionSettings;
 }
 
 /**

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -83,7 +83,8 @@ export type ChatChangeEvent =
     | ChatResponseChangedEvent
     | ChatChangeHierarchyBranchEvent
     | ChatInteractionNeededEvent
-    | ChatSessionStatusChangedEvent;
+    | ChatSessionStatusChangedEvent
+    | ChatSettingsChangedEvent;
 
 export interface ChatAddRequestEvent {
     kind: 'addRequest';
@@ -148,6 +149,11 @@ export interface ChatInteractionNeededEvent {
 export interface ChatSessionStatusChangedEvent {
     kind: 'statusChanged';
     status: ChatSessionStatus;
+}
+
+export interface ChatSettingsChangedEvent {
+    kind: 'settingsChanged';
+    settings: ChatSessionSettings;
 }
 
 export namespace ChatChangeEvent {
@@ -233,6 +239,12 @@ export interface ChatHierarchyBranchItem<TRequest extends ChatRequestModel = Cha
 }
 
 export interface CommonChatSessionSettings {
+    /**
+     * Language model (or alias) id to use for this session only, overriding the agent's default.
+     * New sessions start without an override and use the agent's configured model. Cleared to
+     * revert to the default.
+     */
+    modelId?: string;
     /** Reasoning configuration for this session; applied to reasoning-capable models. */
     reasoning?: ReasoningSettings;
     /** Per-session tool confirmation timeout in seconds. Overrides the global preference when set. */
@@ -1112,6 +1124,10 @@ export interface ChatResponseModel {
      * Indicates whether the prompt variant was customized/edited
      */
     readonly isPromptVariantEdited?: boolean;
+    /**
+     * The identifier of the language model that produced this response, if recorded.
+     */
+    readonly languageModel?: string;
     readonly tokenUsage?: ResponseTokenUsage;
     toSerializable(): SerializableChatResponseData;
 }
@@ -1209,6 +1225,12 @@ export class MutableChatModel implements ChatModel, Disposable {
             }, this, this.toDispose);
         }
 
+        // Restore per-session settings (e.g. the per-session model override) so the chat input can
+        // reflect the previous selection.
+        if (data.settings) {
+            this._settings = data.settings;
+        }
+
         // Restore the hierarchy structure with all alternatives
         this._hierarchy = new ChatRequestHierarchyImpl<MutableChatRequestModel>(data.hierarchy, requestMap);
 
@@ -1276,6 +1298,9 @@ export class MutableChatModel implements ChatModel, Disposable {
 
     setSettings(settings: ChatSessionSettings): void {
         this._settings = settings;
+        // Emit a change so listeners (e.g. session auto-save) persist selector-only or dialog-only
+        // settings updates that are not accompanied by another model change.
+        this._onDidChangeEmitter.fire({ kind: 'settingsChanged', settings });
     }
 
     addChildModel(child: MutableChatModel): Disposable {
@@ -1347,7 +1372,8 @@ export class MutableChatModel implements ChatModel, Disposable {
             location: this.location,
             hierarchy,
             requests: serializedRequests,
-            responses: serializedResponses
+            responses: serializedResponses,
+            settings: this._settings
         };
     }
 
@@ -3273,6 +3299,7 @@ export class MutableChatResponseModel implements ChatResponseModel {
     protected _cancellationToken: CancellationTokenSource;
     protected _promptVariantId?: string;
     protected _isPromptVariantEdited?: boolean;
+    protected _languageModel?: string;
     protected _tokenUsage?: ResponseTokenUsage;
     protected _tokenUsageEntries: ResponseTokenUsage[] = [];
 
@@ -3318,6 +3345,7 @@ export class MutableChatResponseModel implements ChatResponseModel {
         this._progressMessages = [];
         this._promptVariantId = data.promptVariantId;
         this._isPromptVariantEdited = data.isPromptVariantEdited ?? false;
+        this._languageModel = data.languageModel;
         this._tokenUsage = data.tokenUsage;
 
         if (data.errorMessage) {
@@ -3398,6 +3426,10 @@ export class MutableChatResponseModel implements ChatResponseModel {
         return this._isPromptVariantEdited ?? false;
     }
 
+    get languageModel(): string | undefined {
+        return this._languageModel;
+    }
+
     get tokenUsage(): ResponseTokenUsage | undefined {
         return this._tokenUsage;
     }
@@ -3419,6 +3451,12 @@ export class MutableChatResponseModel implements ChatResponseModel {
     setPromptVariantInfo(variantId: string | undefined, isEdited: boolean): void {
         this._promptVariantId = variantId;
         this._isPromptVariantEdited = isEdited;
+        this._onDidChangeEmitter.fire();
+    }
+
+    /** Records the identifier of the language model that produced this response. */
+    setLanguageModel(languageModel: string | undefined): void {
+        this._languageModel = languageModel;
         this._onDidChangeEmitter.fire();
     }
 
@@ -3499,6 +3537,7 @@ export class MutableChatResponseModel implements ChatResponseModel {
             errorMessage: this.errorObject?.message,
             promptVariantId: this._promptVariantId,
             isPromptVariantEdited: this._isPromptVariantEdited,
+            languageModel: this._languageModel,
             tokenUsage: this._tokenUsage,
             content: this.response.content.map(c => {
                 const serialized = c.toSerializable?.();

--- a/packages/ai-core/src/common/language-model.spec.ts
+++ b/packages/ai-core/src/common/language-model.spec.ts
@@ -16,6 +16,7 @@
 
 import { expect } from 'chai';
 import {
+    DefaultLanguageModelRegistryImpl,
     isCompactionResponsePart,
     isLanguageModelStreamResponsePart,
     isModelMatching,
@@ -171,6 +172,48 @@ describe('isToolCallContent', () => {
         expect(isToolCallContent(value)).to.be.false;
     });
 
+});
+
+describe('DefaultLanguageModelRegistryImpl', () => {
+    function createRegistry(): DefaultLanguageModelRegistryImpl {
+        const registry = new DefaultLanguageModelRegistryImpl();
+        // No DI container in this unit test, so resolve the internal `initialized` gate manually.
+        (registry as unknown as { markInitialized: () => void }).markInitialized();
+        return registry;
+    }
+
+    function model(id: string): LanguageModel {
+        return { id, status: { status: 'ready' } } as LanguageModel;
+    }
+
+    it('getLanguageModels returns a fresh array so consumers can detect changes by reference', async () => {
+        const registry = createRegistry();
+        registry.addLanguageModels([model('a')]);
+
+        const first = await registry.getLanguageModels();
+        expect(first).to.have.length(1);
+
+        registry.addLanguageModels([model('b')]);
+        const second = await registry.getLanguageModels();
+
+        // A new snapshot must be a different array reference (React memoization relies on this).
+        expect(second).to.not.equal(first);
+        // The earlier snapshot must not be mutated in place by later registry changes.
+        expect(first.map(m => m.id)).to.deep.equal(['a']);
+        expect(second.map(m => m.id)).to.deep.equal(['a', 'b']);
+    });
+
+    it('reflects removals in a fresh snapshot without mutating an earlier one', async () => {
+        const registry = createRegistry();
+        registry.addLanguageModels([model('a'), model('b')]);
+        const before = await registry.getLanguageModels();
+
+        registry.removeLanguageModels(['a']);
+        const after = await registry.getLanguageModels();
+
+        expect(before.map(m => m.id)).to.deep.equal(['a', 'b']);
+        expect(after.map(m => m.id)).to.deep.equal(['b']);
+    });
 });
 
 describe('compaction contract', () => {

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -726,7 +726,9 @@ export class DefaultLanguageModelRegistryImpl implements LanguageModelRegistry {
 
     async getLanguageModels(): Promise<LanguageModel[]> {
         await this.initialized;
-        return this.languageModels;
+        // Return a fresh array (not the internal, mutated-in-place list) so consumers relying on
+        // reference equality - e.g. React memoization in the chat model selector - detect changes.
+        return [...this.languageModels];
     }
 
     async getLanguageModel(id: string): Promise<LanguageModel | undefined> {

--- a/packages/core/src/browser/style/select-component.css
+++ b/packages/core/src/browser/style/select-component.css
@@ -99,6 +99,22 @@
   background: var(--theia-list-activeSelectionBackground);
 }
 
+.theia-select-component-dropdown .theia-select-component-option.disabled,
+.theia-select-component-dropdown .theia-select-component-option.disabled .theia-select-component-option-detail {
+  color: var(--theia-disabledForeground);
+  cursor: default;
+}
+
+.theia-select-component-dropdown .theia-select-component-option.disabled .theia-select-component-option-value {
+  text-decoration: line-through;
+}
+
+/* Keep a hovered/selected disabled option readable against the active-selection background. */
+.theia-select-component-dropdown .theia-select-component-option.disabled.selected,
+.theia-select-component-dropdown .theia-select-component-option.disabled.selected .theia-select-component-option-detail {
+  color: var(--theia-list-activeSelectionForeground);
+}
+
 .theia-select-component-dropdown .theia-select-component-separator {
   width: 84px;
   height: 1px;

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -243,13 +243,18 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             selected = this.nextNotSeparator('forwards');
         }
         const selectedItemLabel = options[selected]?.label ?? options[selected]?.value;
+        // Expose when the currently shown option is disabled so consumers can style the field to match
+        // it (e.g. the option previewed while navigating), instead of a fixed committed-value class.
+        const selectionDisabled = !!options[selected]?.disabled;
+        const fieldClassName = `theia-select-component${this.props.className ? ` ${this.props.className}` : ''}`
+            + `${selectionDisabled ? ' theia-select-component-selection-disabled' : ''}`;
         return <>
             <div
                 id={this.props.id}
                 key="select-component"
                 ref={this.fieldRef}
                 tabIndex={0}
-                className={`theia-select-component${this.props.className ? ` ${this.props.className}` : ''}`}
+                className={fieldClassName}
                 onClick={e => this.handleClickEvent(e)}
                 onBlur={
                     () => {
@@ -280,7 +285,8 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             }
             count++;
         }
-        while (options[selected]?.separator && count < length);
+        // Skip separators and disabled options so keyboard navigation never lands on a non-selectable entry.
+        while ((options[selected]?.separator || options[selected]?.disabled) && count < length);
         return selected;
     }
 
@@ -303,9 +309,12 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
                 });
             } else {
                 this.toggleVisibility();
+                // Start on the first selectable option (startFrom -1 evaluates index 0 first), so a
+                // leading separator or disabled option is skipped instead of becoming the active row.
+                const selected = this.nextNotSeparator('forwards', -1);
                 this.setState({
-                    selected: 0,
-                    hover: 0,
+                    selected,
+                    hover: selected,
                 });
             }
         } else if (ev.key === 'Enter') {
@@ -313,7 +322,10 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
                 this.toggleVisibility();
             } else {
                 const selected = this.state.selected;
-                this.selectOption(selected, this.props.options[selected]);
+                const option = this.props.options[selected];
+                if (!option?.disabled) {
+                    this.selectOption(selected, option);
+                }
             }
         } else if (ev.key === 'Escape' || ev.key === 'Tab') {
             this.hide(undefined, true);
@@ -414,18 +426,21 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             return <div key={index} className="theia-select-component-separator" />;
         }
         const selected = this.state.hover;
+        const disabled = !!option.disabled;
         return (
             <div
                 key={index}
                 data-option-index={index}
-                className={`theia-select-component-option${index === selected ? ' selected' : ''}`}
+                className={`theia-select-component-option${index === selected ? ' selected' : ''}${disabled ? ' disabled' : ''}`}
                 onMouseOver={() => {
                     this.setState({
                         hover: index
                     });
                 }}
                 onMouseDown={() => {
-                    this.selectOption(index, option);
+                    if (!disabled) {
+                        this.selectOption(index, option);
+                    }
                 }}
             >
                 <div key="value" className="theia-select-component-option-value">{option.label ?? option.value}</div>


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Adds a per-session language model selector to the AI chat input, so a user can run an individual chat with a model other than the agent's configured default. (Relates to the model-management work — replace with the tracking issue, e.g. `#318` WP9.)

- **Model selector** in the chat input next to the mode/reasoning selectors. Picking a model sets `CommonChatSessionSettings.modelId` and overrides the agent default **for the current chat only**; the first option ("Default", showing the resolved default) reverts. No "save to default" — the override is intentionally session-scoped.
- **Override is actually used:** it is resolved directly at request time (via `getReadyLanguageModel`), bypassing the per-agent model from the AI settings that would otherwise take precedence.
- **In-thread model badge:** the model used for a response is recorded and shown as a subtle badge next to the prompt-variant badge, matching the AI History badge.
- **Persistence:** per-session settings and the recorded model are serialized, so the selected model and the badges are restored on reload. Selector-only and dialog-only settings changes are persisted too (via a settings-changed event picked up by session auto-save).
- **Unavailable override:** if the selected model becomes unavailable (e.g. its provider key is removed), the selection is kept but clearly flagged — the collapsed selector shows it in red with a strike-through, and it appears as a disabled, struck-through entry in the dropdown; requests fall back to the agent default.
- **Robustness:** the override is preserved when saving the session settings dialog; the available-model list refreshes live and in a stable, sorted order when providers change; only the model selector shrinks/ellipsizes when the row gets tight, keeping the token usage and send/stop button fully visible.
- **Supporting changes:** `SelectComponent` now honors its previously ignored `disabled` option field (disabled entries are non-selectable and skipped in keyboard nav); `LanguageModelRegistry.getLanguageModels` returns a fresh snapshot so UI consumers relying on reference equality reliably reflect model add/remove/status changes.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. Open an AI chat. Next to the mode/reasoning selectors, pick a non-default model — the selector label turns accent-colored. Send a prompt: the response shows a model badge with that model, and AI History lists the same model.
2. Switch back to **Default** → subsequent requests use the agent's configured model again.
3. Reload the workbench → the restored session keeps the selected model and the badges.
4. Change the agent's model in AI Configuration → the selector's "Default (…)" updates immediately.
5. Open the session settings dialog, change reasoning/timeout, save → the per-session model override is kept.
6. Narrow the chat panel with a long model name selected → the name truncates with `…`, the dropdown arrow stays visible, and token usage + send/stop remain visible.
7. Select a model, then remove that provider's API key in AI Configuration → the selector shows the model in red with a strike-through, the dropdown lists it as a disabled struck-through entry, and requests fall back to the agent default. Re-add the key → it becomes selectable again and the model list keeps a stable order.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- **Rework the chat-input options row:** it's getting crowded. Group related controls (e.g. reasoning + model) so the toolbar scales better. At very narrow widths the fixed left-hand controls (agent/mode/reasoning) can still crowd the row once the model selector has shrunk as far as it can.
- **Model selector search:** once model discovery is in place, add a search possibility to the model selector, as the model list might get too long.
- **Model display names:** once model discovery is in place, populate `LanguageModelMetaData.name` from the provider endpoints (e.g. Anthropic `display_name`) and show display names instead of raw ids in the model selector, the response badge, and AI History.
- **CLI-backed agents:** Codex / Claude Code agents drive their own model selection and ignore the session override; consider hiding the selector for them (or wiring it through where feasible).
- **Serialization scope:** the whole per-session settings object is now persisted (this also gives reasoning/compaction persistence for free) — confirm that's the desired behavior or narrow it if not.
- Minor: revisit the selector's `max-width` (200px) once the row is restructured.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
