### PR TITLE
AI: support allowedTools/disallowedTools tool policies on chat agents

### DIFF
--- a/doc/Migration.md
+++ b/doc/Migration.md
@@ -126,6 +126,21 @@ A new framework API, `AiConfigurationService` (`@theia/ai-core`), wraps `Prefere
 - Prefer `AiConfigurationService` over `PreferenceService` for `ai-features.*` keys in frontend code. Its `get`/`inspect` are workspace-trust-aware (workspace/folder values are suppressed while the workspace is untrusted); writes (`set`/`update`) are never gated by trust.
 - **Behavior change:** the AI terminal's shell-command allowlist/denylist (`ai-features.terminal.shellCommand{Allowlist,Denylist}`) are now read trust-aware via `AiConfigurationService`. Previously they were read with a raw `PreferenceService.get`, so an untrusted workspace could contribute allowlist entries. Now workspace/folder-scoped entries are suppressed until the workspace is trusted (an untrusted workspace can no longer widen the shell allowlist). User- and default-scoped entries are unaffected.
 
+#### Optional per-agent tool policy: `allowedTools`/`disallowedTools` [#17851](https://github.com/eclipse-theia/theia/pull/17851)
+
+Chat agents (built-in and custom) can now optionally cap and deny which of their already-granted tools are exposed to the model, via `allowedTools`/`disallowedTools` glob lists enforced centrally in `ChatToolRequestService`. Both keys are entirely optional; omitting them preserves today's behavior exactly.
+
+**End-user-facing:**
+
+- Custom agents defined in `agent.md` may add `allowedTools`/`disallowedTools` frontmatter keys, next to `name`/`description`/`defaultLLM`/`showInChat` (introduced in v1.73.0), each a list of case-sensitive glob patterns (`*` matches any character sequence, every other character is literal). A tool is exposed only if it matches some `allowedTools` pattern (omitted list = no cap) and no `disallowedTools` pattern (omitted list = deny nothing); `disallowedTools` always wins over `allowedTools`. These lists only filter tools already parsed from the prompt/request — they never grant a tool that nothing referenced.
+- Delegated chat sessions (created via agent delegation) no longer honor tool names mentioned in the delegation request text: previously such wording could grant the delegated agent tools the delegating agent never intended to hand over. Only the skill-loading tool (`getSkillFileContent`) is still grantable this way, so a delegating agent can still prime a sub-agent with a skill. This fixes [#17836](https://github.com/eclipse-theia/theia/issues/17836).
+
+**Adopter-facing:**
+
+- `ChatAgent` (`@theia/ai-chat`) gained optional `allowedTools`/`disallowedTools: string[]` properties; `AbstractChatAgent` passes `this` as the new optional `agent` parameter on the three `ChatToolRequestService` calls it makes. If you implement `ChatAgent` directly rather than extending `AbstractChatAgent` and want the policy enforced, pass the agent as that same optional parameter to `ChatToolRequestService.getChatToolRequests`/`toChatToolRequests`.
+- `CustomAgentDescription` (`@theia/ai-core`) and `CustomAgentFrontmatter` gained the same two optional properties, round-tripped through `readCustomAgentFile`/`serializeCustomAgentFile`. A frontmatter key present with a value that is not a string array now causes the whole `agent.md` file to be rejected on read, the same convention already used for a mistyped `showInChat`.
+- `CustomAgentFactory` gained two new optional trailing parameters, `allowedTools?: string[]` and `disallowedTools?: string[]`; existing callers are unaffected since the parameters are optional and appended at the end.
+
 ### v1.73.0
 
 #### Custom agents reorganized into per-agent folders [#17523](https://github.com/eclipse-theia/theia/pull/17523)

--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -132,14 +132,19 @@ export default new ContainerModule(bind => {
     bind(PendingToolConfirmationTracker).toSelf().inSingletonScope();
 
     bind(CustomChatAgent).toSelf();
-    bind(CustomAgentFactory).toFactory<CustomChatAgent, [string, string, string, string, string, boolean | undefined, CustomAgentPromptVariant[] | undefined]>(
-        ctx => (id, name, description, prompt, defaultLLM, showInChat, promptVariants) => {
+    bind(CustomAgentFactory).toFactory<
+        CustomChatAgent,
+        [string, string, string, string, string, boolean | undefined, CustomAgentPromptVariant[] | undefined, string[] | undefined, string[] | undefined]
+    >(
+        ctx => (id, name, description, prompt, defaultLLM, showInChat, promptVariants, allowedTools, disallowedTools) => {
             const agent = ctx.container.get<CustomChatAgent>(CustomChatAgent);
             agent.id = id;
             agent.name = name;
             agent.description = description;
             agent.prompt = prompt;
             agent.promptVariants = promptVariants;
+            agent.allowedTools = allowedTools;
+            agent.disallowedTools = disallowedTools;
             agent.languageModelRequirements = [{
                 purpose: 'chat',
                 identifier: defaultLLM,

--- a/packages/ai-chat/src/browser/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/browser/chat-tool-request-service.ts
@@ -15,8 +15,7 @@
 // *****************************************************************************
 
 import { ToolInvocationContext, ToolRequest } from '@theia/ai-core';
-import { ILogger } from '@theia/core';
-import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatToolRequestService, normalizeToolArgs } from '../common/chat-tool-request-service';
 import { raceConfirmationWithTimeout } from '../common/chat-tool-confirmation-timeout';
 import { MutableChatRequestModel, ToolCallChatResponseContent } from '../common/chat-model';
@@ -28,9 +27,6 @@ import { ToolConfirmationManager } from './chat-tool-preference-bindings';
  */
 @injectable()
 export class FrontendChatToolRequestService extends ChatToolRequestService {
-
-    @inject(ILogger) @named('ChatToolRequestService')
-    protected readonly logger: ILogger;
 
     @inject(ToolConfirmationManager)
     protected readonly confirmationManager: ToolConfirmationManager;

--- a/packages/ai-chat/src/browser/custom-agent-factory.ts
+++ b/packages/ai-chat/src/browser/custom-agent-factory.ts
@@ -25,5 +25,7 @@ export type CustomAgentFactory = (
     prompt: string,
     defaultLLM: string,
     showInChat?: boolean,
-    promptVariants?: CustomAgentPromptVariant[]
+    promptVariants?: CustomAgentPromptVariant[],
+    allowedTools?: string[],
+    disallowedTools?: string[]
 ) => CustomChatAgent;

--- a/packages/ai-chat/src/browser/custom-agent-frontend-application-contribution.ts
+++ b/packages/ai-chat/src/browser/custom-agent-frontend-application-contribution.ts
@@ -105,7 +105,10 @@ export class AICustomAgentsFrontendApplicationContribution implements FrontendAp
             this.knownCustomAgents.delete(id);
         });
         customAgentsToAdd.forEach(agent => {
-            this.customAgentFactory(agent.id, agent.name, agent.description, agent.prompt, agent.defaultLLM, agent.showInChat, agent.promptVariants);
+            this.customAgentFactory(
+                agent.id, agent.name, agent.description, agent.prompt, agent.defaultLLM,
+                agent.showInChat, agent.promptVariants, agent.allowedTools, agent.disallowedTools
+            );
             this.knownCustomAgents.set(agent.id, agent);
         });
     }

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -177,6 +177,15 @@ export interface ChatAgent extends Agent {
     locations: ChatAgentLocation[];
     iconClass?: string;
     modes?: ChatMode[];
+    /**
+     * Optional glob patterns capping this agent's toolset. A tool parsed from the prompt or
+     * request survives only if it matches one of these patterns. Omitted = no cap. Entries are
+     * case-sensitive; `*` matches any character sequence, all other characters are literal.
+     * These lists filter parsed tools — they never grant tools that nothing referenced.
+     */
+    allowedTools?: string[];
+    /** Optional glob patterns denying tools. Omitted = deny nothing. Deny wins over allow. */
+    disallowedTools?: string[];
     invoke(request: MutableChatRequestModel, chatAgentService?: ChatAgentService): Promise<void>;
 }
 
@@ -211,6 +220,8 @@ export abstract class AbstractChatAgent implements ChatAgent {
     prompts: PromptVariantSet[] = [];
     agentSpecificVariables: AgentSpecificVariables[] = [];
     functions: string[] = [];
+    allowedTools?: string[];
+    disallowedTools?: string[];
     protected readonly abstract defaultLanguageModelPurpose: string;
     protected systemPromptId: string | undefined = undefined;
     protected additionalToolRequests: ToolRequest[] = [];
@@ -268,9 +279,9 @@ export abstract class AbstractChatAgent implements ChatAgent {
 
             const systemMessageToolRequests = systemMessageDescription?.functionDescriptions?.values();
             const tools = [
-                ...this.chatToolRequestService.getChatToolRequests(request),
-                ...this.chatToolRequestService.toChatToolRequests(systemMessageToolRequests ? Array.from(systemMessageToolRequests) : [], request),
-                ...this.chatToolRequestService.toChatToolRequests(this.additionalToolRequests, request)
+                ...this.chatToolRequestService.getChatToolRequests(request, this),
+                ...this.chatToolRequestService.toChatToolRequests(systemMessageToolRequests ? Array.from(systemMessageToolRequests) : [], request, this),
+                ...this.chatToolRequestService.toChatToolRequests(this.additionalToolRequests, request, this)
             ];
             const deferredSet = new Set<string>();
             request.message.deferredToolIds?.forEach(id => deferredSet.add(id));

--- a/packages/ai-chat/src/common/chat-tool-request-service.spec.ts
+++ b/packages/ai-chat/src/common/chat-tool-request-service.spec.ts
@@ -15,7 +15,9 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { isEmptyToolArgs, normalizeToolArgs } from './chat-tool-request-service';
+import { ChatToolRequestService, isEmptyToolArgs, matchesToolPattern, normalizeToolArgs } from './chat-tool-request-service';
+import { ToolRequest } from '@theia/ai-core';
+import { MutableChatRequestModel } from './chat-model';
 
 describe('Tool Arguments Utilities', () => {
 
@@ -93,5 +95,61 @@ describe('Tool Arguments Utilities', () => {
 
             expect(normalizeToolArgs(fromStream)).to.equal(normalizeToolArgs(fromHandler));
         });
+    });
+});
+
+describe('matchesToolPattern', () => {
+    it('matches an exact id', () => expect(matchesToolPattern('getFile', 'getFile')).to.be.true);
+    it('rejects a different id', () => expect(matchesToolPattern('getFile', 'getFiles')).to.be.false);
+    it('matches everything with *', () => expect(matchesToolPattern('*', 'anything')).to.be.true);
+    it('matches a prefix glob', () => expect(matchesToolPattern('mcp_*', 'mcp_search')).to.be.true);
+    it('matches a suffix glob', () => expect(matchesToolPattern('*_search', 'mcp_search')).to.be.true);
+    it('matches an infix glob', () => expect(matchesToolPattern('k2_*_query', 'k2_fabric_query')).to.be.true);
+    it('treats regex metacharacters as literals', () => {
+        expect(matchesToolPattern('a.b', 'a.b')).to.be.true;
+        expect(matchesToolPattern('a.b', 'axb')).to.be.false;
+    });
+    it('is case-sensitive', () => expect(matchesToolPattern('GetFile', 'getfile')).to.be.false);
+    it('combines a literal metacharacter with a glob', () => {
+        expect(matchesToolPattern('a.*_x', 'a.foo_x')).to.be.true;
+        expect(matchesToolPattern('a.*_x', 'aXfoo_x')).to.be.false;
+    });
+});
+
+describe('ChatToolRequestService agent tool policy', () => {
+    const tool = (id: string): ToolRequest => ({ id, name: id, parameters: { type: 'object', properties: {} }, handler: async () => undefined });
+    const requestModel = (toolIds: string[], rootSessionId?: string): MutableChatRequestModel => ({
+        message: { toolRequests: new Map(toolIds.map(id => [id, tool(id)])) },
+        session: { rootSessionId }
+    } as unknown as MutableChatRequestModel);
+    const service = new ChatToolRequestService();
+    const ids = (tools: ToolRequest[]) => tools.map(t => t.id);
+
+    it('leaves tools untouched without an agent policy', () => {
+        expect(ids(service.toChatToolRequests([tool('a'), tool('b')], requestModel([])))).to.deep.equal(['a', 'b']);
+    });
+    it('caps to allowedTools', () => {
+        expect(ids(service.toChatToolRequests([tool('a'), tool('b')], requestModel([]), { allowedTools: ['a'] }))).to.deep.equal(['a']);
+    });
+    it('allows nothing on an explicit empty allowedTools', () => {
+        expect(ids(service.toChatToolRequests([tool('a')], requestModel([]), { allowedTools: [] }))).to.deep.equal([]);
+    });
+    it('removes disallowedTools matches, deny wins over allow', () => {
+        expect(ids(service.toChatToolRequests([tool('a'), tool('b')], requestModel([]), { allowedTools: ['*'], disallowedTools: ['a'] }))).to.deep.equal(['b']);
+    });
+    it('applies globs in both lists', () => {
+        expect(ids(service.toChatToolRequests([tool('mcp_x'), tool('other')], requestModel([]), { disallowedTools: ['mcp_*'] }))).to.deep.equal(['other']);
+    });
+    it('grants request tools in a non-delegated session', () => {
+        expect(ids(service.getChatToolRequests(requestModel(['a', 'getSkillFileContent'])))).to.deep.equal(['a', 'getSkillFileContent']);
+    });
+    it('caps request grants to the allowlist in a delegated session', () => {
+        expect(ids(service.getChatToolRequests(requestModel(['a', 'getSkillFileContent'], 'root')))).to.deep.equal(['getSkillFileContent']);
+    });
+    it('subjects the delegation allowlist to the agent deny list', () => {
+        expect(ids(service.getChatToolRequests(requestModel(['getSkillFileContent'], 'root'), { disallowedTools: ['getSkillFileContent'] }))).to.deep.equal([]);
+    });
+    it('does not apply the delegated-session request-text cap to the declared path', () => {
+        expect(ids(service.toChatToolRequests([tool('a')], requestModel([], 'root')))).to.deep.equal(['a']);
     });
 });

--- a/packages/ai-chat/src/common/chat-tool-request-service.ts
+++ b/packages/ai-chat/src/common/chat-tool-request-service.ts
@@ -15,7 +15,8 @@
 // *****************************************************************************
 
 import { ToolInvocationContext, ToolRequest } from '@theia/ai-core';
-import { injectable } from '@theia/core/shared/inversify';
+import { ILogger } from '@theia/core';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
 import { MutableChatRequestModel, MutableChatResponseModel } from './chat-model';
 
 /**
@@ -75,6 +76,32 @@ export function assertChatContext(ctx: unknown): asserts ctx is ChatToolContext 
 export type ChatToolRequest = ToolRequest<ChatToolContext>;
 
 /**
+ * The subset of a chat agent that is relevant to tool filtering. Structurally satisfied by
+ * `ChatAgent` (kept as a separate structural interface so the service does not depend on the
+ * chat-agents module and tests can pass plain objects).
+ *
+ * Semantics: effective toolset = (parsed tools ∩ `allowedTools`) − `disallowedTools`.
+ * Omitted `allowedTools` = no cap; omitted `disallowedTools` = deny nothing; deny always wins.
+ * Entries are case-sensitive globs: `*` matches any character sequence, all other characters are
+ * literal. The lists filter the tools that were parsed from the prompt/request — they never add
+ * tools that nothing referenced.
+ */
+export interface AgentToolPolicy {
+    id?: string;
+    allowedTools?: string[];
+    disallowedTools?: string[];
+}
+
+/**
+ * Matches a tool id against a policy pattern. `*` matches any character sequence; every other
+ * character is literal. Anchored full match, case-sensitive.
+ */
+export function matchesToolPattern(pattern: string, toolId: string): boolean {
+    const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, char => char === '*' ? '.*' : `\\${char}`);
+    return new RegExp(`^${escaped}$`).test(toolId);
+}
+
+/**
  * Wraps tool requests in a chat context.
  *
  * This service extracts tool requests from a given chat request model and wraps their
@@ -83,30 +110,55 @@ export type ChatToolRequest = ToolRequest<ChatToolContext>;
 @injectable()
 export class ChatToolRequestService {
 
+    @inject(ILogger) @named('ChatToolRequestService')
+    protected readonly logger: ILogger;
+
+    /**
+     * Tool ids that a delegation request's text may still grant to the delegated agent. By default
+     * only the skill-loading tool, so a delegating agent can prime a sub-agent with a skill
+     * (the id is a literal because its constant lives in @theia/ai-ide, which this package must
+     * not depend on). Subclasses may override to widen or clear the allowlist.
+     */
+    protected readonly delegationRequestGrantAllowlist: string[] = ['getSkillFileContent'];
+
     /**
      * Extracts tool requests from a chat request and wraps them to provide chat context.
      * @param request The chat request containing tool requests
+     * @param agent optional tool policy of the invoking agent; tools not permitted by the policy are filtered out
      * @returns Tool requests with handlers that receive ChatToolContext
      */
-    getChatToolRequests(request: MutableChatRequestModel): ToolRequest[] {
+    getChatToolRequests(request: MutableChatRequestModel, agent?: AgentToolPolicy): ToolRequest[] {
         const toolRequests = request.message.toolRequests.size > 0 ? [...request.message.toolRequests.values()] : undefined;
         if (!toolRequests) {
             return [];
         }
-        return this.toChatToolRequests(toolRequests, request);
+        // Request-text grants in a delegated session are capped to an explicit allowlist: the
+        // request text was authored by the delegating LLM, so its wording must not determine the
+        // delegated agent's toolset (https://github.com/eclipse-theia/theia/issues/17836).
+        const granted = this.isDelegatedSession(request)
+            ? toolRequests.filter(tool => {
+                if (this.delegationRequestGrantAllowlist.includes(tool.id)) {
+                    return true;
+                }
+                this.logger?.info(`Dropped the '${tool.id}' tool grant from a delegated session's request: a delegation prompt does not grant tools.`);
+                return false;
+            })
+            : toolRequests;
+        return this.toChatToolRequests(granted, request, agent);
     }
 
     /**
      * Wraps multiple tool requests to provide chat context to their handlers.
      * @param toolRequests The original tool requests
      * @param request The chat request to use for context
+     * @param agent optional tool policy of the invoking agent; tools not permitted by the policy are filtered out
      * @returns Wrapped tool requests whose handlers receive ChatToolContext
      */
