### PR TITLE
Allow terminal paste without browser permission query

### DIFF
--- a/packages/terminal/src/browser/terminal-frontend-contribution.ts
+++ b/packages/terminal/src/browser/terminal-frontend-contribution.ts
@@ -946,8 +946,13 @@ export class TerminalFrontendContribution implements FrontendApplicationContribu
             keybinding: 'ctrlcmd+k',
             when: 'terminalFocus'
         });
+        // A passthrough binding claims ctrlcmd+v for the terminal (winning over the global
+        // CommonCommands.PASTE binding via the local terminalFocus context) but runs no command,
+        // letting the keystroke reach xterm's native paste event. That avoids the permission-gated
+        // Clipboard API (navigator.clipboard.readText) that the PASTE_TERMINAL command requires, while
+        // preserving bracketed paste. terminal.enablePaste is enforced in TerminalWidgetImpl.customKeyHandler.
         keybindings.registerKeybinding({
-            command: TerminalCommands.PASTE_TERMINAL.id,
+            command: KeybindingRegistry.PASSTHROUGH_PSEUDO_COMMAND,
             keybinding: 'ctrlcmd+v',
             when: 'terminalFocus'
         });

--- a/packages/terminal/src/browser/terminal-widget-impl.ts
+++ b/packages/terminal/src/browser/terminal-widget-impl.ts
@@ -1196,8 +1196,15 @@ export class TerminalWidgetImpl extends TerminalWidget implements StatefulWidget
         if (ctrlCmdCopy && this.enableCopy && this.term.hasSelection()) {
             return false;
         }
-        if (ctrlCmdPaste && this.enablePaste) {
-            return false;
+        if (ctrlCmdPaste) {
+            if (this.enablePaste) {
+                // Defer to the browser's native paste event (see the ctrlcmd+v passthrough keybinding).
+                return false;
+            }
+            // Paste disabled: cancel the native paste so the preference is honored even where xterm
+            // would otherwise let the key through to the browser (e.g. cmd+v on macOS). Non-macOS
+            // ctrl+v still reaches the shell as ^V below.
+            event.preventDefault();
         }
         return true;
     }


### PR DESCRIPTION
#### What it does

Fixes #17810 (https://github.com/eclipse-theia/theia/issues/17810): a regression from #17603 where terminal paste (ctrl/cmd+v) routed through ClipboardService.readText() (the permission-gated async Clipboard API), causing a clipboard permission prompt on every paste on managed Chromium-based browsers where the policy is "ask every time."

The ctrl/cmd+v terminal keybinding is now a `PASSTHROUGH_PSEUDO_COMMAND` scoped to `terminalFocus`. It still shadows the global `CommonCommands.PASTE` binding via local-context priority, but instead of running a command it lets the keystroke reach `xterm`'s `textarea`, so `xterm`'s native paste event handles it without requesting clipboard permission, and bracketed paste is preserved. `terminal.enablePaste` is still honored in `TerminalWidgetImpl.customKeyHandler`.

The `PASTE_TERMINAL` command is unchanged and still backs the context-menu and command-palette paste, where there is no native paste event and `readText()` is the only option - that will still trigger browser permission queries.

#### How to test

1. Open a terminal, copy text elsewhere, and paste with ctrl/cmd+v -> text is inserted.
2. Paste a multi-line snippet into a bash/zsh/python REPL -> bracketed paste holds (lines aren't executed/auto-indented individually).
3. Set `terminal.enablePaste: false` -> ctrl/cmd+v no longer pastes; context-menu/palette Paste still work (possibly with query).
4. Context-menu → Paste and the "Paste into Active Terminal" command still paste.
5. Non-terminal contexts (editor, inputs) are unaffected.

#### Follow-ups

- With terminal.enablePaste: false, ctrl/cmd+v now sends ^V to the shell rather than falling through to the global paste command (which previously still pasted). This is the more faithful reading of the preference, but is a minor behavior change for that edge case.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
