### PR TITLE
feat(ai): add configurable server-side compaction thresholds

### DIFF
--- a/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
+++ b/packages/ai-anthropic/src/browser/anthropic-frontend-application-contribution.ts
@@ -17,10 +17,14 @@
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { AnthropicLanguageModelsManager, AnthropicModelDescription } from '../common';
-import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF, SERVER_SIDE_COMPACTION_PREF } from '../common/anthropic-preferences';
-import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES, PREFERENCE_NAME_SERVER_SIDE_COMPACTION } from '@theia/ai-core/lib/common/ai-core-preferences';
+import {
+    API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF, SERVER_SIDE_COMPACTION_PREF, SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF
+} from '../common/anthropic-preferences';
+import {
+    AICorePreferences, PREFERENCE_NAME_MAX_RETRIES, PREFERENCE_NAME_SERVER_SIDE_COMPACTION, PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD
+} from '@theia/ai-core/lib/common/ai-core-preferences';
 import { PreferenceService } from '@theia/core';
-import { resolveCompactionDefault, ServerSideCompactionSetting } from '@theia/ai-core';
+import { resolveCompactionDefault, resolveCompactionTokenThresholdDefault, ServerSideCompactionSetting } from '@theia/ai-core';
 
 const ANTHROPIC_PROVIDER_ID = 'anthropic';
 
@@ -64,7 +68,10 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                 } else if (event.preferenceName === 'http.proxy') {
                     this.manager.setProxyUrl(this.preferenceService.get<string>('http.proxy', undefined));
                     this.updateAllModels();
-                } else if (event.preferenceName === SERVER_SIDE_COMPACTION_PREF || event.preferenceName === PREFERENCE_NAME_SERVER_SIDE_COMPACTION) {
+                } else if (event.preferenceName === SERVER_SIDE_COMPACTION_PREF ||
+                    event.preferenceName === PREFERENCE_NAME_SERVER_SIDE_COMPACTION ||
+                    event.preferenceName === SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF ||
+                    event.preferenceName === PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD) {
                     this.updateAllModels();
                 } else if (event.preferenceName === CUSTOM_ENDPOINTS_PREF) {
                     this.handleCustomModelChanges(this.preferenceService.get<Partial<AnthropicModelDescription>[]>(CUSTOM_ENDPOINTS_PREF, []));
@@ -105,6 +112,7 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                 model.maxRetries === newModel.maxRetries &&
                 model.useCaching === newModel.useCaching &&
                 model.serverSideCompactionEnabledByDefault === newModel.serverSideCompactionEnabledByDefault &&
+                model.serverSideCompactionTokenThresholdByDefault === newModel.serverSideCompactionTokenThresholdByDefault &&
                 model.enableStreaming === newModel.enableStreaming));
 
         this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
@@ -127,6 +135,9 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
         const globalCompaction = this.preferenceService.get<boolean>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION, true);
         const compactionOverride = this.preferenceService.get<ServerSideCompactionSetting>(SERVER_SIDE_COMPACTION_PREF, 'default');
         const serverSideCompactionEnabledByDefault = resolveCompactionDefault(globalCompaction, compactionOverride);
+        const globalThreshold = this.preferenceService.get<number>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD, undefined);
+        const providerThreshold = this.preferenceService.get<number>(SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF, undefined);
+        const serverSideCompactionTokenThresholdByDefault = resolveCompactionTokenThresholdDefault(globalThreshold, providerThreshold);
 
         return {
             id: id,
@@ -135,7 +146,8 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
             enableStreaming: true,
             useCaching: true,
             maxRetries: maxRetries,
-            serverSideCompactionEnabledByDefault
+            serverSideCompactionEnabledByDefault,
+            serverSideCompactionTokenThresholdByDefault
         };
     }
 
@@ -144,6 +156,9 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
         const globalCompaction = this.preferenceService.get<boolean>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION, true);
         const compactionOverride = this.preferenceService.get<ServerSideCompactionSetting>(SERVER_SIDE_COMPACTION_PREF, 'default');
         const serverSideCompactionEnabledByDefault = resolveCompactionDefault(globalCompaction, compactionOverride);
+        const globalThreshold = this.preferenceService.get<number>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD, undefined);
+        const providerThreshold = this.preferenceService.get<number>(SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF, undefined);
+        const serverSideCompactionTokenThresholdByDefault = resolveCompactionTokenThresholdDefault(globalThreshold, providerThreshold);
         return preferences.reduce((acc, pref) => {
             if (!pref.model || !pref.url || typeof pref.model !== 'string' || typeof pref.url !== 'string') {
                 return acc;
@@ -158,7 +173,8 @@ export class AnthropicFrontendApplicationContribution implements FrontendApplica
                     enableStreaming: pref.enableStreaming ?? true,
                     useCaching: pref.useCaching ?? true,
                     maxRetries: pref.maxRetries ?? maxRetries,
-                    serverSideCompactionEnabledByDefault
+                    serverSideCompactionEnabledByDefault,
+                    serverSideCompactionTokenThresholdByDefault
                 }
             ];
         }, []);