-    toChatToolRequests(toolRequests: ToolRequest[] | undefined, request: MutableChatRequestModel): ToolRequest[] {
+    toChatToolRequests(toolRequests: ToolRequest[] | undefined, request: MutableChatRequestModel, agent?: AgentToolPolicy): ToolRequest[] {
         if (!toolRequests) {
             return [];
         }
-        return toolRequests.map(toolRequest => this.toChatToolRequest(toolRequest, request));
+        return this.filterByAgentToolPolicy(toolRequests, agent).map(toolRequest => this.toChatToolRequest(toolRequest, request));
     }
 
     /**
@@ -123,6 +175,40 @@ export class ChatToolRequestService {
             handler: async (arg_string: string, ctx?: ToolInvocationContext) =>
                 toolRequest.handler(arg_string, this.createToolContext(request, ctx))
         };
+    }
+
+    /**
+     * Checks whether the given request belongs to a delegated session, i.e. one created by
+     * `AgentDelegationTool.delegateToAgent` (and restored on session deserialization).
+     * @param request The chat request to check
+     * @returns `true` if `request.session.rootSessionId` is set
+     */
+    protected isDelegatedSession(request: MutableChatRequestModel): boolean {
+        return request.session.rootSessionId !== undefined;
+    }
+
+    /**
+     * Applies the agent's tool policy: a tool survives only if it matches some `allowedTools`
+     * pattern (no list = no cap) and no `disallowedTools` pattern. Deny wins.
+     * @param toolRequests The candidate tool requests
+     * @param agent optional tool policy of the invoking agent; tools not permitted by the policy are filtered out
+     * @returns Tool requests permitted by the policy
+     */
+    protected filterByAgentToolPolicy(toolRequests: ToolRequest[], agent?: AgentToolPolicy): ToolRequest[] {
+        if (!agent || (!agent.allowedTools && !agent.disallowedTools?.length)) {
+            return toolRequests;
+        }
+        return toolRequests.filter(tool => {
+            if (agent.disallowedTools?.some(pattern => matchesToolPattern(pattern, tool.id))) {
+                this.logger?.info(`Dropped tool '${tool.id}' for agent '${agent.id ?? '<unknown>'}': matched disallowedTools.`);
+                return false;
+            }
+            if (agent.allowedTools && !agent.allowedTools.some(pattern => matchesToolPattern(pattern, tool.id))) {
+                this.logger?.info(`Dropped tool '${tool.id}' for agent '${agent.id ?? '<unknown>'}': not matched by allowedTools.`);
+                return false;
+            }
+            return true;
+        });
     }
 
     /**

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.spec.ts
@@ -810,6 +810,76 @@ describe('DefaultPromptFragmentCustomizationService - custom agent scopes', () =
         expect(agents).to.have.lengthOf(1);
         expect(agents[0].description).to.equal('agents version');
     });
+
+    describe('allowedTools/disallowedTools frontmatter', () => {
+        // Mirrors serializeCustomAgentFile's own logic (a key is only written when defined) using
+        // serializeFrontmatter directly: serializeCustomAgentFile itself is not exported, and the
+        // actual write path (createCustomAgentFile) additionally needs an OpenerService, which this
+        // harness does not stub. serializeFrontmatter is the primitive that both go through, so it
+        // is the nearest public seam for exercising serialization without new scaffolding.
+        const agentFileWithTools = (name: string, description: string, allowedTools?: string[], disallowedTools?: string[]): string => {
+            const metadata: Record<string, unknown> = { name, description, defaultLLM: 'default/universal' };
+            if (allowedTools !== undefined) {
+                metadata.allowedTools = allowedTools;
+            }
+            if (disallowedTools !== undefined) {
+                metadata.disallowedTools = disallowedTools;
+            }
+            return serializeFrontmatter(metadata, `${name} prompt`);
+        };
+
+        it('carries allowedTools and disallowedTools through verbatim', async () => {
+            service.setCustomAgentDirs(['/ws/.agents']);
+            fileService.write(
+                agentMd(new URI('file:///ws/.agents'), 'foo'),
+                agentFileWithTools('Foo', 'Foo agent', ['toolA', 'mcp_*'], ['toolB'])
+            );
+
+            const agents = await service.getCustomAgents();
+
+            expect(agents).to.have.lengthOf(1);
+            expect(agents[0].allowedTools).to.deep.equal(['toolA', 'mcp_*']);
+            expect(agents[0].disallowedTools).to.deep.equal(['toolB']);
+        });
+
+        it('rejects the agent file when allowedTools is not an array', async () => {
+            service.setCustomAgentDirs(['/ws/.agents']);
+            fileService.write(
+                agentMd(new URI('file:///ws/.agents'), 'foo'),
+                '---\nname: Foo\ndescription: Foo agent\ndefaultLLM: default/universal\nallowedTools: notAnArray\n---\nFoo prompt'
+            );
+
+            const agents = await service.getCustomAgents();
+
+            expect(agents.map(a => a.id)).to.not.include('foo');
+        });
+
+        it('serialize round-trip: a description with both keys serializes and round-trips them', async () => {
+            service.setCustomAgentDirs(['/ws/.agents']);
+            const content = agentFileWithTools('Foo', 'Foo agent', ['toolA'], ['toolB']);
+            expect(content).to.contain('allowedTools:');
+            expect(content).to.contain('disallowedTools:');
+            fileService.write(agentMd(new URI('file:///ws/.agents'), 'foo'), content);
+
+            const [agent] = await service.getCustomAgents();
+
+            expect(agent.allowedTools).to.deep.equal(['toolA']);
+            expect(agent.disallowedTools).to.deep.equal(['toolB']);
+        });
+
+        it('serialize round-trip: a description without either key omits both from the frontmatter', async () => {
+            service.setCustomAgentDirs(['/ws/.agents']);
+            const content = agentFileWithTools('Foo', 'Foo agent');
+            expect(content).to.not.contain('allowedTools');
+            expect(content).to.not.contain('disallowedTools');
+            fileService.write(agentMd(new URI('file:///ws/.agents'), 'foo'), content);
+
+            const [agent] = await service.getCustomAgents();
+
+            expect(agent.allowedTools).to.be.undefined;
+            expect(agent.disallowedTools).to.be.undefined;
+        });
+    });
 });
 
 describe('DefaultPromptFragmentCustomizationService - custom agent change detection', () => {

--- a/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
+++ b/packages/ai-core/src/browser/frontend-prompt-customization-service.ts
@@ -66,8 +66,14 @@ interface CustomAgentFrontmatter {
     description: string;
     defaultLLM: string;
     showInChat?: boolean;
+    allowedTools?: string[];
+    disallowedTools?: string[];
     /** Allowed but ignored when present; if set, must match the folder name. */
     id?: string;
+}
+
+function isStringArray(value: unknown): value is string[] {
+    return Array.isArray(value) && value.every(entry => typeof entry === 'string');
 }
 
 namespace CustomAgentFrontmatter {
@@ -83,6 +89,12 @@ namespace CustomAgentFrontmatter {
             return false;
         }
         if ('id' in entry && typeof entry.id !== 'string') {
+            return false;
+        }
+        if ('allowedTools' in entry && !isStringArray(entry.allowedTools)) {
+            return false;
+        }
+        if ('disallowedTools' in entry && !isStringArray(entry.disallowedTools)) {
             return false;
         }
         return true;
@@ -1538,6 +1550,8 @@ export class DefaultPromptFragmentCustomizationService implements PromptFragment
             prompt: body,
             defaultLLM: metadata.defaultLLM,
             showInChat: metadata.showInChat,
+            ...(metadata.allowedTools !== undefined ? { allowedTools: metadata.allowedTools } : {}),
+            ...(metadata.disallowedTools !== undefined ? { disallowedTools: metadata.disallowedTools } : {}),
             ...(promptVariants.length > 0 ? { promptVariants } : {})
         };
     }
