### PR TITLE
feat(ai-chat): notify agents about external file changes

### DIFF
--- a/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
+++ b/packages/ai-chat/src/browser/ai-chat-frontend-module.ts
@@ -42,6 +42,8 @@ import { CustomAgentFactory } from './custom-agent-factory';
 import { ChatToolRequestService } from '../common/chat-tool-request-service';
 import { FrontendChatToolRequestService } from './chat-tool-request-service';
 import { ChangeSetFileService } from './change-set-file-service';
+import { FileReadTracker } from '../common/file-read-tracker';
+import { FileReadTrackerImpl } from './file-read-tracker-impl';
 import { ContextVariableLabelProvider } from './context-variable-label-provider';
 import { ContextFileVariableLabelProvider } from './context-file-variable-label-provider';
 import { FileChatVariableContribution } from './file-chat-variable-contribution';
@@ -167,6 +169,9 @@ export default new ContainerModule(bind => {
     bind(LabelProviderContribution).toService(ContextVariableLabelProvider);
     bind(ContextFileVariableLabelProvider).toSelf().inSingletonScope();
     bind(LabelProviderContribution).toService(ContextFileVariableLabelProvider);
+
+    bind(FileReadTrackerImpl).toSelf().inSingletonScope();
+    bind(FileReadTracker).toService(FileReadTrackerImpl);
 
     bind(ChangeSetFileService).toSelf().inSingletonScope();
     bind(ChangeSetFileElementFactory).toFactory(ctx => (args: ChangeSetElementArgs) => {

--- a/packages/ai-chat/src/browser/change-set-file-element.ts
+++ b/packages/ai-chat/src/browser/change-set-file-element.ts
@@ -34,6 +34,7 @@ import { insertFinalNewline } from '@theia/monaco/lib/browser/monaco-utilities';
 import { MonacoEditorModel } from '@theia/monaco/lib/browser/monaco-editor-model';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
 import { ChangeSetElement } from '../common';
+import { FileReadTracker } from '../common/file-read-tracker';
 import { SerializableChangeSetElement } from '../common/chat-model-serialization';
 import { createChangeSetFileUri } from './change-set-file-resource';
 import { ChangeSetFileService } from './change-set-file-service';
@@ -105,6 +106,9 @@ export class ChangeSetFileElement implements ChangeSetElement {
     protected readonly logger: ILogger;
     @inject(MonacoWorkspace)
     protected readonly monacoWorkspace: MonacoWorkspace;
+
+    @inject(FileReadTracker)
+    protected readonly fileReadTracker: FileReadTracker;
 
     protected readonly toDispose = new DisposableCollection();
     protected _state: ChangeSetElementState;
@@ -303,13 +307,12 @@ export class ChangeSetFileElement implements ChangeSetElement {
         if (this.type === 'delete') {
             await this.changeSetFileService.delete(this.uri);
             this.state = 'applied';
-            this.changeSetFileService.closeDiff(this.readOnlyUri);
-            return;
+        } else {
+            await this.applyChangesWithMonaco(contents);
         }
-
-        // Load Monaco model for the base file URI and apply changes
-        await this.applyChangesWithMonaco(contents);
         this.changeSetFileService.closeDiff(this.readOnlyUri);
+        // Re-snapshot so the agent's own write is not reported back as external, reading because code actions and formatting on save alter the target state.
+        await this.fileReadTracker.recordRead(this.elementProps.chatSessionId, this.uri);
     }
 
     async writeChanges(contents?: string): Promise<void> {

--- a/packages/ai-chat/src/browser/file-read-tracker-impl.spec.ts
+++ b/packages/ai-chat/src/browser/file-read-tracker-impl.spec.ts
@@ -20,7 +20,11 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { Emitter, Event, URI } from '@theia/core';
-import { FileChangesEvent, FileChangeType } from '@theia/filesystem/lib/common/files';
+import { BinaryBuffer } from '@theia/core/lib/common/buffer';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileChangesEvent, FileChangeType, FileOperationError, FileOperationResult, FileStat } from '@theia/filesystem/lib/common/files';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { expect } from 'chai';
 import { FileReadTrackerImpl } from './file-read-tracker-impl';
 
@@ -28,15 +32,32 @@ disableJSDOM();
 
 const SESSION = 'session-1';
 const OTHER_SESSION = 'session-2';
-const FILE = new URI('file:///workspace/a.ts');
-const FILE_LABEL = '/workspace/a.ts';
+const ROOT = new URI('file:///workspace');
+const FILE = ROOT.resolve('a.ts');
+/** As `resolveRelativePath` expects it back: root name plus path within that root. */
+const FILE_LABEL = 'workspace/a.ts';
 
-/** Drives the tracker against in-memory content: `contents` stands in for whatever `readCurrentContent` would resolve. */
+/** Drives the tracker against in-memory content: `contents` stands in for the files on disk. */
 class TestFileReadTracker extends FileReadTrackerImpl {
     readonly contents = new Map<string, string>([[FILE.toString(), 'original']]);
-    /** Makes reading fail, as an unreadable file or a disposed document would. */
+    /** Makes reading fail as a file too large to compare would, rather than as a missing one. */
     readFails = false;
+    /** Runs once inside a read, to change the file while the tracker is still reading it. */
+    duringNextRead?: () => void;
+    /** The encoding the files are stored in: `read` decodes with it, `readFile` hands back their bytes. */
+    encoding: BufferEncoding = 'utf8';
     protected override readonly maxFilesPerSession = 2;
+    /** The workspace roots labels are built against. */
+    readonly roots = [ROOT];
+    protected override readonly workspaceService = {
+        tryGetRoots: () => this.roots.map(resource => ({ resource } as FileStat))
+    } as WorkspaceService;
+    protected override readonly monacoWorkspace = { getTextDocument: () => undefined } as unknown as MonacoWorkspace;
+    /** Both decoders, so that a test can tell which one the tracker reads through. */
+    protected override readonly fileService = {
+        read: async (uri: URI) => ({ value: this.contentOf(uri) }),
+        readFile: async (uri: URI) => ({ value: BinaryBuffer.wrap(Buffer.from(this.contentOf(uri), this.encoding)) })
+    } as unknown as FileService;
     protected readonly fileChangeEmitter = new Emitter<FileChangesEvent>();
     protected readonly documentChangeEmitter = new Emitter<string>();
 
@@ -54,16 +75,19 @@ class TestFileReadTracker extends FileReadTrackerImpl {
         return this.documentChangeEmitter.event;
     }
 
-    protected override async readCurrentContent(uri: URI): Promise<string> {
-        const content = this.readFails ? undefined : this.contents.get(uri.toString());
-        if (content === undefined) {
-            throw new Error(`cannot read ${uri}`);
+    /** Stands in for the file on disk, failing the way the file service would. */
+    protected contentOf(uri: URI): string {
+        if (this.readFails) {
+            throw new FileOperationError(`${uri} is too large`, FileOperationResult.FILE_TOO_LARGE);
         }
+        const content = this.contents.get(uri.toString());
+        if (content === undefined) {
+            throw new FileOperationError(`${uri} does not exist`, FileOperationResult.FILE_NOT_FOUND);
+        }
+        const during = this.duringNextRead;
+        this.duringNextRead = undefined;
+        during?.();
         return content;
-    }
-
-    protected override getLabel(uri: URI): string {
-        return uri.path.toString();
     }
 
     /** Records what the agent saw, as `getFileContent` does. */
@@ -179,14 +203,29 @@ describe('FileReadTrackerImpl', () => {
         expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
     });
 
-    it('reports a file it cannot read, and does not block writing it', async () => {
+    it('keeps reporting a file it cannot read, and does not allow overwriting it', async () => {
         const tracker = new TestFileReadTracker();
         await tracker.agentRead();
         tracker.fileChanged(FILE);
         tracker.readFails = true;
 
         expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
-        expect(await tracker.isStale(SESSION, FILE)).to.be.false;
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
+        expect(await tracker.isStale(SESSION, FILE)).to.be.true;
+    });
+
+    it('reports a change made while the read recording it was still in flight', async () => {
+        const tracker = new TestFileReadTracker();
+        tracker.duringNextRead = () => {
+            tracker.contents.set(FILE.toString(), 'the user typed something');
+            tracker.documentChanged();
+        };
+
+        // no content handed in, so the tracker reads it itself
+        await tracker.recordRead(SESSION, FILE);
+
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
+        expect(await tracker.isStale(SESSION, FILE)).to.be.true;
     });
 
     it('records nothing when the content cannot be read', async () => {
@@ -210,6 +249,45 @@ describe('FileReadTrackerImpl', () => {
         expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
     });
 
+    it('compares a file the read tools decode as UTF-16, not as UTF-8', async () => {
+        const tracker = new TestFileReadTracker();
+        tracker.encoding = 'utf16le'; // as a Windows-written `.ps1` is stored
+        await tracker.agentRead();
+
+        tracker.fileChanged(FILE);
+
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+    });
+
+    describe('naming changed files', () => {
+
+        /** How the notice names `file` after it changed, in a workspace with the given extra roots. */
+        async function nameOf(file: URI, ...extraRoots: URI[]): Promise<string[]> {
+            const tracker = new TestFileReadTracker();
+            tracker.roots.push(...extraRoots);
+            tracker.contents.set(file.toString(), 'original');
+            await tracker.agentRead(file);
+            tracker.somebodyElseChanges('changed', file);
+            return tracker.getChangedFiles(SESSION);
+        }
+
+        it('names a file by the root it is in', async () => {
+            expect(await nameOf(new URI('file:///elsewhere/lib/b.ts'), new URI('file:///elsewhere/lib'))).to.deep.equal(['lib/b.ts']);
+        });
+
+        it('names a file by its root when that root is listed twice', async () => {
+            expect(await nameOf(FILE, ROOT)).to.deep.equal([FILE_LABEL]);
+        });
+
+        it('names a file by uri when two roots share the name it would use', async () => {
+            expect(await nameOf(FILE, new URI('file:///elsewhere/workspace'))).to.deep.equal([FILE.toString()]);
+        });
+
+        it('names a file by uri when it is outside every root', async () => {
+            expect(await nameOf(new URI('file:///etc/hosts'))).to.deep.equal(['file:///etc/hosts']);
+        });
+    });
+
     it('evicts the least recently recorded file beyond the per-session limit', async () => {
         const tracker = new TestFileReadTracker();
         const files = ['a', 'b', 'c'].map(name => new URI(`file:///workspace/${name}.ts`));
@@ -220,7 +298,7 @@ describe('FileReadTrackerImpl', () => {
 
         files.forEach(uri => tracker.somebodyElseChanges('changed', uri));
 
-        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal(['/workspace/b.ts', '/workspace/c.ts']);
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal(['workspace/b.ts', 'workspace/c.ts']);
     });
 
     it('keeps a re-read file tracked, evicting the one untouched for longest', async () => {
@@ -235,6 +313,6 @@ describe('FileReadTrackerImpl', () => {
         tracker.somebodyElseChanges('changed', a);
         tracker.somebodyElseChanges('changed', b);
 
-        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal(['/workspace/a.ts']);
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal(['workspace/a.ts']);
     });
 });

--- a/packages/ai-chat/src/browser/file-read-tracker-impl.spec.ts
+++ b/packages/ai-chat/src/browser/file-read-tracker-impl.spec.ts
@@ -1,0 +1,240 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ehab Younes.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { Emitter, Event, URI } from '@theia/core';
+import { FileChangesEvent, FileChangeType } from '@theia/filesystem/lib/common/files';
+import { expect } from 'chai';
+import { FileReadTrackerImpl } from './file-read-tracker-impl';
+
+disableJSDOM();
+
+const SESSION = 'session-1';
+const OTHER_SESSION = 'session-2';
+const FILE = new URI('file:///workspace/a.ts');
+const FILE_LABEL = '/workspace/a.ts';
+
+/** Drives the tracker against in-memory content: `contents` stands in for whatever `readCurrentContent` would resolve. */
+class TestFileReadTracker extends FileReadTrackerImpl {
+    readonly contents = new Map<string, string>([[FILE.toString(), 'original']]);
+    /** Makes reading fail, as an unreadable file or a disposed document would. */
+    readFails = false;
+    protected override readonly maxFilesPerSession = 2;
+    protected readonly fileChangeEmitter = new Emitter<FileChangesEvent>();
+    protected readonly documentChangeEmitter = new Emitter<string>();
+
+    constructor() {
+        super();
+        // `@postConstruct` only runs on container resolution, so wire the listeners here.
+        this.init();
+    }
+
+    protected override get fileChanges(): Event<FileChangesEvent> {
+        return this.fileChangeEmitter.event;
+    }
+
+    protected override get documentChanges(): Event<string> {
+        return this.documentChangeEmitter.event;
+    }
+
+    protected override async readCurrentContent(uri: URI): Promise<string> {
+        const content = this.readFails ? undefined : this.contents.get(uri.toString());
+        if (content === undefined) {
+            throw new Error(`cannot read ${uri}`);
+        }
+        return content;
+    }
+
+    protected override getLabel(uri: URI): string {
+        return uri.path.toString();
+    }
+
+    /** Records what the agent saw, as `getFileContent` does. */
+    agentRead(uri = FILE, sessionId = SESSION): Promise<void> {
+        return this.recordRead(sessionId, uri, this.contents.get(uri.toString()));
+    }
+
+    /** Changes content behind the agent's back and notifies the tracker, as the workspace would. */
+    somebodyElseChanges(content: string, uri = FILE): void {
+        this.contents.set(uri.toString(), content);
+        this.fileChanged(uri);
+    }
+
+    somebodyElseDeletes(uri = FILE): void {
+        this.contents.delete(uri.toString());
+        this.fileChanged(uri);
+    }
+
+    fileChanged(...uris: URI[]): void {
+        this.fileChangeEmitter.fire(new FileChangesEvent(uris.map(resource => ({ resource, type: FileChangeType.UPDATED }))));
+    }
+
+    documentChanged(uri = FILE): void {
+        this.documentChangeEmitter.fire(uri.toString());
+    }
+}
+
+describe('FileReadTrackerImpl', () => {
+
+    it('reports a file that changed after it was read', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+
+        tracker.somebodyElseChanges('changed');
+
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
+        expect(await tracker.isStale(SESSION, FILE)).to.be.true;
+    });
+
+    it('reports a file whose unsaved document changed', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+
+        tracker.contents.set(FILE.toString(), 'the user typed something');
+        tracker.documentChanged();
+
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
+    });
+
+    it('keeps reporting a change until the file is read again', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+        tracker.somebodyElseChanges('changed');
+        expect(await tracker.getChangedFiles(SESSION)).to.have.lengthOf(1);
+        expect(await tracker.getChangedFiles(SESSION)).to.have.lengthOf(1);
+
+        await tracker.agentRead();
+
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+        expect(await tracker.isStale(SESSION, FILE)).to.be.false;
+    });
+
+    it('ignores files that were never read', async () => {
+        const tracker = new TestFileReadTracker();
+
+        tracker.somebodyElseChanges('changed');
+
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+        expect(await tracker.isStale(SESSION, FILE)).to.be.false;
+    });
+
+    it('ignores a change that left the content untouched', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+
+        // e.g. saving an unmodified document, or a formatter that had nothing to do
+        tracker.fileChanged(FILE);
+
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+        expect(await tracker.isStale(SESSION, FILE)).to.be.false;
+    });
+
+    it('stops reporting once an edit is undone', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+        tracker.somebodyElseChanges('changed');
+        expect(await tracker.getChangedFiles(SESSION)).to.have.lengthOf(1);
+
+        tracker.somebodyElseChanges('original');
+
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+    });
+
+    it('reports a deleted file once, then forgets it and allows writing it', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+
+        tracker.somebodyElseDeletes();
+
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+        expect(await tracker.isStale(SESSION, FILE)).to.be.false;
+    });
+
+    it('forgets a file that no longer exists when it is recorded', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+        tracker.somebodyElseDeletes();
+
+        // as the change set element does after applying a deletion
+        await tracker.recordRead(SESSION, FILE);
+
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+    });
+
+    it('reports a file it cannot read, and does not block writing it', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+        tracker.fileChanged(FILE);
+        tracker.readFails = true;
+
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
+        expect(await tracker.isStale(SESSION, FILE)).to.be.false;
+    });
+
+    it('records nothing when the content cannot be read', async () => {
+        const tracker = new TestFileReadTracker();
+        tracker.readFails = true;
+
+        await tracker.recordRead(SESSION, FILE);
+
+        expect(await tracker.getChangedFiles(SESSION)).to.be.empty;
+    });
+
+    it('treats a write by another session as an external change', async () => {
+        const tracker = new TestFileReadTracker();
+        await tracker.agentRead();
+        await tracker.agentRead(FILE, OTHER_SESSION);
+
+        tracker.somebodyElseChanges('written by the other session');
+        await tracker.recordRead(OTHER_SESSION, FILE);
+
+        expect(await tracker.getChangedFiles(OTHER_SESSION)).to.be.empty;
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal([FILE_LABEL]);
+    });
+
+    it('evicts the least recently recorded file beyond the per-session limit', async () => {
+        const tracker = new TestFileReadTracker();
+        const files = ['a', 'b', 'c'].map(name => new URI(`file:///workspace/${name}.ts`));
+        for (const uri of files) {
+            tracker.contents.set(uri.toString(), 'original');
+            await tracker.agentRead(uri);
+        }
+
+        files.forEach(uri => tracker.somebodyElseChanges('changed', uri));
+
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal(['/workspace/b.ts', '/workspace/c.ts']);
+    });
+
+    it('keeps a re-read file tracked, evicting the one untouched for longest', async () => {
+        const tracker = new TestFileReadTracker();
+        const [a, b, c] = ['a', 'b', 'c'].map(name => new URI(`file:///workspace/${name}.ts`));
+        [a, b, c].forEach(uri => tracker.contents.set(uri.toString(), 'original'));
+        await tracker.agentRead(a);
+        await tracker.agentRead(b);
+        await tracker.agentRead(a);
+        await tracker.agentRead(c);
+
+        tracker.somebodyElseChanges('changed', a);
+        tracker.somebodyElseChanges('changed', b);
+
+        expect(await tracker.getChangedFiles(SESSION)).to.deep.equal(['/workspace/a.ts']);
+    });
+});

--- a/packages/ai-chat/src/browser/file-read-tracker-impl.ts
+++ b/packages/ai-chat/src/browser/file-read-tracker-impl.ts
@@ -1,0 +1,185 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ehab Younes.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event, URI } from '@theia/core';
+import { LabelProvider } from '@theia/core/lib/browser';
+import { hash } from '@theia/core/lib/common/hash';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { FileService } from '@theia/filesystem/lib/browser/file-service';
+import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
+import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { FileReadTracker } from '../common/file-read-tracker';
+
+/** The content an agent saw, and whether anything has since signalled a possible change. */
+interface TrackedFile {
+    seenHash: number;
+    maybeStale: boolean;
+}
+
+@injectable()
+export class FileReadTrackerImpl implements FileReadTracker {
+
+    @inject(FileService)
+    protected readonly fileService: FileService;
+
+    @inject(MonacoWorkspace)
+    protected readonly monacoWorkspace: MonacoWorkspace;
+
+    @inject(LabelProvider)
+    protected readonly labelProvider: LabelProvider;
+
+    /** Session id -> tracked file uri -> state. Both levels are insertion ordered and bounded. */
+    protected readonly sessions = new Map<string, Map<string, TrackedFile>>();
+
+    /**
+     * Arbitrary bounds. Sessions are never disposed here, as that would mean depending on the `ChatService`
+     * that owns the agents using this service, so the least recently used are evicted; that only loses a notice.
+     */
+    protected readonly maxSessions: number = 32;
+    protected readonly maxFilesPerSession: number = 200;
+
+    /** A file grown past this is reported as changed and dropped instead of read to compare. The read tools hand an agent far less. */
+    protected readonly maxComparedFileSize: number = 4 * 1024 * 1024;
+
+    /** Only flags entries; reading and hashing happens in {@link isStale} and {@link getChangedFiles}. */
+    @postConstruct()
+    protected init(): void {
+        this.fileChanges(event => this.handleFileChanges(event));
+        this.documentChanges(uri => this.invalidate(uri));
+    }
+
+    protected get fileChanges(): Event<FileChangesEvent> {
+        return this.fileService.onDidFilesChange;
+    }
+
+    /** Uris of documents whose unsaved content changed, which never reaches the file system. */
+    protected get documentChanges(): Event<string> {
+        return Event.map(this.monacoWorkspace.onDidChangeTextDocument, event => event.model.uri);
+    }
+
+    async recordRead(sessionId: string, uri: URI, content?: string): Promise<void> {
+        const key = uri.toString();
+        const current = content ?? await this.resolveContent(uri);
+        if (current === undefined) {
+            this.sessions.get(sessionId)?.delete(key);
+            return;
+        }
+        const files = this.touchSession(sessionId);
+        // Re-insert to move the key last, so eviction drops the least recently used.
+        files.delete(key);
+        files.set(key, { seenHash: hash(current), maybeStale: false });
+        this.evictOverflow(files, this.maxFilesPerSession);
+    }
+
+    async isStale(sessionId: string, uri: URI): Promise<boolean> {
+        const files = this.sessions.get(sessionId);
+        if (!files) {
+            return false;
+        }
+        const key = uri.toString();
+        const tracked = files.get(key);
+        if (!tracked?.maybeStale) {
+            return false;
+        }
+        return await this.recheck(files, key, tracked) === 'changed';
+    }
+
+    async getChangedFiles(sessionId: string): Promise<string[]> {
+        const files = this.sessions.get(sessionId);
+        if (!files) {
+            return [];
+        }
+        const labels = await Promise.all([...files]
+            .filter(([, tracked]) => tracked.maybeStale)
+            .map(async ([key, tracked]) => await this.recheck(files, key, tracked) === 'unchanged' ? undefined : this.getLabel(new URI(key))));
+        return labels.filter((label): label is string => label !== undefined);
+    }
+
+    /**
+     * Flags the tracked files the event touched, by uri lookup rather than {@link FileChangesEvent.contains},
+     * which scans the whole change list. A deleted parent folder is therefore only noticed on the next read.
+     */
+    protected handleFileChanges(event: FileChangesEvent): void {
+        for (const change of event.changes) {
+            this.invalidate(change.resource.toString());
+        }
+    }
+
+    /** Compares a flagged file against what the agent saw, clearing the flag when the contents match again. */
+    protected async recheck(files: Map<string, TrackedFile>, key: string, tracked: TrackedFile): Promise<'unchanged' | 'changed' | 'gone'> {
+        const current = await this.resolveContent(new URI(key));
+        if (current === undefined) {
+            files.delete(key);
+            return 'gone';
+        }
+        if (hash(current) === tracked.seenHash) {
+            tracked.maybeStale = false;
+            return 'unchanged';
+        }
+        return 'changed';
+    }
+
+    /** `undefined` when the content cannot be resolved at all, which both callers treat as gone. */
+    protected async resolveContent(uri: URI): Promise<string | undefined> {
+        try {
+            return await this.readCurrentContent(uri);
+        } catch {
+            return undefined;
+        }
+    }
+
+    /** The content the agent would be handed now, preferring the open editor document as `getFileContent` does. */
+    protected async readCurrentContent(uri: URI): Promise<string> {
+        const document = this.monacoWorkspace.getTextDocument(uri.toString());
+        if (document) {
+            return document.getText();
+        }
+        return (await this.fileService.readFile(uri, { limits: { size: this.maxComparedFileSize } })).value.toString();
+    }
+
+    /** A path the agent can pass back to `getFileContent`. */
+    protected getLabel(uri: URI): string {
+        return this.labelProvider.getLongName(uri);
+    }
+
+    protected invalidate(uriString: string): void {
+        for (const files of this.sessions.values()) {
+            const tracked = files.get(uriString);
+            if (tracked) {
+                tracked.maybeStale = true;
+            }
+        }
+    }
+
+    protected touchSession(sessionId: string): Map<string, TrackedFile> {
+        const files = this.sessions.get(sessionId) ?? new Map<string, TrackedFile>();
+        // Re-insert to move the key last, so eviction drops the least recently used.
+        this.sessions.delete(sessionId);
+        this.sessions.set(sessionId, files);
+        this.evictOverflow(this.sessions, this.maxSessions);
+        return files;
+    }
+
+    /** Drops entries from the front, which insertion order makes the least recently used ones. */
+    protected evictOverflow(entries: Map<string, unknown>, limit: number): void {
+        for (const key of entries.keys()) {
+            if (entries.size <= limit) {
+                return;
+            }
+            entries.delete(key);
+        }
+    }
+}

--- a/packages/ai-chat/src/browser/file-read-tracker-impl.ts
+++ b/packages/ai-chat/src/browser/file-read-tracker-impl.ts
@@ -15,17 +15,18 @@
 // *****************************************************************************
 
 import { Event, URI } from '@theia/core';
-import { LabelProvider } from '@theia/core/lib/browser';
 import { hash } from '@theia/core/lib/common/hash';
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
+import { FileChangesEvent, FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
 import { MonacoWorkspace } from '@theia/monaco/lib/browser/monaco-workspace';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
 import { FileReadTracker } from '../common/file-read-tracker';
 
 /** The content an agent saw, and whether anything has since signalled a possible change. */
 interface TrackedFile {
-    seenHash: number;
+    /** `undefined` until the read determining it returns, so that it matches no content. */
+    seenHash?: number;
     maybeStale: boolean;
 }
 
@@ -38,8 +39,8 @@ export class FileReadTrackerImpl implements FileReadTracker {
     @inject(MonacoWorkspace)
     protected readonly monacoWorkspace: MonacoWorkspace;
 
-    @inject(LabelProvider)
-    protected readonly labelProvider: LabelProvider;
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
 
     /** Session id -> tracked file uri -> state. Both levels are insertion ordered and bounded. */
     protected readonly sessions = new Map<string, Map<string, TrackedFile>>();
@@ -51,7 +52,7 @@ export class FileReadTrackerImpl implements FileReadTracker {
     protected readonly maxSessions: number = 32;
     protected readonly maxFilesPerSession: number = 200;
 
-    /** A file grown past this is reported as changed and dropped instead of read to compare. The read tools hand an agent far less. */
+    /** A file grown past this is not read to compare, so a flagged one stays reported as changed. The read tools hand an agent far less. */
     protected readonly maxComparedFileSize: number = 4 * 1024 * 1024;
 
     /** Only flags entries; reading and hashing happens in {@link isStale} and {@link getChangedFiles}. */
@@ -72,16 +73,21 @@ export class FileReadTrackerImpl implements FileReadTracker {
 
     async recordRead(sessionId: string, uri: URI, content?: string): Promise<void> {
         const key = uri.toString();
-        const current = content ?? await this.resolveContent(uri);
-        if (current === undefined) {
-            this.sessions.get(sessionId)?.delete(key);
-            return;
-        }
         const files = this.touchSession(sessionId);
         // Re-insert to move the key last, so eviction drops the least recently used.
         files.delete(key);
-        files.set(key, { seenHash: hash(current), maybeStale: false });
+        // Tracked before the read, so a change arriving during it flags this entry instead of being overwritten.
+        const tracked: TrackedFile = { maybeStale: false };
+        files.set(key, tracked);
         this.evictOverflow(files, this.maxFilesPerSession);
+        const current = content ?? await this.resolveContent(uri);
+        if (current === undefined) {
+            if (files.get(key) === tracked) { // a later read may own the entry by now
+                files.delete(key);
+            }
+            return;
+        }
+        tracked.seenHash = hash(current);
     }
 
     async isStale(sessionId: string, uri: URI): Promise<boolean> {
@@ -120,10 +126,15 @@ export class FileReadTrackerImpl implements FileReadTracker {
 
     /** Compares a flagged file against what the agent saw, clearing the flag when the contents match again. */
     protected async recheck(files: Map<string, TrackedFile>, key: string, tracked: TrackedFile): Promise<'unchanged' | 'changed' | 'gone'> {
-        const current = await this.resolveContent(new URI(key));
-        if (current === undefined) {
-            files.delete(key);
-            return 'gone';
+        let current: string;
+        try {
+            current = await this.readCurrentContent(new URI(key));
+        } catch (error) {
+            if (this.isFileNotFound(error)) {
+                files.delete(key);
+                return 'gone';
+            }
+            return 'changed';
         }
         if (hash(current) === tracked.seenHash) {
             tracked.maybeStale = false;
@@ -132,7 +143,11 @@ export class FileReadTrackerImpl implements FileReadTracker {
         return 'changed';
     }
 
-    /** `undefined` when the content cannot be resolved at all, which both callers treat as gone. */
+    protected isFileNotFound(error: unknown): boolean {
+        return error instanceof FileOperationError && error.fileOperationResult === FileOperationResult.FILE_NOT_FOUND;
+    }
+
+    /** `undefined` when the content cannot be read at all. */
     protected async resolveContent(uri: URI): Promise<string | undefined> {
         try {
             return await this.readCurrentContent(uri);
@@ -147,12 +162,20 @@ export class FileReadTrackerImpl implements FileReadTracker {
         if (document) {
             return document.getText();
         }
-        return (await this.fileService.readFile(uri, { limits: { size: this.maxComparedFileSize } })).value.toString();
+        return (await this.fileService.read(uri, { limits: { size: this.maxComparedFileSize } })).value;
     }
 
-    /** A path the agent can pass back to `getFileContent`. */
+    /** A path the agent can pass back to `getFileContent`, which takes `<rootName>/<relativePath>` as well as a uri. */
     protected getLabel(uri: URI): string {
-        return this.labelProvider.getLongName(uri);
+        const roots = this.workspaceService.tryGetRoots().map(root => root.resource);
+        for (const root of roots) {
+            const relativePath = root.relative(uri)?.toString();
+            // A basename shared with another root would resolve to that other root.
+            if (relativePath && !roots.some(other => other.path.base === root.path.base && !other.isEqual(root))) {
+                return `${root.path.base}/${relativePath}`;
+            }
+        }
+        return uri.toString();
     }
 
     protected invalidate(uriString: string): void {

--- a/packages/ai-chat/src/common/chat-agents.spec.ts
+++ b/packages/ai-chat/src/common/chat-agents.spec.ts
@@ -33,6 +33,9 @@ import {
     ThinkingChatResponseContentImpl,
 } from './chat-model';
 import { ParsedChatRequest, ParsedChatRequestTextPart } from './parsed-chat-request';
+import { FileReadTracker } from './file-read-tracker';
+import { ILogger } from '@theia/core';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 
 class TestChatAgent extends AbstractChatAgent {
     readonly id = 'test-agent';
@@ -58,6 +61,18 @@ class TestChatAgent extends AbstractChatAgent {
 
     public setLanguageModelRegistry(registry: LanguageModelRegistry): void {
         this.languageModelRegistry = registry;
+    }
+
+    public exposeAppendExternalFileChangeNotice(request: MutableChatRequestModel, messages: LanguageModelMessage[]): Promise<void> {
+        return this.appendExternalFileChangeNotice(request, messages);
+    }
+
+    public setFileReadTracker(tracker: FileReadTracker): void {
+        this.fileReadTracker = tracker;
+    }
+
+    public setLogger(logger: ILogger): void {
+        this.logger = logger;
     }
 }
 
@@ -290,5 +305,64 @@ describe('AbstractChatAgent.getLanguageModelForRequest', () => {
             error = e as Error;
         }
         expect(error).to.be.an('error');
+    });
+});
+
+describe('AbstractChatAgent.appendExternalFileChangeNotice', () => {
+
+    function createAgent(getChangedFiles: () => Promise<string[]>): TestChatAgent {
+        const agent = new TestChatAgent();
+        agent.setLogger(new MockLogger());
+        agent.setFileReadTracker({
+            recordRead: async () => { },
+            isStale: async () => false,
+            getChangedFiles
+        });
+        return agent;
+    }
+
+    function createRequest(): MutableChatRequestModel {
+        return new MutableChatModel(ChatAgentLocation.Panel).addRequest(createParsedRequest('Hello'));
+    }
+
+    function textsOf(messages: LanguageModelMessage[]): string[] {
+        return messages.flatMap(message => message.type === 'text' ? [message.text] : []);
+    }
+
+    it('appends a trailing user message listing the changed files', async () => {
+        const agent = createAgent(async () => ['/workspace/a.ts', '/workspace/b.ts']);
+        const messages: LanguageModelMessage[] = [];
+
+        await agent.exposeAppendExternalFileChangeNotice(createRequest(), messages);
+
+        expect(messages).to.have.lengthOf(1);
+        expect(messages[0].actor).to.equal('user');
+        expect(textsOf(messages)[0]).to.contain('/workspace/a.ts').and.to.contain('/workspace/b.ts');
+    });
+
+    it('appends nothing when no file changed', async () => {
+        const agent = createAgent(async () => []);
+        const messages: LanguageModelMessage[] = [];
+
+        await agent.exposeAppendExternalFileChangeNotice(createRequest(), messages);
+
+        expect(messages).to.be.empty;
+    });
+
+    it('appends nothing when no tracker is bound', async () => {
+        const messages: LanguageModelMessage[] = [];
+
+        await new TestChatAgent().exposeAppendExternalFileChangeNotice(createRequest(), messages);
+
+        expect(messages).to.be.empty;
+    });
+
+    it('does not fail the request when the changed files cannot be determined', async () => {
+        const agent = createAgent(async () => { throw new Error('tracker unavailable'); });
+        const messages: LanguageModelMessage[] = [];
+
+        await agent.exposeAppendExternalFileChangeNotice(createRequest(), messages);
+
+        expect(messages).to.be.empty;
     });
 });

--- a/packages/ai-chat/src/common/chat-agents.ts
+++ b/packages/ai-chat/src/common/chat-agents.ts
@@ -62,6 +62,7 @@ import {
 import { ContributionProvider, ILogger, isArray, nls } from '@theia/core';
 import { inject, injectable, named, optional, postConstruct } from '@theia/core/shared/inversify';
 import { ChatAgentService } from './chat-agent-service';
+import { FileReadTracker } from './file-read-tracker';
 import {
     ChatModel,
     ChatRequestModel,
@@ -200,6 +201,8 @@ export abstract class AbstractChatAgent implements ChatAgent {
 
     @inject(TokenUsageService) @optional() protected tokenUsageService: TokenUsageService | undefined;
 
+    @inject(FileReadTracker) @optional() protected fileReadTracker: FileReadTracker | undefined;
+
     readonly abstract id: string;
     readonly abstract name: string;
     readonly abstract languageModelRequirements: LanguageModelRequirement[];
@@ -255,6 +258,7 @@ export abstract class AbstractChatAgent implements ChatAgent {
             }
 
             const messages = await this.getMessages(request.session);
+            await this.appendExternalFileChangeNotice(request, messages);
 
             if (systemMessageDescription) {
                 const systemMsg: LanguageModelMessage = {
@@ -292,6 +296,27 @@ export abstract class AbstractChatAgent implements ChatAgent {
 
         } catch (e) {
             this.handleError(request, e);
+        }
+    }
+
+    /**
+     * Tells the agent which files it read were meanwhile changed by somebody else. A trailing user message
+     * rather than the cached system message; providers requiring alternating roles merge same-role runs.
+     */
+    protected async appendExternalFileChangeNotice(request: MutableChatRequestModel, messages: LanguageModelMessage[]): Promise<void> {
+        try {
+            const changedFiles = await this.fileReadTracker?.getChangedFiles(request.session.id);
+            if (changedFiles?.length) {
+                messages.push({
+                    actor: 'user',
+                    type: 'text',
+                    text: `The following files changed since you last read them: ${changedFiles.join(', ')}. ` +
+                        'Read them again before relying on their content or overwriting them.'
+                });
+            }
+        } catch (error) {
+            // Advisory, so failing to determine it must not fail the request.
+            this.logger.warn('Could not determine externally changed files.', error);
         }
     }
 

--- a/packages/ai-chat/src/common/file-read-tracker.ts
+++ b/packages/ai-chat/src/common/file-read-tracker.ts
@@ -1,0 +1,29 @@
+// *****************************************************************************
+// Copyright (C) 2026 Ehab Younes.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { URI } from '@theia/core';
+
+export const FileReadTracker = Symbol('FileReadTracker');
+
+/** Tracks the content an agent has seen per chat session, so that changes by anyone else can be reported back to it. */
+export interface FileReadTracker {
+    /** Snapshots `uri` as the session's agent just saw it, or forgets it if it is gone. Pass `content` when at hand to save a read. */
+    recordRead(sessionId: string, uri: URI, content?: string): Promise<void>;
+    /** Whether `uri` differs from what the session's agent last saw. `false` if never read or gone: neither holds content a write could discard. */
+    isStale(sessionId: string, uri: URI): Promise<boolean>;
+    /** Files changed since the session's agent read them, reported again until it reads them anew so an ignored notice cannot get lost. */
+    getChangedFiles(sessionId: string): Promise<string[]>;
+}

--- a/packages/ai-chat/src/common/index.ts
+++ b/packages/ai-chat/src/common/index.ts
@@ -27,5 +27,6 @@ export * from './custom-chat-agent';
 export * from './parsed-chat-request';
 export * from './context-variables';
 export * from './chat-tool-request-service';
+export * from './file-read-tracker';
 export * from './chat-tool-confirmation-timeout';
 export * from './provider-error-formatter';

--- a/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
@@ -35,7 +35,7 @@ import {
     DefaultFileChangeSetTitleProvider,
     ReplaceContentInFileFunctionHelperV2
 } from './file-changeset-functions';
-import { ChatToolContext, MutableChatRequestModel, MutableChatResponseModel, MutableChatModel } from '@theia/ai-chat';
+import { ChatToolContext, FileReadTracker, MutableChatRequestModel, MutableChatResponseModel, MutableChatModel } from '@theia/ai-chat';
 import { ChangeSet, ChangeSetElement } from '@theia/ai-chat/lib/common/change-set';
 import { Container } from '@theia/core/shared/inversify';
 import { AccessibleRootContribution, WorkspaceFunctionScope } from './workspace-functions';
@@ -267,6 +267,51 @@ describe('File Changeset Functions Cancellation Tests', () => {
         const suggestFileReplacements = container.get(SuggestFileReplacements);
         expect(SuggestFileReplacements.ID).to.equal('suggestFileReplacements');
         expect(suggestFileReplacements.getTool().id).to.equal('suggestFileReplacements');
+    });
+
+    describe('stale file guard', () => {
+        /** Stands in for the tracker: the file counts as changed until the agent reads it again. */
+        function bindTracker(): FileReadTracker & { stale: boolean } {
+            const tracker: FileReadTracker & { stale: boolean } = {
+                stale: true,
+                recordRead: async () => { tracker.stale = false; },
+                isStale: async () => tracker.stale,
+                getChangedFiles: async () => []
+            };
+            container.bind(FileReadTracker).toConstantValue(tracker);
+            return tracker;
+        }
+
+        it('WriteFileContent refuses to overwrite a file that changed since it was read', async () => {
+            bindTracker();
+            const handler = container.get(WriteFileContent).getTool().handler;
+
+            const result = await handler(JSON.stringify({ path: 'test.txt', content: 'new content' }), mockCtx);
+
+            const jsonResponse = typeof result === 'string' ? JSON.parse(result) : result;
+            expect(jsonResponse.error).to.match(/changed since you last read it/);
+        });
+
+        it('SuggestFileContent refuses to propose overwriting a file that changed since it was read', async () => {
+            bindTracker();
+            const handler = container.get(SuggestFileContent).getTool().handler;
+
+            const result = await handler(JSON.stringify({ path: 'test.txt', content: 'new content' }), mockCtx);
+
+            const jsonResponse = typeof result === 'string' ? JSON.parse(result) : result;
+            expect(jsonResponse.error).to.match(/changed since you last read it/);
+        });
+
+        it('WriteFileContent writes once the agent has read the file again', async () => {
+            const tracker = bindTracker();
+            const handler = container.get(WriteFileContent).getTool().handler;
+            await handler(JSON.stringify({ path: 'test.txt', content: 'new content' }), mockCtx);
+
+            await tracker.recordRead(mockCtx.request.session.id, new URI('file:///workspace/test.txt'));
+
+            const result = await handler(JSON.stringify({ path: 'test.txt', content: 'new content' }), mockCtx);
+            expect(result).to.equal('Successfully wrote content to file test.txt.');
+        });
     });
 });
 

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -13,14 +13,14 @@
 //
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
-import { assertChatContext, ChatToolContext } from '@theia/ai-chat';
+import { assertChatContext, ChatToolContext, FileReadTracker } from '@theia/ai-chat';
 import { ChangeSet } from '@theia/ai-chat/lib/common/change-set';
 import { ChangeSetElementArgs, ChangeSetFileElement, ChangeSetFileElementFactory } from '@theia/ai-chat/lib/browser/change-set-file-element';
 import { ToolInvocationContext, ToolProvider, ToolRequest, ToolRequestParameters, ToolRequestParametersProperties } from '@theia/ai-core';
 import { ContentReplacerV1Impl, Replacement, ContentReplacer } from '@theia/core/lib/common/content-replacer';
 import { ContentReplacerV2Impl } from '@theia/core/lib/common/content-replacer-v2-impl';
 import { URI } from '@theia/core/lib/common/uri';
-import { inject, injectable } from '@theia/core/shared/inversify';
+import { inject, injectable, optional } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { WorkspaceFunctionScope } from './workspace-functions';
 
@@ -54,6 +54,14 @@ function createPathShortLabel(args: string, hasMore: boolean): { label: string; 
     return undefined;
 }
 
+/**
+ * Whole-file writes from an outdated read would silently discard whatever changed in between. The replacement
+ * tools need no such guard: they re-read and fail when their matched content is gone.
+ */
+function staleFileError(path: string): string {
+    return `File ${path} changed since you last read it. Read it again before overwriting it, so that the changes made in the meantime are not lost.`;
+}
+
 export const FileChangeSetTitleProvider = Symbol('FileChangeSetTitleProvider');
 
 export interface FileChangeSetTitleProvider {
@@ -75,6 +83,10 @@ export class SuggestFileContent implements ToolProvider {
 
     @inject(FileChangeSetTitleProvider)
     protected readonly fileChangeSetTitleProvider: FileChangeSetTitleProvider;
+
+    /** Optional: the guard is advisory, so containers without a tracker still get a working tool. */
+    @inject(FileReadTracker) @optional()
+    protected readonly fileReadTracker: FileReadTracker | undefined;
 
     getTool(): ToolRequest {
         return {
@@ -113,6 +125,9 @@ export class SuggestFileContent implements ToolProvider {
                     uri = await this.workspaceFunctionScope.resolveAccessiblePath(path);
                 } catch (error) {
                     return JSON.stringify({ error: error.message });
+                }
+                if (await this.fileReadTracker?.isStale(chatSessionId, uri)) {
+                    return JSON.stringify({ error: staleFileError(path) });
                 }
                 let type: ChangeSetElementArgs['type'] = 'modify';
                 if (content === '') {
@@ -156,6 +171,10 @@ export class WriteFileContent implements ToolProvider {
     @inject(FileChangeSetTitleProvider)
     protected readonly fileChangeSetTitleProvider: FileChangeSetTitleProvider;
 
+    /** Optional: the guard is advisory, so containers without a tracker still get a working tool. */
+    @inject(FileReadTracker) @optional()
+    protected readonly fileReadTracker: FileReadTracker | undefined;
+
     getTool(): ToolRequest {
         return {
             id: WriteFileContent.ID,
@@ -193,6 +212,9 @@ export class WriteFileContent implements ToolProvider {
                     uri = await this.workspaceFunctionScope.resolveAccessiblePath(path);
                 } catch (error) {
                     return JSON.stringify({ error: error.message });
+                }
+                if (await this.fileReadTracker?.isStale(chatSessionId, uri)) {
+                    return JSON.stringify({ error: staleFileError(path) });
                 }
                 let type = 'modify';
                 if (content === '') {

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -2164,6 +2164,13 @@ describe('WorkspaceFunctionScope Multi-Root Tests', () => {
                 const result = workspaceScope.resolveRelativePath('app/src/index.ts');
                 expect(result.toString()).to.equal('file:///workspace/a/app/src/index.ts');
             });
+
+            // The forms the external file change notice names files by: a root name for the mapped root, a uri for the other.
+            it('resolves a uri for the unmapped root', async () => {
+                workspaceScope = createScope(['file:///workspace/a/app', 'file:///workspace/b/app']);
+                const unmapped = 'file:///workspace/b/app/src/index.ts';
+                expect((await workspaceScope.resolveAccessiblePath(unmapped)).toString()).to.equal(unmapped);
+            });
         });
     });
 
@@ -2318,5 +2325,6 @@ describe('WorkspaceFunctionScope Multi-Root Tests', () => {
                 expect(resolved.toString()).to.equal(fileUri.toString());
             }
         });
+
     });
 });

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -14,6 +14,7 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 import { AiConfigurationService, ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
+import { ChatToolContext, FileReadTracker } from '@theia/ai-chat';
 import { CancellationToken, Disposable, OS, PreferenceService, URI, Path } from '@theia/core';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
@@ -790,7 +791,7 @@ export class FileContentFunction implements ToolProvider {
             },
             handler: (arg_string: string, ctx?: ToolInvocationContext) => {
                 const { file, offset, limit } = this.parseArg(arg_string);
-                return this.getFileContent(file, ctx?.cancellationToken, offset, limit);
+                return this.getFileContent(file, ctx, offset, limit);
             },
             providerName: undefined,
             getArgumentsShortLabel: (args: string): { label: string; hasMore: boolean } | undefined => {
@@ -823,12 +824,17 @@ export class FileContentFunction implements ToolProvider {
     @inject(PreferenceService)
     protected readonly preferences: PreferenceService;
 
+    /** Optional: tracking is advisory, so containers without a tracker still get a working tool. */
+    @inject(FileReadTracker) @optional()
+    protected readonly fileReadTracker: FileReadTracker | undefined;
+
     private parseArg(arg_string: string): { file: string; offset?: number; limit?: number } {
         const result = JSON.parse(arg_string);
         return { file: result.file, offset: result.offset, limit: result.limit };
     }
 
-    private async getFileContent(file: string, cancellationToken?: CancellationToken, offset?: number, limit?: number): Promise<string> {
+    private async getFileContent(file: string, ctx?: ToolInvocationContext, offset?: number, limit?: number): Promise<string> {
+        const cancellationToken = ctx?.cancellationToken;
         if (cancellationToken?.isCancellationRequested) {
             return JSON.stringify({ error: 'Operation cancelled by user' });
         }
@@ -857,20 +863,23 @@ export class FileContentFunction implements ToolProvider {
         const isPaginated = offset !== undefined || limit !== undefined;
 
         if (isEditorOpen) {
-            return this.handleEditorContent(openEditorValue!, maxSizeKB, offset, limit);
+            return this.handleEditorContent(targetUri, openEditorValue!, maxSizeKB, ctx, offset, limit);
         } else if (isPaginated) {
             return this.readStreamedSlice(targetUri, maxSizeKB, offset, limit);
         } else {
-            return this.handleFullDiskRead(targetUri, maxSizeKB);
+            return this.handleFullDiskRead(targetUri, maxSizeKB, ctx);
         }
     }
 
-    private handleEditorContent(content: string, maxSizeKB: number, offset?: number, limit?: number): string {
+    private async handleEditorContent(
+        targetUri: URI, content: string, maxSizeKB: number, ctx?: ToolInvocationContext, offset?: number, limit?: number
+    ): Promise<string> {
         if (offset === undefined && limit === undefined) {
             const sizeKB = this.sizeInKB(content);
             if (sizeKB > maxSizeKB) {
                 return this.buildFileSizeLimitError(sizeKB, maxSizeKB);
             }
+            await this.trackRead(targetUri, content, ctx);
             return content;
         }
 
@@ -888,7 +897,17 @@ export class FileContentFunction implements ToolProvider {
         return `${header}\n${result}`;
     }
 
-    private async handleFullDiskRead(targetUri: URI, maxSizeKB: number): Promise<string> {
+    /**
+     * Remembers the content handed to the agent, if it came from a chat session at all. Only full reads are
+     * tracked: a slice says nothing about the rest of the file, so the streaming path is skipped.
+     */
+    private async trackRead(targetUri: URI, content: string, ctx?: ToolInvocationContext): Promise<void> {
+        if (ChatToolContext.is(ctx)) {
+            await this.fileReadTracker?.recordRead(ctx.request.session.id, targetUri, content);
+        }
+    }
+
+    private async handleFullDiskRead(targetUri: URI, maxSizeKB: number, ctx?: ToolInvocationContext): Promise<string> {
         try {
             const stat = await this.fileService.resolve(targetUri);
             if (stat.size !== undefined) {
@@ -907,6 +926,7 @@ export class FileContentFunction implements ToolProvider {
             if (sizeKB > maxSizeKB) {
                 return this.buildFileSizeLimitError(sizeKB, maxSizeKB);
             }
+            await this.trackRead(targetUri, rawContent, ctx);
             return rawContent;
         } catch (error) {
             if (error instanceof FileOperationError) {


### PR DESCRIPTION
#### What it does

Fixes #17710. An agent that read a file was never told when the user, another agent or a formatter changed it, so it kept reasoning about content that no longer existed, and the whole-file write tools overwrote it.

- `FileReadTracker` (`ai-chat`) hashes, per session, the content an agent was handed. `getFileContent` records what it returns, change set elements re-snapshot after applying.
- `AbstractChatAgent.invoke` appends a trailing user message listing the files that changed since the agent read them, repeated until it reads them again.
- `writeFileContent` and `suggestFileContent` refuse to overwrite a file that changed since it was read, so the agent re-reads before it writes.

Notes for review:

- The replacement tools need no guard: they re-read at write time and fail when their matched content is gone.
- The notice is a trailing user message, not part of the cached system message. Anthropic and Gemini merge consecutive same-role messages.
- Applied writes re-snapshot by re-reading, since code actions and formatting on save alter what was written.
- Events only flag entries; content is compared lazily and only for flagged ones, so an idle workspace costs no IO per request.
- Determining the notice is advisory: when it fails the request proceeds without it. The tracker is `@optional()` in the tool providers, so containers without it keep working.

#### How to test

1. Let an agent read a file, edit that file yourself, send a follow-up: the request lists the file (visible in the AI History view). Have the agent read it again and the notice stops. Works for unsaved editor changes too.
2. Let an agent read a file, edit and save it yourself, then ask for a full rewrite: the write is refused, the agent re-reads, your edit survives.
3. Let an agent write one file twice in a turn with format-on-save enabled: neither write is refused and no notice follows.

`npx lerna run test --scope @theia/ai-chat --scope @theia/ai-ide`

#### Follow-ups

- Changes are reported at turn boundaries only. A change made mid-turn is caught by the write guard but not reported until the next request; reporting it earlier means appending to the results of tools this PR does not own, some of which return JSON that renderers parse.
- Tracking is in memory, so a frontend reload drops it and the agent is notified again only after it reads the file anew.
- Retained state is bounded (32 sessions, 200 files each, least recently used evicted). Evicting an entry loses a notification.
- A tracked file grown past 4 MB is reported as changed and dropped, rather than read into the frontend to be compared.
- A deleted parent folder does not flag its tracked children; the next read or the write guard catches it.
- Pre-existing and unrelated: `processReplacementsCommon` reads its starting content from disk while `getFileContent` and `ChangeSetFileService.write` are editor-first, so replacements overwrite unsaved editor changes. Happy to file a separate issue.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/eclipse-theia/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)
