### PR TITLE
fix(navigator): support pasting files from the menu in browser apps

### DIFF
--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -2317,7 +2317,6 @@
       "autoReveal": "Auto Reveal",
       "clipboardWarn": "Access to the clipboard is denied. Check your browser's permission.",
       "clipboardWarnFirefox": "Clipboard API is not available. It can be enabled by '{0}' preference on '{1}' page. Then reload Theia. Note, it will allow FireFox getting full access to the system clipboard.",
-      "nothingToPaste": "The clipboard does not contain workspace files that can be pasted here.",
       "openWithSystemEditor": "Open With System Editor",
       "refresh": "Refresh in Explorer",
       "reveal": "Reveal in Explorer",

--- a/packages/core/i18n/nls.json
+++ b/packages/core/i18n/nls.json
@@ -2317,6 +2317,7 @@
       "autoReveal": "Auto Reveal",
       "clipboardWarn": "Access to the clipboard is denied. Check your browser's permission.",
       "clipboardWarnFirefox": "Clipboard API is not available. It can be enabled by '{0}' preference on '{1}' page. Then reload Theia. Note, it will allow FireFox getting full access to the system clipboard.",
+      "nothingToPaste": "The clipboard does not contain workspace files that can be pasted here.",
       "openWithSystemEditor": "Open With System Editor",
       "refresh": "Refresh in Explorer",
       "reveal": "Reveal in Explorer",

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -34,7 +34,6 @@ import { OpenerService, open } from '../browser/opener-service';
 import { ApplicationShell } from './shell/application-shell';
 import { SHELL_TABBAR_CONTEXT_CLOSE, SHELL_TABBAR_CONTEXT_COPY, SHELL_TABBAR_CONTEXT_PIN, SHELL_TABBAR_CONTEXT_SPLIT } from './shell/tab-bars';
 import { AboutDialog } from './about-dialog';
-import * as browser from './browser';
 import URI from '../common/uri';
 import { ContextKey, ContextKeyService } from './context-key-service';
 import { OS, isOSX, isWindows, EOL } from '../common/os';
@@ -75,10 +74,12 @@ import { timeout } from '../common/promise-util';
 
 export const supportCut = environment.electron.is() || document.queryCommandSupported('cut');
 export const supportCopy = environment.electron.is() || document.queryCommandSupported('copy');
-// Chrome incorrectly returns true for document.queryCommandSupported('paste')
-// when the paste feature is available but the calling script has insufficient
-// privileges to actually perform the action
-export const supportPaste = environment.electron.is() || (!browser.isChrome && document.queryCommandSupported('paste'));
+// Browsers block programmatic paste (document.execCommand('paste') is a no-op and
+// document.queryCommandSupported('paste') returns false), so supportPaste is effectively
+// electron-only. Keeping it false in browsers is intentional: the ctrlcmd+v keybinding stays
+// unregistered, so native paste events reach widget-level listeners (e.g. the navigator), and
+// menu paste is handled by dedicated handlers using the async clipboard API.
+export const supportPaste = environment.electron.is() || document.queryCommandSupported('paste');
 
 export const RECENT_COMMANDS_STORAGE_KEY = 'commands';
 

