### PR TITLE
refresh active file watchers on files.watcherExclude change

### DIFF
--- a/packages/filesystem/src/browser/file-service-watcher.spec.ts
+++ b/packages/filesystem/src/browser/file-service-watcher.spec.ts
@@ -893,4 +893,84 @@ describe('FileService applies files.watcherExclude to all watchers', () => {
         // so the root watcher subsumes it — a single OS watcher instead of two.
         expect(liveWatcherCount(mockProvider)).to.equal(1);
     });
+
+    it('refreshes watcher excludes when files.watcherExclude preference changes', async () => {
+        const preferenceChanged = new Emitter<{ preferenceName: string }>();
+        const initialExclude = { '**/node_modules/**': true };
+
+        // Set up preferences with both get and onPreferenceChanged
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fileService as any).preferences = {
+            get: (name: string) => (name === 'files.watcherExclude' ? initialExclude : undefined) as any,
+            get onPreferenceChanged() { return preferenceChanged.event; },
+        };
+
+        fileService.watch(new URI('file:///project'), { recursive: true, excludes: [] });
+        await flush();
+
+        expect(mockProvider.watchers).to.have.lengthOf(1);
+        let excludes = mockProvider.watchers[0].options.excludes;
+        expect(excludes).to.include('**/node_modules/**');
+
+        // Change the preference — add a new exclude pattern
+        const newExclude = { '**/node_modules/**': true, '**/build/**': true };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fileService as any).preferences.get = (name: string) => (name === 'files.watcherExclude' ? newExclude : undefined) as any;
+
+        // Fire the preference change event
+        preferenceChanged.fire({ preferenceName: 'files.watcherExclude' });
+
+        excludes = mockProvider.watchers[0].options.excludes;
+        expect(excludes).to.include('**/node_modules/**');
+        expect(excludes).to.include('**/build/**');
+    });
+
+    it('does not recreate the OS watcher when excludes change', async () => {
+        const preferenceChanged = new Emitter<{ preferenceName: string }>();
+        const initialExclude = { '**/node_modules/**': true };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fileService as any).preferences = {
+            get: (name: string) => (name === 'files.watcherExclude' ? initialExclude : undefined) as any,
+            get onPreferenceChanged() { return preferenceChanged.event; },
+        };
+
+        fileService.watch(new URI('file:///project'), { recursive: true, excludes: [] });
+        await flush();
+
+        const originalWatcher = mockProvider.watchers[0];
+
+        // Change the preference
+        const newExclude = { '**/node_modules/**': true, '**/build/**': true };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fileService as any).preferences.get = (name: string) => (name === 'files.watcherExclude' ? newExclude : undefined) as any;
+        preferenceChanged.fire({ preferenceName: 'files.watcherExclude' });
+
+        // The original OS watcher should still be alive (not recreated)
+        expect(originalWatcher.disposed).to.be.false;
+        expect(liveWatcherCount(mockProvider)).to.equal(1);
+    });
+
+    it('skips refresh when excludes have not actually changed', async () => {
+        const preferenceChanged = new Emitter<{ preferenceName: string }>();
+        const initialExclude = { '**/node_modules/**': true };
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fileService as any).preferences = {
+            get: (name: string) => (name === 'files.watcherExclude' ? initialExclude : undefined) as any,
+            get onPreferenceChanged() { return preferenceChanged.event; },
+        };
+
+        fileService.watch(new URI('file:///project'), { recursive: true, excludes: [] });
+        await flush();
+
+        const originalWatcher = mockProvider.watchers[0];
+        const initialWatcherCount = liveWatcherCount(mockProvider);
+
+        // Fire the event without changing the exclude value
+        preferenceChanged.fire({ preferenceName: 'files.watcherExclude' });
+
+        expect(liveWatcherCount(mockProvider)).to.equal(initialWatcherCount);
+        expect(originalWatcher.disposed).to.be.false;
+    });
 });

