### PR TITLE
fix(filesystem): require connection token on file endpoints

### DIFF
--- a/packages/core/src/electron-node/hosting/electron-backend-hosting-module.spec.ts
+++ b/packages/core/src/electron-node/hosting/electron-backend-hosting-module.spec.ts
@@ -1,0 +1,42 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from 'inversify';
+import electronBackendHostingModule from './electron-backend-hosting-module';
+import { HttpConnectionValidator } from '../../node/hosting/browser-connection-token';
+
+describe('electron-backend-hosting-module', () => {
+
+    it('should bind a no-op HttpConnectionValidator that calls next() unconditionally', () => {
+        const container = new Container();
+        container.load(electronBackendHostingModule);
+        const validator = container.get<HttpConnectionValidator>(HttpConnectionValidator);
+
+        let nextCalled = false;
+        let sentStatus: number | undefined;
+        // No cookie provided: the no-op validator must still call next() and never send a status.
+        const req = { headers: {} as Record<string, string | undefined> };
+        const res = { sendStatus: (status: number) => { sentStatus = status; } };
+        const next = (): void => { nextCalled = true; };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        validator.validateRequest(req as any, res as any, next as any);
+
+        expect(nextCalled).to.be.true;
+        expect(sentStatus).to.be.undefined;
+    });
+});

--- a/packages/core/src/electron-node/hosting/electron-backend-hosting-module.ts
+++ b/packages/core/src/electron-node/hosting/electron-backend-hosting-module.ts
@@ -16,9 +16,17 @@
 
 import { ContainerModule } from 'inversify';
 import { WsRequestValidatorContribution } from '../../node/ws-request-validators';
+import { HttpConnectionValidator } from '../../node/hosting/browser-connection-token';
 import { ElectronWsOriginValidator } from './electron-ws-origin-validator';
 
 export default new ContainerModule(bind => {
     bind(ElectronWsOriginValidator).toSelf().inSingletonScope();
     bind(WsRequestValidatorContribution).toService(ElectronWsOriginValidator);
+
+    // Electron uses its own `ElectronSecurityToken`, so the connection-token cookie is not used.
+    // Bind a no-op validator so consumers can inject it uniformly.
+    const noopValidator: HttpConnectionValidator = {
+        validateRequest: (_req, _res, next) => next()
+    };
+    bind(HttpConnectionValidator).toConstantValue(noopValidator);
 });

--- a/packages/core/src/node/hosting/backend-hosting-module.ts
+++ b/packages/core/src/node/hosting/backend-hosting-module.ts
@@ -19,7 +19,7 @@ import { BackendApplicationContribution } from '../backend-application';
 import { WsRequestValidatorContribution } from '../ws-request-validators';
 import { BackendApplicationHosts } from './backend-application-hosts';
 import {
-    BrowserConnectionToken, BrowserConnectionTokenBackendContribution, createBrowserConnectionToken
+    BrowserConnectionToken, BrowserConnectionTokenBackendContribution, HttpConnectionValidator, createBrowserConnectionToken
 } from './browser-connection-token';
 import { WsOriginValidator } from './ws-origin-validator';
 
@@ -28,9 +28,12 @@ export default new ContainerModule(bind => {
     bind(WsOriginValidator).toSelf().inSingletonScope();
     bind(WsRequestValidatorContribution).toService(WsOriginValidator);
 
-    // Cookie-based connection token protects both HTTP and WebSocket endpoints.
+    // Cookie-based connection token. It is validated on WebSocket upgrades and bootstrapped
+    // (set as a cookie) on every HTTP request; HTTP enforcement is opt-in per route via
+    // `HttpConnectionValidator`.
     bind(BrowserConnectionToken).toConstantValue(createBrowserConnectionToken());
     bind(BrowserConnectionTokenBackendContribution).toSelf().inSingletonScope();
     bind(BackendApplicationContribution).toService(BrowserConnectionTokenBackendContribution);
     bind(WsRequestValidatorContribution).toService(BrowserConnectionTokenBackendContribution);
+    bind(HttpConnectionValidator).toService(BrowserConnectionTokenBackendContribution);
 });

--- a/packages/core/src/node/hosting/browser-connection-token.spec.ts
+++ b/packages/core/src/node/hosting/browser-connection-token.spec.ts
@@ -16,6 +16,7 @@
 
 import { expect } from 'chai';
 import * as http from 'http';
