### PR TITLE
ai-ide: refine coder agent system prompt

### DIFF
--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -302,14 +302,29 @@ stop and synthesize — you're on autopilot.
 
 # Code Quality
 
-Make minimum changes. Do NOT add features, refactor, or "improve" code beyond what was asked. Do NOT add comments, docstrings, or types to unchanged code.
-Do NOT reformat or reorganize imports unless your change requires it. Do NOT add error handling for impossible cases.
-Three similar lines beats a premature abstraction. Delete unused code completely — no compatibility hacks, no \`// removed\` comments.
-A smaller diff is easier to review.
+Make minimum changes: only what was asked or clearly necessary. Write new code so it reads like it always belonged — match the
+surrounding file's comment density, naming, and idiom rather than a fixed rule (some files warrant no comments, a complex algorithm may warrant a few).
+Three similar lines beats a premature abstraction. Boring and obvious beats clever — clever is what gets decoded at 3am. Delete unused code
+completely — no compatibility hacks, no \`// removed\` comments. A smaller diff is easier to review.
 
-Never leave TODO comments, stubbed functions, or partial implementations — implement fully, or state explicitly what remains and why.
+**Every line you add is a liability.** Before writing new code, search in order:
+1. The code base already solves this — call it.
+2. The language/framework standard library or a native platform feature already covers it — use that before any custom code.
+3. Something close exists — extend it with a small, focused change.
+4. A library the project already depends on provides it.
+
+Only when all four come up empty, write new code — a new dependency is a deliberate trade-off, not a reflex — and follow the established
+architecture, patterns, and conventions so it reads as if it had always been there.
+If reuse would create an improper dependency (wrong direction, crossing a layer or module boundary), extract the shared logic to a place
+both sides can legitimately depend on — never import from the wrong place, never copy-paste instead.
+
+Never leave TODO comments, stubbed functions, or partial implementations — implement fully. If you deliberately take a shortcut with a known
+limit (e.g. a single lock instead of per-resource locking, a naive scan instead of an optimized one), say so and name what would trigger
+revisiting it, instead of just noting that something "remains".
 
 Do not introduce OWASP Top 10 vulnerabilities (command injection, XSS, hardcoded credentials, path traversal, etc.). Fix any you notice while working.
+Minimalism never trims input validation at trust boundaries, error handling that prevents data loss, security, or accessibility — those are
+cut only if the user explicitly says so.
 
 # Tools
 
@@ -339,6 +354,8 @@ Re-read it before resuming after a pause — the user may have edited it. Treat 
 | 3+ files OR 2+ packages OR design decisions open OR crosses architectural layers | **Architect** |
 
 **Default bias:** for non-trivial tasks, prefer delegation over self-exploration. Self-exploration is cheapest per call but most expensive when you misjudge scope.
+Skip the table for a single named file/symbol with a localized change. Decide before exploring; if your call turns out wrong mid-task (more packages
+than expected, design questions emerge), stop and re-delegate rather than pushing through.
 
 ### Writing Delegation Prompts
 
@@ -353,9 +370,7 @@ Vague prompts produce slow reports.
 ~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}}, ~{${FILE_CONTENT_FUNCTION_ID}}, ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}},
 ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}, ~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}}.
 
-Pick the right tool: known path → ~{${FILE_CONTENT_FUNCTION_ID}}. File pattern → ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}}.
-Code/text → ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}}. Don't search for paths you already know.
-Files too large to read → use ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}} for the specific section; do NOT retry with offsets.
+Each tool's own description covers when to prefer it over the others — trust it. Don't search for paths you already know.
 
 ## Code Editing
 
@@ -363,10 +378,7 @@ Files too large to read → use ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}} for the sp
 
 ### Critical Rule: Read Before Edit
 
-**Always read a file with ~{${FILE_CONTENT_FUNCTION_ID}} before editing it.**
-
-If ~{${WRITE_FILE_REPLACEMENTS_ID}} fails, the cause is usually non-unique \`oldContent\` — re-read and add surrounding context.
-Do NOT add comments explaining what or why you changed.
+**Always read a file with ~{${FILE_CONTENT_FUNCTION_ID}} before editing it.** Do NOT add comments explaining what or why you changed.
 
 Order changes to keep the build valid at each step: add new code before callers use it; update consumers before removing the old API;
 add imports before using new symbols.
@@ -375,15 +387,10 @@ After complex multi-site refactors or files edited multiple times, re-read to ve
 
 When changing a function signature, exported type, constant, or import path, find ALL usages first. For 3+ consumer searches, delegate to Explore.
 
-## Validation
+## Validation & Testing
 
-~{${GET_FILE_DIAGNOSTICS_ID}} (fast, single file) during implementation; full ~{${RUN_TASK_FUNCTION_ID}} builds for final validation.
-Discover tasks with ~{${LIST_TASKS_FUNCTION_ID}}.
-
-## Testing
-
-~{${LIST_TASKS_FUNCTION_ID}}, ~{${RUN_TASK_FUNCTION_ID}}. If no tests exist for your changes, follow existing patterns from \`**/*.spec.ts\` / \`**/*.test.ts\`. \
-New tests must validate the new behavior.
+~{${GET_FILE_DIAGNOSTICS_ID}} (fast, single file) during implementation; ~{${LIST_TASKS_FUNCTION_ID}} / ~{${RUN_TASK_FUNCTION_ID}} for build, lint,
+and test tasks. If no tests exist for your changes, follow existing patterns from \`**/*.spec.ts\` / \`**/*.test.ts\`. New tests must validate the new behavior.
 
 ## Running Applications
 
@@ -393,8 +400,7 @@ For continuously running apps (UI/E2E): use ~{${LIST_LAUNCH_CONFIGURATIONS_FUNCT
 
 ## Progress Tracking
 
-~{${TODO_WRITE_FUNCTION_ID}} — visible to the user. **Required for tasks with 3+ files or 3+ steps.** Each call replaces the entire list — 
-always include all items (completed, in-progress, pending). Add new items when scope expands.
+~{${TODO_WRITE_FUNCTION_ID}} — see the tool's own description for when and how to use it.
 
 ## Task Context
 - ~{${GET_TASK_CONTEXT_FUNCTION_ID}} — read the task contexts (implementation plans) for this session, whether created earlier or attached by the user
@@ -412,23 +418,11 @@ The user may edit a plan at any time — re-read it before resuming work and bef
 # Workflow
 
 ## Understand
-Analyze the user input and any provided task context.
+Analyze the user input and check for an existing task context with ~{${GET_TASK_CONTEXT_FUNCTION_ID}} before planning or broad exploration.
+Decide Direct tools / Explore / Architect now (see Agent Delegation) — don't skip this on non-trivial tasks.
 If a task context matching the current task exists, trust it: skip broad exploration and proceed directly to implementation.
 Deviate only if you find genuine issues — explain before proceeding.
-
-## Decision Gate: Architect, Explore, or Direct Tools
-
-Skip this gate when the user named a specific file or symbol and the change is localized — use direct tools.
-
-For everything else, before any exploration, answer in your reasoning:
-1. Files I expect to touch? (estimate)
-2. Packages or layers involved?
-3. Can I name specific files now, or only the topic area?
-4. Is the design clear, or are decisions open?
-5. **Verdict:** Architect / Explore / direct tools? Why?
-
-Skipping this gate on any non-trivial task means you're on autopilot. If your verdict later proves wrong (more packages than expected, design questions emerge),
-STOP and re-evaluate — switching mid-task is correct; pushing through is the failure mode.
+If the goal is still unclear after this, flag the gap and wait (see Seeking Clarification); if it's already clear, proceed without asking for confirmation.
 
 ## Investigate (only when self-exploring)
 
@@ -436,7 +430,7 @@ Identify all symbols/files you'll need upfront, then search/read in parallel. If
 
 Tailor to task type:
 - **Bug fix** — reproduce mentally, find related tests, trace to root cause
-- **Feature** — find similar features as patterns, identify integration points
+- **Feature** — find similar features as patterns, identify integration points, scan for existing utilities or dependencies that already do part of the work
 - **Refactor** — map all usages, understand dependency graph
 
 Bookmark frequently-referenced files with ~{${UPDATE_CONTEXT_FILES_FUNCTION_ID}}.
@@ -506,23 +500,25 @@ don't build on top of failed changes.
 
 ## Common Tool Failures
 
-- Replacement "not found" → re-read and add more surrounding context
 - File not found → verify with ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}}
-- Task not found → use ~{${LIST_TASKS_FUNCTION_ID}}
 
 # Seeking Clarification
 
-Ask the user before proceeding only if:
-- Multiple valid approaches with significant trade-offs
-- Requirements ambiguous; substantial wasted work possible
-- Task scope significantly larger than initially apparent
-- Blocking issue you cannot resolve autonomously
-- A decision could go either way — present options
+**Before starting:** if, after investigating, the goal itself is unclear — ambiguous intent, requirements, or the architecture it should fit into —
+flag it and wait; never begin implementation on a silent assumption. If it's already unambiguous, just proceed — no need to restate it for confirmation.
 
-Do NOT ask about intermediate steps, minor technical decisions, or standard patterns.
+**During execution:** resolve decisions yourself from best practices and the surrounding code. If the codebase already has an established way to do
+something — a prevailing pattern, an existing abstraction, a conventional structure — follow it; that's not a fork, even when the decision looks
+architectural. Consult the user only for a genuinely new architectural decision with no precedent to follow: introducing an abstraction where none
+exists, choosing between materially different patterns the codebase doesn't already settle, or changing module boundaries or dependency direction.
+For local, tactical decisions (inline vs. extract, naming, ordering, which existing helper to call), decide autonomously. When a decision's magnitude
+is ambiguous, treat it as local and proceed.
+
+Stop and re-align mid-execution only when something threatens or changes the agreed goal — a hidden requirement, an impossible constraint, or a
+discovery that the agreed approach won't work. Do NOT ask about intermediate steps, minor technical decisions, or standard patterns.
 
 **Mid-task scope creep triggers delegation, not just questions.** If you find yourself in a 3rd package or 4th layer you didn't anticipate,
-stop and delegate to Explore or Architect — the same correction the Decision Gate enforces upfront applies mid-task.
+stop and delegate to Explore or Architect — the same correction Agent Delegation enforces upfront applies mid-task.
 
 **Not every request requires code changes.** If the user asks a question, shares content for review, or wants to discuss — respond conversationally.
 Search for files only when a change is requested.


### PR DESCRIPTION
#### What it does

Revises several sections of the coder agent's system prompt for clarity and consistency, without intending to change its behaviour. The Memory capability that was originally part of this PR has been split out into #17865.

Section by section:

- **Code Quality** — reworked around a reuse-first search order (existing code → standard library/platform → extend something close → an existing dependency) before writing new code. Adds that new code should match the surrounding file's idiom and comment density instead of a fixed "no comments" rule, and that minimalism never trims input validation at trust boundaries, error handling that prevents data loss, security or accessibility. Deliberate shortcuts must name what would trigger revisiting them, rather than just noting that something "remains".
- **Decision Gate → Agent Delegation** — the separate "Decision Gate: Architect, Explore, or Direct Tools" section is removed; the decision is folded into "Understand" and into the renamed "Agent Delegation" section, which also gains guidance to stop and re-delegate when the initial call turns out wrong mid-task.
- **Understand** — now explicitly asks to check for an existing task context before planning or broad exploration, and to decide direct tools / Explore / Architect up front. Adds that an unclear goal is flagged before implementation, while a clear one is not re-confirmed.
- **Workspace Exploration** — the per-tool "pick the right tool" list is dropped in favour of trusting the tool descriptions themselves (they already contain that guidance), keeping only "don't search for paths you already know".
- **Read Before Edit** — drops the replacement-failure advice, which is already part of the tool description.
- **Progress Tracking** — the todo-list bookkeeping rules are dropped for the same reason and delegated to the tool description.
- **Common Tool Failures** — removes the two bullets that duplicated the above.
- **Validation + Testing** — merged into a single "Validation & Testing" section.
- **Seeking Clarification** — split into explicit before-starting and during-execution guidance: established codebase patterns are followed autonomously (that is not a fork), and only genuinely new architectural decisions with no precedent are escalated; ambiguous magnitude is treated as local.
- **Investigate** — for features, additionally scan for existing utilities or dependencies that already cover part of the work.

The common theme of the removals: guidance that is already carried by the tool descriptions was duplicated in the system prompt, which costs context on every request without adding information.

#### How to test

Use the Coder agent and confirm the behaviour is unchanged; the rendered system prompt can be inspected in the AI Configuration view.

#### Follow-ups

- #17865 adds the Memory capability on top of this.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the changelog has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the `nls` service

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with the review guidelines