### PR TITLE
fix(navigator): keep in-app file clipboard in sync and await pastes

### DIFF
--- a/packages/core/src/browser/browser-clipboard-service.ts
+++ b/packages/core/src/browser/browser-clipboard-service.ts
@@ -17,6 +17,7 @@
 import { injectable, inject } from 'inversify';
 import { isFirefox } from './browser';
 import { ClipboardService } from './clipboard-service';
+import { Emitter, Event } from '../common/event';
 import { ILogger } from '../common/logger';
 import { MessageService } from '../common/message-service';
 import { nls } from '../common/nls';
@@ -40,6 +41,9 @@ export class BrowserClipboardService implements ClipboardService {
 
     @inject(ILogger)
     protected readonly logger: ILogger;
+
+    protected readonly onDidWriteTextEmitter = new Emitter<string>();
+    readonly onDidWriteText: Event<string> = this.onDidWriteTextEmitter.event;
 
     async readText(): Promise<string> {
         let permission;
@@ -82,6 +86,7 @@ export class BrowserClipboardService implements ClipboardService {
             // in FireFox, Clipboard API isn't gated with the permissions
             try {
                 await this.getClipboardAPI().writeText(value);
+                this.onDidWriteTextEmitter.fire(value);
                 return;
             } catch (e2) {
                 this.logger.error('Failed writing to the clipboard.', e2);
@@ -103,7 +108,8 @@ export class BrowserClipboardService implements ClipboardService {
             ));
             return;
         }
-        return this.getClipboardAPI().writeText(value);
+        await this.getClipboardAPI().writeText(value);
+        this.onDidWriteTextEmitter.fire(value);
     }
 
     protected async queryPermission(name: string): Promise<PermissionStatus> {

--- a/packages/core/src/browser/clipboard-service.ts
+++ b/packages/core/src/browser/clipboard-service.ts
@@ -14,10 +14,12 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import { Event } from '../common/event';
 import { MaybePromise } from '../common/types';
 
 export const ClipboardService = Symbol('ClipboardService');
 export interface ClipboardService {
     readText(): MaybePromise<string>;
     writeText(value: string): MaybePromise<void>;
+    readonly onDidWriteText?: Event<string>;
 }

--- a/packages/core/src/browser/clipboard-service.ts
+++ b/packages/core/src/browser/clipboard-service.ts
@@ -18,8 +18,17 @@ import { Event } from '../common/event';
 import { MaybePromise } from '../common/types';
 
 export const ClipboardService = Symbol('ClipboardService');
+/**
+ * Access to the system clipboard. Reading may require a user permission prompt in browsers.
+ */
 export interface ClipboardService {
+    /** Returns the clipboard text, or an empty string if it cannot be read. */
     readText(): MaybePromise<string>;
+    /** Writes the given text to the clipboard. */
     writeText(value: string): MaybePromise<void>;
+    /**
+     * Emitted with the written text after {@link writeText} updated the clipboard.
+     * Such writes dispatch no DOM `copy` event, so this is the only way to observe them.
+     */
     readonly onDidWriteText?: Event<string>;
 }

--- a/packages/core/src/electron-browser/electron-clipboard-service.ts
+++ b/packages/core/src/electron-browser/electron-clipboard-service.ts
@@ -16,10 +16,14 @@
 
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { injectable } from 'inversify';
+import { Emitter, Event } from '../common/event';
 import { ClipboardService } from '../browser/clipboard-service';
 
 @injectable()
 export class ElectronClipboardService implements ClipboardService {
+
+    protected readonly onDidWriteTextEmitter = new Emitter<string>();
+    readonly onDidWriteText: Event<string> = this.onDidWriteTextEmitter.event;
 
     readText(): string {
         return window.electronTheiaCore.readClipboard();
@@ -27,6 +31,7 @@ export class ElectronClipboardService implements ClipboardService {
 
     writeText(value: string): void {
         window.electronTheiaCore.writeClipboard(value);
+        this.onDidWriteTextEmitter.fire(value);
     }
 
 }

--- a/packages/navigator/src/browser/navigator-contribution.spec.ts
+++ b/packages/navigator/src/browser/navigator-contribution.spec.ts
@@ -46,11 +46,7 @@ describe('FileNavigatorContribution', () => {
 
     function createNavigatorWidgetStub(): FileNavigatorWidget {
         return {
-            model: {
-                get selectedFileStatNodes(): FileStatNode[] {
-                    return selectedNodes;
-                }
-            },
+            canPasteFiles: (raw?: string): boolean => raw !== '' && selectedNodes.length > 0,
             pasteFiles: (raw: string): boolean => {
                 pastedTexts.push(raw);
                 return true;

--- a/packages/navigator/src/browser/navigator-contribution.spec.ts
+++ b/packages/navigator/src/browser/navigator-contribution.spec.ts
@@ -42,14 +42,16 @@ describe('FileNavigatorContribution', () => {
     let fileClipboardText: string | undefined;
     let systemClipboardReads: number;
     let pastedTexts: string[];
+    let pasteError: Error | undefined;
+    let errorMessages: string[];
     let selectedNodes: FileStatNode[];
 
     function createNavigatorWidgetStub(): FileNavigatorWidget {
         return {
             canPasteFiles: (raw?: string): boolean => raw !== '' && selectedNodes.length > 0,
-            pasteFiles: (raw: string): boolean => {
+            pasteFiles: (raw: string): Promise<boolean> => {
                 pastedTexts.push(raw);
-                return true;
+                return pasteError ? Promise.reject(pasteError) : Promise.resolve(true);
             }
         } as unknown as FileNavigatorWidget;
     }
@@ -59,6 +61,8 @@ describe('FileNavigatorContribution', () => {
         fileClipboardText = undefined;
         systemClipboardReads = 0;
         pastedTexts = [];
+        pasteError = undefined;
+        errorMessages = [];
         selectedNodes = [];
         navigatorWidget = createNavigatorWidgetStub();
         currentWidget = navigatorWidget;
@@ -86,6 +90,11 @@ describe('FileNavigatorContribution', () => {
             },
             fileClipboard: {
                 get: (): string | undefined => fileClipboardText
+            },
+            messageService: {
+                error: (message: string): void => {
+                    errorMessages.push(message);
+                }
             }
         });
     });
@@ -139,6 +148,13 @@ describe('FileNavigatorContribution', () => {
             await contribution['pasteIntoNavigator']();
             expect(pastedTexts).to.deep.equal(['file:///workspace/copied-outside.txt']);
             expect(systemClipboardReads).to.equal(1);
+        });
+
+        it('should report a failed paste instead of rejecting unhandled', async () => {
+            clipboardText = 'file:///workspace/a.txt';
+            pasteError = new Error('Parent of file has to be a FileStatNode');
+            await contribution['pasteIntoNavigator']();
+            expect(errorMessages).to.deep.equal(['Parent of file has to be a FileStatNode']);
         });
     });
 });

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -394,7 +394,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         if (widget) {
             const text = this.fileClipboard.get() ?? await this.clipboardService.readText();
             if (text) {
-                widget.pasteFiles(text);
+                await widget.pasteFiles(text);
             }
         }
     }

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -380,7 +380,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     protected canPasteIntoNavigator(): boolean {
         const widget = this.tryGetWidget();
-        return !!widget && this.shell.currentWidget === widget && widget.model.selectedFileStatNodes.length > 0;
+        return !!widget && this.shell.currentWidget === widget && widget.canPasteFiles();
     }
 
     /**

--- a/packages/navigator/src/browser/navigator-contribution.ts
+++ b/packages/navigator/src/browser/navigator-contribution.ts
@@ -38,6 +38,7 @@ import {
     isOSX,
     MenuModelRegistry,
     MenuPath,
+    MessageService,
     Mutable,
     PreferenceScope,
     PreferenceService,
@@ -130,6 +131,9 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
 
     @inject(NavigatorFileClipboard)
     protected readonly fileClipboard: NavigatorFileClipboard;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
 
     @inject(CommandRegistry)
     protected readonly commandRegistry: CommandRegistry;
@@ -394,7 +398,7 @@ export class FileNavigatorContribution extends AbstractViewContribution<FileNavi
         if (widget) {
             const text = this.fileClipboard.get() ?? await this.clipboardService.readText();
             if (text) {
-                await widget.pasteFiles(text);
+                await widget.pasteFiles(text).catch(error => this.messageService.error(error.message));
             }
         }
     }

--- a/packages/navigator/src/browser/navigator-file-clipboard.spec.ts
+++ b/packages/navigator/src/browser/navigator-file-clipboard.spec.ts
@@ -22,6 +22,8 @@ FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
+import { Emitter } from '@theia/core/lib/common/event';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { NavigatorFileClipboard } from './navigator-file-clipboard';
 
 disableJSDOM();
@@ -30,6 +32,7 @@ describe('NavigatorFileClipboard', () => {
 
     let jsdomCleanup: () => void;
     let clipboard: NavigatorFileClipboard;
+    let onDidWriteTextEmitter: Emitter<string>;
 
     before(() => {
         jsdomCleanup = enableJSDOM();
@@ -38,10 +41,20 @@ describe('NavigatorFileClipboard', () => {
         jsdomCleanup();
     });
 
-    beforeEach(() => {
+    function createClipboard(clipboardService: ClipboardService): NavigatorFileClipboard {
         const container = new Container();
+        container.bind(ClipboardService).toConstantValue(clipboardService);
         container.bind(NavigatorFileClipboard).toSelf().inSingletonScope();
-        clipboard = container.get(NavigatorFileClipboard);
+        return container.get(NavigatorFileClipboard);
+    }
+
+    beforeEach(() => {
+        onDidWriteTextEmitter = new Emitter<string>();
+        clipboard = createClipboard({
+            readText: async () => '',
+            writeText: async () => undefined,
+            onDidWriteText: onDidWriteTextEmitter.event
+        });
     });
 
     it('should return undefined when nothing was copied', () => {
@@ -80,5 +93,21 @@ describe('NavigatorFileClipboard', () => {
         clipboard.set('file:///workspace/a.txt');
         document.body.dispatchEvent(new window.Event('cut', { bubbles: true }));
         expect(clipboard.get()).to.be.undefined;
+    });
+
+    it('should sync the content when text is written through the clipboard service', () => {
+        // e.g. Copy Path writes via ClipboardService.writeText, which dispatches no DOM copy event
+        clipboard.set('file:///workspace/a.txt');
+        onDidWriteTextEmitter.fire('/workspace/b.txt');
+        expect(clipboard.get()).to.equal('/workspace/b.txt');
+    });
+
+    it('should work with a clipboard service lacking the optional write event', () => {
+        clipboard = createClipboard({
+            readText: async () => '',
+            writeText: async () => undefined
+        });
+        clipboard.set('file:///workspace/a.txt');
+        expect(clipboard.get()).to.equal('file:///workspace/a.txt');
     });
 });

--- a/packages/navigator/src/browser/navigator-file-clipboard.spec.ts
+++ b/packages/navigator/src/browser/navigator-file-clipboard.spec.ts
@@ -95,11 +95,11 @@ describe('NavigatorFileClipboard', () => {
         expect(clipboard.get()).to.be.undefined;
     });
 
-    it('should sync the content when text is written through the clipboard service', () => {
+    it('should clear the content when text is written through the clipboard service', () => {
         // e.g. Copy Path writes via ClipboardService.writeText, which dispatches no DOM copy event
         clipboard.set('file:///workspace/a.txt');
         onDidWriteTextEmitter.fire('/workspace/b.txt');
-        expect(clipboard.get()).to.equal('/workspace/b.txt');
+        expect(clipboard.get()).to.be.undefined;
     });
 
     it('should work with a clipboard service lacking the optional write event', () => {

--- a/packages/navigator/src/browser/navigator-file-clipboard.ts
+++ b/packages/navigator/src/browser/navigator-file-clipboard.ts
@@ -14,7 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { injectable, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 
 /**
  * In-app store for file URIs copied in the navigator.
@@ -28,6 +29,9 @@ import { injectable, postConstruct } from '@theia/core/shared/inversify';
 @injectable()
 export class NavigatorFileClipboard {
 
+    @inject(ClipboardService)
+    protected readonly clipboardService: ClipboardService;
+
     protected content: string | undefined;
 
     @postConstruct()
@@ -36,6 +40,9 @@ export class NavigatorFileClipboard {
         // own (bubbling) copy listener, which runs after this capturing listener
         document.addEventListener('copy', this.clear, true);
         document.addEventListener('cut', this.clear, true);
+        // writes through the ClipboardService (e.g. Copy Path) dispatch no DOM event;
+        // adopt their content so the store stays in sync with the system clipboard
+        this.clipboardService.onDidWriteText?.(value => this.set(value));
     }
 
     set(content: string): void {

--- a/packages/navigator/src/browser/navigator-file-clipboard.ts
+++ b/packages/navigator/src/browser/navigator-file-clipboard.ts
@@ -40,9 +40,9 @@ export class NavigatorFileClipboard {
         // own (bubbling) copy listener, which runs after this capturing listener
         document.addEventListener('copy', this.clear, true);
         document.addEventListener('cut', this.clear, true);
-        // writes through the ClipboardService (e.g. Copy Path) dispatch no DOM event;
-        // adopt their content so the store stays in sync with the system clipboard
-        this.clipboardService.onDidWriteText?.(value => this.set(value));
+        // writes through the ClipboardService (e.g. Copy Path) dispatch no DOM event either,
+        // so invalidate the store here to let consumers fall back to the system clipboard
+        this.clipboardService.onDidWriteText?.(this.clear);
     }
 
     set(content: string): void {

--- a/packages/navigator/src/browser/navigator-widget.spec.ts
+++ b/packages/navigator/src/browser/navigator-widget.spec.ts
@@ -91,27 +91,39 @@ describe('FileNavigatorWidget', () => {
 
     describe('pasteFiles', () => {
 
-        it('should not paste anything for empty clipboard text', () => {
+        it('should not paste anything for empty clipboard text', async () => {
             selectedNodes = [targetNode];
-            expect(widget.pasteFiles('')).to.be.false;
+            expect(await widget.pasteFiles('')).to.be.false;
             expect(copiedSources).to.have.lengthOf(0);
         });
 
-        it('should not paste anything if no target node is selected', () => {
-            expect(widget.pasteFiles('file:///workspace/some-file.txt')).to.be.false;
+        it('should not paste anything if no target node is selected', async () => {
+            expect(await widget.pasteFiles('file:///workspace/some-file.txt')).to.be.false;
             expect(copiedSources).to.have.lengthOf(0);
         });
 
-        it('should copy valid workspace URIs to the selected target', () => {
+        it('should copy valid workspace URIs to the selected target', async () => {
             selectedNodes = [targetNode];
-            expect(widget.pasteFiles('file:///workspace/a.txt\nfile:///workspace/dir/b.txt')).to.be.true;
+            expect(await widget.pasteFiles('file:///workspace/a.txt\nfile:///workspace/dir/b.txt')).to.be.true;
             expect(copiedSources.map(uri => uri.toString())).to.deep.equal([
                 'file:///workspace/a.txt',
                 'file:///workspace/dir/b.txt'
             ]);
         });
 
-        it('should skip blank lines, invalid URIs and URIs outside the workspace', () => {
+        it('should resolve only after the copies completed', async () => {
+            selectedNodes = [targetNode];
+            let completedCopies = 0;
+            widget.model.copy = async (source: URI): Promise<URI> => {
+                await new Promise(resolve => setTimeout(resolve, 5));
+                completedCopies++;
+                return source;
+            };
+            expect(await widget.pasteFiles('file:///workspace/a.txt\nfile:///workspace/b.txt')).to.be.true;
+            expect(completedCopies).to.equal(2);
+        });
+
+        it('should skip blank lines, invalid URIs and URIs outside the workspace', async () => {
             selectedNodes = [targetNode];
             const raw = [
                 '',
@@ -120,44 +132,81 @@ describe('FileNavigatorWidget', () => {
                 'file:///outside/c.txt',
                 'file:///workspace/d.txt'
             ].join('\n');
-            expect(widget.pasteFiles(raw)).to.be.true;
+            expect(await widget.pasteFiles(raw)).to.be.true;
             expect(copiedSources.map(uri => uri.toString())).to.deep.equal(['file:///workspace/d.txt']);
             expect(infoMessages).to.have.lengthOf(0);
         });
 
-        it('should paste files given as absolute file system paths', () => {
+        it('should paste files given as absolute file system paths', async () => {
             selectedNodes = [targetNode];
-            expect(widget.pasteFiles('/workspace/e.txt')).to.be.true;
+            expect(await widget.pasteFiles('/workspace/e.txt')).to.be.true;
             expect(copiedSources.map(uri => uri.toString())).to.deep.equal(['file:///workspace/e.txt']);
             expect(infoMessages).to.have.lengthOf(0);
         });
 
-        it('should paste files given as Windows-style absolute paths', () => {
+        it('should paste files given as Windows-style absolute paths', async () => {
             widget = createWidget(URI.fromFilePath('C:\\workspace'));
             selectedNodes = [targetNode];
-            expect(widget.pasteFiles('C:\\workspace\\sub\\f.txt')).to.be.true;
+            expect(await widget.pasteFiles('C:\\workspace\\sub\\f.txt')).to.be.true;
             expect(copiedSources.map(uri => uri.toString())).to.deep.equal([URI.fromFilePath('C:\\workspace\\sub\\f.txt').toString()]);
             expect(infoMessages).to.have.lengthOf(0);
         });
 
-        it('should not paste relative paths', () => {
+        it('should not paste relative paths', async () => {
             selectedNodes = [targetNode];
-            expect(widget.pasteFiles('workspace/relative.txt')).to.be.true;
+            expect(await widget.pasteFiles('workspace/relative.txt')).to.be.true;
             expect(copiedSources).to.have.lengthOf(0);
         });
 
-        it('should inform the user when the clipboard contains no pastable files', () => {
+        it('should inform the user when the clipboard contains no pastable files', async () => {
             selectedNodes = [targetNode];
-            expect(widget.pasteFiles('not a uri')).to.be.true;
+            expect(await widget.pasteFiles('not a uri')).to.be.true;
             expect(copiedSources).to.have.lengthOf(0);
             expect(infoMessages).to.have.lengthOf(1);
         });
 
-        it('should stay silent for empty clipboard text or missing paste target', () => {
-            expect(widget.pasteFiles('file:///workspace/a.txt')).to.be.false;
+        it('should stay silent for empty clipboard text or missing paste target', async () => {
+            expect(await widget.pasteFiles('file:///workspace/a.txt')).to.be.false;
             selectedNodes = [targetNode];
-            expect(widget.pasteFiles('')).to.be.false;
+            expect(await widget.pasteFiles('')).to.be.false;
             expect(infoMessages).to.have.lengthOf(0);
+        });
+    });
+
+    describe('asPastedFileUri', () => {
+
+        it('should interpret UNC paths as file URIs', () => {
+            const uri = widget['asPastedFileUri']('\\\\server\\share\\f.txt');
+            expect(uri?.toString()).to.equal(URI.fromFilePath('\\\\server\\share\\f.txt').toString());
+        });
+    });
+
+    describe('handlePaste', () => {
+
+        function pasteEvent(text: string): ClipboardEvent & { prevented: number } {
+            const event = {
+                prevented: 0,
+                clipboardData: { getData: () => text },
+                preventDefault(): void {
+                    event.prevented++;
+                }
+            };
+            return event as unknown as ClipboardEvent & { prevented: number };
+        }
+
+        it('should consume the event only when clipboard text and a paste target are available', () => {
+            const noTarget = pasteEvent('file:///workspace/a.txt');
+            widget['handlePaste'](noTarget);
+            expect(noTarget.prevented).to.equal(0);
+
+            selectedNodes = [targetNode];
+            const noText = pasteEvent('');
+            widget['handlePaste'](noText);
+            expect(noText.prevented).to.equal(0);
+
+            const pastable = pasteEvent('file:///workspace/a.txt');
+            widget['handlePaste'](pastable);
+            expect(pastable.prevented).to.equal(1);
         });
     });
 

--- a/packages/navigator/src/browser/navigator-widget.spec.ts
+++ b/packages/navigator/src/browser/navigator-widget.spec.ts
@@ -39,6 +39,7 @@ describe('FileNavigatorWidget', () => {
     let selectedNodes: FileStatNode[];
     let storedClipboardContents: string[];
     let infoMessages: string[];
+    let errorMessages: string[];
     let widget: FileNavigatorWidget;
 
     const targetNode = { id: 'target', uri: workspaceRoot } as FileStatNode;
@@ -48,6 +49,7 @@ describe('FileNavigatorWidget', () => {
         selectedNodes = [];
         storedClipboardContents = [];
         infoMessages = [];
+        errorMessages = [];
         const model = {
             get selectedFileStatNodes(): FileStatNode[] {
                 return selectedNodes;
@@ -71,6 +73,9 @@ describe('FileNavigatorWidget', () => {
         const messageService = {
             info: (message: string): void => {
                 infoMessages.push(message);
+            },
+            error: (message: string): void => {
+                errorMessages.push(message);
             }
         } as unknown as MessageService;
         Object.assign(navigator, { workspaceService, fileClipboard, messageService });
@@ -207,6 +212,29 @@ describe('FileNavigatorWidget', () => {
             const pastable = pasteEvent('file:///workspace/a.txt');
             widget['handlePaste'](pastable);
             expect(pastable.prevented).to.equal(1);
+        });
+
+        it('should report a failed paste instead of rejecting unhandled', async () => {
+            selectedNodes = [targetNode];
+            widget.model.copy = () => Promise.reject(new Error('Parent of file has to be a FileStatNode'));
+            widget['handlePaste'](pasteEvent('file:///workspace/a.txt'));
+            await new Promise(resolve => setTimeout(resolve, 0));
+            expect(errorMessages).to.deep.equal(['Parent of file has to be a FileStatNode']);
+        });
+    });
+
+    describe('canPasteFiles', () => {
+
+        it('should require a paste target', () => {
+            expect(widget.canPasteFiles()).to.be.false;
+            selectedNodes = [targetNode];
+            expect(widget.canPasteFiles()).to.be.true;
+        });
+
+        it('should reject empty clipboard text if it is already known', () => {
+            selectedNodes = [targetNode];
+            expect(widget.canPasteFiles('')).to.be.false;
+            expect(widget.canPasteFiles('file:///workspace/a.txt')).to.be.true;
         });
     });
 

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -136,8 +136,11 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
 
     protected handlePaste(event: ClipboardEvent): void {
         if (event.clipboardData) {
-            if (this.pasteFiles(event.clipboardData.getData('text/plain'))) {
+            const raw = event.clipboardData.getData('text/plain');
+            // the consume decision must be made synchronously, before pasteFiles completes
+            if (raw && this.model.selectedFileStatNodes.length > 0) {
                 event.preventDefault();
+                this.pasteFiles(raw);
             }
         }
     }
@@ -146,9 +149,10 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
      * Pastes the files given as newline-separated URIs or absolute paths into the selected directory.
      *
      * @param raw the clipboard text, expected to hold one file URI or absolute file system path per line
-     * @returns `true` if the paste was handled, i.e. clipboard text and a paste target were available
+     * @returns `true` if the paste was handled, i.e. clipboard text and a paste target were available;
+     *   the promise resolves once all file copies have completed
      */
-    pasteFiles(raw: string): boolean {
+    async pasteFiles(raw: string): Promise<boolean> {
         if (!raw) {
             return false;
         }
@@ -164,9 +168,7 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
             ));
             return true;
         }
-        for (const source of sources) {
-            this.model.copy(source, target);
-        }
+        await Promise.all(sources.map(source => this.model.copy(source, target)));
         return true;
     }
 
@@ -188,7 +190,7 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
     /** Interprets the given clipboard line as a URI or an absolute file system path, e.g. from the Copy Path command. */
     protected asPastedFileUri(candidate: string): URI | undefined {
         // check for absolute paths first: Windows paths like C:\foo also parse as URLs (scheme 'c:')
-        if (candidate.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(candidate)) {
+        if (candidate.startsWith('/') || candidate.startsWith('\\\\') || /^[a-zA-Z]:[\\/]/.test(candidate)) {
             return URI.fromFilePath(candidate);
         }
         try {

--- a/packages/navigator/src/browser/navigator-widget.tsx
+++ b/packages/navigator/src/browser/navigator-widget.tsx
@@ -138,11 +138,21 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
         if (event.clipboardData) {
             const raw = event.clipboardData.getData('text/plain');
             // the consume decision must be made synchronously, before pasteFiles completes
-            if (raw && this.model.selectedFileStatNodes.length > 0) {
+            if (this.canPasteFiles(raw)) {
                 event.preventDefault();
-                this.pasteFiles(raw);
+                this.pasteFiles(raw).catch(error => this.messageService.error(error.message));
             }
         }
+    }
+
+    /**
+     * Whether {@link pasteFiles} would handle a paste, i.e. a paste target is selected and,
+     * if already known, the clipboard text is not empty.
+     *
+     * @param raw the clipboard text, if it has been obtained already
+     */
+    canPasteFiles(raw?: string): boolean {
+        return raw !== '' && this.model.selectedFileStatNodes.length > 0;
     }
 
     /**
@@ -153,13 +163,10 @@ export class FileNavigatorWidget extends AbstractNavigatorTreeWidget {
      *   the promise resolves once all file copies have completed
      */
     async pasteFiles(raw: string): Promise<boolean> {
-        if (!raw) {
+        if (!this.canPasteFiles(raw)) {
             return false;
         }
         const target = this.model.selectedFileStatNodes[0];
-        if (!target) {
-            return false;
-        }
         const sources = this.parsePastedUris(raw);
         if (sources.length === 0) {
             this.messageService.info(nls.localize(


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

- Add an optional onDidWriteText event to ClipboardService, emitted by the browser and electron implementations; such writes dispatch no DOM event, so in-app caches had no way to observe them
- Sync the in-app file clipboard with service writes so commands like Copy Path no longer leave menu paste with stale content
- Accept UNC paths as paste sources
- Await the file copies so the paste command resolves once pasting completed; the paste event is consumed based on a synchronous check of clipboard text and paste target

Relates to https://github.com/eclipse-theia/theia/issues/17828

#### How to test

  1. Start the browser example with a workspace containing a few files and a folder.
  2. Regression: select a file, copy it (Ctrl+C or context menu), select a folder, Paste (context menu or Ctrl+V) → file is pasted.
  3. Stale-store fix: copy file a in the explorer, then invoke Copy Path on a different file b, select a folder, Paste from the context menu → b is pasted (before this fix, the stale a was pasted again; also
  works without a clipboard permission prompt).
  4. UNC paths (Windows only): in a workspace on a UNC share, Copy Path on a file, select a folder, Paste → the file is pasted (previously dropped with the "clipboard does not contain workspace files"
  message).
  5. Electron: repeat step 3 to cover the electron clipboard service path.
  
#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