--- a/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
+++ b/packages/ai-anthropic/src/common/anthropic-language-models-manager.ts
@@ -34,6 +34,8 @@ export interface AnthropicModelDescription {
     maxRetries: number;
     /** Resolved default enablement of server-side compaction (global preference folded with the per-provider override). Defaults to disabled when omitted. */
     serverSideCompactionEnabledByDefault?: boolean;
+    /** Resolved default input-token threshold for server-side compaction. `undefined` preserves the provider default. */
+    serverSideCompactionTokenThresholdByDefault?: number;
 }
 export interface AnthropicLanguageModelsManager {
     apiKey: string | undefined;

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -69,7 +69,8 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             type: 'integer',
             minimum: SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM,
             markdownDescription: nls.localize('theia/ai/anthropic/compactionTokenThreshold/description',
-                'Override the global input-token threshold for server-side compaction for Anthropic models. When unset, the global setting or provider default applies.'),
+                'Override the global input-token threshold for server-side compaction for Anthropic models. When unset, the global setting or provider default applies. ' +
+                'If set, the value must be at least 50,000 tokens.'),
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [CUSTOM_ENDPOINTS_PREF]: {

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE, PREFERENCE_NAME_SERVER_SIDE_COMPACTION } from '@theia/ai-core/lib/common/ai-core-preferences';
+import { SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM } from '@theia/ai-core/lib/common/language-model';
 import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.anthropic.AnthropicApiKey';
