### PR TITLE
Fix OVSX queries for deployed extensions

### DIFF
--- a/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-contribution-adapter.spec.ts
@@ -72,12 +72,61 @@ class StubModel {
     }
 }
 
+class UpdateInstalledModel extends VSXExtensionsModel {
+    readonly refreshed: string[] = [];
+
+    runUpdateInstalled(): Promise<void> {
+        return this.updateInstalled();
+    }
+
+    protected override setExtension(id: string, version?: string): VSXExtension {
+        return { id, version } as VSXExtension;
+    }
+
+    protected override refresh(id: string, version?: string): Promise<VSXExtension | undefined> {
+        this.refreshed.push(`${id}@${version}`);
+        return Promise.resolve(undefined);
+    }
+}
+
+function buildUpdateInstalledModel(deployed: string[], installed: string[]): UpdateInstalledModel {
+    const model = new UpdateInstalledModel();
+    Object.assign(model, {
+        pluginServer: {
+            getDeployedPluginIds: async () => deployed,
+            getUninstalledPluginIds: async () => [],
+            getDisabledPluginIds: async () => [],
+            getInstalledPluginIds: async () => installed,
+            getDeployedPlugins: async () => []
+        },
+        pluginSupport: { getPlugin: () => undefined },
+        progressService: {
+            withProgress: async <T>(_text: string, _location: string, task: () => Promise<T>): Promise<T> => task()
+        }
+    });
+    return model;
+}
+
 function buildAdapter(model: StubModel): VSXExtensionsContributionAdapter {
     const container = new Container();
     container.bind(VSXExtensionsModel).toConstantValue(model as unknown as VSXExtensionsModel);
     container.bind(VSXExtensionsContributionAdapter).toSelf().inSingletonScope();
     return container.get(VSXExtensionsContributionAdapter);
 }
+
+describe('VSXExtensionsModel.updateInstalled', () => {
+
+    it('skips registry refreshes for deployed extension versions', async () => {
+        const model = buildUpdateInstalledModel(
+            ['pub.deployed@1.0.0'],
+            ['pub.deployed@1.0.0', 'pub.undeployed@2.0.0']
+        );
+
+        await model.runUpdateInstalled();
+
+        expect(model.refreshed).to.deep.equal(['pub.undeployed@2.0.0']);
+    });
+});
 
 describe('VSXExtensionsContributionAdapter.resolveInstalled', () => {
 

--- a/packages/vsx-registry/src/browser/vsx-extensions-model.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-model.ts
@@ -374,7 +374,9 @@ export class VSXExtensionsModel {
                 if (idAndVersion) {
                     this._versionedInstalled.delete(versionedId);
                     this.setExtension(idAndVersion.id, idAndVersion.version);
-                    refreshing.push(this.refresh(idAndVersion.id, idAndVersion.version));
+                    if (!this.deployed.has(versionedId)) {
+                        refreshing.push(this.refresh(idAndVersion.id, idAndVersion.version));
+                    }
                 }
             }
             for (const id of this._versionedInstalled) {


### PR DESCRIPTION
#### What it does

Fixes #17769.

`VSXExtensionsModel.updateInstalled()` now skips registry refreshes for exact extension versions that the plugin server already reports as deployed. This removes the cold-start race with the frontend plugin contribution sync without suppressing refreshes for installed but undeployed extensions.

The change also adds a regression test covering both deployed and undeployed installed versions.

#### How to test

- `npx lerna run compile --scope @theia/vsx-registry --include-dependencies --stream --concurrency=4`
- `npm run lint --workspace @theia/vsx-registry`
- `npm test --workspace @theia/vsx-registry` (70 passing)

For a manual performance check, start a backend with multiple builtins and OVSX router registries, then connect during plugin deployment. Deployed builtin versions should no longer trigger per-extension OVSX metadata queries.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

N/A

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no user-facing text added)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)