### PR TITLE
fix(browser-only): fail fast instead of hanging when backend services are unavailable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - [ai-chat-ui] replaced scroll-direction heuristics in `ChatViewTreeWidget` with Virtuoso's `atBottomStateChange` for reliable auto-scroll during streaming [#17728](https://github.com/eclipse-theia/theia/pull/17728)
 - [ai-vercel-ai] deprecated `@theia/ai-vercel-ai` package [#TBD](https://github.com/eclipse-theia/theia/pull/TBD)
 - [electron] upgraded Electron from 39.8.7 to 42.3.0 (Node 24, Chromium 148) [#17586](https://github.com/eclipse-theia/theia/pull/17586)
+- [core, plugin-ext] fixed browser-only application startup hanging forever when startup code awaits unavailable backend services: frontend-only RPC proxies now reject requests instead of queuing them indefinitely, layout contributions are guarded during startup, and the plugin startup deferreds resolve when plugin loading fails [#17794](https://github.com/eclipse-theia/theia/pull/17794)
 
 <a name="breaking_changes_1.74.0">[Breaking Changes:](#breaking_changes_1.74.0)</a>
 

--- a/packages/core/src/browser-only/messaging/frontend-only-service-connection-provider.ts
+++ b/packages/core/src/browser-only/messaging/frontend-only-service-connection-provider.ts
@@ -24,6 +24,33 @@ export class FrontendOnlyConnectionSource implements ConnectionSource {
     onConnectionDidOpen = new Emitter<Channel>().event;
 }
 
+/**
+ * Proxy factory for services without a frontend-only implementation. There is no backend,
+ * so no channel will ever open and requests would otherwise be queued forever, blocking
+ * any caller that awaits the result, e.g. during application startup.
+ * Instead, requests fail immediately and notifications (fire-and-forget) resolve silently.
+ */
+export class FrontendOnlyRpcProxyFactory<T extends object> extends RpcProxyFactory<T> {
+
+    constructor(protected readonly path: string, target?: object) {
+        super(target);
+    }
+
+    override get(target: T, p: PropertyKey, receiver: unknown): unknown {
+        if (typeof p !== 'string') {
+            return undefined;
+        }
+        // members handled by the base proxy without a connection
+        if (['setClient', 'getClient', 'onDidOpenConnection', 'onDidCloseConnection', 'then', 'toJSON'].includes(p)) {
+            return super.get(target, p, receiver);
+        }
+        if (this.isNotification(p)) {
+            return () => Promise.resolve();
+        }
+        return () => Promise.reject(new Error(`Request '${p}' on service '${this.path}' is unavailable: no backend in frontend-only mode.`));
+    }
+}
+
 @injectable()
 export class FrontendOnlyServiceConnectionProvider extends ServiceConnectionProvider {
 
@@ -33,10 +60,12 @@ export class FrontendOnlyServiceConnectionProvider extends ServiceConnectionProv
     onSocketDidOpen = Event.None;
     onSocketDidClose = Event.None;
     onIncomingMessageActivity = Event.None;
-    override createProxy<T extends object>(path: unknown, target?: unknown): RpcProxy<T> {
+    override createProxy<T extends object>(path: string, target?: object): RpcProxy<T> {
         this.logger.debug(`[Frontend-Only Fallback] Created proxy connection for ${path}`);
-        const factory = target instanceof RpcProxyFactory ? target : new RpcProxyFactory<T>(target);
-        return factory.createProxy();
+        if (target instanceof RpcProxyFactory) {
+            return target.createProxy();
+        }
+        return new FrontendOnlyRpcProxyFactory<T>(path, target).createProxy();
     }
     override listen(path: string, handler: ServiceConnectionProvider.ConnectionHandler, reconnect: boolean): void {
         this.logger.debug('[Frontend-Only Fallback] Listen to websocket connection requested');

--- a/packages/core/src/browser/frontend-application.ts
+++ b/packages/core/src/browser/frontend-application.ts
@@ -237,8 +237,12 @@ export class FrontendApplication {
     protected async createDefaultLayout(): Promise<void> {
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.initializeLayout) {
-                await this.measureContribution(contribution, 'initializeLayout',
-                    () => contribution.initializeLayout!(this));
+                try {
+                    await this.measureContribution(contribution, 'initializeLayout',
+                        () => contribution.initializeLayout!(this));
+                } catch (error) {
+                    this.logger.error('Could not initialize the layout of contribution', error);
+                }
             }
         }
     }
@@ -246,8 +250,12 @@ export class FrontendApplication {
     protected async fireOnDidInitializeLayout(): Promise<void> {
         for (const contribution of this.contributions.getContributions()) {
             if (contribution.onDidInitializeLayout) {
-                await this.measureContribution(contribution, 'onDidInitializeLayout',
-                    () => contribution.onDidInitializeLayout!(this));
+                try {
+                    await this.measureContribution(contribution, 'onDidInitializeLayout',
+                        () => contribution.onDidInitializeLayout!(this));
+                } catch (error) {
+                    this.logger.error('Could not notify contribution of layout initialization', error);
+                }
             }
         }
     }

--- a/packages/plugin-ext/src/hosted/common/hosted-plugin.ts
+++ b/packages/plugin-ext/src/hosted/common/hosted-plugin.ts
@@ -148,6 +148,10 @@ export abstract class AbstractHostedPluginSupport<PM extends AbstractPluginManag
             await this.runOperation(() => this.doLoad());
         } catch (e) {
             console.error('Failed to load plugins:', e);
+            // Resolve the startup deferreds so that clients awaiting `willStart` or `didStart`,
+            // e.g. file system provider activations, do not hang forever on a failed load.
+            this.deferredWillStart.resolve();
+            this.deferredDidStart.resolve();
         }
     }), 50, { leading: true });
 


### PR DESCRIPTION



<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Frontend-only RPC proxies queued requests forever because no channel ever opens, deadlocking any caller that awaits a backend service. This blocked application startup, e.g. via ResolveMcpFrontendContribution.onStart and preference initialization (user-storage provider activation waiting on HostedPluginSupport.willStart).

- FrontendOnlyServiceConnectionProvider: reject requests immediately with the service path in the error, resolve notifications silently
- FrontendApplication: guard per-contribution initializeLayout and onDidInitializeLayout like the other lifecycle phases
- AbstractHostedPluginSupport: resolve willStart/didStart when plugin loading fails so dependents (e.g. file system provider activation) do not wait forever

This is a conceptual change but it's a cleaner one than the current one:
 - The console immediately shows where additional work is necessary instead of hiding it
 - Any startup await which waits for the backend no longer immediately breaks browser-only

#### How to test

```
npm run build:browser-only && npm run start:browser-only
```

Open `localhost:3000` and observe that browser-only starts again.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