+import { environment } from '../../common';
 import {
     BrowserConnectionToken,
     BrowserConnectionTokenBackendContribution,
@@ -162,6 +163,97 @@ describe('BrowserConnectionTokenBackendContribution', () => {
             expect(result.nextCalled).to.be.true;
             expect(result.cookieCalls).to.have.length(1);
             expect(result.cookieCalls[0].value).to.equal(token.value);
+        });
+    });
+
+    describe('validateRequest (HTTP token enforcement)', () => {
+
+        interface ValidationResult {
+            nextCalled: boolean;
+            sentStatus?: number;
+        }
+
+        function callValidate(cookieValue?: string): ValidationResult {
+            const contribution = createContribution();
+            const result: ValidationResult = { nextCalled: false };
+
+            const req = { headers: {} as Record<string, string | undefined> };
+            if (cookieValue !== undefined) {
+                req.headers.cookie = `${BROWSER_TOKEN_COOKIE_NAME}=${cookieValue}`;
+            }
+
+            const res = {
+                sendStatus: (status: number) => { result.sentStatus = status; }
+            };
+
+            const next = (): void => { result.nextCalled = true; };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (contribution as any).validateRequest(req, res, next);
+            return result;
+        }
+
+        it('should allow request with valid token cookie', () => {
+            const result = callValidate(token.value);
+            expect(result.nextCalled).to.be.true;
+            expect(result.sentStatus).to.be.undefined;
+        });
+
+        it('should reject request with no cookie', () => {
+            const result = callValidate();
+            expect(result.nextCalled).to.be.false;
+            expect(result.sentStatus).to.equal(403);
+        });
+
+        it('should reject request with invalid token', () => {
+            const result = callValidate('wrong-token');
+            expect(result.nextCalled).to.be.false;
+            expect(result.sentStatus).to.equal(403);
+        });
+
+        it('should reject request with stale token from previous server', () => {
+            const staleToken = createBrowserConnectionToken().value;
+            const result = callValidate(staleToken);
+            expect(result.nextCalled).to.be.false;
+            expect(result.sentStatus).to.equal(403);
+        });
+
+        it('should reject request with empty token', () => {
+            const result = callValidate('');
+            expect(result.nextCalled).to.be.false;
+            expect(result.sentStatus).to.equal(403);
+        });
+    });
+
+    describe('Electron deployment (no-op)', () => {
+
+        let originalIsElectron: () => boolean;
+
+        beforeEach(() => {
+            originalIsElectron = environment.electron.is;
+            environment.electron.is = () => true;
+        });
+
+        afterEach(() => {
+            environment.electron.is = originalIsElectron;
+        });
+
+        it('validateRequest should call next() without a cookie', () => {
+            const contribution = createContribution();
+            let nextCalled = false;
+            let sentStatus: number | undefined;
+            const req = { headers: {} as Record<string, string | undefined> };
+            const res = { sendStatus: (status: number) => { sentStatus = status; } };
+            const next = (): void => { nextCalled = true; };
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (contribution as any).validateRequest(req, res, next);
+            expect(nextCalled).to.be.true;
+            expect(sentStatus).to.be.undefined;
+        });
+
+        it('allowWsUpgrade should return true without a cookie', () => {
+            const contribution = createContribution();
+            expect(contribution.allowWsUpgrade(createRequest())).to.be.true;
         });
     });
 });

--- a/packages/core/src/node/hosting/browser-connection-token.ts
+++ b/packages/core/src/node/hosting/browser-connection-token.ts
@@ -33,6 +33,26 @@ export interface BrowserConnectionToken {
     value: string;
 }
 
