### PR TITLE
AI: resolve hidden pinned agents in delegated sessions

### DIFF
--- a/packages/ai-chat/src/common/chat-service-pinned-agent.spec.ts
+++ b/packages/ai-chat/src/common/chat-service-pinned-agent.spec.ts
@@ -74,17 +74,38 @@ describe('ChatService pinned agent behavior', () => {
         prompts: []
     };
 
+    const mockHiddenAgent: ChatAgent = {
+        id: 'hidden-worker',
+        name: 'Hidden Worker',
+        description: 'Test agent that is hidden from chat (showInChat: false)',
+        locations: [ChatAgentLocation.Panel],
+        invoke: async () => { },
+        languageModelRequirements: [],
+        tags: [],
+        variables: [],
+        agentSpecificVariables: [],
+        functions: [],
+        prompts: []
+    };
+
     class MockChatAgentService {
         private agents = new Map<string, ChatAgent>([
             ['pinned-agent', mockPinnedAgent],
             ['mentioned-agent', mockMentionedAgent],
-            ['default-agent', mockDefaultAgent]
+            ['default-agent', mockDefaultAgent],
+            ['hidden-worker', mockHiddenAgent]
         ]);
+
+        /** Mirrors ChatAgentServiceImpl: agents with showInChat === false are only returned with includeHidden. */
+        private hiddenIds = new Set<string>(['hidden-worker']);
 
         readonly onDidChangeAgents = { dispose: () => { } };
         readonly onDefaultAgentChanged = { dispose: () => { } };
 
-        getAgent(id: string): ChatAgent | undefined {
+        getAgent(id: string, includeHidden: boolean = false): ChatAgent | undefined {
+            if (!includeHidden && this.hiddenIds.has(id)) {
+                return undefined;
+            }
             return this.agents.get(id);
         }
 
@@ -221,5 +242,40 @@ describe('ChatService pinned agent behavior', () => {
 
         // The selected agent (mentioned-agent) becomes the new pinned agent
         expect(session.pinnedAgent).to.equal(mockMentionedAgent);
+    });
+
+    it('should resolve a hidden pinned agent instead of falling back to the default agent', () => {
+        // AgentDelegationTool pins the delegated agent on the session it creates; worker agents
+        // are typically hidden (showInChat: false). The pin is an explicit choice, so it must
+        // resolve even for hidden agents — falling back to the default agent would silently run
+        // the wrong agent with the wrong prompt and toolset.
+        const session = createMockSession(mockHiddenAgent);
+        const parsedRequest: ParsedChatRequest = {
+            request: { text: 'test message' },
+            parts: [new ParsedChatRequestTextPart({ start: 0, endExclusive: 'test message'.length }, 'test message')],
+            toolRequests: new Map(),
+            variables: []
+        };
+
+        const agent = chatService.getAgent(parsedRequest, session);
+        expect(agent).to.equal(mockHiddenAgent);
+    });
+
+    it('should resolve a hidden pinned agent when the request mentions that hidden agent', () => {
+        // A delegated request's text is '@<agentId> <prompt>'. The mention of a hidden agent does
+        // not resolve (mentions stay hidden-excluding), but the pin must still catch it.
+        const session = createMockSession(mockHiddenAgent);
+        const parsedRequest: ParsedChatRequest = {
+            request: { text: '@hidden-worker test' },
+            parts: [
+                new ParsedChatRequestAgentPart({ start: 0, endExclusive: '@hidden-worker'.length }, 'hidden-worker', 'hidden-worker'),
+                new ParsedChatRequestTextPart({ start: '@hidden-worker '.length, endExclusive: '@hidden-worker test'.length }, 'test')
+            ],
+            toolRequests: new Map(),
+            variables: []
+        };
+
+        const agent = chatService.getAgent(parsedRequest, session);
+        expect(agent).to.equal(mockHiddenAgent);
     });
 });

--- a/packages/ai-chat/src/common/chat-service.ts
+++ b/packages/ai-chat/src/common/chat-service.ts
@@ -450,8 +450,12 @@ export class ChatServiceImpl implements ChatService {
             return mentionedAgent;
         } else if (session.pinnedAgent) {
             // If we have a valid pinned agent, use it (pinned agent may become stale
-            // if it was disabled; so we always need to recheck)
-            const pinnedAgent = this.chatAgentService.getAgent(session.pinnedAgent.id);
+            // if it was disabled; so we always need to recheck). A pin is an explicit choice —
+            // e.g. AgentDelegationTool pins the delegated agent on the session it creates, and
+            // worker agents are often hidden (showInChat: false) — so hidden agents are honored
+            // here, while plain @-mentions above stay hidden-excluding. Without this, a request
+            // in a session pinned to a hidden agent silently falls back to the default agent.
+            const pinnedAgent = this.chatAgentService.getAgent(session.pinnedAgent.id, true);
             if (pinnedAgent) {
                 return pinnedAgent;
             }
@@ -550,9 +554,10 @@ export class ChatServiceImpl implements ChatService {
         const model = new MutableChatModel(serialized.model);
         await this.restoreSessionData(model, serialized.model);
 
-        // Determine pinned agent
+        // Determine pinned agent (hidden agents included — a restored pin, like a live one,
+        // is an explicit choice; see getPinnedAgent)
         const pinnedAgent = serialized.pinnedAgentId
-            ? this.chatAgentService.getAgent(serialized.pinnedAgentId)
+            ? this.chatAgentService.getAgent(serialized.pinnedAgentId, true)
             : undefined;
 
         // Register as session


### PR DESCRIPTION
#### What it does

Fixes #17849.

`AgentDelegationTool.delegateToAgent` supports hidden agents: it validates its target with `getAgent(agentId, /* includeHidden */ true)` and pins it on the session it creates. But `ChatServiceImpl` re-checked that pin with the hidden-excluding `getAgent(id)`, so for a target with `showInChat: false` — the usual configuration for worker sub-agents — the pin was dropped and the request fell through to the **default chat agent**, which then handled the delegated session with its own prompt and toolset (including tools the worker was never meant to have, such as `delegateToAgent`). The delegation widget labels the sub-session with the *intended* agent id, so the substitution was invisible. The same lookup was used when restoring a serialized session's pinned agent, so restored delegated sessions mis-routed too.

Both pinned-agent lookups now include hidden agents: a pin is an explicit programmatic choice, unlike a user-typed `@`-mention, which intentionally stays hidden-excluding.

#### How to test

`npx lerna run --scope @theia/ai-chat test` — 354 passing, including two new specs in `chat-service-pinned-agent.spec.ts` (the mock agent service now models `ChatAgentServiceImpl`'s `includeHidden` semantics).

Manually: define a custom agent with `showInChat: false`, have another agent delegate to it via `delegateToAgent`, and confirm the sub-session is handled by that agent (its prompt and toolset) rather than by the default chat agent.

#### Follow-ups

None. Related: the per-agent tool policies proposed in #17844 only take effect for hidden worker agents once this lands, since the policy travels with the agent that would otherwise never run.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

Behavior fix only: a session pinned to a hidden agent now resolves to that agent instead of silently falling back to the default one. No API changes.

#### Attribution

Contributed on behalf of K2view.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
