### PR TITLE
fix(navigator): match files.exclude relative to workspace

### DIFF
--- a/packages/navigator/src/browser/navigator-filter.spec.ts
+++ b/packages/navigator/src/browser/navigator-filter.spec.ts
@@ -17,8 +17,13 @@
 import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJSDOM = enableJSDOM();
 
+import URI from '@theia/core/lib/common/uri';
+import { FileStat } from '@theia/filesystem/lib/common/files';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { expect } from 'chai';
-import { FileNavigatorFilterPredicate } from './navigator-filter';
+import * as sinon from 'sinon';
+import { FileNavigatorPreferences } from '../common/navigator-preferences';
+import { FileNavigatorFilter, FileNavigatorFilterPredicate } from './navigator-filter';
 
 disableJSDOM();
 
@@ -28,15 +33,40 @@ interface Input {
     readonly excludes: string[];
 }
 
+class TestFileNavigatorFilter extends FileNavigatorFilter {
+    constructor(
+        protected override readonly workspaceService: WorkspaceService,
+        filterPredicate: FileNavigatorFilter.Predicate
+    ) {
+        super({} as FileNavigatorPreferences);
+        this.filterPredicate = filterPredicate;
+    }
+
+    testFilter(item: { id: string }): boolean {
+        return this.filterItem(item);
+    }
+}
+
+function toFileStatNode(uri: URI): { id: string; uri: URI; fileStat: FileStat } {
+    return {
+        id: uri.toString(),
+        uri,
+        fileStat: FileStat.dir(uri.toString())
+    };
+}
+
 describe('navigator-filter-glob', () => {
 
-    const pathPrefix = 'file:///some/path/to';
-    const toItem = (id: string) => ({ id: `${pathPrefix}${id}` });
+    const toItem = (id: string) => ({ id: id.replace(/^\//, '') });
     const itemsToFilter = [
         '/.git/',
         '/.git/a',
         '/.git/b',
 
+        '/a.js',
+        '/dist/',
+
+        '/src/dist/',
         '/src/foo/',
         '/src/foo/a.js',
         '/src/foo/b.js',
@@ -70,11 +100,12 @@ describe('navigator-filter-glob', () => {
             },
             includes: [
                 '/src/foo/a.ts',
+                '/src/foo/a.js',
+                '/test/baz/bar/a.js',
                 '/.git/'
             ],
             excludes: [
-                '/src/foo/a.js',
-                '/test/baz/bar/a.js'
+                '/a.js'
             ]
         },
         {
@@ -97,12 +128,12 @@ describe('navigator-filter-glob', () => {
                 '**/.git/**': true
             },
             includes: [
-                '/src/foo/a.ts'
+                '/src/foo/a.ts',
+                '/src/foo/a.js'
             ],
             excludes: [
                 '/.git/',
-                '/src/foo/a.js',
-                '/test/baz/bar/a.js'
+                '/a.js'
             ]
         },
         {
@@ -127,6 +158,28 @@ describe('navigator-filter-glob', () => {
             excludes: [
 
             ]
+        },
+        {
+            patterns: {
+                'dist': true
+            },
+            includes: [
+                '/src/dist/'
+            ],
+            excludes: [
+                '/dist/'
+            ]
+        },
+        {
+            patterns: {
+                '*/dist': true
+            },
+            includes: [
+                '/dist/'
+            ],
+            excludes: [
+                '/src/dist/'
+            ]
         }
     ] as Input[]).forEach((test, index) => {
         it(`${index < 10 ? `0${index + 1}` : `${index + 1}`} glob-filter: (${Object.keys(test.patterns).map(key => `${key} [${test.patterns[key]}]`).join(', ')}) `, () => {
@@ -137,6 +190,21 @@ describe('navigator-filter-glob', () => {
         });
     });
 
+});
+
+describe('navigator-filter workspace paths', () => {
+    const workspaceRoot = new URI('file:///workspace');
+    const workspaceService = sinon.createStubInstance(WorkspaceService);
+    workspaceService.getWorkspaceRootUri.returns(workspaceRoot);
+    const filter = new TestFileNavigatorFilter(workspaceService, new FileNavigatorFilterPredicate({ dist: true }));
+
+    it('matches files.exclude against workspace-relative paths', () => {
+        const rootDist = new URI('file:///workspace/dist');
+        const nestedDist = new URI('file:///workspace/src/dist');
+
+        expect(filter.testFilter(toFileStatNode(rootDist))).to.be.false;
+        expect(filter.testFilter(toFileStatNode(nestedDist))).to.be.true;
+    });
 });
 
 function includes<T>(array: T[], item: T, message: string = `Expected ${JSON.stringify(array)} to include ${JSON.stringify(item)}.`): void {

--- a/packages/navigator/src/browser/navigator-filter.ts
+++ b/packages/navigator/src/browser/navigator-filter.ts
@@ -14,13 +14,15 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
-import { Minimatch } from 'minimatch';
-import { MaybePromise } from '@theia/core/lib/common/types';
-import { Event, Emitter } from '@theia/core/lib/common/event';
-import { FileSystemPreferences, FileSystemConfiguration } from '@theia/filesystem/lib/common/filesystem-preferences';
-import { FileNavigatorPreferences, FileNavigatorConfiguration } from '../common/navigator-preferences';
 import { PreferenceChangeEvent } from '@theia/core';
+import { Event, Emitter } from '@theia/core/lib/common/event';
+import { MaybePromise } from '@theia/core/lib/common/types';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { FileStatNode } from '@theia/filesystem/lib/browser';
+import { FileSystemPreferences, FileSystemConfiguration } from '@theia/filesystem/lib/common/filesystem-preferences';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { Minimatch } from 'minimatch';
+import { FileNavigatorPreferences, FileNavigatorConfiguration } from '../common/navigator-preferences';
 
 /**
  * Filter for omitting elements from the navigator. For more details on the exclusion patterns,
@@ -35,6 +37,9 @@ export class FileNavigatorFilter {
 
     @inject(FileSystemPreferences)
     protected readonly filesPreferences: FileSystemPreferences;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     constructor(
         @inject(FileNavigatorPreferences) protected readonly preferences: FileNavigatorPreferences
@@ -60,7 +65,12 @@ export class FileNavigatorFilter {
     }
 
     protected filterItem(item: { id: string }): boolean {
-        return this.filterPredicate.filter(item);
+        let relativePath: string | undefined;
+        if (FileStatNode.is(item)) {
+            const workspaceRoot = this.workspaceService.getWorkspaceRootUri(item.uri);
+            relativePath = workspaceRoot?.relative(item.uri)?.toString();
+        }
+        return this.filterPredicate.filter({ id: relativePath ?? item.id });
     }
 
     protected fireFilterChanged(): void {
@@ -156,7 +166,7 @@ export class FileNavigatorFilterPredicate implements FileNavigatorFilter.Predica
     }
 
     protected createDelegate(pattern: string): FileNavigatorFilter.Predicate {
-        const delegate = new Minimatch(pattern, { matchBase: true });
+        const delegate = new Minimatch(pattern);
         return {
             filter: item => !delegate.match(item.id)
         };


### PR DESCRIPTION
#### What it does

Fixes #17670.

- Matches `files.exclude` patterns against workspace-relative navigator paths instead of full node URIs.
- Removes `matchBase` so root and nested glob patterns follow VS Code semantics.
- Adds regression coverage for `dist`, `*/dist`, root-only `*.js`, and URI-to-workspace-relative conversion.

#### How to test

Automated:

```sh
npx lerna run compile --scope @theia/navigator
npx lerna run test --scope @theia/navigator
npx lerna run lint --scope @theia/navigator
npm run compile
```

All commands pass; the navigator suite has 37 passing tests and the full compile covers 91 projects.

Manual:

1. Create `dist` and `src/dist` folders in a workspace.
2. Set `"files.exclude": { "dist": true }` and verify only the root `dist` is hidden.
3. Set `"files.exclude": { "*/dist": true }` and verify only `src/dist` is hidden.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

N/A.

#### Review checklist

- [ ] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no user-facing text was added)
