### PR TITLE
fix(toolbar): update application toolbar enablement on widget and context changes

### DIFF
--- a/packages/toolbar/src/browser/toolbar.tsx
+++ b/packages/toolbar/src/browser/toolbar.tsx
@@ -15,9 +15,9 @@
 // *****************************************************************************
 
 import * as React from '@theia/core/shared/react';
-import { Anchor, ContextMenuAccess, KeybindingRegistry, Widget, WidgetManager } from '@theia/core/lib/browser';
+import { Anchor, ApplicationShell, ContextMenuAccess, KeybindingRegistry, Widget, WidgetManager } from '@theia/core/lib/browser';
 import { TabBarToolbar, TabBarToolbarFactory } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
-import { injectable, inject, postConstruct } from '@theia/core/shared/inversify';
+import { injectable, inject, postConstruct, interfaces } from '@theia/core/shared/inversify';
 import { DisposableCollection, MenuPath, PreferenceService, ProgressService } from '@theia/core';
 import { FrontendApplicationStateService } from '@theia/core/lib/browser/frontend-application-state';
 import { ProgressBarFactory } from '@theia/core/lib/browser/progress-bar-factory';
@@ -26,6 +26,7 @@ import {
     ToolbarAlignment,
     ToolbarAlignmentString,
     ToolbarItemPosition,
+    LateInjector,
 } from './toolbar-interfaces';
 import { ToolbarController } from './toolbar-controller';
 import { ToolbarMenus } from './toolbar-constants';
@@ -43,6 +44,7 @@ export class ToolbarImpl extends TabBarToolbar {
     @inject(KeybindingRegistry) protected readonly keybindingRegistry: KeybindingRegistry;
     @inject(ProgressBarFactory) protected readonly progressFactory: ProgressBarFactory;
     @inject(ProgressService) protected readonly progressService: ProgressService;
+    @inject(LateInjector) protected readonly lateInjector: <T>(id: interfaces.ServiceIdentifier<T>) => T;
 
     protected currentlyDraggedItem: HTMLDivElement | undefined;
     protected draggedStartingPosition: ToolbarItemPosition | undefined;
@@ -58,13 +60,19 @@ export class ToolbarImpl extends TabBarToolbar {
     protected async doInit(): Promise<void> {
         this.hide();
         await this.model.ready.promise;
+        const shell = this.lateInjector(ApplicationShell);
 
         this.updateInlineItems();
+        this.setCurrent(shell.currentWidget);
         this.update();
         this.model.onToolbarModelDidUpdate(() => {
             this.updateInlineItems();
             this.update();
         });
+        this.toDispose.push(shell.onDidChangeCurrentWidget(({ newValue }) => {
+            this.setCurrent(newValue ?? undefined);
+            this.maybeUpdate();
+        }));
         this.model.onToolbarDidChangeBusyState(isBusy => {
             if (isBusy) {
                 this.isBusyDeferred = new Deferred<void>();
@@ -82,18 +90,27 @@ export class ToolbarImpl extends TabBarToolbar {
         this.toDisposeOnUpdateItems.dispose();
         this.toDisposeOnUpdateItems = new DisposableCollection();
         this.inline.clear();
+        this.toolbarContextKeys = new Set();
         const { items } = this.model.toolbarItems;
 
         for (const column of Object.keys(items)) {
             for (const group of items[column as ToolbarAlignment]) {
                 for (const item of group) {
                     this.inline.set(item.id, item);
+                    if (item.when) {
+                        this.contextKeyService.parseKeys(item.when)?.forEach(key => this.toolbarContextKeys.add(key));
+                    }
                     if (item.onDidChange) {
                         this.toDisposeOnUpdateItems.push(item.onDidChange(() => this.maybeUpdate()));
                     }
                 }
             }
         }
+    }
+
+    override updateTarget(current?: Widget): void {
+        this.setCurrent(current);
+        this.maybeUpdate();
     }
 
     protected handleContextMenu = (e: React.MouseEvent<HTMLDivElement>): ContextMenuAccess => this.doHandleContextMenu(e);


### PR DESCRIPTION
#### What it does

Fixes #17771.

The application toolbar (`ToolbarImpl`) extends `TabBarToolbar` but drives itself through its own `updateInlineItems()` instead of the base `updateItems()`/`updateTarget()`. As a result it never set `this.current` and never populated `toolbarContextKeys`, so the base class's re-render triggers (`contextKeyService.onDidChange` and the active-widget path) never fired for it. Toolbar items only refreshed when the toolbar model changed, which is why adding or removing an item made the stale enablement correct itself.

This change:
- Tracks the shell's current widget and re-renders when it changes, so command-enablement-driven items (e.g. "Split Editor Right") update when the active editor changes.
- Collects the items' `when` context keys into `toolbarContextKeys` so `contextKeyService.onDidChange` re-renders context-driven items.
- Overrides `updateTarget` so the base's context-change handler refreshes the model-driven toolbar items instead of replacing them with registry items.

`ApplicationShell` is resolved lazily via the package's existing `LateInjector` utility (the same pattern already used in `ToolbarStorageProvider`). Injecting it directly during the toolbar's construction — which happens inside `ApplicationShellWithToolbarOverride`'s own initialization — resolves a second, orphaned shell instance whose events never fire.

#### How to test

1. Enable the toolbar via the `Toggle Application Toolbar` command.
2. With no editor open, `Split Editor Right` is disabled.
3. Open a text file — the item becomes enabled immediately. On `master` it stays disabled until an unrelated toolbar item is added.
4. Close the editor again — the item returns to disabled. The enablement now tracks the active editor live.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no user-facing text is added by this change)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