@@ -66,7 +67,7 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
         },
         [SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF]: {
             type: 'integer',
-            minimum: 1,
+            minimum: SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM,
             markdownDescription: nls.localize('theia/ai/anthropic/compactionTokenThreshold/description',
                 'Override the global input-token threshold for server-side compaction for Anthropic models. When unset, the global setting or provider default applies.'),
             title: AI_CORE_PREFERENCES_TITLE,

--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -21,6 +21,7 @@ export const API_KEY_PREF = 'ai-features.anthropic.AnthropicApiKey';
 export const MODELS_PREF = 'ai-features.anthropic.AnthropicModels';
 export const CUSTOM_ENDPOINTS_PREF = 'ai-features.anthropicCustom.customAnthropicModels';
 export const SERVER_SIDE_COMPACTION_PREF = 'ai-features.anthropic.serverSideCompaction';
+export const SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF = 'ai-features.anthropic.serverSideCompactionTokenThreshold';
 
 export const AnthropicPreferencesSchema: PreferenceSchema = {
     properties: {
@@ -61,6 +62,13 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
                 '({0}). When effectively enabled, the Anthropic Beta Messages API is used so the provider can summarize ' +
                 'older turns once the conversation grows past its threshold.',
                 `\`#${PREFERENCE_NAME_SERVER_SIDE_COMPACTION}#\``),
+            title: AI_CORE_PREFERENCES_TITLE,
+        },
+        [SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF]: {
+            type: 'integer',
+            minimum: 1,
+            markdownDescription: nls.localize('theia/ai/anthropic/compactionTokenThreshold/description',
+                'Override the global input-token threshold for server-side compaction for Anthropic models. When unset, the global setting or provider default applies.'),
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [CUSTOM_ENDPOINTS_PREF]: {

--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -840,10 +840,15 @@ describe('AnthropicModel', () => {
             return undefined;
         }
 
-        function createCompactionModel(serverSideCompactionEnabledByDefault: boolean, serverSideCompactionSupport: boolean = true): TestableAnthropicModel {
+        function createCompactionModel(
+            serverSideCompactionEnabledByDefault: boolean,
+            serverSideCompactionSupport: boolean = true,
+            serverSideCompactionTokenThresholdByDefault?: number
+        ): TestableAnthropicModel {
             return new TestableAnthropicModel(
                 'test-id', 'claude-opus-4-6', { status: 'ready' }, true, false, () => 'test-key', undefined,
-                DEFAULT_MAX_TOKENS, 3, undefined, undefined, undefined, undefined, undefined, undefined, serverSideCompactionSupport, serverSideCompactionEnabledByDefault
+                DEFAULT_MAX_TOKENS, 3, undefined, undefined, undefined, undefined, undefined, undefined, serverSideCompactionSupport,
+                serverSideCompactionEnabledByDefault, serverSideCompactionTokenThresholdByDefault
             );
         }
 
@@ -901,6 +906,29 @@ describe('AnthropicModel', () => {
 
                 expect(beta.betas).to.deep.equal(['compact-2026-01-12']);
                 expect(beta.context_management).to.deep.equal({ edits: [{ type: 'compact_20260112' }] });
+            });
+
+            it('adds the model default token threshold', () => {
+                const model = createCompactionModel(true, true, 280_000);
+                const params = model.callApplyCompactionParams(baseParams(), { messages: [] });
+                const beta = params as Anthropic.MessageCreateParams & Anthropic.Beta.Messages.MessageCreateParams;
+
+                expect(beta.context_management).to.deep.equal({
+                    edits: [{ type: 'compact_20260112', trigger: { type: 'input_tokens', value: 280_000 } }]
+                });
+            });
+
+            it('uses the session token threshold over the model default', () => {
+                const model = createCompactionModel(true, true, 280_000);
+                const params = model.callApplyCompactionParams(baseParams(), {
+                    messages: [],
+                    compaction: { tokenThreshold: 300_000 }
+                });
+                const beta = params as Anthropic.MessageCreateParams & Anthropic.Beta.Messages.MessageCreateParams;
+
+                expect(beta.context_management).to.deep.equal({
+                    edits: [{ type: 'compact_20260112', trigger: { type: 'input_tokens', value: 300_000 } }]
+                });
             });
 
             it('leaves params unchanged when compaction is disabled by default', () => {

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -28,6 +28,7 @@ import {
     LanguageModelTextResponse,
     ReasoningApi,
     ReasoningSupport,
+    resolveCompactionTokenThreshold,
     resolveServerSideCompaction,
     ServerToolCallResponsePart,
     ServerToolDescriptor,
@@ -330,7 +331,8 @@ export class AnthropicModel implements LanguageModel {
         public maxInputTokens?: number,
         public serverTools?: ServerToolDescriptor[],
         public serverSideCompactionSupport: boolean = false,
-        public serverSideCompactionEnabledByDefault: boolean = false
+        public serverSideCompactionEnabledByDefault: boolean = false,
+        public serverSideCompactionTokenThresholdByDefault?: number
     ) { }
 
     protected getSettings(request: LanguageModelRequest): Readonly<Record<string, unknown>> {
@@ -354,8 +356,14 @@ export class AnthropicModel implements LanguageModel {
             return params;
         }
         const betaParams = params as T & Anthropic.Beta.Messages.MessageCreateParams;
+        const tokenThreshold = resolveCompactionTokenThreshold(this.serverSideCompactionTokenThresholdByDefault, request.compaction);
         betaParams.betas = ['compact-2026-01-12'];
-        betaParams.context_management = { edits: [{ type: 'compact_20260112' }] };
+        betaParams.context_management = {
+            edits: [{
+                type: 'compact_20260112',
+                ...(tokenThreshold !== undefined && { trigger: { type: 'input_tokens', value: tokenThreshold } })
+            }]
+        };
         return betaParams;
     }
 

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -94,7 +94,8 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                 supportsXHighEffort: metadata.supportsXHighEffort,
                 maxInputTokens: metadata.maxInputTokens,
                 serverSideCompactionSupport: metadata.serverSideCompactionSupport,
-                serverSideCompactionEnabledByDefault: modelDescription.serverSideCompactionEnabledByDefault ?? false
+                serverSideCompactionEnabledByDefault: modelDescription.serverSideCompactionEnabledByDefault ?? false,
+                serverSideCompactionTokenThresholdByDefault: modelDescription.serverSideCompactionTokenThresholdByDefault
             });
         } else {
             this.languageModelRegistry.addLanguageModels([
@@ -115,7 +116,8 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
                     metadata.maxInputTokens,
                     ANTHROPIC_SERVER_TOOLS,
                     metadata.serverSideCompactionSupport,
-                    modelDescription.serverSideCompactionEnabledByDefault ?? false
+                    modelDescription.serverSideCompactionEnabledByDefault ?? false,
+                    modelDescription.serverSideCompactionTokenThresholdByDefault
                 )
             ]);
         }

--- a/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
+++ b/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { ChatSessionSettings, CommonChatSessionSettings } from '@theia/ai-chat';
+import { SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM } from '@theia/ai-core';
 import { InMemoryResources, URI, nls } from '@theia/core';
 import { AbstractDialog, Message } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
@@ -141,23 +142,27 @@ const ServerSideCompactionSection: React.FC<ServerSideCompactionSectionProps> = 
                     </option>
                 </select>
             </div>
-            <div className="session-settings-compaction-threshold-container">
-                <label htmlFor="compaction-token-threshold">
-                    {nls.localize('theia/ai/session-settings-dialog/compactionTokenThreshold', 'Token threshold:')}
-                </label>
-                <input
-                    type="number"
-                    id="compaction-token-threshold"
-                    min={1}
-                    step={1}
-                    value={compactionTokenThreshold ?? ''}
-                    placeholder={nls.localizeByDefault('Default')}
-                    onChange={e => {
-                        const value = Number(e.target.value);
-                        onCompactionTokenThresholdChange(Number.isInteger(value) && value > 0 ? value : undefined);
-                    }}
-                />
-            </div>
+            {compactionOverride !== false && (
+                <div className="session-settings-compaction-threshold-container">
+                    <label htmlFor="compaction-token-threshold">
+                        {nls.localize('theia/ai/session-settings-dialog/compactionTokenThreshold', 'Token threshold:')}
+                    </label>
+                    <input
+                        type="number"
+                        id="compaction-token-threshold"
+                        min={SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM}
+                        step={1}
+                        value={compactionTokenThreshold ?? ''}
+                        placeholder={nls.localizeByDefault('Default')}
+                        onChange={e => {
+                            const value = Number(e.target.value);
+                            onCompactionTokenThresholdChange(
+                                Number.isInteger(value) && value >= SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM ? value : undefined
+                            );
+                        }}
+                    />
+                </div>
+            )}
         </div>
     );
 };

--- a/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
+++ b/packages/ai-chat-ui/src/browser/session-settings-dialog.tsx
@@ -85,12 +85,16 @@ type CompactionOverride = boolean | undefined;
 
 interface ServerSideCompactionSectionProps {
     compactionOverride: CompactionOverride;
+    compactionTokenThreshold: number | undefined;
     onCompactionOverrideChange: (value: CompactionOverride) => void;
+    onCompactionTokenThresholdChange: (value: number | undefined) => void;
 }
 
 const ServerSideCompactionSection: React.FC<ServerSideCompactionSectionProps> = ({
     compactionOverride,
-    onCompactionOverrideChange
+    compactionTokenThreshold,
+    onCompactionOverrideChange,
+    onCompactionTokenThresholdChange
 }) => {
     const selectValue = compactionOverride === true ? 'enabled' : compactionOverride === false ? 'disabled' : 'default';
 
@@ -137,6 +141,23 @@ const ServerSideCompactionSection: React.FC<ServerSideCompactionSectionProps> = 
                     </option>
                 </select>
             </div>
+            <div className="session-settings-compaction-threshold-container">
+                <label htmlFor="compaction-token-threshold">
+                    {nls.localize('theia/ai/session-settings-dialog/compactionTokenThreshold', 'Token threshold:')}
+                </label>
+                <input
+                    type="number"
+                    id="compaction-token-threshold"
+                    min={1}
+                    step={1}
+                    value={compactionTokenThreshold ?? ''}
+                    placeholder={nls.localizeByDefault('Default')}
+                    onChange={e => {
+                        const value = Number(e.target.value);
+                        onCompactionTokenThresholdChange(Number.isInteger(value) && value > 0 ? value : undefined);
+                    }}
+                />
+            </div>
         </div>
     );
 };
@@ -166,20 +187,24 @@ interface DialogContentProps {
     confirmationTimeoutEnabled: boolean;
     confirmationTimeoutSeconds: number;
     compactionOverride: CompactionOverride;
+    compactionTokenThreshold: number | undefined;
     errorMessage: string;
     onConfirmationTimeoutEnabledChange: (enabled: boolean) => void;
     onConfirmationTimeoutSecondsChange: (seconds: number) => void;
     onCompactionOverrideChange: (value: CompactionOverride) => void;
+    onCompactionTokenThresholdChange: (value: number | undefined) => void;
 }
 
 const DialogContent: React.FC<DialogContentProps> = ({
     confirmationTimeoutEnabled,
     confirmationTimeoutSeconds,
     compactionOverride,
+    compactionTokenThreshold,
     errorMessage,
     onConfirmationTimeoutEnabledChange,
     onConfirmationTimeoutSecondsChange,
-    onCompactionOverrideChange
+    onCompactionOverrideChange,
+    onCompactionTokenThresholdChange
 }) => (
     <div className="session-settings-container">
         <ConfirmationTimeoutSection
@@ -190,7 +215,9 @@ const DialogContent: React.FC<DialogContentProps> = ({
         />
         <ServerSideCompactionSection
             compactionOverride={compactionOverride}
+            compactionTokenThreshold={compactionTokenThreshold}
             onCompactionOverrideChange={onCompactionOverrideChange}
+            onCompactionTokenThresholdChange={onCompactionTokenThresholdChange}
         />
         <AdvancedSettingsSection
             sectionHeader={nls.localize('theia/ai/session-settings-dialog/advancedSettings', 'Advanced Settings (JSON)')}
@@ -209,6 +236,7 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
     protected confirmationTimeoutSeconds: number;
 
     protected compactionOverride: boolean | undefined;
+    protected compactionTokenThreshold: number | undefined;
 
     protected preservedReasoning: CommonChatSessionSettings['reasoning'];
 
@@ -238,6 +266,7 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
 
         // Read the per-session compaction override (undefined = use global/per-provider setting).
         this.compactionOverride = this.settings.commonSettings?.compaction?.enabled;
+        this.compactionTokenThreshold = this.settings.commonSettings?.compaction?.tokenThreshold;
 
         // Extract confirmation timeout settings from commonSettings
         const savedTimeout = this.settings.commonSettings?.confirmationTimeout;
@@ -293,10 +322,12 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
                 confirmationTimeoutEnabled={this.confirmationTimeoutEnabled}
                 confirmationTimeoutSeconds={this.confirmationTimeoutSeconds}
                 compactionOverride={this.compactionOverride}
+                compactionTokenThreshold={this.compactionTokenThreshold}
                 errorMessage={this.errorMessage}
                 onConfirmationTimeoutEnabledChange={this.handleConfirmationTimeoutEnabledChange}
                 onConfirmationTimeoutSecondsChange={this.handleConfirmationTimeoutSecondsChange}
                 onCompactionOverrideChange={this.handleCompactionOverrideChange}
+                onCompactionTokenThresholdChange={this.handleCompactionTokenThresholdChange}
             />
         );
     }
@@ -415,6 +446,13 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
         this.attachEditorContainer();
     };
 
+    protected handleCompactionTokenThresholdChange = (value: number | undefined): void => {
+        this.compactionTokenThreshold = value;
+        this.updateSettingsFromCommonSettings();
+        this.render();
+        this.attachEditorContainer();
+    };
+
     protected updateSettingsFromCommonSettings(): void {
         const commonSettings: CommonChatSessionSettings = {};
         if (this.preservedReasoning) {
@@ -426,8 +464,11 @@ export class SessionSettingsDialog extends AbstractDialog<ChatSessionSettings> {
         if (this.confirmationTimeoutEnabled && !isNaN(this.confirmationTimeoutSeconds) && this.confirmationTimeoutSeconds > 0) {
             commonSettings.confirmationTimeout = this.confirmationTimeoutSeconds;
         }
-        if (this.compactionOverride !== undefined) {
-            commonSettings.compaction = { enabled: this.compactionOverride };
+        if (this.compactionOverride !== undefined || this.compactionTokenThreshold !== undefined) {
+            commonSettings.compaction = {
+                enabled: this.compactionOverride,
+                tokenThreshold: this.compactionTokenThreshold
+            };
         }
         this.settings.commonSettings = Object.keys(commonSettings).length > 0 ? commonSettings : undefined;
     }

--- a/packages/ai-chat-ui/src/browser/style/index.css
+++ b/packages/ai-chat-ui/src/browser/style/index.css
@@ -1457,13 +1457,21 @@ details.theia-tool-confirmation-args>summary::marker {
   color: var(--theia-disabledForeground);
 }
 
-.session-settings-timeout-container input[type="number"] {
+.session-settings-timeout-container input[type="number"],
+.session-settings-compaction-threshold-container input[type="number"] {
   width: 100px;
   padding: 4px 8px;
   border: 1px solid var(--theia-input-border);
   border-radius: 4px;
   background-color: var(--theia-input-background);
   color: var(--theia-input-foreground);
+}
+
+.session-settings-compaction-threshold-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
 }
 
 .session-settings-timeout-container input[type="number"]:disabled {

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -249,7 +249,7 @@ export interface CommonChatSessionSettings {
     reasoning?: ReasoningSettings;
     /** Per-session tool confirmation timeout in seconds. Overrides the global preference when set. */
     confirmationTimeout?: number;
-    /** Per-session server-side compaction settings; `compaction.enabled`, when set, wins over the per-provider and global settings. */
+    /** Per-session server-side compaction settings; set values win over the per-provider and global settings. */
     compaction?: CompactionSettings;
 }
 

--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -57,7 +57,7 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
             minimum: SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM,
             description: nls.localize('theia/ai/core/serverSideCompactionTokenThreshold/description',
                 'Default input-token threshold at which provider-native server-side compaction should run. Providers and individual chat sessions ' +
-                'can override this value. When unset, the provider chooses its default threshold.'),
+                'can override this value. When unset, the provider chooses its default threshold. If set, the value must be at least 50,000 tokens.'),
         },
         [PREFERENCE_NAME_PROMPT_TEMPLATES]: {
             title: AI_CORE_PREFERENCES_TITLE,

--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -35,6 +35,7 @@ export const PREFERENCE_NAME_MAX_RETRIES = 'ai-features.modelSettings.maxRetries
 export const PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE = 'ai-features.notifications.default';
 export const PREFERENCE_NAME_SKILL_DIRECTORIES = 'ai-features.skills.skillDirectories';
 export const PREFERENCE_NAME_SERVER_SIDE_COMPACTION = 'ai-features.chat.serverSideCompaction';
+export const PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD = 'ai-features.chat.serverSideCompactionTokenThreshold';
 
 export const LANGUAGE_MODEL_ALIASES_PREFERENCE = 'ai-features.languageModelAliases';
 
@@ -49,6 +50,14 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
                 'sessions continue past the context limit. Each provider offers its own override, and individual chat sessions ' +
                 'can override this in their session settings. Models without support ignore it.'),
             default: true,
+        },
+        [PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD]: {
+            title: AI_CORE_PREFERENCES_TITLE,
+            type: 'integer',
+            minimum: 1,
+            description: nls.localize('theia/ai/core/serverSideCompactionTokenThreshold/description',
+                'Default input-token threshold at which provider-native server-side compaction should run. Providers and individual chat sessions ' +
+                'can override this value. When unset, the provider chooses its default threshold.'),
         },
         [PREFERENCE_NAME_PROMPT_TEMPLATES]: {
             title: AI_CORE_PREFERENCES_TITLE,
@@ -251,6 +260,7 @@ export interface AICoreConfiguration {
     [PREFERENCE_NAME_DEFAULT_NOTIFICATION_TYPE]: NotificationType | undefined;
     [PREFERENCE_NAME_SKILL_DIRECTORIES]: string[] | undefined;
     [PREFERENCE_NAME_SERVER_SIDE_COMPACTION]: boolean | undefined;
+    [PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD]: number | undefined;
 }
 
 export interface RequestSetting {

--- a/packages/ai-core/src/common/ai-core-preferences.ts
+++ b/packages/ai-core/src/common/ai-core-preferences.ts
@@ -24,7 +24,7 @@ import {
     NOTIFICATION_TYPE_DESCRIPTIONS,
     NotificationType
 } from './notification-types';
-import { ReasoningSettings } from './language-model';
+import { ReasoningSettings, SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM } from './language-model';
 import { PreferenceSchema } from '@theia/core/lib/common/preferences/preference-schema';
 
 export const AI_CORE_PREFERENCES_TITLE = nls.localize('theia/ai-core/preferences/title', 'AI Features');
@@ -54,7 +54,7 @@ export const aiCorePreferenceSchema: PreferenceSchema = {
         [PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD]: {
             title: AI_CORE_PREFERENCES_TITLE,
             type: 'integer',
-            minimum: 1,
+            minimum: SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM,
             description: nls.localize('theia/ai/core/serverSideCompactionTokenThreshold/description',
                 'Default input-token threshold at which provider-native server-side compaction should run. Providers and individual chat sessions ' +
                 'can override this value. When unset, the provider chooses its default threshold.'),

--- a/packages/ai-core/src/common/language-model.spec.ts
+++ b/packages/ai-core/src/common/language-model.spec.ts
@@ -24,6 +24,8 @@ import {
     LanguageModel,
     LanguageModelSelector,
     resolveCompactionDefault,
+    resolveCompactionTokenThreshold,
+    resolveCompactionTokenThresholdDefault,
     resolveServerSideCompaction
 } from './language-model';
 
@@ -236,6 +238,14 @@ describe('compaction contract', () => {
         expect(resolveCompactionDefault(false, 'default')).to.equal(false);
         expect(resolveCompactionDefault(false, 'enabled')).to.equal(true);
         expect(resolveCompactionDefault(true, 'disabled')).to.equal(false);
+    });
+    it('resolves compaction token thresholds with session, provider, global precedence', () => {
+        expect(resolveCompactionTokenThresholdDefault(undefined, undefined)).to.equal(undefined);
+        expect(resolveCompactionTokenThresholdDefault(100_000, undefined)).to.equal(100_000);
+        expect(resolveCompactionTokenThresholdDefault(100_000, 200_000)).to.equal(200_000);
+        expect(resolveCompactionTokenThreshold(undefined, undefined)).to.equal(undefined);
+        expect(resolveCompactionTokenThreshold(200_000, undefined)).to.equal(200_000);
+        expect(resolveCompactionTokenThreshold(200_000, { tokenThreshold: 300_000 })).to.equal(300_000);
     });
     it('resolves server-side compaction with capability gate and session-wins precedence', () => {
         // capability gate

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -327,6 +327,8 @@ export namespace ToolRequest {
 export interface CompactionSettings {
     /** Explicit enablement for this session; when set it wins over the model's default. `undefined` means "no explicit choice". */
     enabled?: boolean;
+    /** Input-token threshold for this session; when set it wins over the model's default. `undefined` preserves the provider default. */
+    tokenThreshold?: number;
 }
 
 /** Per-provider override for server-side compaction; combined with the global preference by {@link resolveCompactionDefault}. */
@@ -346,6 +348,20 @@ export function resolveCompactionDefault(globalEnabled: boolean, perProviderOver
         return false;
     }
     return globalEnabled;
+}
+
+export function resolveCompactionTokenThresholdDefault(
+    globalThreshold: number | undefined,
+    perProviderThreshold: number | undefined
+): number | undefined {
+    return perProviderThreshold ?? globalThreshold;
+}
+
+export function resolveCompactionTokenThreshold(
+    thresholdByDefault: number | undefined,
+    compaction: CompactionSettings | undefined
+): number | undefined {
+    return compaction?.tokenThreshold ?? thresholdByDefault;
 }
 
 /**

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -319,14 +319,14 @@ export namespace ToolRequest {
             (!('required' in obj) || (Array.isArray(obj.required) && obj.required.every(prop => typeof prop === 'string')));
     }
 }
+// Anthropic requires at least 50,000 tokens, so use one conservative minimum for all compaction settings.
+export const SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM = 50_000;
+
 /**
  * Per-session/per-request server-side compaction settings, carried verbatim from the chat
  * session's common settings to the request. Kept as an object so further parameters can be
  * added later.
  */
-// Anthropic requires at least 50,000 tokens, so use one conservative minimum for all compaction settings.
-export const SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM = 50_000;
-
 export interface CompactionSettings {
     /** Explicit enablement for this session; when set it wins over the model's default. `undefined` means "no explicit choice". */
     enabled?: boolean;

--- a/packages/ai-core/src/common/language-model.ts
+++ b/packages/ai-core/src/common/language-model.ts
@@ -324,6 +324,9 @@ export namespace ToolRequest {
  * session's common settings to the request. Kept as an object so further parameters can be
  * added later.
  */
+// Anthropic requires at least 50,000 tokens, so use one conservative minimum for all compaction settings.
+export const SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM = 50_000;
+
 export interface CompactionSettings {
     /** Explicit enablement for this session; when set it wins over the model's default. `undefined` means "no explicit choice". */
     enabled?: boolean;

--- a/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
+++ b/packages/ai-openai/src/browser/openai-frontend-application-contribution.ts
@@ -16,10 +16,14 @@
 
 import { FrontendApplicationContribution } from '@theia/core/lib/browser';
 import { inject, injectable } from '@theia/core/shared/inversify';
-import { ReasoningSupport, resolveCompactionDefault, ServerSideCompactionSetting } from '@theia/ai-core';
+import { ReasoningSupport, resolveCompactionDefault, resolveCompactionTokenThresholdDefault, ServerSideCompactionSetting } from '@theia/ai-core';
 import { OpenAiLanguageModelsManager, OpenAiModelDescription, OPENAI_PROVIDER_ID } from '../common';
-import { API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF, SERVER_SIDE_COMPACTION_PREF, USE_RESPONSE_API_PREF } from '../common/openai-preferences';
-import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES, PREFERENCE_NAME_SERVER_SIDE_COMPACTION } from '@theia/ai-core/lib/common/ai-core-preferences';
+import {
+    API_KEY_PREF, CUSTOM_ENDPOINTS_PREF, MODELS_PREF, SERVER_SIDE_COMPACTION_PREF, SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF, USE_RESPONSE_API_PREF
+} from '../common/openai-preferences';
+import {
+    AICorePreferences, PREFERENCE_NAME_MAX_RETRIES, PREFERENCE_NAME_SERVER_SIDE_COMPACTION, PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD
+} from '@theia/ai-core/lib/common/ai-core-preferences';
 import { PreferenceService } from '@theia/core';
 
 @injectable()
@@ -65,7 +69,9 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     this.updateAllModels();
                 } else if (event.preferenceName === SERVER_SIDE_COMPACTION_PREF) {
                     this.updateAllModels();
-                } else if (event.preferenceName === PREFERENCE_NAME_SERVER_SIDE_COMPACTION) {
+                } else if (event.preferenceName === PREFERENCE_NAME_SERVER_SIDE_COMPACTION ||
+                    event.preferenceName === SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF ||
+                    event.preferenceName === PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD) {
                     this.updateAllModels();
                 } else if (event.preferenceName === 'http.proxy') {
                     this.manager.setProxyUrl(this.preferenceService.get<string>('http.proxy', undefined));
@@ -111,6 +117,7 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                 model.enableStreaming === newModel.enableStreaming &&
                 model.useResponseApi === newModel.useResponseApi &&
                 model.serverSideCompactionEnabledByDefault === newModel.serverSideCompactionEnabledByDefault &&
+                model.serverSideCompactionTokenThresholdByDefault === newModel.serverSideCompactionTokenThresholdByDefault &&
                 reasoningSupportEquals(model.reasoningSupport, newModel.reasoningSupport)));
 
         this.manager.removeLanguageModels(...modelsToRemove.map(model => model.id));
@@ -134,6 +141,9 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
         const globalCompaction = this.preferenceService.get<boolean>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION, true);
         const compactionOverride = this.preferenceService.get<ServerSideCompactionSetting>(SERVER_SIDE_COMPACTION_PREF, 'default');
         const serverSideCompactionEnabledByDefault = resolveCompactionDefault(globalCompaction, compactionOverride);
+        const globalThreshold = this.preferenceService.get<number>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD, undefined);
+        const providerThreshold = this.preferenceService.get<number>(SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF, undefined);
+        const serverSideCompactionTokenThresholdByDefault = resolveCompactionTokenThresholdDefault(globalThreshold, providerThreshold);
         return {
             id: id,
             model: modelId,
@@ -141,7 +151,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
             apiVersion: true,
             maxRetries: maxRetries,
             useResponseApi: useResponseApi,
-            serverSideCompactionEnabledByDefault
+            serverSideCompactionEnabledByDefault,
+            serverSideCompactionTokenThresholdByDefault
         };
     }
 
@@ -152,6 +163,9 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
         const globalCompaction = this.preferenceService.get<boolean>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION, true);
         const compactionOverride = this.preferenceService.get<ServerSideCompactionSetting>(SERVER_SIDE_COMPACTION_PREF, 'default');
         const serverSideCompactionEnabledByDefault = resolveCompactionDefault(globalCompaction, compactionOverride);
+        const globalThreshold = this.preferenceService.get<number>(PREFERENCE_NAME_SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD, undefined);
+        const providerThreshold = this.preferenceService.get<number>(SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF, undefined);
+        const serverSideCompactionTokenThresholdByDefault = resolveCompactionTokenThresholdDefault(globalThreshold, providerThreshold);
         return preferences.reduce((acc, pref) => {
             if (!pref.model || !pref.url || typeof pref.model !== 'string' || typeof pref.url !== 'string') {
                 return acc;
@@ -171,7 +185,8 @@ export class OpenAiFrontendApplicationContribution implements FrontendApplicatio
                     maxRetries: pref.maxRetries ?? maxRetries,
                     useResponseApi: pref.useResponseApi ?? false,
                     reasoningSupport: isReasoningSupport(pref.reasoningSupport) ? pref.reasoningSupport : undefined,
-                    serverSideCompactionEnabledByDefault
+                    serverSideCompactionEnabledByDefault,
+                    serverSideCompactionTokenThresholdByDefault
                 }
             ];
         }, []);

--- a/packages/ai-openai/src/common/openai-language-models-manager.ts
+++ b/packages/ai-openai/src/common/openai-language-models-manager.ts
@@ -52,6 +52,8 @@ export interface OpenAiModelDescription {
     reasoningSupport?: ReasoningSupport;
     /** Resolved default enablement of server-side compaction (global preference folded with the per-provider override). Defaults to disabled when omitted. */
     serverSideCompactionEnabledByDefault?: boolean;
+    /** Resolved default input-token threshold for server-side compaction. `undefined` preserves the provider default. */
+    serverSideCompactionTokenThresholdByDefault?: number;
 }
 export interface OpenAiLanguageModelsManager {
     apiKey: string | undefined;

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { AI_CORE_PREFERENCES_TITLE, PREFERENCE_NAME_SERVER_SIDE_COMPACTION } from '@theia/ai-core/lib/common/ai-core-preferences';
+import { SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM } from '@theia/ai-core/lib/common/language-model';
 import { LINUX_ENV_HINT, nls, PreferenceSchema } from '@theia/core';
 
 export const API_KEY_PREF = 'ai-features.openAiOfficial.openAiApiKey';
@@ -75,7 +76,7 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
         },
         [SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF]: {
             type: 'integer',
-            minimum: 1,
+            minimum: SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM,
             markdownDescription: nls.localize('theia/ai/openai/compactionTokenThreshold/description',
                 'Override the global input-token threshold for server-side compaction for official OpenAI models. When unset, the global setting or provider default applies.'),
             title: AI_CORE_PREFERENCES_TITLE,

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -21,6 +21,7 @@ export const API_KEY_PREF = 'ai-features.openAiOfficial.openAiApiKey';
 export const MODELS_PREF = 'ai-features.openAiOfficial.officialOpenAiModels';
 export const USE_RESPONSE_API_PREF = 'ai-features.openAiOfficial.useResponseApi';
 export const SERVER_SIDE_COMPACTION_PREF = 'ai-features.openAiOfficial.serverSideCompaction';
+export const SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF = 'ai-features.openAiOfficial.serverSideCompactionTokenThreshold';
 export const CUSTOM_ENDPOINTS_PREF = 'ai-features.openAiCustom.customOpenAiModels';
 
 export const OpenAiPreferencesSchema: PreferenceSchema = {
@@ -70,6 +71,13 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
                 'the Chat Completions API ignores it. "default" follows the global chat setting ({0}). When effectively ' +
                 'enabled, the Response API is asked to summarize older turns once the conversation grows past the provider\'s threshold.',
                 `\`#${PREFERENCE_NAME_SERVER_SIDE_COMPACTION}#\``),
+            title: AI_CORE_PREFERENCES_TITLE,
+        },
+        [SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_PREF]: {
+            type: 'integer',
+            minimum: 1,
+            markdownDescription: nls.localize('theia/ai/openai/compactionTokenThreshold/description',
+                'Override the global input-token threshold for server-side compaction for official OpenAI models. When unset, the global setting or provider default applies.'),
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [CUSTOM_ENDPOINTS_PREF]: {

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -78,7 +78,8 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             type: 'integer',
             minimum: SERVER_SIDE_COMPACTION_TOKEN_THRESHOLD_MINIMUM,
             markdownDescription: nls.localize('theia/ai/openai/compactionTokenThreshold/description',
-                'Override the global input-token threshold for server-side compaction for official OpenAI models. When unset, the global setting or provider default applies.'),
+                'Override the global input-token threshold for server-side compaction for official OpenAI models. When unset, the global setting or provider default applies. ' +
+                'If set, the value must be at least 50,000 tokens.'),
             title: AI_CORE_PREFERENCES_TITLE,
         },
         [CUSTOM_ENDPOINTS_PREF]: {

--- a/packages/ai-openai/src/node/openai-language-model.spec.ts
+++ b/packages/ai-openai/src/node/openai-language-model.spec.ts
@@ -48,13 +48,18 @@ function createModel(modelId: string, reasoningSupport?: ReasoningSupport): Test
     );
 }
 
-function createCompactionModel(serverSideCompactionEnabledByDefault: boolean, useResponseApi: boolean = true): TestableOpenAiModel {
+function createCompactionModel(
+    serverSideCompactionEnabledByDefault: boolean,
+    useResponseApi: boolean = true,
+    serverSideCompactionTokenThresholdByDefault?: number
+): TestableOpenAiModel {
     return new TestableOpenAiModel(
         'test-id', 'gpt-5', { status: 'ready' }, true,
         () => 'test-key', () => undefined,
         false, undefined, undefined,
         new OpenAiModelUtils(), new OpenAiResponseApiUtils(),
-        'developer', 3, useResponseApi, undefined, undefined, undefined, useResponseApi, serverSideCompactionEnabledByDefault
+        'developer', 3, useResponseApi, undefined, undefined, undefined, useResponseApi, serverSideCompactionEnabledByDefault,
+        serverSideCompactionTokenThresholdByDefault
     );
 }
 
@@ -146,6 +151,18 @@ describe('OpenAiModel server-side compaction (Response API)', () => {
         const result = model.callApplyResponseApiCompaction({ stream: true }, { messages: [] });
         expect(result.context_management).to.deep.equal([{ type: 'compaction' }]);
         expect(result.stream).to.equal(true);
+    });
+
+    it('adds the model default token threshold', () => {
+        const model = createCompactionModel(true, true, 200_000);
+        const result = model.callApplyResponseApiCompaction({}, { messages: [] });
+        expect(result.context_management).to.deep.equal([{ type: 'compaction', compact_threshold: 200_000 }]);
+    });
+
+    it('uses the session token threshold over the model default', () => {
+        const model = createCompactionModel(true, true, 200_000);
+        const result = model.callApplyResponseApiCompaction({}, { messages: [], compaction: { tokenThreshold: 300_000 } });
+        expect(result.context_management).to.deep.equal([{ type: 'compaction', compact_threshold: 300_000 }]);
     });
 
     it('leaves settings unchanged when model default is off and request has no compaction setting', () => {

--- a/packages/ai-openai/src/node/openai-language-model.ts
+++ b/packages/ai-openai/src/node/openai-language-model.ts
@@ -25,6 +25,7 @@ import {
     ImageContent,
     LanguageModelStatus,
     ReasoningSupport,
+    resolveCompactionTokenThreshold,
     resolveServerSideCompaction
 } from '@theia/ai-core';
 import { CancellationToken } from '@theia/core';
@@ -112,7 +113,8 @@ export class OpenAiModel implements LanguageModel {
         public reasoningSupport?: ReasoningSupport,
         public maxInputTokens?: number,
         public serverSideCompactionSupport: boolean = false,
-        public serverSideCompactionEnabledByDefault: boolean = false
+        public serverSideCompactionEnabledByDefault: boolean = false,
+        public serverSideCompactionTokenThresholdByDefault?: number
     ) { }
 
     /** Reasoning-level translation lives in {@link openAiReasoningFor}. */
@@ -259,7 +261,14 @@ export class OpenAiModel implements LanguageModel {
      */
     protected applyResponseApiCompaction(settings: Record<string, unknown>, request: LanguageModelRequest): Record<string, unknown> {
         if (resolveServerSideCompaction(this.serverSideCompactionSupport, this.serverSideCompactionEnabledByDefault, request.compaction)) {
-            return { ...settings, context_management: [{ type: 'compaction' }] };
+            const tokenThreshold = resolveCompactionTokenThreshold(this.serverSideCompactionTokenThresholdByDefault, request.compaction);
+            return {
+                ...settings,
+                context_management: [{
+                    type: 'compaction',
+                    ...(tokenThreshold !== undefined && { compact_threshold: tokenThreshold })
+                }]
+            };
         }
         return settings;
     }

--- a/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
+++ b/packages/ai-openai/src/node/openai-language-models-manager-impl.ts
@@ -114,7 +114,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                     reasoningSupport: metadata.reasoningSupport,
                     maxInputTokens: metadata.maxInputTokens,
                     serverSideCompactionSupport: metadata.serverSideCompactionSupport,
-                    serverSideCompactionEnabledByDefault: modelDescription.serverSideCompactionEnabledByDefault ?? false
+                    serverSideCompactionEnabledByDefault: modelDescription.serverSideCompactionEnabledByDefault ?? false,
+                    serverSideCompactionTokenThresholdByDefault: modelDescription.serverSideCompactionTokenThresholdByDefault
                 });
             } else {
                 this.languageModelRegistry.addLanguageModels([
@@ -137,7 +138,8 @@ export class OpenAiLanguageModelsManagerImpl implements OpenAiLanguageModelsMana
                         metadata.reasoningSupport,
                         metadata.maxInputTokens,
                         metadata.serverSideCompactionSupport,
-                        modelDescription.serverSideCompactionEnabledByDefault ?? false
+                        modelDescription.serverSideCompactionEnabledByDefault ?? false,
+                        modelDescription.serverSideCompactionTokenThresholdByDefault
                     )
                 ]);
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Add global, per-provider, and per-session token thresholds for server-side compaction. Translate the resolved threshold to the native OpenAI Responses and Anthropic Messages API request formats.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Set any of the tresholds and activate the compaction. You should see the compaction triggering when you reach this session size. 
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