--- a/packages/filesystem/src/browser/file-service-watcher.spec.ts
+++ b/packages/filesystem/src/browser/file-service-watcher.spec.ts
@@ -20,7 +20,7 @@ let disableJSDOM = enableJSDOM();
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
 FrontendApplicationConfigProvider.set({});
 
-import { Disposable, Emitter, URI } from '@theia/core';
+import { Disposable, Emitter, Event, URI } from '@theia/core';
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { FileChange, FileChangeType, FileSystemProvider, FileSystemProviderCapabilities, WatchOptions } from '../common/files';
@@ -901,8 +901,8 @@ describe('FileService applies files.watcherExclude to all watchers', () => {
         // Set up preferences with both get and onPreferenceChanged
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (fileService as any).preferences = {
-            get: (name: string) => (name === 'files.watcherExclude' ? initialExclude : undefined) as any,
-            get onPreferenceChanged() { return preferenceChanged.event; },
+            get: (name: string): unknown => (name === 'files.watcherExclude' ? initialExclude : undefined),
+            get onPreferenceChanged(): Event<{ preferenceName: string }> { return preferenceChanged.event; },
         };
 
         fileService.watch(new URI('file:///project'), { recursive: true, excludes: [] });
@@ -931,8 +931,8 @@ describe('FileService applies files.watcherExclude to all watchers', () => {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (fileService as any).preferences = {
-            get: (name: string) => (name === 'files.watcherExclude' ? initialExclude : undefined) as any,
-            get onPreferenceChanged() { return preferenceChanged.event; },
+            get: (name: string): unknown => (name === 'files.watcherExclude' ? initialExclude : undefined),
+            get onPreferenceChanged(): Event<{ preferenceName: string }> { return preferenceChanged.event; },
         };
 
         fileService.watch(new URI('file:///project'), { recursive: true, excludes: [] });
@@ -957,8 +957,8 @@ describe('FileService applies files.watcherExclude to all watchers', () => {
 
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         (fileService as any).preferences = {
-            get: (name: string) => (name === 'files.watcherExclude' ? initialExclude : undefined) as any,
-            get onPreferenceChanged() { return preferenceChanged.event; },
+            get: (name: string): unknown => (name === 'files.watcherExclude' ? initialExclude : undefined),
+            get onPreferenceChanged(): Event<{ preferenceName: string }> { return preferenceChanged.event; },
         };
 
         fileService.watch(new URI('file:///project'), { recursive: true, excludes: [] });

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -313,6 +313,11 @@ export class FileService {
         for (const contribution of this.contributions.getContributions()) {
             contribution.registerFileSystemProviders(this);
         }
+        this.onDidChangeWatcherExcludeDisposable = this.preferences.onPreferenceChanged((e: { preferenceName: string }) => {
+            if (e.preferenceName === 'files.watcherExclude') {
+                this.refreshWatcherExcludes();
+            }
+        });
     }
 
     // #region Events
@@ -1428,6 +1433,7 @@ export class FileService {
 
     // #region File Watching
 
+    private onDidChangeWatcherExcludeDisposable = new Disposable();
     private onDidFilesChangeEmitter = new Emitter<FileChangesEvent>();
     /**
      * An event that is emitted when files are changed on the disk.
@@ -1485,6 +1491,77 @@ export class FileService {
             }
         }
         return Array.from(resolved);
+    }
+
+    /**
+     * Refresh the exclude patterns on all active watchers when
+     * `files.watcherExclude` preference changes.
+     *
+     * Walks every entry in `activeWatchers`, rebuilds its excludes
+     * from the current preference value, recompiles Minimatch for
+     * recursive entries, and re-keys the entry in the map and
+     * recursive index as needed.
+     */
+    protected refreshWatcherExcludes(): void {
+        for (const [key, entry] of this.activeWatchers) {
+            // Rebuild excludes from current preference value
+            const resolved = this.resolveWatcherExcludes(entry.resource, []);
+
+            // Quick check: skip if excludes haven't changed
+            const oldExcludes = entry.options.excludes;
+            if (oldExcludes.length === resolved.length &&
+                oldExcludes.every((e, i) => e === resolved[i])) {
+                continue;
+            }
+
+            // Compute new key: keep provider+resource+recursive parts, replace excludes
+            const keyParts = key.split(',');
+            const excludesPart = resolved.join(',');
+            const newKey = keyParts.slice(0, keyParts.length - 1).join(',') + ',' + excludesPart;
+            if (newKey === key) {
+                continue;
+            }
+
+            // Update entry in place
+            (entry as any).key = newKey;
+            entry.options.excludes = resolved;
+
+            if (this.isRecursiveWatcherEntry(entry)) {
+                (entry as any).compiledExcludes = resolved.map(
+                    pattern => new Minimatch(pattern, { dot: true })
+                );
+            }
+
+            // Remove old key, set new key (entry object reference stays the same)
+            this.activeWatchers.delete(key);
+            this.activeWatchers.set(newKey, entry);
+
+            // Update subsumedChildren keys that reference this entry's old key
+            if (this.isRecursiveWatcherEntry(entry)) {
+                const subsumedChildren = (entry as RecursiveWatcherEntry).subsumedChildren;
+                for (const childKey of subsumedChildren) {
+                    const childParts = childKey.split(',');
+                    if (childParts[0] === key) {
+                        childParts[0] = newKey;
+                        const newChildKey = childParts.join(',');
+                        subsumedChildren.delete(childKey);
+                        subsumedChildren.add(newChildKey);
+                        const child = this.activeWatchers.get(childKey);
+                        if (child) {
+                            this.activeWatchers.delete(childKey);
+                            (child as any).key = newChildKey;
+                            this.activeWatchers.set(newChildKey, child);
+                        }
+                    }
+                }
+
+                // Re-index recursive watchers at the new key
+                if (entry.realWatcher) {
+                    const tree = this.getRecursiveWatcherIndex(entry.provider);
+                    tree.set(entry.resource, newKey);
+                }
+            }
+        }
     }
 
     async doWatch(resource: URI, options: WatchOptions): Promise<Disposable> {

--- a/packages/filesystem/src/browser/file-service.ts
+++ b/packages/filesystem/src/browser/file-service.ts
@@ -1433,7 +1433,7 @@ export class FileService {
 
     // #region File Watching
 
-    private onDidChangeWatcherExcludeDisposable = new Disposable();
+    private onDidChangeWatcherExcludeDisposable: Disposable;
     private onDidFilesChangeEmitter = new Emitter<FileChangesEvent>();
     /**
      * An event that is emitted when files are changed on the disk.


### PR DESCRIPTION
CLOSES: #17699 

#### What it does

  When `files.watcherExclude` preference changes, existing file watchers
  now update their exclude patterns in place without recreating the
  underlying OS watcher. This fixes a gap where newly-excluded directories
  continued consuming OS file watches and emitting events, and newly-included
  directories remained unwatched.

  Follow-up to #17630 which widened where excludes are applied (every watcher
  rather than specific callers) but did not add live re-watching on preference
  change.

  #### How to test

  1. Open a workspace with the default `files.watcherExclude` settings
  2. Change `files.watcherExclude` in settings (e.g. add `"**/build/**": true`)
  3. Verify that the `build` subtree stops being watched (no longer emits events)
  4. Run the new tests: `npx lerna run test --scope @theia/filesystem`

  #### Follow-ups

  None identified. The implementation is a self-contained follow-up to #17630.

  #### Breaking changes

  - [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes
  section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been
  updated.

  #### Attribution

  #### Review checklist

  - [x] As an author, I have thoroughly tested my changes and carefully followed [the review 
  guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
  - [x] User-facing text is internationalized using the `nls` service (for details, please see the
  [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-gu
  idelines.md#internationalizationlocalization) in the Coding Guidelines)

  #### Reminder for reviewers

  - As a reviewer, I agree to behave in accordance with [the review 
  guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