--- a/packages/navigator/src/browser/navigator-contribution.spec.ts
+++ b/packages/navigator/src/browser/navigator-contribution.spec.ts
@@ -1,0 +1,123 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { Widget } from '@theia/core/lib/browser';
+import { OpenerService } from '@theia/core/lib/browser/opener-service';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { WorkspacePreferences } from '@theia/workspace/lib/common';
+import { FileStatNode } from '@theia/filesystem/lib/browser';
+import { FileNavigatorContribution } from './navigator-contribution';
+import { FileNavigatorPreferences } from '../common/navigator-preferences';
+import { FileNavigatorFilter } from './navigator-filter';
+import { FileNavigatorWidget } from './navigator-widget';
+
+disableJSDOM();
+
+describe('FileNavigatorContribution', () => {
+
+    let contribution: FileNavigatorContribution;
+    let navigatorWidget: FileNavigatorWidget | undefined;
+    let currentWidget: Widget | undefined;
+    let clipboardText: string;
+    let pastedTexts: string[];
+    let selectedNodes: FileStatNode[];
+
+    function createNavigatorWidgetStub(): FileNavigatorWidget {
+        return {
+            model: {
+                get selectedFileStatNodes(): FileStatNode[] {
+                    return selectedNodes;
+                }
+            },
+            pasteFiles: (raw: string): boolean => {
+                pastedTexts.push(raw);
+                return true;
+            }
+        } as unknown as FileNavigatorWidget;
+    }
+
+    beforeEach(() => {
+        clipboardText = '';
+        pastedTexts = [];
+        selectedNodes = [];
+        navigatorWidget = createNavigatorWidgetStub();
+        currentWidget = navigatorWidget;
+        contribution = new FileNavigatorContribution(
+            {} as FileNavigatorPreferences,
+            {} as OpenerService,
+            {} as FileNavigatorFilter,
+            {} as WorkspaceService,
+            {} as WorkspacePreferences
+        );
+        Object.assign(contribution, {
+            widgetManager: {
+                tryGetWidget: (): FileNavigatorWidget | undefined => navigatorWidget
+            },
+            shell: {
+                get currentWidget(): Widget | undefined {
+                    return currentWidget;
+                }
+            },
+            clipboardService: {
+                readText: async (): Promise<string> => clipboardText
+            }
+        });
+    });
+
+    describe('canPasteIntoNavigator', () => {
+
+        it('should be disabled if the navigator widget has not been created', () => {
+            navigatorWidget = undefined;
+            expect(contribution['canPasteIntoNavigator']()).to.be.false;
+        });
+
+        it('should be disabled if the navigator is not the current widget', () => {
+            selectedNodes = [{ id: 'target' } as FileStatNode];
+            currentWidget = undefined;
+            expect(contribution['canPasteIntoNavigator']()).to.be.false;
+        });
+
+        it('should be disabled if no paste target is selected', () => {
+            expect(contribution['canPasteIntoNavigator']()).to.be.false;
+        });
+
+        it('should be enabled if the navigator is the current widget and a paste target is selected', () => {
+            selectedNodes = [{ id: 'target' } as FileStatNode];
+            expect(contribution['canPasteIntoNavigator']()).to.be.true;
+        });
+    });
+
+    describe('pasteIntoNavigator', () => {
+
+        it('should paste the clipboard text into the navigator', async () => {
+            clipboardText = 'file:///workspace/a.txt';
+            await contribution['pasteIntoNavigator']();
+            expect(pastedTexts).to.deep.equal(['file:///workspace/a.txt']);
+        });
+
+        it('should not paste anything for empty clipboard text', async () => {
+            await contribution['pasteIntoNavigator']();
+            expect(pastedTexts).to.have.lengthOf(0);
+        });
+    });
+});

