### PR TITLE
build: allow dependency install scripts for npm 12

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -40,7 +40,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
               base="${{ github.event.pull_request.base.sha }}"
               git fetch --depth=1 origin "$base" >/dev/null 2>&1 || true
-              git diff --name-only "$base" HEAD | grep -qx 'package-lock.json' || exit 0
+              git diff --name-only "$base" HEAD | grep -qxE 'package(-lock)?\.json' || exit 0
           fi
           node scripts/verify-lockfile-platforms.js
 

--- a/doc/lockfile-maintenance.md
+++ b/doc/lockfile-maintenance.md
@@ -26,7 +26,16 @@ git diff --stat package-lock.json
 node scripts/verify-lockfile-platforms.js
 ```
 
-The verifier checks that known Linux entries still carry their `libc` field. It also runs in CI, so a lockfile that lost them cannot be merged.
+The verifier checks that known Linux entries still carry their `libc` field, and that `allowScripts` is in sync (see below). It also runs in CI, so a lockfile that lost them cannot be merged.
+
+## Keeping `allowScripts` in sync
+
+npm 12 does not run dependency lifecycle scripts unless the package is listed in the `allowScripts` allowlist in the root `package.json`. Adding, removing, or updating dependencies can therefore require an `allowScripts` change:
+
+- A new dependency with an install script must be added with `true` if the script is required (native bindings, downloaded binaries) or `false` if it is cosmetic or unused. Recording it as `false` also keeps `npm install` free of warnings.
+- A dependency that no longer has an install script must be removed from the list.
+
+Missing `true` entries are easy to overlook because `npm ci` still succeeds — the failure only shows up later, when a native module is loaded or a build step needs its binary. `node scripts/verify-lockfile-platforms.js` cross-checks the allowlist against every lockfile entry with `hasInstallScript` and fails on unlisted or stale entries, so run it after changing dependencies as well.
 
 ## Outlook
 

--- a/package.json
+++ b/package.json
@@ -125,5 +125,24 @@
     "ms-vscode.js-debug-companion",
     "vscode.extension-editing",
     "ms-python.vscode-pylance"
-  ]
+  ],
+  "allowScripts": {
+    "@google/genai": false,
+    "@parcel/watcher": true,
+    "@vscode/vsce-sign": false,
+    "@vscode/windows-ca-certs": true,
+    "core-js": false,
+    "cpu-features": true,
+    "drivelist": true,
+    "esbuild": true,
+    "fsevents": true,
+    "keytar": true,
+    "msgpackr-extract": true,
+    "native-keymap": true,
+    "node-pty": true,
+    "nx": false,
+    "protobufjs": false,
+    "puppeteer": true,
+    "ssh2": true
+  }
 }

--- a/scripts/verify-lockfile-platforms.js
+++ b/scripts/verify-lockfile-platforms.js
@@ -15,24 +15,39 @@
 // *****************************************************************************
 // @ts-check
 
-// Verify that package-lock.json still carries the `libc` fields on Linux
-// optional-dep entries. npm strips these fields when the lockfile is
-// regenerated on a host that does not consume them (e.g. glibc-only), and
-// their absence breaks `npm ci` on Alpine and other musl-based images.
+// Verify two properties of the committed package-lock.json:
 //
-// Missing entries (whole packages dropped from the lockfile) are handled by
-// scripts/npm-install-with-platforms.js on a normal regeneration, so this
-// check focuses on the libc field specifically.
+// 1. It still carries the `libc` fields on Linux optional-dep entries. npm
+//    strips these fields when the lockfile is regenerated on a host that does
+//    not consume them (e.g. glibc-only), and their absence breaks `npm ci` on
+//    Alpine and other musl-based images.
+//    Missing entries (whole packages dropped from the lockfile) are handled by
+//    scripts/npm-install-with-platforms.js on a normal regeneration, so this
+//    check focuses on the libc field specifically.
+//    If this fails, the fix is scripts/npm-install-with-platforms.js.
 //
-// Run in CI. If this fails, the fix is scripts/npm-install-with-platforms.js.
+// 2. Every dependency with an install script is listed in the root
+//    `allowScripts` allowlist. npm 12 does not run dependency lifecycle
+//    scripts unless they are allowlisted, so a new dependency with an install
+//    script silently stops building its native bindings.
+//    If this fails, the fix is to add the package to `allowScripts` in
+//    package.json with `true` (script is needed) or `false` (script is
+//    cosmetic or unused).
+//
+// Run in CI. See doc/lockfile-maintenance.md.
 
 const path = require('path');
 const fs = require('fs');
 
-const lockPath = path.resolve(__dirname, '..', 'package-lock.json');
-/** @type {{ packages?: Record<string, { libc?: string[] }> }} */
+const root = path.resolve(__dirname, '..');
+const lockPath = path.join(root, 'package-lock.json');
+/** @type {{ packages?: Record<string, { libc?: string[], hasInstallScript?: boolean }> }} */
 const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
 const packages = lock.packages || {};
+
+/** @type {{ allowScripts?: Record<string, boolean> }} */
+const rootPackage = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+const allowScripts = rootPackage.allowScripts || {};
 
 /** Entries that must carry the given `libc` value. */
 const requiredLibc = [
@@ -48,28 +63,72 @@ const requiredLibc = [
     { name: '@parcel/watcher-linux-x64-musl',    libc: 'musl'  },
 ];
 
-const errors = [];
+const libcErrors = [];
 
 for (const { name, libc } of requiredLibc) {
     const entry = packages[`node_modules/${name}`];
     if (!entry) {
-        errors.push(`missing entry: ${name}`);
+        libcErrors.push(`missing entry: ${name}`);
         continue;
     }
     if (!Array.isArray(entry.libc) || !entry.libc.includes(libc)) {
-        errors.push(`${name}: expected libc=[${libc}], got ${JSON.stringify(entry.libc)}`);
+        libcErrors.push(`${name}: expected libc=[${libc}], got ${JSON.stringify(entry.libc)}`);
     }
 }
 
-if (errors.length > 0) {
+/**
+ * Names of all dependencies in the lockfile that declare an install script.
+ * Workspace entries (the root package and `dev-packages/*`) are excluded: their
+ * lifecycle scripts are part of this repository and always run.
+ */
+const installScriptDependencies = new Set();
+const nodeModules = 'node_modules/';
+for (const [location, entry] of Object.entries(packages)) {
+    if (!entry.hasInstallScript) {
+        continue;
+    }
+    const index = location.lastIndexOf(nodeModules);
+    if (index < 0) {
+        continue;
+    }
+    installScriptDependencies.add(location.slice(index + nodeModules.length));
+}
+
+const unlisted = [...installScriptDependencies].filter(name => !(name in allowScripts)).sort();
+const stale = Object.keys(allowScripts).filter(name => !installScriptDependencies.has(name)).sort();
+
+if (libcErrors.length > 0) {
     console.error('package-lock.json is missing libc fields on Linux entries:');
-    for (const e of errors) {
+    for (const e of libcErrors) {
         console.error(`  - ${e}`);
     }
     console.error('');
     console.error('Run: node scripts/npm-install-with-platforms.js');
+}
+
+if (unlisted.length > 0) {
+    console.error('Dependencies with install scripts are missing from `allowScripts` in package.json:');
+    for (const name of unlisted) {
+        console.error(`  - ${name}`);
+    }
+    console.error('');
+    console.error('Add each one with `true` if the script is required (e.g. native bindings)');
+    console.error('or `false` if it is cosmetic or unused.');
+}
+
+if (stale.length > 0) {
+    console.error('`allowScripts` in package.json lists packages that no longer have install scripts:');
+    for (const name of stale) {
+        console.error(`  - ${name}`);
+    }
+    console.error('');
+    console.error('Remove these entries.');
+}
+
+if (libcErrors.length > 0 || unlisted.length > 0 || stale.length > 0) {
     console.error('See: doc/lockfile-maintenance.md');
     process.exit(1);
 }
 
 console.log('package-lock.json libc coverage OK.');
+console.log('`allowScripts` covers all dependencies with install scripts.');


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

npm 12 disables dependency lifecycle scripts by default, so npm ci no longer builds native modules and browser/electron build fail at the native step.

Add an allowScripts allowlist so npm 12 users are unblocked. Native bindings, the esbuild bundler and the puppeteer test runner are allowed. Cosmetic or unused scripts (donation banners, no-ops and the vsce dev tool) are recorded as denied to keep installs warning-free without granting them script execution.

#### How to test

- Install npm 12 e.g. `npm install npm -g`
- `npm ci && npm run build:browser` does not fail

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