+export const HttpConnectionValidator = Symbol('HttpConnectionValidator');
+
+/**
+ * Express middleware provider that rejects HTTP requests lacking a valid connection token.
+ *
+ * The connection-token cookie is only *bootstrapped* globally (see
+ * {@link BrowserConnectionTokenBackendContribution}); enforcement is opt-in per route.
+ * Security-sensitive HTTP endpoints (e.g. the filesystem upload/download routes) should
+ * inject this and apply {@link validateRequest} as route middleware. Non-sensitive routes
+ * (the initial HTML page, static assets) must not use it, as they legitimately have no
+ * cookie yet on the very first page load.
+ */
+export interface HttpConnectionValidator {
+    /**
+     * Express middleware that calls `next()` when the request carries a valid connection-token
+     * cookie (or when running in Electron) and responds with `403` otherwise.
+     */
+    validateRequest(req: express.Request, res: express.Response, next: express.NextFunction): void;
+}
+
 /**
  * Validates WebSocket and HTTP requests using a cookie-based connection token.
  *
@@ -40,13 +60,18 @@ export interface BrowserConnectionToken {
  * as a `SameSite=Strict; HttpOnly` cookie on the first page load. Cross-origin pages
  * cannot obtain or send this cookie, so their requests are rejected.
  *
+ * The cookie is *bootstrapped* for every HTTP request (via {@link expressMiddleware}) so that
+ * browsers always receive it, but HTTP requests are only *rejected* on routes that opt in to
+ * enforcement via {@link validateRequest} (see {@link HttpConnectionValidator}). WebSocket
+ * upgrades are always validated (see {@link allowWsUpgrade}).
+ *
  * This complements the origin validator: non-browser callers that omit the Origin
  * header (e.g. Node.js scripts) still cannot reach the backend without the cookie.
  *
  * Skipped in Electron deployments (which use their own `ElectronSecurityToken`).
  */
 @injectable()