--- a/packages/navigator/src/browser/navigator-contribution.spec.ts
+++ b/packages/navigator/src/browser/navigator-contribution.spec.ts
@@ -39,6 +39,8 @@ describe('FileNavigatorContribution', () => {
     let navigatorWidget: FileNavigatorWidget | undefined;
     let currentWidget: Widget | undefined;
     let clipboardText: string;
+    let fileClipboardText: string | undefined;
+    let systemClipboardReads: number;
     let pastedTexts: string[];
     let selectedNodes: FileStatNode[];
 
@@ -58,6 +60,8 @@ describe('FileNavigatorContribution', () => {
 
     beforeEach(() => {
         clipboardText = '';
+        fileClipboardText = undefined;
+        systemClipboardReads = 0;
         pastedTexts = [];
         selectedNodes = [];
         navigatorWidget = createNavigatorWidgetStub();
@@ -79,7 +83,13 @@ describe('FileNavigatorContribution', () => {
                 }
             },
             clipboardService: {
-                readText: async (): Promise<string> => clipboardText
+                readText: async (): Promise<string> => {
+                    systemClipboardReads++;
+                    return clipboardText;
+                }
+            },
+            fileClipboard: {
+                get: (): string | undefined => fileClipboardText
             }
         });
     });
@@ -118,6 +128,21 @@ describe('FileNavigatorContribution', () => {
         it('should not paste anything for empty clipboard text', async () => {
             await contribution['pasteIntoNavigator']();
             expect(pastedTexts).to.have.lengthOf(0);
+        });
+
+        it('should prefer the file clipboard over the system clipboard', async () => {
+            fileClipboardText = 'file:///workspace/copied-in-app.txt';
+            clipboardText = 'file:///workspace/copied-outside.txt';
+            await contribution['pasteIntoNavigator']();
+            expect(pastedTexts).to.deep.equal(['file:///workspace/copied-in-app.txt']);
+            expect(systemClipboardReads).to.equal(0);
+        });
+
+        it('should fall back to the system clipboard if the file clipboard is empty', async () => {
+            clipboardText = 'file:///workspace/copied-outside.txt';
+            await contribution['pasteIntoNavigator']();
+            expect(pastedTexts).to.deep.equal(['file:///workspace/copied-outside.txt']);
+            expect(systemClipboardReads).to.equal(1);
         });
     });
 });

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -64,6 +64,7 @@ import { FileSystemCommands } from '@theia/filesystem/lib/browser/filesystem-fro
 import { NavigatorDiff, NavigatorDiffCommands } from './navigator-diff';
 import { DirNode, FileNode } from '@theia/filesystem/lib/browser';
 import { FileNavigatorModel } from './navigator-model';
+import { NavigatorFileClipboard } from './navigator-file-clipboard';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
 import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-widget';
@@ -126,6 +127,9 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     @inject(ClipboardService)
     protected readonly clipboardService: ClipboardService;
+
+    @inject(NavigatorFileClipboard)
+    protected readonly fileClipboard: NavigatorFileClipboard;
 
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
@@ -380,14 +384,15 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
     }
 
     /**
-     * Pastes files into the navigator using the async clipboard API. The default
+     * Pastes files into the navigator without a trusted paste event. The default
      * `CommonCommands.PASTE` handler relies on `document.execCommand('paste')`, which browsers
-     * block for programmatic invocations, e.g. from the menu.
+     * block for programmatic invocations, e.g. from the menu. Prefers the in-app file clipboard
+     * as reading the system clipboard may require a user permission prompt in browsers.
      */
     protected async pasteIntoNavigator(): Promise<void> {
         const widget = this.tryGetWidget();
         if (widget) {
-            const text = await this.clipboardService.readText();
+            const text = this.fileClipboard.get() ?? await this.clipboardService.readText();
             if (text) {
                 widget.pasteFiles(text);
             }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -345,6 +345,10 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             isEnabled: widget => this.withWidget(widget, () => this.workspaceService.opened),
             isVisible: widget => this.withWidget(widget, () => this.workspaceService.opened)
         });
+        registry.registerHandler(CommonCommands.PASTE.id, {
+            isEnabled: () => this.canPasteIntoNavigator(),
+            execute: () => this.pasteIntoNavigator()
+        });
     }
 
     protected get editorWidgets(): NavigatableWidget[] {
@@ -368,6 +372,26 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
             return cb(widget);
         }
         return false;
