### PR TITLE
Fix window control style on Electron custom title bars

### DIFF
--- a/packages/core/src/electron-browser/menu/electron-menu-style.css
+++ b/packages/core/src/electron-browser/menu/electron-menu-style.css
@@ -60,7 +60,9 @@
   position: absolute;
   top: 0;
   right: 0;
-  height: 100%;
+  height: var(--theia-private-menubar-height, 32px);
+  z-index: var(--theia-menu-z-index);
+  background: var(--theia-titleBar-activeBackground);
 }
 
 #window-controls .control-button {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

Ensures window controls stay visible during small resize.
Fixes https://github.com/eclipse-theia/theia/issues/17834

#### How to test

1. Open Theia Electron and set the window.titleBarStyle to 'custom' (instead of 'native')
2. Make the window smaller
3. See how the menus no longer overlay with the window controls and the window controls stay fully visible

https://github.com/user-attachments/assets/43409ed2-19d5-49ff-8f97-23b5d8b39b37

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