@@ -2069,6 +2083,12 @@ function serializeCustomAgentFile(agent: CustomAgentDescription): string {
     };
     if (agent.showInChat !== undefined) {
         metadata.showInChat = agent.showInChat;
+    }
+    if (agent.allowedTools !== undefined) {
+        metadata.allowedTools = agent.allowedTools;
+    }
+    if (agent.disallowedTools !== undefined) {
+        metadata.disallowedTools = agent.disallowedTools;
     }
     return serializeFrontmatter(metadata, agent.prompt);
 }

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -611,5 +611,62 @@ describe('CustomAgentDescription', () => {
             expect(CustomAgentDescription.is({ id: 'test' })).to.be.false;
             expect(CustomAgentDescription.is({ id: 'test', name: 'Test' })).to.be.false;
         });
+
+        it('should return true for valid description with allowedTools/disallowedTools string arrays', () => {
+            const description = { ...validDescription, allowedTools: ['a', 'b*'], disallowedTools: ['c'] };
+            expect(CustomAgentDescription.is(description)).to.be.true;
+        });
+
+        it('should return false for description with non-array allowedTools', () => {
+            const description = { ...validDescription, allowedTools: 'notAnArray' };
+            expect(CustomAgentDescription.is(description)).to.be.false;
+        });
+
+        it('should return false for description with non-string-array allowedTools', () => {
+            const description = { ...validDescription, allowedTools: [1] };
+            expect(CustomAgentDescription.is(description)).to.be.false;
+        });
+
+        it('should return false for description with non-array disallowedTools', () => {
+            const description = { ...validDescription, disallowedTools: 'notAnArray' };
+            expect(CustomAgentDescription.is(description)).to.be.false;
+        });
+
+        it('should return false for description with non-string-array disallowedTools', () => {
+            const description = { ...validDescription, disallowedTools: [1] };
+            expect(CustomAgentDescription.is(description)).to.be.false;
+        });
+    });
+
+    describe('equals()', () => {
+        const base = {
+            id: 'test-agent',
+            name: 'Test Agent',
+            description: 'A test agent',
+            prompt: 'You are a test agent',
+            defaultLLM: 'gpt-4'
+        };
+
+        it('should return true when both sides omit allowedTools/disallowedTools', () => {
+            expect(CustomAgentDescription.equals(base, { ...base })).to.be.true;
+        });
+
+        it('should return true when both sides carry equal allowedTools/disallowedTools lists', () => {
+            const a = { ...base, allowedTools: ['a', 'b'], disallowedTools: ['c'] };
+            const b = { ...base, allowedTools: ['a', 'b'], disallowedTools: ['c'] };
+            expect(CustomAgentDescription.equals(a, b)).to.be.true;
+        });
+
+        it('should return false when only allowedTools differ', () => {
+            const a = { ...base, allowedTools: ['a', 'b'] };
+            const b = { ...base, allowedTools: ['a'] };
+            expect(CustomAgentDescription.equals(a, b)).to.be.false;
+        });
+
+        it('should return false when only disallowedTools differ', () => {
+            const a = { ...base, disallowedTools: ['a', 'b'] };
+            const b = { ...base, disallowedTools: ['b', 'a'] };
+            expect(CustomAgentDescription.equals(a, b)).to.be.false;
+        });
     });
 });

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -186,6 +186,16 @@ export interface CustomAgentDescription {
     showInChat?: boolean;
 
     /**
+     * Optional glob patterns capping this agent's toolset. A tool parsed from the prompt or
+     * request survives only if it matches one of these patterns. Omitted = no cap. Entries are
+     * case-sensitive; `*` matches any character sequence, all other characters are literal.
+     * These lists filter parsed tools — they never grant tools that nothing referenced.
+     */
+    allowedTools?: string[];
+    /** Optional glob patterns denying tools. Omitted = deny nothing. Deny wins over allow. */
+    disallowedTools?: string[];
+
+    /**
      * Optional additional prompt variants for this agent. Loaded from sibling
      * `.prompttemplate` files in the same `<scope>/agents/<id>/` folder.
      */
@@ -193,6 +203,15 @@ export interface CustomAgentDescription {
 }
 
 export namespace CustomAgentDescription {
+    /**
+     * Compares two optional string arrays for equality (order-sensitive).
+     */
+    function stringArrayEquals(a?: readonly string[], b?: readonly string[]): boolean {
+        if (a === b) { return true; }
+        if (!a || !b || a.length !== b.length) { return false; }
+        return a.every((value, index) => value === b[index]);
+    }
+
     /**
      * Type guard to check if an object is a CustomAgentDescription
      */
@@ -219,6 +238,12 @@ export namespace CustomAgentDescription {
         if ('showInChat' in entry && typeof entry.showInChat !== 'boolean') {
             return false;
         }
+        if ('allowedTools' in entry && !(Array.isArray(entry.allowedTools) && entry.allowedTools.every(value => typeof value === 'string'))) {
+            return false;
+        }
+        if ('disallowedTools' in entry && !(Array.isArray(entry.disallowedTools) && entry.disallowedTools.every(value => typeof value === 'string'))) {
+            return false;
+        }
         return true;
     }
 
@@ -232,6 +257,8 @@ export namespace CustomAgentDescription {
             && a.prompt === b.prompt
             && a.defaultLLM === b.defaultLLM
             && a.showInChat === b.showInChat
+            && stringArrayEquals(a.allowedTools, b.allowedTools)
+            && stringArrayEquals(a.disallowedTools, b.disallowedTools)
             && CustomAgentPromptVariant.arrayEquals(a.promptVariants, b.promptVariants);
     }
 }


### PR DESCRIPTION
#### What it does

Fixes #17844: optional per-agent tool filtering for chat agents.

Agents may declare `allowedTools`/`disallowedTools` — built-in agents via the `ChatAgent` interface, custom agents via `agent.md` frontmatter (validated by the existing frontmatter guards and round-tripped on serialization). Enforcement is centralized in `ChatToolRequestService`, the single point all three tool sources already flow through in `AbstractChatAgent.invoke`:

- effective toolset = (parsed tools ∩ `allowedTools`) − `disallowedTools`; **deny always wins**
- the lists **filter, they never grant** — they only narrow tools already referenced by the prompt or request
- omitting both keys preserves today's behavior exactly; an explicit empty `allowedTools` declares no tools
- entries are case-sensitive, full-string globs where `*` matches any character sequence (e.g. `mcp_*`)

Also fixes #17836: in a delegated session, tool names mentioned in the delegation request's free text no longer grant tools. That text is authored by the delegating LLM, so even a prohibition like "you cannot use `~{someTool}`" used to hand over exactly that tool. Request-text grants there are now capped to a protected allowlist (default `['getSkillFileContent']`, so skill-primed delegation keeps working). Nested delegation is deliberately *not* blocked globally — it stays governed per agent by each agent's own lists.

Adjacent and out of scope: tool references that reach a delegated agent's *system prompt* through resolved variables (see Follow-ups).

#### How to test

`npx lerna run --scope @theia/ai-chat test` (370 passing) and `npx lerna run --scope @theia/ai-core test` (376 passing) — new specs cover the glob matcher, the policy semantics, the delegation cap, and frontmatter parse/reject/round-trip.

Manually:

1. Create `.agents/agents/policy-test/agent.md` whose prompt references two tools via `~{}`, with `disallowedTools` naming one of them → only the other is offered to the model.
2. `allowedTools: []` → no tools offered. `disallowedTools: ['<sharedPrefix>*']` → both dropped.
3. #17836 repro: have an agent delegate with a prompt mentioning `~{someTool}` → the delegated session does not receive that grant (a `getSkillFileContent` reference still does).

#### Follow-ups

- `CustomAgentFactory` now takes nine positional parameters; it should become a single object parameter.
- `SkillDescription.allowedTools` (`packages/ai-core/src/common/skill.ts`) is parsed but enforced nowhere; it could share this evaluation.
- Consider surfacing the delegated-session grant allowlist (`delegationRequestGrantAllowlist`, currently a protected member with a hard-coded tool id) as a preference or contribution point, if configuration is preferred over subclassing.
- Evaluate filtering variable-resolved tool references on the system-prompt path for delegated sessions.
- Surface the two keys in the AI Configuration view's per-agent UI.
- For *hidden* worker agents (`showInChat: false`), policies only take effect together with #17849, fixed in #17850 — the policy otherwise travels with an agent that never runs. This PR is independent of that one.

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

All API additions are optional: new optional properties on `ChatAgent`, `CustomAgentDescription` and `CustomAgentFrontmatter`, optional trailing parameters on `CustomAgentFactory`, and an optional `agent` parameter on the existing public `ChatToolRequestService.getChatToolRequests`/`toChatToolRequests`. The one behavioral change — delegated sessions no longer inheriting grants from the delegation request text — is the #17836 fix and only makes grants stricter, never looser.

#### Attribution

Contributed on behalf of K2view.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