+    }
+
+    protected canPasteIntoNavigator(): boolean {
+        const widget = this.tryGetWidget();
+        return !!widget && this.shell.currentWidget === widget && widget.model.selectedFileStatNodes.length > 0;
+    }
+
+    /**
+     * Pastes files into the navigator using the async clipboard API. The default
+     * `CommonCommands.PASTE` handler relies on `document.execCommand('paste')`, which browsers
+     * block for programmatic invocations, e.g. from the menu.
+     */
+    protected async pasteIntoNavigator(): Promise<void> {
+        const widget = this.tryGetWidget();
+        if (widget) {
+            const text = await this.clipboardService.readText();
+            if (text) {
+                widget.pasteFiles(text);
+            }
+        }
     }
 
     override registerMenus(registry: MenuModelRegistry): void {

--- a/packages/navigator/src/browser/navigator-file-clipboard.spec.ts
+++ b/packages/navigator/src/browser/navigator-file-clipboard.spec.ts
@@ -1,0 +1,84 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { NavigatorFileClipboard } from './navigator-file-clipboard';
+
+disableJSDOM();
+
+describe('NavigatorFileClipboard', () => {
+
+    let jsdomCleanup: () => void;
+    let clipboard: NavigatorFileClipboard;
+
+    before(() => {
+        jsdomCleanup = enableJSDOM();
+    });
+    after(() => {
+        jsdomCleanup();
+    });
+
+    beforeEach(() => {
+        const container = new Container();
+        container.bind(NavigatorFileClipboard).toSelf().inSingletonScope();
+        clipboard = container.get(NavigatorFileClipboard);
+    });
+
+    it('should return undefined when nothing was copied', () => {
+        expect(clipboard.get()).to.be.undefined;
+    });
+
+    it('should return the copied text', () => {
+        clipboard.set('file:///workspace/a.txt');
+        expect(clipboard.get()).to.equal('file:///workspace/a.txt');
+    });
+
+    it('should treat empty text as unset', () => {
+        clipboard.set('');
+        expect(clipboard.get()).to.be.undefined;
+    });
+
+    it('should keep the content when set during a copy event', () => {
+        // simulates the navigator updating the clipboard within its own copy listener
+        const listener = () => clipboard.set('file:///workspace/a.txt');
+        document.addEventListener('copy', listener);
+        try {
+            document.body.dispatchEvent(new window.Event('copy', { bubbles: true }));
+        } finally {
+            document.removeEventListener('copy', listener);
+        }
+        expect(clipboard.get()).to.equal('file:///workspace/a.txt');
+    });
+
+    it('should clear the content when something else is copied', () => {
+        clipboard.set('file:///workspace/a.txt');
+        document.body.dispatchEvent(new window.Event('copy', { bubbles: true }));
+        expect(clipboard.get()).to.be.undefined;
+    });
+
+    it('should clear the content when something else is cut', () => {
+        clipboard.set('file:///workspace/a.txt');
+        document.body.dispatchEvent(new window.Event('cut', { bubbles: true }));
+        expect(clipboard.get()).to.be.undefined;
+    });
+});

--- a/packages/navigator/src/browser/navigator-file-clipboard.ts
+++ b/packages/navigator/src/browser/navigator-file-clipboard.ts
@@ -1,0 +1,52 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, postConstruct } from '@theia/core/shared/inversify';
+
+/**
+ * In-app store for file URIs copied in the navigator.
+ *
+ * Reading the system clipboard from a browser requires a user permission prompt.
+ * By remembering what the navigator itself copied, pasting within the application
+ * works without accessing the system clipboard. The store cannot observe copies
+ * made in external applications; consumers should fall back to the system
+ * clipboard when the store is empty.
+ */
+@injectable()
+export class NavigatorFileClipboard {
+
+    protected content: string | undefined;
+
+    @postConstruct()
+    protected init(): void {
+        // any copy or cut invalidates the store; the navigator repopulates it in its
+        // own (bubbling) copy listener, which runs after this capturing listener
+        document.addEventListener('copy', this.clear, true);
+        document.addEventListener('cut', this.clear, true);
+    }
+
+    set(content: string): void {
+        this.content = content || undefined;
+    }
+
+    get(): string | undefined {
+        return this.content;
+    }
+
+    protected clear = (): void => {
+        this.content = undefined;
+    };
+}

--- a/packages/navigator/src/browser/navigator-frontend-module.ts
+++ b/packages/navigator/src/browser/navigator-frontend-module.ts
@@ -42,6 +42,7 @@ import { OpenEditorsWidget } from './open-editors-widget/navigator-open-editors-
 import { NavigatorTreeDecorator } from './navigator-decorator-service';
 import { NavigatorDeletedEditorDecorator } from './open-editors-widget/navigator-deleted-editor-decorator';
 import { NavigatorSymlinkDecorator } from './navigator-symlink-decorator';
