### PR TITLE
[vscode] API bump and nls update to 1.130.0

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,7 +18,7 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.125.0';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.130.0';
 
 /**
  * The default supported monaco editor version the framework supports.

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -103,7 +103,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
 
     protected static readonly RENAME_CHAT_BUTTON: QuickInputButton = {
         iconClass: 'codicon-edit',
-        tooltip: nls.localizeByDefault('Rename Chat'),
+        tooltip: nls.localizeByDefault('Rename chat'),
     };
     protected static readonly REMOVE_CHAT_BUTTON: QuickInputButton = {
         iconClass: 'codicon-remove-close',
@@ -623,7 +623,7 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
     protected async deleteSession(sessionId: string, confirm = false): Promise<void> {
         if (confirm) {
             const confirmed = await new ConfirmDialog({
-                title: nls.localize('theia/ai/chat-ui/deleteChat', 'Delete Chat'),
+                title: nls.localizeByDefault('Delete Chat'),
                 msg: nls.localizeByDefault('Are you sure you want to delete this chat?')
             }).open();
             if (!confirmed) {

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/delegation-tool-renderer.tsx
@@ -297,7 +297,7 @@ class DelegatedChat extends React.Component<DelegatedChatProps, DelegatedChatSta
                 statusText = nls.localizeByDefault('completed');
             } else if (isError) {
                 statusIcon = 'codicon-error';
-                statusText = nls.localize('theia/ai/chat-ui/delegation-response-renderer/status/error', 'error');
+                statusText = nls.localizeByDefault('error');
             } else {
                 statusIcon = 'codicon-loading';
                 statusText = nls.localize('theia/ai/chat-ui/delegation-response-renderer/status/generating', 'generating...');

--- a/packages/ai-claude-code/src/browser/renderers/glob-tool-renderer.tsx
+++ b/packages/ai-claude-code/src/browser/renderers/glob-tool-renderer.tsx
@@ -111,7 +111,7 @@ const GlobToolComponent: React.FC<{
     const expandedContent = (
         <div className="claude-code-tool details">
             <div className="claude-code-tool detail-row">
-                <span className="claude-code-tool detail-label">{nls.localize('theia/ai/claude-code/pattern', 'Pattern')}</span>
+                <span className="claude-code-tool detail-label">{nls.localizeByDefault('Pattern')}</span>
                 <code className="claude-code-tool detail-value">{input.pattern}</code>
             </div>
             <div className="claude-code-tool detail-row">

--- a/packages/ai-claude-code/src/browser/renderers/grep-tool-renderer.tsx
+++ b/packages/ai-claude-code/src/browser/renderers/grep-tool-renderer.tsx
@@ -156,7 +156,7 @@ const GrepToolComponent: React.FC<{
     const expandedContent = (
         <div className="claude-code-tool details">
             <div className="claude-code-tool detail-row">
-                <span className="claude-code-tool detail-label">{nls.localize('theia/ai/claude-code/pattern', 'Pattern')}</span>
+                <span className="claude-code-tool detail-label">{nls.localizeByDefault('Pattern')}</span>
                 <code className="claude-code-tool detail-value">"{input.pattern}"</code>
             </div>
             <div className="claude-code-tool detail-row">

--- a/packages/ai-history/src/browser/ai-history-exchange-card.tsx
+++ b/packages/ai-history/src/browser/ai-history-exchange-card.tsx
@@ -233,7 +233,7 @@ const RequestCard: React.FC<RequestCardProps> = ({ request, index, totalRequests
 
                 <details>
                     <summary>
-                        {nls.localize('theia/ai/history/request-card/response', 'Response')}
+                        {nls.localizeByDefault('Response')}
                     </summary>
                     <div className='response-content'>
                         {getResponseContent()}

--- a/packages/ai-ide/src/browser/ai-allow-all-mode-chat-banner.tsx
+++ b/packages/ai-ide/src/browser/ai-allow-all-mode-chat-banner.tsx
@@ -145,8 +145,8 @@ export class AiAllowAllModeChatBanner implements ChatBannerProvider {
             <button
                 type='button'
                 className={`theia-ai-allow-all-mode-strip-dismiss ${codicon('close')}`}
-                title={nls.localize('theia/ai/ide/allowAllMode/dismiss', 'Hide for this session')}
-                aria-label={nls.localize('theia/ai/ide/allowAllMode/dismiss', 'Hide for this session')}
+                title={nls.localizeByDefault('Hide for this session')}
+                aria-label={nls.localizeByDefault('Hide for this session')}
                 onClick={this.handleDismiss}
             />
         </div>;

--- a/packages/ai-ide/src/browser/chat-session-item-action-contribution.ts
+++ b/packages/ai-ide/src/browser/chat-session-item-action-contribution.ts
@@ -58,13 +58,13 @@ export class DefaultChatSessionItemActionContribution implements ChatSessionItem
             {
                 commandId: ChatCommands.AI_CHAT_RENAME_SESSION.id,
                 iconClass: codicon('edit'),
-                tooltip: nls.localizeByDefault('Rename Chat'),
+                tooltip: nls.localizeByDefault('Rename chat'),
                 priority: 0,
             },
             {
                 commandId: ChatCommands.AI_CHAT_DELETE_SESSION.id,
                 iconClass: codicon('remove-close'),
-                tooltip: nls.localize('theia/ai/ide/deleteChat', 'Delete Chat'),
+                tooltip: nls.localizeByDefault('Delete Chat'),
                 priority: 10,
             },
         ];

--- a/packages/ai-ide/src/browser/chat-session-tooltip.ts
+++ b/packages/ai-ide/src/browser/chat-session-tooltip.ts
@@ -189,7 +189,7 @@ export function buildSessionTooltip(
     const exchangeLabel = count === 1
         ? nls.localize('theia/ai/ide/tooltip/oneExchange', '1 exchange')
         : nls.localize('theia/ai/ide/tooltip/multipleExchanges', '{0} exchanges', count);
-    addDefinitionEntry(definitionList, nls.localize('theia/ai/ide/tooltip/messages', 'Messages'), exchangeLabel);
+    addDefinitionEntry(definitionList, nls.localizeByDefault('Messages'), exchangeLabel);
 
     const date = session.lastInteraction ?? new Date(metadata.saveDate);
     addDefinitionEntry(definitionList, nls.localize('theia/ai/ide/tooltip/lastActivity', 'Last activity'), date.toLocaleString());

--- a/packages/ai-mcp-ui/src/browser/mcp-command-contribution.ts
+++ b/packages/ai-mcp-ui/src/browser/mcp-command-contribution.ts
@@ -237,7 +237,7 @@ export class MCPCommandContribution implements CommandContribution {
         if (status === MCPServerStatus.Running || status === MCPServerStatus.Connected) {
             const toolNames = tools && tools.length > 0
                 ? tools.map(tool => tool.name).join(',')
-                : nls.localize('theia/ai/mcp/tool/noTools', 'No tools available.');
+                : nls.localizeByDefault('No tools available.');
             this.messageService.info(
                 nls.localize('theia/ai/mcp/info/serverStarted', 'MCP server "{0}" successfully started. Registered tools: {1}', serverName, toolNames)
             );

--- a/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
+++ b/packages/ai-mcp/src/browser/mcp-configuration-widget.tsx
@@ -251,7 +251,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
             ? nls.localizeByDefault('Connect')
             : nls.localizeByDefault('Start Server');
         const startingLabel = isRemote
-            ? nls.localize('theia/ai/mcpConfiguration/connectingServer', 'Connecting...')
+            ? nls.localizeByDefault('Connecting...')
             : nls.localizeByDefault('Starting...');
         const stopLabel = isRemote
             ? nls.localizeByDefault('Disconnect')
@@ -399,7 +399,7 @@ export class AIMCPConfigurationWidget extends ReactWidget {
         }
         return (
             <div className="mcp-property-row">
-                <span className="mcp-property-label">{nls.localize('theia/ai/mcpConfiguration/headers', 'Headers')}:</span>
+                <span className="mcp-property-label">{nls.localizeByDefault('Headers')}:</span>
                 <div className="mcp-property-value">
                     {Object.entries(server.headers).map(([key, value]) => (
                         <div key={key} className="mcp-env-entry">

--- a/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
+++ b/packages/ai-mcp/src/browser/mcp-server-edit-dialog.tsx
@@ -161,7 +161,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                 </div>
 
                 <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/form/serverType', 'Server Type')}:</label>
+                    <label>{nls.localizeByDefault('Server Type')}:</label>
                     <SelectComponent
                         className="theia-select"
                         defaultValue={this.formData.serverType}
@@ -323,7 +323,7 @@ export class MCPServerEditDialog extends ReactDialog<MCPServerFormData | undefin
                 )}
 
                 <div className="mcp-form-field">
-                    <label>{nls.localize('theia/ai/mcpConfiguration/headers', 'Headers')}:</label>
+                    <label>{nls.localizeByDefault('Headers')}:</label>
                     <textarea
                         className="theia-input"
                         defaultValue={this.formData.headers}

--- a/packages/ai-mcp/src/common/mcp-preferences.ts
+++ b/packages/ai-mcp/src/common/mcp-preferences.ts
@@ -126,7 +126,7 @@ Example configuration:\n\
                     },
                     headers: {
                         type: 'object',
-                        title: nls.localize('theia/ai/mcp/servers/headers/title', 'Headers'),
+                        title: nls.localizeByDefault('Headers'),
                         markdownDescription: nls.localize('theia/ai/mcp/servers/headers/mdDescription',
                             'Optional additional headers included with each request to the server. Header values are stored in preferences as plain text; ' +
                             'avoid workspace settings if they contain sensitive values.'),

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -770,6 +770,7 @@
 			"inline",
 			"inlineCompletionsAccessibilityVerbose",
 			"inlineSuggest.edits.allowCodeShifting",
+			"inlineSuggest.edits.longDistanceHintContextLineCount",
 			"inlineSuggest.edits.renderSideBySide",
 			"inlineSuggest.edits.showCollapsed",
 			"inlineSuggest.edits.showLongDistanceHint",
@@ -926,7 +927,6 @@
 			"suggest.insertMode.whenQuickSuggestion",
 			"suggest.insertMode.whenTriggerCharacter",
 			"suggest.localityBonus",
-			"suggest.maxVisibleSuggestions.dep",
 			"suggest.preview",
 			"suggest.selectionMode",
 			"suggest.shareSuggestSelections",
@@ -1123,6 +1123,8 @@
 			"isComposing",
 			"isEmbeddedDiffEditor",
 			"multiDiffEditorAllCollapsed",
+			"multiDiffEditorItemAllUnchangedRegionsShown",
+			"multiDiffEditorRenderSideBySide",
 			"standaloneColorPickerFocused",
 			"standaloneColorPickerVisible",
 			"stickyScrollFocused",
@@ -2361,6 +2363,7 @@
 			"editorSuggestWidgetBackground",
 			"editorSuggestWidgetBorder",
 			"editorSuggestWidgetFocusHighlightForeground",
+			"editorSuggestWidgetFocusOutline",
 			"editorSuggestWidgetForeground",
 			"editorSuggestWidgetHighlightForeground",
 			"editorSuggestWidgetSelectedBackground",
@@ -2525,6 +2528,8 @@
 			"accessibility.signals.terminalCommandFailed",
 			"accessibility.signals.terminalCommandSucceeded",
 			"accessibility.signals.terminalQuickFix",
+			"accessibility.signals.voiceModeStarted",
+			"accessibility.signals.voiceModeStopped",
 			"accessibilitySignals.chatEditModifiedFile",
 			"accessibilitySignals.chatRequestSent",
 			"accessibilitySignals.chatResponseReceived",
@@ -2558,6 +2563,8 @@
 			"accessibilitySignals.terminalCommandFailed",
 			"accessibilitySignals.terminalCommandSucceeded",
 			"accessibilitySignals.terminalQuickFix.name",
+			"accessibilitySignals.voiceModeStarted",
+			"accessibilitySignals.voiceModeStopped",
 			"accessibilitySignals.voiceRecordingStarted",
 			"accessibilitySignals.voiceRecordingStopped"
 		],
@@ -2607,6 +2614,9 @@
 		"vs/platform/actionWidget/browser/actionList": [
 			"actionList.filter.ariaLabel",
 			"actionList.filter.placeholder",
+			"actionList.header.dismiss",
+			"actionList.inlineToggle.off",
+			"actionList.inlineToggle.on",
 			"actionList.remove",
 			"actionList.submenuHint",
 			{
@@ -2648,17 +2658,15 @@
 			"selectPrevCodeAction.title",
 			"toggleSectionCodeAction.title"
 		],
-		"vs/platform/agentHost/common/agentHost.config.contribution": [
-			"chat.agentHost.enabled",
-			"chat.agents.copilotCli.hideExtensionHost",
-			"chat.editor.copilotCli.hideExtensionHost",
-			"chat.editor.defaultProvider",
-			"chat.editor.defaultProvider.copilotAh",
-			"chat.editor.defaultProvider.copilotEh",
-			"chat.editor.defaultProvider.local",
-			"chatAgentHostConfigurationTitle"
+		"vs/platform/agentHost/browser/agentHostConnectionsService": [
+			"agentHost.connection.ambient"
+		],
+		"vs/platform/agentHost/browser/agentHostEnablementService": [
+			"chat.agentHost.enabled"
 		],
 		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
+			"agentHost.config.claudeUseCopilotProxy.description",
+			"agentHost.config.claudeUseCopilotProxy.title",
 			"agentHost.config.customizations.description",
 			"agentHost.config.customizations.descriptionField",
 			"agentHost.config.customizations.displayName",
@@ -2667,25 +2675,68 @@
 			"agentHost.config.customizations.uri",
 			"agentHost.config.defaultShell.description",
 			"agentHost.config.defaultShell.title",
-			"agentHost.config.enableCustomTerminalTool.description",
-			"agentHost.config.enableCustomTerminalTool.title",
-			"agentHost.config.rubberDuck.description",
-			"agentHost.config.rubberDuck.title"
+			"agentHost.config.githubEnterpriseUri.description",
+			"agentHost.config.githubEnterpriseUri.title"
+		],
+		"vs/platform/agentHost/common/agentHostEnablementService": [
+			"agentHostEnabled",
+			"chat.agentHost.enabled",
+			"chat.agents.copilotCli.hideExtensionHost",
+			"chat.defaultToCopilotHarness",
+			"chat.editor.copilotCli.hideExtensionHost",
+			"chat.editor.localAgent.enabled",
+			"chat.editor.preferCopilotHarness",
+			"chatAgentHostConfigurationTitle"
 		],
 		"vs/platform/agentHost/common/agentHostSchema": [
+			"agentHost.config.autoReplyEnabled.description",
+			"agentHost.config.autoReplyEnabled.title",
+			"agentHost.config.codexAgentEnabled.description",
+			"agentHost.config.codexAgentEnabled.title",
+			"agentHost.config.globalAutoApproveEnabled.description",
+			"agentHost.config.globalAutoApproveEnabled.title",
+			"agentHost.config.mcpServers.arg.title",
+			"agentHost.config.mcpServers.args.description",
+			"agentHost.config.mcpServers.args.title",
+			"agentHost.config.mcpServers.command.description",
+			"agentHost.config.mcpServers.command.title",
+			"agentHost.config.mcpServers.cwd.description",
+			"agentHost.config.mcpServers.cwd.title",
+			"agentHost.config.mcpServers.description",
+			"agentHost.config.mcpServers.entry.description",
+			"agentHost.config.mcpServers.entry.title",
+			"agentHost.config.mcpServers.env.description",
+			"agentHost.config.mcpServers.env.title",
+			"agentHost.config.mcpServers.headers.description",
+			"agentHost.config.mcpServers.headers.title",
+			"agentHost.config.mcpServers.title",
+			"agentHost.config.mcpServers.type.description",
+			"agentHost.config.mcpServers.type.title",
+			"agentHost.config.mcpServers.url.description",
+			"agentHost.config.mcpServers.url.title",
+			"agentHost.config.preferLongContextEnabled.description",
+			"agentHost.config.preferLongContextEnabled.title",
 			"agentHost.config.sessionSyncEnabled.description",
 			"agentHost.config.sessionSyncEnabled.title",
+			"agentHost.config.systemProxyEnabled.description",
+			"agentHost.config.systemProxyEnabled.title",
 			"agentHost.config.telemetryLevel.description",
 			"agentHost.config.telemetryLevel.title",
+			"agentHost.config.terminalAutoApproveEnabled.description",
+			"agentHost.config.terminalAutoApproveEnabled.title",
+			"agentHost.config.terminalAutoApproveRules.description",
+			"agentHost.config.terminalAutoApproveRules.title",
 			"agentHost.sessionConfig.autoApprove",
-			"agentHost.sessionConfig.autoApprove.autopilot",
-			"agentHost.sessionConfig.autoApprove.autopilotDescription",
+			"agentHost.sessionConfig.autoApprove.assisted",
+			"agentHost.sessionConfig.autoApprove.assistedDescription",
 			"agentHost.sessionConfig.autoApprove.bypass",
 			"agentHost.sessionConfig.autoApprove.bypassDescription",
 			"agentHost.sessionConfig.autoApprove.default",
 			"agentHost.sessionConfig.autoApprove.defaultDescription",
 			"agentHost.sessionConfig.autoApproveDescription",
 			"agentHost.sessionConfig.mode",
+			"agentHost.sessionConfig.mode.autopilot",
+			"agentHost.sessionConfig.mode.autopilotDescription",
 			"agentHost.sessionConfig.mode.interactive",
 			"agentHost.sessionConfig.mode.interactiveDescription",
 			"agentHost.sessionConfig.mode.plan",
@@ -2698,17 +2749,38 @@
 			"agentHost.sessionConfig.permissionsDescription"
 		],
 		"vs/platform/agentHost/common/agentHostStarter.config.contribution": [
+			"chat.agentHost.byokModels.enabled",
 			"chat.agentHost.claudeAgent.enabled",
+			"chat.agentHost.claudeAgent.enabled.policy",
 			"chat.agentHost.codexAgent.binaryArgs",
 			"chat.agentHost.codexAgent.codexHome",
 			"chat.agentHost.codexAgent.enabled",
+			"chat.agentHost.codexAgent.enabled.policy",
 			"chat.agentHost.codexAgent.sdkRoot",
 			"chat.agentHost.otel.captureContent",
+			"chat.agentHost.otel.captureContent.policy",
 			"chat.agentHost.otel.dbSpanExporter.enabled",
 			"chat.agentHost.otel.enabled",
+			"chat.agentHost.otel.enabled.policy",
 			"chat.agentHost.otel.exporterType",
+			"chat.agentHost.otel.headers",
+			"chat.agentHost.otel.headers.policy",
 			"chat.agentHost.otel.otlpEndpoint",
+			"chat.agentHost.otel.otlpEndpoint.policy",
+			"chat.agentHost.otel.otlpProtocol",
+			"chat.agentHost.otel.otlpProtocol.policy",
 			"chat.agentHost.otel.outfile",
+			"chat.agentHost.otel.outfile.policy",
+			"chat.agentHost.otel.protocol.policy",
+			"chat.agentHost.otel.protocol.policy.console",
+			"chat.agentHost.otel.protocol.policy.file",
+			"chat.agentHost.otel.protocol.policy.otlpGrpc",
+			"chat.agentHost.otel.protocol.policy.otlpHttp",
+			"chat.agentHost.otel.resourceAttributes",
+			"chat.agentHost.otel.resourceAttributes.policy",
+			"chat.agentHost.otel.serviceName",
+			"chat.agentHost.otel.serviceName.policy",
+			"chat.agentHost.systemProxy.enabled",
 			"chatAgentHostStarterConfigurationTitle"
 		],
 		"vs/platform/agentHost/common/changesetUri": [
@@ -2724,19 +2796,50 @@
 		],
 		"vs/platform/agentHost/common/claudeModelConfig": [
 			"claude.modelThinkingLevel.description",
-			"claude.modelThinkingLevel.high",
-			"claude.modelThinkingLevel.low",
-			"claude.modelThinkingLevel.max",
-			"claude.modelThinkingLevel.medium",
-			"claude.modelThinkingLevel.title",
-			"claude.modelThinkingLevel.xhigh"
+			"claude.modelThinkingLevel.title"
+		],
+		"vs/platform/agentHost/common/copilotCliConfig": [
+			"agentHost.config.copilotSdkLogLevel.description",
+			"agentHost.config.copilotSdkLogLevel.info",
+			"agentHost.config.copilotSdkLogLevel.title",
+			"agentHost.config.copilotSdkLogLevel.trace",
+			"agentHost.config.enableCustomTerminalTool.description",
+			"agentHost.config.enableCustomTerminalTool.title",
+			"agentHost.config.modelCapabilityOverrides.description",
+			"agentHost.config.modelCapabilityOverrides.entry.description",
+			"agentHost.config.modelCapabilityOverrides.entry.title",
+			"agentHost.config.modelCapabilityOverrides.family.description",
+			"agentHost.config.modelCapabilityOverrides.family.title",
+			"agentHost.config.modelCapabilityOverrides.title",
+			"agentHost.config.opus48Prompt.description",
+			"agentHost.config.opus48Prompt.title",
+			"agentHost.config.reasoningEffortOverride.description",
+			"agentHost.config.reasoningEffortOverride.title",
+			"agentHost.config.rubberDuck.description",
+			"agentHost.config.rubberDuck.title"
+		],
+		"vs/platform/agentHost/common/reasoningEffort": [
+			"reasoningEffort.high",
+			"reasoningEffort.highDescription",
+			"reasoningEffort.low",
+			"reasoningEffort.lowDescription",
+			"reasoningEffort.max",
+			"reasoningEffort.maxDescription",
+			"reasoningEffort.medium",
+			"reasoningEffort.mediumDescription",
+			"reasoningEffort.minimal",
+			"reasoningEffort.minimalDescription",
+			"reasoningEffort.none",
+			"reasoningEffort.noneDescription",
+			"reasoningEffort.xhigh",
+			"reasoningEffort.xhighDescription"
 		],
 		"vs/platform/agentHost/common/sandboxConfigSchema": [
 			"agentHost.config.sandbox.advancedRuntime.title",
 			"agentHost.config.sandbox.allowedDomains.item.title",
 			"agentHost.config.sandbox.allowedDomains.title",
+			"agentHost.config.sandbox.allowNetwork.title",
 			"agentHost.config.sandbox.allowUnsandboxedCommands.title",
-			"agentHost.config.sandbox.autoApproveUnsandboxedCommands.title",
 			"agentHost.config.sandbox.deniedDomains.item.title",
 			"agentHost.config.sandbox.deniedDomains.title",
 			"agentHost.config.sandbox.enabled.title",
@@ -2765,33 +2868,59 @@
 		"vs/platform/agentHost/node/agentHostCommitOperationProvider": [
 			"agentHost.changeset.commit"
 		],
+		"vs/platform/agentHost/node/agentHostDiscardChangesOperationHandler": [
+			"agentHost.changeset.discardChanges.cancelled",
+			"agentHost.changeset.discardChanges.discarded"
+		],
+		"vs/platform/agentHost/node/agentHostDiscardChangesOperationProvider": [
+			"agentHost.changeset.discardChanges",
+			"agentHost.changeset.discardChanges.confirmation"
+		],
 		"vs/platform/agentHost/node/agentHostMain": [
 			"agentHost"
 		],
 		"vs/platform/agentHost/node/agentHostPullRequestOperationHandler": [
 			"agentHost.changeset.pr.authRequired",
+			"agentHost.changeset.pr.autoMerge.merge",
+			"agentHost.changeset.pr.autoMerge.noNodeId",
+			"agentHost.changeset.pr.autoMerge.rebase",
+			"agentHost.changeset.pr.autoMerge.squash",
 			"agentHost.changeset.pr.body",
 			"agentHost.changeset.pr.cancelled",
 			"agentHost.changeset.pr.commitMessage",
 			"agentHost.changeset.pr.computeChangesFailed",
 			"agentHost.changeset.pr.created",
+			"agentHost.changeset.pr.created.autoMerge",
+			"agentHost.changeset.pr.created.autoMergeFailed",
 			"agentHost.changeset.pr.createdDraft",
 			"agentHost.changeset.pr.existing",
+			"agentHost.changeset.pr.existing.autoMerge",
+			"agentHost.changeset.pr.existing.autoMergeFailed",
 			"agentHost.changeset.pr.noChanges"
 		],
 		"vs/platform/agentHost/node/agentHostPullRequestOperationProvider": [
 			"agentHost.changeset.createDraftPR",
-			"agentHost.changeset.createPR"
+			"agentHost.changeset.createPR",
+			"agentHost.changeset.createPRAutoMerge",
+			"agentHost.changeset.createPRAutoRebase",
+			"agentHost.changeset.createPRAutoSquash"
 		],
 		"vs/platform/agentHost/node/agentHostRenameCommand": [
 			"agentHostSlashCommand.rename.description"
 		],
-		"vs/platform/agentHost/node/agentService": [
-			"agentHost.forkedSessionFallback",
-			"agentHost.forkedTitlePrefix"
+		"vs/platform/agentHost/node/agentHostSyncOperationHandler": [
+			"agentHost.changeset.sync.cancelled",
+			"agentHost.changeset.sync.synced"
 		],
-		"vs/platform/agentHost/node/agentSideEffects": [
-			"agentHostRename.renamed"
+		"vs/platform/agentHost/node/agentHostSyncOperationProvider": [
+			"agentHost.changeset.sync"
+		],
+		"vs/platform/agentHost/node/agentService": [
+			"agentHost.download.agentSdkTitle",
+			"agentHost.forkedChatFallback",
+			"agentHost.forkedSessionFallback",
+			"agentHost.forkedTitlePrefix",
+			"agentHost.importedSessionFallback"
 		],
 		"vs/platform/agentHost/node/claude/claudeAgent": [
 			"claude.sessionConfig.permissionMode",
@@ -2803,8 +2932,6 @@
 			"claude.sessionConfig.permissionMode.bypassPermissionsDescription",
 			"claude.sessionConfig.permissionMode.default",
 			"claude.sessionConfig.permissionMode.defaultDescription",
-			"claude.sessionConfig.permissionMode.dontAsk",
-			"claude.sessionConfig.permissionMode.dontAskDescription",
 			"claude.sessionConfig.permissionMode.plan",
 			"claude.sessionConfig.permissionMode.planDescription",
 			"claude.sessionConfig.permissionModeDescription",
@@ -2821,6 +2948,7 @@
 			"claude.permission.mcp.title",
 			"claude.permission.read.title",
 			"claude.permission.shell.title",
+			"claude.permission.skill.title",
 			"claude.permission.url.title",
 			"claude.permission.write.title",
 			"claude.tool.askUserQuestion",
@@ -2837,7 +2965,12 @@
 			"claude.tool.notebookEdit",
 			"claude.tool.notebookRead",
 			"claude.tool.read",
+			"claude.tool.skill",
 			"claude.tool.task",
+			"claude.tool.taskCreate",
+			"claude.tool.taskGet",
+			"claude.tool.taskList",
+			"claude.tool.taskUpdate",
 			"claude.tool.todoWrite",
 			"claude.tool.webFetch",
 			"claude.tool.write",
@@ -2847,7 +2980,6 @@
 			"claude.toolComplete.edit",
 			"claude.toolComplete.editFile",
 			"claude.toolComplete.failed",
-			"claude.toolComplete.generic",
 			"claude.toolComplete.glob",
 			"claude.toolComplete.globPattern",
 			"claude.toolComplete.grep",
@@ -2857,7 +2989,17 @@
 			"claude.toolComplete.lsPath",
 			"claude.toolComplete.read",
 			"claude.toolComplete.readFile",
+			"claude.toolComplete.skill",
+			"claude.toolComplete.skillNamed",
 			"claude.toolComplete.task",
+			"claude.toolComplete.taskComplete",
+			"claude.toolComplete.taskCreate",
+			"claude.toolComplete.taskCreateNamed",
+			"claude.toolComplete.taskDelete",
+			"claude.toolComplete.taskGet",
+			"claude.toolComplete.taskList",
+			"claude.toolComplete.taskStart",
+			"claude.toolComplete.taskUpdate",
 			"claude.toolComplete.todoWrite",
 			"claude.toolComplete.webFetch",
 			"claude.toolComplete.webFetchGeneric",
@@ -2875,19 +3017,42 @@
 			"claude.toolInvoke.lsPath",
 			"claude.toolInvoke.read",
 			"claude.toolInvoke.readFile",
+			"claude.toolInvoke.skill",
+			"claude.toolInvoke.skillNamed",
+			"claude.toolInvoke.taskComplete",
+			"claude.toolInvoke.taskCreate",
+			"claude.toolInvoke.taskCreateNamed",
+			"claude.toolInvoke.taskDelete",
+			"claude.toolInvoke.taskGet",
+			"claude.toolInvoke.taskList",
+			"claude.toolInvoke.taskStart",
+			"claude.toolInvoke.taskUpdate",
 			"claude.toolInvoke.todoWrite",
 			"claude.toolInvoke.webFetch",
 			"claude.toolInvoke.webFetchGeneric"
 		],
-		"vs/platform/agentHost/node/claude/customizations/claudeSdkCustomizationBundler": [
-			"claude.discovered.displayName"
+		"vs/platform/agentHost/node/claude/customizations/claudeBuiltinCommands": [
+			"claude.builtin.claudeApi",
+			"claude.builtin.codeReview",
+			"claude.builtin.fewerPermissionPrompts",
+			"claude.builtin.init",
+			"claude.builtin.keybindingsHelp",
+			"claude.builtin.loop",
+			"claude.builtin.review",
+			"claude.builtin.run",
+			"claude.builtin.securityReview",
+			"claude.builtin.simplify",
+			"claude.builtin.updateConfig",
+			"claude.builtin.verify",
+			"claude.builtin.writeASkill",
+			"claude.builtinAgent.claude",
+			"claude.builtinAgent.claudeCodeGuide",
+			"claude.builtinAgent.explore",
+			"claude.builtinAgent.generalPurpose",
+			"claude.builtinAgent.plan"
 		],
 		"vs/platform/agentHost/node/codex/codexAgent": [
 			"codex.modelThinkingLevel.description",
-			"codex.modelThinkingLevel.high",
-			"codex.modelThinkingLevel.low",
-			"codex.modelThinkingLevel.medium",
-			"codex.modelThinkingLevel.minimal",
 			"codex.modelThinkingLevel.title",
 			"codex.sessionConfig.additionalDirectories",
 			"codex.sessionConfig.additionalDirectories.item",
@@ -2903,13 +3068,31 @@
 			"codex.sessionConfig.approvalPolicy.untrustedDescription",
 			"codex.sessionConfig.approvalPolicyDescription",
 			"codex.sessionConfig.modelReasoningEffort",
-			"codex.sessionConfig.modelReasoningEffort.high",
-			"codex.sessionConfig.modelReasoningEffort.low",
-			"codex.sessionConfig.modelReasoningEffort.medium",
-			"codex.sessionConfig.modelReasoningEffort.minimal",
 			"codex.sessionConfig.modelReasoningEffortDescription",
 			"codex.sessionConfig.networkAccessEnabled",
 			"codex.sessionConfig.networkAccessEnabledDescription",
+			"codex.sessionConfig.permissionsPreset",
+			"codex.sessionConfig.permissionsPreset.autoReview",
+			"codex.sessionConfig.permissionsPreset.autoReviewDescription",
+			"codex.sessionConfig.permissionsPreset.default",
+			"codex.sessionConfig.permissionsPreset.defaultDescription",
+			"codex.sessionConfig.permissionsPreset.fullAccess",
+			"codex.sessionConfig.permissionsPreset.fullAccessDescription",
+			"codex.sessionConfig.permissionsPresetDescription",
+			"codex.sessionConfig.personality",
+			"codex.sessionConfig.personality.friendly",
+			"codex.sessionConfig.personality.friendlyDescription",
+			"codex.sessionConfig.personality.none",
+			"codex.sessionConfig.personality.noneDescription",
+			"codex.sessionConfig.personality.pragmatic",
+			"codex.sessionConfig.personality.pragmaticDescription",
+			"codex.sessionConfig.personalityDescription",
+			"codex.sessionConfig.reasoningSummary",
+			"codex.sessionConfig.reasoningSummary.auto",
+			"codex.sessionConfig.reasoningSummary.concise",
+			"codex.sessionConfig.reasoningSummary.detailed",
+			"codex.sessionConfig.reasoningSummary.none",
+			"codex.sessionConfig.reasoningSummaryDescription",
 			"codex.sessionConfig.sandboxMode",
 			"codex.sessionConfig.sandboxMode.dangerFullAccess",
 			"codex.sessionConfig.sandboxMode.dangerFullAccessDescription",
@@ -2927,27 +3110,14 @@
 			"codexAgent.displayName"
 		],
 		"vs/platform/agentHost/node/copilot/copilotAgent": [
-			"agentHost.sessionConfig.branch",
-			"agentHost.sessionConfig.branchDescription",
-			"agentHost.sessionConfig.isolation",
-			"agentHost.sessionConfig.isolation.folder",
-			"agentHost.sessionConfig.isolation.folderDescription",
-			"agentHost.sessionConfig.isolation.worktree",
-			"agentHost.sessionConfig.isolation.worktreeDescription",
-			"agentHost.sessionConfig.isolationDescription",
-			"copilot.modelContextTier.default",
-			"copilot.modelContextTier.description",
-			"copilot.modelContextTier.longerSessions",
-			"copilot.modelContextTier.longerSessionsNoCompaction",
-			"copilot.modelContextTier.title",
+			"copilot.modelContextSize.default",
+			"copilot.modelContextSize.description",
+			"copilot.modelContextSize.longerSessions",
+			"copilot.modelContextSize.title",
 			"copilot.modelThinkingLevel.description",
-			"copilot.modelThinkingLevel.high",
-			"copilot.modelThinkingLevel.low",
-			"copilot.modelThinkingLevel.medium",
 			"copilot.modelThinkingLevel.title",
-			"copilot.modelThinkingLevel.xhigh",
-			"copilotAgent.pluginParseError",
-			"copilotAgent.worktreeCreated"
+			"copilotAgent.description",
+			"copilotAgent.pluginParseError"
 		],
 		"vs/platform/agentHost/node/copilot/copilotAgentSession": [
 			"agentHost.planReview.autopilot.description",
@@ -2961,31 +3131,31 @@
 			"agentHost.planReview.interactive.label",
 			"agentHost.planReview.questionMessage",
 			"agentHost.planReview.title",
-			"agentHost.planReview.viewPlanLink",
 			"agentHost.unsandboxedCommandConfirmation.blockedDomains",
 			"agentHost.unsandboxedCommandConfirmation.generic",
 			"agentHost.unsandboxedCommandConfirmation.reason",
 			"agentHost.unsandboxedCommandConfirmation.title.blockedDomains",
-			"agentHost.unsandboxedCommandConfirmation.title.generic"
-		],
-		"vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider": [
-			"copilotSlashCommand.compact.description",
-			"copilotSlashCommand.plan.description",
-			"copilotSlashCommand.research.description",
-			"copilotSlashCommand.rubberDuck.description"
+			"agentHost.unsandboxedCommandConfirmation.title.generic",
+			"copilotAgent.compactionCompleted",
+			"copilotSlashCommand.selectSubcommandResult"
 		],
 		"vs/platform/agentHost/node/copilot/copilotSystemNotification": [
 			"agentHost.copilot.systemNotification.agentCompleted",
+			"agentHost.copilot.systemNotification.agentFailed",
+			"agentHost.copilot.systemNotification.agentIdle",
+			"agentHost.copilot.systemNotification.instructionDiscovered",
+			"agentHost.copilot.systemNotification.newInboxMessage",
 			"agentHost.copilot.systemNotification.shellCompleted",
-			"agentHost.copilot.systemNotification.shellDescriptionCompleted",
-			"agentHost.copilot.systemNotification.shellIdCompleted"
+			"agentHost.copilot.systemNotification.shellDescriptionCompleted"
 		],
 		"vs/platform/agentHost/node/copilot/copilotToolDisplay": [
+			"copilot.permission.create.title",
 			"copilot.permission.default.message",
 			"copilot.permission.default.title",
 			"copilot.permission.mcp.defaultTool",
 			"copilot.permission.mcp.title",
 			"copilot.permission.read.title",
+			"copilot.permission.shell.bypass.title",
 			"copilot.permission.shell.title",
 			"copilot.permission.url.message",
 			"copilot.permission.url.title",
@@ -2996,20 +3166,23 @@
 			"toolComplete.editFile",
 			"toolComplete.exitPlanMode",
 			"toolComplete.failed",
-			"toolComplete.generic",
 			"toolComplete.glob",
 			"toolComplete.globPattern",
 			"toolComplete.grep",
 			"toolComplete.grepPattern",
+			"toolComplete.listAgents",
 			"toolComplete.patch",
 			"toolComplete.patchFile",
 			"toolComplete.patchFiles",
+			"toolComplete.readAgent",
+			"toolComplete.readAgentGeneric",
 			"toolComplete.readTerminal",
 			"toolComplete.shell",
 			"toolComplete.shellCmd",
 			"toolComplete.skill",
 			"toolComplete.skillName",
 			"toolComplete.sql",
+			"toolComplete.task",
 			"toolComplete.view",
 			"toolComplete.viewFile",
 			"toolComplete.viewFileFromLine",
@@ -3017,6 +3190,8 @@
 			"toolComplete.viewFileRange",
 			"toolComplete.webFetch",
 			"toolComplete.webFetchGeneric",
+			"toolComplete.writeAgent",
+			"toolComplete.writeAgentGeneric",
 			"toolComplete.writeShell",
 			"toolComplete.writeShellCmd",
 			"toolInvoke.create",
@@ -3024,7 +3199,6 @@
 			"toolInvoke.edit",
 			"toolInvoke.editFile",
 			"toolInvoke.exitPlanMode",
-			"toolInvoke.generic",
 			"toolInvoke.glob",
 			"toolInvoke.globPattern",
 			"toolInvoke.grep",
@@ -3038,6 +3212,7 @@
 			"toolInvoke.skill",
 			"toolInvoke.skillName",
 			"toolInvoke.sql",
+			"toolInvoke.task",
 			"toolInvoke.view",
 			"toolInvoke.viewFile",
 			"toolInvoke.viewFileFromLine",
@@ -3047,6 +3222,7 @@
 			"toolInvoke.webFetchGeneric",
 			"toolInvoke.writeShell",
 			"toolInvoke.writeShellCmd",
+			"toolMarkdown.taskComplete",
 			"toolName.applyPatch",
 			"toolName.askUser",
 			"toolName.codeqlChecker",
@@ -3091,10 +3267,86 @@
 			"toolName.writeBash",
 			"toolName.writePowerShell"
 		],
+		"vs/platform/agentHost/node/localCommands/bangLocalCommand": [
+			"agentHostBang.background",
+			"agentHostBang.exited",
+			"agentHostBang.failed",
+			"agentHostBang.interactive",
+			"agentHostBang.ran",
+			"agentHostBang.shellExited",
+			"agentHostBang.terminal",
+			"agentHostBang.timedOut"
+		],
+		"vs/platform/agentHost/node/localCommands/renameLocalCommand": [
+			"agentHostRename.renamed"
+		],
 		"vs/platform/agentHost/node/sessionPermissions": [
 			"sessionPermissions.allowOnce",
 			"sessionPermissions.allowSession",
 			"sessionPermissions.skip"
+		],
+		"vs/platform/agentHost/node/shared/agentFeedbackServerTools": [
+			"toolComplete.addComment",
+			"toolComplete.deleteComments",
+			"toolComplete.listComments",
+			"toolComplete.listComments.many",
+			"toolComplete.listComments.one",
+			"toolComplete.resolveComments",
+			"toolComplete.viewUnreviewedComments",
+			"toolInvoke.addComment",
+			"toolInvoke.deleteComments",
+			"toolInvoke.listComments",
+			"toolInvoke.resolveComments",
+			"toolInvoke.viewUnreviewedComments",
+			"toolName.addComment",
+			"toolName.deleteComments",
+			"toolName.listComments",
+			"toolName.resolveComments",
+			"toolName.viewUnreviewedComments"
+		],
+		"vs/platform/agentHost/node/shared/sessionServerTools": [
+			"toolComplete.createChat",
+			"toolComplete.createSession",
+			"toolComplete.deleteSession",
+			"toolComplete.getCurrentSession",
+			"toolComplete.getSessionContext",
+			"toolComplete.listSessions",
+			"toolComplete.listSessions.many",
+			"toolComplete.listSessions.one",
+			"toolComplete.sendMessage",
+			"toolInvoke.createChat",
+			"toolInvoke.createSession",
+			"toolInvoke.deleteSession",
+			"toolInvoke.getCurrentSession",
+			"toolInvoke.getSessionContext",
+			"toolInvoke.listSessions",
+			"toolInvoke.sendMessage",
+			"toolName.createChat",
+			"toolName.createSession",
+			"toolName.deleteSession",
+			"toolName.getCurrentSession",
+			"toolName.getSessionContext",
+			"toolName.listSessions",
+			"toolName.sendMessage"
+		],
+		"vs/platform/agentHost/node/shared/worktreeIsolation": [
+			"agentHost.sessionConfig.branch",
+			"agentHost.sessionConfig.branchDescription",
+			"agentHost.sessionConfig.isolation",
+			"agentHost.sessionConfig.isolation.folder",
+			"agentHost.sessionConfig.isolation.folderDescription",
+			"agentHost.sessionConfig.isolation.worktree",
+			"agentHost.sessionConfig.isolation.worktreeDescription",
+			"agentHost.sessionConfig.isolationDescription",
+			"agentHost.sessionConfig.worktreeBranchPrefix",
+			"agentHost.sessionConfig.worktreeBranchPrefixDescription",
+			"agentHost.sessionConfig.worktreeIncludeFiles",
+			"agentHost.sessionConfig.worktreeIncludeFilesDescription",
+			"agentHost.sessionConfig.worktreeIncludeFilesItem",
+			"agentHost.worktreeCreated",
+			"sessionWorkingDirectoryMissing",
+			"sessionWorkingDirectoryMissingWithReason",
+			"worktreeRecreateBranchMissing"
 		],
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
 			"ssh.failedToReadPrivateKey",
@@ -3117,12 +3369,32 @@
 			"wslProgressPreparingCLI",
 			"wslUnsupportedPlatform"
 		],
+		"vs/platform/browserView/common/browserPermissions": [
+			"browserPermission.camera.description",
+			"browserPermission.camera.label",
+			"browserPermission.clipboard.description",
+			"browserPermission.clipboard.label",
+			"browserPermission.devices.description",
+			"browserPermission.devices.label",
+			"browserPermission.location.description",
+			"browserPermission.location.label",
+			"browserPermission.microphone.description",
+			"browserPermission.microphone.label",
+			"browserPermission.notifications.description",
+			"browserPermission.notifications.label",
+			"browserPermission.sensors.description",
+			"browserPermission.sensors.label"
+		],
 		"vs/platform/browserView/common/browserView": [
 			"browserZoomAccessibilityLabel",
 			"browserZoomPercent"
 		],
 		"vs/platform/browserView/electron-main/browserSession": [
 			"browserSession.untrustedFile"
+		],
+		"vs/platform/browserView/electron-main/browserSessionPermissions": [
+			"browser.device.hid",
+			"browser.device.usb"
 		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
 			"browser.contextMenu.addElementToChat",
@@ -3138,6 +3410,7 @@
 			"browser.contextMenu.reload"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
+			"config.policy.bothPolicyAndReference",
 			"config.policy.duplicate",
 			"config.property.duplicate",
 			"config.property.empty",
@@ -3298,7 +3571,6 @@
 		],
 		"vs/platform/extensionManagement/common/abstractExtensionManagementService": [
 			"incompatible platform",
-			"incompatibleAPI",
 			"learn why",
 			"malicious extension",
 			"MarketPlaceDisabled",
@@ -3406,8 +3678,6 @@
 			"invalidManifest"
 		],
 		"vs/platform/extensions/common/extensionValidator": [
-			"apiProposalMismatch1",
-			"apiProposalMismatch2",
 			"extensionDescription.activationEvents1",
 			"extensionDescription.activationEvents2",
 			"extensionDescription.browser1",
@@ -3587,6 +3857,8 @@
 			"filtered.network"
 		],
 		"vs/platform/mcp/common/allowedMcpServersService": [
+			"mcp server is denied",
+			"mcp server not in allowlist",
 			"mcp servers are not allowed"
 		],
 		"vs/platform/mcp/common/mcpGalleryService": [
@@ -3632,6 +3904,7 @@
 			},
 			"mHide",
 			"mHideOthers",
+			"miCancellingUpdate",
 			"miCheckForUpdates",
 			"miCheckingForUpdates",
 			"miDownloadingUpdate",
@@ -4235,8 +4508,11 @@
 		],
 		"vs/platform/theme/common/sizes/baseSizes": [
 			"bodyFontSize",
+			"bodyFontSize.deprecated",
 			"bodyFontSizeSmall",
+			"bodyFontSizeSmall.deprecated",
 			"bodyFontSizeXSmall",
+			"bodyFontSizeXSmall.deprecated",
 			"codiconFontSize",
 			"codiconFontSizeCompact",
 			"cornerRadiusCircle",
@@ -4245,6 +4521,16 @@
 			"cornerRadiusSmall",
 			"cornerRadiusXLarge",
 			"cornerRadiusXSmall",
+			"fontSizeBody1",
+			"fontSizeBody2",
+			"fontSizeHeading1",
+			"fontSizeHeading2",
+			"fontSizeHeading3",
+			"fontSizeLabel1",
+			"fontSizeLabel2",
+			"fontSizeLabel3",
+			"fontWeightRegular",
+			"fontWeightSemiBold",
 			"spacingNone",
 			"spacingSize100",
 			"spacingSize120",
@@ -4529,6 +4815,7 @@
 			"codeWorkspace"
 		],
 		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"agentsWindowRecentWorkspace",
 			{
 				"key": "cancel",
 				"comment": [
@@ -4583,14 +4870,12 @@
 			"agentPanelCloseIcon",
 			"agentSidebarToggleClosedIcon",
 			"agentSidebarToggleOpenIcon",
-			"openAndCloseSecondarySidebar",
+			"closePanel",
+			"hideSecondarySideBar",
 			"openAndCloseSidebar",
-			"secondarySidebarHidden",
-			"secondarySidebarVisible",
+			"showSecondarySideBar",
 			"sidebarHidden",
 			"sidebarVisible",
-			"togglePanel",
-			"toggleSecondarySidebar",
 			"toggleSidebar",
 			"toggleWindowAlwaysOnTop"
 		],
@@ -4598,10 +4883,11 @@
 			"auxiliaryBarAriaLabel"
 		],
 		"vs/sessions/browser/parts/chatCompositeBar": [
+			"chatCompositeBar.addChat",
 			"chatTabsAriaLabel",
-			"closeChat",
+			"deleteChat",
 			"renameChat",
-			"renameChat.prompt"
+			"renameChat.aria"
 		],
 		"vs/sessions/browser/parts/menubar.contribution": [
 			{
@@ -4630,6 +4916,12 @@
 			},
 			{
 				"key": "mPreferences",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			{
+				"key": "mSelection",
 				"comment": [
 					"&& denotes a mnemonic"
 				]
@@ -4719,8 +5011,15 @@
 			"mobileTopBar.singleFileChangedTooltip"
 		],
 		"vs/sessions/browser/parts/sessionHeader": [
-			"agentSessions.newSession",
 			"renameSession.aria"
+		],
+		"vs/sessions/browser/parts/sessionReadOnlyBanner": [
+			"sessionReadOnlyBanner.message"
+		],
+		"vs/sessions/browser/parts/sessionView": [
+			"sessionReadOnlyBanner.archived",
+			"sessionReadOnlyBanner.message",
+			"sessionReadOnlyBanner.restore"
 		],
 		"vs/sessions/browser/sessionsSetUpService": [
 			"loading",
@@ -4751,33 +5050,55 @@
 			"agents"
 		],
 		"vs/sessions/common/contextkeys": [
-			"activeSessionHasGitRepository",
-			"activeSessionHasGitSyncActionRunning",
-			"activeSessionProviderId",
 			"activeSessions",
-			"activeSessionType",
-			"activeSessionUsesCombinedConfigPicker",
-			"activeSessionWorkspaceIsVirtual",
-			"chatSessionProviderId",
-			"chatSessionType",
+			"agentSessionsHasDockedDetails",
+			"agentSessionsSinglePaneChangesTabMissing",
+			"agentSessionsSinglePaneFilesTabMissing",
+			"agentSessionsSinglePaneLayoutEnabled",
 			"editorMaximized",
-			"isActiveSessionArchived",
+			"isQuickChatSession",
 			"multipleSessionsVisible",
+			"sessionActiveChatHasSubagents",
+			"sessionActiveChatIsClosable",
+			"sessionActiveChatIsDeletable",
+			"sessionChatsPickerVisible",
+			"sessionHarnessPickerVisible",
+			"sessionHasChanges",
+			"sessionHasGitRepository",
+			"sessionHasGitSyncActionRunning",
+			"sessionHasMultipleCommittedChats",
+			"sessionHasMultipleOpenChats",
+			"sessionHasPullRequest",
+			"sessionHasWorkspace",
+			"sessionId",
 			"sessionIsArchived",
 			"sessionIsCreated",
 			"sessionIsMaximized",
+			"sessionIsolationPickerVisible",
 			"sessionIsRead",
 			"sessionIsSticky",
+			"sessionProviderId",
 			"sessionsAquariumActive",
+			"sessionsBlockedSessionsVisible",
 			"sessionsCanGoBack",
 			"sessionsCanGoForward",
 			"sessionsFocus",
+			"sessionShouldShowChatTabs",
 			"sessionsIsPhoneLayout",
 			"sessionsKeyboardVisible",
+			"sessionsPickerVisible",
+			"sessionsTitleBarNewSessionEnabled",
+			"sessionSupportsDelete",
+			"sessionSupportsFork",
 			"sessionSupportsMultipleChats",
+			"sessionSupportsRename",
 			"sessionsVisible",
 			"sessionsWelcomeVisible",
-			"sessionWorkspacePickerGroup"
+			"sessionType",
+			"sessionUsesCombinedConfigPicker",
+			"sessionWorkspaceIsVirtual",
+			"sessionWorkspacePickerGroup",
+			"sessionWorkspacePickerVisible"
 		],
 		"vs/sessions/common/sizes": [
 			"agents.fontSize.body1",
@@ -4789,11 +5110,14 @@
 			"agents.fontSize.label2",
 			"agents.fontSize.label3",
 			"agents.fontWeight.regular",
-			"agents.fontWeight.semiBold"
+			"agents.fontWeight.semiBold",
+			"agents.layout.floatingPanelGap"
 		],
 		"vs/sessions/common/theme": [
 			"activeSessionView.background",
 			"activeSessionView.foreground",
+			"agentFeedbackEditorWidget.background",
+			"agentFeedbackEditorWidget.border",
 			"agentFeedbackInputWidget.border",
 			"agents.background",
 			"agentsBadge.background",
@@ -4840,7 +5164,7 @@
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution": [
 			"agentFeedback.submitFeedbackCount"
 		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachment": [
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachmentEntry": [
 			"agentFeedback.many",
 			"agentFeedback.one"
 		],
@@ -4861,22 +5185,28 @@
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution": [
 			"agentFeedback.add",
 			"agentFeedback.addAndSubmit",
+			"agentFeedback.addAtCurrentLine",
 			"agentFeedback.addComment",
 			"agentFeedback.addFeedback",
 			"altEnter",
 			"enter"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay": [
+			"agentFeedback.submitCountShort",
 			"nOfM",
 			"zero"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution": [
-			"acceptComment",
+			"acceptAgentFeedbackTooltip",
+			"acceptFeedbackButton",
+			"acceptPRFeedbackTooltip",
 			"addReplyPlaceholder",
 			"addToComment",
 			"agentReviewComment",
 			"collapse",
-			"convertComment",
+			"deleteAgentFeedbackTooltip",
+			"deleteFeedbackButton",
+			"deletePRFeedbackTooltip",
 			"editComment",
 			"expand",
 			"lineNumber",
@@ -4894,6 +5224,10 @@
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackOverviewRulerContribution": [
 			"editorOverviewRuler.agentFeedbackForeground"
+		],
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands": [
+			"agentFeedbackReview.agentReview",
+			"agentFeedbackReview.prReview"
 		],
 		"vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView": [
 			"aiCustomization"
@@ -4916,6 +5250,7 @@
 		],
 		"vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews": [
 			"aiCustomizationTree",
+			"automations",
 			"builtinWithCount",
 			"customAgents",
 			"extensionsWithCount",
@@ -4939,11 +5274,95 @@
 			"openInVSCode"
 		],
 		"vs/sessions/contrib/aquarium/browser/aquarium.contribution": [
+			"aquarium.simulateStreak",
+			"aquarium.simulateStreak.alive",
+			"aquarium.simulateStreak.aliveDetail",
+			"aquarium.simulateStreak.clear",
+			"aquarium.simulateStreak.clearDetail",
+			"aquarium.simulateStreak.countInvalid",
+			"aquarium.simulateStreak.countPrompt",
+			"aquarium.simulateStreak.died",
+			"aquarium.simulateStreak.diedDetail",
+			"aquarium.simulateStreak.placeholder",
 			"sessions.developerJoy.enabled"
 		],
 		"vs/sessions/contrib/aquarium/browser/aquariumOverlay": [
 			"aquarium.hide",
-			"aquarium.show"
+			"aquarium.reviveBadge",
+			"aquarium.reviveLabel.one",
+			"aquarium.reviveLabel.other",
+			"aquarium.show",
+			"aquarium.streakLabel.one",
+			"aquarium.streakLabel.other"
+		],
+		"vs/sessions/contrib/automations/browser/automationDialog": [
+			"automation.form.branch.capabilityLoadingReason",
+			"automation.form.branch.chooseReason",
+			"automation.form.branch.detached",
+			"automation.form.branch.folderModeReason",
+			"automation.form.branch.loadError",
+			"automation.form.branch.loadErrorReason",
+			"automation.form.branch.loading",
+			"automation.form.branch.loadingReason",
+			"automation.form.branch.noBranches",
+			"automation.form.branch.noBranchesReason",
+			"automation.form.branch.noFolderReason",
+			"automation.form.branch.noRepo",
+			"automation.form.branch.noRepoReason",
+			"automation.form.branch.select",
+			"automation.form.branch.unknown",
+			"automation.form.branch.unsupportedReason",
+			"automation.form.branchRequired",
+			"automation.form.day",
+			"automation.form.enabled",
+			"automation.form.folderRequired",
+			"automation.form.harnessChip.action",
+			"automation.form.interval",
+			"automation.form.isolation.checkboxAriaLabel",
+			"automation.form.isolation.worktree",
+			"automation.form.isolation.worktreeNoFolder",
+			"automation.form.isolation.worktreeUnavailable",
+			"automation.form.isolationGroup.action",
+			"automation.form.name",
+			"automation.form.namePlaceholder",
+			"automation.form.nameRequired",
+			"automation.form.noWorkspace",
+			"automation.form.noWorkspace.description",
+			"automation.form.prompt",
+			"automation.form.prompt.placeholder",
+			"automation.form.promptRequired",
+			"automation.form.sessionTypeRequired",
+			"automation.form.time",
+			"automation.form.workspacePicker.action",
+			"automation.form.workspacePicker.pickAriaLabel",
+			"automation.form.workspacePicker.selectedAriaLabel",
+			"automation.interval.daily",
+			"automation.interval.hourly",
+			"automation.interval.manual",
+			"automation.interval.weekly",
+			"pickWorkspace"
+		],
+		"vs/sessions/contrib/automations/browser/automationDialogService": [
+			"automation.dialog.cancel",
+			"automation.dialog.create",
+			"automation.dialog.createDescription",
+			"automation.dialog.createTitle",
+			"automation.dialog.editDescription",
+			"automation.dialog.editTitle",
+			"automation.dialog.save"
+		],
+		"vs/sessions/contrib/automations/browser/automationRunner": [
+			"automationRunFailed",
+			"automationRunner.cancelled",
+			"automationRunner.sessionFailed"
+		],
+		"vs/sessions/contrib/automations/browser/automations.contribution": [
+			"chat.automations.enabled",
+			"chat.automations.runTimeoutMinutes"
+		],
+		"vs/sessions/contrib/automations/browser/automationScheduler": [
+			"automation.timedOut",
+			"automations.crashRecoveryReason"
 		],
 		"vs/sessions/contrib/changes/browser/changes.contribution": [
 			"changes",
@@ -4954,31 +5373,50 @@
 					"&& denotes a mnemonic"
 				]
 			},
+			"sessionChangesEditor.label",
 			"sessions.changes.openSingleFileDiff"
 		],
-		"vs/sessions/contrib/changes/browser/changesTitleBarWidget": [
-			"agentSecondarySidebarToggleClosedIcon",
-			"agentSecondarySidebarToggleOpenIcon",
-			"hideChanges",
-			"showChanges",
-			"toggleSecondarySidebarTooltip"
+		"vs/sessions/contrib/changes/browser/changesActions": [
+			"agentSessions.changes",
+			"agentSessions.changes.collapseUnchangedRegions",
+			"agentSessions.changes.expandFullFile",
+			"agentSessions.changes.file",
+			"agentSessions.changes.files",
+			"agentSessions.changes.openFile",
+			"agentSessions.viewChanges.ariaLabel",
+			"agentSessions.viewChanges.tooltip",
+			"agentSessions.viewChanges.tooltip.branch"
+		],
+		"vs/sessions/contrib/changes/browser/changesetReviewActions": [
+			"changeset.viewed"
 		],
 		"vs/sessions/contrib/changes/browser/changesView": [
 			"changes",
+			"changesView.diffStats.file",
+			"changesView.diffStats.files",
 			"changesView.diffStats.label",
 			"changesView.noChanges",
 			"changesView.viewChanges",
 			"changesViewTree",
 			"chatEditing.versionsPicker",
-			"sessions.changes.title",
+			"revealChecks",
 			"setListViewMode",
 			"setTreeViewMode"
 		],
 		"vs/sessions/contrib/changes/browser/changesViewActions": [
+			"agentSessions.collapseAllDiffs",
+			"agentSessions.expandAllDiffs",
+			"agentSessions.setChangesListViewMode",
+			"agentSessions.setChangesTreeViewMode",
+			"changes",
+			"changesView.headerActions",
 			"openChanges",
 			"openChangesView",
 			"openFile",
-			"openPullRequest"
+			"openPullRequest",
+			"showInlineDiff",
+			"showSideBySideDiff",
+			"toggleDiffView"
 		],
 		"vs/sessions/contrib/changes/browser/checksActions": [
 			"ci.failedState",
@@ -4992,10 +5430,42 @@
 			"ci.checksLabel",
 			"ci.checksListAriaLabel",
 			"ci.checkTitle",
-			"ci.fixChecks",
 			"ci.openOnGitHub",
 			"ci.rerunCheck",
 			"ci.toggleChecks"
+		],
+		"vs/sessions/contrib/changes/browser/sessionChangesEditor": [
+			"changeset.notViewed.tooltip",
+			"changeset.viewed.tooltip",
+			"sessionChangesEditor.fileCounts"
+		],
+		"vs/sessions/contrib/changes/browser/sessionChangesEditorInput": [
+			"sessionChangesEditor.name"
+		],
+		"vs/sessions/contrib/changes/browser/sessionChangesService": [
+			"sessions.changes.title"
+		],
+		"vs/sessions/contrib/changes/browser/sessionFilesWidget": [
+			"sessionFiles.created",
+			"sessionFiles.deleted",
+			"sessionFiles.diffLabel",
+			"sessionFiles.fileAriaLabel",
+			"sessionFiles.hover",
+			"sessionFiles.label",
+			"sessionFiles.listAriaLabel",
+			"sessionFiles.modified",
+			"sessionFiles.openFileAction",
+			"sessionFiles.title",
+			"sessionFiles.toggle"
+		],
+		"vs/sessions/contrib/changes/browser/sessionsChangesAccessibilityHelp": [
+			"sessionsChanges.checks",
+			"sessionsChanges.diffView",
+			"sessionsChanges.overview",
+			"sessionsChanges.sessionFiles",
+			"sessionsChanges.sessionFilesToggle",
+			"sessionsChanges.tree",
+			"sessionsChanges.viewMode"
 		],
 		"vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService": [
 			"commitToRepoFailed",
@@ -5005,6 +5475,7 @@
 			"skillUI.commit",
 			"skillUI.createDraftPr",
 			"skillUI.createPr",
+			"skillUI.fixCi",
 			"skillUI.generateRunCommands",
 			"skillUI.mergeChanges",
 			"skillUI.updatePr"
@@ -5013,19 +5484,33 @@
 			"branchChatSession",
 			"branchChatSessionTooltip"
 		],
+		"vs/sessions/contrib/chat/browser/branchPicker": [
+			"branchPicker.ariaLabel",
+			"branchPicker.disabledAriaLabel",
+			"branchPicker.empty",
+			"branchPicker.filter",
+			"branchPicker.loading",
+			"branchPicker.retry",
+			"branchPicker.select",
+			"branchPicker.triggerAriaLabel",
+			"branchPicker.unavailable",
+			"branchPicker.unavailableAriaLabel"
+		],
 		"vs/sessions/contrib/chat/browser/chat.contribution": [
 			"chat.agentHost.runWorktreeCreatedTasks",
 			"chat.agentSessions.scopedInputHistory",
-			"chat.newEdits.label"
+			"sessions.newSession.label"
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
 			"mobileSessionTypePicker.title"
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet": [
+			"mobileWorkspacePicker.cancel",
 			"mobileWorkspacePicker.caption",
 			"mobileWorkspacePicker.foldersSection",
 			"mobileWorkspacePicker.noFolders",
 			"mobileWorkspacePicker.searchFolders",
+			"mobileWorkspacePicker.selectCurrentFolder",
 			"mobileWorkspacePicker.title"
 		],
 		"vs/sessions/contrib/chat/browser/modelPicker": [
@@ -5046,6 +5531,9 @@
 			"chatInput.accessibilityHelp",
 			"chatInput.accessibilityHelpNoKb",
 			"loading",
+			"newChatInput.status.otel.learnMore",
+			"newChatInput.status.otel.manage",
+			"newChatInput.status.otel.title",
 			"send",
 			"sendWithBackgroundHint",
 			"sessionsChatInput.placeholder.describeTheOutcome",
@@ -5062,7 +5550,10 @@
 			"sessionsChatInput.placeholder.whatWillYouCreate",
 			"sessionsChatInput.placeholder.whatWillYouLaunch",
 			"sessionsChatInput.placeholder.whatWillYouShipToday",
-			"sessionsChatInput.placeholder.whatWouldYouLikeToAutomate"
+			"sessionsChatInput.placeholder.whatWouldYouLikeToAutomate",
+			"sessionsStt.dictate",
+			"sessionsStt.preparing",
+			"sessionsStt.stop"
 		],
 		"vs/sessions/contrib/chat/browser/newChatInSessionWidget": [
 			"newChatInSessionPlaceholder",
@@ -5070,7 +5561,15 @@
 			"subSessionTip.dismiss",
 			"subSessionTip.message"
 		],
+		"vs/sessions/contrib/chat/browser/newChatVoice": [
+			"agentsVoice.connecting",
+			"agentsVoice.disconnect",
+			"agentsVoice.openSettings",
+			"agentsVoice.pttStopInChat",
+			"agentsVoice.startVoiceInChat"
+		],
 		"vs/sessions/contrib/chat/browser/newChatWidget": [
+			"newChatHeader",
 			"newSessionChooseWorkspace",
 			"newSessionIn",
 			"newSessionWith",
@@ -5157,9 +5656,55 @@
 			"workspaceStorageLabel",
 			"workspaceStorageTooltip"
 		],
+		"vs/sessions/contrib/chat/browser/sessionBackgroundActivitiesControl": [
+			"backgroundActivities.activeBrowsers",
+			"backgroundActivities.activeSubagents",
+			"backgroundActivities.ariaLabel",
+			"backgroundActivities.browser",
+			"backgroundActivities.browsers",
+			"backgroundActivities.mixed",
+			"backgroundActivities.open",
+			"backgroundActivities.show",
+			"backgroundActivities.subagent",
+			"backgroundActivities.subagents"
+		],
+		"vs/sessions/contrib/chat/browser/sessionChatInputToolbar": [
+			"sessions.lastTurnChanges.title"
+		],
+		"vs/sessions/contrib/chat/browser/sessionChatInputToolbarDebug": [
+			"sessions.debug.chatPills.agentFeedback",
+			"sessions.debug.chatPills.apply",
+			"sessions.debug.chatPills.autoIncrementChanges",
+			"sessions.debug.chatPills.browsers",
+			"sessions.debug.chatPills.cancel",
+			"sessions.debug.chatPills.ciFailed",
+			"sessions.debug.chatPills.ciPending",
+			"sessions.debug.chatPills.clear",
+			"sessions.debug.chatPills.deletions",
+			"sessions.debug.chatPills.description",
+			"sessions.debug.chatPills.files",
+			"sessions.debug.chatPills.inputBanners",
+			"sessions.debug.chatPills.insertions",
+			"sessions.debug.chatPills.markdownFiles",
+			"sessions.debug.chatPills.nonNegativeInteger",
+			"sessions.debug.chatPills.prFeedback",
+			"sessions.debug.chatPills.subagents",
+			"sessions.debug.chatPills.title",
+			"sessions.debug.showFakeChatPills",
+			"sessionsChatPillsDebugAvailable"
+		],
+		"vs/sessions/contrib/chat/browser/sessionReferenceCompletions": [
+			"currentSessionLabel",
+			"untitledSession"
+		],
 		"vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp": [
+			"sessionsChat.backgroundActivities",
 			"sessionsChat.changes",
+			"sessionsChat.closeChat",
+			"sessionsChat.contextReferences",
+			"sessionsChat.conversations",
 			"sessionsChat.customizations",
+			"sessionsChat.deleteChat",
 			"sessionsChat.filesView",
 			"sessionsChat.history",
 			"sessionsChat.input",
@@ -5167,12 +5712,17 @@
 			"sessionsChat.mobileConfig",
 			"sessionsChat.navigateNextSession",
 			"sessionsChat.navigatePreviousSession",
+			"sessionsChat.openPullRequest",
 			"sessionsChat.overview",
+			"sessionsChat.quickChat",
 			"sessionsChat.sessionsView",
+			"sessionsChat.toggleSidePanel",
+			"sessionsChat.viewAllChanges",
 			"sessionsChat.workspace"
 		],
 		"vs/sessions/contrib/chat/browser/sessionTypePicker": [
 			"sessionTypePicker.ariaLabel",
+			"sessionTypePicker.itemAriaLabel",
 			"sessionTypePicker.triggerAriaLabel"
 		],
 		"vs/sessions/contrib/chat/browser/sessionWorkspacePicker": [
@@ -5198,6 +5748,13 @@
 			"activeFile",
 			"fileEntryDescription"
 		],
+		"vs/sessions/contrib/chat/browser/voiceInputDecorations": [
+			"voiceMode.bargeInHint",
+			"voiceMode.bargeInHintNoKb",
+			"voiceMode.clickMicOrBargeInHint",
+			"voiceMode.listening",
+			"voiceMode.pttOrBargeInHint"
+		],
 		"vs/sessions/contrib/chat/browser/webWorkspacePicker": [
 			"scopedWorkspacePicker.selectFolder"
 		],
@@ -5209,15 +5766,34 @@
 			"sessions.runCodeReview",
 			"sessions.runCodeReview.tooltip"
 		],
+		"vs/sessions/contrib/editor/browser/addTabActions": [
+			"newBrowserTab",
+			"newChangesTab",
+			"newFileTab",
+			"newSearchTab"
+		],
 		"vs/sessions/contrib/editor/browser/editor.contribution": [
 			"addFileAsContext",
 			"closeMainEditorPart",
+			"hideMainEditorPart",
 			"maximizeMainEditorPart",
 			"openEditorInModal",
 			"openModalEditorInEditor",
-			"pullEditorLeft",
-			"pushEditorRight",
 			"restoreMainEditorPart"
+		],
+		"vs/sessions/contrib/editor/browser/emptyFileEditor": [
+			"emptyFileEditor.description",
+			"emptyFileEditor.search",
+			"emptyFileEditor.searchAria",
+			"emptyFileEditor.searchAriaNoKeybinding",
+			"emptyFileEditor.searchTooltip",
+			"emptyFileEditor.searchTooltipNoKeybinding"
+		],
+		"vs/sessions/contrib/editor/browser/emptyFileEditor.contribution": [
+			"emptyFileEditor.label"
+		],
+		"vs/sessions/contrib/editor/browser/emptyFileEditorInput": [
+			"emptyFileEditor.name"
 		],
 		"vs/sessions/contrib/files/browser/files.contribution": [
 			"collapseExplorerFolders",
@@ -5235,6 +5811,52 @@
 		"vs/sessions/contrib/files/browser/filesView": [
 			"filesView.noFiles"
 		],
+		"vs/sessions/contrib/files/browser/workspaceFolderActions": [
+			"agentSessions.files",
+			"agentSessions.openFilesView.ariaLabel",
+			"agentSessions.openFilesView.tooltip"
+		],
+		"vs/sessions/contrib/github/browser/pullRequestActions": [
+			"agentSessions.openPullRequest",
+			"agentSessions.openPullRequest.tooltip",
+			"agentSessions.openPullRequest.tooltipWithNumber"
+		],
+		"vs/sessions/contrib/github/browser/pullRequestHover": [
+			"agentSessions.pullRequestHover.baseFallback",
+			"agentSessions.pullRequestHover.bodyFallback",
+			"agentSessions.pullRequestHover.headFallback",
+			"agentSessions.pullRequestHover.onDate",
+			"agentSessions.pullRequestHover.titleFallback"
+		],
+		"vs/sessions/contrib/layout/browser/baseSessionLayoutController": [
+			"agentSecondarySidebarToggleClosedIcon",
+			"agentSecondarySidebarToggleOpenIcon",
+			"openAndCloseSidePanel",
+			"sidePanelHidden",
+			"sidePanelVisible",
+			"toggleSecondarySidebar"
+		],
+		"vs/sessions/contrib/layout/browser/sessions.layout.contribution": [
+			"sessions.layout.autoCollapseSessionsSidebar",
+			"sessions.layout.singlePaneDetailPanel"
+		],
+		"vs/sessions/contrib/layout/browser/singlePane/singlePaneResponsiveSidebarStrategy": [
+			"toggleDetails"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour": [
+			"sessions.onboarding.isolation.description",
+			"sessions.onboarding.isolation.title",
+			"sessions.onboarding.workspace.description",
+			"sessions.onboarding.workspace.title"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTour": [
+			"sessions.onboarding.newSessionView.harness.description",
+			"sessions.onboarding.newSessionView.harness.title",
+			"sessions.onboarding.newSessionView.isolation.description",
+			"sessions.onboarding.newSessionView.isolation.title",
+			"sessions.onboarding.newSessionView.workspace.description",
+			"sessions.onboarding.newSessionView.workspace.title"
+		],
 		"vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked": [
 			"accountGate.approvedOrgs",
 			"accountGate.aria",
@@ -5251,6 +5873,39 @@
 			"policyBlocked.openVSCode",
 			"policyBlocked.title"
 		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution": [
+			"sessions.promptTimeline.rail",
+			"sessions.promptTimeline.stickyHeader"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineActions": [
+			"promptTimeline.category",
+			"promptTimeline.emptyPrompt",
+			"promptTimeline.goToPrompt",
+			"promptTimeline.nFiles",
+			"promptTimeline.oneFile",
+			"promptTimeline.pickPlaceholder",
+			"promptTimeline.statDetail"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineCard": [
+			"promptTimeline.groupedCount",
+			"promptTimeline.nFiles",
+			"promptTimeline.noEdits",
+			"promptTimeline.oneFile",
+			"promptTimeline.reviewChangesForPrompt"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineModel": [
+			"promptTimeline.reviewTitle",
+			"promptTimeline.tick",
+			"promptTimeline.tickGrouped"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail": [
+			"promptTimeline.railLabel"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader": [
+			"promptTimeline.emptyPrompt",
+			"promptTimeline.stickyCount",
+			"promptTimeline.stickyLabel"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker": [
 			"agentHostAgentPicker"
 		],
@@ -5259,9 +5914,23 @@
 			"agentHostClaudePermissionModePicker.triggerAriaLabel",
 			"permissions.learnMore"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostCodexApprovalsPicker": [
+			"agentHostCodexApprovalsPicker.ariaLabel",
+			"agentHostCodexApprovalsPicker.triggerAriaLabel",
+			"codexApprovals.learnMore"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
 			"agentHostModePicker.ariaLabel",
 			"agentHostModePicker.triggerAriaLabel"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate": [
+			"agentHostPermissionPicker.allowAll.detail",
+			"agentHostPermissionPicker.approveWhenSafe.detail",
+			"agentHostPermissionPicker.askWhenNeeded.detail",
+			"agentHostPermissionPicker.assistedHover",
+			"agentHostPermissionPicker.autoApproveHover",
+			"agentHostPermissionPicker.autopilotApprovalsHover",
+			"agentHostPermissionPicker.defaultApprovalsHover"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
 			"copySessionBranchName"
@@ -5271,15 +5940,11 @@
 			"lastTurnChangesDescription"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker": [
-			"agentHostAutoApprove.autopilot.warning.detail",
-			"agentHostAutoApprove.autopilot.warning.title",
-			"agentHostAutoApprove.bypass.warning.detail",
-			"agentHostAutoApprove.bypass.warning.title",
-			"agentHostAutoApprove.warning.cancel",
-			"agentHostAutoApprove.warning.confirm",
-			"agentHostAutoApprove.warning.detailWithDefaultSetting",
 			"agentHostNewSessionApprovePicker",
+			"agentHostNewSessionCodexApprovalsPicker",
 			"agentHostNewSessionModePicker",
+			"agentHostNewSessionPermissionModePicker",
+			"agentHostRunningSessionCodexApprovalsPicker",
 			"agentHostRunningSessionConfigPicker",
 			"agentHostRunningSessionModePicker",
 			"agentHostRunningSessionPermissionModePicker",
@@ -5289,6 +5954,8 @@
 			"agentHostSessionConfig.boolean.onLabel",
 			"agentHostSessionConfig.boolean.true",
 			"agentHostSessionConfig.filter",
+			"agentHostSessionConfig.isolation.worktree",
+			"agentHostSessionConfig.policyDisabled",
 			"agentHostSessionConfig.triggerAria",
 			"agentHostSessionConfig.triggerAriaReadOnly",
 			"agentHostSessionConfigPicker",
@@ -5297,8 +5964,7 @@
 			"mobileAgentHostSessionConfig.repoSheet.branchSearchPlaceholder",
 			"mobileAgentHostSessionConfig.repoSheet.branchSection",
 			"mobileAgentHostSessionConfig.repoSheet.isolationSection",
-			"mobileAgentHostSessionConfig.repoSheet.title",
-			"selected"
+			"mobileAgentHostSessionConfig.repoSheet.title"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSettings.contribution": [
 			"agentHostSettings.label",
@@ -5328,9 +5994,15 @@
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider": [
 			"copilotCLI",
+			"deleteChat.confirm",
+			"deleteChat.delete",
+			"deleteChat.detail",
+			"new chat",
 			"new session",
+			"newChatTab",
 			"noAgents",
-			"notConnectedSend"
+			"notConnectedSend",
+			"sessionNotCommitted"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
 			"exportAgentHostDebugLogs"
@@ -5344,11 +6016,15 @@
 		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
 			"openSessionEventsFile"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/openSubagentChat": [
+			"chat.subagent.openChat",
+			"chat.subagent.openChat.aria"
+		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker": [
-			"branchPicker.ariaLabel",
-			"branchPicker.filter",
 			"branchPicker.select",
-			"branchPicker.triggerAriaLabel"
+			"isolationMode.worktree",
+			"isolationPicker.checkboxAriaLabel",
+			"isolationPicker.noGitRepo"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker": [
 			"claude.permissionMode.acceptEdits",
@@ -5371,8 +6047,6 @@
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
 			"branchPicker",
 			"claudePermissionModePicker",
-			"deleteSession",
-			"isolationPicker",
 			"modePicker",
 			"permissionPicker"
 		],
@@ -5394,29 +6068,13 @@
 			"deleteChat.confirm",
 			"deleteChat.delete",
 			"deleteChat.detail",
-			"deleteSession.confirm",
-			"deleteSession.delete",
-			"deleteSession.detail",
-			"deleteSession.detailMultiple",
 			"new chat",
 			"new session",
 			"repositories",
 			"sessionWorkspaceGroup.github"
 		],
-		"vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker": [
-			"isolationMode.folder",
-			"isolationMode.worktree",
-			"isolationPicker.ariaLabel",
-			"isolationPicker.triggerAriaLabel"
-		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/mobilePermissionPicker": [
 			"permissionPicker.title",
-			"permissions.autoApprove",
-			"permissions.autoApprove.subtext",
-			"permissions.autopilot",
-			"permissions.autopilot.subtext",
-			"permissions.default",
-			"permissions.default.subtext",
 			"permissions.learnMore"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker": [
@@ -5427,17 +6085,19 @@
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/permissionPicker": [
 			"permissionPicker.ariaLabel",
 			"permissionPicker.triggerAriaLabel",
+			"permissionPicker.triggerAriaLabelWithDescription",
+			"permissions.assisted",
+			"permissions.assisted.description",
+			"permissions.assisted.subtext",
 			"permissions.autoApprove",
-			"permissions.autoApprove.label",
 			"permissions.autoApprove.subtext",
 			"permissions.autopilot",
 			"permissions.autopilot.description",
-			"permissions.autopilot.label",
 			"permissions.autopilot.subtext",
 			"permissions.default",
-			"permissions.default.label",
 			"permissions.default.subtext",
-			"permissions.learnMore"
+			"permissions.learnMore",
+			"permissions.policyDescription"
 		],
 		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution": [
 			"sessions.chat.localAgent.enabled"
@@ -5538,6 +6198,10 @@
 			"tunnelNoneFound",
 			"tunnelPickPlaceholder",
 			"tunnelPickTitle",
+			"updateRemoteAgentHost",
+			"updateRemoteAgentHost.none",
+			"updateRemoteAgentHost.noneUpgradable",
+			"updateRemoteAgentHost.pick",
 			"wslConnectFailed",
 			"wslConnecting",
 			"wslDistroDefault",
@@ -5610,21 +6274,53 @@
 			},
 			"openSearch"
 		],
+		"vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners": [
+			"ci.checksFailed",
+			"ci.checksFailedPending",
+			"ci.dismiss",
+			"ci.fixChecks",
+			"ci.oneCheckFailed",
+			"ci.revealChecks",
+			"comments.address",
+			"comments.agent.many",
+			"comments.agent.one",
+			"comments.dismiss",
+			"comments.many",
+			"comments.one",
+			"comments.pr.many",
+			"comments.pr.one",
+			"comments.reveal"
+		],
 		"vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget": [
 			"customizations"
 		],
+		"vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel": [
+			"nSessionsFailingCI",
+			"nSessionsQuestion",
+			"nSessionsRequireInput",
+			"nSessionsTerminalApproval",
+			"oneSessionFailingCI",
+			"oneSessionQuestion",
+			"oneSessionRequiresInput",
+			"oneSessionTerminalApproval"
+		],
+		"vs/sessions/contrib/sessions/browser/blockedSessionsList": [
+			"ciFailureIgnored",
+			"ignoreCIFailure",
+			"ignoreInputNeeded",
+			"inputNeededIgnored",
+			"sessionsRequiringInput"
+		],
 		"vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution": [
 			"agents",
-			"customizationAction",
+			"automations",
 			"hooks",
 			"instructions",
 			"mcpServers",
+			"overview",
 			"plugins",
-			"sessions.customizations.sidebarMode",
-			"sessions.customizations.sidebarMode.section",
-			"sessions.customizations.sidebarMode.single",
-			"sessions.customizations.sidebarMode.welcome",
-			"skills"
+			"skills",
+			"tools"
 		],
 		"vs/sessions/contrib/sessions/browser/mobile/mobileOverlayContribution": [
 			"mobileChangesNotAvailable",
@@ -5633,8 +6329,7 @@
 		],
 		"vs/sessions/contrib/sessions/browser/sessionHoverContent": [
 			"agentSessions.fileChanged",
-			"agentSessions.filesChanged",
-			"agentSessions.newSession"
+			"agentSessions.filesChanged"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"agentSessions.view.label",
@@ -5644,19 +6339,27 @@
 				"comment": [
 					"&& denotes a mnemonic"
 				]
-			}
+			},
+			"sessions.list.showEmptyDefaultGroups"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsActions": [
 			"chatCompositeBar.addChat",
+			"chatCompositeBar.addChat.compact",
 			"chatCompositeBar.close",
+			"chatCompositeBar.conversations",
 			"chatCompositeBar.maximize",
 			"chatCompositeBar.pin",
 			"chatCompositeBar.pinView",
+			"chatCompositeBar.reopenLastClosedChat",
 			"chatCompositeBar.unmaximize",
 			"chatCompositeBar.unpin",
 			"chatCompositeBar.unpinView",
+			"closeActiveChat",
+			"closeAllChats",
 			"closeAllSessions",
+			"closedChatsGroup",
 			"closeEditorArea",
+			"deleteActiveChat",
 			"focusActiveSession",
 			"focusLastSessionInGrid",
 			"focusSessionInGrid",
@@ -5672,34 +6375,66 @@
 					"&& denotes a mnemonic"
 				]
 			},
+			"navigateNextChat",
+			"navigatePreviousChat",
+			"newChatButtonAriaLabel",
+			"newChatButtonAriaLabelWithoutKeybinding",
+			"newChatButtonTitle",
+			"newChatButtonTitleWithoutKeybinding",
+			"newCompact",
 			"newSession",
+			"newSessionButtonAriaLabel",
+			"newSessionButtonAriaLabelWithoutKeybinding",
+			"newSessionButtonTitle",
+			"newSessionButtonTitleWithoutKeybinding",
+			"openChatsGroup",
 			"otherSessions",
+			"quickSwitchNextChat",
+			"quickSwitchPreviousChat",
 			"recentlyOpened",
 			"renameSessionHeader",
+			"searchChats",
 			"searchSessions",
 			"sessionsGoBack",
 			"sessionsGoBackTooltip",
 			"sessionsGoForward",
 			"sessionsGoForwardTooltip",
+			"showChatsPicker",
 			"showSessionsPicker",
-			"untitledSession"
+			"untitledChat"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget": [
 			"agentSessionsControl",
 			"agentSessionsShowSessions",
-			"newSession",
+			"nSessionsApproved",
+			"oneSessionApproved",
+			"showAllSessions",
 			"showSessions"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
+			"addToGroupAction",
 			"allowAction",
 			"allowActionOnce",
 			"archived",
+			"chatsSection",
+			"ci.blockedRow",
+			"ci.fixCI",
+			"ci.fixCITooltip",
+			"createGroupAction",
+			"deleteGroupAction",
 			"failed",
-			"lastSevenDays",
+			"moveToGroupAction",
 			"needsInput",
+			"newGroupName",
+			"noChats",
 			"older",
+			"pendingVoiceResponse",
 			"pinned",
+			"recent",
+			"removeFromGroupAction",
+			"renameGroupAction",
 			"secondsDuration",
+			"sessionGroupName",
 			"sessionItemAria",
 			"sessions.dragLabel",
 			"sessionsList",
@@ -5713,21 +6448,14 @@
 			"showMoreWorkspaceCompact",
 			"showMoreWorkspacesAria",
 			"showMoreWorkspacesCompact",
-			"today",
 			"unknown",
-			"working",
-			"yesterday"
+			"working"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsView": [
 			"filterArchived",
 			"filterRead",
 			"groupByTime",
 			"groupByWorkspace",
-			"newCompact",
-			"newSessionButtonAriaLabel",
-			"newSessionButtonAriaLabelWithoutKeybinding",
-			"newSessionButtonTitle",
-			"newSessionButtonTitleWithoutKeybinding",
 			"resetFilters",
 			"sessionsHeader",
 			"sortByCreated",
@@ -5741,6 +6469,10 @@
 			"statusNeedsInput"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
+			"archiveGroupSessions.archive",
+			"archiveGroupSessions.confirm",
+			"archiveGroupSessions.confirmSingle",
+			"archiveGroupSessions.detail",
 			"archivePinnedSectionSessions.confirm",
 			"archivePinnedSectionSessions.confirmSingle",
 			"archiveSection",
@@ -5751,22 +6483,30 @@
 			"archiveSession",
 			"closeSession",
 			"collapseAllGroups",
+			"deleteSession",
+			"deleteSession.confirm",
+			"deleteSession.delete",
+			"deleteSession.detail",
+			"deleteSession.error",
+			"deleteSessions.confirm",
+			"deleteSessions.error",
 			"doNotAskAgain",
-			"doNotAskAgain2",
 			"filter",
 			"filterSessions",
 			"find",
 			"groupByTime",
 			"groupByWorkspace",
+			"markAllInGroupAsDone",
 			"markAllRead",
-			"markAsDone",
 			"markRead",
 			"markUnread",
 			"navigateNextSession",
 			"navigateNextSession.mnemonic",
 			"navigatePreviousSession",
 			"navigatePreviousSession.mnemonic",
+			"newQuickChat",
 			"newSessionForWorkspace",
+			"newSessionInGroup",
 			"openToTheSide",
 			"pinSession",
 			"refresh",
@@ -5778,9 +6518,6 @@
 			"showRecentSessions",
 			"sortByCreated",
 			"sortByUpdated",
-			"unarchiveSection",
-			"unarchiveSectionSessions.confirm",
-			"unarchiveSectionSessions.unarchive",
 			"unarchiveSession",
 			"unpinSession"
 		],
@@ -5793,24 +6530,8 @@
 			"openInTerminal",
 			"showAllTerminals"
 		],
-		"vs/sessions/contrib/tunnelHost/electron-browser/toggleRemoteConnectionsActionViewItem": [
-			"tunnelHost.hover.connecting",
-			"tunnelHost.hover.enabled",
-			"tunnelHost.hover.idle",
-			"tunnelHost.hover.sharing",
-			"tunnelHost.hover.showOutput",
-			"tunnelHost.toast"
-		],
 		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution": [
-			"showTunnelHostOutput",
-			"toggleSharing",
-			"tunnelHost.category",
-			"tunnelHost.enableMicrosoftAuth",
-			"tunnelHost.error"
-		],
-		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHostService": [
-			"tunnelHost.noAuth",
-			"tunnelHost.outputChannel"
+			"toggleSharing"
 		],
 		"vs/sessions/electron-browser/actions/vscodeActions": [
 			"openInVSCode",
@@ -5823,11 +6544,10 @@
 			"join.closeStorage"
 		],
 		"vs/sessions/services/sessions/common/session": [
+			"agentSessions.newChat",
+			"agentSessions.newSession",
 			"sessionWorkspaceGroup.local",
 			"sessionWorkspaceGroup.remote"
-		],
-		"vs/sessions/services/sessions/common/sessionsManagement": [
-			"activeSessionSupportsMultiChat"
 		],
 		"vs/sessions/services/workspace/browser/workspaceContextService": [
 			"agentsWindow"
@@ -6865,6 +7585,7 @@
 			"filteredTypes.typeParameter",
 			"filteredTypes.variable",
 			"icons",
+			"showEditorType",
 			"symbolpath",
 			"symbolpath.last",
 			"symbolpath.off",
@@ -6887,6 +7608,7 @@
 			"cmd.toggle",
 			"cmd.toggle.short",
 			"cmd.toggle2",
+			"editorType.hover",
 			"empty",
 			{
 				"key": "miBreadcrumbs2",
@@ -7490,7 +8212,8 @@
 			"groupAriaLabelLong",
 			"groupLabel",
 			"groupLabelLong",
-			"moveErrorDetails"
+			"moveErrorDetails",
+			"reopenWith"
 		],
 		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
 			"watermark.findInFiles",
@@ -7614,6 +8337,15 @@
 			"ariaLabelEditorActionsLayout",
 			"draggedEditorGroup"
 		],
+		"vs/workbench/browser/parts/editor/editorTypePicker": [
+			"builtinProviderDisplayName",
+			"editorType.labelWithSource",
+			"editorType.openModified",
+			"editorType.openOriginal",
+			"editorType.setDefault",
+			"editorType.setDefaultDiff",
+			"textDiffEditor"
+		],
 		"vs/workbench/browser/parts/editor/modalEditorPart": [
 			"modalEditorPart",
 			"navigationCounter",
@@ -7622,6 +8354,7 @@
 			"toggleSidebar"
 		],
 		"vs/workbench/browser/parts/editor/multiEditorTabsControl": [
+			"addTab",
 			"ariaLabelTabActions"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
@@ -7900,6 +8633,7 @@
 			}
 		],
 		"vs/workbench/browser/parts/titlebar/menubarControl": [
+			"cancellingUpdate",
 			{
 				"key": "checkForUpdates",
 				"comment": [
@@ -8171,6 +8905,7 @@
 			"menuBarVisibility",
 			"menuBarVisibility.mac",
 			"mergeWindow",
+			"modernUI",
 			"mouseBackForwardToNavigate",
 			{
 				"key": "navigationControlEnabled",
@@ -8849,6 +9584,12 @@
 			"accessibility.signals.terminalQuickFix",
 			"accessibility.signals.terminalQuickFix.announcement",
 			"accessibility.signals.terminalQuickFix.sound",
+			"accessibility.signals.voiceModeStarted",
+			"accessibility.signals.voiceModeStarted.announcement",
+			"accessibility.signals.voiceModeStarted.sound",
+			"accessibility.signals.voiceModeStopped",
+			"accessibility.signals.voiceModeStopped.announcement",
+			"accessibility.signals.voiceModeStopped.sound",
 			"accessibility.signals.voiceRecordingStarted",
 			"accessibility.signals.voiceRecordingStarted.sound",
 			"accessibility.signals.voiceRecordingStopped",
@@ -8871,6 +9612,7 @@
 			"sound.enabled.on",
 			"speechLanguage.auto",
 			"terminal.integrated.accessibleView.closeOnKeyPress",
+			"verbosity.automations",
 			"verbosity.chat.description",
 			"verbosity.chatQuestionCarousel",
 			"verbosity.comments",
@@ -8887,7 +9629,9 @@
 			"verbosity.notification",
 			"verbosity.replEditor.description",
 			"verbosity.scm",
+			"verbosity.sessionsChanges",
 			"verbosity.sessionsChat",
+			"verbosity.survey",
 			"verbosity.terminal.description",
 			"verbosity.terminalChatOutput.description",
 			"verbosity.walkthrough",
@@ -8963,77 +9707,47 @@
 			"openDiffEditorAnnouncement"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution": [
-			"agents.voice.alwaysOnTop",
 			"agents.voice.backendUrl",
 			"agents.voice.enabled",
-			"agents.voice.textToSpeech",
+			"agents.voice.handsFree",
+			"agents.voice.language",
+			"agents.voice.language.auto",
+			"agents.voice.language.de",
+			"agents.voice.language.en",
+			"agents.voice.language.es",
+			"agents.voice.language.fr",
+			"agents.voice.language.it",
+			"agents.voice.language.ja",
+			"agents.voice.language.ko",
+			"agents.voice.language.pt",
+			"agents.voice.language.zh",
+			"agents.voice.liveTranscript",
+			"agents.voice.showTranscript",
+			"agents.voice.speakResponses",
+			"agents.voice.turn.silenceMs",
+			"agents.voice.turn.silenceMs.disabled",
+			"agents.voice.turn.stopPhrases",
+			"agents.voice.voice",
+			"agents.voice.voice.daniel",
+			"agents.voice.voice.kevin",
+			"agents.voice.voice.maya",
+			"agents.voice.voice.victoria",
+			"agentsVoice.cancelActiveRequest",
+			"agentsVoice.connecting",
+			"agentsVoice.disconnect",
+			"agentsVoice.openSettings",
+			"agentsVoice.pttStopInChat",
+			"agentsVoice.selectMicrophone",
+			"agentsVoice.simulateConnection",
+			"agentsVoice.startVoiceInChat",
 			"agentsVoiceConfigurationTitle",
 			"agentsVoicePushToTalk",
+			"current",
+			"noMicrophones",
 			"resetAgentsVoiceOnboarding",
-			"toggleAgentsVoiceWindow"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget": [
-			"agentsVoice.feedbackError"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidgetBinding": [
-			"agentsVoice.chat",
-			"agentsVoice.otherSessions",
-			"agentsVoice.untitledSession"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/confirmationComponent": [
-			"agentsVoice.approve",
-			"agentsVoice.deny",
-			"agentsVoice.openInVSCode"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/feedbackDialog": [
-			"agentsVoice.cancel",
-			"agentsVoice.feedbackConsent",
-			"agentsVoice.feedbackError",
-			"agentsVoice.feedbackPlaceholder",
-			"agentsVoice.feedbackThanks",
-			"agentsVoice.sendFeedback",
-			"agentsVoice.submit",
-			"agentsVoice.submitting"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/headerComponent": [
-			"agentsVoice.configureKeybinding",
-			"agentsVoice.disconnect",
-			"agentsVoice.minimize",
-			"agentsVoice.openMiniView",
-			"agentsVoice.pushToTalkSpace",
-			"agentsVoice.sendFeedback"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/onboardingComponent": [
-			"agentsVoice.changeHotkeySuffix",
-			"agentsVoice.changePttKey",
-			"agentsVoice.configureHotkey",
-			"agentsVoice.connecting",
-			"agentsVoice.feedbackDesc",
-			"agentsVoice.getStarted",
-			"agentsVoice.miniViewSuffix",
-			"agentsVoice.openMiniView",
-			"agentsVoice.pttDesc",
-			"agentsVoice.pttHoldDesc",
-			"agentsVoice.welcomeDesc",
-			"agentsVoice.welcomeTitle"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/sessionListComponent": [
-			"agentsVoice.approve",
-			"agentsVoice.deny",
-			"agentsVoice.newSession",
-			"agentsVoice.noActiveSessions",
-			"agentsVoice.openInVSCode",
-			"agentsVoice.openSessionAction",
-			"agentsVoice.sendTo",
-			"agentsVoice.sendToActive",
-			"agentsVoice.stop",
-			"agentsVoice.stopSessionAction"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/statusRowsComponent": [
-			"agentsVoice.done",
-			"agentsVoice.needsInput",
-			"agentsVoice.noActiveSessions",
-			"agentsVoice.working"
+			"selectMic",
+			"systemDefault",
+			"unknownDevice"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscripts.contribution": [
 			"agentsVoice.showTranscripts",
@@ -9143,6 +9857,12 @@
 			},
 			"accountPreferences",
 			"accounts",
+			{
+				"key": "agentHostMcpServers",
+				"comment": [
+					"The placeholder {0} is the name of an agent host, e.g. a remote machine or the local machine"
+				]
+			},
 			"manageMcpServers",
 			"manageTrustedMcpServers",
 			"manageTrustedMcpServers.cancel",
@@ -9265,7 +9985,7 @@
 			"browserFullPageScreenshot",
 			"browserScreenshot",
 			"consoleLogs",
-			"workbench.browser.agentHostChatToolsEnabled"
+			"workbench.browser.sendElementsToChat.attachImages"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorEmulationFeatures": [
 			"browser.device.dimensionsLabel",
@@ -9386,6 +10106,27 @@
 			},
 			"browser.urlPlaceholder"
 		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserPermissionsFeature": [
+			"browser.device.kind.bluetooth",
+			"browser.device.kind.hid",
+			"browser.device.kind.serial",
+			"browser.device.kind.usb",
+			"browser.device.placeholder",
+			"browser.device.title",
+			"browser.managePermissions",
+			"browser.permissions.allow",
+			"browser.permissions.block",
+			"browser.permissions.noOrigin",
+			"browser.permissions.placeholder",
+			"browser.permissions.prompt",
+			"browser.permissions.saveMany",
+			"browser.permissions.saveOne",
+			"browser.permissions.state.allowed",
+			"browser.permissions.state.ask",
+			"browser.permissions.state.blocked",
+			"browser.permissions.state.default",
+			"browser.permissions.title"
+		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserRemoteFeatures": [
 			"browser.connectedLocally.file",
 			"browser.connectedLocally.generic",
@@ -9410,6 +10151,30 @@
 			"browser.linkOpenedHint.label",
 			"browser.linkOpenedHint.openSettings",
 			"browser.newTabAction",
+			{
+				"comment": [
+					"This is the description for a setting."
+				],
+				"key": "browser.newTabPlacement"
+			},
+			{
+				"comment": [
+					"This is the description for a setting."
+				],
+				"key": "browser.newTabPlacement.activeGroup"
+			},
+			{
+				"comment": [
+					"This is the description for a setting."
+				],
+				"key": "browser.newTabPlacement.sideGroup"
+			},
+			{
+				"comment": [
+					"This is the description for a setting."
+				],
+				"key": "browser.newTabPlacement.window"
+			},
 			"browser.openAction",
 			"browser.openFileAction",
 			{
@@ -9701,6 +10466,7 @@
 			"singleCodeBlockHint",
 			"singleFileTreeHint",
 			"singleTableHint",
+			"toolAuthenticationHint",
 			"toolInvocationsHint",
 			"toolInvocationsHintDetails",
 			"toolInvocationsHintKb",
@@ -9712,6 +10478,10 @@
 			"notificationDetail"
 		],
 		"vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView": [
+			"autoModeResolutionA11y",
+			"autoModeResolutionA11yFallback",
+			"autoModeResolutionA11yNonReasoning",
+			"autoModeResolutionA11yReasoning",
 			"binaryOutput",
 			"errored",
 			"extensionsList",
@@ -9726,6 +10496,7 @@
 			"thinkingContent",
 			"todoItem",
 			"todoListCount",
+			"toolAuthenticationA11yView",
 			"toolPostApprovalA11yView"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions": [
@@ -9739,10 +10510,12 @@
 			"toggleThinkingContentAccessibleView"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
+			"chat.agentHostApprovalsPicker",
 			"chat.announcement",
 			"chat.attachments.removal",
 			"chat.differencePanel",
 			"chat.differenceQuick",
+			"chat.fileChangesDisclosure",
 			"chat.focusMostRecentTerminal",
 			"chat.focusMostRecentTerminalOutput",
 			"chat.focusQuestionCarousel",
@@ -9786,6 +10559,7 @@
 			"inlineChat.requestHistory",
 			"inlineChat.toolbar",
 			"workbench.action.chat.announceConfirmation",
+			"workbench.action.chat.cancelSpeechToText",
 			"workbench.action.chat.editing.attachFiles",
 			"workbench.action.chat.focus",
 			"workbench.action.chat.focusAgentSessionsViewer",
@@ -9798,6 +10572,7 @@
 			"workbench.action.chat.openAgentHostFolderPicker",
 			"workbench.action.chat.previousUserPrompt",
 			"workbench.action.chat.restoreLastCheckpoint",
+			"workbench.action.chat.toggleSpeechToText",
 			"workbench.action.chat.undoEdits",
 			"workbench.action.openAgentsWindow"
 		],
@@ -9837,6 +10612,7 @@
 			"insertTroubleshootSlashCommand",
 			"insertTroubleshootSlashCommand.short",
 			"interactiveSession.clearHistory.label",
+			"interactiveSession.compactAgentHostConversation.label",
 			"interactiveSession.focusInput.label",
 			"interactiveSession.focusQuestionCarousel.label",
 			"interactiveSession.focusQuestionCarouselTerminal.label",
@@ -9905,6 +10681,9 @@
 			"workbench.action.chat.attachSelection.label"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatContinueInAction": [
+			"chat.delegation.inlinePrompt",
+			"chat.delegation.transcriptContent",
+			"chat.delegation.transcriptName",
 			"chat.learnMore",
 			"continueChatInSession",
 			"continueChatInSession",
@@ -10033,6 +10812,7 @@
 			"chatDebugLog.openExportedFile"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatPluginActions": [
+			"installFromSourceFailed",
 			"installPluginFromSource",
 			"localMarketplace",
 			"managedMarketplace",
@@ -10072,6 +10852,19 @@
 			"toggle.isPartialQuery",
 			"toggle.query"
 		],
+		"vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions": [
+			"chat.speechToText.cancel",
+			"chat.speechToText.hold",
+			"chat.speechToText.preparing",
+			"chat.speechToText.selectMicrophone",
+			"chat.speechToText.start",
+			"chat.speechToText.stop",
+			"chatStt.current",
+			"chatStt.noMicrophones",
+			"chatStt.selectMic",
+			"chatStt.systemDefault",
+			"chatStt.unknownDevice"
+		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"chat.retry.confirmation.checkbox",
 			"chat.retry.confirmation.message2",
@@ -10104,6 +10897,11 @@
 			"configToolSets",
 			"configureTools",
 			"defaultBucketLabel",
+			"deleteToolSet.confirm.detail",
+			"deleteToolSet.confirm.message",
+			"deleteToolSet.confirm.primary",
+			"deleteToolSet.error",
+			"deleteUserBucket",
 			"editUserBucket",
 			"manageToolApproval",
 			"mcpShowOutput",
@@ -10155,6 +10953,8 @@
 			"exportDebugLogs.folderDialogTitle",
 			"exportDebugLogs.noFiles.activeSession",
 			"exportDebugLogs.noFiles.currentWindow",
+			"exportDebugLogs.privacyWarning",
+			"exportDebugLogs.privacyWarning.internal",
 			"exportDebugLogs.saveError"
 		],
 		"vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction": [
@@ -10188,6 +10988,11 @@
 			"cloneFailed",
 			"preparingMarketplace",
 			"pullFailed",
+			"purgeAndRecloneMarketplace",
+			"purgeMarketplaceFailed",
+			"purgeMarketplaceSuccess",
+			"purgingMarketplace",
+			"recloningMarketplace",
 			"showGitOutput",
 			"updatingPlugin"
 		],
@@ -10204,30 +11009,62 @@
 			"noAgentPlugins",
 			"update"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider": [
+			"alwaysAdded",
+			"alwaysIncluded",
+			"contextInstructions"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth": [
+			"agentHost.signInDialogTitle",
+			"agentHost.signInFailed"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution": [
-			"agentHost.displayName",
 			"agentHostHarnessLabel.local"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
+			"agentHostChatInputPicker.approvalsHover",
+			"agentHostChatInputPicker.approvalsLevelHoverReadOnly",
 			"agentHostChatInputPicker.ariaLabel",
+			"agentHostChatInputPicker.assistedApprovalsHover",
+			"agentHostChatInputPicker.autoApproveHover",
+			"agentHostChatInputPicker.autopilotApprovalsHover",
 			"agentHostChatInputPicker.boolean.false",
 			"agentHostChatInputPicker.boolean.offLabel",
 			"agentHostChatInputPicker.boolean.onLabel",
 			"agentHostChatInputPicker.boolean.true",
+			"agentHostChatInputPicker.defaultApprovalsHover",
 			"agentHostChatInputPicker.filter",
 			"agentHostChatInputPicker.learnMorePermissions",
+			"agentHostChatInputPicker.policyDisabledHover",
 			"agentHostChatInputPicker.triggerAria",
-			"agentHostChatInputPicker.triggerAriaReadOnly",
-			"selected"
+			"agentHostChatInputPicker.triggerAriaReadOnly"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution": [
 			"agentHost.autoApprovePicker",
+			"agentHost.codexApprovalsPicker",
 			"agentHost.folderPicker",
 			"agentHost.modePicker",
 			"agentHost.permissionModePicker"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService": [
+			"agentHost.mcpServer.authRequired",
+			"agentHost.mcpServer.disabled",
+			"agentHost.mcpServer.error",
+			"agentHost.mcpServer.outputChannel",
+			"agentHost.mcpServer.ready",
+			"agentHost.mcpServer.starting",
+			"agentHost.mcpServer.stopped"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostDownloadProgress": [
+			"agentHost.download.megabytes",
+			"agentHost.download.percent",
+			"agentHost.download.titleFallback"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem": [
 			"agentHost.selectFolder"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider": [
+			"agentHost.auto.discount"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution": [
 			"agentHost.permission.allow",
@@ -10241,19 +11078,69 @@
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler": [
 			"agentHost.authRequired",
 			"agentHost.elicit.url.cancel",
-			"agentHost.elicit.url.instruction",
 			"agentHost.elicit.url.open",
 			"agentHost.elicit.url.title",
 			"agentHost.forkedSessionLabel",
-			"agentHost.responseDetails.credit",
-			"agentHost.responseDetails.credits",
-			"agentHost.turnError"
+			"agentHost.mcpToolAuthentication.cancelled",
+			"agentHost.mcpToolAuthentication.cancelledError",
+			"agentHost.otherClientTool.skipped",
+			"agentHost.otherClientTool.skippedError",
+			"agentHost.preparingSession",
+			"agentHost.sessionLoadFailed",
+			"agentHost.sessionLoadFailedLabel",
+			"agentHost.turnError",
+			"agentHost.workspaceTrust"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSettings.contribution": [
+			"agentHostSettings.label",
+			"openAgentHostSettings"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSettingsFileSystemProvider": [
+			"agentHostSettings.header",
+			"agentHostSettings.notObject",
+			"agentHostSettings.parseError",
+			"agentHostSettings.saveHint"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
 			"agentHostTerminal.local"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentSessionSettings.contribution": [
+			"agentSessionSettings.label",
+			"openAgentSessionSettings"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentSessionSettingsFileSystemProvider": [
+			"chatAgentSessionSettings.header",
+			"chatAgentSessionSettings.notObject",
+			"chatAgentSessionSettings.parseError",
+			"chatAgentSessionSettings.saveHint"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/importLocalConversationToAgentSession": [
+			"chat.importConversation.subagent",
+			"chat.importConversation.toolFailed"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter": [
-			"ahp.running"
+			"agentFeedback.many",
+			"agentFeedback.one",
+			"agentFeedback.reveal",
+			"agentFeedback.reviewMessage",
+			"agentFeedback.reviewTitle",
+			"agentHost.elicit.url.instruction",
+			"agentHost.elicit.url.title",
+			"agentHost.otherClientTool.running",
+			"agentHost.responseDetails.credit",
+			"agentHost.responseDetails.credits",
+			"agentHost.responseDetails.resolvedModel",
+			"chat.inputRequest.boolean.false",
+			"chat.inputRequest.boolean.true",
+			"contextAttribution.category.system",
+			"contextAttribution.category.userContext",
+			"contextAttribution.label.mcpTools",
+			"contextAttribution.label.messages",
+			"contextAttribution.label.plugins",
+			"contextAttribution.label.skills",
+			"contextAttribution.label.subAgents",
+			"contextAttribution.label.toolDefinitions",
+			"contextAttribution.label.toolResults"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionHoverWidget": [
 			"agentSessionCompleted",
@@ -10268,6 +11155,8 @@
 			"agentSessionReadIndicatorForeground",
 			"agentSessionSelectedBadgeBorder",
 			"agentSessionSelectedUnfocusedBadgeBorder",
+			"chat.session.providerDescription.agentHostCodex",
+			"chat.session.providerDescription.agentHostCopilot",
 			"chat.session.providerDescription.background",
 			"chat.session.providerDescription.claude",
 			"chat.session.providerDescription.cloud",
@@ -10405,6 +11294,7 @@
 			"date.fromNow.days.multiple.ago",
 			"date.fromNow.days.singular",
 			"date.fromNow.days.singular.ago",
+			"pendingVoiceResponse",
 			"secondsDuration"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/experiments/agentSessionProjection": [
@@ -10486,6 +11376,9 @@
 		"vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability": [
 			"chat.sessionType.noModels",
 			"chat.sessionType.noModelsHover",
+			"chat.sessionType.signInHover",
+			"chat.sessionType.signInLink",
+			"chat.sessionType.signInMobile",
 			"chat.sessionType.upgradeHover",
 			"chat.sessionType.upgradeLink",
 			"chat.sessionType.upgradeMobile"
@@ -10493,6 +11386,7 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons": [
 			"aiCustomizationAddIcon",
 			"aiCustomizationAgentIcon",
+			"aiCustomizationAutomationIcon",
 			"aiCustomizationBuiltinIcon",
 			"aiCustomizationExtensionIcon",
 			"aiCustomizationHookIcon",
@@ -10502,6 +11396,7 @@
 			"aiCustomizationPromptIcon",
 			"aiCustomizationRunIcon",
 			"aiCustomizationSkillIcon",
+			"aiCustomizationToolsIcon",
 			"aiCustomizationUserIcon",
 			"aiCustomizationViewIcon",
 			"aiCustomizationWorkspaceIcon"
@@ -10655,6 +11550,8 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor": [
 			"agents",
 			"agentsDesc",
+			"automations",
+			"automationsDesc",
 			"backToList",
 			"backToListTooltip",
 			"backToMcpList",
@@ -10663,6 +11560,10 @@
 			"backToOverviewTooltip",
 			"backToPluginList",
 			"backToPluginListTooltip",
+			"backToPromptMigration",
+			"backToPromptMigrationTooltip",
+			"backToToolsList",
+			"backToToolsListTooltip",
 			"cancelSaveTarget",
 			"customizationPreviewAriaLabel",
 			"editorActionButtonFailed",
@@ -10680,9 +11581,14 @@
 			"instructions",
 			"instructionsDesc",
 			"learnMoreModels",
+			"learnMoreSkills",
 			"localHarnessLabel",
 			"mcpServers",
 			"mcpServersDesc",
+			"migrationShortcutAriaLabel",
+			"migrationShortcutAriaLabelWithCount",
+			"migrationShortcutLabel",
+			"migrationShortcutTooltip",
 			"models",
 			"modelsDesc",
 			"modelsDescription",
@@ -10694,6 +11600,34 @@
 			"previewNoBody",
 			"previewNoFrontMatter",
 			"previewUnknownFieldDescription",
+			"promptMigrationConfirmButton",
+			"promptMigrationConfirmDetailUser",
+			"promptMigrationConfirmDetailWorkspace",
+			"promptMigrationConfirmDetailWorkspaceAndUser",
+			"promptMigrationConfirmMessage",
+			"promptMigrationConverted",
+			"promptMigrationConvertedWithReview",
+			"promptMigrationDeletePromptFilesCheckbox",
+			"promptMigrationFilesFailed",
+			"promptMigrationFilesFailedWithRemainder",
+			"promptMigrationNoFilesConverted",
+			"promptMigrationNoSkillFolders",
+			"promptMigrationPageButton",
+			"promptMigrationPageButtonTooltip",
+			"promptMigrationPageButtonWithCount",
+			"promptMigrationPageDescription",
+			"promptMigrationPageDescriptionUser",
+			"promptMigrationPageDescriptionWorkspace",
+			"promptMigrationPageDescriptionWorkspaceAndUser",
+			"promptMigrationPageEmpty",
+			"promptMigrationPageTitle",
+			"promptMigrationPickWorkspaceSkillFolder",
+			"promptMigrationSearchEmpty",
+			"promptMigrationSearchPlaceholder",
+			"promptMigrationSelectAriaLabel",
+			"promptMigrationSelectGroupAriaLabel",
+			"promptMigrationUserGroup",
+			"promptMigrationWorkspaceGroup",
 			"prompts",
 			"promptsDesc",
 			"saveBuiltinCopyAndChooseLocation",
@@ -10705,10 +11639,10 @@
 			"saved",
 			"sectionAriaLabelWithCount",
 			"sectionsAriaLabel",
-			"selectHarness",
-			"selectTargetDirectory",
 			"skills",
 			"skillsDesc",
+			"tools",
+			"toolsDesc",
 			"userSaveTarget",
 			"workspaceSaveTarget"
 		],
@@ -10721,6 +11655,8 @@
 			"agentsDesc",
 			"browse",
 			"browseCategoryAriaLabel",
+			"convertPromptFilesAriaLabel",
+			"convertToSkills",
 			"gettingStartedDesc",
 			"gettingStartedTitle",
 			"hooks",
@@ -10729,19 +11665,105 @@
 			"instructionsDesc",
 			"mcpServers",
 			"mcpServersDesc",
+			"migratePromptFiles",
 			"new",
 			"newCategoryAriaLabel",
 			"plugins",
 			"pluginsDesc",
+			"promptMigrationCardDescriptionUser",
+			"promptMigrationCardDescriptionWorkspace",
+			"promptMigrationCardDescriptionWorkspaceAndUser",
 			"sentToChat",
 			"skills",
 			"skillsDesc",
+			"tools",
+			"toolsDesc",
 			"welcomeHeadingWithHarness",
 			"welcomeSubtitle",
 			"workflowInputAriaLabel",
 			"workflowInputPlaceholder",
 			"workflowSubmitAriaLabel",
 			"workflowSubmitTooltip"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/automationsAccessibilityHelp": [
+			"automations.help.actionDelete",
+			"automations.help.actionEdit",
+			"automations.help.actionHistory",
+			"automations.help.actionRun",
+			"automations.help.actionsHeader",
+			"automations.help.actionToggle",
+			"automations.help.closingDesc",
+			"automations.help.closingHeader",
+			"automations.help.dialogFields",
+			"automations.help.dialogHeader",
+			"automations.help.dialogValidation",
+			"automations.help.header",
+			"automations.help.historyDesc",
+			"automations.help.historyHeader",
+			"automations.help.intro",
+			"automations.help.layoutDesc",
+			"automations.help.layoutHeader",
+			"automations.help.settingsHeader",
+			"automations.help.settingVerbosity",
+			"automations.help.statusDesc",
+			"automations.help.statusHeader"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget": [
+			"automationAriaLabel",
+			"automationAriaLabelDisabled",
+			"automationCreatedStatus",
+			"automationCreateFailed",
+			"automationDeletedStatus",
+			"automationDisabled",
+			"automationDisabledStatus",
+			"automationEnabledStatus",
+			"automationFolderLabel",
+			"automationQuickChatLabel",
+			"automationQuickChatTitle",
+			"automationsDisabledDetail",
+			"automationsDisabledTitle",
+			"automationsEmptyCta",
+			"automationsEmptyMessage",
+			"automationsEmptyTitle",
+			"automationsHeaderSubtitle",
+			"automationsHeaderTitle",
+			"automationsListAriaLabel",
+			"automationStartedStatus",
+			"automationUpdatedStatus",
+			"automationUpdateFailed",
+			"confirmDeleteAutomation",
+			"confirmDeleteAutomationDetail",
+			"delete",
+			"deleteAutomation",
+			"disableAutomation",
+			"editAutomation",
+			"enableAutomation",
+			"hideHistory",
+			"historyAriaLabel",
+			"historyMore",
+			"lastRun",
+			"newAutomation",
+			"newAutomationTooltip",
+			"nextRun",
+			"nextRunNever",
+			"noRunsYet",
+			"openRunSession",
+			"openRunSessionFailed",
+			"runHistory",
+			"runNow",
+			"runStarted",
+			"runStatusCompleted",
+			"runStatusFailed",
+			"runStatusPending",
+			"runStatusRunning",
+			"runTriggerCatchUp",
+			"runTriggerManual",
+			"runTriggerSchedule",
+			"scheduleDaily",
+			"scheduleHourly",
+			"scheduleManual",
+			"scheduleWeekly",
+			"showHistory"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService": [
 			"generateName",
@@ -10756,19 +11778,47 @@
 			"pluginSourceMarketplace",
 			"pluginSourceMarketplaceUnknown"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedExtensionToolsDetail": [
+			"toolDetailBy",
+			"toolDetailEmpty",
+			"toolDetailIncludedTools",
+			"toolDetailLoadingTools",
+			"toolDetailNoTools",
+			"toolDetailToolsError",
+			"toolDetailToolsLoaded",
+			"toolDetailToolsLoadedOne"
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail": [
 			"mcpDetailEmpty",
 			"mcpScopeUser",
 			"mcpScopeWorkspace"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/galleryItemRenderer": [
+			"galleryItemBy",
+			"galleryItemInstall",
+			"galleryItemInstalled",
+			"galleryItemInstalling"
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget": [
+			"activeSessionMcpServerOptions",
+			"activeSessionMcpServerStart",
+			"activeSessionMcpServerStop",
 			"addMcpServer",
 			"addServer",
 			"addServerTooltip",
+			"agentHostMcpServerDisable",
+			"agentHostMcpServerDisableForWorkspace",
+			"agentHostMcpServerEnable",
+			"agentHostMcpServerEnableForWorkspace",
+			"authRequired",
 			"backToInstalled",
 			"browseMarketplace",
 			"builtInGroup",
 			"builtInGroupDescription",
+			"builtinMcpServerDisable",
+			"builtinMcpServerDisableForWorkspace",
+			"builtinMcpServerEnable",
+			"builtinMcpServerEnableForWorkspace",
 			"collapsed",
 			"confirmUninstallPluginMcp",
 			"confirmUninstallPluginMcpDetail",
@@ -10780,9 +11830,6 @@
 			"extensionGroupDescription",
 			"fromPlugin",
 			"galleryError",
-			"install",
-			"installed",
-			"installing",
 			"learnMoreMcp",
 			"loadingGallery",
 			"mcpAccessDisabledByPolicy",
@@ -10791,6 +11838,7 @@
 			"mcpAccessDisabledTitle",
 			"mcpBrowseBack",
 			"mcpGroupAriaLabel",
+			"mcpServerAriaLabelWithStatus",
 			"mcpServers",
 			"mcpServersDescription",
 			"mcpServersListAriaLabel",
@@ -10802,7 +11850,12 @@
 			"running",
 			"searchGalleryPlaceholder",
 			"searchMcpPlaceholder",
+			"sessionMcpServerDisable",
+			"sessionMcpServerEnable",
+			"showMcpServerOutput",
 			"showPlugin",
+			"signIn",
+			"signInToMcpServer",
 			"starting",
 			"stopped",
 			"tryAgainLater",
@@ -10817,10 +11870,10 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget": [
 			"addPlugin",
 			"addRemotePlugins",
+			"backToInstalledPlugins",
 			"browseMarketplace",
 			"browseMarketplaceUnsupportedWeb",
 			"browseToAdd",
-			"byPublisher",
 			"collapsed",
 			"createPlugin",
 			"disabledGroup",
@@ -10831,10 +11884,7 @@
 			"enabledGroupDescription",
 			"enablePlugin",
 			"expanded",
-			"install",
-			"installed",
 			"installFromSource",
-			"installing",
 			"learnMorePlugins",
 			"loadingMarketplace",
 			"marketplaceError",
@@ -10843,6 +11893,7 @@
 			"noMatchingPlugins",
 			"noPlugins",
 			"noRemotePlugins",
+			"pluginBrowseBack",
 			"pluginGroupAriaLabel",
 			"pluginInstalledItemAriaLabelDisabled",
 			"pluginInstalledItemAriaLabelEnabled",
@@ -10873,6 +11924,53 @@
 			"onContextTooltip",
 			"uiIntegrationBadge"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/toolsListWidget": [
+			"clientToolSet.copilotCli.description",
+			"clientToolSet.copilotCli.detail",
+			"confirmUninstallToolExtension",
+			"confirmUninstallToolExtensionDetail",
+			"copilotCliTool.applyPatch",
+			"copilotCliTool.askUser",
+			"copilotCliTool.create",
+			"copilotCliTool.edit",
+			"copilotCliTool.glob",
+			"copilotCliTool.grep",
+			"copilotCliTool.listAgents",
+			"copilotCliTool.listShell",
+			"copilotCliTool.readAgent",
+			"copilotCliTool.readShell",
+			"copilotCliTool.shell",
+			"copilotCliTool.skill",
+			"copilotCliTool.stopShell",
+			"copilotCliTool.task",
+			"copilotCliTool.view",
+			"copilotCliTool.webFetch",
+			"copilotCliTool.writeShell",
+			"learnMoreTools",
+			"noMatchingTools",
+			"searchPlaceholder",
+			"toolsBrowseBack",
+			"toolsBrowseError",
+			"toolsBrowseLoading",
+			"toolsBrowseMarketplace",
+			"toolsBrowseNoResults",
+			"toolsBrowsePlaceholder",
+			"toolsBrowseTryAgain",
+			"toolsListSubtitle",
+			"toolsListTitle",
+			"toolsMarketplaceAria",
+			"toolsNoMatches",
+			"toolsRowEnabledOfTotal",
+			"toolsSearchAria",
+			"toolsSetCheckbox",
+			"toolsSetExtensionDetail",
+			"toolsSetReadOnly",
+			"toolsToolCheckbox",
+			"toolsTreeAria",
+			"tryDifferentSearch",
+			"uninstallExtension",
+			"uninstallExtensionBtn"
+		],
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentResolveService": [
 			"imageTooLarge",
 			"imageTooLargeMessage"
@@ -10885,6 +11983,8 @@
 			"chat.attachment.saveImageButton",
 			"chat.attachment.saveImageError",
 			"chat.attachment.withDeleteHint",
+			"chat.autoImageAttachment",
+			"chat.autoImageAttachmentHover",
 			"chat.browserToolsDisabled",
 			"chat.browserToolsDisabled.aria",
 			"chat.browserViewAttachment.aria",
@@ -10907,7 +12007,6 @@
 			"chat.folderImageLimitExceededHover",
 			"chat.imageAttachment",
 			"chat.imageAttachmentHover",
-			"chat.imageAttachmentPreviewFeaturesDisabled",
 			"chat.imageAttachmentWarning",
 			"chat.imageLimitExceededAttachment",
 			"chat.imageLimitExceededHover",
@@ -10924,6 +12023,7 @@
 			"chat.terminalCommandHoverCommandTitle",
 			"chat.terminalCommandHoverCommandTitleExit",
 			"chat.terminalCommandHoverOutputTitle",
+			"chat.unsupportedImageAttachment",
 			"instructions",
 			"instructions.label",
 			"prompt",
@@ -10977,9 +12077,17 @@
 			"chat.agent.thinkingMode.collapsedPreview",
 			"chat.agent.thinkingMode.fixedScrolling",
 			"chat.agent.thinkingStyle",
+			"chat.agentHost.agentDebugLog.enabled",
+			"chat.agentHost.agentDebugLog.maxEventsInMemory",
 			"chat.agentHost.ahpJsonlLogging",
-			"chat.agentHost.clientTools",
+			"chat.agentHost.copilotSdk.logLevel",
+			"chat.agentHost.copilotSdk.logLevel.info",
+			"chat.agentHost.copilotSdk.logLevel.trace",
 			"chat.agentHost.customTerminalTool.enabled",
+			"chat.agentHost.modelCapabilityOverrides",
+			"chat.agentHost.modelCapabilityOverrides.family",
+			"chat.agentHost.opus48Prompt.enabled",
+			"chat.agentHost.reasoningEffortOverride",
 			"chat.agentHost.sdkSandbox.enabled",
 			"chat.agentHost.sdkSandbox.enabled.allowNetwork",
 			"chat.agentHost.sdkSandbox.enabled.off",
@@ -11013,14 +12121,33 @@
 			"chat.artifacts.rules.byMimeType",
 			"chat.artifacts.rules.groupName",
 			"chat.artifacts.rules.onlyShowGroup",
+			"chat.assistedPermissions.enabled",
 			"chat.autopilot.advanced.enabled",
 			"chat.autoReply.description",
+			"chat.byokUtilityModelDefault.copilot.description",
+			"chat.byokUtilityModelDefault.copilot.label",
+			"chat.byokUtilityModelDefault.description",
+			"chat.byokUtilityModelDefault.mainAgent.description",
+			"chat.byokUtilityModelDefault.mainAgent.label",
+			"chat.byokUtilityModelDefault.none.description",
+			"chat.byokUtilityModelDefault.none.label",
 			"chat.checkpoints.enabled",
 			"chat.checkpoints.showFileChanges",
 			"chat.codeBlock.showProgressAnimation.description",
 			"chat.contextUsage.enabled",
-			"chat.customizations.harnessSelector.enabled",
+			"chat.customizations.promptMigration.enabled",
 			"chat.customizations.structuredPreview.enabled",
+			"chat.defaultConfiguration.approvals.allowAll",
+			"chat.defaultConfiguration.approvals.assisted",
+			"chat.defaultConfiguration.approvals.default",
+			"chat.defaultConfiguration.approvals.description",
+			"chat.defaultConfiguration.mode.autopilot",
+			"chat.defaultConfiguration.mode.description",
+			"chat.defaultConfiguration.mode.interactive",
+			"chat.defaultConfiguration.mode.plan",
+			"chat.defaultConfiguration.settingDescription",
+			"chat.defaultModel.description",
+			"chat.defaultModel.policy",
 			"chat.detectParticipant.enabled",
 			"chat.disableAIFeatures",
 			"chat.editing.autoAcceptDelay",
@@ -11029,11 +12156,12 @@
 			"chat.editing.explainChanges.enabled",
 			"chat.editing.openChangedFileInDiffEditor",
 			"chat.editing.revealNextChangeOnResolve",
-			"chat.editMode.hidden",
 			"chat.editor.claude.preferAgentHost",
+			"chat.editor.codex.preferAgentHost",
 			"chat.editorAssociations",
 			"chat.editRequests",
 			"chat.exitAfterDelegation",
+			"chat.experimental.collectInstructionsInExtension",
 			"chat.experimental.detectParticipant.enabled",
 			"chat.experimental.detectParticipant.enabled.deprecated",
 			"chat.experimental.incrementalRendering.animationStyle",
@@ -11049,18 +12177,19 @@
 			"chat.experimental.incrementalRendering.buffering.paragraph",
 			"chat.experimental.incrementalRendering.buffering.word",
 			"chat.experimental.incrementalRendering.enabled",
+			"chat.experimental.permissionsSandboxToggle.enabled",
 			"chat.experimentalSessionsWindowOverride",
 			"chat.exploreAgent.defaultModel.description",
 			"chat.extensionToolsEnabled",
 			"chat.extensionUnification.enabled",
 			"chat.fontFamily",
 			"chat.fontSize",
-			"chat.generalPurposeAgent.enabled",
 			"chat.growthNotification",
 			"chat.hookFilesLocations.description",
 			"chat.hookFilesLocations.invalidPath",
 			"chat.hookFilesLocations.title",
 			"chat.implicitContext.enabled.1",
+			"chat.implicitContext.includeActiveEditor",
 			"chat.implicitContext.suggestedContext",
 			"chat.implicitContext.value",
 			"chat.implicitContext.value.always",
@@ -11081,6 +12210,11 @@
 			"chat.mcp.access.any",
 			"chat.mcp.access.none",
 			"chat.mcp.access.registry",
+			"chat.mcp.allowedServers",
+			"chat.mcp.allowedServers.policy",
+			"chat.mcp.allowedServers.serverCommand",
+			"chat.mcp.allowedServers.serverName",
+			"chat.mcp.allowedServers.serverUrl",
 			"chat.mcp.assisted.nuget.enabled.description",
 			"chat.mcp.autostart",
 			"chat.mcp.autostart.never",
@@ -11089,6 +12223,11 @@
 			"chat.mcp.collisionBehavior",
 			"chat.mcp.collisionBehavior.disable",
 			"chat.mcp.collisionBehavior.suffix",
+			"chat.mcp.deniedServers",
+			"chat.mcp.deniedServers.policy",
+			"chat.mcp.deniedServers.serverCommand",
+			"chat.mcp.deniedServers.serverName",
+			"chat.mcp.deniedServers.serverUrl",
 			"chat.mcp.gallery.enabled",
 			"chat.mcp.serverSampling",
 			"chat.mcp.serverSampling.allowedDuringChat",
@@ -11136,10 +12275,19 @@
 			"chat.restoreLastPanelSession",
 			"chat.reusablePrompts.config.locations.description",
 			"chat.reusablePrompts.config.locations.title",
-			"chat.sendElementsToChat.attachImages",
 			"chat.sessionSync.enabled",
 			"chat.sessionSync.enabled.policy",
 			"chat.sessionSync.excludeRepositories",
+			"chat.speechToText.enabled",
+			"chat.speechToText.mode.auto",
+			"chat.speechToText.mode.description",
+			"chat.speechToText.mode.pushToTalk",
+			"chat.speechToText.mode.toggle",
+			"chat.speechToText.model",
+			"chat.speechToText.model.base",
+			"chat.speechToText.model.nemotron",
+			"chat.speechToText.model.small",
+			"chat.speechToText.model.tiny",
 			"chat.subagents.allowInvocationsFromSubagents",
 			"chat.subagents.allowInvocationsFromSubagents.md",
 			"chat.tips.enabled",
@@ -11156,6 +12304,11 @@
 			"chat.tools.riskAssessment.model",
 			"chat.tools.terminal.simpleCollapsible",
 			"chat.tools.todos.showWidget",
+			"chat.turnStatusPills",
+			"chat.turnStatusPills.browser",
+			"chat.turnStatusPills.changes",
+			"chat.turnStatusPills.objectDeprecated",
+			"chat.turnStatusPills.preview",
 			"chat.undoRequests.restoreInput",
 			"chat.unifiedAgentsBar.enabled",
 			"chat.upvoteAnimation",
@@ -11182,6 +12335,7 @@
 			"chat.useSkillAdherencePrompt.title",
 			"chat.utilityModel.description",
 			"chat.utilitySmallModel.description",
+			"chat.verbose",
 			"chat.viewProgressBadge.enabled",
 			"chat.viewSessions.enabled",
 			"chat.viewSessions.orientation",
@@ -11202,6 +12356,68 @@
 			"mcp.enterpriseManagedAuth.idp.policy",
 			"mcp.gallery.serviceUrl",
 			"mcp.list"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider": [
+			"agentHost.debug.aborted",
+			"agentHost.debug.agentDiscovery",
+			"agentHost.debug.compaction",
+			"agentHost.debug.compactionFailed",
+			"agentHost.debug.compactionTokens",
+			"agentHost.debug.customizationDisabled",
+			"agentHost.debug.customizationDiscovery",
+			"agentHost.debug.customizationLoaded",
+			"agentHost.debug.customizationLoadedSkipped",
+			"agentHost.debug.customizationsResolved",
+			"agentHost.debug.customizationsResolvedDetails",
+			"agentHost.debug.fullPrompt",
+			"agentHost.debug.hookDiscovery",
+			"agentHost.debug.hookError",
+			"agentHost.debug.hookErrorContext",
+			"agentHost.debug.hookFailed",
+			"agentHost.debug.hookRan",
+			"agentHost.debug.hookRecoverable",
+			"agentHost.debug.hookUnrecoverable",
+			"agentHost.debug.mcpDiscovery",
+			"agentHost.debug.modelChanged",
+			"agentHost.debug.modelChangeEffort",
+			"agentHost.debug.modelChangeFromTo",
+			"agentHost.debug.permissionIntention",
+			"agentHost.debug.permissionKind",
+			"agentHost.debug.permissionPath",
+			"agentHost.debug.permissionPending",
+			"agentHost.debug.permissionPendingValue",
+			"agentHost.debug.permissionResolved",
+			"agentHost.debug.permissionResult",
+			"agentHost.debug.promptDiscovery",
+			"agentHost.debug.reasoning",
+			"agentHost.debug.response",
+			"agentHost.debug.ruleDiscovery",
+			"agentHost.debug.sessionCliVersion",
+			"agentHost.debug.sessionError",
+			"agentHost.debug.sessionErrorTyped",
+			"agentHost.debug.sessionRepoBranch",
+			"agentHost.debug.sessionStarted",
+			"agentHost.debug.sessionStartedDetails",
+			"agentHost.debug.sessionStartedModel",
+			"agentHost.debug.sessionWarning",
+			"agentHost.debug.sessionWarningTyped",
+			"agentHost.debug.skillDiscovery",
+			"agentHost.debug.skillInvoked",
+			"agentHost.debug.subagentModel",
+			"agentHost.debug.subagentName",
+			"agentHost.debug.subagentTokens",
+			"agentHost.debug.subagentToolCalls",
+			"agentHost.debug.unknownError",
+			"agentHost.debug.untitledSession",
+			"agentHost.debug.userRequest"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources": [
+			"agentHostLogs.channel",
+			"agentHostLogs.cliLog",
+			"agentHostLogs.events",
+			"agentHostLogs.remoteProcess",
+			"agentHostLogs.wire",
+			"agentHostLogs.wireN"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatCustomizationDiscoveryRenderer": [
 			"chatDebug.configureLocations",
@@ -11285,6 +12501,7 @@
 			"chatDebug.cache.modelTurn",
 			"chatDebug.cache.msChip",
 			"chatDebug.cache.noFindings",
+			"chatDebug.cache.noSignatureNote",
 			"chatDebug.cache.notPresent",
 			"chatDebug.cache.noTurns",
 			"chatDebug.cache.noTurnsForAgents",
@@ -11443,6 +12660,11 @@
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditorInput": [
 			"chatDebugEditorLabelIcon",
 			"chatDebugInputName"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEnablement": [
+			"chatDebug.loggingDisabled",
+			"chatDebug.openSetting",
+			"chatDebug.wireLogLoggingDisabled"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventDetailRenderer": [
 			"chatDebug.detail.agent",
@@ -11607,6 +12829,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView": [
 			"chatDebug.agentFlowChart",
+			"chatDebug.ahpLog",
 			"chatDebug.cacheExplorer",
 			"chatDebug.detail.created",
 			"chatDebug.detail.lastActivity",
@@ -11645,6 +12868,51 @@
 			"chatDebug.toolCall.statusLabel",
 			"chatDebug.toolCall.success",
 			"chatDebug.toolCall.toolLabel"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugWireLogView": [
+			"chatDebug.ahpLog",
+			"chatDebug.title",
+			"chatDebug.wireLog.badge.notification",
+			"chatDebug.wireLog.badge.request",
+			"chatDebug.wireLog.badge.response",
+			"chatDebug.wireLog.chip.errors",
+			"chatDebug.wireLog.chip.frames",
+			"chatDebug.wireLog.chip.pending",
+			"chatDebug.wireLog.chip.requests",
+			"chatDebug.wireLog.chip.slowest",
+			"chatDebug.wireLog.disabledHint",
+			"chatDebug.wireLog.empty",
+			"chatDebug.wireLog.enableToCapture",
+			"chatDebug.wireLog.error",
+			"chatDebug.wireLog.filterAria",
+			"chatDebug.wireLog.filterPlaceholder",
+			"chatDebug.wireLog.footerRemote",
+			"chatDebug.wireLog.footerTail",
+			"chatDebug.wireLog.frameId",
+			"chatDebug.wireLog.inbound",
+			"chatDebug.wireLog.loading",
+			"chatDebug.wireLog.loadMore",
+			"chatDebug.wireLog.loadMoreTitle",
+			"chatDebug.wireLog.ms",
+			"chatDebug.wireLog.noFrames",
+			"chatDebug.wireLog.noMatches",
+			"chatDebug.wireLog.notAgentHost",
+			"chatDebug.wireLog.openFile",
+			"chatDebug.wireLog.outbound",
+			"chatDebug.wireLog.refresh",
+			"chatDebug.wireLog.responseLabel",
+			"chatDebug.wireLog.s",
+			"chatDebug.wireLog.section.error",
+			"chatDebug.wireLog.section.params",
+			"chatDebug.wireLog.section.responseError",
+			"chatDebug.wireLog.section.result",
+			"chatDebug.wireLog.showingCount",
+			"chatDebug.wireLog.sourceLabel",
+			"chatDebug.wireLog.statusError",
+			"chatDebug.wireLog.statusErrorCode",
+			"chatDebug.wireLog.statusPending",
+			"chatDebug.wireLog.truncatedFrame",
+			"chatDebug.wireLog.unavailable"
 		],
 		"vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions": [
 			"accept",
@@ -11770,7 +13038,8 @@
 			"diff.generic"
 		],
 		"vs/workbench/contrib/chat/browser/chatImageCarouselService": [
-			"chatImageCarousel.allImages"
+			"chatImageCarousel.allImages",
+			"chatImageCarousel.currentInput"
 		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution": [
 			"enableChatForByok",
@@ -11788,6 +13057,8 @@
 		"vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget": [
 			"cacheCost.ariaLabel.plural",
 			"cacheCost.ariaLabel.singular",
+			"cacheWriteCost.ariaLabel.plural",
+			"cacheWriteCost.ariaLabel.singular",
 			"capabilities",
 			"capability.agent",
 			"capability.tools",
@@ -11796,9 +13067,12 @@
 			"collapse",
 			"collapseAll",
 			"cost",
-			"cost.cache",
 			"cost.cacheHover.plural",
 			"cost.cacheHover.singular",
+			"cost.cacheRead",
+			"cost.cacheWrite",
+			"cost.cacheWriteHover.plural",
+			"cost.cacheWriteHover.singular",
 			"cost.input",
 			"cost.inputHover.plural",
 			"cost.inputHover.singular",
@@ -11821,11 +13095,15 @@
 			"models.agentMode",
 			"models.cacheCost.plural",
 			"models.cacheCost.singular",
+			"models.cacheWriteCost.plural",
+			"models.cacheWriteCost.singular",
 			"models.capabilities",
 			"models.configureModel",
 			"models.contextSize",
 			"models.deleteAction",
 			"models.deleteConfirmation",
+			"models.deprecation.link.label",
+			"models.deprecation.link.tooltip",
 			"models.enableModelProvider",
 			"models.goToSettings",
 			"models.hideGroup",
@@ -11836,6 +13114,8 @@
 			"models.installProviderExtensions",
 			"models.longContextCacheCost.plural",
 			"models.longContextCacheCost.singular",
+			"models.longContextCacheWriteCost.plural",
+			"models.longContextCacheWriteCost.singular",
 			"models.longContextInputCost.plural",
 			"models.longContextInputCost.singular",
 			"models.longContextOutputCost.plural",
@@ -11913,6 +13193,10 @@
 			"showExtension",
 			"vscode.extension.contributes.chatParticipant"
 		],
+		"vs/workbench/contrib/chat/browser/chatPromoNotification": [
+			"chat.promo.endsAt",
+			"chat.promo.tryModel"
+		],
 		"vs/workbench/contrib/chat/browser/chatQuotaNotification": [
 			"manageBudget",
 			"manageBudget2",
@@ -11921,6 +13205,7 @@
 			"quota.approaching.free",
 			"quota.approaching.managed",
 			"quota.approaching.overageEnabled",
+			"quota.approaching.switchToAuto",
 			"quota.approaching.title",
 			"quota.blocked.managed",
 			"quota.blocked.managed.title",
@@ -11932,10 +13217,20 @@
 			"quota.exhausted.title",
 			"quota.overage.desc",
 			"quota.overage.title",
+			"quota.trajectory.learnMoreStandalone",
+			"quota.trajectory.learnMoreTooltip",
+			{
+				"key": "quota.trajectory.message",
+				"comment": [
+					"{Locked=\"[\"}",
+					"{Locked=\"]({0})\"}"
+				]
+			},
 			"rateLimit.resets",
 			"rateLimit.session",
 			"rateLimit.weekly",
 			"signIn",
+			"switchToAuto",
 			"upgrade",
 			"upgrade2"
 		],
@@ -11970,6 +13265,7 @@
 			"chatSessionsExtPoint.inputPlaceholder",
 			"chatSessionsExtPoint.name",
 			"chatSessionsExtPoint.order",
+			"chatSessionsExtPoint.requiresCopilotSignIn",
 			"chatSessionsExtPoint.requiresCustomModels",
 			"chatSessionsExtPoint.supportsAutoModel",
 			"chatSessionsExtPoint.supportsFileAttachments",
@@ -12145,6 +13441,8 @@
 			"manageBudget",
 			"modelLabel",
 			"premiumChatsLabel",
+			"premiumCreditsUsed",
+			"premiumCreditsUsedCompact",
 			"premiumIncluded",
 			"premiumIncludedCompact",
 			"premiumLimitReached",
@@ -12181,17 +13479,19 @@
 			"upgrade"
 		],
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry": [
-			"chatAndCompletionsQuotaExceededStatus",
 			"chatQuotaExceededStatus",
-			"chatSessionInProgressStatus",
-			"chatSessionsInProgressStatus",
+			"chatResumedStatus",
 			"chatStatus",
 			"chatStatusAria",
 			"completionsDisabledStatus",
-			"completionsQuotaExceededStatus",
 			"completionsSnoozedStatus",
 			"copilotDisabledStatus",
 			"signIn"
+		],
+		"vs/workbench/contrib/chat/browser/chatTerminalCommandPaste": [
+			"paste",
+			"pasteAndDontAskAgain",
+			"terminalCommandPasteWarning"
 		],
 		"vs/workbench/contrib/chat/browser/chatTipCatalog": [
 			"tip.agentsWindow",
@@ -12282,7 +13582,8 @@
 			"cloningSource",
 			"installingPlugin",
 			"invalidSource",
-			"localSourceNotSupported",
+			"localNoPlugins",
+			"localSourceNotFound",
 			"noPluginsFound",
 			"pluginDirInvalid",
 			"pluginDirNotFound",
@@ -12290,6 +13591,7 @@
 			"pluginSourceNotFound",
 			"selectPlugin",
 			"showOutput",
+			"strictMarketplaceBlockedInstall",
 			{
 				"key": "trustAndInstall",
 				"comment": [
@@ -12300,7 +13602,8 @@
 			"trustMarketplaceDetail",
 			"updateAllFailed",
 			"updateAllSuccess",
-			"updatingAllPlugins"
+			"updatingAllPlugins",
+			"viewPolicySettings"
 		],
 		"vs/workbench/contrib/chat/browser/pluginSources": [
 			"checkoutPluginSourceFailed",
@@ -12512,6 +13815,10 @@
 			"configure-tools.capitalized.ellipsis",
 			"placeholder"
 		],
+		"vs/workbench/contrib/chat/browser/promptSyntax/promptToolSetsCodeLensProvider": [
+			"configure-tools.capitalized.ellipsis",
+			"placeholder"
+		],
 		"vs/workbench/contrib/chat/browser/promptSyntax/promptUrlHandler": [
 			"confirmInstallAgent",
 			"confirmInstallInstructions",
@@ -12549,10 +13856,35 @@
 			"configure-skills",
 			"configure-skills.short"
 		],
+		"vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService": [
+			"chatStt.audioError",
+			"chatStt.captureError",
+			"chatStt.connectError",
+			"chatStt.downloading",
+			"chatStt.downloadingPercent",
+			"chatStt.loadingModel",
+			"chatStt.micError",
+			"chatStt.modelError",
+			"chatStt.notSupported",
+			"chatStt.preparingModel"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/dictationSession": [
+			"chatStt.listening"
+		],
 		"vs/workbench/contrib/chat/browser/tools/chatToolRiskAssessmentService": [
 			"riskDefaultGreen",
 			"riskDefaultOrange",
 			"riskDefaultRed"
+		],
+		"vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution": [
+			"clientToolSet.browser.description",
+			"clientToolSet.browser.detail",
+			"clientToolSet.notebooks.description",
+			"clientToolSet.notebooks.detail",
+			"clientToolSet.tasks.description",
+			"clientToolSet.tasks.detail",
+			"clientToolSet.vscode.description",
+			"clientToolSet.vscode.detail"
 		],
 		"vs/workbench/contrib/chat/browser/tools/languageModelToolsConfirmationService": [
 			"allowCombinationGlobally",
@@ -12642,6 +13974,8 @@
 			"bad_name2",
 			"chat.configureToolSets",
 			"chat.configureToolSets.add",
+			"chat.configureToolSets.createFromCurrentSelection",
+			"chat.configureToolSets.fileAlreadyExists",
 			"chat.configureToolSets.placeholder",
 			"chat.configureToolSets.short",
 			"input.placeholder",
@@ -12650,6 +13984,8 @@
 			"schema.icon",
 			"schema.tools",
 			"tool.description",
+			"toolSetName.bad_name",
+			"toolSetName.placeholder",
 			"toolsetSchema.json"
 		],
 		"vs/workbench/contrib/chat/browser/tools/usagesTool": [
@@ -12670,6 +14006,15 @@
 			"chatViewsWelcome.title",
 			"chatViewsWelcome.when",
 			"vscode.extension.contributes.chatViewsWelcome"
+		],
+		"vs/workbench/contrib/chat/browser/voiceClient/micCaptureService": [
+			"mic.hardwareMuted",
+			"mic.permissionDenied"
+		],
+		"vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController": [
+			"voice.connectFailed",
+			"voice.fatalDisconnect",
+			"voice.movedToAnotherWindow"
 		],
 		"vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService": [
 			"agentsVoice.action.approve",
@@ -12707,7 +14052,19 @@
 			"anonymousRateLimited",
 			"enableMoreAIFeatures"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatAutoModeResolutionContentPart": [
+			"autoModeResolution.detail",
+			"autoModeResolution.fallback",
+			"autoModeResolution.nonReasoning",
+			"autoModeResolution.reasoning",
+			"autoModeResolution.title"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart": [
+			"chat.checkpointFileChanges",
+			"chat.fileChanges.accessibleSummary",
+			"chat.fileChanges.manyFiles",
+			"chat.fileChanges.oneFile",
+			"chat.viewFileChangesSummary",
 			"chat.viewFileChangesSummary"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCodeCitationContentPart": [
@@ -12798,6 +14155,11 @@
 			"chat.renderedCodeBlockLabel",
 			"summary"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpAuthenticationContentPart": [
+			"mcp.auth.authenticating",
+			"mcp.auth.multiple",
+			"mcp.auth.single"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersInteractionContentPart": [
 			"mcp.server.options.tooltip",
 			"mcp.skip.link",
@@ -12807,6 +14169,9 @@
 			"mcp.starting",
 			"mcp.starting.servers",
 			"mcp.working.mcp"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersStartingContentPart": [
+			"mcp.starting.servers"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMultiDiffContentPart": [
 			"chatEditingSession.fileCounts",
@@ -12853,6 +14218,7 @@
 			"toolCallUnresponsive"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart": [
+			"chat.questionCarousel.answered",
 			"chat.questionCarousel.collapseTitle",
 			"chat.questionCarousel.combinedFocusTerminalHint",
 			"chat.questionCarousel.combinedFocusTerminalHintNoKb",
@@ -12895,10 +14261,8 @@
 			"submit"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart": [
-			"clickToContinue",
 			"manageBudget",
-			"upgradeToCopilotPro",
-			"waitWarning"
+			"upgradeToCopilotPro"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart": [
 			"addToChat",
@@ -12918,6 +14282,8 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart": [
 			"chat.subagent.completedDefaultDescription",
+			"chat.subagent.creditsTooltip",
+			"chat.subagent.creditTooltip",
 			"chat.subagent.defaultDescription",
 			"chat.subagent.modelTooltip",
 			"chat.subagent.pendingConfirmation",
@@ -12951,6 +14317,7 @@
 			"chat.thinking.deletedFile",
 			"chat.thinking.deletions",
 			"chat.thinking.deletions.one",
+			"chat.thinking.duration.seconds",
 			"chat.thinking.editedFile",
 			"chat.thinking.editingFile",
 			"chat.thinking.editingFiles",
@@ -12976,6 +14343,7 @@
 			"chat.thinking.thinking.5",
 			"chat.thinking.thinking.6",
 			"chat.thinking.titleWithDiff",
+			"chat.thinking.titleWithDuration",
 			"chat.thinking.tool.1",
 			"chat.thinking.tool.2",
 			"chat.thinking.tool.3",
@@ -13020,6 +14388,16 @@
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTreeContentPart": [
 			"treeAriaLabel"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart": [
+			"chat.turnChanges.accessibleSummary",
+			"chat.turnChanges.manyFiles",
+			"chat.turnChanges.oneFile",
+			"chat.turnChanges.preview",
+			"chat.turnChanges.viewAllAccessible",
+			"chat.turnPreview.tooltip",
+			"chat.viewTurnFileChangesSummary",
+			"chatTurnPills.changes.title"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatWorkspaceEditContentPart": [
 			"created",
 			"deleted",
@@ -13044,6 +14422,16 @@
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart": [
 			"skip"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart": [
+			"agentFeedback.cancel",
+			"agentFeedback.collapseComment",
+			"agentFeedback.delete",
+			"agentFeedback.expandComment",
+			"agentFeedback.none",
+			"agentFeedback.openFile",
+			"agentFeedback.reveal",
+			"agentFeedback.revealComment"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart": [
 			"allow",
 			"cancel",
@@ -13060,11 +14448,17 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatModifiedFilesConfirmationSubPart": [
 			"manyFilesChanged",
+			"manyFilesCreated",
 			"modifiedFilesAllChangesTitle",
 			"modifiedFilesCounts",
 			"modifiedFilesSummaryWithCounts",
 			"oneFileChanged",
+			"oneFileCreated",
 			"viewAllChanges"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatOtherClientToolProgressPart": [
+			"agentHost.otherClientTool.runningWithSkip",
+			"agentHost.otherClientTool.runningWithSkip.a11y"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatSandboxPrerequisiteConfirmationSubPart": [
 			"missingDeps.install",
@@ -13123,6 +14517,12 @@
 			"showTerminal",
 			"showTerminalOutput",
 			"terminalToolCommand"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolAuthenticationSubPart": [
+			"chat.toolAuthentication.authenticate",
+			"chat.toolAuthentication.cancel",
+			"chat.toolAuthentication.message",
+			"chat.toolAuthentication.title"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationCarouselPart": [
 			"allow",
@@ -13188,6 +14588,8 @@
 			"chat.planReview.autopilot",
 			"chat.planReview.feedback",
 			"chat.planReview.feedbackInline",
+			"chat.planReview.openFullPlan",
+			"chat.planReview.openFullPlanFile",
 			"chat.planReview.rejected",
 			"chat.planReview.required",
 			"chat.questionCarouselAlertMany",
@@ -13196,6 +14598,9 @@
 			"chat.questionCarouselSignalMany",
 			"chat.questionCarouselSignalOne",
 			"chatConfirmationAction",
+			"chatRequestSentAt",
+			"chatResponseCompletedAt",
+			"chatResponseElapsed",
 			"checkpointRestore",
 			"confirmationPending",
 			"confirmationsPending",
@@ -13214,6 +14619,24 @@
 			"usedAgent",
 			"usedAgentSlashCommand",
 			"working"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner": [
+			"chatReadOnlyBanner.message"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatRestoreCheckpointActionViewItem": [
+			"chat.restoreCheckpoint.cancelTooltip",
+			"chat.restoreCheckpoint.confirm",
+			"chat.restoreCheckpoint.confirmTooltip"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatTurnPills": [
+			"chatTurnPills.ariaLabel",
+			"chatTurnPills.changes.ariaLabel",
+			"chatTurnPills.changes.file",
+			"chatTurnPills.changes.files",
+			"chatTurnPills.changes.tooltip",
+			"chatTurnPills.preview.label",
+			"chatTurnPills.preview.more",
+			"chatTurnPills.preview.tooltipOne"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatWidget": [
 			"agentTitle",
@@ -13263,57 +14686,6 @@
 			"chatInput.mode.edit",
 			"chatInput.model"
 		],
-		"vs/workbench/contrib/chat/browser/widget/input/chatInputStatusActionViewItem": [
-			"chat.inputStatus.otel.manageSettings",
-			"chat.inputStatus.otel.title"
-		],
-		"vs/workbench/contrib/chat/browser/widget/input/chatModelPicker": [
-			"chat.effort.costHint",
-			"chat.effort.header",
-			"chat.manageModels",
-			"chat.manageModels.tooltip",
-			"chat.modelPicker.adminDescription",
-			"chat.modelPicker.adminHover",
-			"chat.modelPicker.adminLink",
-			"chat.modelPicker.ariaLabel",
-			"chat.modelPicker.auto",
-			"chat.modelPicker.checkUpdateHover",
-			"chat.modelPicker.downloadUpdateHover",
-			"chat.modelPicker.effortAriaLabel",
-			"chat.modelPicker.effortTooltip",
-			"chat.modelPicker.noModels",
-			"chat.modelPicker.otherModels",
-			"chat.modelPicker.pin",
-			"chat.modelPicker.pinned",
-			"chat.modelPicker.restartUpdateHover",
-			"chat.modelPicker.search",
-			"chat.modelPicker.tokensAriaLabel",
-			"chat.modelPicker.tokensTooltip",
-			"chat.modelPicker.unpin",
-			"chat.modelPicker.updateDescription",
-			"chat.modelPicker.upgradeHover",
-			"chat.modelPicker.upgradeHoverProPlus",
-			"chat.modelPicker.upgradeLink",
-			"chat.priceCategory.high",
-			"chat.priceCategory.low",
-			"chat.priceCategory.medium",
-			"chat.priceCategory.unknown",
-			"chat.priceCategory.veryHigh",
-			"chat.tokens.costHint",
-			"chat.tokens.header",
-			"models.cacheCostLabel",
-			"models.configurable",
-			"models.contextSize",
-			"models.cost",
-			"models.costValuePlural",
-			"models.costValueSingular",
-			"models.effortDefault",
-			"models.inputCostLabel",
-			"models.longContextPriceTitle",
-			"models.outputCostLabel",
-			"models.priceCategoryTitle",
-			"models.priceTitle"
-		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter": [
 			"chatPhoneInput.autoLabel",
 			"chatPhoneInput.triggerAriaLabel"
@@ -13362,8 +14734,92 @@
 			"pastedSymbolReference",
 			"pasteHtmlAsMarkdown"
 		],
-		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem": [
-			"chat.modelPicker.label"
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerActionItem": [
+			"chat.modelPicker.modelsLabel",
+			"chat.modelPicker.restrictedHover",
+			"chat.modelPicker.setupRequiredHover"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerConfiguration": [
+			"chat.config.cacheBreakHint",
+			"chat.effort.header",
+			"chat.modelPicker.effortAriaLabel",
+			"chat.modelPicker.tokensAriaLabel",
+			"chat.tokens.header",
+			"models.configDefault"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerHover": [
+			"chat.category.lightweight",
+			"chat.category.powerful",
+			"chat.category.versatile",
+			"chat.promo.discountBadge",
+			"chat.promo.endsAt",
+			"models.cacheCostLabel",
+			"models.cacheWriteCostLabel",
+			"models.configurable",
+			"models.contextSize",
+			"models.cost",
+			"models.cost.unknown",
+			"models.creditsPerMillionTokens",
+			"models.defaultContext",
+			"models.inputCostLabel",
+			"models.longContext",
+			"models.outputCostLabel"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItems": [
+			"chat.manageModels",
+			"chat.manageModels.tooltip",
+			"chat.modelPicker.adminDescription",
+			"chat.modelPicker.adminHover",
+			"chat.modelPicker.adminLink",
+			"chat.modelPicker.auto",
+			"chat.modelPicker.checkUpdateHover",
+			"chat.modelPicker.copilotGroup",
+			"chat.modelPicker.downloadUpdateHover",
+			"chat.modelPicker.noModels",
+			"chat.modelPicker.otherModels",
+			"chat.modelPicker.pin",
+			"chat.modelPicker.pinned",
+			"chat.modelPicker.restartUpdateHover",
+			"chat.modelPicker.restrictedMode",
+			"chat.modelPicker.restrictedMode.trust",
+			"chat.modelPicker.restrictedMode.trustTooltip",
+			"chat.modelPicker.setupRequired",
+			"chat.modelPicker.setupRequired.signIn",
+			"chat.modelPicker.setupRequired.signInTooltip",
+			"chat.modelPicker.unpin",
+			"chat.modelPicker.updateDescription",
+			"chat.modelPicker.upgradeHover",
+			"chat.modelPicker.upgradeHoverProPlus",
+			"chat.modelPicker.upgradeLink",
+			"chat.promo.discount"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerPresentation": [
+			"chat.priceCategory.high",
+			"chat.priceCategory.low",
+			"chat.priceCategory.medium",
+			"chat.priceCategory.unknown",
+			"chat.priceCategory.veryHigh"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerWidget": [
+			"chat.cacheBreak.learnMore",
+			"chat.modelPicker.activating",
+			"chat.modelPicker.ariaLabel",
+			"chat.modelPicker.ariaLabelRestricted",
+			"chat.modelPicker.ariaLabelSetupRequired",
+			"chat.modelPicker.auto",
+			"chat.modelPicker.cacheBreakHint",
+			"chat.modelPicker.configTooltip",
+			"chat.modelPicker.modelsLabel",
+			"chat.modelPicker.noModels",
+			"chat.modelPicker.search",
+			"chat.modelPicker.trustMessage"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelProviderIcons": [
+			"chatModelProviderClaudeIcon",
+			"chatModelProviderCopilotIcon",
+			"chatModelProviderGeminiIcon",
+			"chatModelProviderGenericIcon",
+			"chatModelProviderOpenAIIcon"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem": [
 			"built-in",
@@ -13374,27 +14830,34 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem": [
 			"permissions.ariaLabel",
+			"permissions.ariaLabelWithDescription",
+			"permissions.assisted",
+			"permissions.assisted.description",
+			"permissions.assisted.label",
+			"permissions.assisted.subtext",
 			"permissions.autoApprove",
 			"permissions.autoApprove.description",
 			"permissions.autoApprove.label",
-			"permissions.autoApprove.policyDescription",
-			"permissions.autoApprove.policyDisabled",
 			"permissions.autoApprove.subtext",
 			"permissions.autopilot",
 			"permissions.autopilot.description",
 			"permissions.autopilot.label",
-			"permissions.autopilot.policyDescription",
-			"permissions.autopilot.policyDisabled",
 			"permissions.autopilot.subtext",
 			"permissions.default",
 			"permissions.default.description",
 			"permissions.default.label",
+			"permissions.default.sandbox.toggle",
+			"permissions.default.sandbox.toggle.title",
 			"permissions.default.subtext",
+			"permissions.defaultSandboxed.label",
 			"permissions.ext.locked",
-			"permissions.learnMore"
+			"permissions.learnMore",
+			"permissions.policyDescription",
+			"permissions.policyDisabled"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem": [
 			"chat.learnMoreAgentTypes",
+			"chat.sessionTarget.ariaDescription",
 			"chat.sessionTarget.category.agent",
 			"chat.sessionTarget.category.other"
 		],
@@ -13432,6 +14895,10 @@
 			"outputReserved",
 			"qualityWarning",
 			"quotaDisplay",
+			"sessionCost",
+			"sessionCostCredit",
+			"sessionCostCredits",
+			"sessionInfo",
 			"tokenCount",
 			"uncategorized"
 		],
@@ -13440,11 +14907,15 @@
 			"contextUsagePercentageLabel"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane": [
-			"agentsVoice.voiceChatTitle",
 			"chat.loadSessionFailed",
 			"newSession",
 			"sessionInProgress",
-			"sessions"
+			"sessions",
+			"voiceMode.bargeInHint",
+			"voiceMode.bargeInHintNoKb",
+			"voiceMode.clickMicOrBargeInHint",
+			"voiceMode.listening",
+			"voiceMode.pttOrBargeInHint"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewTitleControl": [
 			"chat",
@@ -13464,6 +14935,7 @@
 			"agentSessionsViewerVisible",
 			"agentSessionType",
 			"agentSupportsAttachments",
+			"chatAgentHostProviderId",
 			"chatAgentModeDisabledByPolicy",
 			"chatContextUsageHasBeenOpened",
 			"chatEditApplied",
@@ -13479,10 +14951,13 @@
 			"chatHasAgents",
 			"chatHasCanDelegateProviders",
 			"chatHasFileAttachments",
+			"chatHasPendingDelegationTarget",
 			"chatHasPendingRequests",
 			"chatHasUsedCreateSlashCommands",
+			"chatIsAgentHostSession",
 			"chatIsEnabled",
 			"chatIsKatexMathElement",
+			"chatIsReadonly",
 			"chatItemId",
 			"chatLastItemId",
 			"chatModelId",
@@ -13515,10 +14990,14 @@
 			"chatSessionSupportsFork",
 			"chatSessionType",
 			"chatSkipRequestInProgressMessage",
+			"chatSpeechToTextConfigured",
+			"chatSpeechToTextPreparing",
+			"chatSpeechToTextRecording",
 			"enableRemoteCodingAgentPromptFileOverlay",
 			"filePartOfEditSession",
 			"hasRemoteCodingAgent",
 			"inAgentSessionsWelcome",
+			"inAutomationsDialog",
 			"inChat",
 			"inChatEditor",
 			"inChatQuestionCarousel",
@@ -13547,6 +15026,15 @@
 			"chat.attachmentSummary.file.one",
 			"chat.attachmentSummary.image.many",
 			"chat.attachmentSummary.image.one"
+		],
+		"vs/workbench/contrib/chat/common/automations/schedule": [
+			"automation.day.fri",
+			"automation.day.mon",
+			"automation.day.sat",
+			"automation.day.sun",
+			"automation.day.thu",
+			"automation.day.tue",
+			"automation.day.wed"
 		],
 		"vs/workbench/contrib/chat/common/chatErrorMessages": [
 			"chatError.aMoment",
@@ -13587,6 +15075,7 @@
 			"chatError.quota.additionalSpend",
 			"chatError.quota.business",
 			"chatError.quota.default",
+			"chatError.quota.edu",
 			"chatError.quota.free",
 			"chatError.quota.generic",
 			"chatError.quota.individual",
@@ -13602,6 +15091,8 @@
 			"chatError.quota.ubb.businessDate",
 			"chatError.quota.ubb.default",
 			"chatError.quota.ubb.defaultDate",
+			"chatError.quota.ubb.edu",
+			"chatError.quota.ubb.eduDate",
 			"chatError.quota.ubb.free",
 			"chatError.quota.ubb.freeDate",
 			"chatError.quota.ubb.individual",
@@ -13720,15 +15211,23 @@
 			"editsDescription"
 		],
 		"vs/workbench/contrib/chat/common/chatPermissionWarnings": [
-			"permissions.autoApprove.warning.cancel",
+			"permissions.assisted",
+			"permissions.assisted.warning.confirm",
+			"permissions.assisted.warning.detail",
+			"permissions.assisted.warning.title",
+			"permissions.autoApprove",
 			"permissions.autoApprove.warning.confirm",
 			"permissions.autoApprove.warning.detail",
 			"permissions.autoApprove.warning.title",
-			"permissions.autopilot.warning.cancel",
 			"permissions.autopilot.warning.confirm",
 			"permissions.autopilot.warning.detail",
 			"permissions.autopilot.warning.title",
+			"permissions.warning.cancel",
 			"permissions.warning.dontShowAgain"
+		],
+		"vs/workbench/contrib/chat/common/chatProgressFormatting": [
+			"minutesSeconds",
+			"seconds"
 		],
 		"vs/workbench/contrib/chat/common/chatService/chatServiceImpl": [
 			"agentDebugLog.troubleshootDisabled",
@@ -13736,7 +15235,6 @@
 			"newChat"
 		],
 		"vs/workbench/contrib/chat/common/customizationHarnessService": [
-			"harness.cli",
 			"harness.local"
 		],
 		"vs/workbench/contrib/chat/common/editing/chatEditingService": [
@@ -13745,6 +15243,11 @@
 			"chatMultidiff.autoGenerated"
 		],
 		"vs/workbench/contrib/chat/common/languageModels": [
+			"autoModel.description",
+			"autoModel.discount",
+			"autoModel.learnMore",
+			"chat.providerDeprecation.install",
+			"chat.providerDeprecation.message",
 			"configureLanguageModelGroup",
 			"enterName",
 			"enterValue",
@@ -13756,6 +15259,8 @@
 			"vscode.extension.contributes.languageModelChatProviders",
 			"vscode.extension.contributes.languageModels.configuration",
 			"vscode.extension.contributes.languageModels.configuration.secret",
+			"vscode.extension.contributes.languageModels.deprecation",
+			"vscode.extension.contributes.languageModels.deprecation.link",
 			"vscode.extension.contributes.languageModels.displayName",
 			"vscode.extension.contributes.languageModels.emptyVendor",
 			"vscode.extension.contributes.languageModels.managementCommand",
@@ -13778,6 +15283,7 @@
 			"filteredContentRetry",
 			"waitingAnswer",
 			"waitingForPostApproval",
+			"waitingForToolAuthentication",
 			"waitingPlanReview"
 		],
 		"vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation": [
@@ -13886,9 +15392,16 @@
 			"hookType.userPromptSubmit.label"
 		],
 		"vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptCodeActions": [
+			"enableGithubMcpServerSetting",
 			"expandToolNames",
+			"installGithubMcpServer",
+			"installPlaywrightMcpServer",
 			"migrateToAgent",
 			"renameToAgent",
+			"searchExtensionMarketplace",
+			"searchExtensionMarketplaceGeneric",
+			"searchMcpServerMarketplace",
+			"searchMcpServerMarketplaceGeneric",
 			"updateAllToolNames",
 			"updateToolName"
 		],
@@ -14127,7 +15640,9 @@
 			"promptValidator.inferDeprecated",
 			"promptValidator.invalidFileReference",
 			"promptValidator.invalidPermissionValue",
+			"promptValidator.missingGithubMcpServer",
 			"promptValidator.missingHandoffProperties",
+			"promptValidator.missingPlaywrightMcpServer",
 			"promptValidator.modeDeprecated",
 			"promptValidator.modeDeprecated.useAgent",
 			"promptValidator.modelArrayItemMustBeNonEmpty",
@@ -14156,7 +15671,6 @@
 			"promptValidator.targetMustBeString",
 			"promptValidator.toolDeprecated",
 			"promptValidator.toolDeprecatedMultipleNames",
-			"promptValidator.toolNotFound",
 			"promptValidator.toolsMustBeArrayOrMap",
 			"promptValidator.toolsOnlyInAgent",
 			"promptValidator.unknownAttribute.github-agent",
@@ -14165,12 +15679,15 @@
 			"promptValidator.unknownAttribute.rules",
 			"promptValidator.unknownAttribute.skill",
 			"promptValidator.unknownAttribute.vscode-agent",
+			"promptValidator.unknownExtensionReference",
 			"promptValidator.unknownGithubProperty",
 			"promptValidator.unknownHandoffProperty",
 			"promptValidator.unknownHookProperty",
 			"promptValidator.unknownHookType",
 			"promptValidator.unknownMatcherProperty",
+			"promptValidator.unknownMcpServerReference",
 			"promptValidator.unknownPermissionScope",
+			"promptValidator.unknownToolReference",
 			"promptValidator.unknownVariableReference",
 			"promptValidator.userInvocableMustBeBoolean"
 		],
@@ -14187,6 +15704,7 @@
 			"source.userData"
 		],
 		"vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl": [
+			"builtin.capitalized",
 			"extension.with.id",
 			"plugin.capitalized",
 			"user-data-dir.capitalized"
@@ -14349,6 +15867,25 @@
 			"exportAgentTracesDB.label",
 			"exportAgentTracesDB.notFound"
 		],
+		"vs/workbench/contrib/chat/electron-browser/actions/networkDiagnosticsAction": [
+			"workbench.action.chat.agentHostNetworkDiagnostics.label"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/profileAgentHostAction": [
+			"profileAgentHost",
+			"profileAgentHost.cpuProfiles",
+			"profileAgentHost.noInspectPort",
+			"profileAgentHost.notification",
+			"profileAgentHost.saveDialogTitle",
+			"profileAgentHost.saveFailed",
+			"profileAgentHost.startFailed",
+			"profileAgentHost.statusAriaLabel",
+			"profileAgentHost.statusName",
+			"profileAgentHost.statusText",
+			"profileAgentHost.statusTooltip",
+			"profileAgentHost.stop",
+			"profileAgentHost.stopFailed",
+			"stopAgentHostProfile"
+		],
 		"vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions": [
 			"keywordActivation.status.active",
 			"keywordActivation.status.inactive",
@@ -14433,6 +15970,25 @@
 			"quit.message",
 			"reloadTheWindow.detail",
 			"reloadTheWindow.message"
+		],
+		"vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem": [
+			"tunnelHost.hover.connecting",
+			"tunnelHost.hover.enabled",
+			"tunnelHost.hover.idle",
+			"tunnelHost.hover.sharing",
+			"tunnelHost.hover.showOutput",
+			"tunnelHost.toast"
+		],
+		"vs/workbench/contrib/chat/electron-browser/tunnelHost.contribution": [
+			"showTunnelHostOutput",
+			"toggleSharing",
+			"tunnelHost.category",
+			"tunnelHost.enableMicrosoftAuth",
+			"tunnelHost.error"
+		],
+		"vs/workbench/contrib/chat/electron-browser/tunnelHostService": [
+			"tunnelHost.noAuth",
+			"tunnelHost.outputChannel"
 		],
 		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
 			"alwaysSave",
@@ -15078,10 +16634,11 @@
 			"contributes.displayName",
 			"contributes.priority",
 			"contributes.priority.default",
-			"contributes.priority.diff",
-			"contributes.priority.editor",
-			"contributes.priority.merge",
+			"contributes.priority.diffEditor",
+			"contributes.priority.mergeEditor",
+			"contributes.priority.never",
 			"contributes.priority.option",
+			"contributes.priority.textEditor",
 			"contributes.selector",
 			"contributes.selector.filenamePattern",
 			"contributes.viewType",
@@ -15979,6 +17536,7 @@
 		],
 		"vs/workbench/contrib/debug/browser/exceptionWidget": [
 			"close",
+			"copy",
 			"debugExceptionWidgetBackground",
 			"debugExceptionWidgetBorder",
 			"exceptionThrown",
@@ -16773,8 +18331,6 @@
 			"notFound",
 			"notInstalled",
 			"noUpdatesAvailable",
-			"off",
-			"on",
 			"recently published filter",
 			"recentlyPublishedExtensions",
 			"refreshExtension",
@@ -18367,19 +19923,13 @@
 			"issueReporterEditorInputName",
 			"issueReporterIcon"
 		],
-		"vs/workbench/contrib/issue/browser/issueReporterEditorPane": [
-			"noData",
-			"noExperiments",
-			"openSystemSettings",
-			"recordingTooLarge",
-			"screenRecordingPermissionDenied",
-			"screenRecordingPermissionDeniedGeneric"
-		],
 		"vs/workbench/contrib/issue/browser/issueReporterOverlay": [
 			"abExperiments",
 			"additionalInformation",
 			"additionalPerformanceData",
 			"additionalPerformanceDataDescription",
+			"agentsWindow",
+			"agentsWindowPlaceholder",
 			"attachments",
 			"back",
 			"bug",
@@ -18397,9 +19947,6 @@
 			"descriptionPlaceholder",
 			"descriptionRequired",
 			"editScreenshot",
-			"excludeAllExtraAttachments",
-			"excludeAllExtraAttachmentsAria",
-			"expand",
 			"extension",
 			"extensionData",
 			"extensionExternalIssueUrl",
@@ -18416,9 +19963,6 @@
 			"generateTitleBtn",
 			"generatingTitle",
 			"hideToolbarInScreenshots",
-			"includeAllExtraAttachments",
-			"includeAllExtraAttachmentsAria",
-			"includeInIssue",
 			"issueTargetRepo",
 			"issueTitle",
 			"issueTitlePlaceholder",
@@ -18431,7 +19975,6 @@
 			"marketplace",
 			"marketplacePlaceholder",
 			"maxAttachmentsReached",
-			"minimize",
 			"next",
 			"noDelay",
 			"noDescription",
@@ -18441,6 +19984,7 @@
 			"or",
 			"perfGuidance",
 			"performanceIssue",
+			"perfWikiLink",
 			"previewOnGitHub",
 			"recordingActive",
 			"recordingThumbnailAlt",
@@ -18448,6 +19992,12 @@
 			"refresh",
 			"refreshPerformanceData",
 			"reportIssue",
+			{
+				"key": "reviewGuidanceLabelWizard",
+				"comment": [
+					"{Locked=\"https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions\"}"
+				]
+			},
 			"reviewSubmit",
 			"runningProcesses",
 			"screenshot",
@@ -18610,6 +20160,14 @@
 			},
 			"tasksQuickAccessPlaceholder"
 		],
+		"vs/workbench/contrib/issue/electron-browser/issueReporterEditorPane": [
+			"noData",
+			"noExperiments",
+			"openSystemSettings",
+			"recordingTooLarge",
+			"screenRecordingPermissionDenied",
+			"screenRecordingPermissionDeniedGeneric"
+		],
 		"vs/workbench/contrib/issue/electron-browser/issueReporterService": [
 			"noCurrentExperiments",
 			"pasteData",
@@ -18619,6 +20177,10 @@
 		],
 		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
 			"toggleKeybindingsLog"
+		],
+		"vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution": [
+			"systemWideKeybindings.registrationFailed",
+			"systemWideKeybindings.whenIgnored"
 		],
 		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
 			"detectlang",
@@ -18974,6 +20536,7 @@
 			"mcp.addContext.placeholder"
 		],
 		"vs/workbench/contrib/mcp/browser/mcpCommands": [
+			"mcp.actions.enablement",
 			"mcp.actions.resources",
 			"mcp.actions.sampling",
 			"mcp.actions.status",
@@ -18981,16 +20544,24 @@
 			"mcp.addConfiguration.description",
 			"mcp.addServer",
 			"mcp.addServer.description",
+			"mcp.agentHost.authenticate",
 			"mcp.agentHost.disable",
+			"mcp.agentHost.disableSession",
+			"mcp.agentHost.disableWorkspace",
 			"mcp.agentHost.enable",
+			"mcp.agentHost.enableSession",
+			"mcp.agentHost.enableWorkspace",
 			"mcp.agentHost.noServers",
 			"mcp.agentHost.noServers.description",
+			"mcp.agentHost.restartUnsupported",
 			"mcp.agentHost.showLocal",
+			"mcp.agentHost.startError",
 			"mcp.agentHost.status.authRequired",
 			"mcp.agentHost.status.error",
 			"mcp.agentHost.status.ready",
 			"mcp.agentHost.status.starting",
 			"mcp.agentHost.status.stopped",
+			"mcp.agentHost.stopError",
 			"mcp.agentHostOptions",
 			"mcp.autoStart",
 			"mcp.browseResources",
@@ -19114,6 +20685,8 @@
 			"mcp.serverType.pip.description",
 			"mcp.serverType.placeholder",
 			"mcp.target..remote.description",
+			"mcp.target.agentHost",
+			"mcp.target.local",
 			"mcp.target.placeholder",
 			"mcp.target.remote",
 			"mcp.target.title",
@@ -19169,10 +20742,13 @@
 			"mcp.start",
 			"mcp.stop",
 			"mcp.variableNotFound",
+			"server.authRequired",
 			"server.disabled",
 			"server.error",
 			"server.promptcount",
 			"server.running",
+			"server.runningInOneOtherSession",
+			"server.runningInOtherSessions",
 			"server.starting",
 			"server.toolCount"
 		],
@@ -20468,6 +22044,19 @@
 			"vetoAutoExtHostRestart",
 			"vetoExtHostRestart"
 		],
+		"vs/workbench/contrib/onboarding/browser/onboarding.contribution": [
+			"onboarding.developerMode",
+			"onboarding.enabled",
+			"onboarding.resetShownState"
+		],
+		"vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay": [
+			"spotlight.back",
+			"spotlight.counter",
+			"spotlight.done",
+			"spotlight.endTour",
+			"spotlight.endTour.tooltip",
+			"spotlight.next"
+		],
 		"vs/workbench/contrib/outline/browser/outline.contribution": [
 			"filteredTypes.array",
 			"filteredTypes.boolean",
@@ -20746,10 +22335,13 @@
 			"settings.focusFile",
 			"settings.focusLevelUp",
 			"settings.focusSearch",
+			"settings.focusSearchFromSettings",
 			"settings.focusSettingControl",
+			"settings.focusSettingsFromSearchOnEnter",
 			"settings.focusSettingsList",
 			"settings.focusSettingsTOC",
 			"settings.showContextMenu",
+			"settings.showPreviousSearch",
 			"settings.toggleAiSearch",
 			"settingsEditor2",
 			"showDefaultKeybindings",
@@ -20822,6 +22414,12 @@
 			"oneResult",
 			"oneResultWithAiAvailable",
 			"SearchSettings.AriaLabel",
+			{
+				"key": "SearchSettings.PlaceholderWithHistory",
+				"comment": [
+					"Placeholder for the settings search input hinting that the up and down arrow keys navigate the search history. The character inserted for {0} is ⇅ to represent the up and down arrow keys."
+				]
+			},
 			"settings",
 			"settings require trust",
 			"showAiResultsDisabled",
@@ -21899,7 +23497,6 @@
 			"filterSortOrder",
 			"filterSortOrder.default",
 			"filterSortOrder.recency",
-			"maintainFileSearchCacheDeprecated",
 			{
 				"key": "miViewSearch",
 				"comment": [
@@ -21921,9 +23518,6 @@
 			"search.experimental.useIgnoreFilesInFindFiles",
 			"search.followSymlinks",
 			"search.globalFindClipboard",
-			"search.location",
-			"search.location.deprecationMessage",
-			"search.maintainFileSearchCache",
 			"search.maxResults",
 			"search.mode",
 			"search.mode.newEditor",
@@ -21943,7 +23537,6 @@
 			"search.showLineNumbers",
 			"search.smartCase",
 			"search.sortOrder",
-			"search.usePCRE2",
 			"search.useReplacePreview",
 			"searchSortOrder.countAscending",
 			"searchSortOrder.countDescending",
@@ -21955,10 +23548,7 @@
 			"textSearchPickerPlaceholder",
 			"useGlobalIgnoreFiles",
 			"useIgnoreFiles",
-			"useParentIgnoreFiles",
-			"usePCRE2Deprecated",
-			"useRipgrep",
-			"useRipgrepDeprecated"
+			"useParentIgnoreFiles"
 		],
 		"vs/workbench/contrib/search/browser/searchAccessibilityHelp": [
 			"search.closingDesc",
@@ -22448,6 +24038,61 @@
 			"remindLater",
 			"surveyQuestion",
 			"takeSurvey"
+		],
+		"vs/workbench/contrib/surveys/browser/survey.contribution": [
+			"openSurvey",
+			"survey.help.overview",
+			"survey.help.select",
+			"survey.help.submit",
+			"surveyEditorPaneTitle"
+		],
+		"vs/workbench/contrib/surveys/browser/surveyEditorInput": [
+			"surveyIcon"
+		],
+		"vs/workbench/contrib/surveys/browser/surveyEditorPane": [
+			"survey.pane.ariaLabel",
+			"survey.questionOptional",
+			"survey.submitFeedback",
+			"survey.submitHint",
+			"survey.success.detail",
+			"survey.success.message"
+		],
+		"vs/workbench/contrib/surveys/browser/surveyQuestions": [
+			"survey.copilotPmf.description",
+			"survey.copilotPmf.q1",
+			"survey.copilotPmf.q1.extremely",
+			"survey.copilotPmf.q1.notAtAll",
+			"survey.copilotPmf.q1.slightly",
+			"survey.copilotPmf.q1.somewhat",
+			"survey.copilotPmf.q1.very",
+			"survey.copilotPmf.q2",
+			"survey.copilotPmf.q2.automating",
+			"survey.copilotPmf.q2.gettingUnstuck",
+			"survey.copilotPmf.q2.multiFile",
+			"survey.copilotPmf.q2.noClearValue",
+			"survey.copilotPmf.q2.other",
+			"survey.copilotPmf.q2.planning",
+			"survey.copilotPmf.q2.reviewing",
+			"survey.copilotPmf.q2.shippingFaster",
+			"survey.copilotPmf.q2.understanding",
+			"survey.copilotPmf.q3",
+			"survey.copilotPmf.q3.biggerTasks",
+			"survey.copilotPmf.q3.context",
+			"survey.copilotPmf.q3.cost",
+			"survey.copilotPmf.q3.other",
+			"survey.copilotPmf.q3.reviewingTime",
+			"survey.copilotPmf.q3.security",
+			"survey.copilotPmf.q3.setup",
+			"survey.copilotPmf.q3.slow",
+			"survey.copilotPmf.q3.steering",
+			"survey.copilotPmf.q3.trust",
+			"survey.copilotPmf.q4",
+			"survey.copilotPmf.q4.10to19",
+			"survey.copilotPmf.q4.20plus",
+			"survey.copilotPmf.q4.3to5",
+			"survey.copilotPmf.q4.6to9",
+			"survey.copilotPmf.q4.lessThan3",
+			"survey.copilotPmf.title"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"configured",
@@ -23739,6 +25384,9 @@
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool": [
 			"confirmTerminalCommandTool.displayName",
+			"confirmTerminalCommandTool.sandboxBypass.message",
+			"confirmTerminalCommandTool.sandboxBypass.message.reason",
+			"confirmTerminalCommandTool.sandboxBypass.title",
 			"confirmTerminalCommandTool.userDescription"
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool": [
@@ -23775,14 +25423,17 @@
 			"runInTerminal.missingDeps.cancelled",
 			"runInTerminal.missingDeps.failed",
 			"runInTerminal.missingDeps.install",
+			"runInTerminal.missingDeps.installed",
 			"runInTerminal.missingDeps.message",
 			"runInTerminal.missingDeps.recheckFailed",
 			"runInTerminal.missingDeps.title",
 			"runInTerminal.missingDeps.unknown",
+			"runInTerminal.missingDeps.unsupportedInstaller",
 			"runInTerminal.presentationOverride",
 			"runInTerminal.presentationOverride.inDirectory",
 			"runInTerminal.presentationOverride.inDirectory.withoutLanguage",
 			"runInTerminal.presentationOverride.withoutLanguage",
+			"runInTerminal.sandbox.fileAccessDenied",
 			"runInTerminal.sensitiveInput.autoCancelMessage",
 			"runInTerminal.sensitiveInput.autoCancelTitle",
 			"runInTerminal.sensitiveInput.cancel",
@@ -23873,11 +25524,10 @@
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration": [
 			"agentSandbox.allowAutoApprove",
+			"agentSandbox.allowNetwork",
 			"agentSandbox.allowUnsandboxedCommands",
-			"agentSandbox.autoApproveUnsandboxedCommands",
 			"agentSandbox.enabled.deprecated",
 			"agentSandbox.enabledSetting",
-			"agentSandbox.enabledSetting.allowNetworkDescription",
 			"agentSandbox.enabledSetting.offDescription",
 			"agentSandbox.enabledSetting.onDescription",
 			"agentSandbox.fileSystemLinux.deprecated",
@@ -23895,8 +25545,8 @@
 			"agentSandbox.retryWithAllowNetworkRequests",
 			"agentSandbox.runtimeSetting",
 			"agentSandbox.windowsEnabledSetting",
-			"agentSandbox.windowsEnabledSetting.allowNetworkDescription",
 			"agentSandbox.windowsEnabledSetting.offDescription",
+			"agentSandbox.windowsEnabledSetting.onDescription",
 			"agentSandbox.windowsFileSystemSetting",
 			"agentSandbox.windowsFileSystemSetting.allowRead",
 			"agentSandbox.windowsFileSystemSetting.allowWrite",
@@ -23939,6 +25589,7 @@
 			"idlePollInterval.description",
 			"idleSilenceTimeoutMs.description",
 			"ignoreDefaultAutoApproveRules.description",
+			"outputCompaction.description",
 			"outputDeltas.description",
 			"outputLocation.chat",
 			"outputLocation.description",
@@ -24079,7 +25730,6 @@
 			"copilotCliHintAriaLabel",
 			"disableHint",
 			"disableInitialHint",
-			"emptyHintText",
 			{
 				"key": "hintTextDismiss",
 				"comment": [
@@ -24094,18 +25744,10 @@
 				]
 			},
 			"hintTextDismissProse",
-			{
-				"key": "inlineChatHint",
-				"comment": [
-					"Preserve double-square brackets and their order"
-				]
-			},
-			"openChatHint",
 			"showSuggestHint"
 		],
 		"vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration": [
-			"terminal.integrated.initialHint",
-			"terminal.integrated.initialHintCopilotCli"
+			"terminal.integrated.initialHint"
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
 			"workbench.action.terminal.openDetectedLink",
@@ -24952,6 +26594,8 @@
 			"unassigned"
 		],
 		"vs/workbench/contrib/update/browser/update": [
+			"cancellingUpdate",
+			"cancellingUpdateMenuEntry",
 			"checkForUpdates",
 			"checkingForUpdates",
 			"checkingForUpdates2",
@@ -24960,6 +26604,7 @@
 			"DownloadingUpdate",
 			"installingUpdate",
 			"installUpdate...",
+			"noUpdatesAvailable",
 			"read the release notes",
 			"relaunchDetailInsiders",
 			"relaunchDetailStable",
@@ -25022,6 +26667,7 @@
 			}
 		],
 		"vs/workbench/contrib/update/browser/updateTitleBarEntry": [
+			"updateIndicator.cancelling",
 			"updateIndicator.checking",
 			"updateIndicator.downloading",
 			"updateIndicator.installing",
@@ -25035,6 +26681,8 @@
 			"updateTooltip.autoUpdateManual",
 			"updateTooltip.autoUpdateNone",
 			"updateTooltip.autoUpdateStart",
+			"updateTooltip.cancellingPleaseWait",
+			"updateTooltip.cancellingTitle",
 			"updateTooltip.checkingForUpdatesTitle",
 			"updateTooltip.checkingPleaseWait",
 			"updateTooltip.copyVersion",
@@ -26205,7 +27853,6 @@
 			"trustedWindowSubtitle",
 			"trustedWorkspace",
 			"trustedWorkspaceSubtitle",
-			"trustMessage",
 			{
 				"key": "trustOrg",
 				"comment": [
@@ -26213,7 +27860,6 @@
 					"The {1} will be a host name where repositories are hosted."
 				]
 			},
-			"trustParentButton",
 			"trustUri",
 			"untrustedDebugging",
 			"untrustedDescription",
@@ -26274,6 +27920,7 @@
 			"revealUserDataFolder",
 			"showContentTracing",
 			"showGPUInfo",
+			"startHeapTracing",
 			"startTracing",
 			"startTracing.ariaLabel",
 			"startTracing.name",
@@ -26306,6 +27953,7 @@
 			"current",
 			"disableWindowAlwaysOnTop",
 			"enableWindowAlwaysOnTop",
+			"focusWindow",
 			{
 				"key": "miCloseWindow",
 				"comment": [
@@ -26937,15 +28585,18 @@
 			"editorResolver.conflictingDefaults",
 			"editorResolver.keepDefault",
 			"promptOpenWith.configureDefault",
+			"promptOpenWith.configureDefaultDiff",
 			"promptOpenWith.currentDefault",
 			"promptOpenWith.currentDefaultAndActive",
 			"promptOpenWith.currentlyActive",
 			"promptOpenWith.placeHolder",
+			"promptOpenWith.updateDefaultDiffPlaceHolder",
 			"promptOpenWith.updateDefaultPlaceHolder"
 		],
 		"vs/workbench/services/editor/common/editorResolverService": [
 			"editor.diffEditorAssociations",
-			"editor.editorAssociations"
+			"editor.editorAssociations",
+			"editor.markdownDefaultEditorInAgentsWindow"
 		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
 			"bisect",
@@ -27010,9 +28661,9 @@
 			"cannot change enablement malicious",
 			"cannot change enablement virtual workspace",
 			"cannot change invalid extension enablement",
-			"cannot disable auth extension",
-			"cannot disable auth extension in workspace",
 			"cannot disable language pack extension",
+			"cannot disable settings sync auth extension",
+			"cannot disable settings sync auth extension in workspace",
 			"extensionsDisabled",
 			"noWorkspace",
 			"Reload"
@@ -27121,7 +28772,6 @@
 			"remote"
 		],
 		"vs/workbench/services/extensionManagement/electron-browser/remoteExtensionManagementService": [
-			"incompatibleAPI",
 			"notFoundCompatibleDependency",
 			"notFoundReleaseExtension"
 		],
@@ -27363,6 +29013,7 @@
 			"keybindings.json.command",
 			"keybindings.json.key",
 			"keybindings.json.removalCommand",
+			"keybindings.json.systemWide",
 			"keybindings.json.title",
 			"keybindings.json.when",
 			"nonempty",
@@ -28915,6 +30566,7 @@
 			"Quick suggestions show as ghost text",
 			"Controls whether the accessibility hint should be provided to screen reader users when an inline completion is shown.",
 			"Controls whether showing a suggestion will shift the code to make space for the suggestion inline.",
+			"Controls how many lines of surrounding context are shown above and below the target line in the long distance inline suggestion preview. Set to 0 to only show the target line.",
 			"Controls whether larger suggestions can be shown side by side.",
 			"Controls whether the suggestion will show as collapsed until jumping to it.",
 			"Controls whether long distance inline suggestions are shown.",
@@ -29065,7 +30717,6 @@
 			"Select a suggestion only when triggering IntelliSense as you type.",
 			"Select a suggestion only when triggering IntelliSense from a trigger character.",
 			"Controls whether sorting favors words that appear close to the cursor.",
-			"This setting is deprecated. The suggest widget can now be resized.",
 			"Controls whether to preview the suggestion outcome in the editor.",
 			"Controls whether a suggestion is selected when the widget shows. Note that this only applies to automatically triggered suggestions ({0} and {1}) and that a suggestion is always selected when explicitly invoked, e.g via `Ctrl+Space`.",
 			"Controls whether remembered suggestion selections are shared between multiple workspaces and windows (needs `#editor.suggestSelection#`).",
@@ -29239,6 +30890,8 @@
 			"Whether the editor is in the composition mode",
 			"Whether the context is an embedded diff editor",
 			"Whether all files in multi diff editor are collapsed",
+			"Whether all unchanged regions of a multi diff editor file are revealed",
+			"Whether the multi diff editor renders diffs side by side instead of inline",
 			"Whether the standalone color picker is focused",
 			"Whether the standalone color picker is visible",
 			"Whether the sticky scroll is focused",
@@ -30212,6 +31865,7 @@
 			"Background color of the suggest widget.",
 			"Border color of the suggest widget.",
 			"Color of the match highlights in the suggest widget when an item is focused.",
+			"Outline color of the focused (keyboard-navigated) entry in the suggest widget.",
 			"Foreground color of the suggest widget.",
 			"Color of the match highlights in the suggest widget.",
 			"Background color of the selected entry in the suggest widget.",
@@ -30366,6 +32020,8 @@
 			"Command Failed",
 			"Command Succeeded",
 			"Quick Fix",
+			"Voice Mode Started",
+			"Voice Mode Stopped",
 			"Chat Edit Modified File",
 			"Chat Request Sent",
 			"Chat Response Received",
@@ -30399,6 +32055,8 @@
 			"Terminal Command Failed",
 			"Terminal Command Succeeded",
 			"Terminal Quick Fix",
+			"Voice Mode Started",
+			"Voice Mode Stopped",
 			"Voice Recording Started",
 			"Voice Recording Stopped"
 		],
@@ -30432,6 +32090,9 @@
 		"vs/platform/actionWidget/browser/actionList": [
 			"Filter items",
 			"Search...",
+			"Dismiss",
+			"{0}, off",
+			"{0}, on",
 			"Remove",
 			"{0}, use right arrow to access options",
 			"Action Widget",
@@ -30453,17 +32114,15 @@
 			"Select previous action",
 			"Toggle section"
 		],
-		"vs/platform/agentHost/common/agentHost.config.contribution": [
-			"When enabled, some agents run in a separate agent host process.",
-			"When enabled, hides the Extension Host Copilot CLI entry from the Agents window picker.",
-			"When enabled, hides the Extension Host Copilot CLI entry from the editor window chat picker.",
-			"Controls which provider is used as the default for new editor chat sessions.",
-			"Use the Agent Host Copilot CLI",
-			"Use the Extension Host Copilot CLI",
-			"Use the built-in VS Code local chat harness",
-			"Chat Agent Host"
+		"vs/platform/agentHost/browser/agentHostConnectionsService": [
+			"Local"
+		],
+		"vs/platform/agentHost/browser/agentHostEnablementService": [
+			"When enabled, some agents run in a separate agent host process."
 		],
 		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
+			"When enabled (the default), the Claude agent routes all requests through GitHub Copilot. When disabled, Claude talks to Anthropic directly using your own credentials (API key or Claude subscription).",
+			"Route Claude Through Copilot",
 			"Plugins configured on this agent host and available to remote sessions.",
 			"Description",
 			"Name",
@@ -30472,25 +32131,68 @@
 			"Plugin URI",
 			"Absolute path to the shell executable used by host-managed terminals. Normally pushed by the connected VS Code client from `terminal.integrated.agentHostProfile.<os>` (falling back to `terminal.integrated.defaultProfile.<os>`); when unset, the agent host falls back to the system shell. Only the path is supported; `args` and `env` from the workbench profile are not piped through yet. The workbench only pushes this for the local agent host — remote agent host operators should set this directly in the remote machine's `agent-host-config.json`.",
 			"Default Shell",
-			"When enabled, Copilot SDK sessions use Agent Host's terminal tool override instead of the SDK's default terminal behavior.",
-			"Use Agent Host Terminal Tool",
-			"When enabled, the coding agent uses a rubber duck critic subagent to review code changes using a complementary model.",
-			"Rubber Duck Agent"
+			"Optional base URI of a GitHub Enterprise instance (for example \"https://ghe.example.com\" for GitHub Enterprise Server, or \"https://tenant.ghe.com\" for GitHub Enterprise Cloud). When set, the agent host authenticates and makes GitHub API calls against this instance instead of github.com. Normally pushed by the connected VS Code client from the `github-enterprise.uri` setting; remote agent host operators can set it directly in the remote `agent-host-config.json`.",
+			"GitHub Enterprise URI"
+		],
+		"vs/platform/agentHost/common/agentHostEnablementService": [
+			"Whether the local agent host process is enabled.",
+			"When enabled, some agents run in a separate agent host process.",
+			"When enabled, hides the Extension Host Copilot CLI entry from the Agents window picker. Requires `#chat.agentHost.enabled#`.",
+			"When enabled, new editor and panel chat sessions default to the Agent Host Copilot CLI instead of the local harness. Requires `#{0}#`.",
+			"When enabled, hides the Extension Host Copilot CLI entry from the editor window chat picker.",
+			"When enabled, shows the VS Code local chat harness in the chat picker. This setting is ignored in virtual workspaces, where the local chat harness is always available.",
+			"When enabled, prefers the Agent Host Copilot CLI for new editor chat sessions. If the local harness is selected, it is replaced with Copilot once.",
+			"Chat Agent Host"
 		],
 		"vs/platform/agentHost/common/agentHostSchema": [
+			"Whether VS Code's auto-reply setting is enabled. When `true`, `ask_user` questions are auto-answered instead of blocking on the user, mirroring autopilot mode.",
+			"Auto Reply",
+			"Whether the Codex provider is enabled.",
+			"Codex Agent",
+			"Whether VS Code's global auto-approve setting is enabled. When `true`, every tool call is auto-approved, equivalent to a session using Allow all.",
+			"Global Auto Approve",
+			"Argument",
+			"For `stdio` servers, the arguments passed to the command.",
+			"Arguments",
+			"For `stdio` servers, the executable to spawn.",
+			"Command",
+			"For `stdio` servers, the working directory the command runs in.",
+			"Working Directory",
+			"Agent-host-level MCP servers exposed to every session, keyed by server name. Each value is a server configuration (see `<serverName>`).",
+			"A single MCP server entry. The property key is the server name.",
+			"MCP Server",
+			"For `stdio` servers, environment variables set on the spawned process.",
+			"Environment",
+			"For `http` servers, HTTP headers sent with every request.",
+			"Headers",
+			"MCP Servers",
+			"The transport used to reach the server: `stdio` for a local command, `http` for a remote endpoint.",
+			"Server Type",
+			"For `http` servers, the endpoint URL of the MCP server.",
+			"URL",
+			"Whether Copilot Chat's prefer-long-context setting is enabled. When `true`, models with a free long context window only show the long context option in the picker. When `false` (default), the smaller default context option stays selectable.",
+			"Prefer Long Context",
 			"Whether remote session sync is enabled for the copilot-sdk CLI.",
 			"Session Sync",
+			"Whether Copilot sessions automatically discover and use the operating system's proxy configuration.",
+			"System Proxy Discovery",
 			"Most restrictive telemetry level requested by connected clients.",
 			"Telemetry Level",
+			"Whether terminal auto-approve rules forwarded by the connected client are allowed to apply to agent-host shell permission requests.",
+			"Terminal Auto Approve",
+			"Terminal auto-approve rules forwarded by the connected client for agent-host shell permission checks.",
+			"Terminal Auto Approve Rules",
 			"Approvals",
-			"Autopilot (Preview)",
-			"Autonomously iterates from start to finish",
-			"Bypass Approvals",
-			"All tool calls are auto-approved",
-			"Default Approvals",
-			"Copilot uses your configured settings",
+			"Assisted permissions",
+			"Evaluates risk before running tools",
+			"Allow all",
+			"Runs tool calls without asking",
+			"Default approvals",
+			"Asks when approval settings don't apply",
 			"Tool approval behavior for this session",
 			"Agent Mode",
+			"Autopilot",
+			"Autonomously iterates from start to finish",
 			"Interactive",
 			"Step-by-step collaboration",
 			"Plan",
@@ -30503,17 +32205,38 @@
 			"Per-tool session permissions. Updated automatically when approving a tool \"in this Session\"."
 		],
 		"vs/platform/agentHost/common/agentHostStarter.config.contribution": [
+			"When enabled, the agent host wires up the BYOK ('bring your own key') language-model bridge so extension-provided BYOK models can run in agent-host sessions. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
 			"When enabled, the agent host registers the Claude provider (subject to the Claude SDK being reachable). Independent of `#chat.agents.claude.preferAgentHost#` and `#chat.editor.claude.preferAgentHost#`, which choose which integration surfaces Claude. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
+			"Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic Claude Agent SDK directly in the editor. Uses your existing Copilot subscription.",
 			"Additional command-line arguments passed to `codex app-server`. Primarily useful for debugging (for example, `--log-level=debug`).",
 			"Optional override for `$CODEX_HOME`. Controls where the codex binary reads config and writes rollouts. When empty, codex uses its default (`~/.codex`).",
 			"When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
+			"Enable Codex Agent sessions in VS Code. Start and resume agentic coding sessions powered by OpenAI Codex SDK. Uses your existing Copilot subscription.",
 			"Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@openai/codex`. When set, the agent host spawns the Codex binary from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
-			"When enabled, includes prompt and response content in OTel span attributes. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks.",
-			"When enabled, the agent host persists every emitted OTel span to a local SQLite database. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink.",
-			"When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally.",
-			"Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime.",
-			"OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process.",
-			"Output path for span JSON lines when exporter type is `file`. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`.",
+			"When enabled, includes prompt and response content in OTel span attributes. Configurable in user settings only. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks.",
+			"Controls whether Copilot OpenTelemetry export captures prompt, response, and tool content.",
+			"When enabled, the agent host persists every emitted OTel span to a local SQLite database. Configurable in user settings only. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink.",
+			"When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Configurable in user settings only. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally.",
+			"Controls whether Copilot OpenTelemetry export is enabled. When managed, users cannot override the enterprise value.",
+			"Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. Configurable in user settings only. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime.",
+			"Enterprise-managed OTLP exporter headers (e.g. auth tokens) for Copilot OpenTelemetry export. Policy-only and extension-only: applied directly to the Copilot Chat extension's OTLP exporter, never delivered to the agent host process.",
+			"Controls the enterprise-managed OTLP exporter headers for Copilot OpenTelemetry export.",
+			"OTLP endpoint URL when exporter type is `otlp-http` or `otlp-grpc`. Configurable in user settings only. Sets `OTEL_EXPORTER_OTLP_ENDPOINT` inside the agent host process.",
+			"Controls the enterprise-managed OTLP collector endpoint for Copilot OpenTelemetry export.",
+			"Enterprise-managed OTLP wire protocol (`http/json`, `http/protobuf`, or `grpc`) for Copilot OpenTelemetry export. Policy-only: there is no user-facing setting; it carries the managed `telemetry.protocol` so the agent host's `OTEL_EXPORTER_OTLP_PROTOCOL` distinguishes protobuf from json.",
+			"Controls the enterprise-managed OTLP wire protocol (protobuf vs JSON) for Copilot OpenTelemetry export.",
+			"Output path for span JSON lines when exporter type is `file`. Configurable in user settings only. Sets `COPILOT_OTEL_FILE_EXPORTER_PATH`.",
+			"Prevents local file export when enterprise-managed Copilot OpenTelemetry export is configured.",
+			"Controls the enterprise-managed OTLP protocol for Copilot OpenTelemetry export.",
+			"Console exporter is not selected by enterprise managed settings.",
+			"File exporter is not selected by enterprise managed settings.",
+			"Use OTLP over gRPC.",
+			"Use OTLP over HTTP.",
+			"Enterprise-managed OTel resource attributes for Copilot OpenTelemetry export. Policy-only: there is no user-facing setting; it carries the managed `telemetry.resourceAttributes` map so the agent host's `OTEL_RESOURCE_ATTRIBUTES` includes the deployment's attributes.",
+			"Controls the enterprise-managed OTel resource attributes for Copilot OpenTelemetry export.",
+			"Enterprise-managed OTel `service.name` resource attribute for Copilot OpenTelemetry export. Policy-only: there is no user-facing setting; it carries the managed `telemetry.serviceName` so the agent host's `OTEL_SERVICE_NAME` identifies spans from this deployment.",
+			"Controls the enterprise-managed OTel `service.name` resource attribute for Copilot OpenTelemetry export.",
+			"When enabled, Copilot sessions automatically discover and use the operating system's proxy configuration when no proxy environment variable is set.",
 			"Chat Agent Host Starter"
 		],
 		"vs/platform/agentHost/common/changesetUri": [
@@ -30529,19 +32252,50 @@
 		],
 		"vs/platform/agentHost/common/claudeModelConfig": [
 			"Controls how much reasoning effort Claude uses.",
+			"Thinking Level"
+		],
+		"vs/platform/agentHost/common/copilotCliConfig": [
+			"Controls logging from the Copilot SDK runtime. Agent host trace logging always enables trace output.",
+			"Info",
+			"Copilot SDK Log Level",
+			"Trace",
+			"When enabled, Copilot SDK sessions use Agent Host's terminal tool override instead of the SDK's default terminal behavior.",
+			"Use Agent Host Terminal Tool",
+			"Per-model capability overrides for Copilot SDK sessions, keyed by model id. Aliasing a model id to a known `family` routes it to that family's tuned system prompt without changing the model id sent to the runtime. Only affects Copilot SDK sessions; intended for experimentation.",
+			"A single capability override. The property key is the model id.",
+			"Capability Override",
+			"Alias the model's family for prompt/capability routing (e.g. `claude-opus-4-8`).",
+			"Family",
+			"Model Capability Overrides",
+			"When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message.",
+			"Opus 4.8 Agent Prompt",
+			"Overrides the reasoning effort for Copilot SDK sessions regardless of the per-model picker value. Set it to a level the selected model supports (e.g. `low`, `medium`, `high`, `xhigh`); a value that isn't a recognized effort level is ignored and the session falls back to the picker value. Only affects Copilot SDK sessions; intended for experimentation.",
+			"Reasoning Effort Override",
+			"When enabled, the coding agent uses a rubber duck critic subagent to review code changes using a complementary model.",
+			"Rubber Duck Agent"
+		],
+		"vs/platform/agentHost/common/reasoningEffort": [
 			"High",
+			"Greater reasoning depth but slower",
 			"Low",
+			"Faster responses with less reasoning",
 			"Max",
+			"Absolute maximum capability with no constraints",
 			"Medium",
-			"Thinking Level",
-			"Extra High"
+			"Balanced reasoning and speed",
+			"Minimal",
+			"Minimal reasoning for fastest responses",
+			"None",
+			"No reasoning applied",
+			"Extra High",
+			"Highest reasoning depth but slowest"
 		],
 		"vs/platform/agentHost/common/sandboxConfigSchema": [
 			"Advanced Sandbox Runtime",
 			"Domain",
 			"Allowed Network Domains",
+			"Allow Network",
 			"Allow Unsandboxed Commands",
-			"Auto-Approve Unsandboxed Commands",
 			"Domain",
 			"Denied Network Domains",
 			"Sandbox Enabled",
@@ -30568,50 +32322,74 @@
 			"No uncommitted changes to commit."
 		],
 		"vs/platform/agentHost/node/agentHostCommitOperationProvider": [
-			"Commit"
+			"Commit Changes"
+		],
+		"vs/platform/agentHost/node/agentHostDiscardChangesOperationHandler": [
+			"Discard changes operation was cancelled.",
+			"Discarded changes to `{0}`."
+		],
+		"vs/platform/agentHost/node/agentHostDiscardChangesOperationProvider": [
+			"Discard Changes",
+			"Are you sure you want to discard the changes in '{0}'? This action cannot be undone."
 		],
 		"vs/platform/agentHost/node/agentHostMain": [
 			"Agent Host"
 		],
 		"vs/platform/agentHost/node/agentHostPullRequestOperationHandler": [
 			"Sign in to GitHub with repository access to create a pull request.",
+			"merge",
+			"the pull request identifier was not returned by GitHub.",
+			"rebase",
+			"squash",
 			"Created from `{0}` targeting `{1}`.",
 			"Pull request operation was cancelled.",
 			"Agent Host changes for {0}",
 			"Could not compute branch changes to create a pull request.",
 			"Created pull request [#{0}]({1}).",
+			"Created pull request [#{0}]({1}) with auto-merge ({2}) enabled.",
+			"Created pull request [#{0}]({1}), but auto-merge could not be enabled: {2}",
 			"Created draft pull request [#{0}]({1}).",
 			"Pull request [#{0}]({1}) already exists.",
+			"Pull request [#{0}]({1}) already exists; enabled auto-merge ({2}).",
+			"Pull request [#{0}]({1}) already exists, but auto-merge could not be enabled: {2}",
 			"There are no branch changes to create a pull request for."
 		],
 		"vs/platform/agentHost/node/agentHostPullRequestOperationProvider": [
 			"Create Draft Pull Request",
-			"Create Pull Request"
+			"Create Pull Request",
+			"Create Pull Request (Auto-Merge)",
+			"Create Pull Request (Auto-Rebase)",
+			"Create Pull Request (Auto-Squash)"
 		],
 		"vs/platform/agentHost/node/agentHostRenameCommand": [
 			"Rename this chat"
 		],
-		"vs/platform/agentHost/node/agentService": [
-			"Forked Session",
-			"Forked: "
+		"vs/platform/agentHost/node/agentHostSyncOperationHandler": [
+			"Sync operation was cancelled.",
+			"Synced changes."
 		],
-		"vs/platform/agentHost/node/agentSideEffects": [
-			"Renamed: {0}"
+		"vs/platform/agentHost/node/agentHostSyncOperationProvider": [
+			"Sync Changes {0}↑"
+		],
+		"vs/platform/agentHost/node/agentService": [
+			"Downloading {0} agent",
+			"Forked Chat",
+			"Forked Session",
+			"Forked: ",
+			"New Session"
 		],
 		"vs/platform/agentHost/node/claude/claudeAgent": [
 			"Approvals",
-			"Auto-Approve Edits",
-			"Auto-approve file edits; prompt for shell and other tools.",
-			"Auto",
-			"Let the model classifier choose between approve and prompt per call.",
-			"Bypass Approvals",
-			"Auto-approve every tool call.",
-			"Ask Each Time",
-			"Prompt for every tool call.",
-			"Don't Ask",
-			"Auto-approve every tool call without prompting.",
-			"Plan Only (Read-Only)",
-			"Read-only research mode; no tool calls executed.",
+			"Edit Automatically",
+			"Claude edits files without asking, and asks before using other tools.",
+			"Auto Mode",
+			"Claude decides whether to ask for each tool operation.",
+			"Bypass Permissions",
+			"Claude runs all tools without asking.",
+			"Ask Before Edits",
+			"Claude asks before editing files.",
+			"Plan Mode",
+			"Claude creates a plan before making changes.",
 			"How Claude handles tool approvals.",
 			"Claude agent backed by the Anthropic Claude Agent SDK",
 			"Claude"
@@ -30626,6 +32404,7 @@
 			"Allow tool from {0}?",
 			"Read file?",
 			"Run in terminal?",
+			"Run skill?",
 			"Fetch URL?",
 			"Edit file?",
 			"Ask user a question",
@@ -30642,7 +32421,12 @@
 			"Edit notebook",
 			"Read notebook",
 			"Read file",
+			"Run skill",
 			"Run subagent task",
+			"Create task",
+			"Read task",
+			"List tasks",
+			"Update task",
 			"Update todo list",
 			"Fetch URL",
 			"Write file",
@@ -30652,7 +32436,6 @@
 			"Edited file",
 			"Edited {0}",
 			"\"{0}\" failed",
-			"Used \"{0}\"",
 			"Found files",
 			"Found files matching {0}",
 			"Searched files",
@@ -30662,7 +32445,17 @@
 			"Listed {0}",
 			"Read file",
 			"Read {0}",
+			"Ran skill",
+			"Ran skill {0}",
 			"Ran subagent",
+			"Completed task",
+			"Created task",
+			"Created task: {0}",
+			"Deleted task",
+			"Read task",
+			"Read task list",
+			"Started task",
+			"Updated task",
 			"Updated todo list",
 			"Fetched {0}",
 			"Fetched URL",
@@ -30680,19 +32473,42 @@
 			"Listing {0}",
 			"Reading file",
 			"Reading {0}",
+			"Running skill",
+			"Running skill {0}",
+			"Completing task",
+			"Creating task",
+			"Creating task: {0}",
+			"Deleting task",
+			"Reading task",
+			"Reading task list",
+			"Starting task",
+			"Updating task",
 			"Updating todo list",
 			"Fetching {0}",
 			"Fetching URL"
 		],
-		"vs/platform/agentHost/node/claude/customizations/claudeSdkCustomizationBundler": [
-			"Discovered in Claude"
+		"vs/platform/agentHost/node/claude/customizations/claudeBuiltinCommands": [
+			"(Built-In) Reference for the Claude API / Anthropic SDK: model IDs, pricing, params, streaming, tool use, MCP, agents, caching, token counting, migration.",
+			"(Built-In) Review the current diff for correctness bugs and reuse/simplification/efficiency cleanups at a chosen effort level (low→max). Pass `--comment` to post findings as inline PR comments, or `--fix` to apply them to the working tree.",
+			"(Built-In) Scan transcripts for common read-only Bash/MCP calls and add a prioritized allowlist to project `.claude/settings.json` to reduce permission prompts.",
+			"(Built-In) Scan the codebase and generate a `CLAUDE.md` file with project structure, conventions, and instructions for future sessions.",
+			"(Built-In) Customize keyboard shortcuts, rebind keys, add chord bindings, or modify `~/.claude/keybindings.json`.",
+			"(Built-In) Run a prompt or slash command on a recurring interval (e.g. `/loop 5m /foo`, defaults to 10m). For recurring tasks or polling status — not one-off work.",
+			"(Built-In) Review a pull request or set of changes.",
+			"(Built-In) Launch and drive the project's app to see a change working — run, start, or screenshot the app, or confirm a change works in the real app (not just tests).",
+			"(Built-In) Complete a security review of the pending changes on the current branch.",
+			"(Built-In) Review changed code for reuse, simplification, efficiency, and altitude cleanups, then apply the fixes. Quality only — it doesn't hunt for bugs (use `/code-review` for that).",
+			"(Built-In) Configure the Claude Code harness via `settings.json`: hooks for automated behaviors, permissions, env vars, and hook troubleshooting.",
+			"(Built-In) Run the app and observe behavior to confirm a code change actually does what it's supposed to. Use to verify a PR, confirm a fix, or validate local changes before pushing.",
+			"(Built-In) Author a new skill.",
+			"(Built-In) Catch-all for any task that doesn't fit a more specific agent — the default when no agent name is typed.",
+			"(Built-In) Answers questions about the Claude Agent SDK, and the Claude/Anthropic API — features, hooks, slash commands, MCP servers, settings, IDE integrations, SDK agent-building, and API usage. Model: Haiku.",
+			"(Built-In) Read-only search agent for broad fan-out searches across many files when you only need the conclusion; it locates code rather than reviewing it. Model: Haiku.",
+			"(Built-In) General-purpose agent for researching complex questions, searching for code, and executing multi-step tasks.",
+			"(Built-In) Software architect agent for designing implementation plans — step-by-step plans, critical files, and architectural trade-offs."
 		],
 		"vs/platform/agentHost/node/codex/codexAgent": [
 			"Controls how much reasoning effort Codex uses.",
-			"High",
-			"Low",
-			"Medium",
-			"Minimal",
 			"Thinking Level",
 			"Additional Writable Directories",
 			"Directory",
@@ -30708,13 +32524,31 @@
 			"Ask before more command categories so you can review actions more closely.",
 			"How Codex requests approval for tool calls.",
 			"Reasoning Effort",
-			"High",
-			"Low",
-			"Medium",
-			"Minimal",
 			"Controls how much reasoning effort Codex uses.",
 			"Network",
 			"Allow sandboxed tool calls to make outbound network requests. Only applies when Sandbox is Workspace Write.",
+			"Approvals",
+			"Auto-Review",
+			"Same workspace access as Default, but approval requests are routed through the auto-reviewer instead of prompting you.",
+			"Default Permissions",
+			"Codex can read and edit files in the workspace and run routine local commands. It asks before using the internet or going beyond the workspace.",
+			"Full Access",
+			"Codex can edit files outside the workspace and use the internet without asking. Use only when you want full machine access.",
+			"How much Codex can do on its own before asking for approval.",
+			"Personality",
+			"Friendly",
+			"Warmer, more conversational tone.",
+			"Default",
+			"Use Codex's built-in default tone.",
+			"Pragmatic",
+			"Terse, no-nonsense tone focused on actions.",
+			"Tone Codex uses when communicating.",
+			"Reasoning Summary",
+			"Auto",
+			"Concise",
+			"Detailed",
+			"None",
+			"How Codex summarizes its reasoning in the response stream.",
 			"Sandbox",
 			"Full Access (Dangerous)",
 			"Tool calls have unrestricted disk and network access.",
@@ -30732,32 +32566,19 @@
 			"Codex"
 		],
 		"vs/platform/agentHost/node/copilot/copilotAgent": [
-			"Branch",
-			"Base branch to work from",
-			"Isolation",
-			"Folder",
-			"Work directly in the folder",
-			"Worktree",
-			"Create a Git worktree for isolation",
-			"Where the agent should make changes",
 			"Default",
 			"Selects the context window size for this model.",
 			"Longer sessions",
-			"Longer sessions without compaction",
 			"Context Size",
 			"Controls how much reasoning effort the model uses.",
-			"High",
-			"Low",
-			"Medium",
 			"Thinking Level",
-			"Extra High",
-			"Error parsing plugin.",
-			"Created isolated worktree for branch {0}"
+			"Copilot SDK agent running in the local agent host process",
+			"Error parsing plugin."
 		],
 		"vs/platform/agentHost/node/copilot/copilotAgentSession": [
-			"Auto-approve all tool calls and continue until done.",
+			"Continue autonomously until done, using the selected approval level.",
 			"Implement with Autopilot",
-			"Auto-approve all tool calls, including fleet management actions, and continue until done.",
+			"Continue autonomously with fleet management, using the selected approval level.",
 			"Implement with Autopilot Fleet",
 			"Approve the plan without executing it. I will implement it myself.",
 			"Approve Plan Only",
@@ -30766,31 +32587,31 @@
 			"Implement Plan",
 			"How would you like to proceed?",
 			"Review Plan",
-			"View full plan",
 			"This command needs to access blocked network domain(s): {0}.",
 			"This command needs to run outside the sandbox.",
 			"Reason for leaving the sandbox: {0}",
 			"Run Command Outside the Sandbox to Access {0}?",
-			"Run Command Outside the Sandbox?"
-		],
-		"vs/platform/agentHost/node/copilot/copilotSlashCommandCompletionProvider": [
-			"Free up context by compacting the conversation history",
-			"Create an implementation plan before coding",
-			"Run deep research on a topic using search and web sources",
-			"Get an independent critique of the current approach"
+			"Run Command Outside the Sandbox?",
+			"Compaction completed",
+			"The /{0} command requires selecting a subcommand. Available options: {1}"
 		],
 		"vs/platform/agentHost/node/copilot/copilotSystemNotification": [
-			"Background agent completed",
+			"Background agent {0} completed",
+			"Background agent {0} failed",
+			"Background agent {0} is complete",
+			"Instruction discovered: {0}",
+			"New inbox message from {0}",
 			"Shell completed",
-			"`{0}` completed",
-			"Shell `{0}` completed"
+			"`{0}` completed"
 		],
 		"vs/platform/agentHost/node/copilot/copilotToolDisplay": [
+			"Create file?",
 			"Allow the model to call {0}?",
 			"Allow tool call?",
 			"MCP Tool",
 			"Allow tool from {0}?",
-			"Read file?",
+			"Allow reading file outside of workspace?",
+			"Run in terminal outside the sandbox?",
 			"Run in terminal?",
 			"Allow fetching web content?",
 			"Fetch URL?",
@@ -30801,20 +32622,23 @@
 			"Edited {0}",
 			"Exited plan mode",
 			"\"{0}\" failed",
-			"Used \"{0}\"",
 			"Found files",
 			"Found files matching {0}",
 			"Searched files",
 			"Searched for {0}",
+			"Listed agents",
 			"Edited files",
 			"Edited {0}",
 			"Edited {0}",
+			"Read agent {0}",
+			"Read agent",
 			"Read Terminal",
 			"Ran {0} command",
 			"Ran {0}",
 			"Read skill {0}",
 			"Read skill {0}",
 			"Executed SQL query",
+			"Delegated task",
 			"Read file",
 			"Read {0}",
 			"Read {0}, line {1} to the end",
@@ -30822,6 +32646,8 @@
 			"Read {0}, lines {1} to {2}",
 			"Fetched {0}",
 			"Fetched URL",
+			"Wrote to agent {0}",
+			"Wrote to agent",
 			"Sent input to shell",
 			"Sent {0} to shell",
 			"Creating file",
@@ -30829,7 +32655,6 @@
 			"Editing file",
 			"Editing {0}",
 			"Presenting plan",
-			"Using \"{0}\"",
 			"Finding files",
 			"Finding files matching {0}",
 			"Searching files",
@@ -30843,6 +32668,7 @@
 			"Reading skill {0}",
 			"Reading skill {0}",
 			"Executing SQL query",
+			"Delegating task",
 			"Reading file",
 			"Reading {0}",
 			"Reading {0}, line {1} to the end",
@@ -30852,6 +32678,7 @@
 			"Fetching URL",
 			"Sending input to shell",
 			"Sending {0} to shell",
+			"**Task completed:** {0}",
 			"Apply Patch",
 			"Ask User",
 			"CodeQL Security Scan",
@@ -30896,10 +32723,86 @@
 			"Write to Bash",
 			"Write to PowerShell"
 		],
+		"vs/platform/agentHost/node/localCommands/bangLocalCommand": [
+			"Command is running in the background",
+			"Command exited with code {0}",
+			"Failed to run command",
+			"Command opened an interactive terminal",
+			"Ran command",
+			"Shell exited unexpectedly",
+			"Terminal",
+			"Command timed out"
+		],
+		"vs/platform/agentHost/node/localCommands/renameLocalCommand": [
+			"Renamed: {0}"
+		],
 		"vs/platform/agentHost/node/sessionPermissions": [
 			"Allow Once",
 			"Allow in this Session",
 			"Skip"
+		],
+		"vs/platform/agentHost/node/shared/agentFeedbackServerTools": [
+			"Added comment",
+			"Deleted comments",
+			"Checked comments",
+			"Checked {0} comments",
+			"Checked 1 comment",
+			"Resolved comments",
+			"Viewed comments",
+			"Adding comment",
+			"Deleting comments",
+			"Checking comments",
+			"Resolving comments",
+			"Viewing comments",
+			"Add Comment",
+			"Delete Comments",
+			"List Comments",
+			"Resolve Comments",
+			"View Comments"
+		],
+		"vs/platform/agentHost/node/shared/sessionServerTools": [
+			"Created chat",
+			"Created session",
+			"Deleted session",
+			"Checked current session",
+			"Read session context",
+			"Checked sessions",
+			"Checked {0} sessions",
+			"Checked 1 session",
+			"Sent message",
+			"Creating chat",
+			"Creating session",
+			"Deleting session",
+			"Checking current session",
+			"Reading session context",
+			"Checking sessions",
+			"Sending message",
+			"Create Chat",
+			"Create Session",
+			"Delete Session",
+			"Get Current Session",
+			"Get Session Context",
+			"List Sessions",
+			"Send Message"
+		],
+		"vs/platform/agentHost/node/shared/worktreeIsolation": [
+			"Branch",
+			"Base branch to work from",
+			"Isolation",
+			"Folder",
+			"Work directly in the folder",
+			"Worktree",
+			"Create a Git worktree for isolation",
+			"Where the agent should make changes",
+			"Worktree Branch Prefix",
+			"Prefix applied to the branch created for an isolated worktree.",
+			"Worktree Include Files",
+			"Glob patterns for git-ignored files to copy into the isolated worktree.",
+			"Pattern",
+			"Created isolated worktree for branch {0}",
+			"This session couldn't be loaded because its working directory no longer exists: {0}",
+			"This session couldn't be loaded because its worktree is missing and could not be recreated: {0}",
+			"the branch '{0}' no longer exists"
 		],
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
 			"Failed to read private key file: {0}",
@@ -30922,12 +32825,32 @@
 			"Preparing CLI in {0}...",
 			"Unsupported WSL distro platform: {0}"
 		],
+		"vs/platform/browserView/common/browserPermissions": [
+			"Capture video from cameras",
+			"Camera",
+			"Read from and write to the system clipboard",
+			"Clipboard",
+			"Request access to USB, serial, HID, and Bluetooth devices",
+			"Devices",
+			"Access this device's geographic location",
+			"Location",
+			"Capture audio from microphones",
+			"Microphone",
+			"Display desktop notifications",
+			"Notifications",
+			"Read motion and environmental sensors",
+			"Sensors"
+		],
 		"vs/platform/browserView/common/browserView": [
 			"Page Zoom: {0}%",
 			"{0}%"
 		],
 		"vs/platform/browserView/electron-main/browserSession": [
 			"Forbidden. File does not reside within a trusted folder."
+		],
+		"vs/platform/browserView/electron-main/browserSessionPermissions": [
+			"HID Device {0}",
+			"USB Device {0}"
 		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
 			"Add Element to Chat",
@@ -30943,7 +32866,8 @@
 			"Reload"
 		],
 		"vs/platform/configuration/common/configurationRegistry": [
-			"Cannot register '{0}'. The associated policy {1} is already registered with {2}.",
+			"Cannot register '{0}'. A setting must not declare both 'policy' and 'policyReference'.",
+			"Cannot register '{0}'. The associated policy {1} is already registered with {2}. To attach another setting to the same policy, use 'policyReference'.",
 			"Cannot register '{0}'. This property is already registered.",
 			"Cannot register an empty property",
 			"Cannot register '{0}'. This matches property pattern '\\\\[.*\\\\]$' for describing language specific editor settings. Use 'configurationDefaults' contribution.",
@@ -31078,7 +33002,6 @@
 		],
 		"vs/platform/extensionManagement/common/abstractExtensionManagementService": [
 			"The '{0}' extension is not available in {1} for the {2} platform.",
-			"Can't install '{0}' extension. {1}",
 			"Learn Why",
 			"Can't install '{0}' extension since it was reported to be problematic.",
 			"Marketplace is not enabled",
@@ -31181,8 +33104,6 @@
 			"VSIX invalid: package.json is not a JSON file."
 		],
 		"vs/platform/extensions/common/extensionValidator": [
-			"This extension is using the API proposal '{0}' that is not compatible with the current version of VS Code.",
-			"This extension is using the API proposals {0} and '{1}' that are not compatible with the current version of VS Code.",
 			"property `{0}` can be omitted or must be of type `string[]`",
 			"property `{0}` should be omitted if the extension doesn't have a `{1}` or `{2}` property.",
 			"property `{0}` can be omitted or must be of type `string`",
@@ -31345,6 +33266,8 @@
 			"Problems are paused because: \"{0}\" and {1} more"
 		],
 		"vs/platform/mcp/common/allowedMcpServersService": [
+			"This Model Context Protocol server is blocked by your organization's policy. Please contact your administrator for more information.",
+			"This Model Context Protocol server is not in the list of servers allowed by your organization. Please contact your administrator for more information.",
 			"Model Context Protocol servers are disabled in the Editor. Please check your [settings]({0})."
 		],
 		"vs/platform/mcp/common/mcpGalleryService": [
@@ -31365,6 +33288,7 @@
 			"&&Help",
 			"Hide {0}",
 			"Hide Others",
+			"Cancelling Update...",
 			"Check for &&Updates...",
 			"Checking for Updates...",
 			"Downloading Update...",
@@ -31888,8 +33812,11 @@
 		],
 		"vs/platform/theme/common/sizes/baseSizes": [
 			"Base font size. This size is used if not overridden by a component.",
+			"Deprecated: use `fontSize.body1` instead.",
 			"Small font size for secondary content.",
+			"Deprecated: use `fontSize.label1` instead.",
 			"Extra small font size for less prominent content.",
+			"Deprecated: use `fontSize.body2` instead.",
 			"Base font size for codicons.",
 			"Compact font size for codicons.",
 			"Circular corner radius for fully rounded UI elements.",
@@ -31898,6 +33825,16 @@
 			"Small corner radius for compact UI elements.",
 			"Extra large corner radius for very prominent UI elements.",
 			"Extra small corner radius for very compact UI elements.",
+			"Primary body font size.",
+			"Secondary body font size.",
+			"Heading 1 font size (largest heading).",
+			"Heading 2 font size (title).",
+			"Heading 3 font size (subtitle).",
+			"Label 1 font size (section title, tabs).",
+			"Label 2 font size (metadata).",
+			"Label 3 font size (badge).",
+			"Regular font weight (400) for body, labels and metadata.",
+			"SemiBold font weight (600) for headings and strong emphasis.",
 			"No spacing (0px).",
 			"Spacing of 10px.",
 			"Spacing of 12px.",
@@ -31989,7 +33926,7 @@
 			"Show Release Notes after an update. The Release Notes are fetched from a Microsoft online service.",
 			"Check for updates only on startup. Disable automatic background update checks.",
 			"Update",
-			"Configure whether you receive automatic updates. Requires a restart after change. The updates are fetched from a Microsoft online service.",
+			"Configure whether you receive automatic updates. The updates are fetched from a Microsoft online service.",
 			"Show the update indicator in the title bar."
 		],
 		"vs/platform/update/electron-main/notAvailableUpdateDialog": [
@@ -32062,6 +33999,7 @@
 			"Code Workspace"
 		],
 		"vs/platform/workspaces/electron-main/workspacesHistoryMainService": [
+			"Agents Window",
 			"&&Cancel",
 			"&&Clear",
 			"This action is irreversible!",
@@ -32101,25 +34039,24 @@
 			"Icon to close the panel.",
 			"Icon for the sessions sidebar when closed.",
 			"Icon for the sessions sidebar when open.",
-			"Open/Show and Close/Hide Secondary Side Bar",
+			"Hide Panel",
+			"Hide Secondary Side Bar",
 			"Open/Show and Close/Hide Sidebar",
-			"Secondary Side Bar hidden",
-			"Secondary Side Bar shown",
+			"Show Secondary Side Bar",
 			"Primary Side Bar hidden",
 			"Primary Side Bar shown",
-			"Toggle Panel Visibility",
-			"Toggle Secondary Side Bar Visibility",
-			"Toggle Primary Side Bar Visibility",
+			"Toggle Side Bar",
 			"Toggle Always on Top"
 		],
 		"vs/sessions/browser/parts/auxiliaryBarPart": [
 			"Session Details"
 		],
 		"vs/sessions/browser/parts/chatCompositeBar": [
+			"New Chat",
 			"Chats",
-			"Close",
+			"Delete Chat",
 			"Rename",
-			"Rename Chat"
+			"Rename chat"
 		],
 		"vs/sessions/browser/parts/menubar.contribution": [
 			"&&Edit",
@@ -32127,6 +34064,7 @@
 			"&&Go",
 			"&&Help",
 			"&&Preferences",
+			"&&Selection",
 			"&&Terminal",
 			"&&View"
 		],
@@ -32202,8 +34140,15 @@
 			"1 file changed"
 		],
 		"vs/sessions/browser/parts/sessionHeader": [
-			"New Session",
 			"Rename session"
+		],
+		"vs/sessions/browser/parts/sessionReadOnlyBanner": [
+			"This chat is read-only"
+		],
+		"vs/sessions/browser/parts/sessionView": [
+			"Archived sessions are read-only.",
+			"This chat is read-only",
+			"Restore"
 		],
 		"vs/sessions/browser/sessionsSetUpService": [
 			"Loading",
@@ -32225,33 +34170,55 @@
 			"Agents"
 		],
 		"vs/sessions/common/contextkeys": [
-			"Whether the active session has an associated git repository",
-			"Whether the active session has a git sync action currently running",
-			"The provider ID of the active session",
 			"The identifier of the active sessions panel",
-			"The session type of the active session",
-			"Whether the active session's provider offers a combined mode and model configuration picker (used on phone layouts in place of the standalone pickers)",
-			"Whether the active session's workspace is virtual",
-			"The provider ID of a session in context menu overlays",
-			"The session type of a session in context menu overlays",
+			"Whether the single-pane active editor has a docked detail panel (a managed Changes/Files tab or a text file editor)",
+			"Whether the single-pane session supports a Changes editor but its tab is not currently open",
+			"Whether the single-pane session supports a Files tab but its tab is not currently open",
+			"Whether the Agents window is using the single-pane (docked detail panel) layout. Single source of truth for gating single-pane behaviour — set once by the workbench from the layout it was constructed with; features must read this instead of the underlying setting",
 			"Whether the editor area is maximized",
-			"Whether the active session is archived (marked as done)",
+			"Whether the session in scope is a workspace-less quick chat",
 			"Whether more than one session is visible in the sessions part's grid",
-			"Whether the session is archived (marked as done)",
+			"Whether the session view's currently-active chat has spawned subagent (tool-origin) chats, which are listed as a separate group in the Conversations menu",
+			"Whether the session's active chat can be closed (hidden) from the tab strip, i.e. it is not the main chat. Includes read-only subagent chats. Used to scope the close-chat keybinding so it closes the tab instead of the session",
+			"Whether the session's active chat can be permanently deleted from the tab strip, i.e. it is a real, user-created non-main chat (not the main chat and not a tool-spawned subagent chat, which are transient children). Used to scope the delete-chat keybinding",
+			"Whether the chats picker (chats within the active session) is visible",
+			"Whether the new-session view's harness (session type) picker is visible — it is hidden when at most one harness can serve the selected workspace",
+			"Whether the session view's session has pending changes (insertions or deletions)",
+			"Whether the session has an associated git repository",
+			"Whether the session has a git sync action currently running",
+			"Whether the session view's session has more than one committed (non-draft) chat, which drives the Conversations menu visibility",
+			"Whether the session view's session has more than one open chat (the tabs shown in the strip, including in-composer drafts). Used to scope chat-to-chat navigation (next/previous chat, the Ctrl+Tab chat switcher)",
+			"Whether the session view's session is associated with a GitHub pull request",
+			"Whether the session view's session has an associated workspace folder",
+			"The identifier of the session in scope (the active session globally, or a specific session within an isolated component such as the session view or a context menu overlay)",
+			"Whether the session in scope is archived/marked as done (the active session globally, or a specific session within an isolated component such as the session view or a context menu overlay)",
 			"Whether the session view's session has been created (chat view shown, not new-session view)",
 			"Whether the session view is currently maximized in the sessions part's grid",
+			"Whether the new-session view's isolation picker is visible — it is shown only when the isolation option is enabled and the workspace has a git repository",
 			"Whether the session has been marked as read",
 			"Whether the session view's session is sticky in the grid",
+			"The provider ID of the session in scope (the active session globally, or a specific session within an isolated component such as the session view or a context menu overlay)",
 			"Whether the sessions aquarium overlay is active",
+			"Whether the blocked-sessions dropdown (surfacing sessions that require input) is open in the sessions titlebar",
 			"Whether there is a previous session in the navigation history",
 			"Whether there is a next session in the navigation history",
 			"Whether the sessions part has keyboard focus",
+			"Whether the session view's chat tab strip is shown, i.e. the session has more than one chat (counting closed chats) or its single remaining chat's title diverged from the session title. Used to hide the header New Chat button, which the tab strip then offers instead",
 			"Whether the current layout is the phone layout",
 			"Whether the virtual keyboard is visible",
+			"Whether the sessions picker is visible",
+			"Whether the new-session button is shown in the titlebar when the sessions list is hidden (A/B experiment)",
+			"Whether the session can be deleted",
+			"Whether the session view's session supports forking a chat from a turn into a new peer chat",
 			"Whether the session view's session supports multiple chats",
+			"Whether the session can be renamed",
 			"Whether the sessions part is visible",
 			"Whether the sessions welcome overlay is visible",
-			"The currently active group tab in the session workspace picker"
+			"The session type of the session in scope (the active session globally, or a specific session within an isolated component such as the session view or a context menu overlay)",
+			"Whether the session's provider offers a combined mode and model configuration picker (used on phone layouts in place of the standalone pickers)",
+			"Whether the session's workspace is virtual",
+			"The currently active group tab in the session workspace picker",
+			"Whether the new-session view's workspace picker is rendered (as opposed to being replaced by the no-agent-host empty state)"
 		],
 		"vs/sessions/common/sizes": [
 			"Primary body font size for the agents window.",
@@ -32263,11 +34230,14 @@
 			"Label 2 font size for the agents window (metadata).",
 			"Label 3 font size for the agents window (badge).",
 			"Regular font weight (400) for the agents window.",
-			"SemiBold font weight (600) for the agents window."
+			"SemiBold font weight (600) for the agents window.",
+			"Gap between floating panels in the Agents window."
 		],
 		"vs/sessions/common/theme": [
 			"Background color of an active session view in the agent sessions window.",
 			"Foreground color of an active session view in the agent sessions window.",
+			"Background color of the agent feedback widget shown in the editor.",
+			"Border color of the agent feedback widget shown in the editor.",
 			"Border color of the agent feedback input widget shown in the editor.",
 			"Background color of the agent sessions window shell and gradient base.",
 			"Background color of badges in the agent sessions window.",
@@ -32309,7 +34279,7 @@
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution": [
 			"Submit Feedback ({0})"
 		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachment": [
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachmentEntry": [
 			"{0} comments",
 			"1 comment"
 		],
@@ -32330,22 +34300,28 @@
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution": [
 			"Add Feedback",
 			"Add Feedback and Submit",
+			"Add Feedback at Current Line",
 			"Add Comment",
 			"Add Feedback",
 			"Alt+Enter",
 			"Enter"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay": [
+			"Submit {0}",
 			"{0}/{1}",
 			"0/0"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution": [
+			"Share comment with agent",
 			"Accept",
+			"Share PR comment with agent",
 			"Add a comment…",
 			"Add to Comment",
 			"Agent Review",
 			"Collapse",
-			"Convert to Agent Feedback",
+			"Remove agent comment",
+			"Delete",
+			"Remove and mark as resolved on GitHub",
 			"Edit",
 			"Expand",
 			"Line {0}",
@@ -32363,6 +34339,10 @@
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackOverviewRulerContribution": [
 			"Editor overview ruler decoration color for agent feedback. This color should be opaque."
+		],
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackReviewCommands": [
+			"Agent Review",
+			"PR Review"
 		],
 		"vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeView": [
 			"Chat Customization"
@@ -32385,6 +34365,7 @@
 		],
 		"vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews": [
 			"Chat Customization Items",
+			"Automations",
 			"Built-in ({0})",
 			"Custom Agents",
 			"Extensions ({0})",
@@ -32408,41 +34389,144 @@
 			"Open in VS Code"
 		],
 		"vs/sessions/contrib/aquarium/browser/aquarium.contribution": [
+			"Simulate Fish Feeding Streak",
+			"Alive streak",
+			"Show a live feeding streak in the toggle tooltip.",
+			"Clear streak",
+			"Remove all streak state.",
+			"Enter a whole number greater than 0.",
+			"How many days should the streak be?",
+			"Died streak (revivable)",
+			"Park a died streak and offer the revival prompt.",
+			"Pick a streak scenario to simulate",
 			"Adds an easter egg to the Agents window."
 		],
 		"vs/sessions/contrib/aquarium/browser/aquariumOverlay": [
 			"Hide Aquarium",
-			"Show Aquarium"
+			"💔 {0} · Feed again to revive",
+			"{0} — feed a fish to revive your {1} day streak",
+			"{0} — feed a fish to revive your {1} day streak",
+			"Show Aquarium",
+			"{0} — 🔥 {1} day feeding streak",
+			"{0} — 🔥 {1} days feeding streak"
+		],
+		"vs/sessions/contrib/automations/browser/automationDialog": [
+			"Session capabilities are loading.",
+			"Choose the local branch to use as the Worktree base.",
+			"({0})",
+			"Select Worktree to choose a branch.",
+			"Unable to load branches",
+			"Open the branch picker to retry loading local branches.",
+			"Loading branches…",
+			"Local branches are loading.",
+			"No local branches",
+			"No local branches were found in this repository.",
+			"Select a folder to determine its Git branch.",
+			"no git repo",
+			"No Git repository was found for the selected folder.",
+			"Select branch",
+			"—",
+			"The selected session type does not support Worktree branch configuration.",
+			"A branch is required for Worktree isolation.",
+			"Day of week",
+			"Enabled (the scheduler runs this automation when due)",
+			"Workspace folder is required.",
+			"Automations Harness Chip",
+			"Schedule",
+			"Worktree isolation",
+			"New Worktree",
+			"Select a folder to use Worktree isolation.",
+			"Not supported by the selected session type",
+			"Automations Isolation Group",
+			"Name",
+			"e.g. Morning standup notes",
+			"Name is required.",
+			"No workspace",
+			"Run without a backing workspace",
+			"Prompt",
+			"Describe what you want to automate",
+			"Prompt is required.",
+			"Session type is required.",
+			"Time",
+			"Automations Workspace Picker",
+			"Pick a workspace for this automation",
+			"Automation target, {0}",
+			"Daily",
+			"Hourly",
+			"Manual",
+			"Weekly",
+			"workspace"
+		],
+		"vs/sessions/contrib/automations/browser/automationDialogService": [
+			"Cancel",
+			"Create",
+			"Define a prompt that Copilot will run on a schedule against the selected target.",
+			"New automation",
+			"Update the schedule, prompt, or run target for this automation.",
+			"Edit automation",
+			"Save"
+		],
+		"vs/sessions/contrib/automations/browser/automationRunner": [
+			"Automation '{0}' failed: {1}",
+			"Cancelled",
+			"Agent session failed."
+		],
+		"vs/sessions/contrib/automations/browser/automations.contribution": [
+			"Enables the Automations feature: scheduling agent sessions to run on a cadence. When disabled, the Automations entry in the Customizations sidebar, the Automations section in the Customizations editor, and the Automation option in the new-session composer are hidden, and scheduled automations are not dispatched.",
+			"Maximum number of minutes a scheduled automation run is allowed to take before the scheduler cancels it and marks it failed. Prevents a single hung run from permanently blocking subsequent scheduled runs."
+		],
+		"vs/sessions/contrib/automations/browser/automationScheduler": [
+			"Timed out after {0} minute(s).",
+			"Interrupted by app shutdown"
 		],
 		"vs/sessions/contrib/changes/browser/changes.contribution": [
 			"Changes",
 			"View icon for the Changes view.",
 			"Chan&&ges",
+			"Changes",
 			"Controls whether clicking a file in the Changes view opens a single file diff editor instead of the multi file diff editor."
 		],
-		"vs/sessions/contrib/changes/browser/changesTitleBarWidget": [
-			"Icon for the sessions secondary sidebar when closed.",
-			"Icon for the sessions secondary sidebar when open.",
-			"Hide Changes",
-			"Show Changes",
-			"Toggle Secondary Side Bar Visibility"
+		"vs/sessions/contrib/changes/browser/changesActions": [
+			"Changes",
+			"Collapse Unchanged Regions",
+			"Expand Full File",
+			"{0} file",
+			"{0} files",
+			"Open File",
+			"{0}: {1}, +{2}, -{3}",
+			"View Changes",
+			"View Changes ({0})"
+		],
+		"vs/sessions/contrib/changes/browser/changesetReviewActions": [
+			"Viewed"
 		],
 		"vs/sessions/contrib/changes/browser/changesView": [
 			"Changes",
+			"1 file",
+			"{0} files",
 			"{0} files, {1} additions, {2} deletions",
 			"Changed files and other session artifacts will appear here.",
 			"View All Changes",
 			"Changes Tree",
 			"Versions",
-			"Session Changes",
+			"Reveal Checks",
 			"View as List",
 			"View as Tree"
 		],
 		"vs/sessions/contrib/changes/browser/changesViewActions": [
+			"Collapse All Diffs",
+			"Expand All Diffs",
+			"View as List",
+			"View as Tree",
+			"Changes",
+			"Changes Actions",
 			"Open Changes",
 			"Changes",
 			"Open File",
-			"Open Pull Request"
+			"Open Pull Request",
+			"Show Inline Diff",
+			"Show Side by Side Diff",
+			"Toggle Diff View"
 		],
 		"vs/sessions/contrib/changes/browser/checksActions": [
 			"failed",
@@ -32456,10 +34540,42 @@
 			"Checks",
 			"Checks",
 			"{0}: {1}",
-			"Fix Checks",
 			"Open on GitHub",
 			"Rerun Check",
 			"Toggle Checks"
+		],
+		"vs/sessions/contrib/changes/browser/sessionChangesEditor": [
+			"Mark as Viewed",
+			"Mark as Not Viewed",
+			"{0} lines added, {1} lines removed"
+		],
+		"vs/sessions/contrib/changes/browser/sessionChangesEditorInput": [
+			"Changes"
+		],
+		"vs/sessions/contrib/changes/browser/sessionChangesService": [
+			"Session Changes"
+		],
+		"vs/sessions/contrib/changes/browser/sessionFilesWidget": [
+			"Created",
+			"Deleted",
+			"{0} (Session Changes)",
+			"{0}, {1}",
+			"Files created, edited, or deleted outside the workspace during this session. These files are not part of the workspace and won't be committed.",
+			"Other Files",
+			"Other Files",
+			"Modified",
+			"Open File",
+			"{0} ({1})",
+			"Toggle Other Files"
+		],
+		"vs/sessions/contrib/changes/browser/sessionsChangesAccessibilityHelp": [
+			"The Checks section lists the continuous integration checks for the session's pull request. Its header is a button: press Enter or Space to collapse or expand it{0}.",
+			"File diffs can be shown side by side or inline. Use the Toggle Diff View command to switch between them{0}.",
+			"You are in the Changes view. It shows the files changed by the current session as a tree, followed by two collapsible sections: Other Files and Checks.",
+			"The Other Files section lists files that were created, edited, or deleted outside the workspace during this session, such as configuration files in your home directory. These files are not part of the workspace and won't be committed.",
+			"The Other Files header is a button. Press Enter or Space to collapse or expand the list. When expanded, use the arrow keys to move through the files and press Enter to open one: created or deleted files open in an editor, while edited files open as a diff against their pre-session content.",
+			"Use the up and down arrow keys to move between changed files, and the left and right arrow keys to collapse or expand folders. Press Enter to open the selected file's diff.",
+			"The Changes view can show files as a tree or a flat list. Use the view's toolbar actions to switch between Tree and List modes."
 		],
 		"vs/sessions/contrib/chat/browser/aiCustomizationWorkspaceService": [
 			"Your customization was saved to this session's worktree, but we couldn't apply it to the default branch. You may need to apply it manually.",
@@ -32469,6 +34585,7 @@
 			"Used by the Commit button in the Changes toolbar",
 			"Used by the Create Draft Pull Request button in the Changes toolbar",
 			"Used by the Create Pull Request button in the Changes toolbar",
+			"Used by the Fix Checks button in the Changes toolbar",
 			"Used by the Run button in the title bar",
 			"Used by the Merge button in the Changes toolbar",
 			"Used by the Update Pull Request button in the Changes toolbar"
@@ -32477,19 +34594,33 @@
 			"Branch Chat",
 			"Branch to new session"
 		],
+		"vs/sessions/contrib/chat/browser/branchPicker": [
+			"Branch Picker",
+			"{0}. {1}",
+			"No local branches",
+			"Filter branches…",
+			"Loading branches…",
+			"Retry Loading Branches",
+			"Branch",
+			"Pick Branch, {0}",
+			"Unavailable locally",
+			"{0}, unavailable locally"
+		],
 		"vs/sessions/contrib/chat/browser/chat.contribution": [
 			"Whether to automatically run tasks tagged with `\"runOptions\": { \"runOn\": \"worktreeCreated\" }` when a new agent host session worktree is created. Manual `Run Task` invocations are unaffected.",
 			"Controls whether chat input history in the Agents Window is scoped to the current session. Disable this to use shared input history across sessions.",
-			"New Chat"
+			"New Session"
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
 			"Session Type"
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileWorkspacePickerSheet": [
+			"Cancel",
 			"Search to browse folders on the host",
 			"Folders",
 			"No folders match",
 			"Search folders…",
+			"Select '{0}'",
 			"Choose Workspace"
 		],
 		"vs/sessions/contrib/chat/browser/modelPicker": [
@@ -32510,6 +34641,9 @@
 			"Chat input. Press Enter to send out the request. Use {0} for Chat Accessibility Help.",
 			"Chat input. Press Enter to send out the request. Use the Chat Accessibility Help command for more information.",
 			"Loading...",
+			"Learn More",
+			"Manage",
+			"Monitoring with OpenTelemetry enabled",
 			"Send",
 			"Send (Alt-click to start in the background)",
 			"Describe the outcome you want",
@@ -32526,15 +34660,26 @@
 			"What will you create?",
 			"What will you launch?",
 			"What will you ship today?",
-			"What would you like to automate?"
+			"What would you like to automate?",
+			"Dictate (Speech to Text)",
+			"Preparing Speech to Text Model…",
+			"Stop Dictation"
 		],
 		"vs/sessions/contrib/chat/browser/newChatInSessionWidget": [
 			"Ask a follow-up question or start a new topic within this session...",
-			"Sub-session tip",
+			"New chat tip",
 			"Dismiss tip",
-			"This is a sub-session, a new chat in the same workspace. Use it to ask questions, run tasks, or explore ideas with fresh context."
+			"Start a parallel conversation to build on all the changes made in this session."
+		],
+		"vs/sessions/contrib/chat/browser/newChatVoice": [
+			"Connecting...",
+			"Disconnect Voice Mode",
+			"Voice Mode Settings",
+			"Voice Mode: Stop Recording",
+			"Voice Mode"
 		],
 		"vs/sessions/contrib/chat/browser/newChatWidget": [
+			"New Chat",
 			"Start by picking a",
 			"New session in",
 			"with",
@@ -32621,9 +34766,55 @@
 			"Workspace",
 			"Save this task in the current workspace"
 		],
+		"vs/sessions/contrib/chat/browser/sessionBackgroundActivitiesControl": [
+			"{0} Active Browsers",
+			"{0} Active Subagents",
+			"Background Activities",
+			"Browser",
+			"Browsers",
+			"{0} Background Activities",
+			"Open {0}",
+			"Show {0} background activities",
+			"Subagent",
+			"Subagents"
+		],
+		"vs/sessions/contrib/chat/browser/sessionChatInputToolbar": [
+			"Last Turn Changes"
+		],
+		"vs/sessions/contrib/chat/browser/sessionChatInputToolbarDebug": [
+			"Agent Feedback to Address",
+			"Apply",
+			"Automatically increase insertions and deletions every 2 seconds",
+			"Browser Labels",
+			"Cancel",
+			"Failed CI Checks",
+			"Pending CI Checks",
+			"Clear",
+			"Deletions",
+			"Configure the values shown by status pills and input banners. Separate multiple names with commas or new lines.",
+			"Files",
+			"Input Banners",
+			"Insertions",
+			"Markdown File Names",
+			"Enter a whole number greater than or equal to 0.",
+			"PR Feedback to Address",
+			"Subagent Names",
+			"Fake Session Chat UI",
+			"Configure Fake Session Chat UI",
+			"Whether a session chat view is active and can show fake status pills"
+		],
+		"vs/sessions/contrib/chat/browser/sessionReferenceCompletions": [
+			"{0} (current)",
+			"Untitled session"
+		],
 		"vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp": [
+			"Press Shift+Tab from the chat input to reach status pills above it, then press Enter or Space to activate a pill. A pill with multiple background activities opens a picker; use the up and down arrows to navigate, Enter to open an activity, and Escape to dismiss the picker and return focus to the pill.",
 			"Focus the Changes view{0}.",
+			"Activate a chat tab's close button to close (hide) that chat from the tab strip without deleting it; reopen it later from the Conversations menu. The session's main chat cannot be closed.",
+			"Type # in the chat input to attach context. Use #file to reference a file or folder, or #session to reference another agent session. Referencing a session together with the /troubleshoot command analyzes that session's logs instead of the current one. Accept a suggestion with Tab or Enter; the reference appears as a pill above the input that you can remove.",
+			"When a session supports multiple chats, a New Chat button is always shown: as a labeled button in the session header while the session has a single open chat, and as a compact button at the end of the chat tab strip once the session has more than one open chat. Activate it to start a new chat. Once the session has more than one committed chat, a Conversations menu is also shown: in the session header while the tab strip is hidden, and at the end of the chat tab strip once it is shown. Open it to reopen a closed chat: each chat is listed with a checkbox, where checked chats are shown as tabs and unchecked chats are closed (hidden).",
 			"Focus the Chat Customizations view{0}.",
+			"To permanently delete a chat, open the chat tab's context menu and choose Delete Chat. This is destructive and cannot be undone.",
 			"Focus the Files Explorer view{0}.",
 			"Use up and down arrows to navigate your request history in the input box.",
 			"You are in the chat input. Type a message and press Enter to send it.",
@@ -32631,12 +34822,17 @@
 			"On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection.",
 			"Navigate to the next session in the list{0}.",
 			"Navigate to the previous session in the list{0}.",
+			"When the session is associated with a GitHub pull request, the session header shows the pull request number as a button. Activate it to open the pull request on GitHub{0}.",
 			"You are in the Agents window. The Agents window is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options.",
+			"To start a workspace-less quick chat, use the New Quick Chat command{0} or the plus button on the Chats section in the sessions list. A quick chat has no workspace, so the workspace picker does not apply and the Toggle Side Panel command is disabled.",
 			"Focus the Chat Sessions view{0}.",
+			"Toggle the side panel (the editor area together with the auxiliary bar) open or closed{0}.",
+			"The session header shows the diff stats (lines added and removed) as a button. Activate it to open the multi-file diff editor for all of the session's changes{0}.",
 			"Shift+Tab to navigate to the workspace picker and choose a workspace for your session."
 		],
 		"vs/sessions/contrib/chat/browser/sessionTypePicker": [
 			"Session Type",
+			"{0}, {1}",
 			"Pick Session Type, {0}"
 		],
 		"vs/sessions/contrib/chat/browser/sessionWorkspacePicker": [
@@ -32662,6 +34858,13 @@
 			"Active file",
 			"{0} ({1})"
 		],
+		"vs/sessions/contrib/chat/browser/voiceInputDecorations": [
+			"Press {0} to barge in",
+			"Speak to barge in",
+			"Click voice mode to talk or barge in",
+			"Listening...",
+			"Press {0} to talk or barge in"
+		],
 		"vs/sessions/contrib/chat/browser/webWorkspacePicker": [
 			"Select Folder..."
 		],
@@ -32673,15 +34876,34 @@
 			"Run Code Review",
 			"Run Code Review"
 		],
+		"vs/sessions/contrib/editor/browser/addTabActions": [
+			"Browser",
+			"Changes",
+			"Files",
+			"Search"
+		],
 		"vs/sessions/contrib/editor/browser/editor.contribution": [
 			"Add File as Context",
 			"Close Editor Area",
+			"Hide Editor",
 			"Maximize Editor Area",
 			"Open in Modal Editor",
 			"Open in Editor Area",
-			"Show Secondary Side Bar",
-			"Push Editor Right",
 			"Restore Editor Area"
+		],
+		"vs/sessions/contrib/editor/browser/emptyFileEditor": [
+			"Select a file from the Files view",
+			"Search Files",
+			"Search Files ({0})",
+			"Search Files",
+			"Search Files ({0})",
+			"Search Files"
+		],
+		"vs/sessions/contrib/editor/browser/emptyFileEditor.contribution": [
+			"File"
+		],
+		"vs/sessions/contrib/editor/browser/emptyFileEditorInput": [
+			"Files"
 		],
 		"vs/sessions/contrib/files/browser/files.contribution": [
 			"Collapse Folders in Explorer",
@@ -32693,6 +34915,52 @@
 		],
 		"vs/sessions/contrib/files/browser/filesView": [
 			"Folders and files will appear here."
+		],
+		"vs/sessions/contrib/files/browser/workspaceFolderActions": [
+			"Files",
+			"Open Files: {0}",
+			"Open Files"
+		],
+		"vs/sessions/contrib/github/browser/pullRequestActions": [
+			"Open Pull Request",
+			"Open Pull Request",
+			"Open Pull Request #{0}"
+		],
+		"vs/sessions/contrib/github/browser/pullRequestHover": [
+			"target",
+			"No description provided.",
+			"source",
+			"on {0}",
+			"Pull Request #{0}"
+		],
+		"vs/sessions/contrib/layout/browser/baseSessionLayoutController": [
+			"Icon for the sessions secondary sidebar when closed.",
+			"Icon for the sessions secondary sidebar when open.",
+			"Open/Show and Close/Hide the Side Panel (editor area and auxiliary bar)",
+			"Side Panel hidden",
+			"Side Panel shown",
+			"Toggle Side Panel"
+		],
+		"vs/sessions/contrib/layout/browser/sessions.layout.contribution": [
+			"Controls whether the sessions sidebar is automatically collapsed in a narrow Agents window while both the editor and the side panel are open, and shown again once either of them closes.",
+			"Controls whether the Agents window docks the detail panel inside the editor so a single editor tab bar spans across the editor and the detail panel. Requires a window reload to take effect."
+		],
+		"vs/sessions/contrib/layout/browser/singlePane/singlePaneResponsiveSidebarStrategy": [
+			"Toggle Details"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour": [
+			"Use a worktree to work on multiple tasks in the same project without conflicts. Each task stays isolated, so you can experiment freely and safely.",
+			"Isolate Your Work",
+			"Choose between the folders and repositories you work in. Run multiple sessions at once in a single workspace, or across many.",
+			"Work Across Workspaces"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTour": [
+			"Each has different strengths; choose what works best for your task and switch anytime.",
+			"Choose a Harness",
+			"Use a worktree to work on multiple tasks in the same project without conflicts. Each task stays isolated, so you can experiment freely and safely.",
+			"Isolate Your Work",
+			"Choose between the folders and repositories you work in. Run multiple sessions at once in a single workspace, or across many.",
+			"Work Across Workspaces"
 		],
 		"vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked": [
 			"Allowed organizations:",
@@ -32710,6 +34978,39 @@
 			"Open VS Code",
 			"Agents Disabled"
 		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution": [
+			"Controls whether the prompt timeline is shown next to the chat transcript in the Agents window.",
+			"Controls whether the current prompt is pinned to the top of the chat transcript while scrolling in the Agents window."
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineActions": [
+			"Chat",
+			"(empty prompt)",
+			"Go to Prompt...",
+			"{0} files",
+			"1 file",
+			"Go to a prompt in this chat",
+			"+{0} −{1} · {2}"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineCard": [
+			"{0} prompts",
+			"{0} files",
+			"no edits",
+			"1 file",
+			"Review Changes for Prompt: {0}"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineModel": [
+			"Changes · {0}",
+			"Prompt: {0}",
+			"{0} prompts starting with: {1}"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail": [
+			"Prompt timeline"
+		],
+		"vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader": [
+			"(empty prompt)",
+			"{0}/{1}",
+			"Go to prompt {0} of {1}: {2}"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker": [
 			"Agent"
 		],
@@ -32718,9 +35019,23 @@
 			"Pick Approvals, {0}",
 			"Learn more about permissions"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostCodexApprovalsPicker": [
+			"Approvals Picker",
+			"Pick Approvals, {0}",
+			"Learn more about permissions"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
 			"Agent Mode Picker",
 			"Pick Agent Mode, {0}"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostPermissionPickerDelegate": [
+			"Runs tool calls without asking",
+			"Evaluates risk before running tools",
+			"Asks when approval settings don't apply",
+			"An LLM judge evaluates each tool call. Tools it doesn't approve require your approval.",
+			"Copilot runs all tools without asking for approval.",
+			"Copilot runs tools without asking for approval and continues until the task is done.",
+			"Copilot asks before running tools unless your configured settings allow the tool."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
 			"Copy Session Branch Name"
@@ -32730,15 +35045,11 @@
 			"Show only changes made in the last turn"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionConfigPicker": [
-			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.",
-			"Enable Autopilot?",
-			"Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.",
-			"Enable Bypass Approvals?",
-			"Cancel",
-			"Enable",
-			"{0}\n\nTo make this the starting permission level for new chat sessions, change the [{1}](command:workbench.action.openSettings?%5B%22{1}%22%5D) setting.",
 			"Session Approvals",
+			"Approvals",
 			"Agent Mode",
+			"Approvals",
+			"Approvals",
 			"Session Approvals",
 			"Agent Mode",
 			"Approvals",
@@ -32748,6 +35059,8 @@
 			"On",
 			"On",
 			"Filter options...",
+			"New Worktree",
+			"Disabled by your organization. Contact your administrator.",
 			"{0}: {1}",
 			"{0}: {1}, Read-Only",
 			"Session Configuration",
@@ -32756,8 +35069,7 @@
 			"Search branches",
 			"Base Branch",
 			"Isolation",
-			"Worktree",
-			"(Selected)"
+			"Worktree"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSettings.contribution": [
 			"Host Settings",
@@ -32786,16 +35098,22 @@
 			"Edit values below and save to apply. Unknown or non-mutable properties are ignored."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/baseAgentHostSessionsProvider": [
-			"Copilot CLI",
+			"Copilot",
+			"Are you sure you want to delete this chat?",
+			"Delete",
+			"This action cannot be undone.",
+			"New Chat",
 			"New Session",
+			"New Chat",
 			"Agent host has not advertised any agents yet.",
-			"Cannot send request: not connected to agent host."
+			"Cannot send request: not connected to agent host.",
+			"Agent host session was not committed."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
 			"Export Agent Host Debug Logs..."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution": [
-			"When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#{0}#`."
+			"When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#chat.agentHost.enabled#`."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider": [
 			"Local Agent Host"
@@ -32803,11 +35121,15 @@
 		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
 			"Open Copilot CLI State File"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/openSubagentChat": [
+			"Open Subagent",
+			"Open subagent chat: {0}"
+		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker": [
-			"Branch Picker",
-			"Filter branches...",
 			"Branch",
-			"Pick Branch, {0}"
+			"New Worktree",
+			"Worktree isolation",
+			"Git repository required for worktree isolation"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker": [
 			"Edit Automatically",
@@ -32830,8 +35152,6 @@
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
 			"Branch",
 			"Permission Mode",
-			"Delete...",
-			"Isolation Mode",
 			"Mode",
 			"Permissions"
 		],
@@ -32853,29 +35173,13 @@
 			"Are you sure you want to delete this chat?",
 			"Delete",
 			"This action cannot be undone.",
-			"Are you sure you want to delete this session?",
-			"Delete",
-			"This action cannot be undone.",
-			"This will delete all {0} chats in this session. This action cannot be undone.",
 			"New Chat",
 			"New Session",
 			"Repositories",
 			"GitHub"
 		],
-		"vs/sessions/contrib/providers/copilotChatSessions/browser/isolationPicker": [
-			"Folder",
-			"Worktree",
-			"Isolation Mode",
-			"Pick Isolation Mode, {0}"
-		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/mobilePermissionPicker": [
 			"Approvals",
-			"Bypass Approvals",
-			"All tool calls are auto-approved",
-			"Autopilot (Preview)",
-			"Autonomously iterates from start to finish",
-			"Default Approvals",
-			"Copilot uses your configured settings",
 			"Learn more about permissions"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/modePicker": [
@@ -32886,17 +35190,19 @@
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/permissionPicker": [
 			"Permission Picker",
 			"Pick Permission Level, {0}",
-			"Bypass Approvals",
-			"Bypass Approvals",
-			"All tool calls are auto-approved",
+			"Pick Permission Level, {0}, {1}",
+			"Assisted permissions",
+			"An LLM judge evaluates each tool call. Tools it doesn't approve require your approval.",
+			"Evaluates risk before running tools",
+			"Allow all",
+			"Runs tool calls without asking",
 			"Autopilot (Preview)",
 			"Auto-approve all tool calls and continue until the task is done. Autopilot may increase costs.",
-			"Autopilot (Preview)",
 			"Autonomously iterates from start to finish",
-			"Default Approvals",
-			"Default Approvals",
-			"Copilot uses your configured settings",
-			"Learn more about permissions"
+			"Default approvals",
+			"Asks when approval settings don't apply",
+			"Learn more about permissions",
+			"Disabled by enterprise policy"
 		],
 		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution": [
 			"Enable Local VS Code chat sessions in the Agents Window. Reload the window for changes to take effect."
@@ -32905,7 +35211,7 @@
 			"Are you sure you want to delete this chat?",
 			"Delete",
 			"This action cannot be undone.",
-			"Local Chat",
+			"Copilot Chat",
 			"Local",
 			"New Chat",
 			"New Session"
@@ -32997,6 +35303,10 @@
 			"No dev tunnels with agent host support were found. Start a tunnel with 'code tunnel' on another machine.",
 			"Select a dev tunnel to connect to",
 			"Connect via Dev Tunnel",
+			"Update Remote Agent Host Server...",
+			"No remote agent hosts need updating.",
+			"No remote agent hosts can be updated from here. Incompatible hosts must be updated manually, then reconnected.",
+			"Select a remote agent host to update",
 			"Failed to connect to WSL distribution '{0}': {1}",
 			"Connecting to WSL distribution '{0}'...",
 			"Default distribution",
@@ -33064,21 +35374,53 @@
 			"&&Search",
 			"Search"
 		],
+		"vs/sessions/contrib/sessionInputBanners/browser/sessionInputBanners": [
+			"{0} out of {1} checks failed",
+			"{0}, {1} pending",
+			"Hide for this session",
+			"Fix Checks",
+			"1 check failed",
+			"Reveal Checks",
+			"Address Comments",
+			"{0} agent comments",
+			"1 agent comment",
+			"Hide for this session",
+			"{0} comments",
+			"1 comment",
+			"{0} PR comments",
+			"1 PR comment",
+			"Reveal Comments"
+		],
 		"vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget": [
 			"Customizations"
 		],
+		"vs/sessions/contrib/sessions/browser/blockedSessionsIndicatorModel": [
+			"{0} sessions are failing CI",
+			"{0} sessions have questions",
+			"{0} sessions require input",
+			"{0} sessions require terminal approval",
+			"1 session is failing CI",
+			"1 session has a question",
+			"1 session requires input",
+			"1 session requires terminal approval"
+		],
+		"vs/sessions/contrib/sessions/browser/blockedSessionsList": [
+			"CI failure ignored until this session has another CI failure.",
+			"Ignore CI Failure",
+			"Ignore Input Needed",
+			"Input needed ignored until this session needs input again.",
+			"Sessions requiring input"
+		],
 		"vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution": [
 			"Agents",
-			"{0}",
+			"Automations",
 			"Hooks",
 			"Instructions",
 			"MCP Servers",
+			"Overview",
 			"Plugins",
-			"Controls how the Customizations section in the Agents sidebar is presented and what happens when an entry is clicked.",
-			"Show one item per customization category. Clicking a category deep-links to that category's section in the Customizations editor.",
-			"Show a single \"Customizations\" entry instead of one item per category. Clicking it opens the Customizations welcome page.",
-			"Show one item per customization category. Clicking a category opens the Customizations welcome page.",
-			"Skills"
+			"Skills",
+			"Tools"
 		],
 		"vs/sessions/contrib/sessions/browser/mobile/mobileOverlayContribution": [
 			"File-level changes are not available for this session yet.",
@@ -33087,59 +35429,98 @@
 		],
 		"vs/sessions/contrib/sessions/browser/sessionHoverContent": [
 			"1 file changed",
-			"{0} files changed",
-			"New Session"
+			"{0} files changed"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"Sessions",
 			"Icon for Agent Sessions View",
-			"&&Sessions"
+			"&&Sessions",
+			"Controls whether the Chats group is shown in the sessions list even when it is empty."
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsActions": [
 			"New Chat",
+			"New Chat",
 			"Close",
+			"Conversations",
 			"Maximize Session",
 			"Pin Session",
 			"Pin View",
+			"Reopen Last Closed Chat",
 			"Restore Session",
 			"Unpin Session",
 			"Unpin View",
+			"Close Chat",
+			"Close All Chats",
 			"Close All Sessions",
+			"Closed",
 			"Close Editor Area",
+			"Delete Chat",
 			"Focus Active Session",
 			"Focus Last Session in Grid",
 			"Focus Session {0} in Grid",
 			"&&Back",
 			"&&Forward",
+			"Go to Next Chat",
+			"Go to Previous Chat",
+			"New Chat ({0})",
+			"New Chat",
+			"New Chat ({0})",
+			"New Chat",
+			"New",
 			"New Session",
+			"New Session ({0})",
+			"New Session",
+			"New Session ({0})",
+			"New Session",
+			"Open",
 			"other sessions",
+			"Quick Switch to Next Chat",
+			"Quick Switch to Previous Chat",
 			"recently opened",
 			"Rename...",
+			"Search chats by name",
 			"Search sessions by name or folder",
 			"Go Back",
 			"Go Back One Session",
 			"Go Forward",
 			"Go Forward One Session",
+			"Go to Chat in Session",
 			"Show Sessions Picker",
-			"New Session"
+			"Untitled Chat"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget": [
 			"Agent Sessions",
 			"Show Sessions",
-			"New Session",
+			"Approved {0} sessions",
+			"Approved 1 session",
+			"Show All Sessions",
 			"Show Sessions"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
+			"Add to Group",
 			"Allow",
 			"Allow once",
 			"Done",
+			"Chats",
+			"{0} checks failed, {1} pending",
+			"Fix CI",
+			"Fix failing CI checks",
+			"Create Group",
+			"Delete Group",
 			"Failed",
-			"Last 7 Days",
+			"Move to Group",
 			"Input needed",
+			"New Group",
+			"No chats",
 			"Older",
+			"Voice response ready",
 			"Pinned",
+			"Recent",
+			"Remove from Group",
+			"Rename...",
 			"now",
-			"{0}, created {1}",
+			"Group name",
+			"{0}, updated {1}",
 			"{0} sessions",
 			"Sessions",
 			"Show fewer sessions",
@@ -33152,21 +35533,14 @@
 			"+{0} more workspace",
 			"Show {0} more workspaces",
 			"+{0} more workspaces",
-			"Today",
 			"Unknown",
-			"Working...",
-			"Yesterday"
+			"Working..."
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsView": [
 			"Done",
 			"Read",
 			"Group by Time",
 			"Group by Workspace",
-			"New",
-			"New Session ({0})",
-			"New Session",
-			"New Session ({0})",
-			"New Session",
 			"Reset",
 			"Sessions",
 			"Sort by Created",
@@ -33180,6 +35554,10 @@
 			"Input Needed"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
+			"Mark All as Done",
+			"Are you sure you want to mark {0} sessions from '{1}' as done?",
+			"Are you sure you want to mark 1 session from '{0}' as done?",
+			"You can restore sessions later if needed from the sessions view.",
 			"Are you sure you want to mark {0} pinned sessions as done?",
 			"Are you sure you want to mark 1 pinned session as done?",
 			"Mark All as Done",
@@ -33190,21 +35568,29 @@
 			"Mark as Done",
 			"Close Session",
 			"Collapse All Groups",
-			"Do not ask me again",
+			"Delete...",
+			"Are you sure you want to delete this session?",
+			"Delete",
+			"This action cannot be undone.",
+			"Failed to delete the session: {0}",
+			"Are you sure you want to delete {0} sessions?",
+			"Failed to delete the sessions: {0}",
 			"Do not ask me again",
 			"Filter",
 			"Filter Sessions",
 			"Find Session",
 			"Group by Time",
 			"Group by Workspace",
+			"Mark All as Done",
 			"Mark All as Read",
-			"Mark as Done",
 			"Mark as Read",
 			"Mark as Unread",
 			"Go to Next Session",
 			"&&Next Session",
 			"Go to Previous Session",
 			"&&Previous Session",
+			"New Quick Chat",
+			"New Session",
 			"New Session",
 			"Open to the Side",
 			"Pin",
@@ -33217,9 +35603,6 @@
 			"Show Recent Sessions",
 			"Sort by Created",
 			"Sort by Updated",
-			"Restore All",
-			"Are you sure you want to restore {0} sessions?",
-			"Restore All",
 			"Restore",
 			"Unpin"
 		],
@@ -33232,24 +35615,8 @@
 			"Open Terminal",
 			"Show All Terminals"
 		],
-		"vs/sessions/contrib/tunnelHost/electron-browser/toggleRemoteConnectionsActionViewItem": [
-			"Establishing tunnel connection...",
-			"Remote session access is enabled",
-			"Allow remote session access",
-			"Remote session access enabled via tunnel '{0}'",
-			"Show Output",
-			"Remote session access is now enabled"
-		],
 		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution": [
-			"Show Remote Connections Output",
-			"Allow Remote Connections",
-			"Remote Connections",
-			"Enable Microsoft account authentication for agent host tunnels. When disabled, only GitHub authentication is used.",
-			"Failed to toggle remote connections: {0}"
-		],
-		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHostService": [
-			"No authentication token available. Please sign in and try again.",
-			"Remote Connections"
+			"Allow Remote Connections"
 		],
 		"vs/sessions/electron-browser/actions/vscodeActions": [
 			"Open in Editor",
@@ -33262,11 +35629,10 @@
 			"Saving UI state"
 		],
 		"vs/sessions/services/sessions/common/session": [
+			"New Chat",
+			"New Session",
 			"Local",
 			"Remote"
-		],
-		"vs/sessions/services/sessions/common/sessionsManagement": [
-			"Whether the active session supports multiple chats"
 		],
 		"vs/sessions/services/workspace/browser/workspaceContextService": [
 			"Agents Window"
@@ -34039,6 +36405,7 @@
 			"When enabled breadcrumbs show `typeParameter`-symbols.",
 			"When enabled breadcrumbs show `variable`-symbols.",
 			"Render breadcrumb items with icons.",
+			"Controls whether the breadcrumbs bar shows a dropdown to switch between the editors that can open the current file (for example the text editor and a custom editor). The dropdown only appears when a more specialized editor is available.",
 			"Controls whether and how symbols are shown in the breadcrumbs view.",
 			"Only show the current symbol in the breadcrumbs view.",
 			"Do not show symbols in the breadcrumbs view.",
@@ -34061,6 +36428,7 @@
 			"Toggle Breadcrumbs",
 			"Breadcrumbs",
 			"Breadcrumbs",
+			"Editor: {0}",
 			"no elements",
 			"&&Breadcrumbs",
 			"Icon for the separator in the breadcrumbs."
@@ -34399,7 +36767,8 @@
 			"{0}: Editor Group {1}",
 			"Group {0}",
 			"{0}: Group {1}",
-			"Try saving or reverting the editor first and then try again."
+			"Try saving or reverting the editor first and then try again.",
+			"Reopen Editor With"
 		],
 		"vs/workbench/browser/parts/editor/editorGroupWatermark": [
 			"Find in Files",
@@ -34508,6 +36877,15 @@
 			"Editor layout actions",
 			"{0} (+{1})"
 		],
+		"vs/workbench/browser/parts/editor/editorTypePicker": [
+			"Built-in",
+			"{0} - {1}",
+			"Open Modified",
+			"Open Original",
+			"Set Default for '{0}'",
+			"Set Default (Diff Only) for '{0}'",
+			"Text Diff Editor"
+		],
 		"vs/workbench/browser/parts/editor/modalEditorPart": [
 			"Modal Editor Area",
 			"{0} of {1}",
@@ -34516,6 +36894,7 @@
 			"Toggle Sidebar"
 		],
 		"vs/workbench/browser/parts/editor/multiEditorTabsControl": [
+			"Add Tab",
 			"Tab actions"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
@@ -34729,6 +37108,7 @@
 			"&&View"
 		],
 		"vs/workbench/browser/parts/titlebar/menubarControl": [
+			"Cancelling Update...",
 			"Check for &&Updates...",
 			"Checking for Updates...",
 			"D&&ownload Update",
@@ -34895,6 +37275,7 @@
 			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. A setting of 'compact' will move the menu into the side bar.",
 			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and executing `Focus Application Menu` will show it. A setting of 'compact' will move the menu into the side bar.",
 			"Configure an interval in seconds during which the last entry in local file history is replaced with the entry that is being added. This helps reduce the overall number of entries that are added, for example when auto save is enabled. This setting is only applied to entries that have the same source of origin. Changing this setting has no effect on existing local file history entries.",
+			"Controls whether the experimental Modern UI Update is enabled. When on, the side bars and bottom panel are shown as floating cards with rounded corners and gaps, and a set of refreshed workbench styles is applied, matching the Agents window design.",
 			"Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'.",
 			"Controls whether the navigation control is shown in the custom title bar. This setting only has an effect when {0} is not set to {1}.",
 			"Controls whether the navigation control in the title bar is shown.",
@@ -35493,6 +37874,12 @@
 			"Plays a signal - sound (audio cue) and/or announcement (alert) - when terminal Quick Fixes are available.",
 			"Announces when terminal Quick Fixes are available.",
 			"Plays a sound when terminal Quick Fixes are available.",
+			"Plays a signal - sound (audio cue) and/or announcement (alert) - when voice mode has started.",
+			"Announces when voice mode has started.",
+			"Plays a sound when voice mode has started.",
+			"Plays a signal - sound (audio cue) and/or announcement (alert) - when voice mode has stopped.",
+			"Announces when voice mode has stopped.",
+			"Plays a sound when voice mode has stopped.",
 			"Plays a sound / audio cue when the voice recording has started.",
 			"Plays a sound when the voice recording has started.",
 			"Plays a sound / audio cue when the voice recording has stopped.",
@@ -35515,6 +37902,7 @@
 			"Enable sound.",
 			"Auto (Use Display Language)",
 			"On keypress, close the Accessible View and focus the element from which it was invoked.",
+			"Provide information about how to use the Automations section of the Agent Customizations editor, including keyboard navigation and how to inspect scheduled runs.",
 			"Provide information about how to access the chat help menu when the chat input is focused.",
 			"Provide information about how to navigate and interact with the chat question carousel, including how to focus the terminal when applicable.",
 			"Provide information about actions that can be taken in the comment widget or in a file which contains comments.",
@@ -35531,7 +37919,9 @@
 			"Provide information about how to open the notification in an Accessible View.",
 			"Provide information about how to access the REPL editor accessibility help menu when the REPL editor is focused.",
 			"Provide information about how to access the source control accessibility help menu when the input is focused.",
+			"Provide information about how to access the Changes view accessibility help menu when the Changes view is focused.",
 			"Provide information about how to access the Agents window accessibility help menu when the chat input is focused.",
+			"Provide information about how to navigate and interact with the survey editor pane.",
 			"Provide information about how to access the terminal accessibility help menu when the terminal is focused.",
 			"Provide information about how to open the chat terminal output in the Accessible View.",
 			"Provide information about how to open the walkthrough in an Accessible View.",
@@ -35607,77 +37997,47 @@
 			"Diff editor"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution": [
-			"Keep the Voice Mode window always on top of other windows.",
 			"Voice backend WebSocket URL. Leave empty to use the default hosted backend. Set to e.g. `ws://localhost:8000/api/v1/realtime/voice` to point at a backend running on your machine.",
 			"Enable the Voice Mode panel in the chat view for voice-driven coding conversations.",
-			"When enabled, the assistant reads responses aloud. When disabled, responses appear as text transcripts only.",
+			"When enabled, voice mode automatically re-enters listening after the assistant finishes speaking, so you can hold a hands-free back-and-forth conversation. When disabled, you start each turn manually. This controls only the auto-listen loop; how a turn ends is controlled by {0} and {1}.",
+			"The language used for speech recognition and spoken responses. The selectable languages support native voice output. Automatic follows the system or browser locale for speech recognition and uses English voice output when the detected language does not support native voice output. Changing this while voice mode is connected takes effect immediately.",
+			"Automatic",
+			"German",
+			"English",
+			"Spanish",
+			"French",
+			"Italian",
+			"Japanese",
+			"Korean",
+			"Portuguese",
+			"Chinese",
+			"Show your speech as a live, word-by-word transcript while you are speaking. When disabled, your transcript appears only once you finish speaking. Requires `#agents.voice.showTranscript#` to be enabled to be visible.",
+			"Show the voice transcript overlay in the chat input area while voice mode is active. Enable this to read responses as text when `#agents.voice.speakResponses#` is disabled.",
+			"When enabled, the assistant reads responses aloud. When disabled, responses are not spoken; enable `#agents.voice.showTranscript#` to read them as a text transcript instead.",
+			"Trailing silence in milliseconds before the backend ends the turn automatically. Set to `-1` to disable ending the turn on silence, in which case the turn ends only via a stop phrase ({0}) or manually. When enabled, the backend clamps this to its supported range (currently 200-5000 ms) and is the source of truth.",
+			"Do not end the turn on trailing silence.",
+			"Phrases that end the turn when spoken at the end of an utterance. Leave empty to disable ending the turn on a stop phrase, in which case the turn ends only on trailing silence ({0}) or manually. The backend strips the matched phrase from the transcript before it reaches the agent.",
+			"The voice used when the assistant reads responses aloud. Changing this while voice mode is connected takes effect immediately.",
+			"Daniel.",
+			"Kevin.",
+			"Maya.",
+			"Victoria.",
+			"Voice Mode: Cancel Request",
+			"Connecting...",
+			"Disconnect Voice Mode",
+			"Voice Mode Settings",
+			"Voice Mode: Stop Recording",
+			"Voice: Select Microphone",
+			"Voice: Simulate Connection (Dev)",
+			"Voice Mode",
 			"Voice Mode",
 			"Voice Mode: Push to Talk",
+			"(current)",
+			"No microphones found",
 			"Voice: Reset Onboarding",
-			"Voice Mode"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidget": [
-			"Failed to submit"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/agentsVoiceWidgetBinding": [
-			"Chat",
-			"Other",
-			"Untitled session"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/confirmationComponent": [
-			"Approve",
-			"Deny",
-			"Open in VS Code"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/feedbackDialog": [
-			"Cancel",
-			"By submitting, you agree that your session logs and transcript history will be included with your feedback.",
-			"Failed to submit feedback",
-			"What could we improve?",
-			"Thank you for your feedback!",
-			"Send Feedback",
-			"Submit",
-			"Submitting..."
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/headerComponent": [
-			"Configure keybinding",
-			"Disconnect",
-			"Minimize",
-			"Open mini-view",
-			"Push to talk (Space)",
-			"Send feedback"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/onboardingComponent": [
-			"to use it from any app.",
-			"Change push-to-talk key",
-			"Configure a keybinding",
-			"Connecting…",
-			"Use the feedback icon to help us improve your experience.",
-			"Get Started",
-			"to multitask while VS Code is not in the foreground.",
-			"Open the mini-view",
-			"Push-to-talk",
-			"— hold the key while speaking, release when done.",
-			"Speak to an assistant that controls multiple coding agents at once. Get notified when work is done or input is needed.",
-			"Welcome to Voice Chat"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/sessionListComponent": [
-			"Approve",
-			"Deny",
-			"New session",
-			"No active sessions",
-			"Open in VS Code",
-			"Open session",
-			"Send to",
-			"Send to (active)",
-			"Stop",
-			"Stop session"
-		],
-		"vs/workbench/contrib/agentsVoice/browser/components/statusRowsComponent": [
-			"done",
-			"needs input",
-			"No active sessions",
-			"working"
+			"Select a microphone for Voice Mode",
+			"System Default",
+			"Unknown Device ({0})"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscripts.contribution": [
 			"Show Voice Transcripts",
@@ -35777,6 +38137,7 @@
 			"Last used this account {0}",
 			"Manage account preferences for this MCP server",
 			"Accounts",
+			"MCP Servers in {0}",
 			"Choose which MCP servers can access this account",
 			"Manage Trusted MCP Servers",
 			"Cancel",
@@ -35864,7 +38225,7 @@
 			"Browser Full Page Screenshot",
 			"Browser Screenshot",
 			"Console Logs",
-			"When enabled, integrated browser tools are exposed as client-provided tools to agent host sessions in the Sessions window. Requires {0} and {1}."
+			"Controls whether a screenshot of the selected element will be added to the chat."
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorEmulationFeatures": [
 			"Dimensions:",
@@ -35915,7 +38276,7 @@
 			"URL:",
 			"Failed to Load Page",
 			"Not Secure",
-			"This usually means the host is not available or could not be reached from the remote."
+			"This usually means the host could not be found.\nEnsure the URL is correct and the server is accessible from the remote machine."
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorFindFeature": [
 			"Find Next",
@@ -35970,6 +38331,27 @@
 			"Search or enter URL",
 			"Enter a URL"
 		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserPermissionsFeature": [
+			"a Bluetooth device",
+			"an HID device",
+			"a serial port",
+			"a USB device",
+			"Select a device to connect to",
+			"{0} wants to connect to {1}",
+			"Site Permissions",
+			"Allow",
+			"Block",
+			"Permissions can only be managed for web pages.",
+			"Filter permissions",
+			"{0} wants access to {1}",
+			"Save {0} Changes",
+			"Save 1 Change",
+			"Allowed",
+			"Ask",
+			"Blocked",
+			"{0} (default)",
+			"Permissions for {0}"
+		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserRemoteFeatures": [
 			"File URLs are served locally, not over the remote connection.",
 			"Connected locally",
@@ -35994,6 +38376,10 @@
 			"Link opened here",
 			"Open Settings",
 			"New Tab",
+			"Controls where new Integrated Browser tabs are opened.",
+			"New browser tabs open in the currently active editor group.",
+			"New browser tabs open in a dedicated editor group to the side that is reused for subsequent tabs. The group is locked so other editors are not opened into it.",
+			"New browser tabs open in a dedicated window that is reused for subsequent tabs. The window is locked so other editors are not opened into it.",
 			"Open Integrated Browser",
 			"Open in Integrated Browser",
 			"When enabled, localhost links (`localhost`, `127.0.0.1`, `[::1]`) and all-interfaces links (`0.0.0.0`, `[0:0:0:0:0:0:0:0]`, `[::]`) from the terminal, chat, and other sources will open in the Integrated Browser instead of the system browser.",
@@ -36238,6 +38624,7 @@
 			"{0}{1}{2}1 code block: {3} {4}{5}",
 			"1 file tree ",
 			"1 table ",
+			"MCP authentication required for {0}. Use the Authenticate button in the tool call.",
 			"Chat confirmation required: {0}",
 			"Details: {0}",
 			"Chat confirmation required: {0}. Press {1} to accept or {2} to cancel.",
@@ -36249,6 +38636,10 @@
 			"New chat response."
 		],
 		"vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView": [
+			"Routed to {0}. {1} - Confidence {2}%",
+			"Routed to {0}. Unable to resolve.",
+			"Non-reasoning",
+			"Reasoning",
 			"{0} data",
 			"Errored",
 			"Extensions: {0}",
@@ -36263,6 +38654,7 @@
 			"Thinking: {0}",
 			"{0} ({1})",
 			"{0} items: {1}",
+			"MCP authentication required for {0} to continue {1}.",
 			"Approve results of {0}? Result: "
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityActions": [
@@ -36276,10 +38668,12 @@
 			"Toggle Thinking Content in Accessible View"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
+			"When an agent session exposes approval presets, use Tab to reach the Approvals picker and choose how it handles workspace access, commands, and the internet.",
 			"Chat responses will be announced as they come in. A response will indicate the number of code blocks, if any, and then the rest of the response.",
 			"To remove attached contexts, focus an attachment and press Delete or Backspace.",
 			"The chat view is a persistent interface that also supports navigating suggested follow-up questions, while the quick chat view is a transient interface for making and viewing requests.",
 			"The quick chat view is a transient interface for making and viewing requests, while the panel chat view is a persistent interface that also supports navigating suggested follow-up questions.",
+			"File change summaries show the total files, additions, and deletions. Focus the disclosure and press Enter or Space to show or hide the individual files.",
 			"To focus the last chat terminal that ran a tool, invoke the Focus Most Recent Chat Terminal command{0}.",
 			"To focus the output from the last chat terminal tool, invoke the Focus Most Recent Chat Terminal Output command{0}.",
 			"When a chat question appears, toggle focus between the question and the chat input{0}.",
@@ -36323,6 +38717,7 @@
 			"In the input box, use Show Previous{0} and Show Next{1} to navigate your request history. Edit input and use enter or the submit button to run a new request.",
 			"Use tab to reach conditional parts like commands, status, message responses and more.",
 			"To focus pending chat confirmation dialogs, invoke the Focus Chat Confirmation Status command{0}.",
+			"While dictating, invoke the Cancel Dictation command{0} to stop and discard the dictated text.",
 			"- Attach Files{0}.",
 			"To focus the chat request and response list, invoke the Focus Chat command{0}. This will move focus to the most recent response, which you can then navigate using the up and down arrow keys.",
 			"You can focus the agent sessions list by invoking the Focus Agent Sessions command{0}.",
@@ -36335,6 +38730,7 @@
 			"When starting an agent session in a multi-root workspace, you can choose which root folder it runs in by invoking the Folder command{0}, then selecting a folder from the list.",
 			"To navigate to the previous user prompt in the conversation, invoke the Previous User Prompt command{0}.",
 			"- Restore to Last Checkpoint{0}.",
+			"To dictate your request into the input box using on-device speech-to-text, invoke the Dictate command{0}. Invoke it again to stop; recording start and stop are indicated by accessibility signals.",
 			"- Undo Edits{0}.",
 			"To open the Agents Window, invoke the Open Agents Window command{0}. In screen reader mode, this keybinding includes Alt to avoid conflicts with screen reader shortcuts."
 		],
@@ -36374,6 +38770,7 @@
 			"Insert Troubleshoot Command",
 			"Insert /troubleshoot",
 			"Clear Input History",
+			"Compact Conversation",
 			"Focus Chat Input",
 			"Chat: Toggle Focus Between Question and Input",
 			"Chat: Focus Terminal from Question Carousel",
@@ -36442,6 +38839,9 @@
 			"Add Selection to Chat"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatContinueInAction": [
+			"The following is the conversation history from a previous {0} session. Continue working on it.\n\n{1}\n\nUser: {2}",
+			"The following is the conversation history from a previous {0} session. Continue working on it.\n\n{1}",
+			"Previous conversation",
 			"Learn More",
 			"Continue Chat in...",
 			"Continue Chat in...",
@@ -36570,6 +38970,7 @@
 			"Open File"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatPluginActions": [
+			"Failed to install plugin: {0}",
 			"Install Plugin from Source",
 			"Local",
 			"{0} (managed by enterprise policy)",
@@ -36577,8 +38978,8 @@
 			"No plugin marketplaces configured",
 			"Open Folder",
 			"Plugins",
-			"owner/repo or git clone URL",
-			"Enter a GitHub repository or git URL to install a plugin from",
+			"owner/repo, git URL, or local folder path",
+			"Enter a GitHub repository, git URL, or local folder path to install a plugin from",
 			"Enterprise policy manages '{0}', so it can't be removed here.",
 			"Remove Marketplace",
 			"Select a plugin marketplace",
@@ -36608,6 +39009,19 @@
 			"Toggle the quick chat",
 			"Whether the query is partial; it will wait for more user input",
 			"The query to open the quick chat with"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions": [
+			"Cancel Dictation (Speech to Text)",
+			"Hold to Dictate (Speech to Text)",
+			"Preparing Speech to Text Model…",
+			"Dictate: Select Microphone",
+			"Dictate (Speech to Text)",
+			"Stop Dictation",
+			"(current)",
+			"No microphones found",
+			"Select a microphone for dictation",
+			"System Default",
+			"Unknown Device ({0})"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"Don't ask again",
@@ -36641,6 +39055,11 @@
 			"Configure Tool Sets...",
 			"Configure Tools",
 			"Built-In",
+			"This removes the tool set definition from {0}.",
+			"Delete tool set '{0}'?",
+			"Delete",
+			"Failed to delete tool set '{0}': {1}",
+			"Delete Tool Set",
 			"Edit Tool Set",
 			"Manage Approval",
 			"Show Output",
@@ -36692,6 +39111,8 @@
 			"Select Folder for Agent Host Debug Logs",
 			"No log files were found for the active Agent Host session.",
 			"No Agent Host log files were found for the current window.",
+			"Note: This log may contain personal information such as auth tokens, file contents, or terminal output. Please consider sharing privately or reviewing the contents carefully before sharing.",
+			"Note: This log may contain personal information such as auth tokens, file contents, or terminal output. It MUST be shared privately via Slack or in an issue filed on the microsoft/vscode-internalbacklog repo.",
 			"Failed to save debug logs: {0}"
 		],
 		"vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction": [
@@ -36725,6 +39146,11 @@
 			"Failed to install plugin '{0}': {1}",
 			"Preparing plugin marketplace '{0}'...",
 			"Failed to update plugin '{0}': {1}",
+			"Purge Marketplace Cache and Reclone",
+			"Failed to purge plugin marketplace '{0}': {1}",
+			"Recloned plugin marketplace '{0}'. Try updating plugins again.",
+			"Purging plugin marketplace '{0}'...",
+			"Recloning plugin marketplace '{0}'...",
 			"Show Git Output",
 			"Updating plugin '{0}'..."
 		],
@@ -36741,30 +39167,62 @@
 			"No agent plugins found.",
 			"Update"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentCustomizationItemProvider": [
+			"always added",
+			"This instruction is automatically included in every interaction.",
+			"This instruction is automatically included when files matching '{0}' are in context."
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostAuth": [
+			"Sign in to use GitHub Copilot",
+			"Failed to sign in to use GitHub Copilot."
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution": [
-			"{0} - Agent Host",
 			"{0} [Agent Host]"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
+			"Controls whether the agent asks before running tools in this session.",
+			"{0} Read-only.",
 			"{0} Picker",
+			"An LLM judge evaluates each tool call. Tools it doesn't approve require your approval.",
+			"Copilot runs all tools without asking for approval.",
+			"Copilot runs tools without asking for approval and continues until the task is done.",
 			"Off",
 			"Off",
 			"On",
 			"On",
+			"Copilot asks before running tools unless your configured settings allow the tool.",
 			"Filter...",
 			"Learn more about permissions",
+			"Disabled by your organization. Contact your administrator.",
 			"{0}: {1}",
-			"{0}: {1}, Read-Only",
-			"(Selected)"
+			"{0}: {1}, Read-Only"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker.contribution": [
 			"Auto-Approve",
+			"Approvals",
 			"Folder",
 			"Agent Mode",
 			"Approvals"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostCustomizationService": [
+			"Server '{0}' requires authentication ({1})",
+			"Server '{0}' is disabled",
+			"Server '{0}' failed: {1}",
+			"MCP: {0}",
+			"Server '{0}' is running",
+			"Server '{0}' is starting",
+			"Server '{0}' is stopped"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostDownloadProgress": [
+			"{0} MB",
+			"{0}%",
+			"Downloading"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem": [
 			"Folder"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider": [
+			"{0}% discount"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPermissionUiContribution": [
 			"Allow",
@@ -36778,19 +39236,69 @@
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler": [
 			"Authentication is required to start a session. Please sign in and try again.",
 			"Cancel",
-			"Open this URL?",
 			"Open {0}",
 			"Authorization Required",
 			"Forked Session",
-			"{0} credit",
-			"{0} credits",
-			"Error: ({0}) {1}"
+			"Cancelled tool call",
+			"MCP authentication was cancelled",
+			"Skipped {0}",
+			"{0} was skipped from another client",
+			"Preparing session…",
+			"This session couldn't be loaded.",
+			"Couldn't open session",
+			"Error: ({0}) {1}",
+			"AI features are currently only supported in trusted workspaces."
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSettings.contribution": [
+			"Host Settings",
+			"Open Host Settings"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSettingsFileSystemProvider": [
+			"Agent host settings.",
+			"Agent host settings must be a JSON object.",
+			"Failed to parse agent host settings as JSON.",
+			"Edit values below and save to apply. Unknown properties are ignored."
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
 			"Local"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentSessionSettings.contribution": [
+			"Session Settings",
+			"Open Session Settings"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentSessionSettingsFileSystemProvider": [
+			"Session settings for this agent host session.",
+			"Agent session settings must be a JSON object.",
+			"Failed to parse agent session settings as JSON.",
+			"Edit values below and save to apply. Unknown or non-mutable properties are ignored."
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/importLocalConversationToAgentSession": [
+			"Subagent",
+			"Tool failed."
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/stateToProgressAdapter": [
-			"Running {0}..."
+			"{0} comments",
+			"1 comment",
+			"Reveal Selected",
+			"Choose which comments to reveal to the agent. Unchecked comments stay hidden.",
+			"Reveal unreviewed comments?",
+			"Open this URL?",
+			"Authorization Required",
+			"Running {0} on another client...",
+			"{0} credit",
+			"{0} credits",
+			"{0} ({1})",
+			"False",
+			"True",
+			"System",
+			"User Context",
+			"MCP Tools",
+			"Messages",
+			"Plugins",
+			"Skills",
+			"Sub-agents",
+			"Tool Definitions",
+			"Tool Results"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionHoverWidget": [
 			"Completed",
@@ -36805,13 +39313,15 @@
 			"Foreground color for the read indicator in an agent session.",
 			"Border color for the badges in selected agent session items.",
 			"Border color for the badges in selected agent session items when the view is unfocused.",
+			"Delegate tasks to the Codex App Server using the Codex models included in your GitHub Copilot subscription. The agent iterates via chat and works interactively to implement changes on your main workspace.",
+			"Run a Copilot SDK agent in the local agent host process.",
 			"Delegate tasks to a background agent running locally on your machine. The agent iterates via chat and works asynchronously in a Git worktree to implement changes isolated from your main workspace using the GitHub Copilot CLI.",
 			"Delegate tasks to the Claude Agent SDK using the Claude models included in your GitHub Copilot subscription. The agent iterates via chat and works interactively to implement changes on your main workspace.",
 			"Delegate tasks to the GitHub Copilot coding agent. The agent iterates via chat and works asynchronously in the cloud to implement changes and pull requests as needed.",
-			"Opens a new Codex session in the editor. Codex sessions can be managed from the chat sessions view.",
+			"Open a new Codex session using the Codex extension from OpenAI. Codex sessions can be managed from the chat sessions view.",
 			"Learn about Copilot features.",
 			"Run tasks within VS Code chat. The agent iterates via chat and works interactively to implement changes on your main workspace.",
-			"Copilot CLI [Agent Host]",
+			"Copilot",
 			"Copilot CLI",
 			"Cloud",
 			"Local"
@@ -36942,6 +39452,7 @@
 			"2 days ago",
 			"1 day",
 			"1 day ago",
+			"Voice response ready",
 			"now"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/experiments/agentSessionProjection": [
@@ -37023,6 +39534,9 @@
 		"vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability": [
 			"No models available",
 			"No models are available for this agent.",
+			"[Sign in to GitHub Copilot](command:workbench.action.chat.triggerSetup) to use this agent.",
+			"[Sign in](command:workbench.action.chat.triggerSetup)",
+			"Requires sign in",
 			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan) to use this agent.",
 			"[Upgrade](command:workbench.action.chat.upgradePlan)",
 			"Requires GitHub Copilot Pro"
@@ -37030,6 +39544,7 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons": [
 			"Icon for adding new items.",
 			"Icon for custom agents.",
+			"Icon for scheduled automations.",
 			"Icon for built-in items.",
 			"Icon for extension-contributed items.",
 			"Icon for hooks.",
@@ -37039,6 +39554,7 @@
 			"Icon for prompt files.",
 			"Icon for running a prompt or agent.",
 			"Icon for skills.",
+			"Icon for the Tools section.",
 			"Icon for user items.",
 			"Icon for the Agent Customization view.",
 			"Icon for workspace items."
@@ -37192,6 +39708,8 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor": [
 			"Agents",
 			"Define custom agents with specialized personas, tool access, and instructions for specific tasks.",
+			"Automations",
+			"Schedule agent sessions to run on a cadence you choose.",
 			"Back to list",
 			"Back to list",
 			"Back to MCP servers",
@@ -37200,6 +39718,10 @@
 			"Back to overview",
 			"Back to plugins",
 			"Back to plugins",
+			"Back to Migrate Prompt Files",
+			"Back to Migrate Prompt Files",
+			"Back to tools",
+			"Back to tools",
 			"Cancel",
 			"Customization preview",
 			"Failed to finish the prompt action.",
@@ -37217,9 +39739,14 @@
 			"Instructions",
 			"Set always-on instructions that guide AI behavior across your workspace or user profile.",
 			"Learn more about language models",
+			"Learn more about agent skills",
 			"Local",
 			"MCP Servers",
 			"Connect external tool servers that extend AI capabilities with custom tools and data sources.",
+			"Migrate prompt files to skills",
+			"Prompts, {0} deprecated prompt files need migration",
+			"Migrate Prompts",
+			"Convert deprecated prompt files to skills",
 			"Models",
 			"Configure and manage language models available for use.",
 			"Browse and manage language models from different providers. Select models for use in chat, code completion, and other AI features.",
@@ -37231,6 +39758,34 @@
 			"No markdown body found in this file.",
 			"No metadata found in this file.",
 			"Custom metadata field `{0}`.",
+			"Convert to Skills",
+			"This converts {0} user prompt files into skills.",
+			"This converts {0} workspace prompt files into skills.",
+			"This converts {0} workspace prompt files and {1} user prompt files into skills.",
+			"Convert prompt files to skills?",
+			"Converted {0} prompt files to skills.",
+			"Converted {0} prompt files to skills. Review migrated skills that used unsupported prompt headers: {1}.",
+			"Delete original prompt files after migration",
+			"Failed to migrate {0} prompt files: {1}.",
+			"Failed to migrate {0} prompt files: {1}, and {2} more.",
+			"No prompt files were converted.",
+			"No skill folders are configured for the active harness.",
+			"Migrate",
+			"Convert selected prompt files to skills",
+			"Migrate ({0})",
+			"Select prompt files to convert into skills for the active harness.",
+			"Prompt files are not supported for this harness. Found {0} user prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are not supported for this harness. Found {0} workspace prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are not supported for this harness. Found {0} prompt files ({1} workspace, {2} user) that local VS Code can still run, but {3} ignores. Convert them to skills to keep them available.",
+			"No prompt files are available to migrate.",
+			"Migrate Prompt Files",
+			"Select a workspace skill folder for migrated prompts",
+			"No prompt files match your search.",
+			"Type to search...",
+			"Select {0}",
+			"Select all {0} prompt files",
+			"User",
+			"Workspace",
 			"Prompts",
 			"Reusable prompt templates that can be invoked as slash commands.",
 			"Save override",
@@ -37242,10 +39797,10 @@
 			"Saved",
 			"{0}, {1} items",
 			"Agent Customization Sections",
-			"Select customization target",
-			"Select a directory for the new customization file",
 			"Skills",
 			"Create reusable skill files that provide domain-specific knowledge and workflows.",
+			"Tools",
+			"Enable or disable groups of language model tools available to chat.",
 			"User",
 			"Workspace"
 		],
@@ -37258,6 +39813,8 @@
 			"Define custom agents with specialized personas, tool access, and instructions for specific tasks.",
 			"Browse...",
 			"Browse {0}...",
+			"Convert prompt files to skills",
+			"Convert to Skills...",
 			"Describe your preferences and conventions to draft agents, skills, and instructions.",
 			"Customize Your Agent",
 			"Hooks",
@@ -37266,19 +39823,105 @@
 			"Set always-on instructions that guide AI behavior across your workspace or user profile.",
 			"MCP Servers",
 			"Connect external tool servers that extend AI capabilities with custom tools and data sources.",
+			"Migrate",
 			"New...",
 			"New {0}...",
 			"Plugins",
 			"Install and manage agent plugins that add additional tools, skills, and integrations.",
+			"Prompt files are deprecated for this harness. Found {0} global prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are deprecated for this harness. Found {0} workspace prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are deprecated for this harness. Found {0} prompt files ({1} workspace, {2} global) that local VS Code can still run, but {3} ignores. Convert them to skills to keep them available.",
 			"Sent to chat ✓",
 			"Skills",
 			"Create reusable skill files that provide domain-specific knowledge and workflows.",
+			"Tools",
+			"Enable or disable the tools available to chat.",
 			"Agent Customizations for {0}",
 			"Tailor how agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.",
 			"Describe your preferences to customize your agent",
 			"Prefer concise commits, thorough reviews, and tested code...",
 			"Customize agent",
 			"Open in Chat"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/automationsAccessibilityHelp": [
+			"- Delete: removes the automation after a confirmation prompt. Runs already in flight continue to completion.",
+			"- Edit: opens the create/edit dialog with the current values prefilled.",
+			"- Show history: expands an inline list of recent runs for the automation, including their status and any error messages.",
+			"- Run now: spawns a new agent session immediately using the automation’s prompt. The trigger is recorded as Manual.",
+			"Row Actions (Tab between them):",
+			"- Toggle enabled: pauses or resumes scheduled runs. Disabled automations skip their scheduled tick but can still be run manually.",
+			"Press Escape to close this dialog and return focus to the Automations list.",
+			"Closing this dialog:",
+			"The dialog has a Name field, a multi-line Prompt field, a Schedule selector (Manual, Hourly, Daily, Weekly), Time and Day-of-Week fields that appear when relevant, a Workspace target selector, a Session type selector, an isolation selector, a branch selector for supported Worktree sessions, an Agent Mode selector (Use default, Agent, Ask, Edit), and a Permission Mode selector (Use default, Default Approvals, Bypass Approvals, Autopilot). Choose No workspace from the Workspace target selector to run without a backing workspace. Only workspace-less-capable session types are then offered, and the isolation and branch controls do not apply. Folder isolation follows the selected repository’s current branch. Worktree isolation lets you choose a local base branch. The selected configuration is replayed when the scheduler starts a run. Tab and Shift+Tab move between fields; Enter or Space opens a focused selector, and Escape closes an open selector before it closes the dialog.",
+			"Create/Edit Dialog:",
+			"Save is disabled until Name, Prompt, and Session type are set. Workspace-backed automations also require a Workspace folder, and Worktree isolation requires a branch. Activate Cancel or press Escape to dismiss without saving.",
+			"Accessibility Help: Automations",
+			"Each run records its status (Pending, Running, Completed, Failed), the trigger that started it (Schedule, Manual, or Catch-up after VS Code restarts), the time it started, and the time it took. Failed runs include the failure reason.",
+			"Run History:",
+			"Automations let you schedule agent sessions to run on a cadence you choose. When an automation is due, a fresh chat session is created in the background and the prompt is sent automatically.",
+			"The Automations section shows a list of all your automations. Each row displays the automation’s name, schedule (Manual, Hourly, Daily at a time, or Weekly on a day at a time), whether it targets a workspace folder or runs without a workspace, the next scheduled run, and a preview of the prompt. Row action buttons follow on the right.",
+			"Layout:",
+			"Settings ({0} opens Settings):",
+			"- `accessibility.verbosity.automations`: Controls whether this Accessibility Help hint is announced when the Automations section is focused.",
+			"The Automations list announces state changes when you create, update, delete, toggle, or manually run an automation. Verbose announcements can be turned off via the accessibility.verbosity.automations setting.",
+			"Screen Reader Announcements:"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget": [
+			"{0}, {1}, {2}",
+			"{0}, disabled, {1}, {2}",
+			"Created automation {0}",
+			"Failed to create automation.",
+			"Deleted automation {0}",
+			"Disabled",
+			"Disabled automation {0}",
+			"Enabled automation {0}",
+			"in {0}",
+			"without a workspace",
+			"Runs as a workspace-less chat",
+			"Enable “{0}” to make changes.",
+			"Automations are disabled.",
+			"Create automation",
+			"Create an automation to schedule an agent session to run on a cadence you choose.",
+			"No automations yet",
+			"Schedule agent sessions to run on a cadence you choose.",
+			"Automations",
+			"Automations",
+			"Started automation {0}",
+			"Updated automation {0}",
+			"Failed to update automation.",
+			"Delete automation “{0}”?",
+			"Runs already in flight will continue. This cannot be undone.",
+			"Delete",
+			"Delete",
+			"Disable",
+			"Edit",
+			"Enable",
+			"Hide history",
+			"Run history for {0}",
+			"{0} more run(s) not shown.",
+			"Last run {0}",
+			"New automation",
+			"Create a new automation",
+			"Next run {0}",
+			"No scheduled run",
+			"No runs yet.",
+			"Open session",
+			"Failed to open automation session",
+			"Run history",
+			"Run now",
+			"Started {0}",
+			"Completed",
+			"Failed",
+			"Pending",
+			"Running",
+			"Catch-up",
+			"Manual",
+			"Scheduled",
+			"Daily at {0}",
+			"Hourly",
+			"Manual",
+			"Weekly on {0} at {1}",
+			"Show history"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService": [
 			"Name for the new {0}",
@@ -37293,19 +39936,47 @@
 			"From {0}",
 			"Marketplace plugin"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedExtensionToolsDetail": [
+			"by {0}",
+			"No extension selected.",
+			"Included Tools",
+			"Loading tools...",
+			"This extension does not contribute any tools.",
+			"Unable to load the tools for this extension.",
+			"{0} tools",
+			"1 tool"
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedMcpServerDetail": [
 			"No MCP server selected.",
 			"User",
 			"Workspace"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/galleryItemRenderer": [
+			"by {0}",
+			"Install",
+			"Installed",
+			"Installing..."
+		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/mcpListWidget": [
+			"Server Options",
+			"Start Server",
+			"Stop Server",
 			"Add an MCP server configuration to get started",
 			"Add Server",
 			"Add Server",
+			"Disable",
+			"Disable (Workspace)",
+			"Enable",
+			"Enable (Workspace)",
+			"Authentication required",
 			"Back to installed servers",
 			"Browse Marketplace",
 			"Built-in",
 			"MCP servers built into VS Code. These are available automatically.",
+			"Disable",
+			"Disable (Workspace)",
+			"Enable",
+			"Enable (Workspace)",
 			"collapsed",
 			"This MCP server is provided by the plugin '{0}'",
 			"Individual MCP servers from a plugin cannot be removed separately. Would you like to uninstall the entire plugin?",
@@ -37317,9 +39988,6 @@
 			"MCP servers contributed by installed VS Code extensions.",
 			"Plugin: {0}",
 			"Unable to load marketplace",
-			"Install",
-			"Installed",
-			"Installing...",
 			"Learn more about MCP servers",
 			"Loading marketplace...",
 			"Access to MCP servers is disabled by your organization. Contact your organization administrator for more information.",
@@ -37328,6 +39996,7 @@
 			"MCP servers are disabled",
 			"Back",
 			"{0}, {1} items, {2}",
+			"{0}, {1}",
 			"MCP Servers",
 			"An open standard that lets AI use external tools and services. MCP servers provide tools for file operations, databases, APIs, and more.",
 			"MCP Servers",
@@ -37339,7 +40008,12 @@
 			"Running",
 			"Search MCP marketplace...",
 			"Type to search...",
+			"Disable (Session)",
+			"Enable (Session)",
+			"Show output for {0}",
 			"Show Plugin",
+			"Sign In",
+			"Sign in to {0}",
 			"Starting",
 			"Stopped",
 			"Check your connection and try again",
@@ -37349,15 +40023,15 @@
 			"User",
 			"MCP servers configured in your user settings. Private to you and available across all projects.",
 			"Workspace",
-			"MCP servers configured in your workspace settings, shared with your team via version control."
+			"MCP servers configured in your workspace or reported by the active session."
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/pluginListWidget": [
 			"Add Plugin",
 			"Use the toolbar to add remote plugins or install plugins from a source.",
+			"Back to Installed Plugins",
 			"Browse Marketplace",
 			"Browse Marketplace is not available in VS Code for the Web.",
 			"Browse the marketplace to discover and install plugins",
-			"by {0}",
 			"collapsed",
 			"Create Plugin",
 			"Disabled Locally",
@@ -37368,10 +40042,7 @@
 			"Plugins installed in this client and available for syncing to the remote session.",
 			"Enable {0} for sync",
 			"expanded",
-			"Install",
-			"Installed",
 			"Install Plugin from Source",
-			"Installing...",
 			"Learn more about agent plugins",
 			"Loading marketplace...",
 			"Unable to load marketplace",
@@ -37380,6 +40051,7 @@
 			"No plugins match '{0}'",
 			"No plugins installed",
 			"No plugins configured",
+			"Back",
 			"{0}, {1} items, {2}",
 			"{0}. Disabled",
 			"{0}. Enabled",
@@ -37410,6 +40082,53 @@
 			"This instruction is automatically included when files matching '{0}' are in context.",
 			"UI Integration"
 		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/toolsListWidget": [
+			"Copilot CLI",
+			"Built-in tools the Copilot CLI agent runs inside its own runtime.",
+			"Do you want to uninstall the extension '{0}'?",
+			"This extension may contribute more than tools. Uninstalling it removes all of its contributions.",
+			"Apply patches (used by some models instead of edit/create)",
+			"Ask the user a question",
+			"Create new files",
+			"Edit files via string replacement",
+			"Find files matching patterns",
+			"Search for text in files",
+			"List available agents",
+			"List active shell sessions",
+			"Check background agent status",
+			"Read output from a shell session",
+			"Execute commands",
+			"Invoke custom skills",
+			"Terminate a shell session",
+			"Run subagents",
+			"Read files or directories",
+			"Fetch and parse web content",
+			"Send input to a shell session",
+			"Learn more about tools",
+			"No tools match '{0}'",
+			"Type to search...",
+			"Back",
+			"Unable to load marketplace",
+			"Loading marketplace...",
+			"Browse Marketplace",
+			"No tool extensions match '{0}'",
+			"Search the Marketplace...",
+			"Check your connection and try again",
+			"Enable or disable the tools available to chat. Disabled tools are not advertised to the agent. Tools other than Copilot CLI run on the client and require it to be connected.",
+			"Tools",
+			"Tool extensions",
+			"No tools available.",
+			"{0} of {1} tools enabled",
+			"Search tools",
+			"Enable {0}",
+			"Tools contributed by {0}",
+			"These are the agent's built-in tools and cannot be changed.",
+			"Enable {0}",
+			"Tool groups",
+			"Try a different search term",
+			"Uninstall Extension",
+			"Uninstall Extension"
+		],
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentResolveService": [
 			"Image is too large",
 			"The image {0} is too large to be attached."
@@ -37422,6 +40141,8 @@
 			"Save Image As...",
 			"Failed to save image: {0}",
 			"{0} (Delete)",
+			"Attached image, {0}. Image support depends on the model selected by Auto.",
+			"Image support depends on the model selected by Auto.",
 			"Browser tools are not enabled.",
 			"Browser tools are not enabled, {0}",
 			"Attached browser page, {0}",
@@ -37444,7 +40165,6 @@
 			"This folder contains {0} images, which exceeds the maximum of {1} images per request. Older images will not be sent.",
 			"Attached image, {0}",
 			"{0} does not support images.",
-			"Vision is disabled by your organization.",
 			"This GIF was partially omitted - current frame will be sent.",
 			"Image not sent due to limit: {0}",
 			"This image was not sent because the maximum of {0} images per request was exceeded.",
@@ -37461,6 +40181,7 @@
 			"Command",
 			"Command: {0}, exit code: {1}",
 			"Output:",
+			"Image not sent because {0} does not support images: {1}",
 			"Instructions",
 			"Additional Instructions",
 			"Prompt",
@@ -37496,8 +40217,8 @@
 			"Use {0} instead",
 			"Global auto approve also known as \"YOLO mode\" disables manual approval completely for all tools in all workspaces, allowing the agent to act fully autonomously. This is extremely dangerous and is *never* recommended, even containerized environments like Codespaces and Dev Containers have user keys forwarded into the container that could be compromised.\n\nThis feature disables critical security protections and makes it much easier for an attacker to compromise the machine.\n\nNote: This setting only controls tool approval and does not prevent the agent from asking questions. To automatically answer agent questions, use the `#chat.autoReply#` setting.",
 			"Chat",
-			"Allowed domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. When {1} is set to {2}, all domains are allowed. Supports wildcards like {3}. When both allowed and denied lists are empty, all domains are blocked. Denied domains (see {4}) take precedence.",
-			"Denied domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. This does not apply when {1} is set to {2}. Takes precedence over {3}. Supports wildcards like {4}.",
+			"Allowed domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. When {2} is enabled, all domains are allowed. Supports wildcards like {3}. When both allowed and denied lists are empty, all domains are blocked. Denied domains (see {4}) take precedence.",
+			"Denied domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. This does not apply when {2} is enabled. Takes precedence over {3}. Supports wildcards like {4}.",
 			"When enabled, agent mode can be activated from chat and tools in agentic contexts with side effects can be used.",
 			"The maximum number of requests to allow per-turn when using an agent. When the limit is reached, will ask to confirm to continue.",
 			"When enabled, network access by agent tools (fetch tool, integrated browser) is restricted according to {0} and {1}. Domain filtering is also applied to those tools when {2} is enabled.",
@@ -37514,15 +40235,23 @@
 			"Thinking parts will be expanded first, then collapse once we reach a part that is not thinking.",
 			"Show thinking in a fixed-height streaming panel that auto-scrolls; click header to expand to full height.",
 			"Controls how thinking is rendered.",
+			"Enable agent debug logging for agent host sessions: surface their debug events in the agent debug panel. Takes effect immediately; only sessions that run while this is enabled are captured.",
+			"Maximum number of debug events kept in memory per agent host session for the agent debug panel. Older events beyond this limit are dropped from the in-memory buffer, which also lowers the totals (such as token usage) shown in the panel overview.",
 			"When enabled, logs all AHP transport messages for agent host connections to JSONL files under the window's log directory.",
-			"Tool reference names to expose as client-provided tools in agent host sessions.",
+			"Controls the log level for the Copilot SDK runtime used by the local agent host. Changing this setting restarts the Copilot SDK client; active sessions are reloaded when next used.",
+			"Log informational messages. Running VS Code with trace logging still enables all Copilot SDK runtime diagnostics.",
+			"Log all Copilot SDK runtime diagnostics.",
 			"When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior.",
-			"Sandbox mode for the Copilot SDK's built-in shell tool. Only takes effect when `#chat.agentHost.customTerminalTool.enabled#` is `false`; when the Agent Host's own terminal tool is enabled, the engine sandbox is controlled by `#chat.agent.sandbox.enabled#`.",
+			"Per-model capability overrides for Copilot SDK agent sessions, keyed by model id, intended for evaluating preview models against an existing model's profile. For each model id, declare an aliased `family` (for example `claude-opus-4-8`) to route the model to that family's tuned system prompt without a code change; the model id sent to the runtime is unaffected. Only affects Copilot CLI agent sessions.\n\n**Note**: This is an advanced setting for experimentation.",
+			"Alias the model's family for prompt/capability routing (e.g. `claude-opus-4-8`).",
+			"When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message.",
+			"Overrides the reasoning effort for Copilot SDK agent sessions regardless of the per-model picker value. Set it to a level the selected model supports (for example `low`, `medium`, `high`, or `xhigh`) — choosing a level the model does not support may be rejected by the model. A value that isn't a recognized effort level is ignored and the session falls back to the picker value. Applied when a session is created and when its model changes. Only affects Copilot CLI agent sessions.\n\n**Note**: This is an advanced setting for experimentation.",
+			"Sandbox mode for the Copilot SDK's built-in shell tool. Only takes effect when `#chat.agentHost.customTerminalTool.enabled#` is `false`; when the Agent Host's own terminal tool is enabled, the engine sandbox is controlled by `#chat.agent.sandbox.enabled#`. The sandbox applies only to requests that run with default approvals — not when approvals are bypassed — and is not supported on Windows yet.",
 			"The SDK's built-in shell tool runs inside a sandbox with unrestricted outbound network access.",
 			"No sandbox policy is forwarded for the SDK's built-in shell tool — commands run unsandboxed.",
 			"The SDK's built-in shell tool runs inside a sandbox using the configured filesystem policy and host-list-restricted network.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
-			"When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window.",
+			"When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires `#chat.agentHost.enabled#`.",
 			"Specify location(s) of custom agent files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
 			"Agent File Locations",
 			"Shows the agent status as a badge next to the command center.",
@@ -37550,14 +40279,33 @@
 			"Rules for extracting artifacts from tool results by MIME type. Maps MIME type patterns (e.g. 'image/*') to group configuration.",
 			"Display name for the artifact group.",
 			"When true, show only the group header instead of individual items.",
+			"Controls whether Assisted permissions is shown in Agent Host approval pickers.",
 			"Enables **Advanced Autopilot**, a single switch that turns on all advanced Autopilot behaviors that delegate more of the loop to the agent. Currently, after each Autopilot turn a small, fast model evaluates whether your original request is complete; if not, Autopilot keeps working using that evaluation as guidance for the next turn, instead of relying on the agent to signal completion itself.",
 			"Automatically skip question carousels by telling the agent that the user is not available and to use its best judgment. This is an advanced setting and can lead to unintended choices or actions based on incomplete context.",
+			"Use the default GitHub Copilot utility models.",
+			"GitHub Copilot",
+			"Controls the default model used by built-in utility flows when the selected main agent model is a bring your own key (BYOK) model. This setting has no effect when the selected main agent model is provided by GitHub Copilot. A specific model configured in {0} or {1} takes precedence.",
+			"Use the selected BYOK main agent model.",
+			"Main Agent Model",
+			"Do not use a default utility model.",
+			"None",
 			"Enables checkpoints in chat. Checkpoints allow you to restore the chat to a previous state.",
 			"Controls whether to show chat checkpoint file changes.",
 			"When applying edits, show a progress animation in the code block pill. If disabled, shows the progress percentage instead.",
 			"Show the context window usage indicator in the chat input.",
-			"Controls whether the harness selector is shown in the Chat Customizations editor sidebar. When disabled, the editor always shows all customizations without filtering.",
+			"Controls whether the Chat Customizations editor shows the prompt file migration affordances for agent-host harnesses. When disabled, the migration card and sidebar shortcut are hidden.",
 			"Controls whether the Chat Customizations editor shows a structured preview for markdown customization files (agents, skills, instructions, prompts). When disabled, the editor always opens the raw markdown in the embedded code editor.",
+			"Allow All — runs tool calls without asking.",
+			"Assisted permissions — evaluates risk before running tools.",
+			"Ask When Needed — asks when approval settings don't apply.",
+			"The starting approval behavior for new agent sessions. If enterprise policy disables auto approval, new sessions use Ask When Needed.",
+			"Autopilot — autonomously iterate from start to finish.",
+			"The starting mode for new agent sessions.",
+			"Interactive — step-by-step collaboration.",
+			"Plan — plan first, execute when ready.",
+			"Controls the default configuration for new agent sessions (such as Copilot CLI). You can still change the mode and approval behavior per session, and each session remembers what was used.",
+			"The default model for new chat conversations. Use \"auto\" to let Copilot pick a model, a model family name (such as \"opus\" or \"gemini\") to use the latest available model in that family, or a full model id. You can still switch the model within a conversation; each new conversation starts at this model.",
+			"Sets the default chat model for new conversations. Accepts \"auto\", a model family name (such as \"opus\" or \"gemini\"), or a full model id. Users can still switch the model within a conversation.",
 			"Enables chat participant autodetection for panel chat.",
 			"Disable and hide built-in AI features provided by GitHub Copilot, including chat and inline suggestions.",
 			"Delay after which changes made by chat are automatically accepted. Values are in seconds, `0` means disabled and `100` seconds is the maximum.",
@@ -37566,11 +40314,12 @@
 			"Controls whether the Explain button in the Chat panel and the Explain Changes context menu in the SCM view are shown. This is an experimental feature.",
 			"Controls whether selecting a file in the changed files list of a chat response opens it in a diff editor showing the changes made by chat, or in a regular editor. Holding `kbstyle(Alt)` while selecting the file opens it with the opposite behavior.",
 			"Controls whether the editor automatically reveals the next change after keeping or undoing a chat edit.",
-			"When enabled, hides the Edit mode from the chat mode picker.",
 			"When enabled, Claude sessions opened from the regular workbench (sidebar chat) run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window.",
+			"When enabled, Codex sessions opened from the regular workbench (sidebar chat) run inside the agent host process using the Codex App Server instead of the OpenAI extension. Only one Codex implementation surfaces per window. Requires `#chat.agentHost.enabled#` and `#chat.agentHost.codexAgent.enabled#`.",
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for opening files from chat (for example `\"*.md\": \"vscode.markdown.preview.editor\"`).",
 			"Enables editing of requests in the chat. This allows you to change the request content and resubmit it to the model.",
 			"Controls whether the chat panel automatically exits after delegating a request to another session.",
+			"When enabled, automatic instruction collection (.instructions.md, agent instructions, customizations index) is performed by the GitHub Copilot Chat extension instead of the core workbench.",
 			"Enables chat participant autodetection for panel chat.",
 			"This setting is deprecated. Please use `chat.detectParticipant.enabled` instead.",
 			"Controls the animation style for incremental rendering.",
@@ -37586,18 +40335,19 @@
 			"Buffers content until a paragraph break before rendering.",
 			"Reveals content word by word.",
 			"Enables incremental rendering with optional block-level animation when streaming chat responses.",
+			"Controls whether the permissions picker shows an inline \"Sandboxing for terminal\" toggle on the Default Approvals option. The toggle reflects and updates `#chat.agent.sandbox.enabled#`.",
 			"When true, enables sessions-window-specific behavior for extensions.",
 			"Select the default language model to use for the Explore subagent from the available providers.",
 			"Enable using tools contributed by third-party extensions.",
 			"Enables the unification of GitHub Copilot extensions. When enabled, all GitHub Copilot functionality is served from the GitHub Copilot Chat extension. When disabled, the GitHub Copilot and GitHub Copilot Chat extensions operate independently.",
 			"Controls the font family in chat messages.",
 			"Controls the font size in pixels in chat messages.",
-			"Controls whether the built-in General Purpose agent is available as a subagent.",
 			"Controls whether to show a growth notification in the agent sessions view to encourage new users to try Copilot.",
 			"Specify paths to hook configuration files that define custom shell commands to execute at strategic points in an agent's workflow. [Learn More]({0}).\n\nRelative paths are resolved from the root folder(s) of your workspace. Supports Copilot hooks (`*.json`) and Claude Code hooks (`settings.json`, `settings.local.json`).",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
 			"Hook File Locations",
 			"Enables automatically using the active editor as chat context for specified chat locations.",
+			"When enabled, the active editor is automatically forwarded as context, even when it would otherwise only be suggested. Selections and explicitly attached files are always included regardless of this setting.\n\nNote: this setting currently only applies to Agent Host sessions (such as the Copilot CLI).",
 			"Controls whether the new implicit context flow is shown. In Ask and Edit modes, the context will automatically be included. When using an agent, context will be suggested as an attachment. Selections are always included as context.",
 			"The value for the implicit context.",
 			"Implicit context is always enabled.",
@@ -37618,6 +40368,11 @@
 			"Allow access to any installed MCP server.",
 			"No access to MCP servers.",
 			"Allows access to MCP servers installed from the registry that VS Code is connected to.",
+			"Enterprise-managed allowlist that controls which Model Context Protocol servers may be installed and run. When set, only servers matching an entry are permitted; any other server is blocked. Servers can be matched by name, remote URL pattern (with `*` wildcards), or local command invocation. Omit entirely to allow all servers (subject to the deny list). Delivered via enterprise policy for governance; this setting is not surfaced to end users.",
+			"Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list).",
+			"Match a local server by its exact command invocation, given as the command followed by its arguments.",
+			"Match a server by its configured name.",
+			"Match a remote server by its URL. Supports `*` wildcards, for example `https://*.example.com/*`.",
 			"Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from the central registry for .NET packages (NuGet.org).",
 			"Controls whether MCP servers should be automatically started when the chat messages are submitted.",
 			"Never automatically start MCP servers.",
@@ -37626,6 +40381,11 @@
 			"Controls behavior when multiple MCP servers are discovered with the same name. 'disable' disables lower-priority duplicates. 'suffix' appends numeric suffixes to disambiguate.",
 			"Disable lower-priority servers with duplicate names.",
 			"Append numeric suffixes to servers with duplicate names.",
+			"Enterprise-managed denylist of Model Context Protocol servers. Servers matching any entry are unconditionally blocked from being installed or run, even if they also match the allow list — deny rules always take precedence. Servers can be matched by name, remote URL pattern (with `*` wildcards), or local command invocation. Delivered via enterprise policy for governance; this setting is not surfaced to end users.",
+			"Denylist of Model Context Protocol servers. Servers matching any entry are blocked from being installed or run, even if they also match the allow list; deny rules always take precedence.",
+			"Match a local server by its exact command invocation, given as the command followed by its arguments.",
+			"Match a server by its configured name.",
+			"Match a remote server by its URL. Supports `*` wildcards, for example `https://*.example.com/*`.",
 			"Enables the default Marketplace for Model Context Protocol (MCP) servers.",
 			"Configures which models are exposed to MCP servers for sampling (making model requests in the background). This setting can be edited in a graphical way under the `{0}` command.",
 			"Whether this server is allowed to make sampling requests during its tool calls in a chat session.",
@@ -37650,19 +40410,19 @@
 			"Autopilot (Preview)",
 			"Start new chat sessions with Default Approvals.",
 			"Default Approvals",
-			"Controls the default permissions picker mode for new chat sessions. You can still change the permission mode per session, and each session remembers the permission mode that was used. If enterprise policy disables auto approval, new sessions use Default Approvals.",
+			"Controls the default permissions picker mode for new local chat sessions. You can still change the permission mode per session, and each session remembers the permission mode that was used. If enterprise policy disables auto approval, new sessions use Default Approvals.",
 			"Always show progress in chat.",
 			"Select the default language model to use for the Plan agent from the available providers.",
 			"When enabled, the plan review widget mounts an editor inline, as opposed to in a separate editor tab.",
 			"Plugin directories to discover. Each key is a path that points directly to a plugin folder, and the value enables (`true`) or disables (`false`) it. Paths can be absolute, relative to the workspace root, or start with `~/` for the user's home directory.",
 			"Enable agent plugin integration in chat.",
-			"Enterprise-managed plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form (resolved to Copilot CLI install paths); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, also restricts which marketplace-discovered plugins are allowed to load (only IDs mapped to `true` here pass the gate).",
-			"Plugin enablement. Keys are plugin IDs in `<plugin>@<marketplace>` form; values enable or disable the plugin.",
+			"Controls which [agent plugins](https://aka.ms/vscode-agent-plugins) are enabled or disabled. Keys are plugin IDs in `<plugin>@<marketplace>` form (where marketplace is defined in {1}); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, entries are additive: plugins mapped to `true` are enabled in addition to the user's own plugins, and only plugins mapped to `false` are blocked from loading.",
+			"Plugin enablement. Keys are plugin IDs in `{plugin}@{marketplace}` form; values enable or disable the plugin.",
 			"Enterprise-managed additional plugin marketplaces. Unioned with {0}.",
-			"Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`<url>[#ref]`).",
+			"Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`{url}[#ref]`).",
 			"Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo` or `owner/repo#ref`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`, each optionally suffixed with `#ref`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated.",
-			"When enabled, only marketplaces supplied via enterprise policy are trusted. Plugins from any other marketplace will not load.",
-			"Only trust marketplaces supplied via enterprise policy; plugins from any other marketplace will not load.",
+			"Enterprise-managed allowlist of plugin marketplace sources. When set, only marketplaces matching one of these entries can be installed; an empty array blocks all marketplaces. This does not retroactively disable already-installed plugins. Each entry is an object with a `source` discriminator (`github`, `git`, `url`, `npm`, `file`, `directory`, `hostPattern`, or `pathPattern`) and the corresponding fields. Typically delivered via enterprise policy.",
+			"Allowlist of plugin marketplace sources. When set, only marketplaces matching an entry are trusted; an empty array blocks all marketplaces.",
 			"Show an animated gradient border around the chat input while the agent is working or thinking. When enabled and reduced motion is not enabled, this overrides {0} to be off. Has no effect when reduced motion is enabled.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported. Glob patterns are deprecated and will be removed in future versions.",
 			"Configure which prompt files to recommend in the chat welcome view. Each key is a prompt file name, and the value can be `true` to always recommend, `false` to never recommend, or a [when clause](https://aka.ms/vscode-when-clause) expression like `resourceExtname == .js` or `resourceLangId == markdown`.",
@@ -37673,10 +40433,19 @@
 			"Controls whether the last session is restored in panel after restart.",
 			"Specify location(s) of reusable prompt files (`*{0}`) that can be run in Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
 			"Prompt File Locations",
-			"Controls whether a screenshot of the selected element will be added to the chat.",
 			"Enable session sync to GitHub.com. When enabled, Copilot session data is synced to your GitHub account for cross-device access and richer insights. Requires `#github.copilot.chat.localIndex.enabled#` to also be enabled.",
 			"Enable session sync to GitHub.com for cross-device Copilot session history. When disabled by organization policy, session data is kept local only.",
 			"Repository patterns to exclude from session sync. Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repositories will only be stored locally.",
+			"Enables dictating into the chat input using on-device speech-to-text. When enabled on a supported platform, a microphone button appears in the chat input; the transcription model is downloaded on first use and runs locally.",
+			"Tap the dictation shortcut to start and stop, or press and hold it to dictate only while held (push-to-talk).",
+			"Controls how the chat dictation shortcut ({0}) behaves.",
+			"Press and hold the dictation shortcut to dictate; dictation stops as soon as the shortcut is released.",
+			"Tap the dictation shortcut to start dictating and tap again to stop.",
+			"The on-device model used for chat dictation. The model is downloaded on first use and cached on disk. Larger models are more accurate but slower and take longer to download.",
+			"Balanced speed and accuracy (~145MB download).",
+			"NVIDIA Nemotron RNN-T: multilingual (35+ languages, auto-detected), high accuracy, matches the GitHub Copilot app (~800MB download).",
+			"Most accurate; slower and larger (~465MB download).",
+			"Smallest and fastest; lowest accuracy (~75MB download).",
 			"Allow subagents to invoke subagents.",
 			"Controls whether subagents can invoke other subagents. When enabled, nesting is limited to a maximum depth of 5.",
 			"Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features.",
@@ -37693,6 +40462,11 @@
 			"The language model id used to generate tool risk assessments. Should be a small, fast model.",
 			"When enabled, terminal tool calls are always displayed in a collapsible container with a simplified view.",
 			"Controls whether to show the todo list widget above the chat input. When enabled, the widget displays todo items created by the agent and updates as progress is made.",
+			"Controls whether agent status pills are shown above the chat input while a turn is in progress and inside the completed response. Only applies to agent sessions.",
+			"Show a pill for browser activity in the turn.",
+			"Show a pill summarizing the files changed and the lines added and removed in the turn.",
+			"The per-pill object form is deprecated. Use a boolean value instead.",
+			"Show a pill to preview a Markdown or HTML file created or edited in the turn.",
 			"Controls whether the input of the chat should be restored when an undo request is made. The input will be filled with the text of the request that was restored.",
 			"Replaces the command center search box with a unified chat and search widget.",
 			"Controls whether an animation is shown when clicking the thumbs up button on a chat response.",
@@ -37717,8 +40491,9 @@
 			"Use nested AGENTS.md files",
 			"Controls whether a stronger skill adherence prompt is used that encourages the model to immediately invoke skills when relevant rather than just announcing them.",
 			"Use Skill Adherence Prompt",
-			"Override the language model used by built-in utility flows. Leave empty to use the default model.",
-			"Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the default model.",
+			"Override the language model used by built-in utility flows. Leave empty to use the configured default behavior.",
+			"Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the configured default behavior.",
+			"Show request and completion timestamps. Hover over a completion timestamp to show the elapsed response time.",
 			"Show a progress badge on the chat view when an agent session is in progress that is opened in that view.",
 			"Show chat agent sessions when chat is empty or to the side when chat view is wide enough.",
 			"Controls the orientation of the chat agent sessions view when it is shown alongside the chat.",
@@ -37736,9 +40511,71 @@
 			"The OAuth client ID registered with the SSO issuer for this device.",
 			"The OAuth client secret paired with `clientId`. Intended for local development only.",
 			"The OAuth/OIDC issuer URL of the SSO authorization server. Must be an `https://` URL.",
-			"The OAuth/OIDC IdP configuration used for enterprise-managed Model Context Protocol (MCP) server authentication. Delivered through enterprise policy (Windows Group Policy, macOS managed preferences, Linux `/etc/vscode/policy.json`).",
+			"The OAuth/OIDC IdP configuration used for enterprise-managed Model Context Protocol (MCP) server authentication.",
 			"Configure the MCP Gallery service URL to connect to",
 			"List Servers"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/agentHostChatDebugProvider": [
+			"Aborted",
+			"Agent Discovery",
+			"Context Compaction",
+			"Context Compaction Failed",
+			"system={0}, conversation={1}, tools={2} tokens",
+			"disabled",
+			"Customization Discovery",
+			"{0} loaded",
+			"{0} loaded, {1} disabled",
+			"Resolve Customizations",
+			"{0} skills, {1} agents, {2} hooks, {3} instructions",
+			"Full Prompt",
+			"Hook Discovery",
+			"Error Occurred",
+			"Error During {0}",
+			"Hook Failed: {0}",
+			"Hook: {0}",
+			"Recoverable; retrying",
+			"Unrecoverable",
+			"MCP Server Discovery",
+			"Model Changed",
+			"{0} (reasoningEffort={1})",
+			"{0} → {1}",
+			"intention: {0}",
+			"kind: {0}",
+			"path: {0}",
+			"Awaiting Permission: {0}",
+			"pending",
+			"Permission {0}: {1}",
+			"result: {0}",
+			"Prompt Discovery",
+			"Reasoning",
+			"Response",
+			"Instructions Discovery",
+			"CLI {0}",
+			"Error",
+			"Error ({0})",
+			"{0}@{1}",
+			"Session Started",
+			"model={0}, reasoningEffort={1}",
+			"model={0}",
+			"Warning",
+			"Warning ({0})",
+			"Skill Discovery",
+			"Skill Invoked: {0}",
+			"model: {0}",
+			"agent: {0}",
+			"tokens: {0}",
+			"tool calls: {0}",
+			"Unknown error",
+			"Copilot CLI Session {0}",
+			"User Request"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources": [
+			"{0} (Log)",
+			"Copilot CLI Logs",
+			"Session Events (events.jsonl)",
+			"Remote Agent Host Log (agenthost.log)",
+			"AHP Log",
+			"AHP Log — {0}"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatCustomizationDiscoveryRenderer": [
 			"Configure locations",
@@ -37822,6 +40659,7 @@
 			"Model Turn",
 			"[{0}ms]",
 			"No findings for this request pair.",
+			"The request-side prompt (system instructions, tool catalog, and input messages) was not captured for this session, so the prompt-signature diff and root-cause findings are unavailable. The cache-hit numbers above come from reported token usage.",
 			"(not present)",
 			"No model turns recorded for this session yet.",
 			"No model turns match the selected agent filter.",
@@ -37980,6 +40818,11 @@
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEditorInput": [
 			"Icon of the chat debug editor label.",
 			"Agent Debug Logs"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEnablement": [
+			"Agent debug logging is turned off. Enable it to capture and view debug logs for this session.",
+			"Enable in Settings",
+			"AHP logging is turned off. Enable it and reproduce the issue to capture and view client↔host protocol frames for this session."
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugEventDetailRenderer": [
 			"Agent: {0}",
@@ -38144,6 +40987,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugOverviewView": [
 			"Agent Flow Chart",
+			"AHP Log",
 			"Cache Explorer",
 			"Created",
 			"Last Activity",
@@ -38182,6 +41026,51 @@
 			"Status: {0}",
 			"Success",
 			"Tool: {0}"
+		],
+		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugWireLogView": [
+			"AHP Log",
+			"Agent Debug Logs",
+			"notify",
+			"request",
+			"response",
+			"{0} errors",
+			"{0} frames",
+			"{0} pending",
+			"{0} requests",
+			"slowest {0}",
+			"AHP logging is disabled — enable {0} and reproduce to capture client↔host protocol frames.",
+			"The AHP log is empty.",
+			"No AHP log is available. Enable {0} and reproduce the issue to capture protocol frames.",
+			"Failed to read AHP log: {0}",
+			"Filter AHP log frames",
+			"Filter by method, type, or id",
+			"remote",
+			"Showing the most recent frames",
+			"id: {0}",
+			"Agent Host → VS Code",
+			"Loading…",
+			"Load More ({0})",
+			"Load more frames",
+			"{0} ms",
+			"No AHP log was found yet for this session. Interact with the agent to capture protocol frames.",
+			"No frames match '{0}'.",
+			"The AHP Log is available for Agent Host sessions.",
+			"Open Full File",
+			"VS Code → Agent Host",
+			"Refresh",
+			"(response)",
+			"{0} s",
+			"Error",
+			"Params",
+			"Response Error",
+			"Result",
+			"Showing {0} of {1} frames",
+			"AHP log file",
+			"error",
+			"error {0}",
+			"pending",
+			"Large payload values were elided in the log. Open the full file for complete data.",
+			"This AHP log is unavailable."
 		],
 		"vs/workbench/contrib/chat/browser/chatEditing/chatEditingActions": [
 			"Keep",
@@ -38307,7 +41196,8 @@
 			"{0} (changes from chat)"
 		],
 		"vs/workbench/contrib/chat/browser/chatImageCarouselService": [
-			"Conversation Images"
+			"Conversation Images",
+			"Current Input"
 		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution": [
 			"Enabling AI features…",
@@ -38323,8 +41213,10 @@
 			"Icon of the Models Management editor label."
 		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatModelsWidget": [
-			"Cache cost: {0} credits per 1M tokens",
-			"Cache cost: {0} credit per 1M tokens",
+			"Cache read cost: {0} credits per 1M tokens",
+			"Cache read cost: {0} credit per 1M tokens",
+			"Cache write cost: {0} credits per 1M tokens",
+			"Cache write cost: {0} credit per 1M tokens",
 			"Capabilities",
 			"Agent Mode",
 			"Tools",
@@ -38333,9 +41225,12 @@
 			"Collapse",
 			"Collapse All",
 			"Cost (Credits per 1M Tokens)",
-			"Cache: {0}",
-			"Cache: {0} credits per 1M tokens",
-			"Cache: {0} credit per 1M tokens",
+			"Cache Read: {0} credits per 1M tokens",
+			"Cache Read: {0} credit per 1M tokens",
+			"Cache Read: {0}",
+			"Cache Write: {0}",
+			"Cache Write: {0} credits per 1M tokens",
+			"Cache Write: {0} credit per 1M tokens",
 			"In: {0}",
 			"Input: {0} credits per 1M tokens",
 			"Input: {0} credit per 1M tokens",
@@ -38356,13 +41251,17 @@
 			"Name",
 			"Add Model",
 			"Agent Mode",
-			"Cache Cost: {0} credits per 1M tokens",
-			"Cache Cost: {0} credit per 1M tokens",
+			"Cache Read Cost: {0} credits per 1M tokens",
+			"Cache Read Cost: {0} credit per 1M tokens",
+			"Cache Write Cost: {0} credits per 1M tokens",
+			"Cache Write Cost: {0} credit per 1M tokens",
 			"Capabilities",
 			"Configure...",
 			"Context Size",
 			"Delete",
 			"Would you like to delete {0}?",
+			"Migrate",
+			"The Ollama model provider is deprecated. Please migrate to the official extension.",
 			"Add Models",
 			"Open in Language Models (JSON)",
 			"Hide All Models",
@@ -38371,8 +41270,10 @@
 			"Input Cost: {0} credits per 1M tokens",
 			"Input Cost: {0} credit per 1M tokens",
 			"Install Model Providers",
-			"Cache Cost: {0} credits per 1M tokens",
-			"Cache Cost: {0} credit per 1M tokens",
+			"Cache Read Cost: {0} credits per 1M tokens",
+			"Cache Read Cost: {0} credit per 1M tokens",
+			"Cache Write Cost: {0} credits per 1M tokens",
+			"Cache Write Cost: {0} credit per 1M tokens",
 			"Input Cost: {0} credits per 1M tokens",
 			"Input Cost: {0} credit per 1M tokens",
 			"Output Cost: {0} credits per 1M tokens",
@@ -38445,6 +41346,10 @@
 			"Show Extension",
 			"Contributes a chat participant"
 		],
+		"vs/workbench/contrib/chat/browser/chatPromoNotification": [
+			"Ends {0}.",
+			"Try {0}"
+		],
 		"vs/workbench/contrib/chat/browser/chatQuotaNotification": [
 			"Manage Budget",
 			"Manage Budget",
@@ -38453,6 +41358,7 @@
 			"Upgrade to continue past the limit.",
 			"Contact your admin to increase your limits.",
 			"Additional budget is enabled to cover extra usage.",
+			"Switch to Auto to reduce credit usage.",
 			"Credits at {0}%",
 			"Your organization or enterprise has exceeded its Copilot budget. Contact your admin to resume usage.",
 			"Usage Blocked",
@@ -38464,10 +41370,14 @@
 			"Credit Limit Reached",
 			"Additional budget is now covering extra usage.",
 			"Credit Limit Reached",
+			"Learn about optimizing usage",
+			"Learn about optimizing usage",
+			"You're likely to exhaust your AI credits before your billing period. {0}.",
 			"Resets on {0}.",
 			"You've used {0}% of your session rate limit.",
 			"You've used {0}% of your weekly rate limit.",
 			"Sign In",
+			"Switch to Auto",
 			"Upgrade",
 			"Upgrade"
 		],
@@ -38502,6 +41412,7 @@
 			"Placeholder text to display in the chat input box for this session type.",
 			"Name of the dynamically registered chat participant (eg: @agent). Must not contain whitespace.",
 			"Order in which this item should be displayed.",
+			"Whether the chat session relies on a GitHub Copilot account and so cannot be used until the user signs in. Defaults to false.",
 			"When set, the chat session will show a filtered model picker that prefers custom models. This enables the use of standard model picker with contributed sessions.",
 			"Whether the chat session supports the synthetic \"Auto\" model fallback. Defaults to false. When true and no models are available, the picker shows \"Auto\" instead of a \"No models available\" state.",
 			"Whether this chat session supports attaching files or file references.",
@@ -38655,6 +41566,8 @@
 			"Manage Budget",
 			"Model",
 			"Premium requests",
+			"{0} used",
+			"{0} used",
 			"Included with your organization's plan.",
 			"{0} included with your organization's plan.",
 			"Organization limit reached.",
@@ -38692,16 +41605,18 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry": [
 			"Quota reached",
-			"Chat quota reached",
-			"1 agent session in progress",
-			"{0} agent sessions in progress",
+			"Copilot Resumed",
 			"Copilot Status",
 			"Copilot status",
 			"Inline suggestions disabled",
-			"Inline suggestions limit reached",
 			"Inline suggestions snoozed",
 			"Copilot disabled",
 			"Sign In"
+		],
+		"vs/workbench/contrib/chat/browser/chatTerminalCommandPaste": [
+			"Paste",
+			"Paste and Don't Ask Again",
+			"The pasted text starts with \"{0}\", which will run the message as a terminal command when sent. Paste anyway?"
 		],
 		"vs/workbench/contrib/chat/browser/chatTipCatalog": [
 			"Work across multiple projects at once in the [Agents window](command:{0} \"Open Agents Window\").",
@@ -38791,8 +41706,9 @@
 			"Failed to clone plugin source '{0}': {1}",
 			"Cloning plugin source '{0}'...",
 			"Installing plugin '{0}'...",
-			"'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo) or a git clone URL.",
-			"Local file paths are not supported. Enter a GitHub repository (owner/repo) or a git clone URL.",
+			"'{0}' is not a valid plugin source. Enter a GitHub repository (owner/repo), a git clone URL, or a local folder path.",
+			"No plugin or marketplace found in '{0}'. This folder does not contain a plugin or marketplace manifest.",
+			"The folder '{0}' does not exist or is not a directory.",
 			"No plugins found in '{0}'. This does not appear to be a valid plugin marketplace.",
 			"Plugin source directory '{0}' is invalid for repository '{1}'.",
 			"Plugin source directory '{0}' not found in repository '{1}'.",
@@ -38800,12 +41716,14 @@
 			"Plugin source '{0}' not found after cloning.",
 			"Select a plugin to install from '{0}'",
 			"Show Output",
+			"Plugins from '{0}' are blocked by your organization's policy.",
 			"&&Trust",
 			"Trust Plugins from '{0}'?",
 			"Plugins can run code on your machine. Only install plugins from sources you trust.\n\nSource: {0}",
 			"Failed to update: {0}",
 			"Updated plugins: {0}",
-			"Updating plugins..."
+			"Updating plugins...",
+			"View Policy Settings"
 		],
 		"vs/workbench/contrib/chat/browser/pluginSources": [
 			"Failed to checkout plugin '{0}' to requested revision: {1}",
@@ -39002,6 +41920,10 @@
 			"Configure Tools...",
 			"Select tools"
 		],
+		"vs/workbench/contrib/chat/browser/promptSyntax/promptToolSetsCodeLensProvider": [
+			"Configure Tools...",
+			"Select tools"
+		],
 		"vs/workbench/contrib/chat/browser/promptSyntax/promptUrlHandler": [
 			"An external application wants to create a custom agent with content from a URL. Do you want to continue by selecting a destination folder and name?",
 			"An external application wants to create an instructions file with content from a URL. Do you want to continue by selecting a destination folder and name?",
@@ -39034,10 +41956,35 @@
 			"Configure Skills...",
 			"Skills"
 		],
+		"vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService": [
+			"Speech-to-text stopped because audio could not be sent for transcription: {0}",
+			"Could not start audio capture for speech-to-text: {0}",
+			"Could not start speech-to-text: {0}",
+			"Downloading…",
+			"Downloading… {0}%",
+			"Loading model…",
+			"Could not access the microphone for speech-to-text: {0}",
+			"On-device speech-to-text model failed to load: {0}",
+			"On-device speech-to-text is not available on this platform.",
+			"Preparing speech-to-text model…"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/dictationSession": [
+			"Listening…"
+		],
 		"vs/workbench/contrib/chat/browser/tools/chatToolRiskAssessmentService": [
 			"{0} appears to have no observable side effects.",
 			"{0} may modify your workspace or send data over the network.",
 			"{0} performs an action that is hard to undo."
+		],
+		"vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution": [
+			"Integrated Browser",
+			"Open, navigate, and inspect pages in the built-in browser.",
+			"Jupyter Notebooks",
+			"Create and edit Jupyter notebooks and run their cells.",
+			"Tasks and Problems",
+			"Create and run tasks and inspect workspace problems.",
+			"VS Code",
+			"Navigate code, manage extensions, and run built-in VS Code commands."
 		],
 		"vs/workbench/contrib/chat/browser/tools/languageModelToolsConfirmationService": [
 			"Always {0}",
@@ -39118,6 +42065,8 @@
 			"'{0}' is not a valid file name",
 			"Configure Tool Sets...",
 			"Create new tool sets file...",
+			"Create from current selection...",
+			"A file with this name already exists",
 			"Select a tool set to configure",
 			"Tool Sets",
 			"Type tool sets file name",
@@ -39126,6 +42075,8 @@
 			"Icon to use for this tool set in the UI. Uses the \"\\$(name)\"-syntax, like \"\\$(zap)\"",
 			"A list of tools or tool sets to include in this tool set. Cannot be empty and must reference tools the way they are referenced in prompts.",
 			"{1} ({0})\n\n{2}",
+			"Tool set name cannot be empty",
+			"Type new tool set name",
 			"User tool sets configuration"
 		],
 		"vs/workbench/contrib/chat/browser/tools/usagesTool": [
@@ -39137,7 +42088,7 @@
 			"Find references, definitions, and implementations of a symbol"
 		],
 		"vs/workbench/contrib/chat/browser/utilityModelContribution": [
-			"Use the built-in default utility model",
+			"Use the default behavior for utility models",
 			"Default"
 		],
 		"vs/workbench/contrib/chat/browser/viewsWelcome/chatViewsWelcomeHandler": [
@@ -39146,6 +42097,15 @@
 			"The title of the welcome message.",
 			"Condition when the welcome message is shown.",
 			"Contributes a welcome message to a chat view"
+		],
+		"vs/workbench/contrib/chat/browser/voiceClient/micCaptureService": [
+			"Your microphone appears to be muted or disabled, possibly by a hardware switch. Voice Mode won't hear you until it's re-enabled.",
+			"Microphone access was denied. Grant microphone permission in your system settings to use Voice Mode."
+		],
+		"vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController": [
+			"Voice mode could not connect. Please try again.",
+			"Voice disconnected. Tap to start.",
+			"Voice moved to another window. Tap to start."
 		],
 		"vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService": [
 			"Approving...",
@@ -39183,7 +42143,19 @@
 			"Continue the conversation by signing in. Your free account gets 50 premium requests a month plus access to more models and AI features.",
 			"Enable more AI features"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatAutoModeResolutionContentPart": [
+			"{0} - Confidence {1}%",
+			"Unable to resolve",
+			"Non-reasoning",
+			"Reasoning",
+			"Routed to {0}"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatChangesSummaryPart": [
+			"Checkpoint File Changes",
+			"{0}, {1} lines added, {2} lines deleted",
+			"{0} files changed",
+			"1 file changed",
+			"View All File Changes",
 			"View All File Changes"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatCodeCitationContentPart": [
@@ -39254,6 +42226,11 @@
 			"Rendered code block {0}",
 			"Edited {0}, {1}, {2}"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpAuthenticationContentPart": [
+			"Authenticating {0}...",
+			"The MCP servers {0} require authentication. [Authenticate](#authenticate)?",
+			"The MCP server {0} requires authentication. [Authenticate](#authenticate)?"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersInteractionContentPart": [
 			"Show options for {0}",
 			"Skip?",
@@ -39263,6 +42240,9 @@
 			"Starting {0}...",
 			"Starting MCP servers {0}...",
 			"Activating MCP extensions..."
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMcpServersStartingContentPart": [
+			"Starting MCP servers {0}..."
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatMultiDiffContentPart": [
 			"{0} lines added, {1} lines removed",
@@ -39309,6 +42289,7 @@
 			"Waiting for tool '{0}' to respond..."
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart": [
+			"Answered",
 			"Collapse Questions",
 			"{0} Use {1} to focus the terminal.",
 			"{0} Use the Focus Terminal from Question Carousel command to focus the terminal.",
@@ -39351,10 +42332,8 @@
 			"Submit"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuotaExceededPart": [
-			"Click to Retry",
 			"Manage Budget",
-			"Upgrade to GitHub Copilot Pro",
-			"Changes may take a few minutes to take effect."
+			"Upgrade to GitHub Copilot Pro"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatReferencesContentPart": [
 			"Add File to Chat",
@@ -39374,6 +42353,8 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart": [
 			"Ran subagent",
+			"{0} credits",
+			"{0} credit",
 			"Running subagent",
 			"Model: {0}",
 			"1 pending confirmation",
@@ -39407,6 +42388,7 @@
 			"Deleted {0}",
 			"{0} deletions",
 			"1 deletion",
+			"{0}s",
 			"Edited {0}",
 			"Edited file",
 			"Editing files",
@@ -39432,6 +42414,7 @@
 			"Evaluating",
 			"Working",
 			"{0}, {1}, {2}",
+			"{0} - {1}",
 			"Processing",
 			"Preparing",
 			"Loading",
@@ -39476,6 +42459,16 @@
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTreeContentPart": [
 			"File Tree"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatTurnPillsPart": [
+			"{0}, {1} lines added, {2} lines deleted",
+			"{0} files changed",
+			"1 file changed",
+			"Preview",
+			"View all file changes, {0} lines added, {1} lines deleted",
+			"Open Preview: {0}",
+			"View All File Changes",
+			"Turn File Changes"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatWorkspaceEditContentPart": [
 			"Created []({0})",
 			"Deleted `{0}`",
@@ -39500,6 +42493,16 @@
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/abstractToolConfirmationSubPart": [
 			"Skip"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart": [
+			"Cancel",
+			"Show Less",
+			"Delete Comment",
+			"Show More",
+			"No unreviewed comments.",
+			"Open File and Reveal Comment",
+			"Reveal Selected",
+			"Reveal this comment to the agent"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart": [
 			"Allow",
 			"Cancel",
@@ -39516,11 +42519,17 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatModifiedFilesConfirmationSubPart": [
 			"{0} files changed",
+			"{0} files created",
 			"All Changes",
 			"{0} lines added, {1} lines removed",
 			"{0}, {1} lines added, {2} lines removed",
 			"1 file changed",
+			"1 file created",
 			"View All Changes"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatOtherClientToolProgressPart": [
+			"{0} [Skip?](#skip)",
+			"{0} Skip?"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatSandboxPrerequisiteConfirmationSubPart": [
 			"Install",
@@ -39579,6 +42588,12 @@
 			"Show and Focus Terminal",
 			"Show Output",
 			"{0}"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolAuthenticationSubPart": [
+			"Authenticate",
+			"Cancel",
+			"The MCP server {0} requires authentication to continue this tool call.",
+			"MCP authentication required"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatToolConfirmationCarouselPart": [
 			"Allow",
@@ -39644,6 +42659,8 @@
 			"Started implementation with Autopilot",
 			"Provided feedback",
 			"{0}: {1}",
+			"Open full plan file",
+			"Open full plan file ({0})",
 			"Rejected plan",
 			"Plan review required",
 			"Chat input required ({0} questions): {1}",
@@ -39652,6 +42669,9 @@
 			"Chat needs your input ({0} questions).",
 			"Chat needs your input (1 question).",
 			"Selected \"{0}\"",
+			"Sent {0}",
+			"Completed {0}",
+			"Elapsed time {0}",
 			"Checkpoint Restored",
 			"1 confirmation pending",
 			"{0} confirmations pending",
@@ -39670,6 +42690,24 @@
 			"[[(rerun without)]]",
 			"used {0} [[(rerun without)]]",
 			"Working"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner": [
+			"Archived sessions are read-only."
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatRestoreCheckpointActionViewItem": [
+			"Cancel restoring this checkpoint",
+			"Discard Edits",
+			"Confirm restoring this checkpoint and discarding later edits"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatTurnPills": [
+			"Turn status",
+			"View Changes: {0}, +{1}, -{2}",
+			"{0} File",
+			"{0} Files",
+			"View Changes",
+			"Open Preview",
+			"Show All Previewable Files",
+			"Open Preview: {0}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatWidget": [
 			"Build with Agent",
@@ -39712,57 +42750,6 @@
 			"({0}), {1}",
 			"(Edit), edit files in your workspace.",
 			", {0}. "
-		],
-		"vs/workbench/contrib/chat/browser/widget/input/chatInputStatusActionViewItem": [
-			"Manage Settings",
-			"Agent being monitored via [OpenTelemetry]({0})"
-		],
-		"vs/workbench/contrib/chat/browser/widget/input/chatModelPicker": [
-			"Higher levels of thinking may increase costs",
-			"Thinking Effort",
-			"Manage Models...",
-			"Manage Language Models",
-			"Contact your admin",
-			"This model is not available. Contact your administrator to enable it.",
-			"[Contact your admin]({0})",
-			"Pick Model, {0}",
-			"Auto",
-			"This model requires a newer version of VS Code. [Update VS Code](command:update.checkForUpdate) to access it.",
-			"This model requires a newer version of VS Code. [Download Update](command:update.downloadUpdate) to access it.",
-			"Thinking Effort: {0}",
-			"Set Thinking Effort",
-			"No models available",
-			"Other Models",
-			"Pin Model",
-			"Pinned",
-			"This model requires a newer version of VS Code. [Restart to Update](command:update.restartToUpdate) to access it.",
-			"Search models",
-			"Context Size: {0}",
-			"Set Context Size",
-			"Unpin Model",
-			"Update VS Code",
-			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
-			"[Upgrade to GitHub Copilot Pro+](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
-			"[Upgrade](command:workbench.action.chat.upgradePlan \" \")",
-			"High cost",
-			"Low cost",
-			"Medium cost",
-			"{0} cost",
-			"Very high cost",
-			"Larger context may increase cost",
-			"Context Size",
-			"Cached input",
-			"Configurable:",
-			"Max context",
-			"Cost: {0}",
-			"{0} credits",
-			"{0} credit",
-			"{0} (default)",
-			"Input",
-			"Long context cost (per 1M tokens)",
-			"Output",
-			"Cost",
-			"Cost (per 1M tokens)"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatPhoneInputPresenter": [
 			"Auto",
@@ -39812,8 +42799,92 @@
 			"Pasted Symbol Reference",
 			"Paste as Markdown"
 		],
-		"vs/workbench/contrib/chat/browser/widget/input/modelPickerActionItem": [
-			"Pick Model"
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerActionItem": [
+			"Models",
+			"{0} • Unavailable while in Restricted mode. Trust Workspace to enable models.",
+			"{0} • Sign in to GitHub Copilot to choose a model."
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerConfiguration": [
+			"Changing these options mid-session resets the prompt cache and may increase cost.",
+			"Thinking Effort",
+			"Thinking Effort: {0}",
+			"Context Size: {0}",
+			"Context Size",
+			"Default"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerHover": [
+			"Lightweight",
+			"Powerful",
+			"Versatile",
+			"{0}% discount",
+			"Ends {0}.",
+			"Cache Read",
+			"Cache Write",
+			"Configurable",
+			"Max context",
+			"Cost: {0}",
+			"Unknown",
+			"Credits Per 1M Tokens",
+			"Default",
+			"Input",
+			"Long Context",
+			"Output"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItems": [
+			"Manage Models...",
+			"Manage Language Models",
+			"Contact your admin",
+			"This model is not available. Contact your administrator to enable it.",
+			"[Contact your admin]({0})",
+			"Auto",
+			"This model requires a newer version of VS Code. [Update VS Code](command:update.checkForUpdate) to access it.",
+			"Copilot",
+			"This model requires a newer version of VS Code. [Download Update](command:update.downloadUpdate) to access it.",
+			"No models available",
+			"Other Models",
+			"Pin Model",
+			"Pinned",
+			"This model requires a newer version of VS Code. [Restart to Update](command:update.restartToUpdate) to access it.",
+			"Models unavailable while in Restricted mode",
+			"Trust Workspace to enable models...",
+			"Trust the workspace to enable models.",
+			"Sign in to use Copilot",
+			"Sign in to use Copilot...",
+			"Sign in to GitHub Copilot to choose a model.",
+			"Unpin Model",
+			"Update VS Code",
+			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
+			"[Upgrade to GitHub Copilot Pro+](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
+			"[Upgrade](command:workbench.action.chat.upgradePlan \" \")",
+			"{0}% discount"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerPresentation": [
+			"High cost",
+			"Low cost",
+			"Medium cost",
+			"{0} cost",
+			"Very high cost"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerWidget": [
+			"Learn more",
+			"Activating...",
+			"Models, {0}",
+			"Models, unavailable while in Restricted mode",
+			"Models, sign in to use Copilot",
+			"Auto",
+			"Switching models mid-session resets the prompt cache and may increase cost.",
+			"Configure Model",
+			"Models",
+			"No models available",
+			"Search models",
+			"Trusting this workspace enables AI models and chat features."
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelProviderIcons": [
+			"Icon for Claude models.",
+			"Icon for Copilot models.",
+			"Icon for Gemini models.",
+			"Icon for other model providers.",
+			"Icon for OpenAI models."
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem": [
 			"Built-In",
@@ -39824,27 +42895,34 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/permissionPickerActionItem": [
 			"Permission picker, {0}",
-			"Bypass Approvals",
+			"Permission picker, {0}, {1}",
+			"Assisted permissions",
+			"An LLM judge evaluates each tool call. Tools it doesn't approve require your approval.",
+			"Assisted permissions",
+			"Evaluates risk before running tools",
+			"Allow all",
 			"Auto-approve all tool calls and retry on errors",
-			"Bypass Approvals",
-			"Disabled by enterprise policy",
-			"Disabled by enterprise policy",
-			"All tool calls are auto-approved",
+			"Allow all",
+			"Runs tool calls without asking",
 			"Autopilot (Preview)",
 			"Auto-approve all tool calls and continue until the task is done. Autopilot may increase costs.",
 			"Autopilot (Preview)",
-			"Disabled by enterprise policy",
-			"Disabled by enterprise policy",
 			"Autonomously iterates from start to finish",
-			"Default Approvals",
+			"Default approvals",
 			"Use configured approval settings",
-			"Default Approvals",
-			"Copilot uses your configured settings",
+			"Default approvals",
+			"Sandboxing for terminal",
+			"Run terminal commands inside a sandbox that restricts file system and network access",
+			"Asks when approval settings don't apply",
+			"Default approvals (sandboxed)",
 			"This option is locked",
-			"Learn more about permissions"
+			"Learn more about permissions",
+			"Disabled by enterprise policy",
+			"Disabled by enterprise policy"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem": [
 			"Learn about agent types...",
+			"{0}. {1}",
 			"Agent Types",
 			"Other"
 		],
@@ -39876,6 +42954,10 @@
 			"Reserved for response",
 			"Quality may decline as limit nears.",
 			"{0}%",
+			"Session Cost",
+			"{0} credit",
+			"{0} credits",
+			"Session Info",
 			"{0} / {1} tokens",
 			"Uncategorized"
 		],
@@ -39884,11 +42966,15 @@
 			"Context window usage: {0}%"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewPane": [
-			"Voice Mode",
 			"Failed to open chat session: {0}",
 			"New Session",
 			"Agent Session in Progress",
-			"Sessions"
+			"Sessions",
+			"Press {0} to barge in",
+			"Speak to barge in",
+			"Click voice mode to talk or barge in",
+			"Listening...",
+			"Press {0} to talk or barge in"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewTitleControl": [
 			"Chat",
@@ -39908,6 +42994,7 @@
 			"Visibility of the agent sessions view in the chat view.",
 			"The type of the current agent session item.",
 			"True when the chat agent supports attachments.",
+			"The Agent Host provider ID when the chat widget is locked to an Agent Host session.",
 			"True when agent mode is disabled by organization policy.",
 			"True when the user has opened the context window usage details.",
 			"True when the chat text edits have been applied.",
@@ -39923,10 +43010,13 @@
 			"True when the chat has custom agents available.",
 			"True when there are chat session providers with delegation support available.",
 			"True when the chat has file attachments.",
+			"True when a delegation (continue in) target is selected but the request has not been submitted yet.",
 			"True when there are pending requests in the queue.",
 			"True when the user has used any of the /create-* slash commands.",
+			"True when the chat widget is locked to an Agent Host session.",
 			"True when chat is enabled because a default chat participant is activated with an implementation.",
 			"True when focusing a KaTeX math element.",
+			"True when the chat shown in the widget is read-only (non-interactive).",
 			"The id of the chat item.",
 			"The id of the last chat item.",
 			"The short id of the currently selected chat model (for example 'gpt-4.1').",
@@ -39959,10 +43049,14 @@
 			"True when the current chat session provider supports forking conversations.",
 			"The type of the current chat session.",
 			"True when the chat request in progress message should be skipped.",
+			"True when on-device speech-to-text is available for dictating into the chat input.",
+			"True while the on-device speech-to-text model is downloading or loading (the preparation notification is shown).",
+			"True while the chat input is recording audio for speech-to-text transcription.",
 			"Whether the remote coding agent prompt file overlay feature is enabled",
 			"True when the chat widget is within a file with an edit session.",
 			"Whether any remote coding agent is available",
 			"True when the chat input is within the agent sessions welcome page.",
+			"True when the chat input is within the automations dialog.",
 			"True when focus is in the chat widget, false otherwise.",
 			"Whether focus is in a chat editor.",
 			"True when focus is in the chat question carousel.",
@@ -39992,6 +43086,15 @@
 			"Attached {0} images",
 			"Attached 1 image"
 		],
+		"vs/workbench/contrib/chat/common/automations/schedule": [
+			"Friday",
+			"Monday",
+			"Saturday",
+			"Sunday",
+			"Thursday",
+			"Tuesday",
+			"Wednesday"
+		],
 		"vs/workbench/contrib/chat/common/chatErrorMessages": [
 			"a moment",
 			"Canceled",
@@ -40015,7 +43118,8 @@
 			"Sorry, but I can only assist with programming related questions.",
 			"You've reached your additional usage limit for your plan. Upgrade your plan to keep going.",
 			"You've exhausted your credits. To continue working, please contact your organization's Copilot admin or wait for your allowance to renew.",
-			"You've exhausted your premium model quota. To continue working, switch to Auto. For additional paid premium requests, please reach out to your organization's Copilot admin or wait for your allowance to renew.",
+			"You've exhausted your premium model quota. For additional paid premium requests, please reach out to your organization's Copilot admin or wait for your allowance to renew.",
+			"You've exhausted your premium model quota. Please enable additional paid premium requests, upgrade to Copilot Pro, or wait for your allowance to renew.",
 			"You've reached your monthly chat messages quota. Upgrade to Copilot Pro or wait for your allowance to renew.",
 			"Quota Exceeded",
 			"You've exhausted your premium model quota. Please enable additional paid premium requests, upgrade to Copilot Pro+, or wait for your allowance to renew.",
@@ -40024,8 +43128,10 @@
 			"Quota Exceeded\n\nServer Error: {0}\nError Code: {1}",
 			"You've reached your credit limit. To continue working, please contact your organization's Copilot admin or wait for your credits to reset.",
 			"You've reached your credit limit. To continue working, please contact your organization's Copilot admin or wait until your credits reset on {0}.",
-			"You've reached your credit limit. To continue working, switch to Auto. For additional paid credits, please reach out to your organization's Copilot admin or wait for your credits to reset.",
-			"You've reached your credit limit. To continue working, switch to Auto. For additional paid credits, please reach out to your organization's Copilot admin or wait until your credits reset on {0}.",
+			"You've reached your credit limit. For additional paid credits, please reach out to your organization's Copilot admin or wait for your credits to reset.",
+			"You've reached your credit limit. For additional paid credits, please reach out to your organization's Copilot admin or wait until your credits reset on {0}.",
+			"You've reached your monthly credit limit. Please enable additional paid credits, upgrade to Copilot Pro, or wait for your credits to reset.",
+			"You've reached your monthly credit limit. Please enable additional paid credits, upgrade to Copilot Pro, or wait until your credits reset on {0}.",
 			"You've reached your monthly credit limit. Upgrade to Copilot Pro or wait for your credits to reset.",
 			"You've reached your monthly credit limit. Upgrade to Copilot Pro or wait until your credits reset on {0}.",
 			"You've reached your monthly credit limit. Please enable additional paid credits, upgrade to Copilot Pro+, or wait for your credits to reset.",
@@ -40064,15 +43170,23 @@
 			"Edit or refactor selected code"
 		],
 		"vs/workbench/contrib/chat/common/chatPermissionWarnings": [
-			"Cancel",
+			"Auto Approvals",
 			"Enable",
-			"Bypass Approvals will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.\n\nTo make this the starting permission level for new chat sessions, change the [{0}](command:workbench.action.openSettings?%5B%22{0}%22%5D) setting.",
-			"Enable Bypass Approvals?",
-			"Cancel",
+			"{0} uses model recommendations to approve tool calls. Copilot will still ask when the model requires approval, excludes the request from automatic approval, or cannot make a recommendation.\n\nTo make this the starting permission level for new sessions, change the [{1}](command:workbench.action.openSettings?%5B%22{1}%22%5D) setting.",
+			"Enable {0}?",
+			"Bypass Approvals",
 			"Enable",
-			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.\n\nTo make this the starting permission level for new chat sessions, change the [{0}](command:workbench.action.openSettings?%5B%22{0}%22%5D) setting.",
+			"{0} will auto-approve all tool calls without asking for confirmation. This includes file edits, terminal commands, and external tool calls.\n\nTo make this the starting permission level for new sessions, change the [{1}](command:workbench.action.openSettings?%5B%22{1}%22%5D) setting.",
+			"Enable {0}?",
+			"Enable",
+			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.\n\nTo make this the starting permission level for new sessions, change the [{0}](command:workbench.action.openSettings?%5B%22{0}%22%5D) setting.",
 			"Enable Autopilot?",
+			"Cancel",
 			"Don't show again"
+		],
+		"vs/workbench/contrib/chat/common/chatProgressFormatting": [
+			"{0}m {1}s",
+			"{0}s"
 		],
 		"vs/workbench/contrib/chat/common/chatService/chatServiceImpl": [
 			"The `{0}` skill requires `{1}` to be enabled. After enabling, reload the window to apply. [Enable in Settings](command:workbench.action.openSettings?{2})",
@@ -40080,7 +43194,6 @@
 			"New Chat"
 		],
 		"vs/workbench/contrib/chat/common/customizationHarnessService": [
-			"Copilot CLI",
 			"Local"
 		],
 		"vs/workbench/contrib/chat/common/editing/chatEditingService": [
@@ -40089,6 +43202,11 @@
 			"Changes to {0} files"
 		],
 		"vs/workbench/contrib/chat/common/languageModels": [
+			"Auto routes based on your task and real-time system health and model performance.",
+			"Models routed via auto receive a {0}% discount.",
+			"[Learn More]({0})",
+			"Install Extension",
+			"The internal {0} language model provider is being deprecated. Please migrate to the official extension.",
 			"Group Name",
 			"Please enter a name",
 			"Enter value for {0}",
@@ -40100,6 +43218,8 @@
 			"Contribute language model chat providers of a specific vendor.",
 			"Configuration options for the language model chat provider.",
 			"Whether the property is a secret.",
+			"Marks this language model chat provider as deprecated. When set, the Manage Models view renders the provider with a link pointing to a replacement.",
+			"A URL opened when the user clicks the deprecation link shown next to the provider name. Use a 'vscode:extension/<publisher>.<name>' URI to open a replacement extension in the Extensions view.",
 			"The display name of the language model chat provider.",
 			"The vendor field cannot be empty.",
 			"A command to manage the language model chat provider, e.g. 'Manage Copilot models'. This is used in the chat model picker. If not provided, a gear icon is not rendered during vendor selection.",
@@ -40122,6 +43242,7 @@
 			"Response cleared due to content safety filters, retrying with modified prompt.",
 			"Answer questions to continue...",
 			"Approve tool result?",
+			"Authenticate {0} to continue...",
 			"Review the plan to continue..."
 		],
 		"vs/workbench/contrib/chat/common/model/chatProgressTypes/chatToolInvocation": [
@@ -40230,9 +43351,16 @@
 			"User Prompt Submit"
 		],
 		"vs/workbench/contrib/chat/common/promptSyntax/languageProviders/promptCodeActions": [
+			"Enable Built-in GitHub MCP Server",
 			"Expand to {0} tools",
+			"Install GitHub MCP Server from Marketplace",
+			"Install Playwright MCP Server from Marketplace",
 			"Migrate to custom agent file",
 			"Rename to 'agent'",
+			"Search Marketplace for Extension '{0}'",
+			"Search Marketplace for Extension '{0}'",
+			"Search Marketplace for MCP Server '{0}'",
+			"Search Marketplace for MCP Server '{0}'",
 			"Update all tool names",
 			"Update to '{0}'"
 		],
@@ -40471,7 +43599,9 @@
 			"The 'infer' attribute is deprecated in favour of 'user-invocable' and 'disable-model-invocation'.",
 			"Invalid file reference '{0}'.",
 			"Invalid permission value '{0}' for scope '{1}'. Allowed values: {2}.",
+			"Tool alias '{0}' requires the GitHub MCP server. Enable the built-in server with setting 'github.copilot.chat.githubMcpServer.enabled' or install extension 'io.github.github/github-mcp-server' from Extensions (`@mcp github`).",
 			"Missing required properties {0} in handoff object.",
+			"Tool alias '{0}' requires the Playwright MCP server. Install it from Extensions (`@mcp playwright`).",
 			"The 'mode' attribute has been deprecated. The 'agent' attribute is used instead.",
 			"The 'mode' attribute has been deprecated. Please rename it to 'agent'.",
 			"Model names in the array must be non-empty strings.",
@@ -40500,7 +43630,6 @@
 			"The 'target' attribute must be a string.",
 			"Tool or toolset '{0}' has been renamed, use '{1}' instead.",
 			"Tool or toolset '{0}' has been renamed, use the following tools instead: {1}",
-			"Unknown tool '{0}' will be ignored.",
 			"The 'tools' attribute must be an array or a comma separated string.",
 			"The 'tools' attribute is only supported when using agents. Attribute will be ignored.",
 			"Attribute '{0}' is not supported in custom GitHub Copilot agent files. Supported: {1}.",
@@ -40509,12 +43638,15 @@
 			"Attribute '{0}' is not supported in rules files by VS Code agents. Supported: {1}.",
 			"Attribute '{0}' is not supported by VS Code agents. Supported: {1}.",
 			"Attribute '{0}' is not supported in VS Code agent files. Supported: {1}.",
+			"Unknown extension tool '{0}'. It is likely to be a missing extension, please ensure it is installed and enabled.",
 			"Unknown property '{0}' in 'github' object. Supported: 'permissions'.",
 			"Unknown property '{0}' in handoff object. Supported properties are 'label', 'agent', 'prompt' and optional 'send', 'showContinueOn', 'model'.",
 			"Unknown property '{0}' in hook command.",
 			"Unknown hook event type '{0}'. Supported: {1}.",
 			"Unknown property '{0}' in hook matcher.",
+			"Unknown tool '{0}'. It is likely to be a missing MCP server, please ensure it is installed and enabled.",
 			"Unknown permission scope '{0}'. Valid scopes: {1}.",
+			"Unknown tool '{0}' will be ignored.",
 			"Unknown tool or toolset '{0}'.",
 			"The 'user-invocable' attribute must be 'true' or 'false'."
 		],
@@ -40531,6 +43663,7 @@
 			"Global (roams with Settings Sync, only used by VS Code)"
 		],
 		"vs/workbench/contrib/chat/common/promptSyntax/service/promptsServiceImpl": [
+			"Built-in",
 			"Extension: {0}",
 			"Plugin",
 			"User Data"
@@ -40539,7 +43672,7 @@
 			"User Data"
 		],
 		"vs/workbench/contrib/chat/common/tools/builtinTools/askQuestionsTool": [
-			"Question \"{0}\" must have at least two options, or none for free text input.",
+			"Question \"{0}\" must have at least two options, or set allowFreeformInput when providing a single option, or omit options for free text input.",
 			"Asking {0} questions ({1})",
 			"Asked {0} questions ({1})",
 			"Asking a question ({0})",
@@ -40693,6 +43826,25 @@
 			"Export Agent Host Traces Database...",
 			"No agent host trace database found yet. Run an agent session with `#chat.agentHost.otel.dbSpanExporter.enabled#` turned on to populate it."
 		],
+		"vs/workbench/contrib/chat/electron-browser/actions/networkDiagnosticsAction": [
+			"Network Diagnostics"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/profileAgentHostAction": [
+			"Profile Local Agent Host Process",
+			"CPU Profiles",
+			"Could not enable the Node.js inspector for the agent host process.",
+			"Profiling the local agent host process.",
+			"Save Agent Host Profile",
+			"Failed to save or open the agent host profile: {0}",
+			"Failed to start profiling the agent host: {0}",
+			"Profiling Agent Host. Activate to stop profiling.",
+			"Agent Host Profiler",
+			"Profiling Agent Host",
+			"Click to stop profiling.",
+			"Stop",
+			"Failed to stop profiling the agent host: {0}",
+			"Stop Local Agent Host Profile"
+		],
 		"vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions": [
 			"Listening to 'Hey Code'...",
 			"Waiting for voice chat to end...",
@@ -40767,6 +43919,25 @@
 			"A session is in progress. Are you sure you want to quit?",
 			"The session will stop if you reload the window.",
 			"A session is in progress. Are you sure you want to reload the window?"
+		],
+		"vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem": [
+			"Establishing tunnel connection...",
+			"Remote session access is enabled",
+			"Allow remote session access",
+			"Remote session access enabled via tunnel '{0}'",
+			"Show Output",
+			"Remote session access is now enabled"
+		],
+		"vs/workbench/contrib/chat/electron-browser/tunnelHost.contribution": [
+			"Show Remote Connections Output",
+			"Allow Remote Connections",
+			"Remote Connections",
+			"Enable Microsoft account authentication for agent host tunnels. When disabled, only GitHub authentication is used.",
+			"Failed to toggle remote connections: {0}"
+		],
+		"vs/workbench/contrib/chat/electron-browser/tunnelHostService": [
+			"No authentication token available. Please sign in and try again.",
+			"Remote Connections"
 		],
 		"vs/workbench/contrib/codeActions/browser/codeActionsContribution": [
 			"Triggers Code Actions on explicit saves and auto saves triggered by window or focus changes.",
@@ -41319,12 +44490,13 @@
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"Contributed custom editors.",
 			"Human readable name of the custom editor. This is displayed to users when selecting which editor to use.",
-			"Controls if the custom editor is enabled automatically when the user opens a file, diff, or merge editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting.",
+			"Controls if the custom editor is enabled automatically when the user opens a file, diff, or merge editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting. When omitted, the custom editor defaults to `default` for the normal editor and `never` for diff and merge editors, so it is not used for diffs or merges unless it opts in.",
 			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
-			"Controls if the custom editor is enabled automatically when the user opens a diff. When not specified, the value of `editor` is used.",
-			"Controls if the custom editor is enabled automatically when the user opens a file.",
-			"Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified, the value of `editor` is used.",
+			"Controls if the custom editor is enabled automatically when the user opens a diff. When not specified this defaults to `never`, so the custom editor is not used for diffs unless it opts in.",
+			"Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified this defaults to `never`, so the custom editor is not used for merges unless it opts in.",
+			"The editor is never automatically used, and it is also skipped when the user points a `workbench.editorAssociations` entry at it. It can still be opened via the `Reopen With` command or the specialized `workbench.diffEditorAssociations` setting.",
 			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.",
+			"Controls if the custom editor is enabled automatically when the user opens a file. `diffEditor` and `mergeEditor` do not inherit this value; when they are not specified they default to `never`.",
 			"Set of globs that the custom editor is enabled for.",
 			"Glob that the custom editor is enabled for.",
 			"Identifier for the custom editor. This must be unique across all custom editors, so we recommend including your extension id as part of `viewType`. The `viewType` is used when registering custom editors with `vscode.registerCustomEditorProvider` and in the `onCustomEditor:${id}` [activation event](https://code.visualstudio.com/api/references/activation-events).",
@@ -41891,6 +45063,7 @@
 		],
 		"vs/workbench/contrib/debug/browser/exceptionWidget": [
 			"Close",
+			"Copy",
 			"Exception widget background color.",
 			"Exception widget border color.",
 			"Exception has occurred.",
@@ -42541,8 +45714,6 @@
 			"Extension '{0}' not found.",
 			"Extension '{0}' is not installed. Make sure you use the full extension ID, including the publisher, e.g.: ms-dotnettools.csharp.",
 			"All extensions are up to date.",
-			"Off",
-			"On",
 			"Recently Published",
 			"Show Recently Published Extensions",
 			"Refresh",
@@ -42600,7 +45771,7 @@
 		],
 		"vs/workbench/contrib/extensions/browser/extensionsActions": [
 			"Please [review the extension]({0}) and update it manually.",
-			"This extension is not updated yet because new versions are auto updated 2 hours after they are published. It will be auto updated {0}.",
+			"This extension is not updated yet because new versions are auto updated {0} after they are published. It will be auto updated {1}.",
 			"Cancel",
 			"This extension is disabled because it is not supported in {0} for the Web.",
 			"The '{0}' extension is not available in {1}. Click 'More Information' to learn more.",
@@ -43784,19 +46955,13 @@
 			"Report Issue",
 			"Icon for the issue reporter editor."
 		],
-		"vs/workbench/contrib/issue/browser/issueReporterEditorPane": [
-			"No issue reporter data available.",
-			"No current experiments.",
-			"Open System Settings",
-			"Recording stopped automatically: the 100 MB upload limit was reached.",
-			"{0} needs Screen Recording permission to record videos. Grant access in System Settings, then click Record again.",
-			"Screen recording permission was denied. Allow {0} to record the screen and try again."
-		],
 		"vs/workbench/contrib/issue/browser/issueReporterOverlay": [
 			"A/B Experiments",
 			"Additional Information",
 			"Additional Performance Data",
 			"Optionally include currently running processes and workspace metadata to help diagnose performance issues.",
+			"Agents Window",
+			"E.g. Sessions list does not refresh after creating a new session",
 			"Attachments ({0})",
 			"Back",
 			"Bug",
@@ -43814,9 +46979,6 @@
 			"Describe the issue in detail...",
 			"Enter a description to continue.",
 			"Click to edit screenshot",
-			"Exclude All",
-			"Exclude all additional issue data from this issue",
-			"Expand",
 			"Extension",
 			"Extension Data",
 			"This extension uses an external issue reporter. Preview will open that issue reporter.",
@@ -43833,9 +46995,6 @@
 			"Generate from description",
 			"Generating...",
 			"Hide Toolbar in Screenshots",
-			"Include All",
-			"Include all additional issue data in this issue",
-			"Include in issue",
 			"Issue will be created in {0}/{1}.",
 			"Title",
 			"Brief summary of the issue",
@@ -43848,7 +47007,6 @@
 			"Extensions Marketplace",
 			"E.g. Cannot disable installed extension",
 			"Max attachments reached",
-			"Minimize",
 			"Next",
 			"No delay",
 			"(no description)",
@@ -43858,6 +47016,7 @@
 			"or",
 			"Describe what is slow, when it happens, whether it's consistent or intermittent, and any patterns you've noticed.",
 			"Performance Issue",
+			"See the performance issue reporting guide.",
 			"Preview on GitHub",
 			"Recording active",
 			"Recording {0}",
@@ -43865,6 +47024,7 @@
 			"Refresh",
 			"Reload running processes and workspace metadata",
 			"Report Issue",
+			"Before you report an issue here please [review the guidance we provide](https://github.com/microsoft/vscode/wiki/Submitting-Bugs-and-Suggestions). Please complete the form in English.",
 			"Review and submit",
 			"Running Processes",
 			"Screenshot",
@@ -44000,6 +47160,14 @@
 			"Report Performance Issue...",
 			"Type the name of an extension to report on."
 		],
+		"vs/workbench/contrib/issue/electron-browser/issueReporterEditorPane": [
+			"No issue reporter data available.",
+			"No current experiments.",
+			"Open System Settings",
+			"Recording stopped automatically: the 100 MB upload limit was reached.",
+			"{0} needs Screen Recording permission to record videos. Grant access in System Settings, then click Record again.",
+			"Screen recording permission was denied. Allow {0} to record the screen and try again."
+		],
 		"vs/workbench/contrib/issue/electron-browser/issueReporterService": [
 			"No current experiments.",
 			"We have written the needed data into your clipboard because it was too large to send. Please paste.",
@@ -44009,6 +47177,10 @@
 		],
 		"vs/workbench/contrib/keybindings/browser/keybindings.contribution": [
 			"Toggle Keyboard Shortcuts Troubleshooting"
+		],
+		"vs/workbench/contrib/keybindings/electron-browser/systemWideKeybindings.contribution": [
+			"Some system-wide keybindings could not be registered ({0}); the key combination may already be taken by the operating system or another application.",
+			"The \"when\" clause is ignored for system-wide keybindings ({0}); they are always active while {1} is running."
 		],
 		"vs/workbench/contrib/languageDetection/browser/languageDetection.contribution": [
 			"Detect Language from Content",
@@ -44344,6 +47516,7 @@
 			"Select MCP Resource..."
 		],
 		"vs/workbench/contrib/mcp/browser/mcpCommands": [
+			"Enablement",
 			"Resources",
 			"Sampling",
 			"Status",
@@ -44351,16 +47524,24 @@
 			"Installs a new Model Context protocol to the mcp.json settings",
 			"Add Server",
 			"Add a new server configuration",
-			"Disable Server",
-			"Enable Server",
+			"Authenticate",
+			"Disable",
+			"Disable (Session)",
+			"Disable (Workspace)",
+			"Enable",
+			"Enable (Session)",
+			"Enable (Workspace)",
 			"No MCP servers",
 			"This session does not expose any MCP servers",
+			"Restarting MCP server '{0}' is not supported for agent-host servers. Stop and start the server instead.",
 			"Show locally configured servers...",
+			"Failed to start MCP server '{0}': {1}",
 			"Authentication required",
 			"Error",
 			"Running",
 			"Starting",
 			"Stopped",
+			"Failed to stop MCP server '{0}': {1}",
 			"Agent Host Server Options",
 			"Automatically start MCP servers when sending a chat message",
 			"Browse Resources...",
@@ -44479,6 +47660,8 @@
 			"Install from a Pip package name",
 			"Choose the type of MCP server to add",
 			"Available on this remote machine, runs on {0}",
+			"Add to Current Agent Session",
+			"Install Server Locally...",
 			"Select the configuration target",
 			"Remote",
 			"Add MCP Server",
@@ -44534,10 +47717,13 @@
 			"Start",
 			"Stop",
 			"Variable `{0}` not found, did you mean ${{1}}?",
+			"Authentication Required",
 			"Disabled",
 			"Error",
 			"{0} prompts",
 			"Running",
+			"(Running in 1 session)",
+			"(Running in {0} sessions)",
 			"Starting",
 			"{0} tools"
 		],
@@ -45727,6 +48913,19 @@
 			"An extension provided notebook for '{0}' is still open that would close otherwise.",
 			"An extension provided notebook for '{0}' could not be saved."
 		],
+		"vs/workbench/contrib/onboarding/browser/onboarding.contribution": [
+			"Map of onboarding scenario/tour id to whether developer mode is enabled for it. When enabled for a scenario, that onboarding tour ignores usage-based eligibility checks (such as how many sessions you have started), previously persisted shown state, and any linked experiment (so it is shown even if the experiment is not running or you are in the control group). It does not override the {0} setting. The tour is still shown at most once per window session, so reload the window to show it again.",
+			"When enabled, onboarding tours and hints may appear automatically to highlight features. Disabling this does not affect tours you start manually.",
+			"Reset Onboarding Shown State"
+		],
+		"vs/workbench/contrib/onboarding/browser/spotlight/spotlightOverlay": [
+			"Back",
+			"{0} of {1}",
+			"Done",
+			"End Tour",
+			"End Tour (Esc)",
+			"Next"
+		],
 		"vs/workbench/contrib/outline/browser/outline.contribution": [
 			"When enabled, Outline shows `array`-symbols.",
 			"When enabled, Outline shows `boolean`-symbols.",
@@ -45958,10 +49157,13 @@
 			"Focus settings file",
 			"Move Focus Up One Level",
 			"Focus Settings Search",
+			"Focus Settings Search from Settings",
 			"Focus Setting Control",
+			"Focus First Setting from Search",
 			"Focus settings list",
 			"Focus Settings Table of Contents",
 			"Show Setting Context Menu",
+			"Show Previous Search in Settings",
 			"Toggle AI Settings Search",
 			"Settings Editor 2",
 			"Show System Keybindings",
@@ -46034,6 +49236,7 @@
 			"1 Setting Found",
 			"1 Setting Found. AI Results Available",
 			"Search settings",
+			"Search settings ({0} for history)",
 			"Settings",
 			"Workspace Trust",
 			"No AI results available at this time...",
@@ -46936,7 +50139,6 @@
 			"Controls sorting order of editor history in quick open when filtering.",
 			"History entries are sorted by relevance based on the filter value used. More relevant entries appear first.",
 			"History entries are sorted by recency. More recently opened entries appear first.",
-			"The search cache is kept in the extension host which never shuts down, so this setting is no longer needed.",
 			"&&Search",
 			"Shows search results as a list.",
 			"Shows search results as a tree.",
@@ -46953,9 +50155,6 @@
 			"When enabled, the legacy `findFiles` extension API honors the user's `#search.useIgnoreFiles#` setting instead of always ignoring `.gitignore`. Extensions that explicitly pass `null` as the `exclude` argument still get unfiltered results. Telemetry is emitted regardless of this setting to help decide future defaults.",
 			"Controls whether to follow symlinks while searching.",
 			"Controls whether the Search view should read or modify the shared find clipboard on macOS.",
-			"Controls whether the search will be shown as a view in the sidebar or as a panel in the panel area for more horizontal space.",
-			"This setting is deprecated. You can drag the search icon to a new location instead.",
-			"When enabled, the searchService process will be kept alive instead of being shut down after an hour of inactivity. This will keep the file search cache in memory.",
 			"Controls the maximum number of search results, this can be set to `null` (empty) to return unlimited results.",
 			"Controls where new `Search: Find in Files` and `Find in Folder` operations occur: either in the Search view, or in a search editor.",
 			"Search in a new search editor.",
@@ -46975,7 +50174,6 @@
 			"Controls whether to show line numbers for search results.",
 			"Search case-insensitively if the pattern is all lowercase, otherwise, search case-sensitively.",
 			"Controls sorting order of search results.",
-			"Whether to use the PCRE2 regex engine in text search. This enables using some advanced regex features like lookahead and backreferences. However, not all PCRE2 features are supported - only features that are also supported by JavaScript.",
 			"Controls whether to open Replace Preview when selecting or replacing a match.",
 			"Results are sorted by count per file, in ascending order.",
 			"Results are sorted by count per file, in descending order.",
@@ -46987,10 +50185,7 @@
 			"Search for text in your workspace files.",
 			"Controls whether to use your global gitignore file (for example, from `$HOME/.config/git/ignore`) when searching for files. Requires {0} to be enabled.",
 			"Controls whether to use `.gitignore` and `.ignore` files when searching for files.",
-			"Controls whether to use `.gitignore` and `.ignore` files in parent directories when searching for files. Requires {0} to be enabled.",
-			"Deprecated. PCRE2 will be used automatically when using regex features that are only supported by PCRE2.",
-			"This setting is deprecated and now falls back on \"search.usePCRE2\".",
-			"Deprecated. Consider \"search.usePCRE2\" for advanced regex feature support."
+			"Controls whether to use `.gitignore` and `.ignore` files in parent directories when searching for files. Requires {0} to be enabled."
 		],
 		"vs/workbench/contrib/search/browser/searchAccessibilityHelp": [
 			"Press Escape to close Search. Focus returns to the editor, and your search history is preserved.",
@@ -47450,6 +50645,61 @@
 			"Remind Me Later",
 			"Do you mind taking a quick feedback survey?",
 			"Take Survey"
+		],
+		"vs/workbench/contrib/surveys/browser/survey.contribution": [
+			"Open Survey",
+			"You are in a survey form. Use Tab to move between questions and options.",
+			"Use arrow keys within a question to navigate between options, and Space or Enter to select.",
+			"Tab to the Submit button and press Enter once the required question is answered. Additional questions are optional.",
+			"Survey"
+		],
+		"vs/workbench/contrib/surveys/browser/surveyEditorInput": [
+			"Icon for the survey editor."
+		],
+		"vs/workbench/contrib/surveys/browser/surveyEditorPane": [
+			"Survey",
+			"{0} (optional)",
+			"Submit feedback",
+			"Answer the required question to submit",
+			"Your answer helps us understand who needs this most. Thank you.",
+			"Response sent"
+		],
+		"vs/workbench/contrib/surveys/browser/surveyQuestions": [
+			"This short survey helps us understand how well Copilot fits into your workflow.",
+			"How disappointed would you be if you could no longer use Copilot?",
+			"Extremely",
+			"Not at all",
+			"Slightly",
+			"Somewhat",
+			"Very",
+			"What has Copilot helped you with most recently?",
+			"Automating repetitive work",
+			"Getting unstuck on bugs",
+			"Making multi-file changes",
+			"I haven't gotten clear value yet",
+			"None of the above",
+			"Planning an approach",
+			"Improving or reviewing code",
+			"Shipping changes faster",
+			"Understanding the codebase",
+			"What most gets in your way?",
+			"Struggles with bigger tasks",
+			"Missing repo or project context",
+			"Limits, cost, or billing",
+			"None of the above",
+			"Too much time reviewing",
+			"Security or permissions friction",
+			"Setup or integrations are hard",
+			"Too slow / breaks flow",
+			"Too much steering needed",
+			"Output is hard to trust",
+			"How long have you been programming?",
+			"10-19 yr",
+			"20+ yr",
+			"3-5 yr",
+			"6-9 yr",
+			"<3 yr",
+			"Help Us Improve GitHub Copilot"
 		],
 		"vs/workbench/contrib/tasks/browser/abstractTaskService": [
 			"configured tasks",
@@ -48351,7 +51601,7 @@
 			"On macOS and Linux, a new split terminal will use the working directory of the parent terminal. On Windows, this behaves the same as initial.",
 			"A new split terminal will use the working directory that the parent terminal started with.",
 			"A new split terminal will use the workspace root as the working directory. In a multi-root workspace a choice for which root folder to use is offered.",
-			"Controls whether agentic CLIs (such as Claude Code, Codex, GitHub Copilot CLI, and Gemini CLI) are allowed to set the terminal tab title via escape sequences. When disabled, the configured tab title template is used instead.",
+			"Controls whether agentic CLIs (such as Claude Code, Codex, Command Code, GitHub Copilot CLI, and Gemini CLI) are allowed to set the terminal tab title via escape sequences. When disabled, the configured tab title template is used instead.",
 			"A theme color ID to associate with terminal icons by default.",
 			"A codicon ID to associate with terminal icons by default.",
 			"Controls whether terminal tab statuses support animation (eg. in progress tasks).",
@@ -48596,6 +51846,9 @@
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalConfirmationTool": [
 			"Confirm Terminal Command",
+			"This command will run outside the sandbox.",
+			"This command will run outside the sandbox.\n\nReason: {0}",
+			"Run in terminal outside the sandbox?",
 			"Tool for confirming terminal commands"
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool": [
@@ -48617,7 +51870,7 @@
 			"Bubblewrap cannot create the sandbox environment.",
 			"Bubblewrap repair failed (exit code {0}). The command was not executed.",
 			"Could not determine whether the bubblewrap repair succeeded. The command was not executed.",
-			"Bubblewrap still cannot create the required sandbox namespace after remediation. The command was not executed.",
+			"Bubblewrap still cannot create the required sandbox namespace after remediation. Reload the window and try running the command again.",
 			"Repair Bubblewrap Sandbox",
 			"Bubblewrap is installed but cannot create the required sandbox namespace on this system. The command was not executed.",
 			"Explanation: {0}\n\nGoal: {1}",
@@ -48632,14 +51885,17 @@
 			"Sandbox dependency installation was cancelled by the user.",
 			"Sandbox dependency installation failed (exit code {0}). The command was not executed.",
 			"Install",
+			"Sandbox dependencies were installed successfully. If the issue persists, reload the window and try running the command again.",
 			"The following dependencies required for sandboxed execution are not installed: {0}. Would you like to install them?",
 			"Sandbox prerequisites are still not satisfied after installation. The command was not executed.",
 			"Missing Sandbox Dependencies",
 			"Could not determine whether sandbox dependency installation succeeded. The command was not executed.",
+			"The following dependencies required for sandboxed execution are not installed: {0}. Install them using your system package manager, then run the command again.",
 			"Run `{0}` command in `{1}`?",
 			"Run `{0}` command in `{1}` within `{2}`?",
 			"Run command in `{0}` within `{1}`?",
 			"Run command in `{0}`?",
+			"Access Denied: The command was not executed because the terminal sandbox does not allow access to the requested file paths:\n{0}",
 			"The terminal command was prompting for a password or other secret. Auto-approve / autopilot mode cannot safely supply secrets, so the command was cancelled. Run the command interactively if you want to provide the secret.",
 			"Terminal command cancelled — sensitive input required",
 			"Cancel Command",
@@ -48730,11 +51986,10 @@
 		],
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/common/terminalChatAgentToolsConfiguration": [
 			"Controls whether agent mode terminal commands that run inside the sandbox are auto-approved. When disabled, the run in terminal tool uses the existing approval flow. This applies only when {0} is enabled.",
+			"When {0} is enabled, controls whether to allow all network domains in the sandbox. When enabled, the sandbox preserves file system restrictions while relaxing all network restrictions.",
 			"Controls whether agent mode terminal commands can run outside the sandbox after user confirmation when a sandboxed command fails or when sandbox restrictions would block the command. This applies only when {0} is enabled.",
-			"Controls whether agent mode terminal commands that run outside the sandbox are auto-approved. This applies only when both {0} and {1} are enabled.",
 			"Use {0} instead",
-			"Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system.",
-			"Enable sandboxing for agent mode tools and allow all network domains.",
+			"Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system. Use {0} to allow all network domains.",
 			"Disable sandboxing for agent mode tools.",
 			"Enable sandboxing for agent mode tools.",
 			"Use {0} instead",
@@ -48749,11 +52004,11 @@
 			"Array of additional paths to allow write access. Leave empty to disallow writes outside the workspace folders, workspace storage folder, and sandbox temp directory.",
 			"Array of paths to deny read access. Leave empty to allow reading all paths.",
 			"Array of paths to deny write access within allowed paths (takes precedence over allowWrite).",
-			"Controls whether agent mode terminal commands can retry in the sandbox with unrestricted network access after user confirmation. This applies only when {0} is set to `on` and preserves file system sandboxing while relaxing network restrictions for an approved command.",
+			"Controls whether agent mode terminal commands can retry in the sandbox with unrestricted network access after user confirmation. This applies only when {0} is enabled and preserves file system sandboxing while relaxing network restrictions for an approved command.",
 			"Note: this setting is applicable only when {0} is enabled. Key/value pairs are passed through to the root of the sandbox runtime configuration.",
-			"Controls whether agent mode uses sandboxing on Windows.",
-			"Enable sandboxing for agent mode tools on Windows and allow all network domains.",
+			"Controls whether agent mode uses sandboxing on Windows. Use {0} to allow all network domains.",
 			"Disable sandboxing for agent mode tools on Windows.",
+			"Enable sandboxing for agent mode tools on Windows.",
 			"Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on Windows. Paths do not support glob patterns, only literal paths (ex: C:\\src, C:\\Users\\me\\.ssh, .env).",
 			"Array of additional paths to allow read-only access. Takes precedence over denyRead.",
 			"Array of additional paths to allow read/write access. Leave empty to disallow writes outside the workspace folders, workspace storage folder, and sandbox temp directory.",
@@ -48796,6 +52051,7 @@
 			"Configures the idle poll interval in milliseconds used by the run in terminal tool to detect when commands have finished executing. Lower values make command detection faster but may cause false positives on slow systems. This primarily affects terminals without shell integration where idle detection is used instead of shell integration events.",
 			"Number of milliseconds the run in terminal tool will wait for new output from a synchronous command before moving it to a background terminal and returning what was collected so far. The process is not killed — the tool returns the terminal ID so the model can poll, send input, or kill it. Set to {0} to disable.",
 			"Whether to ignore the built-in default auto-approve rules used by the run in terminal tool as defined in {0}. When this setting is enabled, the run in terminal tool will ignore any rule that comes from the default set but still follow rules defined in the user, remote and workspace settings. Use this setting at your own risk; the default auto-approve rules are designed to protect you against running dangerous commands.",
+			"When enabled, the output of commands run by the run in terminal tool is compacted before being returned to the model, reducing the number of tokens spent on noisy output (for example progress bars or repeated log lines) while preserving the important information.",
 			"When enabled, repeated get terminal output tool calls return only output added since the previous poll for the same terminal execution, or a short unchanged-output message when there is no new output.",
 			"Reveal the terminal output within chat only.",
 			"Where to show the output from the run in terminal tool.",
@@ -48921,18 +52177,14 @@
 			"Type copilot to use Copilot CLI.",
 			" Toggle {0} in settings to disable this hint.",
 			"Disable Initial Hint",
-			"Open chat {0}. ",
 			"[[don't show]] this again.",
 			"Start typing to dismiss or don't show this again.",
 			"[[Don't show this again]]",
 			" Start typing to dismiss or ",
-			"[[Open chat]] or start typing to dismiss.",
-			"Open chat or start typing to dismiss.",
 			"Show suggestions {0}. "
 		],
 		"vs/workbench/contrib/terminalContrib/inlineHint/common/terminalInitialHintConfiguration": [
-			"Controls if the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled.",
-			"When enabled, the terminal initial hint will suggest using Copilot CLI by typing {0} instead of opening Copilot Chat."
+			"Controls if the first terminal without input will show a hint about available actions when it is focused. This will only show when {0} is disabled."
 		],
 		"vs/workbench/contrib/terminalContrib/links/browser/terminal.links.contribution": [
 			"Open Detected Link...",
@@ -49744,6 +52996,8 @@
 			"unassigned"
 		],
 		"vs/workbench/contrib/update/browser/update": [
+			"Cancelling {0} update...",
+			"Cancelling Update...",
 			"Check for Updates...",
 			"Checking for {0} updates...",
 			"Checking for Updates...",
@@ -49752,6 +53006,7 @@
 			"Downloading Update...",
 			"Installing Update...",
 			"Install Update... (1)",
+			"There are currently no updates available.",
 			"Welcome to {0} v{1}! Would you like to read the Release Notes?",
 			"Press the reload button to switch to the Insiders version of VS Code.",
 			"Press the reload button to switch to the Stable version of VS Code.",
@@ -49771,14 +53026,14 @@
 			"&&Stable (current)"
 		],
 		"vs/workbench/contrib/update/browser/update.contribution": [
-			"Apply Update...",
+			"Apply Update from File...",
 			"Check for Updates...",
 			"Developer",
 			"Download Update",
 			"Install Update",
 			"Show &&Release Notes",
 			"Download {0}",
-			"Apply Update",
+			"Apply Update from File",
 			"Cannot open the current file as Release Notes",
 			"Restart to Update",
 			"Show Release Notes",
@@ -49789,6 +53044,7 @@
 			"&&Update"
 		],
 		"vs/workbench/contrib/update/browser/updateTitleBarEntry": [
+			"Cancelling...",
 			"Checking...",
 			"Downloading...",
 			"Installing...",
@@ -49802,6 +53058,8 @@
 			"Automatic updates will be checked but not installed automatically.",
 			"Automatic updates are disabled.",
 			"Updates will be applied on restart.",
+			"Cancelling update, please wait...",
+			"Cancelling Update",
 			"Checking for Updates",
 			"Checking for updates, please wait...",
 			"Copy",
@@ -50742,9 +54000,7 @@
 			"You trust the authors of the files in the current window. All features are enabled:",
 			"In a Trusted Workspace",
 			"You trust the authors of the files in the current workspace. All features are enabled:",
-			"Trust the authors of all files in the current folder or its parent '{0}'.",
 			"You will trust all repositories and forks under '{0}' on {1}.",
-			"Trust Parent",
 			"Trust Folder",
 			"Debugging is disabled",
 			"{0} is in a restricted mode intended for safe code browsing.",
@@ -50780,6 +54036,7 @@
 			"Reveal User Data Folder",
 			"Show Content Tracing",
 			"Show GPU Info",
+			"Start Heap Tracing",
 			"Start Tracing",
 			"Recording performance trace. Click to stop recording.",
 			"Performance Trace",
@@ -50807,6 +54064,7 @@
 			"Current Window",
 			"Turn Off Always on Top",
 			"Turn On Always on Top",
+			"Focus Window",
 			"Clos&&e Window",
 			"&&Zoom In",
 			"&&Zoom Out",
@@ -51308,15 +54566,18 @@
 			"There are multiple default editors available for the resource.",
 			"Keep {0}",
 			"Configure default editor for '{0}'...",
+			"Configure default editor (diff only) for '{0}'...",
 			"Default",
 			"Active and Default",
 			"Active",
 			"Select editor for '{0}'",
+			"Select new default editor (diff only) for '{0}'",
 			"Select new default editor for '{0}'"
 		],
 		"vs/workbench/services/editor/common/editorResolverService": [
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for diff views (for example `\"*.md\": \"vscode.markdown.preview.editor\"`). These override `workbench.editorAssociations` for diffs.",
-			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior."
+			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
+			"Controls whether the Markdown editor is used as the default editor for Markdown files in the Agents window."
 		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
 			"Extension Bisect is active and has disabled {0} extensions. Check if you can still reproduce the problem and proceed by selecting from these options.",
@@ -51351,9 +54612,9 @@
 			"Cannot change enablement of {0} extension because it is malicious",
 			"Cannot change enablement of {0} extension because it does not support virtual workspaces",
 			"Cannot change enablement of {0} extension because of it is invalid",
-			"Cannot change enablement {0} extension because Settings Sync depends on it.",
-			"Cannot change enablement of {0} extension in workspace because it contributes authentication providers",
 			"Cannot change enablement of {0} extension because it contributes language packs.",
+			"Cannot change enablement of {0} extension because Settings Sync depends on it.",
+			"Cannot change enablement of {0} extension in workspace because Settings Sync depends on it.",
 			"All installed extensions are temporarily disabled.",
 			"No workspace.",
 			"Reload and Enable Extensions"
@@ -51422,7 +54683,6 @@
 			"Remote"
 		],
 		"vs/workbench/services/extensionManagement/electron-browser/remoteExtensionManagementService": [
-			"Can't install '{0}' extension. {1}",
 			"Can't install '{0}' extension because it is not compatible with the current version of {1} (version {2}).",
 			"Can't install release version of '{0}' extension because it has no release version."
 		],
@@ -51630,6 +54890,7 @@
 			"Name of the command to execute",
 			"Key or key sequence (separated by space)",
 			"Name of the command to remove keyboard shortcut for",
+			"When `true`, registers this keybinding as a system-wide (OS global) shortcut that fires even when the application is not focused. Desktop only. Only single key combinations are supported (no chords), and any `when` clause is ignored for the global trigger.",
 			"Keybindings configuration",
 			"Condition when the key is active.",
 			"expected non-empty value.",


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Bump API compatibility to 1.130.0
  - The bump unblocks extensions targeting 1.130.0
- Update nls.metadata for vscode API 1.130.0
  - Fix suggestions to use `nls.localizeByDefault` or replace removed defaults

No public API changes: `src/vscode-dts/vscode.d.ts` is unchanged between 1.125.0 and 1.130.0, so no `theia.d.ts` updates are required this cycle.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Check the filtered [vscode-theia-comparator/status](https://eclipse-theia.github.io/vscode-theia-comparator/status.html) with the current Theia master and VS Code 1.125.0
- Regarding nls update: CI Lint step is successful and no localization related warnings are shown on startup
- for the hover verbosity: hover a symbol in a ts file for example, e.g. the function definition `requestHover` in `packages/core/src/browser/status-bar/status-bar.tsx#L141`, and verify the verbosity of the hover content can be in/decreased via +/-

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
