### PR TITLE
fix(plugin-ext): scope /hostedPlugin resource requests to the plugin directory

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-reader.spec.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.spec.ts
@@ -1,0 +1,80 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { HostedPluginReader } from './plugin-reader';
+
+class TestHostedPluginReader extends HostedPluginReader {
+    resolve(localPath: string, filePath: string): Promise<string | undefined> {
+        return this.resolveFile(localPath, filePath);
+    }
+}
+
+describe('HostedPluginReader#resolveFile', () => {
+
+    let pluginDir: string;
+    let nearSiblingFile: string;
+    let farSiblingFile: string;
+    const reader = new TestHostedPluginReader();
+
+    before(() => {
+        // Layout:
+        //   <root>/far-sibling.txt        (reachable via `../../far-sibling.txt`)
+        //   <root>/wrapper/sibling.txt    (reachable via `../sibling.txt`)
+        //   <root>/wrapper/plugin/        (pluginDir)
+        //     ├── main.js
+        //     └── media/icon.png
+        const root = fs.mkdtempSync(path.join(os.tmpdir(), 'theia-plugin-reader-'));
+        const wrapper = path.join(root, 'wrapper');
+        pluginDir = path.join(wrapper, 'plugin');
+        fs.mkdirSync(pluginDir, { recursive: true });
+        fs.writeFileSync(path.join(pluginDir, 'main.js'), 'console.log("ok");');
+        fs.mkdirSync(path.join(pluginDir, 'media'));
+        fs.writeFileSync(path.join(pluginDir, 'media', 'icon.png'), 'png');
+        nearSiblingFile = path.join(wrapper, 'sibling.txt');
+        fs.writeFileSync(nearSiblingFile, 'near');
+        farSiblingFile = path.join(root, 'far-sibling.txt');
+        fs.writeFileSync(farSiblingFile, 'far');
+    });
+
+    it('serves a file inside the plugin directory', async () => {
+        expect(await reader.resolve(pluginDir, 'main.js')).to.equal(path.join(pluginDir, 'main.js'));
+        expect(await reader.resolve(pluginDir, 'media/icon.png')).to.equal(path.join(pluginDir, 'media', 'icon.png'));
+    });
+
+    it('resolves extensionless references with the .js fallback', async () => {
+        expect(await reader.resolve(pluginDir, 'main')).to.equal(path.join(pluginDir, 'main.js'));
+    });
+
+    it('returns undefined for a relative path pointing outside the plugin directory', async () => {
+        expect(await reader.resolve(pluginDir, '../sibling.txt')).to.be.undefined;
+    });
+
+    it('returns undefined for a relative path composed of parent-directory segments', async () => {
+        expect(await reader.resolve(pluginDir, '../../far-sibling.txt')).to.be.undefined;
+    });
+
+    it('returns undefined for an absolute path outside the plugin directory', async () => {
+        expect(await reader.resolve(pluginDir, nearSiblingFile)).to.be.undefined;
+    });
+
+    it('returns undefined for a missing file inside the plugin directory', async () => {
+        expect(await reader.resolve(pluginDir, 'does-not-exist.js')).to.be.undefined;
+    });
+});

--- a/packages/plugin-ext/src/hosted/node/plugin-reader.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-reader.ts
@@ -49,8 +49,7 @@ export class HostedPluginReader implements BackendApplicationContribution {
 
             const localPath = this.pluginsIdsFiles.get(pluginId);
             if (localPath) {
-                const absolutePath = path.resolve(localPath, filePath);
-                const resolvedFile = await this.resolveFile(absolutePath);
+                const resolvedFile = await this.resolveFile(localPath, filePath);
                 if (!resolvedFile) {
                     res.status(404).send(`No such file found in '${escape_html(pluginId)}' plugin.`);
                     return;
@@ -79,13 +78,23 @@ export class HostedPluginReader implements BackendApplicationContribution {
     }
 
     /**
-     * Resolves a plugin file path with fallback to .js and .cjs extensions.
+     * Resolves `filePath` under `localPath`, with fallback to `.js`, `.cjs` and `.mjs`
+     * extensions. Returns `undefined` if the resolved path is not under `localPath`
+     * or if no candidate exists on disk.
      *
-     * This handles cases where plugins reference modules without extensions,
-     * which is common in Node.js/CommonJS environments.
-     *
+     * The extension fallback handles cases where plugins reference modules without
+     * extensions, which is common in Node.js/CommonJS environments.
      */
-    protected async resolveFile(absolutePath: string): Promise<string | undefined> {
+    protected async resolveFile(localPath: string, filePath: string): Promise<string | undefined> {
+        const absolutePath = path.resolve(localPath, filePath);
+
+        // `path.relative` yields a path starting with '..' (or an absolute path on
+        // Windows when the drive differs) when `absolutePath` is not under `localPath`.
+        const relativePath = path.relative(localPath, absolutePath);
+        if (relativePath.startsWith('..') || path.isAbsolute(relativePath)) {
+            return undefined;
+        }
+
         const candidates = [absolutePath];
         const pathExtension = path.extname(absolutePath).toLowerCase();
 


### PR DESCRIPTION
#### What it does

Reinstates the check that the `/hostedPlugin/:pluginId/:path(*)` endpoint in `HostedPluginReader` only serves files that resolve under the requested plugin's directory. Previously the endpoint accepted any path resolvable from `path.resolve(localPath, filePath)`, including paths that resolved outside `localPath`.

Details:
- `HostedPluginReader.resolveFile` now takes `(localPath, filePath)` and applies a `path.relative` / `path.isAbsolute` check after `path.resolve`. Paths that do not land under `localPath` return `undefined` and the request handler responds with a 404.
- New unit tests exercise `resolveFile` and the existing extensionless-module resolution.

Note: this reverses the behavioural change from eclipse-theia/theia#16195 (issue eclipse-theia/theia#16193), which had removed the previous scope check to allow serving files located outside the extension directory (e.g. absolute `Uri.file(...)` used as `TreeItem.iconPath` / `QuickInputButton.iconPath`, and dynamically-generated icons in a temp directory). See Follow-ups.

#### How to test

Unit tests:

```
npx lerna run test --scope @theia/plugin-ext
```

`HostedPluginReader#resolveFile` covers:

- files inside the plugin directory (including nested and extensionless references),
- a relative path pointing outside the plugin directory (`..` segments),
- an absolute path pointing outside the plugin directory,
- a missing file inside the plugin directory.

Manual sanity check for the endpoint (browser example):

```
npm run start:browser
```

- Icons and webview assets shipped inside installed plugins load as before.
- A request under `/hostedPlugin/<pluginId>/` that resolves outside that plugin's directory returns 404.

#### Follow-ups

- Restore the #16193 use case (serving resource files located outside the extension directory) in a controlled way. Design sketch: a per-plugin allowed-roots registry populated by the trusted plugin host, mirroring VS Code's `localResourceRoots` model for webviews. #16193 should be reopened to track this.
- Optionally add a `realpath` step on the resolved candidate so symlinks inside a plugin directory cannot point outside it. Small addition, but interacts with legitimate symlinks used by some plugin deployment layouts; better folded into the allowed-roots follow-up together with the extra tests.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

Not an API break, but a user-visible behavioural change: plugins that relied on the behaviour introduced in #16195 to reference files outside their extension directory (absolute-path icons, generated files in a temp directory) will see those requests return 404 until the follow-up lands.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/eclipse-theia/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)