+import { NavigatorFileClipboard } from './navigator-file-clipboard';
 import { FileTreeDecoratorAdapter } from '@theia/filesystem/lib/browser';
 
 export default new ContainerModule(bind => {
@@ -49,6 +50,7 @@ export default new ContainerModule(bind => {
     bind(FileNavigatorFilter).toSelf().inSingletonScope();
 
     bind(NavigatorContextKeyService).toSelf().inSingletonScope();
+    bind(NavigatorFileClipboard).toSelf().inSingletonScope();
 
     bindViewContribution(bind, FileNavigatorContribution);
     bind(FrontendApplicationContribution).toService(FileNavigatorContribution);

--- a/packages/navigator/src/browser/navigator-widget.spec.ts
+++ b/packages/navigator/src/browser/navigator-widget.spec.ts
@@ -28,6 +28,7 @@ import { FileStatNode } from '@theia/filesystem/lib/browser';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileNavigatorWidget } from './navigator-widget';
 import { FileNavigatorModel } from './navigator-model';
+import { NavigatorFileClipboard } from './navigator-file-clipboard';
 
 disableJSDOM();
 
@@ -36,6 +37,7 @@ describe('FileNavigatorWidget', () => {
     const workspaceRoot = new URI('file:///workspace');
     let copiedSources: URI[];
     let selectedNodes: FileStatNode[];
+    let storedClipboardContents: string[];
     let infoMessages: string[];
     let widget: FileNavigatorWidget;
 
@@ -44,6 +46,7 @@ describe('FileNavigatorWidget', () => {
     function createWidget(root: URI = workspaceRoot): FileNavigatorWidget {
         copiedSources = [];
         selectedNodes = [];
+        storedClipboardContents = [];
         infoMessages = [];
         const model = {
             get selectedFileStatNodes(): FileStatNode[] {
@@ -60,12 +63,17 @@ describe('FileNavigatorWidget', () => {
             getWorkspaceRootUri: (uri: URI | undefined): URI | undefined =>
                 uri && root.isEqualOrParent(uri) ? root : undefined
         } as WorkspaceService;
+        const fileClipboard = {
+            set: (content: string): void => {
+                storedClipboardContents.push(content);
+            }
+        } as NavigatorFileClipboard;
         const messageService = {
             info: (message: string): void => {
                 infoMessages.push(message);
             }
         } as unknown as MessageService;
-        Object.assign(navigator, { workspaceService, messageService });
+        Object.assign(navigator, { workspaceService, fileClipboard, messageService });
         return navigator;
     }
 
@@ -150,6 +158,20 @@ describe('FileNavigatorWidget', () => {
             selectedNodes = [targetNode];
             expect(widget.pasteFiles('')).to.be.false;
             expect(infoMessages).to.have.lengthOf(0);
+        });
+    });
+
+    describe('handleCopy', () => {
+
+        it('should record copied URIs in the file clipboard', () => {
+            const sourceNode = { id: 'source', uri: new URI('file:///workspace/a.txt') } as FileStatNode;
+            selectedNodes = [sourceNode];
+            const clipboardEvent = {
+                clipboardData: { setData: () => undefined },
+                preventDefault: () => undefined
+            } as unknown as ClipboardEvent;
+            widget['handleCopy'](clipboardEvent);
+            expect(storedClipboardContents).to.deep.equal(['file:///workspace/a.txt']);
         });
     });
 });

--- a/packages/navigator/src/browser/navigator-widget.spec.ts
+++ b/packages/navigator/src/browser/navigator-widget.spec.ts
@@ -1,0 +1,155 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import { MessageService } from '@theia/core/lib/common/message-service';
+import { ContextMenuRenderer, TreeProps } from '@theia/core/lib/browser';
+import { FileStatNode } from '@theia/filesystem/lib/browser';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { FileNavigatorWidget } from './navigator-widget';
+import { FileNavigatorModel } from './navigator-model';
+
+disableJSDOM();
+
+describe('FileNavigatorWidget', () => {
+
+    const workspaceRoot = new URI('file:///workspace');
+    let copiedSources: URI[];
+    let selectedNodes: FileStatNode[];
+    let infoMessages: string[];
+    let widget: FileNavigatorWidget;
+
+    const targetNode = { id: 'target', uri: workspaceRoot } as FileStatNode;
+
+    function createWidget(root: URI = workspaceRoot): FileNavigatorWidget {
+        copiedSources = [];
+        selectedNodes = [];
+        infoMessages = [];
+        const model = {
+            get selectedFileStatNodes(): FileStatNode[] {
+                return selectedNodes;
+            },
+            copy: (source: URI, target: FileStatNode): Promise<URI> => {
+                expect(target).to.equal(targetNode);
+                copiedSources.push(source);
+                return Promise.resolve(source);
+            }
+        } as unknown as FileNavigatorModel;
+        const navigator = new FileNavigatorWidget({} as TreeProps, model, {} as ContextMenuRenderer);
+        const workspaceService = {
+            getWorkspaceRootUri: (uri: URI | undefined): URI | undefined =>
+                uri && root.isEqualOrParent(uri) ? root : undefined
+        } as WorkspaceService;
+        const messageService = {
+            info: (message: string): void => {
+                infoMessages.push(message);
+            }
+        } as unknown as MessageService;
+        Object.assign(navigator, { workspaceService, messageService });
+        return navigator;
+    }
+
+    let jsdomCleanup: () => void;
+    before(() => {
+        jsdomCleanup = enableJSDOM();
+    });
+    after(() => {
+        jsdomCleanup();
+    });
+
+    beforeEach(() => {
+        widget = createWidget();
+    });
+
+    describe('pasteFiles', () => {
+
+        it('should not paste anything for empty clipboard text', () => {
+            selectedNodes = [targetNode];
+            expect(widget.pasteFiles('')).to.be.false;
+            expect(copiedSources).to.have.lengthOf(0);
+        });
+
+        it('should not paste anything if no target node is selected', () => {
+            expect(widget.pasteFiles('file:///workspace/some-file.txt')).to.be.false;
+            expect(copiedSources).to.have.lengthOf(0);
+        });
+
+        it('should copy valid workspace URIs to the selected target', () => {
+            selectedNodes = [targetNode];
+            expect(widget.pasteFiles('file:///workspace/a.txt\nfile:///workspace/dir/b.txt')).to.be.true;
+            expect(copiedSources.map(uri => uri.toString())).to.deep.equal([
+                'file:///workspace/a.txt',
+                'file:///workspace/dir/b.txt'
+            ]);
+        });
+
+        it('should skip blank lines, invalid URIs and URIs outside the workspace', () => {
+            selectedNodes = [targetNode];
+            const raw = [
+                '',
+                '   ',
+                'not a uri',
+                'file:///outside/c.txt',
+                'file:///workspace/d.txt'
+            ].join('\n');
+            expect(widget.pasteFiles(raw)).to.be.true;
+            expect(copiedSources.map(uri => uri.toString())).to.deep.equal(['file:///workspace/d.txt']);
+            expect(infoMessages).to.have.lengthOf(0);
+        });
+
+        it('should paste files given as absolute file system paths', () => {
+            selectedNodes = [targetNode];
+            expect(widget.pasteFiles('/workspace/e.txt')).to.be.true;
+            expect(copiedSources.map(uri => uri.toString())).to.deep.equal(['file:///workspace/e.txt']);
+            expect(infoMessages).to.have.lengthOf(0);
+        });
+
+        it('should paste files given as Windows-style absolute paths', () => {
+            widget = createWidget(URI.fromFilePath('C:\\workspace'));
+            selectedNodes = [targetNode];
+            expect(widget.pasteFiles('C:\\workspace\\sub\\f.txt')).to.be.true;
+            expect(copiedSources.map(uri => uri.toString())).to.deep.equal([URI.fromFilePath('C:\\workspace\\sub\\f.txt').toString()]);
+            expect(infoMessages).to.have.lengthOf(0);
+        });
+
+        it('should not paste relative paths', () => {
+            selectedNodes = [targetNode];
+            expect(widget.pasteFiles('workspace/relative.txt')).to.be.true;
+            expect(copiedSources).to.have.lengthOf(0);
+        });
+
+        it('should inform the user when the clipboard contains no pastable files', () => {
+            selectedNodes = [targetNode];
+            expect(widget.pasteFiles('not a uri')).to.be.true;
+            expect(copiedSources).to.have.lengthOf(0);
+            expect(infoMessages).to.have.lengthOf(1);
+        });
+
+        it('should stay silent for empty clipboard text or missing paste target', () => {
+            expect(widget.pasteFiles('file:///workspace/a.txt')).to.be.false;
+            selectedNodes = [targetNode];
+            expect(widget.pasteFiles('')).to.be.false;
+            expect(infoMessages).to.have.lengthOf(0);
+        });
+    });
+});

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -17,7 +17,7 @@
 import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
 import { Message } from '@theia/core/shared/@lumino/messaging';
 import URI from '@theia/core/lib/common/uri';
-import { CommandService } from '@theia/core/lib/common';
+import { CommandService, MessageService } from '@theia/core/lib/common';
 import { Key, TreeModel, ContextMenuRenderer, ExpandableTreeNode, TreeProps, TreeNode } from '@theia/core/lib/browser';
 import { DirNode, FileStatNodeData } from '@theia/filesystem/lib/browser';
 import { WorkspaceService, WorkspaceCommands } from '@theia/workspace/lib/browser';
@@ -39,6 +39,7 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
     @inject(CommandService) protected readonly commandService: CommandService;
     @inject(NavigatorContextKeyService) protected readonly contextKeyService: NavigatorContextKeyService;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(MessageService) protected readonly messageService: MessageService;
 
     constructor(
         @inject(TreeProps) props: TreeProps,
@@ -131,31 +132,66 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
 
     protected handlePaste(event: ClipboardEvent): void {
         if (event.clipboardData) {
-            const raw = event.clipboardData.getData('text/plain');
-            if (!raw) {
-                return;
+            if (this.pasteFiles(event.clipboardData.getData('text/plain'))) {
+                event.preventDefault();
             }
-            const target = this.model.selectedFileStatNodes[0];
-            if (!target) {
-                return;
+        }
+    }
+
+    /**
+     * Pastes the files given as newline-separated URIs or absolute paths into the selected directory.
+     *
+     * @param raw the clipboard text, expected to hold one file URI or absolute file system path per line
+     * @returns `true` if the paste was handled, i.e. clipboard text and a paste target were available
+     */
+    pasteFiles(raw: string): boolean {
+        if (!raw) {
+            return false;
+        }
+        const target = this.model.selectedFileStatNodes[0];
+        if (!target) {
+            return false;
+        }
+        const sources = this.parsePastedUris(raw);
+        if (sources.length === 0) {
+            this.messageService.info(nls.localize(
+                'theia/navigator/nothingToPaste',
+                'The clipboard does not contain workspace files that can be pasted here.'
+            ));
+            return true;
+        }
+        for (const source of sources) {
+            this.model.copy(source, target);
+        }
+        return true;
+    }
+
+    protected parsePastedUris(raw: string): URI[] {
+        const uris: URI[] = [];
+        for (const file of raw.split('\n')) {
+            const trimmed = file.trim();
+            if (!trimmed) {
+                continue;
             }
-            event.preventDefault();
-            for (const file of raw.split('\n')) {
-                const trimmed = file.trim();
-                if (!trimmed) {
-                    continue;
-                }
-                try {
-                    new URL(trimmed);
-                } catch {
-                    continue;
-                }
-                const source = new URI(trimmed);
-                if (!this.workspaceService.getWorkspaceRootUri(source)) {
-                    continue;
-                }
-                this.model.copy(source, target);
+            const source = this.asPastedFileUri(trimmed);
+            if (source && this.workspaceService.getWorkspaceRootUri(source)) {
+                uris.push(source);
             }
+        }
+        return uris;
+    }
+
+    /** Interprets the given clipboard line as a URI or an absolute file system path, e.g. from the Copy Path command. */
+    protected asPastedFileUri(candidate: string): URI | undefined {
+        // check for absolute paths first: Windows paths like C:\foo also parse as URLs (scheme 'c:')
+        if (candidate.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(candidate)) {
+            return URI.fromFilePath(candidate);
+        }
+        try {
+            new URL(candidate);
+            return new URI(candidate);
+        } catch {
+            return undefined;
         }
     }
 

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -26,6 +26,7 @@ import { FileNavigatorModel } from './navigator-model';
 import { isOSX, environment } from '@theia/core';
 import * as React from '@theia/core/shared/react';
 import { NavigatorContextKeyService } from './navigator-context-key-service';
+import { NavigatorFileClipboard } from './navigator-file-clipboard';
 import { nls } from '@theia/core/lib/common/nls';
 import { AbstractNavigatorTreeWidget } from './abstract-navigator-tree-widget';
 
@@ -39,6 +40,7 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
     @inject(CommandService) protected readonly commandService: CommandService;
     @inject(NavigatorContextKeyService) protected readonly contextKeyService: NavigatorContextKeyService;
     @inject(WorkspaceService) protected readonly workspaceService: WorkspaceService;
+    @inject(NavigatorFileClipboard) protected readonly fileClipboard: NavigatorFileClipboard;
     @inject(MessageService) protected readonly messageService: MessageService;
 
     constructor(
@@ -125,7 +127,9 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
     protected handleCopy(event: ClipboardEvent): void {
         const uris = this.model.selectedFileStatNodes.map(node => node.uri.toString());
         if (uris.length > 0 && event.clipboardData) {
-            event.clipboardData.setData('text/plain', uris.join('\n'));
+            const content = uris.join('\n');
+            event.clipboardData.setData('text/plain', content);
+            this.fileClipboard.set(content);
         }
         event.preventDefault();
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Register a navigator handler for the common paste command that reads
  the clipboard via the async clipboard API; the default handler relies
  on document.execCommand('paste'), which browsers block outside a
  trusted paste event, so menu paste only showed a warning
- Enable the handler only while the navigator is the current widget and
  a paste target is selected, keeping the default handler as fallback
- Extract pasteFiles from the paste event listener so keyboard and menu
  paste share the same logic
- Accept absolute file system paths, e.g. from the Copy Path command,
  in addition to file URIs, converting them via URI.fromFilePath
- Inform the user when a paste was attempted but the clipboard held no
  pastable workspace files, identical for keyboard and menu paste

Fixes https://github.com/eclipse-theia/theia/issues/17828

feat(navigator): avoid clipboard permission prompt for in-app paste

- Add NavigatorFileClipboard, an in-app store for file URIs copied in
  the navigator; any other copy or cut in the application clears it
- Record copied URIs in the store from the navigator copy listener
- Menu paste prefers the store and only falls back to reading the
  system clipboard, which may prompt for permission in browsers
- Copies in external applications cannot invalidate the store; the
  system clipboard fallback still covers pasting URIs copied there

fix(core): drop obsolete Chrome guard from supportPaste

- Remove the 2017 workaround for Chrome reporting paste support it did
  not grant: current Chrome returns false from queryCommandSupported
- Document why supportPaste stays false in browsers: the unregistered
  ctrlcmd+v keybinding lets native paste events reach widget listeners

Fixes https://github.com/eclipse-theia/theia/issues/10642

#### How to test

1. Start the browser example (npm run start:browser) and open it in Chrome with a workspace containing a file and a folder.
2. Select a file in the File Explorer and copy it (Ctrl+C or context menu Copy — both work).
3. Select the target folder, right-click → Paste.
4. Observe no warning notification; file is pasted. Pressing Ctrl+V does the same.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
