### PR TITLE
Update model defaults

### DIFF
--- a/packages/ai-anthropic/src/common/anthropic-preferences.ts
+++ b/packages/ai-anthropic/src/common/anthropic-preferences.ts
@@ -38,12 +38,14 @@ export const AnthropicPreferencesSchema: PreferenceSchema = {
             description: nls.localize('theia/ai/anthropic/models/description', 'Official Anthropic models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
             default: [
+                'claude-opus-5',
+                'claude-sonnet-5',
+                'claude-fable-5',
                 'claude-opus-4-8',
                 'claude-opus-4-7',
+                'claude-opus-4-6',
                 'claude-sonnet-4-6',
                 'claude-haiku-4-5',
-                'claude-fable-5',
-                'claude-opus-4-6',
             ],
             items: {
                 type: 'string'

--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -29,8 +29,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code',
             defaultModelIds: [
-                'anthropic/claude-opus-4-8',
-                'openai/gpt-5.5',
+                'anthropic/claude-opus-5',
+                'openai/gpt-5.6-sol',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code/description', 'Optimized for code understanding and generation tasks.')
@@ -38,8 +38,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/universal',
             defaultModelIds: [
-                'anthropic/claude-opus-4-8',
-                'openai/gpt-5.5',
+                'anthropic/claude-opus-5',
+                'openai/gpt-5.6-sol',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/universal/description', 'Well-balanced for both code and general language use.')
@@ -47,8 +47,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/code-completion',
             defaultModelIds: [
-                'anthropic/claude-sonnet-4-6',
-                'openai/gpt-5.5',
+                'anthropic/claude-sonnet-5',
+                'openai/gpt-5.6-sol',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/code-completion/description', 'Best suited for code autocompletion scenarios.')
@@ -56,8 +56,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
         {
             id: 'default/summarize',
             defaultModelIds: [
-                'anthropic/claude-opus-4-8',
-                'openai/gpt-5.5',
+                'anthropic/claude-opus-5',
+                'openai/gpt-5.6-sol',
                 'google/gemini-3.1-pro-preview'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/summarize/description', 'Models prioritized for summarization and condensation of content.')
@@ -66,8 +66,8 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             id: 'default/fast',
             defaultModelIds: [
                 'anthropic/claude-haiku-4-5',
-                'openai/gpt-5.4-mini',
-                'google/gemini-3.5-flash'
+                'openai/gpt-5.6-luna',
+                'google/gemini-3.6-flash'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/fast/description',
                 'Faster and cheaper models for simpler tasks like exploration or basic tool calling, where deep reasoning is not required.')

--- a/packages/ai-google/src/common/google-preferences.ts
+++ b/packages/ai-google/src/common/google-preferences.ts
@@ -36,7 +36,7 @@ export const GooglePreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/google/models/description', 'Official Google Gemini models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['gemini-3.1-pro-preview', 'gemini-3.5-flash'],
+            default: ['gemini-3.1-pro-preview', 'gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3.5-flash-lite'],
             items: {
                 type: 'string'
             }

--- a/packages/ai-openai/src/common/openai-preferences.ts
+++ b/packages/ai-openai/src/common/openai-preferences.ts
@@ -39,12 +39,11 @@ on the machine running Theia. Use the environment variable `OPENAI_API_KEY` to s
             description: nls.localize('theia/ai/openai/models/description', 'Official OpenAI models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
             default: [
+                'gpt-5.6-sol',
+                'gpt-5.6-terra',
+                'gpt-5.6-luna',
                 'gpt-5.5',
-                'gpt-5.5-pro',
-                'gpt-5.4',
-                'gpt-5.4-pro',
-                'gpt-5.4-mini',
-                'gpt-5.4-nano'
+                'gpt-5.5-pro'
             ],
             items: {
                 type: 'string'

--- a/packages/ai-openai/src/node/openai-model-defaults.spec.ts
+++ b/packages/ai-openai/src/node/openai-model-defaults.spec.ts
@@ -22,6 +22,16 @@ describe('getOpenAiModelDefaults', () => {
         expect(getOpenAiModelDefaults('totally-made-up-model')).to.deep.equal({});
     });
 
+    describe('GPT-5.6', () => {
+        it('matches the sol, terra, and luna tiers at 1,050,000 with GPT-5 reasoning', () => {
+            for (const id of ['gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna']) {
+                const d = getOpenAiModelDefaults(id);
+                expect(d.contextWindow, id).to.equal(1_050_000);
+                expect(d.reasoningSupport?.supportedLevels, id).to.include('minimal');
+            }
+        });
+    });
+
     describe('GPT-5.5', () => {
         it('matches base and pro at 1,050,000 with GPT-5 reasoning', () => {
             for (const id of ['gpt-5.5', 'gpt-5.5-pro']) {

--- a/packages/ai-openai/src/node/openai-model-defaults.ts
+++ b/packages/ai-openai/src/node/openai-model-defaults.ts
@@ -47,6 +47,7 @@ const O_SERIES_REASONING_SUPPORT: ReasoningSupport = {
  * (e.g. `gpt-4o-2024-08-06` matches `gpt-4o`).
  */
 const OPENAI_MODEL_FAMILIES: ReadonlyArray<readonly [prefix: string, defaults: OpenAiModelDefaults]> = [
+    ['gpt-5.6', { contextWindow: 1_050_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
     ['gpt-5.5', { contextWindow: 1_050_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
     ['gpt-5.4-mini', { contextWindow: 400_000, reasoningSupport: GPT5_REASONING_SUPPORT }],
     ['gpt-5.4-nano', { contextWindow: 400_000, reasoningSupport: GPT5_REASONING_SUPPORT }],


### PR DESCRIPTION
#### What it does

Refreshes the default model lists and model aliases for the Google, Anthropic, and OpenAI providers to the latest available models (as of July 2026).

#### How to test

Use the models.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
