### PR TITLE
feat(plugin-ext): add tabinfo for CustomEditorWidget and viewColumn from the tab bar's index (#17793)

### DIFF
--- a/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
+++ b/packages/plugin-ext/src/main/browser/tabs/tabs-main.ts
@@ -27,6 +27,7 @@ import { DisposableCollection } from '@theia/core';
 import { NotebookEditorWidget } from '@theia/notebook/lib/browser';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { MergeEditor } from '@theia/scm/lib/browser/merge-editor/merge-editor';
+import { CustomEditorWidget } from '../custom-editors/custom-editor-widget';
 
 interface TabInfo {
     tab: TabDto;
@@ -181,7 +182,7 @@ export class TabsMainImpl implements TabsMain, Disposable {
         const oldDto = this.tabGroupModel.get(tabBar);
         const groupId = oldDto?.groupId ?? this.groupIdCounter++;
         const tabs = tabBar.titles.map(title => this.createTabDto(title, groupId));
-        const viewColumn = 0; // TODO: Implement correct viewColumn handling
+        const viewColumn = Math.max(0, this.applicationShell.mainAreaTabBars.indexOf(tabBar));
         return {
             groupId,
             tabs,
@@ -225,6 +226,12 @@ export class TabsMainImpl implements TabsMain, Disposable {
                     uri: toUriComponents(widget.editor.uri.toString())
                 };
             }
+        } else if (widget instanceof CustomEditorWidget) {
+            return {
+                kind: TabInputKind.CustomEditorInput,
+                viewType: widget.viewType,
+                uri: toUriComponents(widget.resource.toString())
+            };
         } else if (widget instanceof ViewContainer) {
             return {
                 kind: TabInputKind.WebviewEditorInput,


### PR DESCRIPTION
#### What it does

Improves the tab info reported to the VS Code plugin host in `tabs-main.ts`:
- Computes `viewColumn` from the tab bar's actual index within the main area's tab bars, instead of always returning `0`.
- Adds a dedicated branch for `CustomEditorWidget` so its tab is reported as `TabInputKind.CustomEditorInput` with the correct `viewType` and resource `uri`, instead of being left unclassified.

Fixes: #17793

#### How to test

Change sample-plugins/sample-namespace/plugin-esm to:

```
import * as vscode from 'vscode';

export function activate(context) {
    context.subscriptions.push(vscode.commands.registerCommand('plugin-esm.hello', () => {
        vscode.window.showInformationMessage('Hello from plugin-esm (ESM)!');
    }));

    const output = vscode.window.createOutputChannel('plugin-esm: tabs');
    context.subscriptions.push(output);
    context.subscriptions.push(vscode.commands.registerCommand('plugin-esm.logTabs', () => {
        output.clear();
        output.show(true);
        for (const group of vscode.window.tabGroups.all) {
            output.appendLine(`Tab group viewColumn=${group.viewColumn} active=${group.isActive}`);
            for (const tab of group.tabs) {
                const input = tab.input;
                output.appendLine(`  tab "${tab.label}": ${JSON.stringify(input)}`);
            }
        }
    }));
}
```

and add the following to its package.json

```json
{
  [...]
  "activationEvents": [
    [...]
    "onCommand:plugin-esm.logTabs"
  ],
  "contributes": {
    "commands": [
      [...],
      {
        "command": "plugin-esm.logTabs",
        "title": "plugin-esm: Log Tab Groups"
      }
    ]
  }
}
```

Then open IDE, welcome is present, open an image (custom-editor) and a file, e.g. desktop.ini, move image to viewColumn 2, and trigger the command. It should log something like:

```
Tab group viewColumn=1 active=false
  tab "Welcome": undefined
  tab "desktop.ini": {"uri":{"$mid":1,"path":"/c:/Users/USER/Desktop/desktop.ini","scheme":"file"}}
Tab group viewColumn=2 active=true
  tab "drag.gif": undefined
```

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
