### PR TITLE
Enable server-side compaction for dateless major model ids

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.spec.ts
@@ -187,6 +187,12 @@ describe('AnthropicLanguageModelsManagerImpl - metadata derivation', () => {
         it('returns false for claude-sonnet-4-5 (older minor version, sonnet variant)', () => {
             expect(capabilityFor('claude-sonnet-4-5')).to.equal(false);
         });
+        it('returns true for claude-opus-5 (dateless major release, no minor segment)', () => {
+            expect(capabilityFor('claude-opus-5')).to.equal(true);
+        });
+        it('returns true for claude-sonnet-5 (dateless major release, no minor segment)', () => {
+            expect(capabilityFor('claude-sonnet-5')).to.equal(true);
+        });
         it('returns true for claude-opus-5-0 (newer major version)', () => {
             expect(capabilityFor('claude-opus-5-0')).to.equal(true);
         });

--- a/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-models-manager-impl.ts
@@ -146,11 +146,16 @@ export class AnthropicLanguageModelsManagerImpl implements AnthropicLanguageMode
      * Heuristic over the model id; override to read the capability from the `/v1/models` endpoint or for custom endpoints.
      */
     protected deriveServerSideCompactionSupport(description: AnthropicModelDescription): boolean {
-        const match = /(opus|sonnet)-(\d+)-(\d+)/.exec(description.model);
+        // The minor segment is optional: dateless major releases omit it (e.g. claude-opus-5, claude-sonnet-5).
+        const match = /(opus|sonnet)-(\d+)(?:-(\d+))?/.exec(description.model);
         if (!match) {
             return false;
         }
         const major = Number(match[2]);
+        // A 4+ digit "major" is a date-style id (e.g. claude-3-opus-20240229), not a versioned model.
+        if (major >= 1000) {
+            return false;
+        }
         // A 4+ digit "minor" is a date suffix on a `.0` model id (e.g. claude-sonnet-4-20250514), not a minor version.
         const minor = Number(match[3]) >= 1000 ? 0 : Number(match[3]);
         return major > 4 || (major === 4 && minor >= 6);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
deriveServerSideCompactionSupport parsed the model id with a regex that required a two-segment version (e.g. opus-4-8), so dateless major releases `claude-opus-5` and `claude-sonnet-5` failed to match and were reported as not supporting server-side compaction. As a result the `compact-2026-01-12` beta header and `compact_20260112` context-management edit were withheld for Opus 5 and Sonnet 5, even though both support the feature.

Make the minor segment optional so single-segment major ids match, and guard against date-style ids (e.g. claude-3-opus-20240229) whose date would otherwise be read as the major version.

Add spec cases for claude-opus-5 and claude-sonnet-5.
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->
enable compaction for sonnet 5 or opus 5 and make sure the requests still work
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
