### PR TITLE
fix(preferences): ignore reserved keys when merging preference values

### DIFF
--- a/packages/core/src/common/preferences/preference-provider.spec.ts
+++ b/packages/core/src/common/preferences/preference-provider.spec.ts
@@ -34,4 +34,21 @@ describe('PreferenceProviderImpl', () => {
         );
         expect(result).deep.equals({ 'configurations': [{ 'name': 'test1', 'request': 'launch' }, { 'name': 'test2' }], 'compounds': [] });
     });
+    it('should ignore reserved keys when merging', () => {
+        const payload = JSON.parse('{"__proto__":{"injected":"yes"}}');
+        const result = PreferenceUtils.merge({ 'safe': true }, payload);
+        // A modified Object.prototype leaks onto every object, so a freshly created `{}`
+        // must not inherit the injected key and the result must stay a plain object.
+        expect(({} as Record<string, unknown>).injected).to.equal(undefined);
+        expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+        expect(result).deep.equals({ 'safe': true });
+    });
+    it('should ignore nested reserved keys when merging', () => {
+        const payload = JSON.parse('{"parent":{"__proto__":{"injected":"yes"},"valid":"true"}}');
+        const result = PreferenceUtils.merge({ 'parent': { 'existing': true } }, payload);
+        // The nested reserved key is dropped while the sibling `valid` is still merged, and a
+        // freshly created `{}` must not inherit the injected key.
+        expect(({} as Record<string, unknown>).injected).to.equal(undefined);
+        expect(result).deep.equals({ 'parent': { 'existing': true, 'valid': 'true' } });
+    });
 });

--- a/packages/core/src/common/preferences/preference-provider.ts
+++ b/packages/core/src/common/preferences/preference-provider.ts
@@ -133,6 +133,23 @@ export interface PreferenceProvider extends Disposable {
 }
 
 export namespace PreferenceUtils {
+    const RESERVED_MERGE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
+    /**
+     * Recursively merges the values of `target` into `source` and returns the merged result.
+     *
+     * Note the direction: `source` is the accumulator that is mutated and returned, while the
+     * values of `target` take precedence for conflicting primitive values. Nested objects are
+     * merged recursively and arrays are concatenated (`source` entries first, then `target`).
+     * If `source` is not a JSON object, a deep copy of `target` is returned instead.
+     *
+     * Only own properties are considered and reserved keys are ignored, so merged results are
+     * always plain data objects.
+     *
+     * @param source the accumulator to merge into; mutated and returned unless it is not an object
+     * @param target the values that are merged into `source` and take precedence on conflicts
+     * @returns the merged result (the mutated `source`, or a deep copy of `target`)
+     */
     export function merge(source: JSONValue | undefined, target: JSONValue): JSONValue {
         if (source === undefined || !JSONExt.isObject(source)) {
             return JSONExt.deepCopy(target);
@@ -141,7 +158,11 @@ export namespace PreferenceUtils {
             return {};
         }
         for (const [key, value] of Object.entries(target)) {
-            if (key in source) {
+            if (RESERVED_MERGE_KEYS.has(key)) {
+                // Skip reserved object keys so merged results stay plain data objects.
+                continue;
+            }
+            if (Object.prototype.hasOwnProperty.call(source, key)) {
                 const sourceValue = source[key];
                 if (JSONExt.isObject(sourceValue) && JSONExt.isObject(value)) {
                     merge(sourceValue, value);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Makes preference value merging more robust:

only merge own properties of the source object
skip reserved object keys so merged results stay plain data objects
No user-facing behavior change for normal preferences.

Related: #8675

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

All `@theia/core` tests, including the new own-property cases, should pass.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