-export class BrowserConnectionTokenBackendContribution implements BackendApplicationContribution, WsRequestValidatorContribution {
+export class BrowserConnectionTokenBackendContribution implements BackendApplicationContribution, WsRequestValidatorContribution, HttpConnectionValidator {
 
     @inject(BrowserConnectionToken)
     protected readonly browserConnectionToken: BrowserConnectionToken;
@@ -82,6 +107,25 @@ export class BrowserConnectionTokenBackendContribution implements BackendApplica
         // No cookie: reject. Legitimate browsers always have the cookie
         // because it is set on the initial page load.
         return false;
+    }
+
+    /**
+     * Reject the request with `403` unless it carries a valid connection-token cookie.
+     * Always allows the request in Electron deployments, consistent with {@link allowWsUpgrade}.
+     */
+    validateRequest(req: express.Request, res: express.Response, next: express.NextFunction): void {
+        if (environment.electron.is()) {
+            next();
+            return;
+        }
+        const token = this.getTokenFromCookie(req);
+        if (token && this.isTokenValid(token)) {
+            next();
+            return;
+        }
+        // No cookie or stale/invalid token: reject. Legitimate browsers always have the cookie
+        // because it is set on the initial page load, and same-origin requests send it automatically.
+        res.sendStatus(403);
     }
 
     protected expressMiddleware(req: express.Request, res: express.Response, next: express.NextFunction): void {

--- a/packages/core/src/node/index.ts
+++ b/packages/core/src/node/index.ts
@@ -23,3 +23,4 @@ export * from './cli';
 export * from './setting-service';
 export { FileSystemLocking } from './filesystem-locking';
 export { BackendRequestAllowedContribution } from './request/backend-request-facade';
+export { HttpConnectionValidator } from './hosting/browser-connection-token';

--- a/packages/filesystem/src/node/download/file-download-endpoint.ts
+++ b/packages/filesystem/src/node/download/file-download-endpoint.ts
@@ -18,8 +18,9 @@
 
 import { injectable, inject, named } from '@theia/core/shared/inversify';
 import { json } from 'body-parser';
-import { Application, Router } from '@theia/core/shared/express';
+import { Application, Router, RequestHandler } from '@theia/core/shared/express';
 import { BackendApplicationContribution } from '@theia/core/lib/node/backend-application';
+import { HttpConnectionValidator } from '@theia/core/lib/node';
 import { FileUri } from '@theia/core/lib/common/file-uri';
 import { FileDownloadHandler } from './file-download-handler';
 
@@ -40,15 +41,20 @@ export class FileDownloadEndpoint implements BackendApplicationContribution {
     @named(FileDownloadHandler.DOWNLOAD_LINK)
     protected readonly downloadLinkHandler: FileDownloadHandler;
 
+    @inject(HttpConnectionValidator)
+    protected readonly connectionValidator: HttpConnectionValidator;
+
     configure(app: Application): void {
+        // Reject unauthenticated/cross-origin requests to the file read endpoints.
+        const guard: RequestHandler = (request, response, next) => this.connectionValidator.validateRequest(request, response, next);
         const router = Router();
         router.get('/download', (request, response) => this.downloadLinkHandler.handle(request, response));
         router.get('/', (request, response) => this.singleFileDownloadHandler.handle(request, response));
         router.put('/', (request, response) => this.multiFileDownloadHandler.handle(request, response));
         // Content-Type: application/json
         app.use(json());
-        app.use(FileDownloadEndpoint.PATH, router);
-        app.get('/file', (request, response) => {
+        app.use(FileDownloadEndpoint.PATH, guard, router);
+        app.get('/file', guard, (request, response) => {
             const uri = new URL(request.url, 'http://localhost').search.slice(1);
             if (!uri) {
                 response.status(400).send('invalid uri');

--- a/packages/filesystem/src/node/upload/node-file-upload-service.spec.ts
+++ b/packages/filesystem/src/node/upload/node-file-upload-service.spec.ts
@@ -1,0 +1,126 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from '@theia/core/shared/fs-extra';
+import { FileUri } from '@theia/core/lib/common/file-uri';
+import { NodeFileUploadService } from './node-file-upload-service';
+
+/** Captures what the upload handler wrote to the Express response. */
+interface CapturedResponse {
+    statusCode?: number;
+    sentStatus?: number;
+    body?: unknown;
+}
+
+describe('NodeFileUploadService', () => {
+
+    let tempDir: string;
+
+    function createService(): NodeFileUploadService {
+        const service = new NodeFileUploadService();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (service as any)['logger'] = { error: () => { } };
+        return service;
+    }
+
+    function createResponse(): { res: unknown, captured: CapturedResponse } {
+        const captured: CapturedResponse = {};
+        const res = {
+            status(code: number): unknown {
+                captured.statusCode = code;
+                return res;
+            },
+            send(body: unknown): void {
+                captured.body = body;
+            },
+            sendStatus(code: number): void {
+                captured.sentStatus = code;
+            }
+        };
+        return { res, captured };
+    }
+
+    async function handleUpload(filePath: string | undefined, body: unknown): Promise<CapturedResponse> {
+        const service = createService();
+        const { res, captured } = createResponse();
+        const request = { file: filePath === undefined ? undefined : { path: filePath }, body };
+        // handleFileUpload is protected; invoke it directly to exercise the input validation.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        await (service as any).handleFileUpload(request, res);
+        return captured;
+    }
+
+    beforeEach(async () => {
+        tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'theia-upload-spec-'));
+    });
+
+    afterEach(async () => {
+        await fs.remove(tempDir);
+    });
+
+    it('should reject a non-file: URI with 400', async () => {
+        const source = path.join(tempDir, 'source.txt');
+        await fs.writeFile(source, 'payload');
+        const captured = await handleUpload(source, { uri: 'http://evil.example/usr/bin/bash' });
+        expect(captured.sentStatus).to.equal(400);
+        // The scoped-write guard must reject before any file operation runs.
+        expect(await fs.pathExists(source)).to.be.true;
+    });
+
+    it('should reject a remote-scheme URI with 400', async () => {
+        const source = path.join(tempDir, 'source.txt');
+        await fs.writeFile(source, 'payload');
+        const captured = await handleUpload(source, { uri: 'vscode-remote://host/usr/bin/bash' });
+        expect(captured.sentStatus).to.equal(400);
+        expect(await fs.pathExists(source)).to.be.true;
+    });
+
+    it('should reject a missing uri field with 400', async () => {
+        const source = path.join(tempDir, 'source.txt');
+        await fs.writeFile(source, 'payload');
+        const captured = await handleUpload(source, {});
+        expect(captured.sentStatus).to.equal(400);
+    });
+
+    it('should reject a missing file with 400', async () => {
+        const target = FileUri.create(path.join(tempDir, 'target.txt')).toString();
+        const captured = await handleUpload(undefined, { uri: target });
+        expect(captured.sentStatus).to.equal(400);
+    });
+
+    it('should accept a file: URI and move the upload to the target', async () => {
+        const source = path.join(tempDir, 'source.txt');
+        await fs.writeFile(source, 'payload');
+        const targetPath = path.join(tempDir, 'target.txt');
+        const target = FileUri.create(targetPath).toString();
+
+        const captured = await handleUpload(source, { uri: target });
+
+        expect(captured.sentStatus).to.be.undefined;
+        expect(captured.statusCode).to.equal(200);
+        // Compare against the canonical fs-path of the URI: on Windows the create/fsPath round-trip
+        // normalizes the drive letter to lower-case (e.g. `C:` -> `c:`), which would otherwise fail
+        // an exact string match against `targetPath` derived from `os.tmpdir()`.
+        expect(captured.body).to.equal(FileUri.fsPath(target));
+        expect(await fs.pathExists(targetPath)).to.be.true;
+        expect(await fs.readFile(targetPath, 'utf8')).to.equal('payload');
+        // The temp source file was moved, not copied.
+        expect(await fs.pathExists(source)).to.be.false;
+    });
+});

--- a/packages/filesystem/src/node/upload/node-file-upload-service.ts
+++ b/packages/filesystem/src/node/upload/node-file-upload-service.ts
@@ -19,16 +19,19 @@ import path = require('path');
 import os = require('os');
 import express = require('@theia/core/shared/express');
 import fs = require('@theia/core/shared/fs-extra');
-import { BackendApplicationContribution, FileUri } from '@theia/core/lib/node';
+import { BackendApplicationContribution, FileUri, HttpConnectionValidator } from '@theia/core/lib/node';
 import { injectable, inject, named } from '@theia/core/shared/inversify';
 import { HTTP_FILE_UPLOAD_PATH } from '../../common/file-upload';
-import { ILogger } from '@theia/core';
+import { ILogger, URI } from '@theia/core';
 
 @injectable()
 export class NodeFileUploadService implements BackendApplicationContribution {
 
     @inject(ILogger) @named('filesystem:NodeFileUploadService')
     protected readonly logger: ILogger;
+
+    @inject(HttpConnectionValidator)
+    protected readonly connectionValidator: HttpConnectionValidator;
 
     private static readonly UPLOAD_DIR = 'theia_upload';
 
@@ -39,8 +42,11 @@ export class NodeFileUploadService implements BackendApplicationContribution {
         ]);
         this.logger.debug(`HTTP file upload URL path: ${http_path}`);
         this.logger.debug(`Backend file upload cache path: ${dest}`);
+        // Reject unauthenticated/cross-origin requests before `multer` writes any temp file.
+        const guard: express.RequestHandler = (request, response, next) => this.connectionValidator.validateRequest(request, response, next);
         app.post(
             http_path,
+            guard,
             // `multer` handles `multipart/form-data` containing our file to upload.
             multer({ dest }).single('file'),
             (request, response, next) => this.handleFileUpload(request, response)
@@ -63,7 +69,7 @@ export class NodeFileUploadService implements BackendApplicationContribution {
 
     protected async handleFileUpload(request: express.Request, response: express.Response): Promise<void> {
         const fields = request.body;
-        if (!request.file || typeof fields !== 'object' || typeof fields.uri !== 'string') {
+        if (!request.file || typeof fields !== 'object' || typeof fields.uri !== 'string' || new URI(fields.uri).scheme !== 'file') {
             response.sendStatus(400); // bad request
             return;
         }

--- a/packages/task/src/node/test/task-test-container.ts
+++ b/packages/task/src/node/test/task-test-container.ts
@@ -22,6 +22,7 @@ import taskBackendModule from '../task-backend-module';
 import filesystemBackendModule from '@theia/filesystem/lib/node/filesystem-backend-module';
 import workspaceServer from '@theia/workspace/lib/node/workspace-backend-module';
 import { messagingBackendModule } from '@theia/core/lib/node/messaging/messaging-backend-module';
+import { HttpConnectionValidator } from '@theia/core/lib/node';
 import { ApplicationPackage } from '@theia/core/shared/@theia/application-package';
 import { TerminalProcess } from '@theia/process/lib/node';
 import { ProcessUtils } from '@theia/core/lib/node/process-utils';
@@ -39,6 +40,13 @@ export function createTaskTestContainer(): Container {
     testContainer.load(filesystemBackendModule);
     testContainer.load(workspaceServer);
     testContainer.load(terminalBackendModule);
+
+    // The filesystem backend contributions require an `HttpConnectionValidator` (bound by the browser/electron
+    // hosting modules, which are not loaded here). Bind a no-op so those contributions can be constructed.
+    const noopConnectionValidator: HttpConnectionValidator = {
+        validateRequest: (_req, _res, next) => next()
+    };
+    testContainer.bind(HttpConnectionValidator).toConstantValue(noopConnectionValidator);
 
     // Make it easier to debug processes.
     testContainer.rebind(TerminalProcess).to(TestTerminalProcess);


### PR DESCRIPTION
#### What it does

The filesystem backend HTTP routes — `POST /file-upload`, and the `/files` router plus `GET /file` — resolved a supplied absolute path (`FileUri.fsPath(uri)`) and wrote (`fs.move(..., { overwrite: true })`) or read (`sendFile` / stream) the filesystem without checking the connection token. The cookie-based connection token was only validated on WebSocket upgrades. Its HTTP middleware merely *bootstrapped* the cookie and always called `next()`. Thus, these routes were gated by neither the token nor an origin check. Because `multipart/form-data` is a CORS-safelisted request type, a cross-origin page could trigger an arbitrary file write (and read) with no token and no preflight.

This PR enforces the connection token on those HTTP endpoints:

- Adds a reusable `HttpConnectionValidator` in `@theia/core`, implemented by `BrowserConnectionTokenBackendContribution.validateRequest`, which rejects requests without a valid `theia-connection-token` cookie ( HTTP error `403`) and is a no-op in Electron (which uses its own `ElectronSecurityToken`). A no-op binding is provided in the Electron hosting module so the service resolves uniformly.
- Applies the validator as route middleware on `POST /file-upload` (before `multer`, so rejected requests write no temp file) and on the `/files` router and `GET /file`.
- Requires the upload target URI to use the `file` scheme (otherwise `400`).

Enforcement is per-endpoint rather than global: the initial page load and static assets legitimately have no cookie yet, so global enforcement would break bootstrap. Legitimate frontend calls are same-origin XHR/`fetch`, which send the `HttpOnly; SameSite=Strict` cookie automatically and are therefore unaffected.

**No workspace-root confinement was added**. In Theia's model an authenticated frontend already has full filesystem access via the WebSocket filesystem provider, so authentication — not workspace scope — is the boundary. Backend-side confinement is also not faithfully enforceable, since the backend does not reliably know a given frontend's workspace roots (they are computed browser-side; the `@theia/filesystem` package cannot depend on `@theia/workspace`).

#### How to test

1. `npm run build:browser` then `npm run start:browser`.
2. **Positive path (must still work):** in the app, drag-drop a file into the explorer to upload, and download a file. Both succeed.
3. **Break out path (must now return 403 and write nothing):**
   ```
   curl -i -X POST http://localhost:3000/file-upload -F 'uri=file:///tmp/pwned' -F 'file=@/etc/hostname'
   curl -i 'http://localhost:3000/file?file%3A%2F%2F%2Fetc%2Fpasswd'
   curl -i 'http://localhost:3000/files/?uri=file%3A%2F%2F%2Fetc%2Fpasswd'
   ```
   Each returns `403`; confirm `/tmp/pwned` is not created.
4. **With a valid cookie (simulating the loaded frontend):** obtain the cookie from `curl -i http://localhost:3000/` and replay it via `-H "Cookie: theia-connection-token=<value>"` — upload/download succeed; a non-`file:` upload URI returns `400`.
5. Unit tests: `npx lerna run test --scope @theia/core` (see the new `validateRequest` block in `browser-connection-token.spec.ts`).
6. Electron sanity: `npm run start:electron` — upload/download unaffected (no-op validator).

**Note on the `Set-Cookie` header in the 403 response.** Reviewers testing with `curl` will notice the `403` response (and `GET /`) includes a `Set-Cookie: theia-connection-token=…` header, and that replaying it in a follow-up `curl` succeeds. This is expected and **not** a bypass of the issue being fixed:

- The token is not a secret credential — it is bootstrapped to every first-time visitor so the app can load. Its protection relies on browser cookie semantics.
- For the actual threat (a **cross-origin web page**), those semantics hold: `HttpOnly` prevents the attacker's JS from reading the value, `Set-Cookie` is a forbidden response header (unreadable via `fetch`, opaque without CORS), and `SameSite=Strict` prevents the browser from attaching the cookie to any cross-site request. So a malicious page can neither read nor replay it. The cross-origin write/read stays blocked.
- `curl` bypasses all three because they are browser-enforced; `curl` is a **direct** network client, not a cross-origin browser. A direct client can always obtain and replay the token (the pre-existing WebSocket `allowWsUpgrade` check has the same property). Protecting against direct/untrusted-network access is out of scope for a connection token and requires a real auth layer (e.g. an authenticating reverse proxy); browser-mode Theia should not be exposed directly to an untrusted network.

#### Follow-ups

- The mini-browser endpoint (`packages/mini-browser/src/node/mini-browser-endpoint.ts`) is another user-supplied-path read surface, but it is served under a separate vhost (`{{uuid}}.mini-browser.{{hostname}}`), so the main-origin `SameSite=Strict` cookie is not sent to it — applying this guard would break it. It has its own WS validator and should be addressed separately.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/eclipse-theia/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)
