### PR TITLE
Fix button order in untitled workspace exit dialog

### DIFF
--- a/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
+++ b/packages/workspace/src/browser/untitled-workspace-exit-dialog.ts
@@ -35,8 +35,8 @@ export class UntitledWorkspaceExitDialog extends AbstractDialog<UntitledWorkspac
         this.contentNode.appendChild(messageNode);
         this.dontSaveButton = this.createButton(nls.localizeByDefault(UntitledWorkspaceExitDialog.Values["Don't Save"]));
         this.dontSaveButton.classList.add('secondary');
-        this.controlPanel.appendChild(this.dontSaveButton);
         this.appendCloseButton(Dialog.CANCEL);
+        this.controlPanel.appendChild(this.dontSaveButton);
         this.appendAcceptButton(nls.localizeByDefault(UntitledWorkspaceExitDialog.Values.Save));
     }
 


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Align the button order in the untitled workspace exit dialog to match the layout of most other dialogs ("Cancel" -> "Don't Save" -> "Save").
See [`ShouldSaveDialog`](https://github.com/eclipse-theia/theia/blob/198b6c9ade1f9fc0f69a8917795d71bb4be35154/packages/core/src/browser/saveable.ts#L374-L409) in packages/core/src/browser/saveable.ts for reference.

Before:
<img width="426" height="136" alt="grafik" src="https://github.com/user-attachments/assets/74ba88ef-4221-4149-a31c-05e0092cd09c" />


With fix:
<img width="424" height="139" alt="grafik" src="https://github.com/user-attachments/assets/2ad9d30b-50b3-4276-83dc-b0e0778c5b54" />

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
