### PR TITLE
feat: implement perspectives + AI First perspective

### DIFF
--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -21,10 +21,13 @@ import {
 } from '@theia/core';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { ConfirmDialog, FrontendApplicationContribution, KeybindingRegistry, Widget } from '@theia/core/lib/browser';
+import { PerspectiveService } from '@theia/core/lib/browser/perspective-service';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import {
     AI_CHAT_HOME,
+    AI_CHAT_OPEN_SESSION,
     AI_CHAT_SHOW_CHATS_COMMAND,
+    AI_FIRST_PERSPECTIVE_ID,
     ChatCommands
 } from './chat-view-commands';
 import { ChatAgent, ChatAgentLocation, ChatService, ChatSessionMetadata, isActiveSessionChangedEvent } from '@theia/ai-chat';
@@ -77,6 +80,9 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
     protected readonly logger: ILogger;
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
+
+    @inject(PerspectiveService)
+    protected readonly perspectiveService: PerspectiveService;
 
     /**
      * Store whether there are persisted sessions to make this information available in
@@ -147,6 +153,10 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
 
         this.checkPersistedSessions();
         this.attachToActiveSession();
+
+        this.perspectiveService.onDidChangePerspective(() => {
+            this.onActiveSessionEmptyChangedEmitter.fire();
+        });
 
         this.chatViewActiveKey = this.contextKeyService.createKey<boolean>('chatViewActive', false);
         this.updateChatViewActiveKey();
@@ -295,6 +305,17 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             isVisible: () => this.activationService.isActive,
             isEnabled: () => this.activationService.canRun
         });
+        registry.registerCommand(AI_CHAT_OPEN_SESSION, {
+            execute: async (sessionId: string) => {
+                const session = await this.chatService.getOrRestoreSession(sessionId);
+                if (!session) {
+                    throw new Error(`Chat session '${sessionId}' not found`);
+                }
+                await this.openView({ activate: true });
+                this.chatService.setActiveSession(sessionId, { focus: false });
+            },
+            isVisible: () => false,
+        });
         registry.registerCommand(AI_CHAT_SHOW_CHATS_COMMAND, {
             execute: async () => {
                 await this.openView();
@@ -393,7 +414,10 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             onDidChange: this.onActiveSessionEmptyChangedEmitter.event,
             // Hide on the overview itself (the active session is empty); only show when there
             // is an actual chat to return from.
-            isVisible: widget => this.activationService.isActive && this.withWidget(widget) && !this.activeSessionEmpty,
+            isVisible: widget => this.activationService.isActive
+                && this.withWidget(widget)
+                && !this.activeSessionEmpty
+                && this.perspectiveService.getActivePerspectiveId() !== AI_FIRST_PERSPECTIVE_ID,
             when: ENABLE_AI_CONTEXT_KEY
         });
         registry.registerItem({

--- a/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
+++ b/packages/ai-chat-ui/src/browser/ai-chat-ui-contribution.ts
@@ -21,13 +21,12 @@ import {
 } from '@theia/core';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { ConfirmDialog, FrontendApplicationContribution, KeybindingRegistry, Widget } from '@theia/core/lib/browser';
-import { PerspectiveService } from '@theia/core/lib/browser/perspective-service';
+import { ACTIVE_PERSPECTIVE_CONTEXT_KEY } from '@theia/core/lib/browser/perspective-service';
 import { ContextKey, ContextKeyService } from '@theia/core/lib/browser/context-key-service';
 import {
     AI_CHAT_HOME,
     AI_CHAT_OPEN_SESSION,
     AI_CHAT_SHOW_CHATS_COMMAND,
-    AI_FIRST_PERSPECTIVE_ID,
     ChatCommands
 } from './chat-view-commands';
 import { ChatAgent, ChatAgentLocation, ChatService, ChatSessionMetadata, isActiveSessionChangedEvent } from '@theia/ai-chat';
@@ -80,9 +79,6 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
     protected readonly logger: ILogger;
     @inject(PreferenceService)
     protected readonly preferenceService: PreferenceService;
-
-    @inject(PerspectiveService)
-    protected readonly perspectiveService: PerspectiveService;
 
     /**
      * Store whether there are persisted sessions to make this information available in
@@ -153,10 +149,6 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
 
         this.checkPersistedSessions();
         this.attachToActiveSession();
-
-        this.perspectiveService.onDidChangePerspective(() => {
-            this.onActiveSessionEmptyChangedEmitter.fire();
-        });
 
         this.chatViewActiveKey = this.contextKeyService.createKey<boolean>('chatViewActive', false);
         this.updateChatViewActiveKey();
@@ -416,9 +408,8 @@ export class AIChatContribution extends AbstractViewContribution<ChatViewWidget>
             // is an actual chat to return from.
             isVisible: widget => this.activationService.isActive
                 && this.withWidget(widget)
-                && !this.activeSessionEmpty
-                && this.perspectiveService.getActivePerspectiveId() !== AI_FIRST_PERSPECTIVE_ID,
-            when: ENABLE_AI_CONTEXT_KEY
+                && !this.activeSessionEmpty,
+            when: `${ENABLE_AI_CONTEXT_KEY} && ${ACTIVE_PERSPECTIVE_CONTEXT_KEY} != 'ai-first'`
         });
         registry.registerItem({
             id: AI_CHAT_SHOW_CHATS_COMMAND.id,

--- a/packages/ai-chat-ui/src/browser/chat-view-commands.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-commands.ts
@@ -93,9 +93,17 @@ export const AI_CHAT_HOME = Command.toLocalizedCommand({
     label: 'Home'
 }, 'theia/ai-chat-ui/home', ChatCommands.CHAT_CATEGORY_KEY);
 
+export const AI_FIRST_PERSPECTIVE_ID = 'ai-first';
+
 export const AI_CHAT_SHOW_CHATS_COMMAND = Command.toLocalizedCommand({
     id: 'ai-chat-ui.show-chats',
     iconClass: codicon('history'),
     category: ChatCommands.CHAT_CATEGORY,
     label: 'Browse all chats...'
 }, 'theia/ai-chat-ui/browseAllChats');
+
+export const AI_CHAT_OPEN_SESSION = Command.toLocalizedCommand({
+    id: 'ai-chat-ui.open-session',
+    category: ChatCommands.CHAT_CATEGORY,
+    label: 'Open Chat Session'
+}, 'theia/ai-chat-ui/openSession', ChatCommands.CHAT_CATEGORY_KEY);

--- a/packages/ai-chat-ui/src/browser/chat-view-commands.ts
+++ b/packages/ai-chat-ui/src/browser/chat-view-commands.ts
@@ -93,8 +93,6 @@ export const AI_CHAT_HOME = Command.toLocalizedCommand({
     label: 'Home'
 }, 'theia/ai-chat-ui/home', ChatCommands.CHAT_CATEGORY_KEY);
 
-export const AI_FIRST_PERSPECTIVE_ID = 'ai-first';
-
 export const AI_CHAT_SHOW_CHATS_COMMAND = Command.toLocalizedCommand({
     id: 'ai-chat-ui.show-chats',
     iconClass: codicon('history'),

--- a/packages/ai-chat/src/common/chat-service-session-events.spec.ts
+++ b/packages/ai-chat/src/common/chat-service-session-events.spec.ts
@@ -1,0 +1,161 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import {
+    ActiveSessionChangedEvent,
+    ChatServiceImpl,
+    DefaultChatAgentId,
+    PinChatAgent,
+    SessionCreatedEvent,
+    SessionDeletedEvent,
+    SessionRenamedEvent
+} from './chat-service';
+import { ChatAgentService } from './chat-agent-service';
+import { ChatRequestParser } from './chat-request-parser';
+import { AIVariableService, ToolInvocationRegistry } from '@theia/ai-core';
+import { ILogger } from '@theia/core';
+import { ChatContentDeserializerRegistry, ChatContentDeserializerRegistryImpl, DefaultChatContentDeserializerContribution } from './chat-content-deserializer';
+import { ChangeSetElementDeserializerRegistry, ChangeSetElementDeserializerRegistryImpl } from './change-set-element-deserializer';
+import { ChatAgent, ChatAgentLocation } from './chat-agents';
+import { ChatRequest } from './chat-model';
+import { ParsedChatRequest, ParsedChatRequestTextPart } from './parsed-chat-request';
+
+describe('ChatService session events', () => {
+    let chatService: ChatServiceImpl;
+    let container: Container;
+
+    const mockDefaultAgent: ChatAgent = {
+        id: 'default-agent',
+        name: 'Default Agent',
+        description: 'Test default agent',
+        locations: [ChatAgentLocation.Panel],
+        invoke: async () => { },
+        languageModelRequirements: [],
+        tags: [],
+        variables: [],
+        agentSpecificVariables: [],
+        functions: [],
+        prompts: []
+    };
+
+    class MockChatAgentService {
+        readonly onDidChangeAgents = { dispose: () => { } };
+        readonly onDefaultAgentChanged = { dispose: () => { } };
+
+        getAgent(id: string): ChatAgent | undefined {
+            return id === 'default-agent' ? mockDefaultAgent : undefined;
+        }
+
+        resolveAgent(): ChatAgent | undefined {
+            return mockDefaultAgent;
+        }
+    }
+
+    class MockChatRequestParser {
+        async parseChatRequest(request: ChatRequest): Promise<ParsedChatRequest> {
+            return {
+                request,
+                parts: [new ParsedChatRequestTextPart({ start: 0, endExclusive: request.text.length }, request.text)],
+                toolRequests: new Map(),
+                variables: []
+            };
+        }
+    }
+
+    class MockAIVariableService {
+        async resolveVariable(): Promise<unknown> {
+            return undefined;
+        }
+    }
+
+    class MockLogger {
+        error(): void { }
+        warn(): void { }
+        info(): void { }
+        debug(): void { }
+    }
+
+    beforeEach(() => {
+        container = new Container();
+
+        container.bind(ChatAgentService).toConstantValue(new MockChatAgentService() as unknown as ChatAgentService);
+        container.bind(ChatRequestParser).toConstantValue(new MockChatRequestParser() as unknown as ChatRequestParser);
+        container.bind(AIVariableService).toConstantValue(new MockAIVariableService() as unknown as AIVariableService);
+        container.bind(ToolInvocationRegistry).toConstantValue({});
+        container.bind(ILogger).toConstantValue(new MockLogger() as unknown as ILogger);
+
+        container.bind(DefaultChatAgentId).toConstantValue({ id: 'default-agent' });
+        container.bind(PinChatAgent).toConstantValue(true);
+
+        const contentRegistry = new ChatContentDeserializerRegistryImpl();
+        new DefaultChatContentDeserializerContribution().registerDeserializers(contentRegistry);
+        container.bind(ChatContentDeserializerRegistry).toConstantValue(contentRegistry);
+        container.bind(ChangeSetElementDeserializerRegistry).toConstantValue(new ChangeSetElementDeserializerRegistryImpl());
+        container.bind(ChatServiceImpl).toSelf().inSingletonScope();
+
+        chatService = container.get(ChatServiceImpl);
+    });
+
+    it('should fire a renamed event when sendRequest sets the session title', async () => {
+        const session = chatService.createSession(ChatAgentLocation.Panel);
+        expect(session.title).to.be.undefined;
+
+        const events: (ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent)[] = [];
+        chatService.onSessionEvent(e => events.push(e));
+
+        await chatService.sendRequest(session.id, { text: 'Hello world' });
+
+        expect(session.title).to.equal('Hello world');
+        const renamedEvents = events.filter(e => e.type === 'renamed');
+        expect(renamedEvents).to.have.length(1);
+        expect((renamedEvents[0] as SessionRenamedEvent).sessionId).to.equal(session.id);
+    });
+
+    it('should not fire a renamed event on subsequent requests when title is already set', async () => {
+        const session = chatService.createSession(ChatAgentLocation.Panel);
+
+        // First request sets the title
+        await chatService.sendRequest(session.id, { text: 'First message' });
+        expect(session.title).to.equal('First message');
+
+        const events: (ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent)[] = [];
+        chatService.onSessionEvent(e => events.push(e));
+
+        // Second request should not trigger a renamed event
+        await chatService.sendRequest(session.id, { text: 'Second message' });
+
+        const renamedEvents = events.filter(e => e.type === 'renamed');
+        expect(renamedEvents).to.have.length(0);
+        // Title should remain the first message
+        expect(session.title).to.equal('First message');
+    });
+
+    it('should fire a renamed event via renameSession', async () => {
+        const session = chatService.createSession(ChatAgentLocation.Panel);
+
+        const events: (ActiveSessionChangedEvent | SessionCreatedEvent | SessionDeletedEvent | SessionRenamedEvent)[] = [];
+        chatService.onSessionEvent(e => events.push(e));
+
+        await chatService.renameSession(session.id, 'New Title');
+
+        expect(session.title).to.equal('New Title');
+        const renamedEvents = events.filter(e => e.type === 'renamed');
+        expect(renamedEvents).to.have.length(1);
+        expect((renamedEvents[0] as SessionRenamedEvent).sessionId).to.equal(session.id);
+    });
+});

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -390,6 +390,7 @@ export class ChatServiceImpl implements ChatService {
         }
         const requestText = request.request.displayText ?? request.request.text;
         session.title = requestText;
+        this.onSessionEventEmitter.fire({ type: 'renamed', sessionId: session.id });
         if (this.chatSessionNamingService) {
             const otherSessionNames = this._sessions.map(s => s.title).filter((title): title is string => title !== undefined);
             const namingService = this.chatSessionNamingService;
@@ -401,6 +402,7 @@ export class ChatServiceImpl implements ChatService {
                             session.title = name;
                             // Trigger persistence when title changes
                             this.saveSession(session.id);
+                            this.onSessionEventEmitter.fire({ type: 'renamed', sessionId: session.id });
                         }
                         didGenerateName = true;
                     }).catch(error => this.logger.error('Failed to generate chat session name', error));

--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { nls } from '@theia/core';
+import { PerspectiveContribution, PerspectiveChromeOptions, PerspectiveService } from '@theia/core/lib/browser/perspective-service';
+import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shell';
+import { EXPLORER_VIEW_CONTAINER_ID } from '@theia/navigator/lib/browser';
+import { SCM_VIEW_CONTAINER_ID } from '@theia/scm/lib/browser/scm-contribution';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { AI_FIRST_PERSPECTIVE_ID } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
+import { AISessionsWidget } from './ai-sessions-widget';
+
+@injectable()
+export class AIFirstPerspectiveContribution implements PerspectiveContribution {
+
+    registerPerspectives(service: PerspectiveService): void {
+        const chromeOptions: PerspectiveChromeOptions = {
+            collapseAreas: ['bottom']
+        };
+        service.registerPerspective({
+            id: AI_FIRST_PERSPECTIVE_ID,
+            label: nls.localize('theia/ai-ide/perspective/aiFirst', 'AI First'),
+            viewPlacements: new Map<string, ApplicationShell.Area>([
+                [ChatViewWidget.ID, 'main'],
+                [EXPLORER_VIEW_CONTAINER_ID, 'right'],
+                [SCM_VIEW_CONTAINER_ID, 'right'],
+                [AISessionsWidget.ID, 'left']
+            ]),
+            chromeOptions
+        });
+    }
+}

--- a/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-first-perspective-contribution.ts
@@ -21,8 +21,9 @@ import { ApplicationShell } from '@theia/core/lib/browser/shell/application-shel
 import { EXPLORER_VIEW_CONTAINER_ID } from '@theia/navigator/lib/browser';
 import { SCM_VIEW_CONTAINER_ID } from '@theia/scm/lib/browser/scm-contribution';
 import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
-import { AI_FIRST_PERSPECTIVE_ID } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { AISessionsWidget } from './ai-sessions-widget';
+
+export const AI_FIRST_PERSPECTIVE_ID = 'ai-first';
 
 @injectable()
 export class AIFirstPerspectiveContribution implements PerspectiveContribution {
@@ -40,6 +41,7 @@ export class AIFirstPerspectiveContribution implements PerspectiveContribution {
                 [SCM_VIEW_CONTAINER_ID, 'right'],
                 [AISessionsWidget.ID, 'left']
             ]),
+            primaryViews: { right: EXPLORER_VIEW_CONTAINER_ID },
             chromeOptions
         });
     }

--- a/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
+++ b/packages/ai-ide/src/browser/ai-sessions-view-contribution.ts
@@ -1,0 +1,67 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { AI_CHAT_HOME, ChatCommands } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
+import { AIViewContribution, ENABLE_AI_CONTEXT_KEY } from '@theia/ai-core/lib/browser';
+import { Command, CommandRegistry, nls } from '@theia/core';
+import { codicon } from '@theia/core/lib/browser';
+import { TabBarToolbarContribution, TabBarToolbarRegistry } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { AISessionsWidget } from './ai-sessions-widget';
+
+export const AI_SESSIONS_TOGGLE_COMMAND_ID = 'aiSessions:toggle';
+
+export const AI_SESSIONS_NEW_SESSION = Command.toLocalizedCommand({
+    id: 'aiSessions:newSession',
+    iconClass: codicon('add'),
+    category: ChatCommands.CHAT_CATEGORY,
+    label: 'New Chat'
+}, 'theia/ai-ide/newChat', ChatCommands.CHAT_CATEGORY_KEY);
+
+@injectable()
+export class AISessionsViewContribution extends AIViewContribution<AISessionsWidget> implements TabBarToolbarContribution {
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
+
+    constructor() {
+        super({
+            widgetId: AISessionsWidget.ID,
+            widgetName: AISessionsWidget.LABEL,
+            defaultWidgetOptions: {
+                area: 'left'
+            },
+            toggleCommandId: AI_SESSIONS_TOGGLE_COMMAND_ID
+        });
+    }
+
+    override registerCommands(commands: CommandRegistry): void {
+        super.registerCommands(commands);
+        commands.registerCommand(AI_SESSIONS_NEW_SESSION, this.commandHandlerFactory({
+            execute: () => this.commandRegistry.executeCommand(AI_CHAT_HOME.id)
+        }));
+    }
+
+    registerToolbarItems(registry: TabBarToolbarRegistry): void {
+        registry.registerItem({
+            id: AI_SESSIONS_NEW_SESSION.id,
+            command: AI_SESSIONS_NEW_SESSION.id,
+            tooltip: nls.localizeByDefault('New Chat'),
+            isVisible: widget => this.activationService.isActive && widget instanceof AISessionsWidget,
+            when: ENABLE_AI_CONTEXT_KEY
+        });
+    }
+}

--- a/packages/ai-ide/src/browser/ai-sessions-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-sessions-widget.tsx
@@ -14,40 +14,36 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ChatWelcomeMessageProvider } from '@theia/ai-chat-ui/lib/browser/chat-tree-view';
+import { ChatAgentService, ChatService, ChatSessionMetadata } from '@theia/ai-chat';
+import { AI_CHAT_OPEN_SESSION } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { formatTimeAgo } from '@theia/ai-chat-ui/lib/browser/chat-date-utils';
-import {
-    ChatAgentService, ChatService, ChatSessionMetadata
-} from '@theia/ai-chat';
-import { BYPASS_MODEL_REQUIREMENT_PREF, WELCOME_SCREEN_SESSIONS_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
-import { AI_CHAT_SHOW_CHATS_COMMAND } from '@theia/ai-chat-ui/lib/browser/chat-view-commands';
 import { ChatSessionItemAction, ChatSessionItemActionContribution } from './chat-session-item-action-contribution';
 import { ChatSessionListService } from './chat-session-list-service';
-import { SectionedSessions, SessionRow, SessionsList } from './chat-session-list-components';
+import { SessionRow, SessionsList } from './chat-session-list-components';
 import { ChatSessionItem } from './chat-session-item';
-import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
-import { CommandRegistry, ContributionProvider, Emitter, Event, PreferenceService } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { CommandRegistry, ContributionProvider, nls } from '@theia/core';
+import { codicon, HoverService, ReactWidget } from '@theia/core/lib/browser';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 
 @injectable()
-export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessageProvider {
+export class AISessionsWidget extends ReactWidget {
 
-    readonly priority = 50;
+    static readonly ID = 'ai-sessions-widget';
+    static readonly LABEL = nls.localize('theia/ai-ide/sessionsView', 'AI Sessions');
+
+    @inject(ChatSessionListService)
+    protected readonly sessionListService: ChatSessionListService;
 
     @inject(ChatService)
     protected readonly chatService: ChatService;
 
-    @inject(CommandRegistry)
-    protected readonly commandRegistry: CommandRegistry;
-
-    @inject(PreferenceService)
-    protected readonly preferenceService: PreferenceService;
-
     @inject(ChatAgentService)
     protected readonly chatAgentService: ChatAgentService;
+
+    @inject(CommandRegistry)
+    protected readonly commandRegistry: CommandRegistry;
 
     @inject(HoverService)
     protected readonly hoverService: HoverService;
@@ -58,14 +54,6 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
     @inject(ContributionProvider) @named(ChatSessionItemActionContribution)
     protected readonly chatSessionItemActionContributions: ContributionProvider<ChatSessionItemActionContribution>;
 
-    @inject(FrontendLanguageModelRegistry)
-    protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
-
-    @inject(ChatSessionListService)
-    protected readonly sessionListService: ChatSessionListService;
-
-    protected _inputEnabled = false;
-
     protected _markdownRenderer: MarkdownRenderer | undefined;
     protected get markdownRenderer(): MarkdownRenderer {
         if (!this._markdownRenderer) {
@@ -74,65 +62,46 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
         return this._markdownRenderer;
     }
 
-    protected readonly onStateChangedEmitter = new Emitter<void>();
-    readonly onStateChanged: Event<void> = this.onStateChangedEmitter.event;
-
     @postConstruct()
     protected init(): void {
-        this.sessionListService.onStateChanged(() => {
-            this.onStateChangedEmitter.fire();
-        });
+        this.id = AISessionsWidget.ID;
+        this.title.label = AISessionsWidget.LABEL;
+        this.title.caption = AISessionsWidget.LABEL;
+        this.title.closable = true;
+        this.title.iconClass = codicon('history');
+        this.addClass('ai-sessions-view');
 
-        this.updateInputEnabled();
-        this.languageModelRegistry.onChange(() => {
-            this.updateInputEnabled();
-        });
-        this.preferenceService.onPreferenceChanged(e => {
-            if (e.preferenceName === BYPASS_MODEL_REQUIREMENT_PREF) {
-                this.updateInputEnabled();
-            } else if (e.preferenceName === WELCOME_SCREEN_SESSIONS_PREF) {
-                this.onStateChangedEmitter.fire();
-            }
-        });
+        this.toDispose.pushAll([
+            this.sessionListService.onStateChanged(() => this.update()),
+            this.sessionListService.onUnreadChanged(() => this.update())
+        ]);
+
+        this.update();
     }
 
-    protected async updateInputEnabled(): Promise<void> {
-        const models = await this.languageModelRegistry.getLanguageModels();
-        const hasReadyModels = models.some(model => model.status.status === 'ready');
-        const bypassed = this.preferenceService.get<boolean>(BYPASS_MODEL_REQUIREMENT_PREF, false);
-        const enabled = hasReadyModels || bypassed;
-        if (this._inputEnabled !== enabled) {
-            this._inputEnabled = enabled;
-            this.onStateChangedEmitter.fire();
-        }
-    }
-
-    renderWelcomeMessage(): React.ReactNode {
-        if (!this._inputEnabled) {
-            return undefined;
-        }
+    protected render(): React.ReactNode {
         const sections = this.sessionListService.getSections();
-        const sessionCount = sections.active.length + sections.restored.length;
-        if (!this.sessionListService.isPersistenceEnabled() || sessionCount === 0) {
-            return undefined;
-        }
-        return this.renderSessionsSection(sections);
-    }
+        const total = sections.active.length + sections.restored.length;
 
-    protected renderSessionsSection(sections: SectionedSessions): React.ReactNode {
-        const maxSessions = this.preferenceService.get<number>(WELCOME_SCREEN_SESSIONS_PREF, 20);
+        if (total === 0) {
+            return (
+                <div className="ai-sessions-view-empty">
+                    <span className={codicon('comment-discussion')} />
+                    <p>{nls.localize('theia/ai-ide/noSessions', 'No chat sessions yet.')}</p>
+                </div>
+            );
+        }
+
         const rows = this.sessionListService.buildRows(sections);
 
         return (
-            <div className="theia-WelcomeMessage" key="sessions-section">
-                <div className="theia-WelcomeMessage-SessionsSection">
-                    <SessionsList
-                        rows={rows}
-                        maxSessions={maxSessions}
-                        renderRow={this.renderSessionRow}
-                        onBrowseAll={this.handleBrowseAllChats}
-                    />
-                </div>
+            <div className="ai-sessions-view-content">
+                <SessionsList
+                    rows={rows}
+                    maxSessions={Number.MAX_SAFE_INTEGER}
+                    renderRow={this.renderSessionRow}
+                    onBrowseAll={() => { }}
+                />
             </div>
         );
     }
@@ -162,9 +131,13 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
                     hoverService={this.hoverService}
                     markdownRenderer={this.markdownRenderer}
                     unreadState={this.sessionListService}
-                    onClick={() => this.handleSessionItemClick(row.session.sessionId)}
+                    onClick={async () => {
+                        await this.commandRegistry.executeCommand(AI_CHAT_OPEN_SESSION.id, row.session.sessionId);
+                    }}
                     actions={this.getSessionActions(row.session)}
-                    onAction={this.handleSessionItemAction}
+                    onAction={(action: ChatSessionItemAction, s: ChatSessionMetadata) => {
+                        this.commandRegistry.executeCommand(action.commandId, s);
+                    }}
                     formatTimeAgo={date => formatTimeAgo(date)}
                     hasChildSessions={hasChildSessions}
                     isChildSession={depth > 0}
@@ -177,17 +150,4 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
             </React.Fragment>
         );
     }
-
-    protected handleSessionItemAction = (action: ChatSessionItemAction, session: ChatSessionMetadata): void => {
-        this.commandRegistry.executeCommand(action.commandId, session);
-    };
-
-    protected handleSessionItemClick = async (sessionId: string): Promise<void> => {
-        await this.chatService.getOrRestoreSession(sessionId);
-        this.chatService.setActiveSession(sessionId, { focus: true });
-    };
-
-    protected handleBrowseAllChats = (): void => {
-        this.commandRegistry.executeCommand(AI_CHAT_SHOW_CHATS_COMMAND.id);
-    };
 }

--- a/packages/ai-ide/src/browser/ai-sessions-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-sessions-widget.tsx
@@ -98,9 +98,7 @@ export class AISessionsWidget extends ReactWidget {
             <div className="ai-sessions-view-content">
                 <SessionsList
                     rows={rows}
-                    maxSessions={Number.MAX_SAFE_INTEGER}
                     renderRow={this.renderSessionRow}
-                    onBrowseAll={() => { }}
                 />
             </div>
         );

--- a/packages/ai-ide/src/browser/chat-session-list-components.tsx
+++ b/packages/ai-ide/src/browser/chat-session-list-components.tsx
@@ -1,0 +1,136 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatSessionMetadata } from '@theia/ai-chat';
+import { buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser';
+import { nls } from '@theia/core/lib/common/nls';
+import * as React from '@theia/core/shared/react';
+
+/** When both Active and Restored sections are non-empty, keep at least this many Restored slots. */
+const RESTORED_MIN_RESERVATION = 5;
+
+export interface SectionedSessions {
+    active: ChatSessionMetadata[];
+    restored: ChatSessionMetadata[];
+}
+
+/** A session row with its optional child sessions. */
+export interface SessionRow {
+    session: ChatSessionMetadata;
+    isRestored: boolean;
+    childSessions: SessionRow[];
+}
+
+/**
+ * The id of a session's immediate parent for tree building. Falls back to the root session id for
+ * sessions persisted before immediate-parent tracking existed, so their hierarchy still renders
+ * (flat under the root, as before).
+ */
+export function parentIdOf(session: ChatSessionMetadata): string | undefined {
+    return session.parentSessionId ?? session.rootSessionId;
+}
+
+export interface VisibleSessionSlots {
+    activeCount: number;
+    restoredCount: number;
+}
+
+/**
+ * Allocates the capped number of visible items between the Active and Restored sections of the
+ * overview. When both sections are non-empty, up to {@link RESTORED_MIN_RESERVATION} slots are
+ * reserved for Restored so active sessions cannot crowd it out entirely. A cap of 0 hides the
+ * inline list (every session stays reachable via the "Browse all chats..." link).
+ */
+export function computeVisibleSessionSlots(activeTotal: number, restoredTotal: number, maxSessions: number): VisibleSessionSlots {
+    const cap = Math.max(0, maxSessions);
+    if (cap === 0) {
+        return { activeCount: 0, restoredCount: 0 };
+    }
+    if (restoredTotal === 0) {
+        return { activeCount: Math.min(activeTotal, cap), restoredCount: 0 };
+    }
+    if (activeTotal === 0) {
+        return { activeCount: 0, restoredCount: Math.min(restoredTotal, cap) };
+    }
+    const reserved = Math.min(restoredTotal, Math.min(RESTORED_MIN_RESERVATION, Math.max(1, cap - 1)));
+    const activeCount = Math.min(activeTotal, cap - reserved);
+    const restoredCount = Math.min(restoredTotal, cap - activeCount);
+    return { activeCount, restoredCount };
+}
+
+export interface SessionsListProps {
+    rows: SessionRow[];
+    /** Total cap on items shown; overflow surfaces via the Browse all link. */
+    maxSessions: number;
+    renderRow: (row: SessionRow) => React.ReactNode;
+    onBrowseAll: () => void;
+}
+
+export function SessionsList({ rows, maxSessions, renderRow, onBrowseAll }: SessionsListProps): React.ReactElement {
+    // Children are rendered inline by their parent row, so only top-level rows appear in the
+    // sections. A child whose parent session is not in the list falls back to top-level (orphan).
+    const topLevelRows = rows.filter(row => {
+        const parentId = parentIdOf(row.session);
+        if (!parentId) {
+            return true;
+        }
+        return !rows.some(r => r.session.sessionId === parentId);
+    });
+
+    const activeRows = topLevelRows.filter(row => !row.isRestored);
+    const restoredRows = topLevelRows.filter(row => row.isRestored);
+
+    const { activeCount, restoredCount } = computeVisibleSessionSlots(activeRows.length, restoredRows.length, maxSessions);
+    const activeVisible = activeRows.slice(0, activeCount);
+    const restoredVisible = restoredRows.slice(0, restoredCount);
+    const hiddenCount = topLevelRows.length - activeVisible.length - restoredVisible.length;
+
+    return (
+        <div className="theia-WelcomeMessage-SessionsList">
+            {activeVisible.length > 0 && (
+                <div className="theia-WelcomeMessage-SessionsGroup">
+                    <div className="theia-WelcomeMessage-SessionsHeader">
+                        {nls.localizeByDefault('Active')}
+                    </div>
+                    {activeVisible.map(row => renderRow(row))}
+                </div>
+            )}
+            {restoredVisible.length > 0 && (
+                <div className="theia-WelcomeMessage-SessionsGroup">
+                    <div className="theia-WelcomeMessage-SessionsHeader">
+                        {nls.localize('theia/ai/ide/sectionRestored', 'Restored')}
+                    </div>
+                    {restoredVisible.map(row => renderRow(row))}
+                </div>
+            )}
+            {hiddenCount > 0 && (
+                <div className="theia-WelcomeMessage-SessionsFooter">
+                    <a className="theia-WelcomeMessage-FooterLink"
+                        {...buttonKeyboardProps(nls.localize('theia/ai/ide/browseAllChats', 'Browse all chats...'))}
+                        onClick={onBrowseAll}
+                        onKeyDown={e => {
+                            if (isActivationKey(e)) {
+                                e.preventDefault();
+                                onBrowseAll();
+                            }
+                        }}>
+                        {nls.localize('theia/ai/ide/browseAllChats', 'Browse all chats...')}
+                    </a>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/packages/ai-ide/src/browser/chat-session-list-components.tsx
+++ b/packages/ai-ide/src/browser/chat-session-list-components.tsx
@@ -73,13 +73,13 @@ export function computeVisibleSessionSlots(activeTotal: number, restoredTotal: n
 
 export interface SessionsListProps {
     rows: SessionRow[];
-    /** Total cap on items shown; overflow surfaces via the Browse all link. */
-    maxSessions: number;
+    /** Total cap on items shown; overflow surfaces via the Browse all link. Defaults to no cap. */
+    maxSessions?: number;
     renderRow: (row: SessionRow) => React.ReactNode;
-    onBrowseAll: () => void;
+    onBrowseAll?: () => void;
 }
 
-export function SessionsList({ rows, maxSessions, renderRow, onBrowseAll }: SessionsListProps): React.ReactElement {
+export function SessionsList({ rows, maxSessions = Number.MAX_SAFE_INTEGER, renderRow, onBrowseAll }: SessionsListProps): React.ReactElement {
     // Children are rendered inline by their parent row, so only top-level rows appear in the
     // sections. A child whose parent session is not in the list falls back to top-level (orphan).
     const topLevelRows = rows.filter(row => {
@@ -116,7 +116,7 @@ export function SessionsList({ rows, maxSessions, renderRow, onBrowseAll }: Sess
                     {restoredVisible.map(row => renderRow(row))}
                 </div>
             )}
-            {hiddenCount > 0 && (
+            {hiddenCount > 0 && onBrowseAll && (
                 <div className="theia-WelcomeMessage-SessionsFooter">
                     <a className="theia-WelcomeMessage-FooterLink"
                         {...buttonKeyboardProps(nls.localize('theia/ai/ide/browseAllChats', 'Browse all chats...'))}

--- a/packages/ai-ide/src/browser/chat-session-list-service.spec.ts
+++ b/packages/ai-ide/src/browser/chat-session-list-service.spec.ts
@@ -212,14 +212,17 @@ describe('ChatSessionListService', () => {
         });
 
         it('reserves up to 5 restored slots when both sections overflow the cap', () => {
+            // 5 slots reserved for restored, the remaining 15 go to active.
             expect(computeVisibleSessionSlots(20, 10, 20)).to.deep.equal({ activeCount: 15, restoredCount: 5 });
         });
 
         it('only reserves as many restored slots as there are restored sessions', () => {
+            // Just 3 restored exist, so active gets the other 17.
             expect(computeVisibleSessionSlots(20, 3, 20)).to.deep.equal({ activeCount: 17, restoredCount: 3 });
         });
 
         it('gives leftover slots to restored when active does not fill its share', () => {
+            // Total (12) fits under the cap, so everything is shown.
             expect(computeVisibleSessionSlots(2, 10, 20)).to.deep.equal({ activeCount: 2, restoredCount: 10 });
         });
 
@@ -390,6 +393,7 @@ describe('ChatSessionListService', () => {
         });
 
         it('propagates a deep descendant needing action up the tree', () => {
+            // Only the leaf C awaits input; both B and the root A must report a descendant needing action.
             const chatService = {
                 getSession: (id: string) => id === 'C' ? loadedSession('C', 'awaitingInput') : loadedSession(id, 'idle')
             } as unknown as ChatService;
@@ -409,6 +413,9 @@ describe('ChatSessionListService', () => {
         });
 
         it('expands every ancestor of a session that needs action, falling back to persisted-only ancestors', () => {
+            // C is loaded and awaiting input; its ancestors B and A exist only in the persisted index
+            // (e.g. C was opened directly from "Browse all chats"). The walk must reach the root A, not
+            // stop at the first ancestor `getSession` cannot resolve.
             const c = loadedSession('C', 'awaitingInput', { rootSessionId: 'A', parentSessionId: 'B' });
             const chatService = {
                 getSession: (id: string) => id === 'C' ? c : undefined

--- a/packages/ai-ide/src/browser/chat-session-list-service.ts
+++ b/packages/ai-ide/src/browser/chat-session-list-service.ts
@@ -1,0 +1,261 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ChatService, ChatSession, ChatSessionMetadata, ChatSessionStatus } from '@theia/ai-chat';
+import { PERSISTED_SESSION_LIMIT_PREF, SESSION_STORAGE_PREF } from '@theia/ai-chat/lib/common/ai-chat-preferences';
+import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
+import { DisposableCollection, Emitter, Event, PreferenceService } from '@theia/core';
+import { ApplicationShell } from '@theia/core/lib/browser';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { UnreadStateProvider } from './chat-session-item';
+import { SectionedSessions, SessionRow, parentIdOf } from './chat-session-list-components';
+
+@injectable()
+export class ChatSessionListService implements UnreadStateProvider {
+
+    @inject(ChatService)
+    protected readonly chatService: ChatService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    private readonly unreadSessions = new Map<string, {
+        unread: boolean;
+        requiresAction: boolean;
+        seenRequests: number;
+        seenCompleted: number;
+        listener: DisposableCollection;
+    }>();
+    private readonly onUnreadChangedEmitter = new Emitter<string>();
+    readonly onUnreadChanged: Event<string> = this.onUnreadChangedEmitter.event;
+
+    protected _persistedSessions: ChatSessionMetadata[] = [];
+
+    /** Expanded root session IDs (default collapsed). */
+    protected expandedRoots = new Set<string>();
+
+    protected readonly onStateChangedEmitter = new Emitter<void>();
+    readonly onStateChanged: Event<void> = this.onStateChangedEmitter.event;
+
+    @postConstruct()
+    protected init(): void {
+        for (const session of this.chatService.getSessions()) {
+            this.watchSession(session);
+        }
+
+        this.chatService.onSessionEvent(event => {
+            if (event.type === 'created') {
+                const s = this.chatService.getSession(event.sessionId);
+                if (s) {
+                    this.watchSession(s);
+                }
+            } else if (event.type === 'activeChange' && event.sessionId) {
+                this.markSessionRead(event.sessionId);
+            } else if (event.type === 'deleted') {
+                this.unwatchSession(event.sessionId);
+            }
+            this.loadSessions();
+        });
+
+        this.loadSessions();
+        this.preferenceService.onPreferenceChanged(e => {
+            if (e.preferenceName === PERSISTED_SESSION_LIMIT_PREF || e.preferenceName === SESSION_STORAGE_PREF) {
+                this.loadSessions();
+            }
+        });
+    }
+
+    isUnread(sessionId: string): boolean {
+        return this.unreadSessions.get(sessionId)?.unread === true;
+    }
+
+    protected watchSession(session: ChatSession): void {
+        if (this.unreadSessions.has(session.id)) {
+            return;
+        }
+        const reqs = session.model.getRequests();
+        const state = {
+            unread: false,
+            requiresAction: ChatSessionStatus.requiresUserAction(session.model.status),
+            seenRequests: reqs.length,
+            seenCompleted: this.countCompleted(reqs),
+            listener: new DisposableCollection()
+        };
+        this.unreadSessions.set(session.id, state);
+
+        session.model.onDidChange(() => {
+            const requiresAction = ChatSessionStatus.requiresUserAction(session.model.status);
+            if (requiresAction !== state.requiresAction) {
+                state.requiresAction = requiresAction;
+                if (requiresAction) {
+                    this.expandAncestors(session);
+                }
+                this.onStateChangedEmitter.fire();
+            }
+            const current = session.model.getRequests();
+            if (current.length > state.seenRequests || this.countCompleted(current) > state.seenCompleted) {
+                const activeSession = this.chatService.getActiveSession();
+                const chatViewFocused = ChatViewWidget.findActive(this.shell) !== undefined;
+                if (chatViewFocused && activeSession && activeSession.id === session.id) {
+                    state.seenRequests = current.length;
+                    state.seenCompleted = this.countCompleted(current);
+                } else if (!state.unread) {
+                    state.unread = true;
+                    this.onUnreadChangedEmitter.fire(session.id);
+                }
+            }
+        }, undefined, state.listener);
+    }
+
+    protected markSessionRead(sessionId: string): void {
+        const state = this.unreadSessions.get(sessionId);
+        if (!state) {
+            return;
+        }
+        const session = this.chatService.getSession(sessionId);
+        const reqs = session?.model.getRequests() ?? [];
+        state.seenRequests = reqs.length;
+        state.seenCompleted = this.countCompleted(reqs);
+        if (state.unread) {
+            state.unread = false;
+            this.onUnreadChangedEmitter.fire(sessionId);
+        }
+    }
+
+    protected unwatchSession(sessionId: string): void {
+        const state = this.unreadSessions.get(sessionId);
+        if (state) {
+            state.listener.dispose();
+            this.unreadSessions.delete(sessionId);
+        }
+    }
+
+    private countCompleted(reqs: ReturnType<ChatSession['model']['getRequests']>): number {
+        return reqs.filter(r => r.response.isComplete).length;
+    }
+
+    isPersistenceEnabled(): boolean {
+        const limit = this.preferenceService.get<number>(PERSISTED_SESSION_LIMIT_PREF, 25);
+        return limit !== 0;
+    }
+
+    protected async loadSessions(): Promise<void> {
+        if (!this.isPersistenceEnabled()) {
+            this._persistedSessions = [];
+            this.onStateChangedEmitter.fire();
+            return;
+        }
+
+        const hasSessions = await this.chatService.hasPersistedSessions();
+        if (!hasSessions) {
+            this._persistedSessions = [];
+            this.onStateChangedEmitter.fire();
+            return;
+        }
+
+        try {
+            const index = await this.chatService.getPersistedSessions();
+            this._persistedSessions = Object.values(index)
+                .toSorted((a, b) => b.saveDate - a.saveDate);
+        } catch (error) {
+            console.error('Failed to load persisted sessions:', error);
+            this._persistedSessions = [];
+        } finally {
+            this.onStateChangedEmitter.fire();
+        }
+    }
+
+    getSections(): SectionedSessions {
+        const activeRaw = this.chatService.getSessions().filter(s => !!s.title);
+        const activeIds = new Set(activeRaw.map(s => s.id));
+        const active: ChatSessionMetadata[] = activeRaw
+            .toSorted((a, b) => (b.lastInteraction?.getTime() ?? 0) - (a.lastInteraction?.getTime() ?? 0))
+            .map(session => ({
+                sessionId: session.id,
+                title: session.title!,
+                saveDate: session.lastInteraction?.getTime() ?? Date.now(),
+                location: session.model.location,
+                pinnedAgentId: session.pinnedAgent?.id,
+                hasError: session.model.status === 'failed',
+                rootSessionId: session.rootSessionId,
+                parentSessionId: session.parentSessionId
+            }));
+        const restored = this._persistedSessions.filter(metadata => !activeIds.has(metadata.sessionId));
+        return { active, restored };
+    }
+
+    toggleExpand(sessionId: string): void {
+        this.expandedRoots = new Set(this.expandedRoots);
+        if (this.expandedRoots.has(sessionId)) {
+            this.expandedRoots.delete(sessionId);
+        } else {
+            this.expandedRoots.add(sessionId);
+        }
+        this.onStateChangedEmitter.fire();
+    }
+
+    isExpanded(sessionId: string): boolean {
+        return this.expandedRoots.has(sessionId);
+    }
+
+    sessionRequiresAction(sessionId: string): boolean {
+        const session = this.chatService.getSession(sessionId);
+        return session !== undefined && ChatSessionStatus.requiresUserAction(session.model.status);
+    }
+
+    descendantRequiresAction(row: SessionRow): boolean {
+        return row.childSessions.some(child =>
+            this.sessionRequiresAction(child.session.sessionId) || this.descendantRequiresAction(child));
+    }
+
+    protected expandAncestors(session: ChatSession): void {
+        const persistedById = new Map(this._persistedSessions.map(metadata => [metadata.sessionId, metadata]));
+        const parentIdFor = (id: string): string | undefined => {
+            const loaded = this.chatService.getSession(id);
+            if (loaded) {
+                return loaded.parentSessionId ?? loaded.rootSessionId;
+            }
+            const metadata = persistedById.get(id);
+            return metadata && parentIdOf(metadata);
+        };
+        const visited = new Set<string>();
+        let parentId = session.parentSessionId ?? session.rootSessionId;
+        while (parentId && !visited.has(parentId)) {
+            visited.add(parentId);
+            this.expandedRoots.add(parentId);
+            parentId = parentIdFor(parentId);
+        }
+    }
+
+    buildRows(sections: SectionedSessions): SessionRow[] {
+        const allSessions = [...sections.active, ...sections.restored];
+        const activeIds = new Set(sections.active.map(s => s.sessionId));
+        const rowsById = new Map<string, SessionRow>();
+        for (const session of allSessions) {
+            rowsById.set(session.sessionId, { session, isRestored: !activeIds.has(session.sessionId), childSessions: [] });
+        }
+        for (const session of allSessions) {
+            const pid = parentIdOf(session);
+            if (pid) {
+                rowsById.get(pid)?.childSessions.push(rowsById.get(session.sessionId)!);
+            }
+        }
+        return [...rowsById.values()];
+    }
+}

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.spec.ts
@@ -23,7 +23,8 @@ import { Emitter } from '@theia/core';
 import { ChatAgentLocation, ChatService, ChatSession, ChatSessionMetadata, ChatSessionStatus } from '@theia/ai-chat';
 import { ChatViewWidget } from '@theia/ai-chat-ui/lib/browser/chat-view-widget';
 import { ApplicationShell, Widget } from '@theia/core/lib/browser';
-import { ChatSessionsWelcomeMessageProvider, SectionedSessions, SessionRow, computeVisibleSessionSlots } from './chat-sessions-welcome-message-provider';
+import { ChatSessionListService } from './chat-session-list-service';
+import { SectionedSessions, SessionRow, computeVisibleSessionSlots } from './chat-session-list-components';
 disableJSDOM();
 
 /**
@@ -32,7 +33,7 @@ disableJSDOM();
  * unread bookkeeping; spinning up the full container would pull in unrelated
  * services and obscure the assertion.
  */
-class TestableProvider extends ChatSessionsWelcomeMessageProvider {
+class TestableService extends ChatSessionListService {
     constructor(chatService: ChatService, shell: ApplicationShell) {
         super();
         (this as unknown as { chatService: ChatService }).chatService = chatService;
@@ -59,6 +60,7 @@ function createFakeSession(id: string): {
         id,
         isActive: false,
         model: {
+            status: 'idle' as ChatSessionStatus,
             getRequests: () => requests,
             onDidChange: onDidChangeEmitter.event,
         }
@@ -70,7 +72,7 @@ function createFakeSession(id: string): {
     };
 }
 
-describe('ChatSessionsWelcomeMessageProvider', () => {
+describe('ChatSessionListService', () => {
 
     describe('unread state', () => {
         let activeSessionId: string | undefined;
@@ -112,33 +114,33 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
         });
 
         it('marks the session unread when a new request arrives and the chat view is not focused', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 's1';
             activeWidget = otherWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(true);
+            expect(service.isUnread('s1')).to.equal(true);
         });
 
         it('does not mark unread when the session is active AND the chat view is focused', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 's1';
             activeWidget = chatViewWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(false);
+            expect(service.isUnread('s1')).to.equal(false);
         });
 
         it('does not mark unread when focus is inside a child widget of the chat view', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 's1';
             // Simulate focus inside a descendant (e.g. AIChatInputWidget): the shell's
@@ -147,42 +149,42 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
             activeWidget = childWidget;
             widgetForActiveElement = childWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(false);
+            expect(service.isUnread('s1')).to.equal(false);
         });
 
         it('marks unread when the session is not the active one, even if the chat view is focused', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = 'other';
             activeWidget = chatViewWidget;
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(true);
+            expect(service.isUnread('s1')).to.equal(true);
         });
 
         it('fires onUnreadChanged once when a session transitions to unread', () => {
-            const provider = new TestableProvider(chatService, shell);
+            const service = new TestableService(chatService, shell);
             const { session, fire, pushRequest } = createFakeSession('s1');
             activeSessionId = undefined;
             activeWidget = otherWidget;
 
             let fired = 0;
-            provider.onUnreadChanged(() => { fired++; });
+            service.onUnreadChanged(() => { fired++; });
 
-            provider.watch(session);
+            service.watch(session);
             pushRequest(true);
             fire();
             pushRequest(true);
             fire();
 
-            expect(provider.isUnread('s1')).to.equal(true);
+            expect(service.isUnread('s1')).to.equal(true);
             expect(fired).to.equal(1);
         });
     });
@@ -210,17 +212,14 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
         });
 
         it('reserves up to 5 restored slots when both sections overflow the cap', () => {
-            // 5 slots reserved for restored, the remaining 15 go to active.
             expect(computeVisibleSessionSlots(20, 10, 20)).to.deep.equal({ activeCount: 15, restoredCount: 5 });
         });
 
         it('only reserves as many restored slots as there are restored sessions', () => {
-            // Just 3 restored exist, so active gets the other 17.
             expect(computeVisibleSessionSlots(20, 3, 20)).to.deep.equal({ activeCount: 17, restoredCount: 3 });
         });
 
         it('gives leftover slots to restored when active does not fill its share', () => {
-            // Total (12) fits under the cap, so everything is shown.
             expect(computeVisibleSessionSlots(2, 10, 20)).to.deep.equal({ activeCount: 2, restoredCount: 10 });
         });
 
@@ -239,11 +238,11 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
 
     describe('getSections', () => {
 
-        class SectionsTestProvider extends ChatSessionsWelcomeMessageProvider {
+        class SectionsTestService extends ChatSessionListService {
             constructor(sessions: ChatSession[], persistedSessions: ChatSessionMetadata[]) {
                 super();
                 (this as unknown as { chatService: ChatService }).chatService = { getSessions: () => sessions } as unknown as ChatService;
-                this._persistedSessions = persistedSessions;
+                (this as unknown as { _persistedSessions: ChatSessionMetadata[] })._persistedSessions = persistedSessions;
             }
             sections(): SectionedSessions {
                 return this.getSections();
@@ -275,7 +274,7 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
         }
 
         function getSections(sessions: ChatSession[], persistedSessions: ChatSessionMetadata[]): SectionedSessions {
-            return new SectionsTestProvider(sessions, persistedSessions).sections();
+            return new SectionsTestService(sessions, persistedSessions).sections();
         }
 
         it('excludes active sessions without a title', () => {
@@ -327,11 +326,11 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
 
     describe('session hierarchy', () => {
 
-        class HierarchyTestProvider extends ChatSessionsWelcomeMessageProvider {
+        class HierarchyTestService extends ChatSessionListService {
             constructor(chatService: ChatService, persistedSessions: ChatSessionMetadata[] = []) {
                 super();
                 (this as unknown as { chatService: ChatService }).chatService = chatService;
-                this._persistedSessions = persistedSessions;
+                (this as unknown as { _persistedSessions: ChatSessionMetadata[] })._persistedSessions = persistedSessions;
             }
             rows(sections: SectionedSessions): SessionRow[] {
                 return this.buildRows(sections);
@@ -374,13 +373,13 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
         }
 
         it('nests a restored A -> B hierarchy with an active C under the root', () => {
-            const provider = new HierarchyTestProvider({ getSession: () => undefined } as unknown as ChatService);
+            const service = new HierarchyTestService({ getSession: () => undefined } as unknown as ChatService);
             const sections: SectionedSessions = {
                 active: [meta('C', { rootSessionId: 'A', parentSessionId: 'B' })],
                 restored: [meta('A'), meta('B', { rootSessionId: 'A', parentSessionId: 'A' })]
             };
 
-            const rows = provider.rows(sections);
+            const rows = service.rows(sections);
             const rowA = findRow(rows, 'A');
             expect(rowA.isRestored).to.equal(true);
             expect(rowA.childSessions.map(c => c.session.sessionId)).to.deep.equal(['B']);
@@ -391,41 +390,37 @@ describe('ChatSessionsWelcomeMessageProvider', () => {
         });
 
         it('propagates a deep descendant needing action up the tree', () => {
-            // Only the leaf C awaits input; both B and the root A must report a descendant needing action.
             const chatService = {
                 getSession: (id: string) => id === 'C' ? loadedSession('C', 'awaitingInput') : loadedSession(id, 'idle')
             } as unknown as ChatService;
-            const provider = new HierarchyTestProvider(chatService);
+            const service = new HierarchyTestService(chatService);
             const sections: SectionedSessions = {
                 active: [meta('C', { rootSessionId: 'A', parentSessionId: 'B' })],
                 restored: [meta('A'), meta('B', { rootSessionId: 'A', parentSessionId: 'A' })]
             };
 
-            const rows = provider.rows(sections);
+            const rows = service.rows(sections);
             const rowA = findRow(rows, 'A');
             const rowB = rowA.childSessions[0];
             const rowC = rowB.childSessions[0];
-            expect(provider.subtreeRequiresAction(rowA)).to.equal(true);
-            expect(provider.subtreeRequiresAction(rowB)).to.equal(true);
-            expect(provider.subtreeRequiresAction(rowC)).to.equal(false);
+            expect(service.subtreeRequiresAction(rowA)).to.equal(true);
+            expect(service.subtreeRequiresAction(rowB)).to.equal(true);
+            expect(service.subtreeRequiresAction(rowC)).to.equal(false);
         });
 
         it('expands every ancestor of a session that needs action, falling back to persisted-only ancestors', () => {
-            // C is loaded and awaiting input; its ancestors B and A exist only in the persisted index
-            // (e.g. C was opened directly from "Browse all chats"). The walk must reach the root A, not
-            // stop at the first ancestor `getSession` cannot resolve.
             const c = loadedSession('C', 'awaitingInput', { rootSessionId: 'A', parentSessionId: 'B' });
             const chatService = {
                 getSession: (id: string) => id === 'C' ? c : undefined
             } as unknown as ChatService;
-            const provider = new HierarchyTestProvider(chatService, [
+            const service = new HierarchyTestService(chatService, [
                 meta('A'),
                 meta('B', { rootSessionId: 'A', parentSessionId: 'A' })
             ]);
 
-            provider.expand(c);
+            service.expand(c);
 
-            expect([...provider.expanded].sort()).to.deep.equal(['A', 'B']);
+            expect([...service.expanded].sort()).to.deep.equal(['A', 'B']);
         });
     });
 });

--- a/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
+++ b/packages/ai-ide/src/browser/chat-sessions-welcome-message-provider.tsx
@@ -27,7 +27,8 @@ import { SectionedSessions, SessionRow, SessionsList } from './chat-session-list
 import { ChatSessionItem } from './chat-session-item';
 import { FrontendLanguageModelRegistry } from '@theia/ai-core/lib/common';
 import { CommandRegistry, ContributionProvider, Emitter, Event, PreferenceService } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ApplicationShell, HoverService } from '@theia/core/lib/browser';
+import { AISessionsWidget } from './ai-sessions-widget';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
@@ -61,10 +62,15 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
     @inject(FrontendLanguageModelRegistry)
     protected readonly languageModelRegistry: FrontendLanguageModelRegistry;
 
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
     @inject(ChatSessionListService)
     protected readonly sessionListService: ChatSessionListService;
 
     protected _inputEnabled = false;
+
+    protected _sessionsWidgetAttached = false;
 
     protected _markdownRenderer: MarkdownRenderer | undefined;
     protected get markdownRenderer(): MarkdownRenderer {
@@ -94,6 +100,27 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
                 this.onStateChangedEmitter.fire();
             }
         });
+
+        this._sessionsWidgetAttached = this.isSessionsWidgetAttached();
+        this.shell.onDidAddWidget(widget => {
+            if (widget.id === AISessionsWidget.ID) {
+                this._sessionsWidgetAttached = true;
+                this.onStateChangedEmitter.fire();
+            }
+        });
+        this.shell.onDidRemoveWidget(widget => {
+            if (widget.id === AISessionsWidget.ID) {
+                this._sessionsWidgetAttached = false;
+                this.onStateChangedEmitter.fire();
+            }
+        });
+    }
+
+    protected isSessionsWidgetAttached(): boolean {
+        const areas: ApplicationShell.Area[] = ['left', 'right', 'main', 'bottom'];
+        return areas.some(area =>
+            this.shell.getWidgets(area).some(w => w.id === AISessionsWidget.ID && !w.isDisposed)
+        );
     }
 
     protected async updateInputEnabled(): Promise<void> {
@@ -108,6 +135,9 @@ export class ChatSessionsWelcomeMessageProvider implements ChatWelcomeMessagePro
     }
 
     renderWelcomeMessage(): React.ReactNode {
+        if (this._sessionsWidgetAttached) {
+            return undefined;
+        }
         if (!this._inputEnabled) {
             return undefined;
         }

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -127,6 +127,11 @@ import { CodeReviewerAgent } from './code-reviewer-agent';
 import { CodeReviewCapabilityContribution } from './code-review-capability-contribution';
 import { PRReviewAgent } from './review/pr-review-agent';
 import { PRReviewCapabilityContribution } from './review/pr-review-capability-contribution';
+import { PerspectiveContribution } from '@theia/core/lib/browser/perspective-service';
+import { AIFirstPerspectiveContribution } from './ai-first-perspective-contribution';
+import { ChatSessionListService } from './chat-session-list-service';
+import { AISessionsWidget } from './ai-sessions-widget';
+import { AISessionsViewContribution } from './ai-sessions-view-contribution';
 
 export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PreferenceContribution).toConstantValue({ schema: aiIdePreferenceSchema });
@@ -193,6 +198,8 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(PRReviewAgent).toSelf().inSingletonScope();
     bind(Agent).toService(PRReviewAgent);
     bind(ChatAgent).toService(PRReviewAgent);
+
+    bind(ChatSessionListService).toSelf().inSingletonScope();
 
     bind(ChatWelcomeMessageProvider).to(IdeChatWelcomeMessageProvider).inSingletonScope();
     bind(ChatWelcomeMessageProvider).to(ChatSessionsWelcomeMessageProvider).inSingletonScope();
@@ -353,4 +360,17 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
 
     bind(FrontendApplicationContribution).to(CodeReviewCapabilityContribution);
     bind(FrontendApplicationContribution).to(PRReviewCapabilityContribution);
+
+    bind(AIFirstPerspectiveContribution).toSelf().inSingletonScope();
+    bind(PerspectiveContribution).toService(AIFirstPerspectiveContribution);
+
+    bind(AISessionsWidget).toSelf();
+    bind(WidgetFactory)
+        .toDynamicValue(ctx => ({
+            id: AISessionsWidget.ID,
+            createWidget: () => ctx.container.get(AISessionsWidget)
+        }))
+        .inSingletonScope();
+    bindViewContribution(bind, AISessionsViewContribution);
+    bind(TabBarToolbarContribution).toService(AISessionsViewContribution);
 });

--- a/packages/ai-ide/src/browser/style/index.css
+++ b/packages/ai-ide/src/browser/style/index.css
@@ -2224,6 +2224,34 @@
   outline-offset: -2px;
 }
 
+/* AI Sessions View */
+.ai-sessions-view {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.ai-sessions-view-content {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--theia-ui-padding) 0;
+}
+
+.ai-sessions-view-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--theia-descriptionForeground);
+  gap: var(--theia-ui-padding);
+}
+
+.ai-sessions-view-empty .codicon {
+  font-size: calc(var(--theia-ui-font-size1) * 2.5);
+  opacity: 0.5;
+}
+
 /* Persistent banner strip rendered above the AI chat content when an AI session
  * override (e.g. --session-preference) is active. */
 .chat-banner-host {
@@ -2289,4 +2317,3 @@
   outline: 1px solid var(--theia-focusBorder);
   outline-offset: -1px;
 }
-

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -146,6 +146,7 @@ import { WidgetStatusBarContribution, WidgetStatusBarService } from './widget-st
 import { SymbolIconColorContribution } from './symbol-icon-color-contribution';
 import { CorePreferences, bindCorePreferences } from '../common/core-preferences';
 import { bindBadgeDecoration } from './badges';
+import { PerspectiveContribution, PerspectiveService, PerspectiveServiceImpl } from './perspective-service';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -482,6 +483,12 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bindRootContributionProvider(bind, UndoRedoHandler);
     bind(DomInputUndoRedoHandler).toSelf().inSingletonScope();
     bind(UndoRedoHandler).toService(DomInputUndoRedoHandler);
+
+    bind(PerspectiveServiceImpl).toSelf().inSingletonScope();
+    bind(PerspectiveService).toService(PerspectiveServiceImpl);
+    bind(FrontendApplicationContribution).toService(PerspectiveServiceImpl);
+    bind(CommandContribution).toService(PerspectiveServiceImpl);
+    bindRootContributionProvider(bind, PerspectiveContribution);
 
     bind(WidgetStatusBarService).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(WidgetStatusBarService);

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -51,7 +51,7 @@ import {
     SidePanelHandler, SidePanelHandlerFactory,
     SidebarMenuWidget, SidebarTopMenuWidgetFactory,
     SplitPositionHandler, DockPanelRendererFactory, ApplicationShellLayoutMigration, ApplicationShellLayoutMigrationError, SidebarBottomMenuWidgetFactory,
-    ShellLayoutTransformer
+    ShellLayoutTransformer, WidgetAreaResolver
 } from './shell';
 import { LabelParser } from './label-parser';
 import { LabelProvider, LabelProviderContribution, DefaultUriLabelProviderContribution } from './label-provider';
@@ -146,7 +146,7 @@ import { WidgetStatusBarContribution, WidgetStatusBarService } from './widget-st
 import { SymbolIconColorContribution } from './symbol-icon-color-contribution';
 import { CorePreferences, bindCorePreferences } from '../common/core-preferences';
 import { bindBadgeDecoration } from './badges';
-import { PerspectiveContribution, PerspectiveService, PerspectiveServiceImpl } from './perspective-service';
+import { PerspectiveContribution, PerspectiveService, PerspectiveServiceImpl, PerspectiveServiceInternal, WidgetAreaResolverImpl } from './perspective-service';
 
 export { bindResourceProvider, bindMessageService, bindPreferenceService };
 
@@ -484,8 +484,11 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
     bind(DomInputUndoRedoHandler).toSelf().inSingletonScope();
     bind(UndoRedoHandler).toService(DomInputUndoRedoHandler);
 
+    bind(WidgetAreaResolverImpl).toSelf().inSingletonScope();
+    bind(WidgetAreaResolver).toService(WidgetAreaResolverImpl);
     bind(PerspectiveServiceImpl).toSelf().inSingletonScope();
     bind(PerspectiveService).toService(PerspectiveServiceImpl);
+    bind(PerspectiveServiceInternal).toService(PerspectiveServiceImpl);
     bind(FrontendApplicationContribution).toService(PerspectiveServiceImpl);
     bind(CommandContribution).toService(PerspectiveServiceImpl);
     bindRootContributionProvider(bind, PerspectiveContribution);

--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -155,8 +155,8 @@ export class HoverService {
         }
         // browsers might insert linebreaks when the hover appears at the edge of the window
         // resetting the position prevents that
-        host.style.left = '0px';
-        host.style.top = '0px';
+        host.style.left = '-9999px';
+        host.style.top = '-9999px';
         document.body.append(host);
         if (!host.matches(':popover-open')) {
             host.showPopover();

--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -155,8 +155,8 @@ export class HoverService {
         }
         // browsers might insert linebreaks when the hover appears at the edge of the window
         // resetting the position prevents that
-        host.style.left = '-9999px';
-        host.style.top = '-9999px';
+        host.style.left = '0px';
+        host.style.top = '0px';
         document.body.append(host);
         if (!host.matches(':popover-open')) {
             host.showPopover();

--- a/packages/core/src/browser/index.ts
+++ b/packages/core/src/browser/index.ts
@@ -55,3 +55,4 @@ export * from './markdown-rendering/markdown-renderer';
 export * from './markdown-rendering/markdown';
 export * from './markdown-rendering/markdown-link-handler';
 export * from './components';
+export * from './perspective-service';

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -1,0 +1,2411 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from './test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { PerspectiveServiceImpl, PerspectiveDescriptor } from './perspective-service';
+import { ApplicationShell } from './shell/application-shell';
+import { AbstractViewContribution, ViewContributionOptions } from './shell/view-contribution';
+import { FrontendApplicationContribution } from './frontend-application-contribution';
+import { DockLayout, Panel, Widget } from '@lumino/widgets';
+import { SidePanel } from './shell/side-panel-handler';
+disableJSDOM();
+
+describe('PerspectiveService', () => {
+    let service: PerspectiveServiceImpl;
+    let addWidgetStub: sinon.SinonStub;
+    let activateWidgetStub: sinon.SinonStub;
+    let getTabBarForStub: sinon.SinonStub;
+    let getAreaForStub: sinon.SinonStub;
+    let getOrCreateWidgetStub: sinon.SinonStub;
+    let getLayoutDataStub: sinon.SinonStub;
+    let setLayoutDataStub: sinon.SinonStub;
+    let collapsePanelStub: sinon.SinonStub;
+    let setStatusBarHiddenByPerspectiveStub: sinon.SinonStub;
+    let setWidgetAreaResolverStub: sinon.SinonStub;
+    let tryGetWidgetStub: sinon.SinonStub;
+    let getWidgetsStub: sinon.SinonStub;
+    let mockLogger: { debug: sinon.SinonStub; warn: sinon.SinonStub };
+    let testWidget: Widget;
+    let toTearDown: () => void;
+
+    beforeEach(() => {
+        toTearDown = enableJSDOM();
+        service = new PerspectiveServiceImpl();
+        testWidget = new Widget();
+        testWidget.id = 'test-widget';
+
+        addWidgetStub = sinon.stub().resolves();
+        activateWidgetStub = sinon.stub().resolves(undefined);
+        getTabBarForStub = sinon.stub().returns(undefined);
+        getAreaForStub = sinon.stub().returns(undefined);
+        getOrCreateWidgetStub = sinon.stub().resolves(testWidget);
+        getLayoutDataStub = sinon.stub().returns({ mainPanel: {}, bottomPanel: {} });
+        setLayoutDataStub = sinon.stub().resolves();
+        collapsePanelStub = sinon.stub().resolves();
+        setStatusBarHiddenByPerspectiveStub = sinon.stub();
+        setWidgetAreaResolverStub = sinon.stub();
+        getWidgetsStub = sinon.stub().returns([]);
+        mockLogger = { debug: sinon.stub(), warn: sinon.stub() };
+
+        const mockShell = {
+            addWidget: addWidgetStub,
+            activateWidget: activateWidgetStub,
+            getTabBarFor: getTabBarForStub,
+            getAreaFor: getAreaForStub,
+            getLayoutData: getLayoutDataStub,
+            setLayoutData: setLayoutDataStub,
+            collapsePanel: collapsePanelStub,
+            setStatusBarHiddenByPerspective: setStatusBarHiddenByPerspectiveStub,
+            setWidgetAreaResolver: setWidgetAreaResolverStub,
+            getWidgets: getWidgetsStub
+        };
+
+        tryGetWidgetStub = sinon.stub().returns(undefined);
+
+        const mockWidgetManager = {
+            getOrCreateWidget: getOrCreateWidgetStub,
+            tryGetWidget: tryGetWidgetStub
+        };
+
+        // Assign mocks via property access since we can't use DI in tests
+        (service as unknown as Record<string, unknown>)['shell'] = mockShell;
+        (service as unknown as Record<string, unknown>)['widgetManager'] = mockWidgetManager;
+        (service as unknown as Record<string, unknown>)['logger'] = mockLogger;
+        (service as unknown as Record<string, unknown>)['appContributions'] = {
+            getContributions: () => [] as FrontendApplicationContribution[]
+        };
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        toTearDown();
+    });
+
+    it('should register a perspective', () => {
+        const descriptor: PerspectiveDescriptor = {
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        };
+
+        service.registerPerspective(descriptor);
+
+        const perspectives = service.getRegisteredPerspectives();
+        expect(perspectives).to.have.lengthOf(1);
+        expect(perspectives[0].id).to.equal('test');
+        expect(perspectives[0].label).to.equal('Test');
+    });
+
+    it('should register multiple perspectives', () => {
+        service.registerPerspective({
+            id: 'perspective-1',
+            label: 'Perspective 1',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspective-2',
+            label: 'Perspective 2',
+            viewPlacements: new Map()
+        });
+
+        expect(service.getRegisteredPerspectives()).to.have.lengthOf(2);
+    });
+
+    it('should return undefined for active perspective when none is set', () => {
+        expect(service.getActivePerspective()).to.be.undefined;
+    });
+
+    it('should return undefined from getAreaForView when no perspective is active', () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        });
+
+        expect(service.getAreaForView('widget-a')).to.be.undefined;
+    });
+
+    it('should return the override area when a perspective is active', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(service.getAreaForView('widget-a')).to.equal('main');
+    });
+
+    it('should return undefined for views not in the perspective placement map', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['widget-a', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(service.getAreaForView('widget-b')).to.be.undefined;
+    });
+
+    it('should switch perspectives and update the active perspective', async () => {
+        service.registerPerspective({
+            id: 'first',
+            label: 'First',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'second',
+            label: 'Second',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('first');
+        expect(service.getActivePerspective()?.id).to.equal('first');
+
+        await service.switchPerspective('second');
+        expect(service.getActivePerspective()?.id).to.equal('second');
+    });
+
+    it('should fire onDidChangePerspective event when switching', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map()
+        });
+
+        const spy = sinon.spy();
+        service.onDidChangePerspective(spy);
+
+        await service.switchPerspective('test');
+
+        expect(spy.calledOnce).to.be.true;
+        expect(spy.calledWith('test')).to.be.true;
+    });
+
+    it('should not switch to a non-existent perspective', async () => {
+        const spy = sinon.spy();
+        service.onDidChangePerspective(spy);
+
+        await service.switchPerspective('nonexistent');
+
+        expect(spy.called).to.be.false;
+        expect(service.getActivePerspective()).to.be.undefined;
+    });
+
+    it('should call onDeactivate on old perspective and onActivate on new perspective', async () => {
+        const onDeactivate = sinon.spy();
+        const onActivate = sinon.spy();
+
+        service.registerPerspective({
+            id: 'old',
+            label: 'Old',
+            viewPlacements: new Map(),
+            onDeactivate
+        });
+        service.registerPerspective({
+            id: 'new',
+            label: 'New',
+            viewPlacements: new Map(),
+            onActivate
+        });
+
+        await service.switchPerspective('old');
+        await service.switchPerspective('new');
+
+        expect(onDeactivate.calledOnce).to.be.true;
+        expect(onActivate.calledOnce).to.be.true;
+        expect(onDeactivate.calledBefore(onActivate)).to.be.true;
+    });
+
+    it('should add widgets to the target area during switch', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
+        expect(addWidgetStub.calledOnce).to.be.true;
+        expect(addWidgetStub.calledWith(testWidget, sinon.match({ area: 'main' }))).to.be.true;
+    });
+
+    it('should skip adding widget if already in the correct area', async () => {
+        getTabBarForStub.returns({});
+        getAreaForStub.returns('main');
+
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('test');
+
+        expect(addWidgetStub.called).to.be.false;
+    });
+
+    it('should call initialize and register contributions', () => {
+        const mockContribution = {
+            registerPerspectives: sinon.spy()
+        };
+
+        (service as unknown as Record<string, unknown>)['contributions'] = {
+            getContributions: () => [mockContribution]
+        };
+
+        service.initialize();
+
+        expect(mockContribution.registerPerspectives.calledOnce).to.be.true;
+        expect(mockContribution.registerPerspectives.calledWith(service)).to.be.true;
+    });
+
+    it('should handle initialize with no contributions', () => {
+        (service as unknown as Record<string, unknown>)['contributions'] = undefined;
+
+        expect(() => service.initialize()).to.not.throw();
+    });
+
+    // --- New tests for no-op guard, layout save/restore, and default perspective ---
+
+    it('should register the default perspective on initialize', () => {
+        service.initialize();
+
+        const perspectives = service.getRegisteredPerspectives();
+        const defaultPerspective = perspectives.find(p => p.id === PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+        expect(defaultPerspective).to.not.be.undefined;
+        expect(defaultPerspective!.label).to.equal('Default');
+        expect(defaultPerspective!.viewPlacements.size).to.equal(0);
+    });
+
+    it('should set the default perspective as the initial active perspective', () => {
+        service.initialize();
+
+        const active = service.getActivePerspective();
+        expect(active).to.not.be.undefined;
+        expect(active!.id).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+    });
+
+    it('should not re-apply when switching to the already-active perspective', async () => {
+        service.registerPerspective({
+            id: 'test',
+            label: 'Test',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]]),
+            onActivate: sinon.spy(),
+            onDeactivate: sinon.spy()
+        });
+
+        await service.switchPerspective('test');
+
+        // Reset all stubs
+        addWidgetStub.resetHistory();
+        setLayoutDataStub.resetHistory();
+        getOrCreateWidgetStub.resetHistory();
+        getLayoutDataStub.resetHistory();
+        const eventSpy = sinon.spy();
+        service.onDidChangePerspective(eventSpy);
+
+        const descriptor = service.getActivePerspective()!;
+        const onActivateSpy = descriptor.onActivate as sinon.SinonSpy;
+        const onDeactivateSpy = descriptor.onDeactivate as sinon.SinonSpy;
+        onActivateSpy.resetHistory();
+        onDeactivateSpy.resetHistory();
+
+        // Switch to the same perspective again
+        await service.switchPerspective('test');
+
+        expect(addWidgetStub.called).to.be.false;
+        expect(setLayoutDataStub.called).to.be.false;
+        expect(getOrCreateWidgetStub.called).to.be.false;
+        expect(getLayoutDataStub.called).to.be.false;
+        expect(eventSpy.called).to.be.false;
+        expect(onActivateSpy.called).to.be.false;
+        expect(onDeactivateSpy.called).to.be.false;
+    });
+
+    it('should save layout when switching away from a perspective', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('perspA');
+
+        const layoutA = { mainPanel: { widgets: ['editor1'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutA);
+
+        // Switch to B — should save A's layout
+        await service.switchPerspective('perspB');
+
+        expect(getLayoutDataStub.called).to.be.true;
+
+        const layoutB = { mainPanel: { widgets: ['something-else'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutB);
+        setLayoutDataStub.resetHistory();
+
+        // Switch back to A — should restore A's saved layout
+        await service.switchPerspective('perspA');
+
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(layoutA)).to.be.true;
+    });
+
+    it('should restore saved layout when switching back to a perspective', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map([['test-widget', 'left' as ApplicationShell.Area]])
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        // Activate A (first time — applies viewPlacements)
+        await service.switchPerspective('perspA');
+
+        const layoutA = { mainPanel: { widgets: ['editor-customized'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutA);
+
+        // Switch to B (saves A's layout)
+        await service.switchPerspective('perspB');
+
+        const layoutB = { mainPanel: { widgets: ['something-else'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(layoutB);
+
+        setLayoutDataStub.resetHistory();
+        getOrCreateWidgetStub.resetHistory();
+        addWidgetStub.resetHistory();
+
+        // Switch back to A — should restore saved layout, NOT apply viewPlacements
+        await service.switchPerspective('perspA');
+
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(layoutA)).to.be.true;
+        expect(getOrCreateWidgetStub.called).to.be.false;
+        expect(addWidgetStub.called).to.be.false;
+    });
+
+    it('should apply viewPlacements on first activation (no saved layout)', async () => {
+        service.registerPerspective({
+            id: 'fresh',
+            label: 'Fresh',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('fresh');
+
+        expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
+        expect(addWidgetStub.calledOnce).to.be.true;
+        expect(addWidgetStub.calledWith(testWidget, sinon.match({ area: 'main' }))).to.be.true;
+        expect(setLayoutDataStub.called).to.be.false;
+    });
+
+    it('should not apply viewPlacements when a saved layout exists', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map([['test-widget', 'left' as ApplicationShell.Area]])
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        // First activation of A — viewPlacements applied
+        await service.switchPerspective('perspA');
+        expect(getOrCreateWidgetStub.called).to.be.true;
+
+        // Switch to B (saves A's layout)
+        await service.switchPerspective('perspB');
+
+        getOrCreateWidgetStub.resetHistory();
+        addWidgetStub.resetHistory();
+
+        // Switch back to A — should restore layout, NOT use viewPlacements
+        await service.switchPerspective('perspA');
+
+        expect(getOrCreateWidgetStub.called).to.be.false;
+        expect(addWidgetStub.called).to.be.false;
+        expect(setLayoutDataStub.called).to.be.true;
+    });
+
+    it('should allow full round-trip: default → custom → default', async () => {
+        service.initialize();
+
+        service.registerPerspective({
+            id: 'ai-first',
+            label: 'AI First',
+            viewPlacements: new Map([['test-widget', 'left' as ApplicationShell.Area]])
+        });
+
+        // Start in default (set by initialize)
+        expect(service.getActivePerspective()?.id).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+
+        const defaultLayout = { mainPanel: { widgets: ['default-editor'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(defaultLayout);
+
+        // Switch to ai-first (saves default layout)
+        await service.switchPerspective('ai-first');
+        expect(service.getActivePerspective()?.id).to.equal('ai-first');
+        expect(getLayoutDataStub.called).to.be.true;
+        expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
+
+        const aiLayout = { mainPanel: { widgets: ['ai-stuff'] }, bottomPanel: {} };
+        getLayoutDataStub.returns(aiLayout);
+
+        setLayoutDataStub.resetHistory();
+
+        // Switch back to default (saves ai-first layout, restores default layout)
+        await service.switchPerspective(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+        expect(service.getActivePerspective()?.id).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(defaultLayout)).to.be.true;
+
+        setLayoutDataStub.resetHistory();
+
+        // Switch back to ai-first (saves default layout again, restores ai-first layout)
+        await service.switchPerspective('ai-first');
+        expect(service.getActivePerspective()?.id).to.equal('ai-first');
+        expect(setLayoutDataStub.calledOnce).to.be.true;
+        expect(setLayoutDataStub.calledWith(aiLayout)).to.be.true;
+    });
+
+    // --- Chrome control options tests ---
+
+    it('should hide status bar when perspective has hideStatusBar', async () => {
+        service.registerPerspective({
+            id: 'chrome-test',
+            label: 'Chrome Test',
+            viewPlacements: new Map(),
+            chromeOptions: { hideStatusBar: true }
+        });
+
+        await service.switchPerspective('chrome-test');
+
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
+    });
+
+    it('should not hide status bar when perspective does not hide it', async () => {
+        service.registerPerspective({
+            id: 'no-chrome',
+            label: 'No Chrome',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('no-chrome');
+
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(false)).to.be.true;
+    });
+
+    it('should collapse areas on first activation only', async () => {
+        service.registerPerspective({
+            id: 'collapse-test',
+            label: 'Collapse Test',
+            viewPlacements: new Map(),
+            chromeOptions: { collapseAreas: ['left'] }
+        });
+        service.registerPerspective({
+            id: 'other',
+            label: 'Other',
+            viewPlacements: new Map()
+        });
+
+        // First activation — should collapse
+        await service.switchPerspective('collapse-test');
+        expect(collapsePanelStub.calledOnce).to.be.true;
+        expect(collapsePanelStub.calledWith('left')).to.be.true;
+
+        collapsePanelStub.resetHistory();
+
+        // Switch away (saves layout)
+        await service.switchPerspective('other');
+
+        collapsePanelStub.resetHistory();
+
+        // Switch back — should restore saved layout, NOT collapse again
+        await service.switchPerspective('collapse-test');
+        expect(collapsePanelStub.called).to.be.false;
+    });
+
+    it('should apply chrome options even when restoring saved layout', async () => {
+        service.registerPerspective({
+            id: 'chrome-test',
+            label: 'Chrome Test',
+            viewPlacements: new Map(),
+            chromeOptions: { hideStatusBar: true }
+        });
+        service.registerPerspective({
+            id: 'other',
+            label: 'Other',
+            viewPlacements: new Map()
+        });
+
+        // First activation
+        await service.switchPerspective('chrome-test');
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
+
+        setStatusBarHiddenByPerspectiveStub.resetHistory();
+
+        // Switch away (saves layout)
+        await service.switchPerspective('other');
+
+        setStatusBarHiddenByPerspectiveStub.resetHistory();
+
+        // Switch back (restores saved layout) — chrome should still be applied
+        await service.switchPerspective('chrome-test');
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
+    });
+
+    it('should collapse multiple areas on first activation', async () => {
+        service.registerPerspective({
+            id: 'multi-collapse',
+            label: 'Multi Collapse',
+            viewPlacements: new Map(),
+            chromeOptions: { collapseAreas: ['left', 'bottom'] }
+        });
+
+        await service.switchPerspective('multi-collapse');
+
+        expect(collapsePanelStub.calledTwice).to.be.true;
+        expect(collapsePanelStub.calledWith('left')).to.be.true;
+        expect(collapsePanelStub.calledWith('bottom')).to.be.true;
+    });
+
+    it('should not collapse areas when perspective has no collapseAreas', async () => {
+        service.registerPerspective({
+            id: 'no-collapse',
+            label: 'No Collapse',
+            viewPlacements: new Map()
+        });
+
+        await service.switchPerspective('no-collapse');
+
+        expect(collapsePanelStub.called).to.be.false;
+    });
+
+    // --- WidgetAreaResolver registration tests ---
+
+    it('should register a widget area resolver on the shell during initialize', () => {
+        service.initialize();
+
+        expect(setWidgetAreaResolverStub.calledOnce).to.be.true;
+        expect(typeof setWidgetAreaResolverStub.firstCall.args[0]).to.equal('function');
+    });
+
+    it('should resolve widget area from active perspective via the registered resolver', async () => {
+        service.initialize();
+
+        service.registerPerspective({
+            id: 'resolver-test',
+            label: 'Resolver Test',
+            viewPlacements: new Map([['my-widget', 'right' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('resolver-test');
+
+        const resolver = setWidgetAreaResolverStub.firstCall.args[0] as (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
+        expect(resolver('my-widget', 'left')).to.equal('right');
+    });
+
+    it('should return undefined from the resolver for unmapped widgets', async () => {
+        service.initialize();
+
+        service.registerPerspective({
+            id: 'resolver-test',
+            label: 'Resolver Test',
+            viewPlacements: new Map([['my-widget', 'right' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('resolver-test');
+
+        const resolver = setWidgetAreaResolverStub.firstCall.args[0] as (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
+        expect(resolver('unknown-widget', 'main')).to.be.undefined;
+    });
+
+    it('should return undefined from the resolver when default perspective is active', () => {
+        service.initialize();
+
+        const resolver = setWidgetAreaResolverStub.firstCall.args[0] as (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
+        // Default perspective has empty viewPlacements
+        expect(resolver('any-widget', 'main')).to.be.undefined;
+    });
+
+    // --- Logger tests ---
+
+    it('should log warning when widget creation fails during switchPerspective', async () => {
+        const widgetError = new Error('No factory registered');
+        getOrCreateWidgetStub.rejects(widgetError);
+
+        service.registerPerspective({
+            id: 'fail-test',
+            label: 'Fail Test',
+            viewPlacements: new Map([['missing-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('fail-test');
+
+        expect(mockLogger.warn.calledOnce).to.be.true;
+        expect(mockLogger.warn.firstCall.args[0]).to.equal('Failed to create or place widget for perspective');
+        expect(mockLogger.warn.firstCall.args[1]).to.equal(widgetError);
+    });
+
+    it('should log warning when widget activation fails during switchPerspective', async () => {
+        const activationError = new Error('Activation failed');
+        activateWidgetStub.rejects(activationError);
+
+        service.registerPerspective({
+            id: 'activate-fail',
+            label: 'Activate Fail',
+            viewPlacements: new Map([['test-widget', 'main' as ApplicationShell.Area]])
+        });
+
+        await service.switchPerspective('activate-fail');
+
+        expect(mockLogger.warn.called).to.be.true;
+        const activateCall = mockLogger.warn.getCalls().find(
+            (c: sinon.SinonSpyCall) => c.args[0] === 'Failed to activate widget for perspective'
+        );
+        expect(activateCall).to.not.be.undefined;
+        expect(activateCall!.args[1]).to.equal(activationError);
+    });
+
+    // --- Reentrancy guard tests ---
+
+    it('should handle two rapid switchPerspective calls without interleaving', async () => {
+        service.registerPerspective({
+            id: 'first',
+            label: 'First',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'second',
+            label: 'Second',
+            viewPlacements: new Map()
+        });
+
+        const promise1 = service.switchPerspective('first');
+        const promise2 = service.switchPerspective('second');
+
+        await Promise.all([promise1, promise2]);
+
+        expect(service.getActivePerspective()?.id).to.equal('second');
+    });
+
+    it('should serialize perspective switches with reentrancy guard', async () => {
+        const callOrder: string[] = [];
+
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map(),
+            onActivate: () => callOrder.push('activate-A')
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map(),
+            onActivate: () => callOrder.push('activate-B')
+        });
+
+        const p1 = service.switchPerspective('perspA');
+        const p2 = service.switchPerspective('perspB');
+
+        await Promise.all([p1, p2]);
+
+        expect(callOrder).to.deep.equal(['activate-A', 'activate-B']);
+        expect(service.getActivePerspective()?.id).to.equal('perspB');
+    });
+
+    it('should serialize three or more concurrent perspective switches', async () => {
+        const callOrder: string[] = [];
+
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map(),
+            onActivate: () => callOrder.push('activate-A')
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map(),
+            onActivate: () => callOrder.push('activate-B')
+        });
+        service.registerPerspective({
+            id: 'perspC',
+            label: 'C',
+            viewPlacements: new Map(),
+            onActivate: () => callOrder.push('activate-C')
+        });
+
+        const p1 = service.switchPerspective('perspA');
+        const p2 = service.switchPerspective('perspB');
+        const p3 = service.switchPerspective('perspC');
+
+        await Promise.all([p1, p2, p3]);
+
+        expect(callOrder).to.deep.equal(['activate-A', 'activate-B', 'activate-C']);
+        expect(service.getActivePerspective()?.id).to.equal('perspC');
+    });
+
+    // --- onLayoutRestored() tests ---
+
+    it('should apply chrome options when onLayoutRestored is called with a registered perspective', () => {
+        service.registerPerspective({
+            id: 'chrome-persp',
+            label: 'Chrome Persp',
+            viewPlacements: new Map(),
+            chromeOptions: { hideStatusBar: true }
+        });
+        service.initialize();
+
+        service.onLayoutRestored('chrome-persp');
+
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
+    });
+
+    it('should not hide status bar when restored perspective has no chrome options', () => {
+        service.registerPerspective({
+            id: 'no-chrome-persp',
+            label: 'No Chrome',
+            viewPlacements: new Map()
+        });
+        service.initialize();
+
+        service.onLayoutRestored('no-chrome-persp');
+
+        expect(setStatusBarHiddenByPerspectiveStub.calledWith(false)).to.be.true;
+    });
+
+    it('should not apply chrome when onLayoutRestored is called with an unregistered perspective', () => {
+        service.initialize();
+
+        service.onLayoutRestored('non-existent');
+
+        expect(setStatusBarHiddenByPerspectiveStub.called).to.be.false;
+    });
+
+    // --- Rejection resilience tests ---
+
+    it('should warn and continue when setLayoutData rejects during saved layout restore', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+
+        // Switch to A, then to B (saves A's layout)
+        await service.switchPerspective('perspA');
+        await service.switchPerspective('perspB');
+
+        // Make setLayoutData reject
+        setLayoutDataStub.rejects(new Error('layout error'));
+
+        const eventSpy = sinon.spy();
+        service.onDidChangePerspective(eventSpy);
+
+        // Switch back to A — should not throw
+        await service.switchPerspective('perspA');
+
+        expect(service.getActivePerspective()?.id).to.equal('perspA');
+        expect(eventSpy.calledOnce).to.be.true;
+        expect(eventSpy.calledWith('perspA')).to.be.true;
+        expect(mockLogger.warn.calledOnce).to.be.true;
+        expect(mockLogger.warn.firstCall.args[0]).to.equal('Failed to apply layout for perspective');
+    });
+
+    it('should warn and continue when collapsePanel rejects on first activation', async () => {
+        service.registerPerspective({
+            id: 'collapse-fail',
+            label: 'Collapse Fail',
+            viewPlacements: new Map(),
+            chromeOptions: { collapseAreas: ['left'] }
+        });
+
+        collapsePanelStub.rejects(new Error('collapse error'));
+
+        const eventSpy = sinon.spy();
+        service.onDidChangePerspective(eventSpy);
+
+        // Switch — should not throw
+        await service.switchPerspective('collapse-fail');
+
+        expect(service.getActivePerspective()?.id).to.equal('collapse-fail');
+        expect(setStatusBarHiddenByPerspectiveStub.called).to.be.true;
+        expect(eventSpy.calledOnce).to.be.true;
+        expect(mockLogger.warn.calledOnce).to.be.true;
+        expect(mockLogger.warn.firstCall.args[0]).to.equal('Failed to apply layout for perspective');
+    });
+
+    it('should not drop queued switches when layout application fails', async () => {
+        service.registerPerspective({
+            id: 'perspA',
+            label: 'A',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspB',
+            label: 'B',
+            viewPlacements: new Map()
+        });
+        service.registerPerspective({
+            id: 'perspC',
+            label: 'C',
+            viewPlacements: new Map()
+        });
+
+        // Switch to A, then to B (saves A's layout)
+        await service.switchPerspective('perspA');
+        await service.switchPerspective('perspB');
+
+        // Make setLayoutData reject only on first call, then resolve
+        setLayoutDataStub.resetBehavior();
+        setLayoutDataStub.onFirstCall().rejects(new Error('layout error'));
+        setLayoutDataStub.onSecondCall().resolves();
+
+        // Queue: switch to A (will fail layout restore), then switch to C
+        const p1 = service.switchPerspective('perspA');
+        const p2 = service.switchPerspective('perspC');
+
+        await Promise.all([p1, p2]);
+
+        expect(service.getActivePerspective()?.id).to.equal('perspC');
+    });
+
+    // --- resetCurrentPerspective tests ---
+
+    describe('resetCurrentPerspective', () => {
+        it('should clear saved layout and re-apply viewPlacements on reset for non-default perspective', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map([['test-widget', 'left' as ApplicationShell.Area]])
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            await service.switchPerspective('perspA');
+
+            const layoutA = { mainPanel: { widgets: ['customized'] }, bottomPanel: {} };
+            getLayoutDataStub.returns(layoutA);
+
+            // Switch to B (saves A's layout)
+            await service.switchPerspective('perspB');
+
+            // Switch back to A (restores saved layout)
+            await service.switchPerspective('perspA');
+
+            // Verify saved layout exists
+            expect(service.getSavedLayout('perspA')).to.not.be.undefined;
+
+            // Reset stubs to track reset behavior
+            setLayoutDataStub.resetHistory();
+            getOrCreateWidgetStub.resetHistory();
+            addWidgetStub.resetHistory();
+            activateWidgetStub.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            // Saved layout should be cleared
+            expect(service.getSavedLayout('perspA')).to.be.undefined;
+
+            // Should re-apply viewPlacements
+            expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
+            expect(addWidgetStub.called).to.be.true;
+        });
+
+        it('should re-apply chrome options (hideStatusBar) on reset', async () => {
+            service.registerPerspective({
+                id: 'chrome-reset',
+                label: 'Chrome Reset',
+                viewPlacements: new Map(),
+                chromeOptions: { hideStatusBar: true, collapseAreas: ['left', 'bottom'] }
+            });
+
+            await service.switchPerspective('chrome-reset');
+
+            setStatusBarHiddenByPerspectiveStub.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            // Chrome options (hideStatusBar) should always be re-applied
+            expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
+        });
+
+        it('should call onActivate callback', async () => {
+            const onActivate = sinon.spy();
+            service.registerPerspective({
+                id: 'activate-reset',
+                label: 'Activate Reset',
+                viewPlacements: new Map(),
+                onActivate
+            });
+
+            await service.switchPerspective('activate-reset');
+            onActivate.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            expect(onActivate.calledOnce).to.be.true;
+        });
+
+        it('should fire onDidChangePerspective event', async () => {
+            service.registerPerspective({
+                id: 'event-reset',
+                label: 'Event Reset',
+                viewPlacements: new Map()
+            });
+
+            await service.switchPerspective('event-reset');
+
+            const spy = sinon.spy();
+            service.onDidChangePerspective(spy);
+
+            await service.resetCurrentPerspective();
+
+            expect(spy.calledOnce).to.be.true;
+            expect(spy.calledWith('event-reset')).to.be.true;
+        });
+
+        it('should not affect other perspectives\' saved layouts', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            // Activate A, then B, to create saved layouts for both
+            await service.switchPerspective('perspA');
+
+            const layoutA = { mainPanel: { widgets: ['a-stuff'] }, bottomPanel: {} };
+            getLayoutDataStub.returns(layoutA);
+
+            await service.switchPerspective('perspB');
+
+            const layoutB = { mainPanel: { widgets: ['b-stuff'] }, bottomPanel: {} };
+            getLayoutDataStub.returns(layoutB);
+
+            // Switch back to A (saves B's layout)
+            await service.switchPerspective('perspA');
+
+            // Reset A
+            await service.resetCurrentPerspective();
+
+            // A's saved layout should be cleared
+            expect(service.getSavedLayout('perspA')).to.be.undefined;
+            // B's saved layout should be preserved
+            expect(service.getSavedLayout('perspB')).to.equal(layoutB);
+        });
+
+        it('should serialize with other switchPerspective calls', async () => {
+            const callOrder: string[] = [];
+
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map(),
+                onActivate: () => callOrder.push('activate-A')
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map(),
+                onActivate: () => callOrder.push('activate-B')
+            });
+
+            await service.switchPerspective('perspA');
+            callOrder.length = 0;
+
+            // Queue a reset and a switch concurrently
+            const p1 = service.resetCurrentPerspective();
+            const p2 = service.switchPerspective('perspB');
+
+            await Promise.all([p1, p2]);
+
+            expect(callOrder).to.deep.equal(['activate-A', 'activate-B']);
+            expect(service.getActivePerspective()?.id).to.equal('perspB');
+        });
+
+        it('should do nothing when no active perspective is set', async () => {
+            // No perspective active (activePerspectiveId is undefined)
+            const spy = sinon.spy();
+            service.onDidChangePerspective(spy);
+
+            await service.resetCurrentPerspective();
+
+            expect(spy.called).to.be.false;
+            expect(getOrCreateWidgetStub.called).to.be.false;
+        });
+    });
+
+    describe('resetDefaultPerspective', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        function createMockViewContribution(
+            options: ViewContributionOptions,
+            hasInitializeLayout: boolean = true
+        ): AbstractViewContribution<Widget> & FrontendApplicationContribution {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const contribution = Object.create(AbstractViewContribution.prototype) as any;
+            contribution.options = options;
+            contribution.widgetManager = {
+                getOrCreateWidget: getOrCreateWidgetStub,
+                tryGetWidget: tryGetWidgetStub
+            };
+            contribution.shell = (service as unknown as Record<string, unknown>)['shell'];
+            if (hasInitializeLayout) {
+                contribution.initializeLayout = sinon.stub().resolves();
+            }
+            return contribution;
+        }
+
+        function createMockNonViewContribution(hasInitializeLayout: boolean = true): FrontendApplicationContribution {
+            const contrib: FrontendApplicationContribution = {};
+            if (hasInitializeLayout) {
+                contrib.initializeLayout = sinon.stub().resolves();
+            }
+            return contrib;
+        }
+
+        it('should relocate open view from wrong area to defaultViewOptions.area', async () => {
+            service.initialize();
+
+            const explorerWidget = new Widget();
+            explorerWidget.id = 'explorer';
+            const explorerPanel = new Panel();
+            Widget.attach(explorerPanel, document.body);
+            explorerPanel.addWidget(explorerWidget);
+
+            tryGetWidgetStub.withArgs('explorer').returns(explorerWidget);
+            getAreaForStub.withArgs(explorerWidget).returns('right');
+
+            const contribution = createMockViewContribution({
+                widgetId: 'explorer',
+                widgetName: 'Explorer',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            await service.resetCurrentPerspective();
+
+            expect(addWidgetStub.calledWith(explorerWidget, sinon.match({ area: 'left' }))).to.be.true;
+
+            explorerPanel.dispose();
+        });
+
+        it('should skip views already in correct area', async () => {
+            service.initialize();
+
+            const explorerWidget = new Widget();
+            explorerWidget.id = 'explorer';
+            const explorerPanel = new Panel();
+            Widget.attach(explorerPanel, document.body);
+            explorerPanel.addWidget(explorerWidget);
+
+            tryGetWidgetStub.withArgs('explorer').returns(explorerWidget);
+            getAreaForStub.withArgs(explorerWidget).returns('left');
+
+            const contribution = createMockViewContribution({
+                widgetId: 'explorer',
+                widgetName: 'Explorer',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            addWidgetStub.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            expect(addWidgetStub.called).to.be.false;
+
+            explorerPanel.dispose();
+        });
+
+        it('should skip views not attached', async () => {
+            service.initialize();
+
+            const explorerWidget = new Widget();
+            explorerWidget.id = 'explorer';
+            // Not attached to any parent
+
+            tryGetWidgetStub.withArgs('explorer').returns(explorerWidget);
+
+            const contribution = createMockViewContribution({
+                widgetId: 'explorer',
+                widgetName: 'Explorer',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            addWidgetStub.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            // Phase 1 should not try to relocate (not attached)
+            // Phase 2 will call initializeLayout
+            expect(addWidgetStub.called).to.be.false;
+        });
+
+        it('should call initializeLayout on AbstractViewContribution instances', async () => {
+            service.initialize();
+
+            const contribution = createMockViewContribution({
+                widgetId: 'explorer',
+                widgetName: 'Explorer',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            await service.resetCurrentPerspective();
+
+            expect((contribution.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
+        });
+
+        it('should NOT call initializeLayout on non-AbstractViewContribution contributions', async () => {
+            service.initialize();
+
+            const nonViewContrib = createMockNonViewContribution(true);
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [nonViewContrib]
+            };
+
+            await service.resetCurrentPerspective();
+
+            expect((nonViewContrib.initializeLayout as sinon.SinonStub).called).to.be.false;
+        });
+
+        it('should handle combined scenario: open view in wrong area + closed view', async () => {
+            service.initialize();
+
+            // Explorer is open but in the wrong area
+            const explorerWidget = new Widget();
+            explorerWidget.id = 'explorer';
+            const panel = new Panel();
+            Widget.attach(panel, document.body);
+            panel.addWidget(explorerWidget);
+
+            tryGetWidgetStub.withArgs('explorer').returns(explorerWidget);
+            getAreaForStub.withArgs(explorerWidget).returns('right');
+
+            const explorerContrib = createMockViewContribution({
+                widgetId: 'explorer',
+                widgetName: 'Explorer',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            // SCM is closed (tryGetWidget returns undefined)
+            tryGetWidgetStub.withArgs('scm').returns(undefined);
+
+            const scmContrib = createMockViewContribution({
+                widgetId: 'scm',
+                widgetName: 'SCM',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [explorerContrib, scmContrib]
+            };
+
+            addWidgetStub.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            // Phase 1: Explorer should be relocated
+            expect(addWidgetStub.calledWith(explorerWidget, sinon.match({ area: 'left' }))).to.be.true;
+            // Phase 2: Both should have initializeLayout called
+            expect((explorerContrib.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
+            expect((scmContrib.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
+
+            panel.dispose();
+        });
+
+        it('should use viewContainerId as effectiveWidgetId when set', async () => {
+            service.initialize();
+
+            const containerWidget = new Widget();
+            containerWidget.id = 'explorer-container';
+            const panel = new Panel();
+            Widget.attach(panel, document.body);
+            panel.addWidget(containerWidget);
+
+            tryGetWidgetStub.withArgs('explorer-container').returns(containerWidget);
+            getAreaForStub.withArgs(containerWidget).returns('right');
+
+            const contribution = createMockViewContribution({
+                widgetId: 'explorer',
+                viewContainerId: 'explorer-container',
+                widgetName: 'Explorer',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            addWidgetStub.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            expect(tryGetWidgetStub.calledWith('explorer-container')).to.be.true;
+            expect(addWidgetStub.calledWith(containerWidget, sinon.match({ area: 'left' }))).to.be.true;
+
+            panel.dispose();
+        });
+
+        it('should handle initializeLayout errors gracefully', async () => {
+            service.initialize();
+
+            const contribution = createMockViewContribution({
+                widgetId: 'broken',
+                widgetName: 'Broken',
+                defaultWidgetOptions: { area: 'left' }
+            });
+            (contribution.initializeLayout as sinon.SinonStub).rejects(new Error('init failed'));
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            // Should not throw
+            await service.resetCurrentPerspective();
+
+            expect(mockLogger.warn.called).to.be.true;
+        });
+
+        it('should handle widget relocation errors gracefully', async () => {
+            service.initialize();
+
+            const explorerWidget = new Widget();
+            explorerWidget.id = 'explorer';
+            const panel = new Panel();
+            Widget.attach(panel, document.body);
+            panel.addWidget(explorerWidget);
+
+            tryGetWidgetStub.withArgs('explorer').returns(explorerWidget);
+            getAreaForStub.withArgs(explorerWidget).returns('right');
+            addWidgetStub.rejects(new Error('relocation failed'));
+
+            const contribution = createMockViewContribution({
+                widgetId: 'explorer',
+                widgetName: 'Explorer',
+                defaultWidgetOptions: { area: 'left' }
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            // Should not throw
+            await service.resetCurrentPerspective();
+
+            expect(mockLogger.warn.called).to.be.true;
+
+            panel.dispose();
+        });
+
+        it('should fire onDidChangePerspective event on default perspective reset', async () => {
+            service.initialize();
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => []
+            };
+
+            const spy = sinon.spy();
+            service.onDidChangePerspective(spy);
+
+            await service.resetCurrentPerspective();
+
+            expect(spy.calledOnce).to.be.true;
+            expect(spy.calledWith(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID)).to.be.true;
+        });
+
+        it('should skip contributions without defaultViewOptions.area', async () => {
+            service.initialize();
+
+            const contribution = createMockViewContribution({
+                widgetId: 'no-area',
+                widgetName: 'No Area',
+                defaultWidgetOptions: {}
+            });
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            addWidgetStub.resetHistory();
+
+            await service.resetCurrentPerspective();
+
+            // Phase 1 should skip (no target area)
+            // Phase 2 should still call initializeLayout
+            expect((contribution.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
+        });
+
+        it('should skip AbstractViewContribution without initializeLayout in Phase 2', async () => {
+            service.initialize();
+
+            const contribution = createMockViewContribution({
+                widgetId: 'no-init',
+                widgetName: 'No Init',
+                defaultWidgetOptions: { area: 'left' }
+            }, false);
+
+            (service as unknown as Record<string, unknown>)['appContributions'] = {
+                getContributions: () => [contribution]
+            };
+
+            // Should not throw
+            await service.resetCurrentPerspective();
+
+            // No initializeLayout to call
+            expect(contribution.initializeLayout).to.be.undefined;
+        });
+    });
+
+    describe('layout healing on perspective switch', () => {
+        it('should replace disposed side panel widget when switching back to a perspective', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            // Create a widget and then dispose it to simulate cross-perspective closure
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'explorer-widget';
+            disposedWidget.dispose();
+            expect(disposedWidget.isDisposed).to.be.true;
+
+            const freshWidget = new Widget();
+            freshWidget.id = 'explorer-widget';
+            getOrCreateWidgetStub.withArgs('explorer-widget').resolves(freshWidget);
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                leftPanel: {
+                    type: 'sidepanel',
+                    items: [{ widget: disposedWidget, rank: 0, expanded: true }]
+                } as SidePanel.LayoutData,
+                mainPanel: undefined,
+                bottomPanel: undefined
+            };
+
+            // Switch to A, then to B
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+
+            // Manually set the saved layout for A with the disposed widget
+            service.setSavedLayout('perspA', savedLayout);
+
+            setLayoutDataStub.resetHistory();
+            getOrCreateWidgetStub.resetHistory();
+
+            // Switch back to A
+            await service.switchPerspective('perspA');
+
+            expect(getOrCreateWidgetStub.calledWith('explorer-widget')).to.be.true;
+            expect(setLayoutDataStub.calledOnce).to.be.true;
+            // The layout should now contain the fresh widget
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            expect(restoredLayout.leftPanel!.items![0].widget).to.equal(freshWidget);
+        });
+
+        it('should replace disposed dock panel widget (main area)', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'editor-widget';
+            disposedWidget.dispose();
+
+            const freshWidget = new Widget();
+            freshWidget.id = 'editor-widget';
+            getOrCreateWidgetStub.withArgs('editor-widget').resolves(freshWidget);
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                mainPanel: {
+                    main: {
+                        type: 'tab-area',
+                        widgets: [disposedWidget],
+                        currentIndex: 0
+                    } as DockLayout.ITabAreaConfig
+                },
+                bottomPanel: undefined
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            setLayoutDataStub.resetHistory();
+            getOrCreateWidgetStub.resetHistory();
+
+            await service.switchPerspective('perspA');
+
+            expect(getOrCreateWidgetStub.calledWith('editor-widget')).to.be.true;
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            expect((restoredLayout.mainPanel!.main as DockLayout.ITabAreaConfig).widgets[0]).to.equal(freshWidget);
+        });
+
+        it('should handle recreation failure gracefully', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'broken-widget';
+            disposedWidget.dispose();
+
+            getOrCreateWidgetStub.withArgs('broken-widget').rejects(new Error('No factory'));
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                leftPanel: {
+                    type: 'sidepanel',
+                    items: [{ widget: disposedWidget, rank: 0, expanded: true }]
+                } as SidePanel.LayoutData,
+                mainPanel: undefined,
+                bottomPanel: undefined
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            mockLogger.warn.resetHistory();
+            setLayoutDataStub.resetHistory();
+
+            await service.switchPerspective('perspA');
+
+            // Widget should be set to undefined in the layout
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            expect(restoredLayout.leftPanel!.items![0].widget).to.be.undefined;
+            // Warn log should have been called
+            expect(mockLogger.warn.called).to.be.true;
+            const healCall = mockLogger.warn.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'Failed to recreate disposed widget for perspective layout'
+            );
+            expect(healCall).to.not.be.undefined;
+            // setLayoutData should still be called
+            expect(setLayoutDataStub.calledOnce).to.be.true;
+        });
+
+        it('should handle recreation failure in dock panel by splicing widget', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'broken-widget';
+            disposedWidget.dispose();
+
+            const goodWidget = new Widget();
+            goodWidget.id = 'good-widget';
+
+            getOrCreateWidgetStub.withArgs('broken-widget').rejects(new Error('No factory'));
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                mainPanel: {
+                    main: {
+                        type: 'tab-area',
+                        widgets: [goodWidget, disposedWidget],
+                        currentIndex: 0
+                    } as DockLayout.ITabAreaConfig
+                },
+                bottomPanel: undefined
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            setLayoutDataStub.resetHistory();
+
+            await service.switchPerspective('perspA');
+
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            const tabArea = restoredLayout.mainPanel!.main as DockLayout.ITabAreaConfig;
+            // The broken widget should have been spliced out
+            expect(tabArea.widgets).to.have.lengthOf(1);
+            expect(tabArea.widgets[0]).to.equal(goodWidget);
+        });
+
+        it('should not touch non-disposed widgets', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const liveWidget = new Widget();
+            liveWidget.id = 'live-widget';
+
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'dead-widget';
+            disposedWidget.dispose();
+
+            const freshWidget = new Widget();
+            freshWidget.id = 'dead-widget';
+            getOrCreateWidgetStub.withArgs('dead-widget').resolves(freshWidget);
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                leftPanel: {
+                    type: 'sidepanel',
+                    items: [
+                        { widget: liveWidget, rank: 0, expanded: true },
+                        { widget: disposedWidget, rank: 1, expanded: false }
+                    ]
+                } as SidePanel.LayoutData,
+                mainPanel: undefined,
+                bottomPanel: undefined
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            getOrCreateWidgetStub.resetHistory();
+            setLayoutDataStub.resetHistory();
+
+            await service.switchPerspective('perspA');
+
+            // Only the disposed widget should trigger getOrCreateWidget
+            expect(getOrCreateWidgetStub.calledOnce).to.be.true;
+            expect(getOrCreateWidgetStub.calledWith('dead-widget')).to.be.true;
+            // The live widget should remain unchanged
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            expect(restoredLayout.leftPanel!.items![0].widget).to.equal(liveWidget);
+            expect(restoredLayout.leftPanel!.items![1].widget).to.equal(freshWidget);
+        });
+
+        it('should handle nested split-area configs', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'nested-widget';
+            disposedWidget.dispose();
+
+            const freshWidget = new Widget();
+            freshWidget.id = 'nested-widget';
+            getOrCreateWidgetStub.withArgs('nested-widget').resolves(freshWidget);
+
+            const liveWidget = new Widget();
+            liveWidget.id = 'other-widget';
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                mainPanel: {
+                    main: {
+                        type: 'split-area',
+                        orientation: 'horizontal',
+                        sizes: [0.5, 0.5],
+                        children: [
+                            {
+                                type: 'tab-area',
+                                widgets: [liveWidget],
+                                currentIndex: 0
+                            } as DockLayout.ITabAreaConfig,
+                            {
+                                type: 'tab-area',
+                                widgets: [disposedWidget],
+                                currentIndex: 0
+                            } as DockLayout.ITabAreaConfig
+                        ]
+                    } as DockLayout.ISplitAreaConfig
+                },
+                bottomPanel: undefined
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            getOrCreateWidgetStub.resetHistory();
+            setLayoutDataStub.resetHistory();
+
+            await service.switchPerspective('perspA');
+
+            expect(getOrCreateWidgetStub.calledWith('nested-widget')).to.be.true;
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            const splitArea = restoredLayout.mainPanel!.main as DockLayout.ISplitAreaConfig;
+            expect((splitArea.children[0] as DockLayout.ITabAreaConfig).widgets[0]).to.equal(liveWidget);
+            expect((splitArea.children[1] as DockLayout.ITabAreaConfig).widgets[0]).to.equal(freshWidget);
+        });
+
+        it('should handle empty/missing panel sections', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                mainPanel: undefined,
+                bottomPanel: undefined,
+                leftPanel: undefined,
+                rightPanel: undefined
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            setLayoutDataStub.resetHistory();
+
+            // Should not throw
+            await service.switchPerspective('perspA');
+
+            expect(setLayoutDataStub.calledOnce).to.be.true;
+        });
+
+        it('should heal bottom panel disposed widgets', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'bottom-widget';
+            disposedWidget.dispose();
+
+            const freshWidget = new Widget();
+            freshWidget.id = 'bottom-widget';
+            getOrCreateWidgetStub.withArgs('bottom-widget').resolves(freshWidget);
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                mainPanel: undefined,
+                bottomPanel: {
+                    config: {
+                        main: {
+                            type: 'tab-area',
+                            widgets: [disposedWidget],
+                            currentIndex: 0
+                        } as DockLayout.ITabAreaConfig
+                    }
+                }
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            getOrCreateWidgetStub.resetHistory();
+            setLayoutDataStub.resetHistory();
+
+            await service.switchPerspective('perspA');
+
+            expect(getOrCreateWidgetStub.calledWith('bottom-widget')).to.be.true;
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            expect((restoredLayout.bottomPanel!.config!.main as DockLayout.ITabAreaConfig).widgets[0]).to.equal(freshWidget);
+        });
+
+        it('should heal right panel disposed widgets', async () => {
+            service.registerPerspective({
+                id: 'perspA',
+                label: 'A',
+                viewPlacements: new Map()
+            });
+            service.registerPerspective({
+                id: 'perspB',
+                label: 'B',
+                viewPlacements: new Map()
+            });
+
+            const disposedWidget = new Widget();
+            disposedWidget.id = 'right-widget';
+            disposedWidget.dispose();
+
+            const freshWidget = new Widget();
+            freshWidget.id = 'right-widget';
+            getOrCreateWidgetStub.withArgs('right-widget').resolves(freshWidget);
+
+            const savedLayout: ApplicationShell.LayoutData = {
+                mainPanel: undefined,
+                bottomPanel: undefined,
+                rightPanel: {
+                    type: 'sidepanel',
+                    items: [{ widget: disposedWidget, rank: 0, expanded: true }]
+                } as SidePanel.LayoutData
+            };
+
+            await service.switchPerspective('perspA');
+            await service.switchPerspective('perspB');
+            service.setSavedLayout('perspA', savedLayout);
+
+            getOrCreateWidgetStub.resetHistory();
+            setLayoutDataStub.resetHistory();
+
+            await service.switchPerspective('perspA');
+
+            expect(getOrCreateWidgetStub.calledWith('right-widget')).to.be.true;
+            const restoredLayout = setLayoutDataStub.firstCall.args[0] as ApplicationShell.LayoutData;
+            expect(restoredLayout.rightPanel!.items![0].widget).to.equal(freshWidget);
+        });
+    });
+
+    describe('Plumbing API (layout persistence)', () => {
+        it('should expose defaultPerspectiveId matching the static constant', () => {
+            expect(service.defaultPerspectiveId).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+        });
+
+        it('should return default perspective ID when none is set', () => {
+            expect(service.getActivePerspectiveId()).to.equal(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
+        });
+
+        it('should return active perspective ID after switching', async () => {
+            service.registerPerspective({
+                id: 'test-persp',
+                label: 'Test',
+                viewPlacements: new Map()
+            });
+            await service.switchPerspective('test-persp');
+            expect(service.getActivePerspectiveId()).to.equal('test-persp');
+        });
+
+        it('should round-trip getSavedLayout/setSavedLayout', () => {
+            const layout = { mainPanel: { widgets: ['w1'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            service.setSavedLayout('persp-x', layout);
+
+            expect(service.getSavedLayout('persp-x')).to.equal(layout);
+        });
+
+        it('should return undefined for non-existent saved layout', () => {
+            expect(service.getSavedLayout('no-such-persp')).to.be.undefined;
+        });
+
+        it('should return correct saved perspective IDs', () => {
+            const layout1 = { mainPanel: {} } as unknown as ApplicationShell.LayoutData;
+            const layout2 = { mainPanel: {} } as unknown as ApplicationShell.LayoutData;
+            service.setSavedLayout('a', layout1);
+            service.setSavedLayout('b', layout2);
+
+            const ids = service.getSavedPerspectiveIds();
+            expect(ids).to.include('a');
+            expect(ids).to.include('b');
+            expect(ids).to.have.lengthOf(2);
+        });
+
+        it('should set active perspective ID only for registered perspectives', () => {
+            service.registerPerspective({
+                id: 'registered',
+                label: 'Registered',
+                viewPlacements: new Map()
+            });
+
+            expect(service.setActivePerspectiveId('registered')).to.be.true;
+            expect(service.getActivePerspectiveId()).to.equal('registered');
+
+            expect(service.setActivePerspectiveId('unregistered')).to.be.false;
+            expect(service.getActivePerspectiveId()).to.equal('registered');
+        });
+
+        it('should clear all saved layouts', () => {
+            const layout = { mainPanel: {} } as unknown as ApplicationShell.LayoutData;
+            service.setSavedLayout('a', layout);
+            service.setSavedLayout('b', layout);
+
+            service.clearSavedLayouts();
+
+            expect(service.getSavedPerspectiveIds()).to.have.lengthOf(0);
+            expect(service.getSavedLayout('a')).to.be.undefined;
+            expect(service.getSavedLayout('b')).to.be.undefined;
+        });
+    });
+
+    describe('collectWidgetIds', () => {
+        it('should collect IDs from side panel items', () => {
+            const widgetA = new Widget();
+            widgetA.id = 'widget-a';
+            const widgetB = new Widget();
+            widgetB.id = 'widget-b';
+
+            const layout: ApplicationShell.LayoutData = {
+                leftPanel: {
+                    type: 'sidepanel',
+                    items: [
+                        { widget: widgetA, rank: 0, expanded: true },
+                        { widget: widgetB, rank: 1, expanded: false }
+                    ]
+                } as SidePanel.LayoutData,
+                mainPanel: undefined,
+                bottomPanel: undefined
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.has('widget-a')).to.be.true;
+            expect(ids.has('widget-b')).to.be.true;
+            expect(ids.size).to.equal(2);
+        });
+
+        it('should collect IDs from dock panel tab-areas', () => {
+            const widgetA = new Widget();
+            widgetA.id = 'tab-widget-a';
+            const widgetB = new Widget();
+            widgetB.id = 'tab-widget-b';
+
+            const layout: ApplicationShell.LayoutData = {
+                mainPanel: {
+                    main: {
+                        type: 'tab-area',
+                        widgets: [widgetA, widgetB],
+                        currentIndex: 0
+                    } as DockLayout.ITabAreaConfig
+                },
+                bottomPanel: undefined
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.has('tab-widget-a')).to.be.true;
+            expect(ids.has('tab-widget-b')).to.be.true;
+            expect(ids.size).to.equal(2);
+        });
+
+        it('should collect IDs from nested split-areas', () => {
+            const widgetA = new Widget();
+            widgetA.id = 'split-a';
+            const widgetB = new Widget();
+            widgetB.id = 'split-b';
+
+            const layout: ApplicationShell.LayoutData = {
+                mainPanel: {
+                    main: {
+                        type: 'split-area',
+                        orientation: 'horizontal',
+                        sizes: [0.5, 0.5],
+                        children: [
+                            {
+                                type: 'tab-area',
+                                widgets: [widgetA],
+                                currentIndex: 0
+                            } as DockLayout.ITabAreaConfig,
+                            {
+                                type: 'tab-area',
+                                widgets: [widgetB],
+                                currentIndex: 0
+                            } as DockLayout.ITabAreaConfig
+                        ]
+                    } as DockLayout.ISplitAreaConfig
+                },
+                bottomPanel: undefined
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.has('split-a')).to.be.true;
+            expect(ids.has('split-b')).to.be.true;
+            expect(ids.size).to.equal(2);
+        });
+
+        it('should return empty set for empty/missing layout sections', () => {
+            const layout: ApplicationShell.LayoutData = {
+                mainPanel: undefined,
+                bottomPanel: undefined,
+                leftPanel: undefined,
+                rightPanel: undefined
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.size).to.equal(0);
+        });
+
+        it('should skip undefined widget entries in tab-areas', () => {
+            const widgetA = new Widget();
+            widgetA.id = 'valid-widget';
+
+            const layout: ApplicationShell.LayoutData = {
+                mainPanel: {
+                    main: {
+                        type: 'tab-area',
+                        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                        widgets: [widgetA, undefined as any],
+                        currentIndex: 0
+                    } as DockLayout.ITabAreaConfig
+                },
+                bottomPanel: undefined
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.has('valid-widget')).to.be.true;
+            expect(ids.size).to.equal(1);
+        });
+
+        it('should skip undefined widget entries in side panel items', () => {
+            const widgetA = new Widget();
+            widgetA.id = 'valid-side-widget';
+
+            const layout: ApplicationShell.LayoutData = {
+                leftPanel: {
+                    type: 'sidepanel',
+                    items: [
+                        { widget: widgetA, rank: 0, expanded: true },
+                        { widget: undefined, rank: 1, expanded: false }
+                    ]
+                } as SidePanel.LayoutData,
+                mainPanel: undefined,
+                bottomPanel: undefined
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.has('valid-side-widget')).to.be.true;
+            expect(ids.size).to.equal(1);
+        });
+
+        it('should collect IDs from bottom panel', () => {
+            const widgetA = new Widget();
+            widgetA.id = 'bottom-widget';
+
+            const layout: ApplicationShell.LayoutData = {
+                mainPanel: undefined,
+                bottomPanel: {
+                    config: {
+                        main: {
+                            type: 'tab-area',
+                            widgets: [widgetA],
+                            currentIndex: 0
+                        } as DockLayout.ITabAreaConfig
+                    }
+                }
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.has('bottom-widget')).to.be.true;
+            expect(ids.size).to.equal(1);
+        });
+
+        it('should collect IDs from all panels', () => {
+            const leftWidget = new Widget();
+            leftWidget.id = 'left-w';
+            const rightWidget = new Widget();
+            rightWidget.id = 'right-w';
+            const mainWidget = new Widget();
+            mainWidget.id = 'main-w';
+            const bottomWidget = new Widget();
+            bottomWidget.id = 'bottom-w';
+
+            const layout: ApplicationShell.LayoutData = {
+                leftPanel: {
+                    type: 'sidepanel',
+                    items: [{ widget: leftWidget, rank: 0, expanded: true }]
+                } as SidePanel.LayoutData,
+                rightPanel: {
+                    type: 'sidepanel',
+                    items: [{ widget: rightWidget, rank: 0, expanded: true }]
+                } as SidePanel.LayoutData,
+                mainPanel: {
+                    main: {
+                        type: 'tab-area',
+                        widgets: [mainWidget],
+                        currentIndex: 0
+                    } as DockLayout.ITabAreaConfig
+                },
+                bottomPanel: {
+                    config: {
+                        main: {
+                            type: 'tab-area',
+                            widgets: [bottomWidget],
+                            currentIndex: 0
+                        } as DockLayout.ITabAreaConfig
+                    }
+                }
+            };
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            const ids = (service as any).collectWidgetIds(layout);
+            expect(ids.has('left-w')).to.be.true;
+            expect(ids.has('right-w')).to.be.true;
+            expect(ids.has('main-w')).to.be.true;
+            expect(ids.has('bottom-w')).to.be.true;
+            expect(ids.size).to.equal(4);
+        });
+    });
+
+    describe('detachStrayWidgets', () => {
+        it('should detach a left-panel widget whose ID is not in the layout ID set', () => {
+            const strayWidget = new Widget();
+            strayWidget.id = 'stray-left';
+            const panel = new Panel();
+            Widget.attach(panel, document.body);
+            panel.addWidget(strayWidget);
+            expect(strayWidget.isAttached).to.be.true;
+
+            getWidgetsStub.withArgs('left').returns([strayWidget]);
+            getWidgetsStub.withArgs('right').returns([]);
+
+            const widgetIds = new Set<string>();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).detachStrayWidgets(widgetIds);
+
+            expect(strayWidget.isAttached).to.be.false;
+
+            panel.dispose();
+        });
+
+        it('should detach a right-panel widget whose ID is not in the layout ID set', () => {
+            const strayWidget = new Widget();
+            strayWidget.id = 'stray-right';
+            const panel = new Panel();
+            Widget.attach(panel, document.body);
+            panel.addWidget(strayWidget);
+            expect(strayWidget.isAttached).to.be.true;
+
+            getWidgetsStub.withArgs('left').returns([]);
+            getWidgetsStub.withArgs('right').returns([strayWidget]);
+
+            const widgetIds = new Set<string>();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).detachStrayWidgets(widgetIds);
+
+            expect(strayWidget.isAttached).to.be.false;
+
+            panel.dispose();
+        });
+
+        it('should NOT detach a widget whose ID IS in the layout ID set', () => {
+            const keptWidget = new Widget();
+            keptWidget.id = 'kept-widget';
+            const panel = new Panel();
+            Widget.attach(panel, document.body);
+            panel.addWidget(keptWidget);
+            expect(keptWidget.isAttached).to.be.true;
+
+            getWidgetsStub.withArgs('left').returns([keptWidget]);
+            getWidgetsStub.withArgs('right').returns([]);
+
+            const widgetIds = new Set<string>(['kept-widget']);
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).detachStrayWidgets(widgetIds);
+
+            expect(keptWidget.isAttached).to.be.true;
+
+            panel.dispose();
+        });
+
+        it('should handle empty side panels gracefully', () => {
+            getWidgetsStub.withArgs('left').returns([]);
+            getWidgetsStub.withArgs('right').returns([]);
+
+            const widgetIds = new Set<string>();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            expect(() => (service as any).detachStrayWidgets(widgetIds)).to.not.throw();
+        });
+
+        it('should detach non-viewPlacements widget that leaked from another perspective', () => {
+            // Simulate: Outline widget is in the left panel but not in the target layout
+            const outlineWidget = new Widget();
+            outlineWidget.id = 'outline-view';
+            const panel = new Panel();
+            Widget.attach(panel, document.body);
+            panel.addWidget(outlineWidget);
+
+            getWidgetsStub.withArgs('left').returns([outlineWidget]);
+            getWidgetsStub.withArgs('right').returns([]);
+
+            // Target layout has no widgets — outline should be detached
+            const widgetIds = new Set<string>();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).detachStrayWidgets(widgetIds);
+
+            expect(outlineWidget.isAttached).to.be.false;
+
+            panel.dispose();
+        });
+
+        it('should detach multiple stray widgets from both panels', () => {
+            const leftStray = new Widget();
+            leftStray.id = 'left-stray';
+            const rightStray = new Widget();
+            rightStray.id = 'right-stray';
+            const leftPanel = new Panel();
+            const rightPanel = new Panel();
+            Widget.attach(leftPanel, document.body);
+            Widget.attach(rightPanel, document.body);
+            leftPanel.addWidget(leftStray);
+            rightPanel.addWidget(rightStray);
+
+            getWidgetsStub.withArgs('left').returns([leftStray]);
+            getWidgetsStub.withArgs('right').returns([rightStray]);
+
+            const widgetIds = new Set<string>();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).detachStrayWidgets(widgetIds);
+
+            expect(leftStray.isAttached).to.be.false;
+            expect(rightStray.isAttached).to.be.false;
+
+            leftPanel.dispose();
+            rightPanel.dispose();
+        });
+
+        describe('stray widget cleanup during perspective switch', () => {
+            let parentPanel: Panel;
+
+            beforeEach(() => {
+                parentPanel = new Panel();
+                Widget.attach(parentPanel, document.body);
+            });
+
+            afterEach(() => {
+                parentPanel.dispose();
+            });
+
+            it('should detach stray widgets when restoring a saved layout', async () => {
+                const chatWidget = new Widget();
+                chatWidget.id = 'chat-view';
+                parentPanel.addWidget(chatWidget);
+
+                getOrCreateWidgetStub.withArgs('chat-view').resolves(chatWidget);
+
+                service.registerPerspective({
+                    id: 'perspA',
+                    label: 'A',
+                    viewPlacements: new Map([['chat-view', 'main' as ApplicationShell.Area]])
+                });
+                service.registerPerspective({
+                    id: 'perspB',
+                    label: 'B',
+                    viewPlacements: new Map()
+                });
+
+                // Activate A (first time — viewPlacements applied)
+                await service.switchPerspective('perspA');
+
+                // Simulate saving A's layout WITHOUT chat-view (user closed it)
+                const layoutAWithoutChat: ApplicationShell.LayoutData = {
+                    mainPanel: {
+                        main: {
+                            type: 'tab-area',
+                            widgets: [],
+                            currentIndex: -1
+                        } as DockLayout.ITabAreaConfig
+                    },
+                    bottomPanel: undefined
+                };
+                getLayoutDataStub.returns(layoutAWithoutChat);
+
+                // Switch to B (saves A's layout without chat)
+                await service.switchPerspective('perspB');
+
+                // chat-view is still attached (simulating the stray scenario)
+                expect(chatWidget.isAttached).to.be.true;
+
+                // When switching back to A, shell.getWidgets returns the stray
+                getWidgetsStub.withArgs('left').returns([chatWidget]);
+                getWidgetsStub.withArgs('right').returns([]);
+
+                // Switch back to A — should restore layout and detach stray chat-view
+                await service.switchPerspective('perspA');
+
+                expect(chatWidget.isAttached).to.be.false;
+            });
+
+            it('should NOT detach a widget that IS in the saved layout (user customization preserved)', async () => {
+                const chatWidget = new Widget();
+                chatWidget.id = 'chat-view';
+                parentPanel.addWidget(chatWidget);
+
+                getOrCreateWidgetStub.withArgs('chat-view').resolves(chatWidget);
+
+                service.registerPerspective({
+                    id: 'perspA',
+                    label: 'A',
+                    viewPlacements: new Map([['chat-view', 'main' as ApplicationShell.Area]])
+                });
+                service.registerPerspective({
+                    id: 'perspB',
+                    label: 'B',
+                    viewPlacements: new Map()
+                });
+
+                // Activate A
+                await service.switchPerspective('perspA');
+
+                // Simulate saving A's layout WITH chat-view in right panel
+                const layoutAWithChat: ApplicationShell.LayoutData = {
+                    rightPanel: {
+                        type: 'sidepanel',
+                        items: [{ widget: chatWidget, rank: 0, expanded: true }]
+                    } as SidePanel.LayoutData,
+                    mainPanel: undefined,
+                    bottomPanel: undefined
+                };
+                getLayoutDataStub.returns(layoutAWithChat);
+
+                // Switch to B (saves A's layout with chat)
+                await service.switchPerspective('perspB');
+
+                // When switching back, chat is in the right panel
+                getWidgetsStub.withArgs('left').returns([]);
+                getWidgetsStub.withArgs('right').returns([chatWidget]);
+
+                // Switch back to A — chat IS in layout, should NOT be detached
+                await service.switchPerspective('perspA');
+
+                expect(chatWidget.isAttached).to.be.true;
+            });
+
+            it('should detach non-viewPlacements widget leaking from another perspective', async () => {
+                // Outline is not in AI First's viewPlacements
+                const outlineWidget = new Widget();
+                outlineWidget.id = 'outline-view';
+                parentPanel.addWidget(outlineWidget);
+
+                service.registerPerspective({
+                    id: 'ai-first',
+                    label: 'AI First',
+                    viewPlacements: new Map([['chat-view', 'main' as ApplicationShell.Area]])
+                });
+                service.registerPerspective({
+                    id: 'default-persp',
+                    label: 'Default',
+                    viewPlacements: new Map()
+                });
+
+                // Activate AI First
+                await service.switchPerspective('ai-first');
+
+                // Save AI First layout without outline
+                const aiLayout: ApplicationShell.LayoutData = {
+                    mainPanel: {
+                        main: {
+                            type: 'tab-area',
+                            widgets: [],
+                            currentIndex: -1
+                        } as DockLayout.ITabAreaConfig
+                    },
+                    bottomPanel: undefined
+                };
+                getLayoutDataStub.returns(aiLayout);
+
+                // Switch to default (saves AI First layout)
+                await service.switchPerspective('default-persp');
+
+                // Outline is open in default's left panel
+                expect(outlineWidget.isAttached).to.be.true;
+
+                // Switch back to AI First — outline is a stray
+                getWidgetsStub.withArgs('left').returns([outlineWidget]);
+                getWidgetsStub.withArgs('right').returns([]);
+
+                await service.switchPerspective('ai-first');
+
+                // Outline should be detached (not in AI First's saved layout)
+                expect(outlineWidget.isAttached).to.be.false;
+            });
+        });
+    });
+});

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -37,7 +37,6 @@ describe('PerspectiveService', () => {
     let getLayoutDataStub: sinon.SinonStub;
     let setLayoutDataStub: sinon.SinonStub;
     let collapsePanelStub: sinon.SinonStub;
-    let setStatusBarHiddenByPerspectiveStub: sinon.SinonStub;
     let widgetAreaResolver: WidgetAreaResolverImpl;
     let tryGetWidgetStub: sinon.SinonStub;
     let getWidgetsStub: sinon.SinonStub;
@@ -59,7 +58,6 @@ describe('PerspectiveService', () => {
         getLayoutDataStub = sinon.stub().returns({ mainPanel: {}, bottomPanel: {} });
         setLayoutDataStub = sinon.stub().resolves();
         collapsePanelStub = sinon.stub().resolves();
-        setStatusBarHiddenByPerspectiveStub = sinon.stub();
         widgetAreaResolver = new WidgetAreaResolverImpl();
         getWidgetsStub = sinon.stub().returns([]);
         mockLogger = { debug: sinon.stub(), warn: sinon.stub() };
@@ -72,7 +70,6 @@ describe('PerspectiveService', () => {
             getLayoutData: getLayoutDataStub,
             setLayoutData: setLayoutDataStub,
             collapsePanel: collapsePanelStub,
-            setStatusBarHiddenByPerspective: setStatusBarHiddenByPerspectiveStub,
             getWidgets: getWidgetsStub
         };
 
@@ -501,31 +498,6 @@ describe('PerspectiveService', () => {
 
     // --- Chrome control options tests ---
 
-    it('should hide status bar when perspective has hideStatusBar', async () => {
-        service.registerPerspective({
-            id: 'chrome-test',
-            label: 'Chrome Test',
-            viewPlacements: new Map(),
-            chromeOptions: { hideStatusBar: true }
-        });
-
-        await service.switchPerspective('chrome-test');
-
-        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
-    });
-
-    it('should not hide status bar when perspective does not hide it', async () => {
-        service.registerPerspective({
-            id: 'no-chrome',
-            label: 'No Chrome',
-            viewPlacements: new Map()
-        });
-
-        await service.switchPerspective('no-chrome');
-
-        expect(setStatusBarHiddenByPerspectiveStub.calledWith(false)).to.be.true;
-    });
-
     it('should collapse areas on first activation only', async () => {
         service.registerPerspective({
             id: 'collapse-test',
@@ -554,35 +526,6 @@ describe('PerspectiveService', () => {
         // Switch back — should restore saved layout, NOT collapse again
         await service.switchPerspective('collapse-test');
         expect(collapsePanelStub.called).to.be.false;
-    });
-
-    it('should apply chrome options even when restoring saved layout', async () => {
-        service.registerPerspective({
-            id: 'chrome-test',
-            label: 'Chrome Test',
-            viewPlacements: new Map(),
-            chromeOptions: { hideStatusBar: true }
-        });
-        service.registerPerspective({
-            id: 'other',
-            label: 'Other',
-            viewPlacements: new Map()
-        });
-
-        // First activation
-        await service.switchPerspective('chrome-test');
-        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
-
-        setStatusBarHiddenByPerspectiveStub.resetHistory();
-
-        // Switch away (saves layout)
-        await service.switchPerspective('other');
-
-        setStatusBarHiddenByPerspectiveStub.resetHistory();
-
-        // Switch back (restores saved layout) — chrome should still be applied
-        await service.switchPerspective('chrome-test');
-        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
     });
 
     it('should collapse multiple areas on first activation', async () => {
@@ -769,39 +712,10 @@ describe('PerspectiveService', () => {
 
     // --- onLayoutRestored() tests ---
 
-    it('should apply chrome options when onLayoutRestored is called with a registered perspective', () => {
-        service.registerPerspective({
-            id: 'chrome-persp',
-            label: 'Chrome Persp',
-            viewPlacements: new Map(),
-            chromeOptions: { hideStatusBar: true }
-        });
+    it('should not throw when onLayoutRestored is called with an unregistered perspective', () => {
         service.initialize();
 
-        service.onLayoutRestored('chrome-persp');
-
-        expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
-    });
-
-    it('should not hide status bar when restored perspective has no chrome options', () => {
-        service.registerPerspective({
-            id: 'no-chrome-persp',
-            label: 'No Chrome',
-            viewPlacements: new Map()
-        });
-        service.initialize();
-
-        service.onLayoutRestored('no-chrome-persp');
-
-        expect(setStatusBarHiddenByPerspectiveStub.calledWith(false)).to.be.true;
-    });
-
-    it('should not apply chrome when onLayoutRestored is called with an unregistered perspective', () => {
-        service.initialize();
-
-        service.onLayoutRestored('non-existent');
-
-        expect(setStatusBarHiddenByPerspectiveStub.called).to.be.false;
+        expect(() => service.onLayoutRestored('non-existent')).to.not.throw();
     });
 
     // --- Rejection resilience tests ---
@@ -855,7 +769,6 @@ describe('PerspectiveService', () => {
         await service.switchPerspective('collapse-fail');
 
         expect(service.getActivePerspective()?.id).to.equal('collapse-fail');
-        expect(setStatusBarHiddenByPerspectiveStub.called).to.be.true;
         expect(eventSpy.calledOnce).to.be.true;
         expect(mockLogger.warn.calledOnce).to.be.true;
         expect(mockLogger.warn.firstCall.args[0]).to.equal('Failed to apply layout for perspective');
@@ -939,24 +852,6 @@ describe('PerspectiveService', () => {
             // Should re-apply viewPlacements
             expect(getOrCreateWidgetStub.calledWith('test-widget')).to.be.true;
             expect(addWidgetStub.called).to.be.true;
-        });
-
-        it('should re-apply chrome options (hideStatusBar) on reset', async () => {
-            service.registerPerspective({
-                id: 'chrome-reset',
-                label: 'Chrome Reset',
-                viewPlacements: new Map(),
-                chromeOptions: { hideStatusBar: true, collapseAreas: ['left', 'bottom'] }
-            });
-
-            await service.switchPerspective('chrome-reset');
-
-            setStatusBarHiddenByPerspectiveStub.resetHistory();
-
-            await service.resetCurrentPerspective();
-
-            // Chrome options (hideStatusBar) should always be re-applied
-            expect(setStatusBarHiddenByPerspectiveStub.calledWith(true)).to.be.true;
         });
 
         it('should call onActivate callback', async () => {

--- a/packages/core/src/browser/perspective-service.spec.ts
+++ b/packages/core/src/browser/perspective-service.spec.ts
@@ -19,7 +19,7 @@ const disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { PerspectiveServiceImpl, PerspectiveDescriptor } from './perspective-service';
+import { PerspectiveServiceImpl, PerspectiveDescriptor, WidgetAreaResolverImpl } from './perspective-service';
 import { ApplicationShell } from './shell/application-shell';
 import { AbstractViewContribution, ViewContributionOptions } from './shell/view-contribution';
 import { FrontendApplicationContribution } from './frontend-application-contribution';
@@ -38,7 +38,7 @@ describe('PerspectiveService', () => {
     let setLayoutDataStub: sinon.SinonStub;
     let collapsePanelStub: sinon.SinonStub;
     let setStatusBarHiddenByPerspectiveStub: sinon.SinonStub;
-    let setWidgetAreaResolverStub: sinon.SinonStub;
+    let widgetAreaResolver: WidgetAreaResolverImpl;
     let tryGetWidgetStub: sinon.SinonStub;
     let getWidgetsStub: sinon.SinonStub;
     let mockLogger: { debug: sinon.SinonStub; warn: sinon.SinonStub };
@@ -60,7 +60,7 @@ describe('PerspectiveService', () => {
         setLayoutDataStub = sinon.stub().resolves();
         collapsePanelStub = sinon.stub().resolves();
         setStatusBarHiddenByPerspectiveStub = sinon.stub();
-        setWidgetAreaResolverStub = sinon.stub();
+        widgetAreaResolver = new WidgetAreaResolverImpl();
         getWidgetsStub = sinon.stub().returns([]);
         mockLogger = { debug: sinon.stub(), warn: sinon.stub() };
 
@@ -73,7 +73,6 @@ describe('PerspectiveService', () => {
             setLayoutData: setLayoutDataStub,
             collapsePanel: collapsePanelStub,
             setStatusBarHiddenByPerspective: setStatusBarHiddenByPerspectiveStub,
-            setWidgetAreaResolver: setWidgetAreaResolverStub,
             getWidgets: getWidgetsStub
         };
 
@@ -88,6 +87,7 @@ describe('PerspectiveService', () => {
         (service as unknown as Record<string, unknown>)['shell'] = mockShell;
         (service as unknown as Record<string, unknown>)['widgetManager'] = mockWidgetManager;
         (service as unknown as Record<string, unknown>)['logger'] = mockLogger;
+        (service as unknown as Record<string, unknown>)['widgetAreaResolver'] = widgetAreaResolver;
         (service as unknown as Record<string, unknown>)['appContributions'] = {
             getContributions: () => [] as FrontendApplicationContribution[]
         };
@@ -612,16 +612,9 @@ describe('PerspectiveService', () => {
         expect(collapsePanelStub.called).to.be.false;
     });
 
-    // --- WidgetAreaResolver registration tests ---
+    // --- WidgetAreaResolver tests ---
 
-    it('should register a widget area resolver on the shell during initialize', () => {
-        service.initialize();
-
-        expect(setWidgetAreaResolverStub.calledOnce).to.be.true;
-        expect(typeof setWidgetAreaResolverStub.firstCall.args[0]).to.equal('function');
-    });
-
-    it('should resolve widget area from active perspective via the registered resolver', async () => {
+    it('should resolve widget area from active perspective via the WidgetAreaResolver', async () => {
         service.initialize();
 
         service.registerPerspective({
@@ -632,8 +625,7 @@ describe('PerspectiveService', () => {
 
         await service.switchPerspective('resolver-test');
 
-        const resolver = setWidgetAreaResolverStub.firstCall.args[0] as (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
-        expect(resolver('my-widget', 'left')).to.equal('right');
+        expect(widgetAreaResolver.resolveArea('my-widget', 'left')).to.equal('right');
     });
 
     it('should return undefined from the resolver for unmapped widgets', async () => {
@@ -647,16 +639,14 @@ describe('PerspectiveService', () => {
 
         await service.switchPerspective('resolver-test');
 
-        const resolver = setWidgetAreaResolverStub.firstCall.args[0] as (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
-        expect(resolver('unknown-widget', 'main')).to.be.undefined;
+        expect(widgetAreaResolver.resolveArea('unknown-widget', 'main')).to.be.undefined;
     });
 
     it('should return undefined from the resolver when default perspective is active', () => {
         service.initialize();
 
-        const resolver = setWidgetAreaResolverStub.firstCall.args[0] as (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
         // Default perspective has empty viewPlacements
-        expect(resolver('any-widget', 'main')).to.be.undefined;
+        expect(widgetAreaResolver.resolveArea('any-widget', 'main')).to.be.undefined;
     });
 
     // --- Logger tests ---
@@ -1083,8 +1073,7 @@ describe('PerspectiveService', () => {
     describe('resetDefaultPerspective', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         function createMockViewContribution(
-            options: ViewContributionOptions,
-            hasInitializeLayout: boolean = true
+            options: ViewContributionOptions
         ): AbstractViewContribution<Widget> & FrontendApplicationContribution {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             const contribution = Object.create(AbstractViewContribution.prototype) as any;
@@ -1094,17 +1083,12 @@ describe('PerspectiveService', () => {
                 tryGetWidget: tryGetWidgetStub
             };
             contribution.shell = (service as unknown as Record<string, unknown>)['shell'];
-            if (hasInitializeLayout) {
-                contribution.initializeLayout = sinon.stub().resolves();
-            }
+            contribution.openView = sinon.stub().resolves(testWidget);
             return contribution;
         }
 
-        function createMockNonViewContribution(hasInitializeLayout: boolean = true): FrontendApplicationContribution {
+        function createMockNonViewContribution(): FrontendApplicationContribution {
             const contrib: FrontendApplicationContribution = {};
-            if (hasInitializeLayout) {
-                contrib.initializeLayout = sinon.stub().resolves();
-            }
             return contrib;
         }
 
@@ -1196,7 +1180,7 @@ describe('PerspectiveService', () => {
             expect(addWidgetStub.called).to.be.false;
         });
 
-        it('should call initializeLayout on AbstractViewContribution instances', async () => {
+        it('should call openView on AbstractViewContribution instances', async () => {
             service.initialize();
 
             const contribution = createMockViewContribution({
@@ -1211,21 +1195,21 @@ describe('PerspectiveService', () => {
 
             await service.resetCurrentPerspective();
 
-            expect((contribution.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
+            expect((contribution.openView as sinon.SinonStub).calledOnce).to.be.true;
+            expect((contribution.openView as sinon.SinonStub).calledWith({ activate: false })).to.be.true;
         });
 
-        it('should NOT call initializeLayout on non-AbstractViewContribution contributions', async () => {
+        it('should NOT call openView on non-AbstractViewContribution contributions', async () => {
             service.initialize();
 
-            const nonViewContrib = createMockNonViewContribution(true);
+            const nonViewContrib = createMockNonViewContribution();
 
             (service as unknown as Record<string, unknown>)['appContributions'] = {
                 getContributions: () => [nonViewContrib]
             };
 
+            // Should not throw
             await service.resetCurrentPerspective();
-
-            expect((nonViewContrib.initializeLayout as sinon.SinonStub).called).to.be.false;
         });
 
         it('should handle combined scenario: open view in wrong area + closed view', async () => {
@@ -1266,9 +1250,9 @@ describe('PerspectiveService', () => {
 
             // Phase 1: Explorer should be relocated
             expect(addWidgetStub.calledWith(explorerWidget, sinon.match({ area: 'left' }))).to.be.true;
-            // Phase 2: Both should have initializeLayout called
-            expect((explorerContrib.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
-            expect((scmContrib.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
+            // Phase 2: Both should have openView called
+            expect((explorerContrib.openView as sinon.SinonStub).calledOnce).to.be.true;
+            expect((scmContrib.openView as sinon.SinonStub).calledOnce).to.be.true;
 
             panel.dispose();
         });
@@ -1306,7 +1290,7 @@ describe('PerspectiveService', () => {
             panel.dispose();
         });
 
-        it('should handle initializeLayout errors gracefully', async () => {
+        it('should handle openView errors gracefully', async () => {
             service.initialize();
 
             const contribution = createMockViewContribution({
@@ -1314,7 +1298,7 @@ describe('PerspectiveService', () => {
                 widgetName: 'Broken',
                 defaultWidgetOptions: { area: 'left' }
             });
-            (contribution.initializeLayout as sinon.SinonStub).rejects(new Error('init failed'));
+            (contribution.openView as sinon.SinonStub).rejects(new Error('openView failed'));
 
             (service as unknown as Record<string, unknown>)['appContributions'] = {
                 getContributions: () => [contribution]
@@ -1373,7 +1357,7 @@ describe('PerspectiveService', () => {
             expect(spy.calledWith(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID)).to.be.true;
         });
 
-        it('should skip contributions without defaultViewOptions.area', async () => {
+        it('should skip contributions without defaultViewOptions.area in Phase 1', async () => {
             service.initialize();
 
             const contribution = createMockViewContribution({
@@ -1391,28 +1375,8 @@ describe('PerspectiveService', () => {
             await service.resetCurrentPerspective();
 
             // Phase 1 should skip (no target area)
-            // Phase 2 should still call initializeLayout
-            expect((contribution.initializeLayout as sinon.SinonStub).calledOnce).to.be.true;
-        });
-
-        it('should skip AbstractViewContribution without initializeLayout in Phase 2', async () => {
-            service.initialize();
-
-            const contribution = createMockViewContribution({
-                widgetId: 'no-init',
-                widgetName: 'No Init',
-                defaultWidgetOptions: { area: 'left' }
-            }, false);
-
-            (service as unknown as Record<string, unknown>)['appContributions'] = {
-                getContributions: () => [contribution]
-            };
-
-            // Should not throw
-            await service.resetCurrentPerspective();
-
-            // No initializeLayout to call
-            expect(contribution.initializeLayout).to.be.undefined;
+            // Phase 2 should still call openView
+            expect((contribution.openView as sinon.SinonStub).calledOnce).to.be.true;
         });
     });
 

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -1,0 +1,583 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable, named, optional } from 'inversify';
+import { DockLayout } from '@lumino/widgets';
+import { ApplicationShell } from './shell/application-shell';
+import { SidePanel } from './shell/side-panel-handler';
+import { FrontendApplicationContribution } from './frontend-application-contribution';
+import { AbstractViewContribution } from './shell/view-contribution';
+import { WidgetManager } from './widget-manager';
+import { ContributionProvider } from '../common/contribution-provider';
+import { Command, CommandContribution, CommandRegistry } from '../common/command';
+import { Emitter, Event } from '../common/event';
+import { ILogger } from '../common/logger';
+import { QuickInputService, QuickPickItem } from '../common/quick-pick-service';
+import { nls } from '../common/nls';
+import { DisposableCollection } from '../common/disposable';
+import { CommonCommands } from './common-commands';
+
+export interface PerspectiveChromeOptions {
+    /** Hide the status bar. Default: false. */
+    hideStatusBar?: boolean;
+    /** Areas to collapse on first activation. User can re-expand freely. */
+    collapseAreas?: ('left' | 'right' | 'bottom')[];
+}
+
+export interface PerspectiveDescriptor {
+    id: string;
+    label: string;
+    /** Widget/view-container ID → target shell area */
+    viewPlacements: Map<string, ApplicationShell.Area>;
+    /** Chrome control options for this perspective */
+    chromeOptions?: PerspectiveChromeOptions;
+    /** Called when perspective is activated */
+    onActivate?(shell: ApplicationShell): void;
+    /** Called when switching away */
+    onDeactivate?(shell: ApplicationShell): void;
+}
+
+export const PerspectiveService = Symbol('PerspectiveService');
+export interface PerspectiveService {
+    // --- High-level API (for general consumers) ---
+
+    /** Event fired whenever the active perspective changes. The payload is the new perspective ID. */
+    readonly onDidChangePerspective: Event<string>;
+
+    /**
+     * Registers a new perspective descriptor.
+     * Contributions should call this from their `PerspectiveContribution.registerPerspectives` callback.
+     */
+    registerPerspective(descriptor: PerspectiveDescriptor): void;
+
+    /**
+     * Switches the workbench to the given perspective.
+     * Saves the current perspective's layout, then restores the target perspective's layout
+     * (or applies its `viewPlacements` on first activation). Concurrent calls are serialized.
+     */
+    switchPerspective(id: string): Promise<void>;
+
+    /** Returns the descriptor of the currently active perspective, or `undefined` if none. */
+    getActivePerspective(): PerspectiveDescriptor | undefined;
+
+    /** Returns the target shell area for a widget in the active perspective, or `undefined` if unmapped. */
+    getAreaForView(viewId: string): ApplicationShell.Area | undefined;
+
+    /** Returns all registered perspective descriptors. */
+    getRegisteredPerspectives(): PerspectiveDescriptor[];
+
+    /** Returns the ID of the currently active perspective. A convenient alternative to `getActivePerspective()?.id` that always returns a string. */
+    getActivePerspectiveId(): string;
+
+    // --- Plumbing API (for layout persistence infrastructure, not general consumers) ---
+
+    /**
+     * Returns the IDs of all perspectives that have a saved (in-memory) layout snapshot.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for layout persistence.
+     */
+    getSavedPerspectiveIds(): string[];
+
+    /**
+     * Returns the saved in-memory layout for a perspective, or `undefined` if none exists.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for layout persistence.
+     */
+    getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined;
+
+    /**
+     * Stores an in-memory layout snapshot for a perspective.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for layout persistence.
+     */
+    setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void;
+
+    /**
+     * Sets the active perspective ID (without triggering a switch).
+     * Returns `true` if the ID corresponds to a registered perspective, `false` otherwise.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` during layout restore.
+     */
+    setActivePerspectiveId(id: string): boolean;
+
+    /**
+     * The ID of the built-in default perspective.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for legacy migration.
+     */
+    readonly defaultPerspectiveId: string;
+
+    /**
+     * Clears all saved in-memory layout snapshots.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` during layout reset.
+     */
+    clearSavedLayouts(): void;
+
+    /**
+     * Called by `ShellLayoutRestorer` after restoring a persisted layout to apply chrome options
+     * (e.g., status bar visibility) for the given perspective.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` after layout restore.
+     */
+    onLayoutRestored(activePerspectiveId: string): void;
+
+    /**
+     * Resets the active perspective to its programmatic state (viewPlacements from its descriptor),
+     * discarding the saved layout. Does not affect other perspectives.
+     */
+    resetCurrentPerspective(): Promise<void>;
+}
+
+export const PerspectiveContribution = Symbol('PerspectiveContribution');
+export interface PerspectiveContribution {
+    registerPerspectives(service: PerspectiveService): void;
+}
+
+@injectable()
+export class PerspectiveServiceImpl implements FrontendApplicationContribution, CommandContribution, PerspectiveService {
+
+    static readonly SWITCH_PERSPECTIVE_COMMAND = Command.toLocalizedCommand({
+        id: 'perspective.switch',
+        category: 'View',
+        label: 'Switch Perspective'
+    }, 'theia/core/perspective/switchPerspective', CommonCommands.VIEW_CATEGORY_KEY);
+
+    static readonly RESET_PERSPECTIVE_COMMAND = Command.toLocalizedCommand({
+        id: 'perspective.reset',
+        category: 'View',
+        label: 'Reset Perspective'
+    }, 'theia/core/perspective/resetPerspective', CommonCommands.VIEW_CATEGORY_KEY);
+
+    @inject(ApplicationShell)
+    protected readonly shell: ApplicationShell;
+
+    @inject(WidgetManager)
+    protected readonly widgetManager: WidgetManager;
+
+    @inject(ContributionProvider) @named(PerspectiveContribution) @optional()
+    protected readonly contributions: ContributionProvider<PerspectiveContribution> | undefined;
+
+    @inject(ContributionProvider) @named(FrontendApplicationContribution)
+    protected readonly appContributions: ContributionProvider<FrontendApplicationContribution>;
+
+    @inject(QuickInputService) @optional()
+    protected readonly quickInputService: QuickInputService | undefined;
+
+    @inject(ILogger) @named('core:PerspectiveService')
+    protected readonly logger: ILogger;
+
+    static readonly DEFAULT_PERSPECTIVE_ID = 'default';
+
+    readonly defaultPerspectiveId = PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
+
+    protected readonly perspectives = new Map<string, PerspectiveDescriptor>();
+    protected activePerspectiveId: string | undefined;
+    protected readonly savedLayouts = new Map<string, ApplicationShell.LayoutData>();
+
+    protected readonly onDidChangePerspectiveEmitter = new Emitter<string>();
+    readonly onDidChangePerspective: Event<string> = this.onDidChangePerspectiveEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection();
+    protected switchInProgress: Promise<void> | undefined;
+
+    onLayoutRestored(activePerspectiveId: string): void {
+        const descriptor = this.perspectives.get(activePerspectiveId);
+        if (descriptor) {
+            this.applyChrome(descriptor);
+        }
+    }
+
+    initialize(): void {
+        this.registerPerspective({
+            id: PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID,
+            label: nls.localizeByDefault('Default'),
+            viewPlacements: new Map()
+        });
+        this.activePerspectiveId = PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
+
+        this.shell.setWidgetAreaResolver((widgetId, _requestedArea) =>
+            this.getAreaForView(widgetId)
+        );
+
+        if (this.contributions) {
+            for (const contribution of this.contributions.getContributions()) {
+                contribution.registerPerspectives(this);
+            }
+        }
+
+        this.toDispose.push(this.onDidChangePerspectiveEmitter);
+    }
+
+    registerPerspective(descriptor: PerspectiveDescriptor): void {
+        this.perspectives.set(descriptor.id, descriptor);
+    }
+
+    async switchPerspective(id: string): Promise<void> {
+        const pending = (this.switchInProgress ?? Promise.resolve())
+            .then(() => this.doSwitchPerspective(id));
+        this.switchInProgress = pending;
+        try {
+            await pending;
+        } finally {
+            if (this.switchInProgress === pending) {
+                this.switchInProgress = undefined;
+            }
+        }
+    }
+
+    protected async doSwitchPerspective(id: string): Promise<void> {
+        if (id === this.activePerspectiveId) {
+            return;
+        }
+
+        const descriptor = this.perspectives.get(id);
+        if (!descriptor) {
+            return;
+        }
+
+        const oldPerspective = this.getActivePerspective();
+        if (oldPerspective?.onDeactivate) {
+            oldPerspective.onDeactivate(this.shell);
+        }
+
+        if (this.activePerspectiveId) {
+            this.savedLayouts.set(this.activePerspectiveId, this.shell.getLayoutData());
+        }
+
+        this.activePerspectiveId = id;
+
+        try {
+            const savedLayout = this.savedLayouts.get(id);
+            if (savedLayout) {
+                const layoutWidgetIds = this.collectWidgetIds(savedLayout);
+                await this.healLayoutData(savedLayout);
+                await this.shell.setLayoutData(savedLayout);
+                this.detachStrayWidgets(layoutWidgetIds);
+            } else {
+                await this.applyViewPlacements(descriptor);
+            }
+        } catch (error) {
+            this.logger.warn('Failed to apply layout for perspective', error);
+        }
+
+        if (descriptor.onActivate) {
+            descriptor.onActivate(this.shell);
+        }
+
+        this.applyChrome(descriptor);
+
+        this.onDidChangePerspectiveEmitter.fire(id);
+    }
+
+    protected async applyViewPlacements(descriptor: PerspectiveDescriptor): Promise<void> {
+        for (const [viewId, area] of descriptor.viewPlacements) {
+            try {
+                const widget = await this.widgetManager.getOrCreateWidget(viewId);
+                const currentTabBar = this.shell.getTabBarFor(widget);
+                if (currentTabBar) {
+                    const currentArea = this.shell.getAreaFor(widget);
+                    if (currentArea === area) {
+                        continue;
+                    }
+                }
+                await this.shell.addWidget(widget, { area });
+            } catch (error) {
+                this.logger.warn('Failed to create or place widget for perspective', error);
+            }
+        }
+
+        for (const [viewId] of descriptor.viewPlacements) {
+            try {
+                await this.shell.activateWidget(viewId);
+            } catch (error) {
+                this.logger.warn('Failed to activate widget for perspective', error);
+            }
+        }
+
+        if (descriptor.chromeOptions?.collapseAreas) {
+            for (const area of descriptor.chromeOptions.collapseAreas) {
+                await this.shell.collapsePanel(area);
+            }
+        }
+    }
+
+    async resetCurrentPerspective(): Promise<void> {
+        const pending = (this.switchInProgress ?? Promise.resolve())
+            .then(() => this.doResetCurrentPerspective());
+        this.switchInProgress = pending;
+        try {
+            await pending;
+        } finally {
+            if (this.switchInProgress === pending) {
+                this.switchInProgress = undefined;
+            }
+        }
+    }
+
+    protected async doResetCurrentPerspective(): Promise<void> {
+        const descriptor = this.getActivePerspective();
+        if (!descriptor) {
+            return;
+        }
+
+        this.savedLayouts.delete(descriptor.id);
+
+        try {
+            if (descriptor.id === PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID) {
+                await this.resetDefaultPerspective();
+            } else {
+                await this.applyViewPlacements(descriptor);
+            }
+        } catch (error) {
+            this.logger.warn('Failed to apply layout for perspective', error);
+        }
+
+        if (descriptor.onActivate) {
+            descriptor.onActivate(this.shell);
+        }
+
+        this.applyChrome(descriptor);
+
+        this.onDidChangePerspectiveEmitter.fire(descriptor.id);
+    }
+
+    protected async resetDefaultPerspective(): Promise<void> {
+        // Phase 1: Relocate open views to their default areas
+        for (const contribution of this.appContributions.getContributions()) {
+            if (contribution instanceof AbstractViewContribution) {
+                const widgetId = contribution.effectiveWidgetId;
+                const targetArea = contribution.defaultViewOptions?.area;
+                if (!widgetId || !targetArea) {
+                    continue;
+                }
+                const widget = this.widgetManager.tryGetWidget(widgetId);
+                if (widget && !widget.isDisposed && widget.isAttached) {
+                    const currentArea = this.shell.getAreaFor(widget);
+                    if (currentArea && currentArea !== targetArea) {
+                        try {
+                            await this.shell.addWidget(widget, { area: targetArea });
+                        } catch (error) {
+                            this.logger.warn('Failed to relocate widget during default perspective reset', widgetId, error);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Phase 2: Re-run initializeLayout on AbstractViewContribution instances
+        // to restore closed views. Non-view contributions (e.g., Terminal) are
+        // skipped to avoid side effects like creating new terminal instances.
+        for (const contribution of this.appContributions.getContributions()) {
+            if (contribution instanceof AbstractViewContribution && contribution.initializeLayout) {
+                try {
+                    await contribution.initializeLayout(undefined!);
+                } catch (error) {
+                    this.logger.warn('Failed to run initializeLayout during default perspective reset', error);
+                }
+            }
+        }
+    }
+
+    protected applyChrome(descriptor: PerspectiveDescriptor): void {
+        this.shell.setStatusBarHiddenByPerspective(descriptor.chromeOptions?.hideStatusBar ?? false);
+    }
+
+    /**
+     * Views may be shared between multiple perspective. If a view exists in two or more perspectives
+     * and is closed in one of them, the shared widget is disposed. When switching back to the other
+     * perspective, we need to restore this widget (i.e. reopen the view).
+     * @param layout
+     */
+    protected async healLayoutData(layout: ApplicationShell.LayoutData): Promise<void> {
+        if (layout.leftPanel) {
+            await this.healSidePanelLayout(layout.leftPanel);
+        }
+        if (layout.rightPanel) {
+            await this.healSidePanelLayout(layout.rightPanel);
+        }
+        if (layout.mainPanel?.main) {
+            await this.healDockAreaConfig(layout.mainPanel.main);
+        }
+        if (layout.bottomPanel?.config?.main) {
+            await this.healDockAreaConfig(layout.bottomPanel.config.main);
+        }
+    }
+
+    protected async healSidePanelLayout(layout: SidePanel.LayoutData): Promise<void> {
+        if (!layout.items) {
+            return;
+        }
+        for (const item of layout.items) {
+            if (item.widget?.isDisposed) {
+                try {
+                    item.widget = await this.widgetManager.getOrCreateWidget(item.widget.id);
+                } catch (error) {
+                    this.logger.warn('Failed to recreate disposed widget for perspective layout', item.widget.id, error);
+                    item.widget = undefined;
+                }
+            }
+        }
+    }
+
+    protected async healDockAreaConfig(config: DockLayout.ITabAreaConfig | DockLayout.ISplitAreaConfig): Promise<void> {
+        if (config.type === 'tab-area') {
+            for (let i = 0; i < config.widgets.length; i++) {
+                const widget = config.widgets[i];
+                if (widget.isDisposed) {
+                    try {
+                        config.widgets[i] = await this.widgetManager.getOrCreateWidget(widget.id);
+                    } catch (error) {
+                        this.logger.warn('Failed to recreate disposed widget for perspective layout', widget.id, error);
+                        config.widgets.splice(i, 1);
+                        i--;
+                    }
+                }
+            }
+        } else if (config.type === 'split-area') {
+            for (const child of config.children) {
+                await this.healDockAreaConfig(child);
+            }
+        }
+    }
+
+    protected collectWidgetIds(layout: ApplicationShell.LayoutData): Set<string> {
+        const ids = new Set<string>();
+        if (layout.leftPanel) {
+            this.collectSidePanelWidgetIds(layout.leftPanel, ids);
+        }
+        if (layout.rightPanel) {
+            this.collectSidePanelWidgetIds(layout.rightPanel, ids);
+        }
+        if (layout.mainPanel?.main) {
+            this.collectDockWidgetIds(layout.mainPanel.main, ids);
+        }
+        if (layout.bottomPanel?.config?.main) {
+            this.collectDockWidgetIds(layout.bottomPanel.config.main, ids);
+        }
+        return ids;
+    }
+
+    protected collectSidePanelWidgetIds(layout: SidePanel.LayoutData, ids: Set<string>): void {
+        if (layout.items) {
+            for (const item of layout.items) {
+                if (item.widget) {
+                    ids.add(item.widget.id);
+                }
+            }
+        }
+    }
+
+    protected collectDockWidgetIds(
+        config: DockLayout.ITabAreaConfig | DockLayout.ISplitAreaConfig,
+        ids: Set<string>
+    ): void {
+        if (config.type === 'tab-area') {
+            for (const widget of config.widgets) {
+                if (widget) {
+                    ids.add(widget.id);
+                }
+            }
+        } else if (config.type === 'split-area') {
+            for (const child of config.children) {
+                this.collectDockWidgetIds(child, ids);
+            }
+        }
+    }
+
+    protected detachStrayWidgets(layoutWidgetIds: Set<string>): void {
+        const sidePanelAreas: ApplicationShell.Area[] = ['left', 'right'];
+        for (const area of sidePanelAreas) {
+            for (const widget of this.shell.getWidgets(area)) {
+                if (!layoutWidgetIds.has(widget.id)) {
+                    // eslint-disable-next-line no-null/no-null
+                    widget.parent = null;
+                }
+            }
+        }
+    }
+
+    getActivePerspective(): PerspectiveDescriptor | undefined {
+        if (this.activePerspectiveId) {
+            return this.perspectives.get(this.activePerspectiveId);
+        }
+        return undefined;
+    }
+
+    getAreaForView(viewId: string): ApplicationShell.Area | undefined {
+        const active = this.getActivePerspective();
+        if (active) {
+            return active.viewPlacements.get(viewId);
+        }
+        return undefined;
+    }
+
+    getRegisteredPerspectives(): PerspectiveDescriptor[] {
+        return Array.from(this.perspectives.values());
+    }
+
+    getActivePerspectiveId(): string {
+        return this.activePerspectiveId ?? PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
+    }
+
+    getSavedPerspectiveIds(): string[] {
+        return Array.from(this.savedLayouts.keys());
+    }
+
+    getSavedLayout(perspectiveId: string): ApplicationShell.LayoutData | undefined {
+        return this.savedLayouts.get(perspectiveId);
+    }
+
+    setSavedLayout(perspectiveId: string, layout: ApplicationShell.LayoutData): void {
+        this.savedLayouts.set(perspectiveId, layout);
+    }
+
+    setActivePerspectiveId(id: string): boolean {
+        if (this.perspectives.has(id)) {
+            this.activePerspectiveId = id;
+            return true;
+        }
+        return false;
+    }
+
+    clearSavedLayouts(): void {
+        this.savedLayouts.clear();
+    }
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(PerspectiveServiceImpl.SWITCH_PERSPECTIVE_COMMAND, {
+            execute: () => this.showPerspectivePicker(),
+            isEnabled: () => this.perspectives.size > 0
+        });
+        commands.registerCommand(PerspectiveServiceImpl.RESET_PERSPECTIVE_COMMAND, {
+            execute: () => this.resetCurrentPerspective(),
+            isEnabled: () => this.activePerspectiveId !== undefined
+        });
+    }
+
+    protected async showPerspectivePicker(): Promise<void> {
+        if (!this.quickInputService) {
+            return;
+        }
+
+        const items: QuickPickItem[] = this.getRegisteredPerspectives().map(p => ({
+            label: p.label,
+            id: p.id,
+            description: this.activePerspectiveId === p.id ? nls.localizeByDefault('Active') : undefined
+        }));
+
+        const selected = await this.quickInputService.showQuickPick(items, {
+            placeholder: nls.localize('theia/core/perspective/selectPerspective', 'Select a perspective')
+        });
+
+        if (selected?.id) {
+            await this.switchPerspective(selected.id);
+        }
+    }
+}

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named, optional } from 'inversify';
 import { DockLayout } from '@lumino/widgets';
-import { ApplicationShell } from './shell/application-shell';
+import { ApplicationShell, WidgetAreaResolver } from './shell/application-shell';
 import { SidePanel } from './shell/side-panel-handler';
 import { FrontendApplicationContribution } from './frontend-application-contribution';
 import { AbstractViewContribution } from './shell/view-contribution';
@@ -27,8 +27,10 @@ import { Emitter, Event } from '../common/event';
 import { ILogger } from '../common/logger';
 import { QuickInputService, QuickPickItem } from '../common/quick-pick-service';
 import { nls } from '../common/nls';
-import { DisposableCollection } from '../common/disposable';
 import { CommonCommands } from './common-commands';
+import { ContextKeyService } from './context-key-service';
+
+export const ACTIVE_PERSPECTIVE_CONTEXT_KEY = 'activePerspectiveId';
 
 export interface PerspectiveChromeOptions {
     /** Hide the status bar. Default: false. */
@@ -44,6 +46,8 @@ export interface PerspectiveDescriptor {
     viewPlacements: Map<string, ApplicationShell.Area>;
     /** Chrome control options for this perspective */
     chromeOptions?: PerspectiveChromeOptions;
+    /** Per-area primary view: the widget to activate last in each shell area, so it gets focus. */
+    primaryViews?: Partial<Record<ApplicationShell.Area, string>>;
     /** Called when perspective is activated */
     onActivate?(shell: ApplicationShell): void;
     /** Called when switching away */
@@ -82,7 +86,24 @@ export interface PerspectiveService {
     /** Returns the ID of the currently active perspective. A convenient alternative to `getActivePerspective()?.id` that always returns a string. */
     getActivePerspectiveId(): string;
 
-    // --- Plumbing API (for layout persistence infrastructure, not general consumers) ---
+    /**
+     * Resets the active perspective to its programmatic state (viewPlacements from its descriptor),
+     * discarding the saved layout. Does not affect other perspectives.
+     */
+    resetCurrentPerspective(): Promise<void>;
+}
+
+export const PerspectiveServiceInternal = Symbol('PerspectiveServiceInternal');
+/**
+ * Internal plumbing API for layout persistence infrastructure.
+ * General consumers should use {@link PerspectiveService} instead.
+ */
+export interface PerspectiveServiceInternal {
+    /**
+     * Returns the ID of the currently active perspective.
+     * @internal Plumbing API, used by `ShellLayoutRestorer` for layout persistence.
+     */
+    getActivePerspectiveId(): string;
 
     /**
      * Returns the IDs of all perspectives that have a saved (in-memory) layout snapshot.
@@ -127,12 +148,6 @@ export interface PerspectiveService {
      * @internal Plumbing API, used by `ShellLayoutRestorer` after layout restore.
      */
     onLayoutRestored(activePerspectiveId: string): void;
-
-    /**
-     * Resets the active perspective to its programmatic state (viewPlacements from its descriptor),
-     * discarding the saved layout. Does not affect other perspectives.
-     */
-    resetCurrentPerspective(): Promise<void>;
 }
 
 export const PerspectiveContribution = Symbol('PerspectiveContribution');
@@ -141,18 +156,31 @@ export interface PerspectiveContribution {
 }
 
 @injectable()
-export class PerspectiveServiceImpl implements FrontendApplicationContribution, CommandContribution, PerspectiveService {
+export class WidgetAreaResolverImpl implements WidgetAreaResolver {
+    protected activePlacementMap = new Map<string, ApplicationShell.Area>();
+
+    setActivePlacementMap(map: Map<string, ApplicationShell.Area>): void {
+        this.activePlacementMap = map;
+    }
+
+    resolveArea(widgetId: string, requestedArea: ApplicationShell.Area): ApplicationShell.Area | undefined {
+        return this.activePlacementMap.get(widgetId);
+    }
+}
+
+@injectable()
+export class PerspectiveServiceImpl implements FrontendApplicationContribution, CommandContribution, PerspectiveService, PerspectiveServiceInternal {
 
     static readonly SWITCH_PERSPECTIVE_COMMAND = Command.toLocalizedCommand({
         id: 'perspective.switch',
-        category: 'View',
-        label: 'Switch Perspective'
+        category: CommonCommands.VIEW_CATEGORY,
+        label: 'Switch Perspective (Experimental)'
     }, 'theia/core/perspective/switchPerspective', CommonCommands.VIEW_CATEGORY_KEY);
 
     static readonly RESET_PERSPECTIVE_COMMAND = Command.toLocalizedCommand({
         id: 'perspective.reset',
-        category: 'View',
-        label: 'Reset Perspective'
+        category: CommonCommands.VIEW_CATEGORY,
+        label: 'Reset Perspective (Experimental)'
     }, 'theia/core/perspective/resetPerspective', CommonCommands.VIEW_CATEGORY_KEY);
 
     @inject(ApplicationShell)
@@ -173,6 +201,12 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
     @inject(ILogger) @named('core:PerspectiveService')
     protected readonly logger: ILogger;
 
+    @inject(WidgetAreaResolver)
+    protected readonly widgetAreaResolver: WidgetAreaResolver;
+
+    @inject(ContextKeyService) @optional()
+    protected readonly contextKeyService: ContextKeyService | undefined;
+
     static readonly DEFAULT_PERSPECTIVE_ID = 'default';
 
     readonly defaultPerspectiveId = PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
@@ -184,7 +218,6 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
     protected readonly onDidChangePerspectiveEmitter = new Emitter<string>();
     readonly onDidChangePerspective: Event<string> = this.onDidChangePerspectiveEmitter.event;
 
-    protected readonly toDispose = new DisposableCollection();
     protected switchInProgress: Promise<void> | undefined;
 
     onLayoutRestored(activePerspectiveId: string): void {
@@ -192,6 +225,7 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
         if (descriptor) {
             this.applyChrome(descriptor);
         }
+        this.updateActivePerspectiveContextKey(activePerspectiveId);
     }
 
     initialize(): void {
@@ -201,18 +235,21 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
             viewPlacements: new Map()
         });
         this.activePerspectiveId = PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID;
-
-        this.shell.setWidgetAreaResolver((widgetId, _requestedArea) =>
-            this.getAreaForView(widgetId)
-        );
+        this.updateActivePerspectiveContextKey(PerspectiveServiceImpl.DEFAULT_PERSPECTIVE_ID);
 
         if (this.contributions) {
             for (const contribution of this.contributions.getContributions()) {
                 contribution.registerPerspectives(this);
             }
         }
+    }
 
-        this.toDispose.push(this.onDidChangePerspectiveEmitter);
+    onStop(): void {
+        this.onDidChangePerspectiveEmitter.dispose();
+    }
+
+    protected updateActivePerspectiveContextKey(id: string): void {
+        this.contextKeyService?.createKey<string>(ACTIVE_PERSPECTIVE_CONTEXT_KEY, id).set(id);
     }
 
     registerPerspective(descriptor: PerspectiveDescriptor): void {
@@ -221,6 +258,7 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
 
     async switchPerspective(id: string): Promise<void> {
         const pending = (this.switchInProgress ?? Promise.resolve())
+            .catch(() => { /* swallow previous rejection so next switch can proceed */ })
             .then(() => this.doSwitchPerspective(id));
         this.switchInProgress = pending;
         try {
@@ -252,6 +290,7 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
         }
 
         this.activePerspectiveId = id;
+        this.widgetAreaResolver.setActivePlacementMap(descriptor.viewPlacements);
 
         try {
             const savedLayout = this.savedLayouts.get(id);
@@ -272,6 +311,7 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
         }
 
         this.applyChrome(descriptor);
+        this.updateActivePerspectiveContextKey(id);
 
         this.onDidChangePerspectiveEmitter.fire(id);
     }
@@ -301,6 +341,18 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
             }
         }
 
+        if (descriptor.primaryViews) {
+            for (const viewId of Object.values(descriptor.primaryViews)) {
+                if (viewId) {
+                    try {
+                        await this.shell.activateWidget(viewId);
+                    } catch (error) {
+                        this.logger.warn('Failed to activate primary view for perspective', error);
+                    }
+                }
+            }
+        }
+
         if (descriptor.chromeOptions?.collapseAreas) {
             for (const area of descriptor.chromeOptions.collapseAreas) {
                 await this.shell.collapsePanel(area);
@@ -310,6 +362,7 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
 
     async resetCurrentPerspective(): Promise<void> {
         const pending = (this.switchInProgress ?? Promise.resolve())
+            .catch(() => { /* swallow previous rejection so next reset can proceed */ })
             .then(() => this.doResetCurrentPerspective());
         this.switchInProgress = pending;
         try {
@@ -371,15 +424,15 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
             }
         }
 
-        // Phase 2: Re-run initializeLayout on AbstractViewContribution instances
-        // to restore closed views. Non-view contributions (e.g., Terminal) are
-        // skipped to avoid side effects like creating new terminal instances.
+        // Phase 2: Re-open closed views via openView({ activate: false }).
+        // Non-view contributions (e.g., Terminal) are skipped to avoid side effects
+        // like creating new terminal instances.
         for (const contribution of this.appContributions.getContributions()) {
-            if (contribution instanceof AbstractViewContribution && contribution.initializeLayout) {
+            if (contribution instanceof AbstractViewContribution) {
                 try {
-                    await contribution.initializeLayout(undefined!);
+                    await contribution.openView({ activate: false });
                 } catch (error) {
-                    this.logger.warn('Failed to run initializeLayout during default perspective reset', error);
+                    this.logger.warn('Failed to open view during default perspective reset', error);
                 }
             }
         }
@@ -496,6 +549,8 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
         for (const area of sidePanelAreas) {
             for (const widget of this.shell.getWidgets(area)) {
                 if (!layoutWidgetIds.has(widget.id)) {
+                    // Detach via parent = null rather than widget.close() to avoid
+                    // disposing the widget — it may be needed by another perspective.
                     // eslint-disable-next-line no-null/no-null
                     widget.parent = null;
                 }
@@ -553,7 +608,7 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(PerspectiveServiceImpl.SWITCH_PERSPECTIVE_COMMAND, {
             execute: () => this.showPerspectivePicker(),
-            isEnabled: () => this.perspectives.size > 0
+            isVisible: () => this.perspectives.size > 1
         });
         commands.registerCommand(PerspectiveServiceImpl.RESET_PERSPECTIVE_COMMAND, {
             execute: () => this.resetCurrentPerspective(),

--- a/packages/core/src/browser/perspective-service.ts
+++ b/packages/core/src/browser/perspective-service.ts
@@ -33,8 +33,6 @@ import { ContextKeyService } from './context-key-service';
 export const ACTIVE_PERSPECTIVE_CONTEXT_KEY = 'activePerspectiveId';
 
 export interface PerspectiveChromeOptions {
-    /** Hide the status bar. Default: false. */
-    hideStatusBar?: boolean;
     /** Areas to collapse on first activation. User can re-expand freely. */
     collapseAreas?: ('left' | 'right' | 'bottom')[];
 }
@@ -221,10 +219,6 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
     protected switchInProgress: Promise<void> | undefined;
 
     onLayoutRestored(activePerspectiveId: string): void {
-        const descriptor = this.perspectives.get(activePerspectiveId);
-        if (descriptor) {
-            this.applyChrome(descriptor);
-        }
         this.updateActivePerspectiveContextKey(activePerspectiveId);
     }
 
@@ -310,7 +304,6 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
             descriptor.onActivate(this.shell);
         }
 
-        this.applyChrome(descriptor);
         this.updateActivePerspectiveContextKey(id);
 
         this.onDidChangePerspectiveEmitter.fire(id);
@@ -396,8 +389,6 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
             descriptor.onActivate(this.shell);
         }
 
-        this.applyChrome(descriptor);
-
         this.onDidChangePerspectiveEmitter.fire(descriptor.id);
     }
 
@@ -436,10 +427,6 @@ export class PerspectiveServiceImpl implements FrontendApplicationContribution, 
                 }
             }
         }
-    }
-
-    protected applyChrome(descriptor: PerspectiveDescriptor): void {
-        this.shell.setStatusBarHiddenByPerspective(descriptor.chromeOptions?.hideStatusBar ?? false);
     }
 
     /**

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -421,10 +421,6 @@ export class ApplicationShell extends Widget {
         this.onDidChangeActiveWidget(updateFocusContextKeys);
     }
 
-    setStatusBarHiddenByPerspective(hidden: boolean): void {
-        this.statusBar.setHiddenByPerspective(hidden);
-    }
-
     protected setTopPanelVisibility(preference: string): void {
         const hiddenPreferences = ['compact', 'hidden'];
         this.topPanel.setHidden(hiddenPreferences.includes(preference));

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -415,6 +415,10 @@ export class ApplicationShell extends Widget {
         this.onDidChangeActiveWidget(updateFocusContextKeys);
     }
 
+    setStatusBarHiddenByPerspective(hidden: boolean): void {
+        this.statusBar.setHiddenByPerspective(hidden);
+    }
+
     protected setTopPanelVisibility(preference: string): void {
         const hiddenPreferences = ['compact', 'hidden'];
         this.topPanel.setHidden(hiddenPreferences.includes(preference));
@@ -973,12 +977,30 @@ export class ApplicationShell extends Widget {
      *
      * Widgets added to the top area are not tracked regarding the _current_ and _active_ states.
      */
+    protected widgetAreaResolver?: WidgetAreaResolver;
+
+    setWidgetAreaResolver(resolver: WidgetAreaResolver | undefined): void {
+        this.widgetAreaResolver = resolver;
+    }
+
+    protected resolveWidgetArea(widget: Widget, options?: Readonly<ApplicationShell.WidgetOptions>): Readonly<ApplicationShell.WidgetOptions> | undefined {
+        if (this.widgetAreaResolver && !options?.ref) {
+            const requestedArea = options?.area || 'main';
+            const resolvedArea = this.widgetAreaResolver(widget.id, requestedArea);
+            if (resolvedArea && resolvedArea !== requestedArea) {
+                return { ...options, area: resolvedArea };
+            }
+        }
+        return options;
+    }
+
     async addWidget(widget: Widget, options?: Readonly<ApplicationShell.WidgetOptions>): Promise<void> {
         if (!widget.id) {
             this.logger.error('Widgets added to the application shell must have a unique id property.');
             return;
         }
-        const { area, addOptions } = this.getInsertionOptions(options);
+        const resolvedOptions = this.resolveWidgetArea(widget, options);
+        const { area, addOptions } = this.getInsertionOptions(resolvedOptions);
         const sidePanelOptions: SidePanel.WidgetOptions = { rank: options?.rank };
         switch (area) {
             case 'main':
@@ -2216,6 +2238,12 @@ export class ApplicationShell extends Widget {
         this.onDidToggleMaximizedEmitter.fire(area);
     }
 }
+
+/**
+ * A function that can override the shell area for a widget.
+ * Returns a new area to use, or `undefined` to keep the original.
+ */
+export type WidgetAreaResolver = (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
 
 /**
  * The namespace for `ApplicationShell` class statics.

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -181,6 +181,12 @@ interface WidgetDragState {
 }
 
 export const MAXIMIZED_CLASS = 'theia-maximized';
+export const WidgetAreaResolver = Symbol('WidgetAreaResolver');
+export interface WidgetAreaResolver {
+    resolveArea(widgetId: string, requestedArea: ApplicationShell.Area): ApplicationShell.Area | undefined;
+    setActivePlacementMap(map: Map<string, ApplicationShell.Area>): void;
+}
+
 /**
  * The application shell manages the top-level widgets of the application. Use this class to
  * add, remove, or activate a widget.
@@ -969,6 +975,20 @@ export class ApplicationShell extends Widget {
         }
     }
 
+    @inject(WidgetAreaResolver) @optional()
+    protected readonly widgetAreaResolver: WidgetAreaResolver | undefined;
+
+    protected resolveWidgetArea(widget: Widget, options?: Readonly<ApplicationShell.WidgetOptions>): Readonly<ApplicationShell.WidgetOptions> | undefined {
+        if (this.widgetAreaResolver && !options?.ref) {
+            const requestedArea = options?.area || 'main';
+            const resolvedArea = this.widgetAreaResolver.resolveArea(widget.id, requestedArea);
+            if (resolvedArea && resolvedArea !== requestedArea) {
+                return { ...options, area: resolvedArea };
+            }
+        }
+        return options;
+    }
+
     /**
      * Add a widget to the application shell. The given widget must have a unique `id` property,
      * which will be used as the DOM id.
@@ -977,23 +997,6 @@ export class ApplicationShell extends Widget {
      *
      * Widgets added to the top area are not tracked regarding the _current_ and _active_ states.
      */
-    protected widgetAreaResolver?: WidgetAreaResolver;
-
-    setWidgetAreaResolver(resolver: WidgetAreaResolver | undefined): void {
-        this.widgetAreaResolver = resolver;
-    }
-
-    protected resolveWidgetArea(widget: Widget, options?: Readonly<ApplicationShell.WidgetOptions>): Readonly<ApplicationShell.WidgetOptions> | undefined {
-        if (this.widgetAreaResolver && !options?.ref) {
-            const requestedArea = options?.area || 'main';
-            const resolvedArea = this.widgetAreaResolver(widget.id, requestedArea);
-            if (resolvedArea && resolvedArea !== requestedArea) {
-                return { ...options, area: resolvedArea };
-            }
-        }
-        return options;
-    }
-
     async addWidget(widget: Widget, options?: Readonly<ApplicationShell.WidgetOptions>): Promise<void> {
         if (!widget.id) {
             this.logger.error('Widgets added to the application shell must have a unique id property.');
@@ -2238,12 +2241,6 @@ export class ApplicationShell extends Widget {
         this.onDidToggleMaximizedEmitter.fire(area);
     }
 }
-
-/**
- * A function that can override the shell area for a widget.
- * Returns a new area to use, or `undefined` to keep the original.
- */
-export type WidgetAreaResolver = (widgetId: string, requestedArea: ApplicationShell.Area) => ApplicationShell.Area | undefined;
 
 /**
  * The namespace for `ApplicationShell` class statics.

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -1,0 +1,703 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '../test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import {
+    ShellLayoutRestorer,
+    PersistedPerspectiveData,
+    PERSPECTIVE_LAYOUTS_STORAGE_KEY
+} from './shell-layout-restorer';
+import { ApplicationShell } from './application-shell';
+disableJSDOM();
+
+describe('ShellLayoutRestorer - Perspective Support', () => {
+    let restorer: ShellLayoutRestorer;
+    let mockStorageService: { setData: sinon.SinonStub; getData: sinon.SinonStub };
+    let mockLogger: { info: sinon.SinonStub; error: sinon.SinonStub; warn: sinon.SinonStub };
+    let mockWidgetManager: { getDescription: sinon.SinonStub };
+    let mockShell: {
+        getLayoutData: sinon.SinonStub;
+        setLayoutData: sinon.SinonStub;
+    };
+    let mockApp: { shell: typeof mockShell };
+    let mockProvider: {
+        getActivePerspectiveId: sinon.SinonStub;
+        getSavedPerspectiveIds: sinon.SinonStub;
+        getSavedLayout: sinon.SinonStub;
+        setSavedLayout: sinon.SinonStub;
+        setActivePerspectiveId: sinon.SinonStub;
+        clearSavedLayouts: sinon.SinonStub;
+        onLayoutRestored: sinon.SinonStub;
+        defaultPerspectiveId: string;
+    };
+    let mockTransformations: { getContributions: sinon.SinonStub };
+    let mockMigrations: { getContributions: sinon.SinonStub };
+    let mockWindowService: { isSafeToShutDown: sinon.SinonStub; reload: sinon.SinonStub };
+    let mockThemeService: { reset: sinon.SinonStub };
+    let toTearDown: () => void;
+
+    beforeEach(() => {
+        toTearDown = enableJSDOM();
+
+        mockStorageService = {
+            setData: sinon.stub().resolves(),
+            getData: sinon.stub().resolves(undefined)
+        };
+        mockLogger = {
+            info: sinon.stub(),
+            error: sinon.stub(),
+            warn: sinon.stub()
+        };
+        mockWidgetManager = {
+            getDescription: sinon.stub().returns(undefined)
+        };
+        mockShell = {
+            getLayoutData: sinon.stub().returns({ version: 999, mainPanel: {}, bottomPanel: {} }),
+            setLayoutData: sinon.stub().resolves()
+        };
+        mockApp = { shell: mockShell };
+        mockProvider = {
+            getActivePerspectiveId: sinon.stub().returns('default'),
+            getSavedPerspectiveIds: sinon.stub().returns([]),
+            getSavedLayout: sinon.stub().returns(undefined),
+            setSavedLayout: sinon.stub(),
+            setActivePerspectiveId: sinon.stub().returns(true),
+            clearSavedLayouts: sinon.stub(),
+            onLayoutRestored: sinon.stub(),
+            defaultPerspectiveId: 'default'
+        };
+        mockTransformations = {
+            getContributions: sinon.stub().returns([])
+        };
+        mockMigrations = {
+            getContributions: sinon.stub().returns([])
+        };
+        mockWindowService = {
+            isSafeToShutDown: sinon.stub().resolves(true),
+            reload: sinon.stub()
+        };
+        mockThemeService = {
+            reset: sinon.stub()
+        };
+
+        restorer = new ShellLayoutRestorer(
+            mockWidgetManager as never,
+            mockLogger as never,
+            mockStorageService as never
+        );
+
+        (restorer as unknown as Record<string, unknown>)['perspectiveService'] = mockProvider;
+        (restorer as unknown as Record<string, unknown>)['transformations'] = mockTransformations;
+        (restorer as unknown as Record<string, unknown>)['migrations'] = mockMigrations;
+        (restorer as unknown as Record<string, unknown>)['windowService'] = mockWindowService;
+        (restorer as unknown as Record<string, unknown>)['themeService'] = mockThemeService;
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        toTearDown();
+    });
+
+    describe('storePerspectiveLayouts', () => {
+        it('should read current shell layout as the active perspective layout', () => {
+
+            mockProvider.getActivePerspectiveId.returns('persp-a');
+            mockProvider.getSavedPerspectiveIds.returns([]);
+            const currentLayout = { version: 999, mainPanel: { items: ['editor1'] }, bottomPanel: {} };
+            mockShell.getLayoutData.returns(currentLayout);
+
+            restorer.storeLayout(mockApp as never);
+
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            const [key, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(key).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            expect(data.activePerspectiveId).to.equal('persp-a');
+            expect(data.layouts['persp-a']).to.be.a('string');
+            // Verify it contains the current shell layout content
+            const parsed = JSON.parse(data.layouts['persp-a']);
+            expect(parsed.mainPanel.items).to.deep.equal(['editor1']);
+        });
+
+        it('should deflate all inactive perspective layouts from provider', () => {
+
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active', 'inactive1', 'inactive2']);
+            const inactiveLayout1 = { version: 999, mainPanel: { items: ['w1'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            const inactiveLayout2 = { version: 999, mainPanel: { items: ['w2'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('inactive1').returns(inactiveLayout1);
+            mockProvider.getSavedLayout.withArgs('inactive2').returns(inactiveLayout2);
+            mockProvider.getSavedLayout.withArgs('active').returns(undefined);
+
+            restorer.storeLayout(mockApp as never);
+
+            const [, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(Object.keys(data.layouts)).to.have.lengthOf(3);
+            expect(data.layouts).to.have.property('active');
+            expect(data.layouts).to.have.property('inactive1');
+            expect(data.layouts).to.have.property('inactive2');
+        });
+
+        it('should use shell layout for active perspective, not provider', () => {
+
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active']);
+            // Provider has stale data for the active perspective
+            const staleLayout = { version: 999, mainPanel: { items: ['stale'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('active').returns(staleLayout);
+            // Shell has the current data
+            const currentLayout = { version: 999, mainPanel: { items: ['current'] }, bottomPanel: {} };
+            mockShell.getLayoutData.returns(currentLayout);
+
+            restorer.storeLayout(mockApp as never);
+
+            const [, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            const parsed = JSON.parse(data.layouts['active']);
+            // Should use shell data, not provider data
+            expect(parsed.mainPanel.items).to.deep.equal(['current']);
+        });
+
+        it('should not write to legacy key', () => {
+            mockProvider.getActivePerspectiveId.returns('default');
+            mockProvider.getSavedPerspectiveIds.returns([]);
+
+            restorer.storeLayout(mockApp as never);
+
+            // Should only write to perspective key, not legacy key
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            expect(mockStorageService.setData.firstCall.args[0]).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+        });
+    });
+
+    describe('restorePerspectiveLayouts', () => {
+        it('should inflate all layouts and push to provider', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'persp-a',
+                layouts: {
+                    'persp-a': JSON.stringify({ version: 999, mainPanel: { items: ['a'] }, bottomPanel: {} }),
+                    'persp-b': JSON.stringify({ version: 999, mainPanel: { items: ['b'] }, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            // Return the inflated layout for the active persp when asked
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                if (id === 'persp-a') {
+                    // After setSavedLayout is called, return the layout
+                    const call = mockProvider.setSavedLayout.getCalls().find(
+                        (c: sinon.SinonSpyCall) => c.args[0] === 'persp-a'
+                    );
+                    return call?.args[1];
+                }
+                return undefined;
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            expect(mockProvider.setSavedLayout.callCount).to.equal(2);
+            // Verify persp-a was set
+            const setACall = mockProvider.setSavedLayout.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'persp-a'
+            );
+            expect(setACall).to.not.be.undefined;
+            // Verify persp-b was set
+            const setBCall = mockProvider.setSavedLayout.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'persp-b'
+            );
+            expect(setBCall).to.not.be.undefined;
+        });
+
+        it('should set active perspective ID on provider', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'my-persp',
+                layouts: {
+                    'my-persp': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockProvider.setActivePerspectiveId.calledWith('my-persp')).to.be.true;
+        });
+
+        it('should apply the active layout to the shell', async () => {
+
+            const layoutData = { version: 999, mainPanel: { items: ['active-item'] }, bottomPanel: {} };
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'active',
+                layouts: {
+                    'active': JSON.stringify(layoutData)
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockShell.setLayoutData.calledOnce).to.be.true;
+            const applied = mockShell.setLayoutData.firstCall.args[0];
+            expect(applied.mainPanel.items).to.deep.equal(['active-item']);
+        });
+
+        it('should apply transformations to all inflated layouts, not just the active one', async () => {
+
+            const transformer = {
+                transformLayoutOnRestore: sinon.stub()
+            };
+            mockTransformations.getContributions.returns([transformer]);
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'persp-a',
+                layouts: {
+                    'persp-a': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} }),
+                    'persp-b': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            // Transformer should be called for both layouts
+            expect(transformer.transformLayoutOnRestore.callCount).to.equal(2);
+        });
+
+        it('should fall back to provider active ID when persisted ID is not registered', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'removed-persp',
+                layouts: {
+                    'removed-persp': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} }),
+                    'default': JSON.stringify({ version: 999, mainPanel: { items: ['default-w'] }, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+            mockProvider.setActivePerspectiveId.returns(false);
+            mockProvider.getActivePerspectiveId.returns('default');
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            // Should apply 'default' layout to shell, not 'removed-persp'
+            const applied = mockShell.setLayoutData.firstCall.args[0];
+            expect(applied.mainPanel.items).to.deep.equal(['default-w']);
+            // onLayoutRestored should be called with 'default'
+            expect(mockProvider.onLayoutRestored.calledWith('default')).to.be.true;
+        });
+
+        it('should return false when no perspective data and no legacy data exists', async () => {
+
+            mockStorageService.getData.resolves(undefined);
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.false;
+        });
+
+        it('should warn when a perspective layout fails to inflate', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'good',
+                layouts: {
+                    'good': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} }),
+                    'bad': 'invalid-json{'
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            // 'good' should be inflated successfully
+            const goodCall = mockProvider.setSavedLayout.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'good'
+            );
+            expect(goodCall).to.not.be.undefined;
+
+            // Should warn about 'bad'
+            expect(mockLogger.warn.called).to.be.true;
+            const warnCall = mockLogger.warn.getCalls().find(
+                (c: sinon.SinonSpyCall) => (c.args[0] as string).includes('bad')
+            );
+            expect(warnCall).to.not.be.undefined;
+        });
+    });
+
+    describe('legacy migration', () => {
+        it('should fall back to legacy key when perspective-layouts is absent', async () => {
+
+            const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy'] }, bottomPanel: {} });
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves(legacyLayout);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            // Should push layout as 'default' perspective
+            expect(mockProvider.setSavedLayout.calledOnce).to.be.true;
+            expect(mockProvider.setSavedLayout.firstCall.args[0]).to.equal('default');
+            // Should set active to 'default'
+            expect(mockProvider.setActivePerspectiveId.calledWith('default')).to.be.true;
+            // Should delete legacy key after migration
+            const legacyClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            );
+            expect(legacyClear).to.not.be.undefined;
+        });
+
+        it('should delete legacy key after successful migration', async () => {
+
+            const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy'] }, bottomPanel: {} });
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves(legacyLayout);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            const legacyClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            );
+            expect(legacyClear).to.not.be.undefined;
+        });
+
+        it('should preserve legacy key when inflate fails', async () => {
+
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves('not-valid-json{');
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.false;
+            // Legacy key should NOT be cleared
+            const legacyClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            );
+            expect(legacyClear).to.be.undefined;
+            // No layout should have been saved
+            expect(mockProvider.setSavedLayout.called).to.be.false;
+            // Should warn about the failure
+            expect(mockLogger.warn.called).to.be.true;
+        });
+
+        it('should apply migrated legacy layout to shell', async () => {
+
+            const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy-w'] }, bottomPanel: {} });
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
+            mockStorageService.getData.withArgs('layout').resolves(legacyLayout);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockShell.setLayoutData.calledOnce).to.be.true;
+        });
+    });
+
+    describe('storePerspectiveLayouts - error isolation', () => {
+        it('should persist other perspectives when one inactive perspective deflate fails', () => {
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active', 'good', 'bad']);
+
+            const goodLayout = { version: 999, mainPanel: { items: ['good'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            // Create a layout with a circular reference that will cause JSON.stringify to throw
+            const badLayout: Record<string, unknown> = { version: 999, mainPanel: {}, bottomPanel: {} };
+            badLayout['self'] = badLayout;
+
+            mockProvider.getSavedLayout.withArgs('good').returns(goodLayout);
+            mockProvider.getSavedLayout.withArgs('bad').returns(badLayout);
+            mockProvider.getSavedLayout.withArgs('active').returns(undefined);
+
+            restorer.storeLayout(mockApp as never);
+
+            // Should still persist — 'active' and 'good' should be in layouts
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            const [key, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(key).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            expect(data.layouts).to.have.property('active');
+            expect(data.layouts).to.have.property('good');
+            expect(data.layouts).to.not.have.property('bad');
+
+            // Should warn about 'bad'
+            expect(mockLogger.warn.called).to.be.true;
+            const warnCall = mockLogger.warn.getCalls().find(
+                (c: sinon.SinonSpyCall) => (c.args[0] as string).includes('bad')
+            );
+            expect(warnCall).to.not.be.undefined;
+        });
+
+        it('should persist inactive perspectives when active perspective deflate fails', () => {
+            mockProvider.getActivePerspectiveId.returns('active');
+            mockProvider.getSavedPerspectiveIds.returns(['active', 'inactive']);
+
+            // Make the shell return a circular structure for the active perspective
+            const circularLayout: Record<string, unknown> = { version: 999, mainPanel: {}, bottomPanel: {} };
+            circularLayout['self'] = circularLayout;
+            mockShell.getLayoutData.returns(circularLayout);
+
+            const inactiveLayout = { version: 999, mainPanel: { items: ['inactive'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('inactive').returns(inactiveLayout);
+
+            restorer.storeLayout(mockApp as never);
+
+            expect(mockStorageService.setData.calledOnce).to.be.true;
+            const [, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            expect(data.layouts).to.not.have.property('active');
+            expect(data.layouts).to.have.property('inactive');
+
+            expect(mockLogger.warn.called).to.be.true;
+        });
+
+        it('should clear storage key when setData rejects', async () => {
+            mockProvider.getActivePerspectiveId.returns('default');
+            mockProvider.getSavedPerspectiveIds.returns([]);
+
+            mockStorageService.setData.onFirstCall().rejects(new Error('storage error'));
+            mockStorageService.setData.onSecondCall().resolves();
+
+            restorer.storeLayout(mockApp as never);
+
+            // Allow the .catch() handler to execute
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            // First call rejects, second call clears the key
+            expect(mockStorageService.setData.calledTwice).to.be.true;
+            expect(mockStorageService.setData.secondCall.args[0]).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            expect(mockStorageService.setData.secondCall.args[1]).to.be.undefined;
+
+            expect(mockLogger.error.called).to.be.true;
+        });
+    });
+
+    describe('restorePerspectiveLayouts - desync fallback', () => {
+        it('should fall back to default perspective when active perspective has no saved layout', async () => {
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'custom',
+                layouts: {
+                    'default': JSON.stringify({ version: 999, mainPanel: { items: ['default-w'] }, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            // 'custom' is a registered perspective, but has no layout entry
+            mockProvider.setActivePerspectiveId.returns(true);
+
+            // Track calls to setActivePerspectiveId to simulate state changes
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.true;
+            // Should have fallen back to default
+            expect(mockLogger.warn.called).to.be.true;
+            const warnCall = mockLogger.warn.getCalls().find(
+                (c: sinon.SinonSpyCall) => (c.args[0] as string).includes('custom')
+            );
+            expect(warnCall).to.not.be.undefined;
+            // Should have called onLayoutRestored with default
+            expect(mockProvider.onLayoutRestored.calledWith('default')).to.be.true;
+        });
+
+        it('should call onLayoutRestored even when falling through to no layout', async () => {
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'custom',
+                layouts: {}
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
+            mockProvider.getSavedLayout.returns(undefined);
+
+            const result = await restorer.restoreLayout(mockApp as never);
+
+            expect(result).to.be.false;
+            // onLayoutRestored should still be called
+            expect(mockProvider.onLayoutRestored.calledOnce).to.be.true;
+        });
+    });
+
+    describe('resetLayout', () => {
+        it('should clear layouts and legacy layout keys', async () => {
+
+            // Access private method
+            await (restorer as unknown as Record<string, () => Promise<void>>)['resetLayout']();
+
+            const setDataCalls = mockStorageService.setData.getCalls();
+            const layoutClear = setDataCalls.find((c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined);
+            const perspClear = setDataCalls.find((c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] === undefined);
+
+            expect(layoutClear).to.not.be.undefined;
+            expect(perspClear).to.not.be.undefined;
+        });
+
+        it('should call provider.clearSavedLayouts', async () => {
+
+            await (restorer as unknown as Record<string, () => Promise<void>>)['resetLayout']();
+
+            expect(mockProvider.clearSavedLayouts.calledOnce).to.be.true;
+        });
+
+        it('should reload the window after reset', async () => {
+
+            await (restorer as unknown as Record<string, () => Promise<void>>)['resetLayout']();
+
+            expect(mockWindowService.reload.calledOnce).to.be.true;
+        });
+    });
+
+    describe('onLayoutRestored callback', () => {
+        it('should call onLayoutRestored on provider after successful restore', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'my-persp',
+                layouts: {
+                    'my-persp': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockProvider.onLayoutRestored.calledOnce).to.be.true;
+            expect(mockProvider.onLayoutRestored.calledWith('my-persp')).to.be.true;
+        });
+
+        it('should call onLayoutRestored even when no layout is restored', async () => {
+
+            mockStorageService.getData.resolves(undefined);
+
+            await restorer.restoreLayout(mockApp as never);
+
+            expect(mockProvider.onLayoutRestored.calledOnce).to.be.true;
+            expect(mockProvider.onLayoutRestored.calledWith('default')).to.be.true;
+        });
+
+        it('should call onLayoutRestored after layout is applied to shell', async () => {
+
+            const persisted: PersistedPerspectiveData = {
+                activePerspectiveId: 'active',
+                layouts: {
+                    'active': JSON.stringify({ version: 999, mainPanel: {}, bottomPanel: {} })
+                }
+            };
+            mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(persisted);
+
+            let currentActiveId = 'default';
+            mockProvider.setActivePerspectiveId.callsFake((id: string) => {
+                currentActiveId = id;
+                return true;
+            });
+            mockProvider.getActivePerspectiveId.callsFake(() => currentActiveId);
+
+            mockProvider.getSavedLayout.callsFake((id: string) => {
+                const call = mockProvider.setSavedLayout.getCalls().find(
+                    (c: sinon.SinonSpyCall) => c.args[0] === id
+                );
+                return call?.args[1];
+            });
+
+            await restorer.restoreLayout(mockApp as never);
+
+            // onLayoutRestored should be called after setLayoutData
+            expect(mockShell.setLayoutData.calledBefore(mockProvider.onLayoutRestored)).to.be.true;
+        });
+    });
+});

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -125,9 +125,11 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
 
             restorer.storeLayout(mockApp as never);
 
-            expect(mockStorageService.setData.calledOnce).to.be.true;
-            const [key, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
-            expect(key).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            const perspCall = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] !== undefined
+            );
+            expect(perspCall).to.not.be.undefined;
+            const data = perspCall!.args[1] as PersistedPerspectiveData;
             expect(data.activePerspectiveId).to.equal('persp-a');
             expect(data.layouts['persp-a']).to.be.a('string');
             // Verify it contains the current shell layout content
@@ -173,15 +175,42 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             expect(parsed.mainPanel.items).to.deep.equal(['current']);
         });
 
-        it('should not write to legacy key', () => {
+        it('should write to legacy key when only default perspective is used', () => {
             mockProvider.getActivePerspectiveId.returns('default');
             mockProvider.getSavedPerspectiveIds.returns([]);
 
             restorer.storeLayout(mockApp as never);
 
-            // Should only write to perspective key, not legacy key
-            expect(mockStorageService.setData.calledOnce).to.be.true;
-            expect(mockStorageService.setData.firstCall.args[0]).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            // Should write to legacy key for backward compatibility
+            const legacyCall = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout'
+            );
+            expect(legacyCall).to.not.be.undefined;
+            // Should clear the perspective key
+            const perspClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] === undefined
+            );
+            expect(perspClear).to.not.be.undefined;
+        });
+
+        it('should write to perspective key when multiple perspectives are used', () => {
+            mockProvider.getActivePerspectiveId.returns('persp-a');
+            mockProvider.getSavedPerspectiveIds.returns(['persp-a', 'persp-b']);
+            const inactiveLayout = { version: 999, mainPanel: { items: ['b'] }, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('persp-b').returns(inactiveLayout);
+            mockProvider.getSavedLayout.withArgs('persp-a').returns(undefined);
+
+            restorer.storeLayout(mockApp as never);
+
+            const perspCall = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] !== undefined
+            );
+            expect(perspCall).to.not.be.undefined;
+            // Should clear the legacy key
+            const legacyClear = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            );
+            expect(legacyClear).to.not.be.undefined;
         });
     });
 
@@ -477,10 +506,12 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
 
             restorer.storeLayout(mockApp as never);
 
-            // Should still persist — 'active' and 'good' should be in layouts
-            expect(mockStorageService.setData.calledOnce).to.be.true;
-            const [key, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
-            expect(key).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+            // Multiple perspectives => writes to PERSPECTIVE_LAYOUTS_STORAGE_KEY and clears legacy
+            const perspCall = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] !== undefined
+            );
+            expect(perspCall).to.not.be.undefined;
+            const data = perspCall!.args[1] as PersistedPerspectiveData;
             expect(data.layouts).to.have.property('active');
             expect(data.layouts).to.have.property('good');
             expect(data.layouts).to.not.have.property('bad');
@@ -507,30 +538,45 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
 
             restorer.storeLayout(mockApp as never);
 
-            expect(mockStorageService.setData.calledOnce).to.be.true;
-            const [, data] = mockStorageService.setData.firstCall.args as [string, PersistedPerspectiveData];
+            // Multiple perspectives (active + inactive) => writes to PERSPECTIVE_LAYOUTS_STORAGE_KEY
+            const perspCall = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] !== undefined
+            );
+            expect(perspCall).to.not.be.undefined;
+            const data = perspCall!.args[1] as PersistedPerspectiveData;
             expect(data.layouts).to.not.have.property('active');
             expect(data.layouts).to.have.property('inactive');
 
             expect(mockLogger.warn.called).to.be.true;
         });
 
-        it('should clear storage key when setData rejects', async () => {
-            mockProvider.getActivePerspectiveId.returns('default');
-            mockProvider.getSavedPerspectiveIds.returns([]);
+        it('should clear storage key when setData rejects (multi-perspective)', async () => {
+            mockProvider.getActivePerspectiveId.returns('persp-a');
+            mockProvider.getSavedPerspectiveIds.returns(['persp-a', 'persp-b']);
+            const layout = { version: 999, mainPanel: {}, bottomPanel: {} } as unknown as ApplicationShell.LayoutData;
+            mockProvider.getSavedLayout.withArgs('persp-b').returns(layout);
 
-            mockStorageService.setData.onFirstCall().rejects(new Error('storage error'));
-            mockStorageService.setData.onSecondCall().resolves();
+            // The perspective-layouts setData call rejects only the first time (when data is present)
+            let perspCallCount = 0;
+            mockStorageService.setData.callsFake((key: string, data: unknown) => {
+                if (key === PERSPECTIVE_LAYOUTS_STORAGE_KEY && data !== undefined) {
+                    perspCallCount++;
+                    return Promise.reject(new Error('storage error'));
+                }
+                return Promise.resolve();
+            });
 
             restorer.storeLayout(mockApp as never);
 
             // Allow the .catch() handler to execute
             await new Promise(resolve => setTimeout(resolve, 0));
 
-            // First call rejects, second call clears the key
-            expect(mockStorageService.setData.calledTwice).to.be.true;
-            expect(mockStorageService.setData.secondCall.args[0]).to.equal(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
-            expect(mockStorageService.setData.secondCall.args[1]).to.be.undefined;
+            expect(perspCallCount).to.equal(1);
+            // Should have attempted to clear the perspective key
+            const clearCall = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === PERSPECTIVE_LAYOUTS_STORAGE_KEY && c.args[1] === undefined
+            );
+            expect(clearCall).to.not.be.undefined;
 
             expect(mockLogger.error.called).to.be.true;
         });

--- a/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.spec.ts
@@ -424,14 +424,9 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
             expect(mockProvider.setSavedLayout.firstCall.args[0]).to.equal('default');
             // Should set active to 'default'
             expect(mockProvider.setActivePerspectiveId.calledWith('default')).to.be.true;
-            // Should delete legacy key after migration
-            const legacyClear = mockStorageService.setData.getCalls().find(
-                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
-            );
-            expect(legacyClear).to.not.be.undefined;
         });
 
-        it('should delete legacy key after successful migration', async () => {
+        it('should keep the legacy key after a successful migration', async () => {
 
             const legacyLayout = JSON.stringify({ version: 999, mainPanel: { items: ['legacy'] }, bottomPanel: {} });
             mockStorageService.getData.withArgs(PERSPECTIVE_LAYOUTS_STORAGE_KEY).resolves(undefined);
@@ -446,10 +441,12 @@ describe('ShellLayoutRestorer - Perspective Support', () => {
 
             await restorer.restoreLayout(mockApp as never);
 
-            const legacyClear = mockStorageService.setData.getCalls().find(
-                (c: sinon.SinonSpyCall) => c.args[0] === 'layout' && c.args[1] === undefined
+            // Restoring must not touch the key: it is rewritten or cleared by the next `storeLayout`,
+            // so a crash before then still finds the layout where it was.
+            const legacyWrite = mockStorageService.setData.getCalls().find(
+                (c: sinon.SinonSpyCall) => c.args[0] === 'layout'
             );
-            expect(legacyClear).to.not.be.undefined;
+            expect(legacyWrite).to.be.undefined;
         });
 
         it('should preserve legacy key when inflate fails', async () => {

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -28,6 +28,7 @@ import { CommonCommands } from '../common-commands';
 import { WindowService } from '../window/window-service';
 import { StopReason } from '../../common/frontend-application-state';
 import { isFunction, isObject, MaybePromise } from '../../common';
+import { PerspectiveService } from '../perspective-service';
 
 /**
  * A contract for widgets that want to store and restore their inner state, between sessions.
@@ -124,6 +125,13 @@ export interface ShellLayoutTransformer {
     transformLayoutOnRestore(layoutData: ApplicationShell.LayoutData): void;
 }
 
+export const PERSPECTIVE_LAYOUTS_STORAGE_KEY = 'layouts';
+
+export interface PersistedPerspectiveData {
+    activePerspectiveId: string;
+    layouts: Record<string, string>;
+}
+
 export const RESET_LAYOUT = Command.toLocalizedCommand({
     id: 'reset.layout',
     category: CommonCommands.VIEW_CATEGORY,
@@ -133,13 +141,16 @@ export const RESET_LAYOUT = Command.toLocalizedCommand({
 @injectable()
 export class ShellLayoutRestorer implements CommandContribution {
 
-    protected storageKey = 'layout';
+    protected readonly legacyStorageKey = 'layout';
     protected shouldStoreLayout: boolean = true;
 
     @inject(ContributionProvider) @named(ApplicationShellLayoutMigration) protected readonly migrations: ContributionProvider<ApplicationShellLayoutMigration>;
     @inject(ContributionProvider) @named(ShellLayoutTransformer) protected readonly transformations: ContributionProvider<ShellLayoutTransformer>;
     @inject(WindowService) protected readonly windowService: WindowService;
     @inject(ThemeService) protected readonly themeService: ThemeService;
+
+    @inject(PerspectiveService)
+    protected readonly perspectiveService: PerspectiveService;
 
     constructor(
         @inject(WidgetManager) protected widgetManager: WidgetManager,
@@ -156,7 +167,9 @@ export class ShellLayoutRestorer implements CommandContribution {
         if (await this.windowService.isSafeToShutDown(StopReason.Reload)) {
             this.logger.info('>>> Resetting layout...');
             this.shouldStoreLayout = false;
-            this.storageService.setData(this.storageKey, undefined);
+            this.storageService.setData(this.legacyStorageKey, undefined);
+            this.perspectiveService.clearSavedLayouts();
+            this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
             this.themeService.reset();
             this.logger.info('<<< The layout has been successfully reset.');
             this.windowService.reload();
@@ -167,29 +180,120 @@ export class ShellLayoutRestorer implements CommandContribution {
         if (this.shouldStoreLayout) {
             try {
                 this.logger.info('>>> Storing the layout...');
-                const layoutData = app.shell.getLayoutData();
-                const serializedLayoutData = this.deflate(layoutData);
-                this.storageService.setData(this.storageKey, serializedLayoutData);
+                this.storePerspectiveLayouts(app);
                 this.logger.info('<<< The layout has been successfully stored.');
             } catch (error) {
-                this.storageService.setData(this.storageKey, undefined);
                 this.logger.error('Error during serialization of layout data', error);
             }
         }
     }
 
+    protected storePerspectiveLayouts(app: FrontendApplication): void {
+        const provider = this.perspectiveService;
+        const activeId = provider.getActivePerspectiveId();
+        const layouts: Record<string, string> = {};
+
+        // Snapshot current shell as the active perspective's layout
+        try {
+            const currentLayout = app.shell.getLayoutData();
+            layouts[activeId] = this.deflate(currentLayout);
+        } catch (error) {
+            this.logger.warn(`Could not deflate layout for active perspective '${activeId}'`, error);
+        }
+
+        // Deflate all other saved (inactive) perspective layouts
+        for (const perspId of provider.getSavedPerspectiveIds()) {
+            if (perspId === activeId) {
+                continue; // already handled above from live shell
+            }
+            try {
+                const layout = provider.getSavedLayout(perspId);
+                if (layout) {
+                    layouts[perspId] = this.deflate(layout);
+                }
+            } catch (error) {
+                this.logger.warn(`Could not deflate layout for perspective '${perspId}'`, error);
+            }
+        }
+
+        const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
+        this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data).catch(error => {
+            this.logger.error('Error persisting perspective layouts, clearing stored data', error);
+            this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
+        });
+    }
+
     async restoreLayout(app: FrontendApplication): Promise<boolean> {
         this.logger.info('>>> Restoring the layout state...');
-        const serializedLayoutData = await this.storageService.getData<string>(this.storageKey);
-        if (serializedLayoutData === undefined) {
-            this.logger.info('<<< Nothing to restore.');
-            return false;
+        return this.restorePerspectiveLayouts(app);
+    }
+
+    protected async restorePerspectiveLayouts(app: FrontendApplication): Promise<boolean> {
+        const persisted = await this.storageService.getData<PersistedPerspectiveData>(PERSPECTIVE_LAYOUTS_STORAGE_KEY);
+
+        let activeId: string | undefined;
+
+        if (persisted) {
+            activeId = persisted.activePerspectiveId;
+            // Inflate all perspective layouts, apply transforms, and push to provider
+            for (const [perspId, deflated] of Object.entries(persisted.layouts)) {
+                try {
+                    const layout = await this.inflate(deflated);
+                    this.transformations.getContributions()
+                        .forEach(t => t.transformLayoutOnRestore(layout));
+                    this.perspectiveService.setSavedLayout(perspId, layout);
+                } catch (error) {
+                    this.logger.warn(`Could not inflate layout for perspective '${perspId}'`, error);
+                }
+            }
+        } else {
+            // Migration: try legacy single-layout key
+            const legacyData = await this.storageService.getData<string>(this.legacyStorageKey);
+            if (legacyData) {
+                try {
+                    const layout = await this.inflate(legacyData);
+                    this.transformations.getContributions()
+                        .forEach(t => t.transformLayoutOnRestore(layout));
+                    this.perspectiveService.setSavedLayout(this.perspectiveService.defaultPerspectiveId, layout);
+                    activeId = this.perspectiveService.defaultPerspectiveId;
+                    this.storageService.setData(this.legacyStorageKey, undefined);
+                } catch (error) {
+                    this.logger.warn('Could not inflate legacy layout for migration', error);
+                }
+            }
         }
-        const layoutData = await this.inflate(serializedLayoutData);
-        this.transformations.getContributions().forEach(transformation => transformation.transformLayoutOnRestore(layoutData));
-        await app.shell.setLayoutData(layoutData);
-        this.logger.info('<<< The layout has been successfully restored.');
-        return true;
+
+        if (activeId) {
+            const accepted = this.perspectiveService.setActivePerspectiveId(activeId);
+            if (!accepted) {
+                activeId = this.perspectiveService.getActivePerspectiveId();
+            }
+        }
+
+        // Apply the active perspective's layout to the shell
+        const effectiveId = activeId ?? this.perspectiveService.getActivePerspectiveId();
+        let activeLayout = this.perspectiveService.getSavedLayout(effectiveId);
+
+        // Fallback: if the active perspective has no saved layout, try the default
+        if (!activeLayout && effectiveId !== this.perspectiveService.defaultPerspectiveId) {
+            this.logger.warn(`No saved layout for perspective '${effectiveId}', falling back to default.`);
+            const defaultId = this.perspectiveService.defaultPerspectiveId;
+            this.perspectiveService.setActivePerspectiveId(defaultId);
+            activeLayout = this.perspectiveService.getSavedLayout(defaultId);
+        }
+
+        if (activeLayout) {
+            await app.shell.setLayoutData(activeLayout);
+            const restoredId = this.perspectiveService.getActivePerspectiveId();
+            this.perspectiveService.onLayoutRestored(restoredId);
+            this.logger.info('<<< The layout has been successfully restored.');
+            return true;
+        }
+
+        // Even with no layout to restore, ensure chrome is applied for whatever perspective is active
+        this.perspectiveService.onLayoutRestored(this.perspectiveService.getActivePerspectiveId());
+        this.logger.info('<<< Nothing to restore.');
+        return false;
     }
 
     protected isWidgetProperty(propertyName: string): boolean {

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -141,7 +141,7 @@ export const RESET_LAYOUT = Command.toLocalizedCommand({
 @injectable()
 export class ShellLayoutRestorer implements CommandContribution {
 
-    protected readonly legacyStorageKey = 'layout';
+    protected storageKey = 'layout';
     protected shouldStoreLayout: boolean = true;
 
     @inject(ContributionProvider) @named(ApplicationShellLayoutMigration) protected readonly migrations: ContributionProvider<ApplicationShellLayoutMigration>;
@@ -167,7 +167,7 @@ export class ShellLayoutRestorer implements CommandContribution {
         if (await this.windowService.isSafeToShutDown(StopReason.Reload)) {
             this.logger.info('>>> Resetting layout...');
             this.shouldStoreLayout = false;
-            this.storageService.setData(this.legacyStorageKey, undefined);
+            this.storageService.setData(this.storageKey, undefined);
             this.perspectiveService.clearSavedLayouts();
             this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
             this.themeService.reset();
@@ -223,7 +223,7 @@ export class ShellLayoutRestorer implements CommandContribution {
             // to the legacy key for backward compatibility.
             const defaultLayout = layouts[provider.defaultPerspectiveId];
             if (defaultLayout) {
-                this.storageService.setData(this.legacyStorageKey, defaultLayout).catch(error => {
+                this.storageService.setData(this.storageKey, defaultLayout).catch(error => {
                     this.logger.error('Error persisting default layout', error);
                 });
             }
@@ -235,7 +235,7 @@ export class ShellLayoutRestorer implements CommandContribution {
                 this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
             });
             // Clear the legacy key when perspectives are in use
-            this.storageService.setData(this.legacyStorageKey, undefined);
+            this.storageService.setData(this.storageKey, undefined);
         }
     }
 
@@ -264,7 +264,7 @@ export class ShellLayoutRestorer implements CommandContribution {
             }
         } else {
             // Migration: try legacy single-layout key
-            const legacyData = await this.storageService.getData<string>(this.legacyStorageKey);
+            const legacyData = await this.storageService.getData<string>(this.storageKey);
             if (legacyData) {
                 try {
                     const layout = await this.inflate(legacyData);
@@ -272,7 +272,7 @@ export class ShellLayoutRestorer implements CommandContribution {
                         .forEach(t => t.transformLayoutOnRestore(layout));
                     this.perspectiveService.setSavedLayout(this.perspectiveService.defaultPerspectiveId, layout);
                     activeId = this.perspectiveService.defaultPerspectiveId;
-                    this.storageService.setData(this.legacyStorageKey, undefined);
+                    this.storageService.setData(this.storageKey, undefined);
                 } catch (error) {
                     this.logger.warn('Could not inflate legacy layout for migration', error);
                 }

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -263,7 +263,9 @@ export class ShellLayoutRestorer implements CommandContribution {
                 }
             }
         } else {
-            // Migration: try legacy single-layout key
+            // Migration: try legacy single-layout key. The key is deliberately left in place here:
+            // `storePerspectiveLayouts` rewrites it (default perspective only) or clears it (perspectives
+            // in use) on shutdown, so an unclean exit right after startup doesn't lose the layout.
             const legacyData = await this.storageService.getData<string>(this.storageKey);
             if (legacyData) {
                 try {
@@ -272,7 +274,6 @@ export class ShellLayoutRestorer implements CommandContribution {
                         .forEach(t => t.transformLayoutOnRestore(layout));
                     this.perspectiveService.setSavedLayout(this.perspectiveService.defaultPerspectiveId, layout);
                     activeId = this.perspectiveService.defaultPerspectiveId;
-                    this.storageService.setData(this.storageKey, undefined);
                 } catch (error) {
                     this.logger.warn('Could not inflate legacy layout for migration', error);
                 }

--- a/packages/core/src/browser/shell/shell-layout-restorer.ts
+++ b/packages/core/src/browser/shell/shell-layout-restorer.ts
@@ -28,7 +28,7 @@ import { CommonCommands } from '../common-commands';
 import { WindowService } from '../window/window-service';
 import { StopReason } from '../../common/frontend-application-state';
 import { isFunction, isObject, MaybePromise } from '../../common';
-import { PerspectiveService } from '../perspective-service';
+import { PerspectiveServiceInternal } from '../perspective-service';
 
 /**
  * A contract for widgets that want to store and restore their inner state, between sessions.
@@ -125,7 +125,7 @@ export interface ShellLayoutTransformer {
     transformLayoutOnRestore(layoutData: ApplicationShell.LayoutData): void;
 }
 
-export const PERSPECTIVE_LAYOUTS_STORAGE_KEY = 'layouts';
+export const PERSPECTIVE_LAYOUTS_STORAGE_KEY = 'perspective-layouts';
 
 export interface PersistedPerspectiveData {
     activePerspectiveId: string;
@@ -149,8 +149,8 @@ export class ShellLayoutRestorer implements CommandContribution {
     @inject(WindowService) protected readonly windowService: WindowService;
     @inject(ThemeService) protected readonly themeService: ThemeService;
 
-    @inject(PerspectiveService)
-    protected readonly perspectiveService: PerspectiveService;
+    @inject(PerspectiveServiceInternal)
+    protected readonly perspectiveService: PerspectiveServiceInternal;
 
     constructor(
         @inject(WidgetManager) protected widgetManager: WidgetManager,
@@ -216,11 +216,27 @@ export class ShellLayoutRestorer implements CommandContribution {
             }
         }
 
-        const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
-        this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data).catch(error => {
-            this.logger.error('Error persisting perspective layouts, clearing stored data', error);
+        const perspectiveIds = Object.keys(layouts);
+        const onlyDefault = perspectiveIds.length <= 1 && (perspectiveIds.length === 0 || perspectiveIds[0] === provider.defaultPerspectiveId);
+        if (onlyDefault) {
+            // If only the default perspective has ever been used, continue writing
+            // to the legacy key for backward compatibility.
+            const defaultLayout = layouts[provider.defaultPerspectiveId];
+            if (defaultLayout) {
+                this.storageService.setData(this.legacyStorageKey, defaultLayout).catch(error => {
+                    this.logger.error('Error persisting default layout', error);
+                });
+            }
             this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
-        });
+        } else {
+            const data: PersistedPerspectiveData = { activePerspectiveId: activeId, layouts };
+            this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, data).catch(error => {
+                this.logger.error('Error persisting perspective layouts, clearing stored data', error);
+                this.storageService.setData(PERSPECTIVE_LAYOUTS_STORAGE_KEY, undefined);
+            });
+            // Clear the legacy key when perspectives are in use
+            this.storageService.setData(this.legacyStorageKey, undefined);
+        }
     }
 
     async restoreLayout(app: FrontendApplication): Promise<boolean> {

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -102,7 +102,7 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
 
     async openView(args: Partial<OpenViewArguments> = {}): Promise<T> {
         const shell = this.shell;
-        const widget = await this.widgetManager.getOrCreateWidget(this.options.viewContainerId || this.viewId);
+        const widget = await this.widgetManager.getOrCreateWidget(this.effectiveWidgetId);
         const tabBar = shell.getTabBarFor(widget);
         const area = shell.getAreaFor(widget);
         if (!tabBar) {

--- a/packages/core/src/browser/shell/view-contribution.ts
+++ b/packages/core/src/browser/shell/view-contribution.ts
@@ -87,6 +87,11 @@ export abstract class AbstractViewContribution<T extends Widget> implements Comm
         return this.options.defaultWidgetOptions;
     }
 
+    /** The widget ID used for shell operations — `viewContainerId` if set, otherwise `widgetId`. */
+    get effectiveWidgetId(): string {
+        return this.options.viewContainerId || this.options.widgetId;
+    }
+
     get widget(): Promise<T> {
         return this.widgetManager.getOrCreateWidget(this.viewId);
     }

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -35,6 +35,8 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
     protected backgroundColor: string | undefined;
     protected color: string | undefined;
 
+    protected perspectiveHidesStatusBar = false;
+
     constructor(
         @inject(CommandService) protected readonly commands: CommandService,
         @inject(LabelParser) protected readonly entryService: LabelParser,
@@ -50,17 +52,26 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         // Hide the status bar until the `workbench.statusBar.visible` preference returns with a `true` value.
         this.hide();
         this.preferences.ready.then(() => {
-            const preferenceValue = this.preferences.get<boolean>('workbench.statusBar.visible', true);
-            this.setHidden(!preferenceValue);
+            this.updateVisibility();
         });
         this.toDispose.push(
             this.preferences.onPreferenceChanged(preference => {
                 if (preference.preferenceName === 'workbench.statusBar.visible') {
-                    this.setHidden(!this.preferences.get('workbench.statusBar.visible', true));
+                    this.updateVisibility();
                 }
             })
         );
         this.toDispose.push(this.viewModel.onDidChange(() => this.debouncedUpdate()));
+    }
+
+    setHiddenByPerspective(hidden: boolean): void {
+        this.perspectiveHidesStatusBar = hidden;
+        this.updateVisibility();
+    }
+
+    protected updateVisibility(): void {
+        const prefHides = !this.preferences.get<boolean>('workbench.statusBar.visible', true);
+        this.setHidden(this.perspectiveHidesStatusBar || prefHides);
     }
 
     protected debouncedUpdate = debounce(() => this.update(), 50);

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -35,7 +35,6 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
     protected backgroundColor: string | undefined;
     protected color: string | undefined;
 
-    protected perspectiveHidesStatusBar = false;
     protected preferencesReady = false;
 
     constructor(
@@ -66,17 +65,12 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         this.toDispose.push(this.viewModel.onDidChange(() => this.debouncedUpdate()));
     }
 
-    setHiddenByPerspective(hidden: boolean): void {
-        this.perspectiveHidesStatusBar = hidden;
-        this.updateVisibility();
-    }
-
     protected updateVisibility(): void {
         if (!this.preferencesReady) {
             return; // Don't change visibility until preferences have loaded
         }
         const prefHides = !this.preferences.get<boolean>('workbench.statusBar.visible', true);
-        this.setHidden(this.perspectiveHidesStatusBar || prefHides);
+        this.setHidden(prefHides);
     }
 
     protected debouncedUpdate = debounce(() => this.update(), 50);

--- a/packages/core/src/browser/status-bar/status-bar.tsx
+++ b/packages/core/src/browser/status-bar/status-bar.tsx
@@ -36,6 +36,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
     protected color: string | undefined;
 
     protected perspectiveHidesStatusBar = false;
+    protected preferencesReady = false;
 
     constructor(
         @inject(CommandService) protected readonly commands: CommandService,
@@ -52,6 +53,7 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
         // Hide the status bar until the `workbench.statusBar.visible` preference returns with a `true` value.
         this.hide();
         this.preferences.ready.then(() => {
+            this.preferencesReady = true;
             this.updateVisibility();
         });
         this.toDispose.push(
@@ -70,6 +72,9 @@ export class StatusBarImpl extends ReactWidget implements StatusBar {
     }
 
     protected updateVisibility(): void {
+        if (!this.preferencesReady) {
+            return; // Don't change visibility until preferences have loaded
+        }
         const prefHides = !this.preferences.get<boolean>('workbench.statusBar.visible', true);
         this.setHidden(this.perspectiveHidesStatusBar || prefHides);
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- add a new perspective service
  - support "Switch perspective" and "Reset perspective"
  - perspectives can specify a list of views and map them to preferred locations (which may override the view's preferred location)
- add a new "AI Sessions" view separate from the AI Chat
  - the Sessions List widget was extracted from the AI Chat's welcome message provider and is now shared between both
- add an "AI First" perspective focusing on AI Chat + AI Sessions

##### About ViewContributions

In Theia, not everything is a "View". Perspectives only work with "Views", so simple "FrontendApplicationContribution" can't be properly referenced from a Perspective (They use imperative code, as opposed to the View's more declarative approach, making them much harder to integrate in a generic fashion).

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- start Theia
- run "View > Switch Perspective > AI First"
- the perspective should show the AI Chat in the center, AI Sessions on the left, Explorer + SCM on the right
- run "View > Switch Perspective > Default"
- the previous layout should be restored
- move views to a different location (e.g. right to center area, left to bottom area, ...), then call View > Reset Perspective
  - the default layout should be restored (i.e. views should move back to their preferred area, and reopened if necessary)
  - additional views (that are not part of the perspective) should remain open where they are

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
