### PR TITLE
ai-ide: add Memory prompt capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ license-check-summary.txt*
 .playwright-mcp/*
 /.theia/chatSessions
 .tmp.cfg
+.agents/memory

--- a/.gitignore
+++ b/.gitignore
@@ -40,4 +40,3 @@ license-check-summary.txt*
 .playwright-mcp/*
 /.theia/chatSessions
 .tmp.cfg
-.agents/memory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@
 
 ## 1.75.0 - tbd
 
+- [ai-ide] added an opt-in "Memory" prompt capability that lets agents maintain a wiki-style knowledge base per workspace, stored in the workspace metadata store and exposed to prompts via the new `{{memoryDirectory}}` variable [#17865](https://github.com/eclipse-theia/theia/pull/17865)
 - [core, monaco] fixed Monaco theme CSS, `SelectComponent` dropdown placement, and the OS font class in secondary windows [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [scm-extra] deprecated `@theia/scm-extra` package [#17882](https://github.com/eclipse-theia/theia/pull/17882)
 
 <a name="breaking_changes_1.75.0">[Breaking Changes:](#breaking_changes_1.75.0)</a>
 
+- [ai-ide] removed `WorkspaceFunctionScope.ensureWithinWorkspace(targetUri, workspaceRootUri)`. Every path-taking AI tool now resolves and checks its argument through `WorkspaceFunctionScope.resolveAccessiblePath(pathOrUri)`, which in addition to the workspace roots accepts locations covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference or contributed via the new `AccessibleRootContribution`. Adopters that called `ensureWithinWorkspace`, or `resolveRelativePath` followed by their own boundary check, should call `resolveAccessiblePath` instead [#17865](https://github.com/eclipse-theia/theia/pull/17865)
 - [core] added `onWindowLoaded` to the `SecondaryWindowService` interface; adopters implementing the interface from scratch (rather than extending `DefaultSecondaryWindowService`) must provide it [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [monaco] removed the `protected secondaryWindowHandler` field from `MonacoFrontendApplicationContribution`; the Monaco theme stylesheet is now injected into every secondary window via `SecondaryWindowService.onWindowLoaded` [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [scm-extra] deprecated the `@theia/scm-extra` extension and stopped publishing it on npm; it has also been removed from the example applications, which drops its `SCM History` view, the `History` context menu items in the navigator and editor, and the `alt+h` keybinding. The view has been non-functional in the default application since the removal of `@theia/git`, as nothing implements `ScmHistorySupport` anymore. Please use the SCM history graph in `@theia/scm` for branch history and the Timeline view in `@theia/timeline` for per-file history instead [#17882](https://github.com/eclipse-theia/theia/pull/17882)

--- a/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.spec.ts
@@ -20,7 +20,7 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
-import { CancellationTokenSource } from '@theia/core';
+import { CancellationTokenSource, PreferenceService } from '@theia/core';
 import {
     SuggestFileContent,
     WriteFileContent,
@@ -38,9 +38,13 @@ import {
 import { ChatToolContext, MutableChatRequestModel, MutableChatResponseModel, MutableChatModel } from '@theia/ai-chat';
 import { ChangeSet, ChangeSetElement } from '@theia/ai-chat/lib/common/change-set';
 import { Container } from '@theia/core/shared/inversify';
-import { WorkspaceFunctionScope } from './workspace-functions';
+import { AccessibleRootContribution, WorkspaceFunctionScope } from './workspace-functions';
+import { bindRootContributionProvider } from '@theia/core/lib/common/contribution-provider';
+import { AiConfigurationService } from '@theia/ai-core';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { WorkspaceService } from '@theia/workspace/lib/browser';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
-import { ChangeSetFileElementFactory, ChangeSetFileElement } from '@theia/ai-chat/lib/browser/change-set-file-element';
+import { ChangeSetElementArgs, ChangeSetFileElementFactory, ChangeSetFileElement } from '@theia/ai-chat/lib/browser/change-set-file-element';
 import { URI } from '@theia/core/lib/common/uri';
 
 disableJSDOM();
@@ -86,7 +90,7 @@ describe('File Changeset Functions Cancellation Tests', () => {
 
         // Mock dependencies
         const mockWorkspaceScope = {
-            resolveRelativePath: () => new URI('file:///workspace/test.txt')
+            resolveAccessiblePath: async () => new URI('file:///workspace/test.txt')
         } as unknown as WorkspaceFunctionScope;
 
         const mockFileService = {
@@ -263,5 +267,106 @@ describe('File Changeset Functions Cancellation Tests', () => {
         const suggestFileReplacements = container.get(SuggestFileReplacements);
         expect(SuggestFileReplacements.ID).to.equal('suggestFileReplacements');
         expect(suggestFileReplacements.getTool().id).to.equal('suggestFileReplacements');
+    });
+});
+
+describe('File Changeset Functions access control', () => {
+    let container: Container;
+    let ctx: ChatToolContext;
+    let written: Array<{ uri: URI; content: string }>;
+    let contributedRoots: URI[];
+
+    before(() => { disableJSDOM = enableJSDOM(); });
+    after(() => { disableJSDOM(); });
+
+    beforeEach(() => {
+        written = [];
+        contributedRoots = [];
+
+        const changeSet: Partial<ChangeSet> = {
+            addElements: () => true,
+            setTitle: () => { },
+            removeElements: () => true,
+            getElementByURI: () => undefined
+        };
+        ctx = {
+            request: {
+                id: 'request-id',
+                session: { id: 'session-id', changeSet: changeSet as ChangeSet } as MutableChatModel
+            } as MutableChatRequestModel,
+            response: {} as MutableChatResponseModel
+        };
+
+        container = new Container();
+        container.bind(WorkspaceService).toConstantValue({
+            roots: [{ resource: new URI('file:///workspace') }],
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService);
+        container.bind(FileService).toConstantValue({
+            exists: async () => true,
+            read: async () => ({ value: { toString: () => 'old content' } }),
+            watch: () => ({ dispose: () => { } }),
+            onDidFilesChange: () => ({ dispose: () => { } })
+        } as unknown as FileService);
+        container.bind(PreferenceService).toConstantValue({ get: <T>(_path: string, defaultValue: T) => defaultValue });
+        container.bind(AiConfigurationService).toConstantValue({
+            get: <T>(_name: string, fallback?: T) => fallback,
+            ready: Promise.resolve(),
+            onDidChangeTrust: () => ({ dispose: () => { } })
+        } as unknown as AiConfigurationService);
+        container.bind(EnvVariablesServer).toConstantValue({
+            getHomeDirUri: async () => 'file:///home/test',
+            getConfigDirUri: async () => 'file:///home/test/.theia'
+        } as unknown as EnvVariablesServer);
+        bindRootContributionProvider(container, AccessibleRootContribution);
+        container.bind(AccessibleRootContribution).toConstantValue({ getRoots: async () => contributedRoots });
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(ChangeSetFileElementFactory).toConstantValue((args: ChangeSetElementArgs) => ({
+            uri: args.uri,
+            apply: async () => {
+                written.push({ uri: args.uri, content: args.targetState ?? '' });
+            }
+        } as ChangeSetFileElement));
+        container.bind(FileChangeSetTitleProvider).to(DefaultFileChangeSetTitleProvider).inSingletonScope();
+        container.bind(ReplaceContentInFileFunctionHelperV2).toSelf();
+        container.bind(WriteFileContent).toSelf();
+        container.bind(WriteFileReplacements).toSelf();
+    });
+
+    const writeContent = (path: string) =>
+        container.get(WriteFileContent).getTool().handler(JSON.stringify({ path, content: 'new content' }), ctx) as Promise<string>;
+    const writeReplacements = (path: string) =>
+        container.get(WriteFileReplacements).getTool().handler(
+            JSON.stringify({ path, replacements: [{ oldContent: 'old content', newContent: 'new content' }] }), ctx
+        ) as Promise<string>;
+
+    it('refuses to write through a .. traversal instead of escaping the workspace', async () => {
+        expect(JSON.parse(await writeContent('../../etc/passwd')).error).to.include('Invalid path');
+        expect(JSON.parse(await writeReplacements('../../etc/passwd')).error).to.include('Invalid path');
+        expect(written).to.be.empty;
+    });
+
+    it('refuses to write to an absolute path outside the workspace', async () => {
+        expect(JSON.parse(await writeContent('/etc/passwd')).error).to.include('not allowed');
+        expect(JSON.parse(await writeReplacements('/etc/passwd')).error).to.include('not allowed');
+        expect(written).to.be.empty;
+    });
+
+    it('refuses to write to the user home directory', async () => {
+        expect(JSON.parse(await writeContent('~/.ssh/authorized_keys')).error).to.include('not allowed');
+        expect(written).to.be.empty;
+    });
+
+    it('writes inside the workspace', async () => {
+        expect(await writeContent('src/index.ts')).to.include('Successfully');
+        expect(written.map(w => w.uri.toString())).to.deep.equal(['file:///workspace/src/index.ts']);
+    });
+
+    it('writes to a contributed root such as the memory directory', async () => {
+        contributedRoots = [new URI('file:///home/test/.theia/workspace-metadata/uuid/memory')];
+        const result = await writeContent('/home/test/.theia/workspace-metadata/uuid/memory/wiki/index.md');
+        expect(result).to.include('Successfully');
+        expect(written.map(w => w.uri.toString())).to.deep.equal(['file:///home/test/.theia/workspace-metadata/uuid/memory/wiki/index.md']);
     });
 });

--- a/packages/ai-ide/src/browser/file-changeset-functions.ts
+++ b/packages/ai-ide/src/browser/file-changeset-functions.ts
@@ -37,6 +37,15 @@ import {
     WRITE_FILE_REPLACEMENTS_SIMPLE_ID
 } from '../common/file-changeset-function-ids';
 
+/**
+ * Description of the `path` parameter shared by all file changeset tools, so that they advertise the
+ * same accepted forms as the read-only workspace tools.
+ */
+const FILE_PATH_PARAMETER_DESCRIPTION = 'Path to the target file. May be workspace-relative ' +
+    '(e.g., "my-project/src/index.ts"), an absolute path, or a `file://` URI. ' +
+    'Absolute / URI forms must point to a location the tools may access, such as a directory listed in the ' +
+    '`ai-features.workspaceFunctions.allowedExternalPaths` preference.';
+
 function createPathShortLabel(args: string, hasMore: boolean): { label: string; hasMore: boolean } | undefined {
     const path = extractJsonStringField(args, 'path');
     if (path) {
@@ -82,8 +91,7 @@ export class SuggestFileContent implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'The path to the file within the workspace ' +
-                            '(e.g., "my-project/src/index.ts", "backend/config/settings.json").'
+                        description: FILE_PATH_PARAMETER_DESCRIPTION
                     },
                     content: {
                         type: 'string',
@@ -100,7 +108,12 @@ export class SuggestFileContent implements ToolProvider {
                 }
                 const { path, content } = JSON.parse(args);
                 const chatSessionId = ctx.request.session.id;
-                const uri = await this.workspaceFunctionScope.resolveRelativePath(path);
+                let uri: URI;
+                try {
+                    uri = await this.workspaceFunctionScope.resolveAccessiblePath(path);
+                } catch (error) {
+                    return JSON.stringify({ error: error.message });
+                }
                 let type: ChangeSetElementArgs['type'] = 'modify';
                 if (content === '') {
                     type = 'delete';
@@ -158,8 +171,7 @@ export class WriteFileContent implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'The path to the file within the workspace ' +
-                            '(e.g., "my-project/src/index.ts", "backend/config/settings.json").'
+                        description: FILE_PATH_PARAMETER_DESCRIPTION
                     },
                     content: {
                         type: 'string',
@@ -176,7 +188,12 @@ export class WriteFileContent implements ToolProvider {
                 }
                 const { path, content } = JSON.parse(args);
                 const chatSessionId = ctx.request.session.id;
-                const uri = await this.workspaceFunctionScope.resolveRelativePath(path);
+                let uri: URI;
+                try {
+                    uri = await this.workspaceFunctionScope.resolveAccessiblePath(path);
+                } catch (error) {
+                    return JSON.stringify({ error: error.message });
+                }
                 let type = 'modify';
                 if (content === '') {
                     type = 'delete';
@@ -256,9 +273,7 @@ export class ReplaceContentInFileFunctionHelper {
             properties: {
                 path: {
                     type: 'string',
-                    description: 'The path to the file within the workspace ' +
-                        '(e.g., "my-project/src/index.ts", "backend/src/main.ts"). ' +
-                        'Must read the file with getFileContent first.'
+                    description: FILE_PATH_PARAMETER_DESCRIPTION + ' Must read the file with getFileContent first.'
                 },
                 replacements: {
                     type: 'array',
@@ -365,7 +380,7 @@ export class ReplaceContentInFileFunctionHelper {
         }
 
         const { path, replacements, reset } = JSON.parse(toolCallString) as { path: string, replacements: Replacement[], reset?: boolean };
-        const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
+        const fileUri = await this.workspaceFunctionScope.resolveAccessiblePath(path);
 
         let startingContent: string;
         if (reset || !ctx.request.session.changeSet) {
@@ -423,7 +438,7 @@ export class ReplaceContentInFileFunctionHelper {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
             }
 
-            const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
+            const fileUri = await this.workspaceFunctionScope.resolveAccessiblePath(path);
             if (ctx.request.session.changeSet.removeElements(fileUri)) {
                 return `Cleared pending change(s) for file ${path}.`;
             } else {
@@ -441,7 +456,7 @@ export class ReplaceContentInFileFunctionHelper {
                 return JSON.stringify({ error: 'Operation cancelled by user' });
             }
 
-            const fileUri = await this.workspaceFunctionScope.resolveRelativePath(path);
+            const fileUri = await this.workspaceFunctionScope.resolveAccessiblePath(path);
 
             if (!ctx.request.session.changeSet) {
                 const originalContent = (await this.fileService.read(fileUri)).value.toString();
@@ -584,8 +599,7 @@ export class ClearFileChanges implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'The path to the file within the workspace ' +
-                            '(e.g., "my-project/src/index.ts", "backend/src/main.ts").'
+                        description: FILE_PATH_PARAMETER_DESCRIPTION
                     }
                 },
                 required: ['path']
@@ -622,8 +636,7 @@ export class GetProposedFileState implements ToolProvider {
                 properties: {
                     path: {
                         type: 'string',
-                        description: 'The path to the file within the workspace ' +
-                            '(e.g., "my-project/src/index.ts", "backend/src/main.ts").'
+                        description: FILE_PATH_PARAMETER_DESCRIPTION
                     }
                 },
                 required: ['path']

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -121,6 +121,7 @@ import { AddressGhReviewCommandContribution } from './address-pr-review-command-
 import { AppTesterCapabilityContribution } from './apptester-capability-contribution';
 import { GitHubCapabilityContribution } from './github-capability-contribution';
 import { ShellExecutionCapabilityContribution } from './shell-execution-capability-contribution';
+import { MemoryCapabilityContribution } from './memory-capability-contribution';
 import { AgentModeConfirmationService, AgentModeConfirmationServiceImpl } from './agent-mode-confirmation-service';
 import { ExploreAgent } from './explore-agent';
 import { CodeReviewerAgent } from './code-reviewer-agent';
@@ -357,6 +358,7 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(FrontendApplicationContribution).to(AppTesterCapabilityContribution);
     bind(FrontendApplicationContribution).to(GitHubCapabilityContribution);
     bind(FrontendApplicationContribution).to(ShellExecutionCapabilityContribution);
+    bind(FrontendApplicationContribution).to(MemoryCapabilityContribution);
 
     bind(FrontendApplicationContribution).to(CodeReviewCapabilityContribution);
     bind(FrontendApplicationContribution).to(PRReviewCapabilityContribution);

--- a/packages/ai-ide/src/browser/frontend-module.ts
+++ b/packages/ai-ide/src/browser/frontend-module.ts
@@ -23,6 +23,7 @@ import { ArchitectAgent } from './architect-agent';
 import { CoderAgent } from './coder-agent';
 import { SummarizeSessionCommandContribution } from './summarize-session-command-contribution';
 import {
+    AccessibleRootContribution,
     FileContentFunction,
     FileDiagnosticProvider,
     FindFilesByPattern,
@@ -31,6 +32,7 @@ import {
     WorkspaceFunctionScope
 } from './workspace-functions';
 import { WorkspaceSearchProvider } from './workspace-search-provider';
+import { MemoryDirectoryVariableContribution } from './memory-directory-variable-contribution';
 import {
     FrontendApplicationContribution,
     WidgetFactory,
@@ -218,6 +220,11 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bindToolProvider(GetSkillFileContent, bind);
     bind(WorkspaceFunctionScope).toSelf().inSingletonScope();
     bindToolProvider(WorkspaceSearchProvider, bind);
+
+    bindRootContributionProvider(bind, AccessibleRootContribution);
+    bind(MemoryDirectoryVariableContribution).toSelf().inSingletonScope();
+    bind(AIVariableContribution).toService(MemoryDirectoryVariableContribution);
+    bind(AccessibleRootContribution).toService(MemoryDirectoryVariableContribution);
 
     bindToolProvider(SuggestFileContent, bind);
     bindToolProvider(WriteFileContent, bind);

--- a/packages/ai-ide/src/browser/memory-capability-contribution.spec.ts
+++ b/packages/ai-ide/src/browser/memory-capability-contribution.spec.ts
@@ -1,0 +1,85 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { PromptService } from '@theia/ai-core';
+import { Container } from '@theia/core/shared/inversify';
+import {
+    FILE_CONTENT_FUNCTION_ID,
+    FIND_FILES_BY_PATTERN_FUNCTION_ID,
+    GET_WORKSPACE_FILE_LIST_FUNCTION_ID,
+    SEARCH_IN_WORKSPACE_FUNCTION_ID
+} from '../common/workspace-functions';
+import { WRITE_FILE_CONTENT_ID, WRITE_FILE_REPLACEMENTS_ID } from '../common/file-changeset-function-ids';
+import { MEMORY_DIRECTORY_VARIABLE } from './memory-directory-variable-contribution';
+import { MemoryCapabilityContribution } from './memory-capability-contribution';
+
+const registerFragment = (): { id: string, template: string } => {
+    const fragments: Array<{ id: string, template: string }> = [];
+    const container = new Container();
+    container.bind(PromptService).toConstantValue({
+        addBuiltInPromptFragment: (fragment: { id: string, template: string }) => fragments.push(fragment)
+    } as unknown as PromptService);
+    container.bind(MemoryCapabilityContribution).toSelf();
+    container.get(MemoryCapabilityContribution).onStart();
+
+    expect(fragments).to.have.lengthOf(1);
+    return fragments[0];
+};
+
+describe('MemoryCapabilityContribution', () => {
+
+    it('registers the memory fragment', () => {
+        const fragment = registerFragment();
+        expect(fragment.id).to.equal('memory');
+        expect(fragment.template).to.contain('## Memory');
+    });
+
+    it('starts the template with unindented front matter, so it parses as such', () => {
+        const { template } = registerFragment();
+        const lines = template.split('\n');
+        expect(lines[0]).to.equal('---');
+        expect(lines[1]).to.match(/^name: /);
+        expect(lines[2]).to.match(/^description: /);
+        expect(lines[3]).to.equal('---');
+    });
+
+    it('points the agent at the memory directory variable instead of a workspace path', () => {
+        const { template } = registerFragment();
+        expect(template).to.contain(`{{${MEMORY_DIRECTORY_VARIABLE.name}}}/wiki/index.md`);
+        expect(template).to.contain(`{{${MEMORY_DIRECTORY_VARIABLE.name}}}/raw/`);
+        expect(template).to.not.contain('.agents/memory');
+    });
+
+    it('resolves the date for raw filenames through the today variable', () => {
+        const { template } = registerFragment();
+        expect(template).to.contain('{{today:inIso8601}}');
+    });
+
+    it('instructs the agent to use the generic workspace tools', () => {
+        const { template } = registerFragment();
+        [
+            FILE_CONTENT_FUNCTION_ID,
+            FIND_FILES_BY_PATTERN_FUNCTION_ID,
+            GET_WORKSPACE_FILE_LIST_FUNCTION_ID,
+            SEARCH_IN_WORKSPACE_FUNCTION_ID,
+            WRITE_FILE_CONTENT_ID,
+            WRITE_FILE_REPLACEMENTS_ID
+        ].forEach(id => {
+            expect(template).to.contain(`~{${id}}`);
+        });
+    });
+});

--- a/packages/ai-ide/src/browser/memory-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/memory-capability-contribution.ts
@@ -1,0 +1,73 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PromptService } from '@theia/ai-core';
+import { nls } from '@theia/core';
+import { GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SEARCH_IN_WORKSPACE_FUNCTION_ID, FIND_FILES_BY_PATTERN_FUNCTION_ID } from '../common/workspace-functions';
+import { WRITE_FILE_REPLACEMENTS_ID, WRITE_FILE_CONTENT_ID } from '../common/file-changeset-function-ids';
+
+@injectable()
+export class MemoryCapabilityContribution implements FrontendApplicationContribution {
+
+  @inject(PromptService)
+  protected readonly promptService: PromptService;
+
+  onStart(): void {
+    this.promptService.addBuiltInPromptFragment({
+      id: 'memory',
+      template: this.buildTemplate()
+    });
+  }
+
+  protected buildTemplate(): string {
+    const name = nls.localize('theia/ai/ide/memoryCapability/name', 'Memory');
+    const description = nls.localize('theia/ai/ide/memoryCapability/description',
+      'Lets the agent maintain a persistent, wiki-style knowledge base in the workspace, so this and future sessions build on \
+            what came before instead of starting from scratch.');
+
+    return `---
+name: ${name}
+description: ${description}
+---
+
+## Memory
+
+**Memory is ENABLED.** Maintain a persistent knowledge base under \`.agents/memory/\` in the workspace, the same way a personal
+LLM-maintained wiki is built: raw material is ingested once, then incrementally *compiled* into a linked set of concept
+articles that you read from on every future task. The raw material itself is not the knowledge base — the compiled wiki is.
+
+- \`.agents/memory/raw/\` — append-only ingest: session transcripts, pasted findings, anything worth preserving verbatim. Write
+  once, don't reorganize; log what happened in a task here (~{${WRITE_FILE_CONTENT_ID}}) as you go.
+- \`.agents/memory/wiki/\` — the actual knowledge base: one short, single-concept \`.md\` article per topic (a project fact, a
+  convention, an environment quirk, a standing decision), cross-linked from \`.agents/memory/wiki/index.md\` and from related
+  articles. This is what you read from, not \`raw/\`.
+- Start of task: read \`.agents/memory/wiki/index.md\` (~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}} / ~{${FILE_CONTENT_FUNCTION_ID}})
+  and follow only the links relevant to the current task — browse the wiki, don't grep a diary.
+- Compile, don't just log: when something durable comes up, fold it into the right existing article
+  (~{${WRITE_FILE_REPLACEMENTS_ID}}) or create a new one linked from \`index.md\` and its related articles — don't leave it
+  stranded only in \`raw/\`.
+- File outputs back in: substantial findings, decisions, or analysis produced during a task should be written into the wiki
+  article they inform, so future queries benefit from this session's work too, not just the next session's memory of it.
+- Lint occasionally: when asked to clean up memory, or an article looks stale, use ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}} /
+  ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}} across \`.agents/memory/wiki/\` to find contradictions, duplicate articles, and
+  missing links, then merge or fix them.
+- Keep the wiki in version control together with the code it describes; it is shared project knowledge, not scratch space.
+
+Use judgement on what's worth compiling — a small number of accurate, well-linked articles beats an exhaustive log.`;
+  }
+}

--- a/packages/ai-ide/src/browser/memory-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/memory-capability-contribution.ts
@@ -24,23 +24,23 @@ import { WRITE_FILE_REPLACEMENTS_ID, WRITE_FILE_CONTENT_ID } from '../common/fil
 @injectable()
 export class MemoryCapabilityContribution implements FrontendApplicationContribution {
 
-  @inject(PromptService)
-  protected readonly promptService: PromptService;
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
 
-  onStart(): void {
-    this.promptService.addBuiltInPromptFragment({
-      id: 'memory',
-      template: this.buildTemplate()
-    });
-  }
+    onStart(): void {
+        this.promptService.addBuiltInPromptFragment({
+            id: 'memory',
+            template: this.buildTemplate()
+        });
+    }
 
-  protected buildTemplate(): string {
-    const name = nls.localize('theia/ai/ide/memoryCapability/name', 'Memory');
-    const description = nls.localize('theia/ai/ide/memoryCapability/description',
-      'Lets the agent maintain a persistent, wiki-style knowledge base in the workspace, so this and future sessions build on \
-            what came before instead of starting from scratch.');
+    protected buildTemplate(): string {
+        const name = nls.localize('theia/ai/ide/memoryCapability/name', 'Memory');
+        const description = nls.localize('theia/ai/ide/memoryCapability/description',
+            'Lets the agent maintain a persistent, wiki-style knowledge base in the workspace, so this and future sessions '
+            + 'build on what came before instead of starting from scratch.');
 
-    return `---
+        return `---
 name: ${name}
 description: ${description}
 ---
@@ -51,13 +51,17 @@ description: ${description}
 LLM-maintained wiki is built: raw material is ingested once, then incrementally *compiled* into a linked set of concept
 articles that you read from on every future task. The raw material itself is not the knowledge base — the compiled wiki is.
 
-- \`.agents/memory/raw/\` — append-only ingest: session transcripts, pasted findings, anything worth preserving verbatim. Write
-  once, don't reorganize; log what happened in a task here (~{${WRITE_FILE_CONTENT_ID}}) as you go.
+- \`.agents/memory/raw/\` — append-only ingest: session transcripts, pasted findings, anything worth preserving verbatim. Keep one
+  file per task, \`raw/<yyyy-mm-dd>-<topic>.md\`: create it with ~{${WRITE_FILE_CONTENT_ID}} as soon as there is something worth
+  keeping and append later findings to it as new sections (~{${WRITE_FILE_REPLACEMENTS_ID}}, so you don't re-emit the whole file).
+  Only ever append to the current task's file — earlier files and a single shared log are both off limits.
 - \`.agents/memory/wiki/\` — the actual knowledge base: one short, single-concept \`.md\` article per topic (a project fact, a
   convention, an environment quirk, a standing decision), cross-linked from \`.agents/memory/wiki/index.md\` and from related
   articles. This is what you read from, not \`raw/\`.
 - Start of task: read \`.agents/memory/wiki/index.md\` (~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}} / ~{${FILE_CONTENT_FUNCTION_ID}})
-  and follow only the links relevant to the current task — browse the wiki, don't grep a diary.
+  and follow only the links relevant to the current task — browse the wiki, don't grep a diary. A workspace without
+  \`.agents/memory/\` simply has no memory yet: don't try to read it, and create it with a stub \`index.md\` the first time you have
+  something durable to record.
 - Compile, don't just log: when something durable comes up, fold it into the right existing article
   (~{${WRITE_FILE_REPLACEMENTS_ID}}) or create a new one linked from \`index.md\` and its related articles — don't leave it
   stranded only in \`raw/\`.
@@ -66,8 +70,13 @@ articles that you read from on every future task. The raw material itself is not
 - Lint occasionally: when asked to clean up memory, or an article looks stale, use ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}} /
   ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}} across \`.agents/memory/wiki/\` to find contradictions, duplicate articles, and
   missing links, then merge or fix them.
-- Keep the wiki in version control together with the code it describes; it is shared project knowledge, not scratch space.
+- Memory is yours to maintain unprompted — that is what separates it from the project info file described below, which is the
+  user's own description of the project and is only updated when they ask for it. Record what you learn in the wiki instead of
+  editing that file.
+- Memory lives in the workspace and is versioned with the code it describes, so it is shared project knowledge rather than scratch
+  space: your writes appear in the user's working tree and get reviewed and committed like any other change. Keep each write small
+  and self-contained, and leave \`.gitignore\` alone — whether memory is tracked is the project's decision, not yours.
 
 Use judgement on what's worth compiling — a small number of accurate, well-linked articles beats an exhaustive log.`;
-  }
+    }
 }

--- a/packages/ai-ide/src/browser/memory-capability-contribution.ts
+++ b/packages/ai-ide/src/browser/memory-capability-contribution.ts
@@ -20,6 +20,7 @@ import { PromptService } from '@theia/ai-core';
 import { nls } from '@theia/core';
 import { GET_WORKSPACE_FILE_LIST_FUNCTION_ID, FILE_CONTENT_FUNCTION_ID, SEARCH_IN_WORKSPACE_FUNCTION_ID, FIND_FILES_BY_PATTERN_FUNCTION_ID } from '../common/workspace-functions';
 import { WRITE_FILE_REPLACEMENTS_ID, WRITE_FILE_CONTENT_ID } from '../common/file-changeset-function-ids';
+import { MEMORY_DIRECTORY_VARIABLE } from './memory-directory-variable-contribution';
 
 @injectable()
 export class MemoryCapabilityContribution implements FrontendApplicationContribution {
@@ -37,8 +38,9 @@ export class MemoryCapabilityContribution implements FrontendApplicationContribu
     protected buildTemplate(): string {
         const name = nls.localize('theia/ai/ide/memoryCapability/name', 'Memory');
         const description = nls.localize('theia/ai/ide/memoryCapability/description',
-            'Lets the agent maintain a persistent, wiki-style knowledge base in the workspace, so this and future sessions '
+            'Lets the agent maintain a persistent, wiki-style knowledge base for the workspace, so this and future sessions '
             + 'build on what came before instead of starting from scratch.');
+        const dir = `{{${MEMORY_DIRECTORY_VARIABLE.name}}}`;
 
         return `---
 name: ${name}
@@ -47,35 +49,37 @@ description: ${description}
 
 ## Memory
 
-**Memory is ENABLED.** Maintain a persistent knowledge base under \`.agents/memory/\` in the workspace, the same way a personal
+Maintain a persistent knowledge base under \`${dir}\`, the same way a personal
 LLM-maintained wiki is built: raw material is ingested once, then incrementally *compiled* into a linked set of concept
 articles that you read from on every future task. The raw material itself is not the knowledge base — the compiled wiki is.
 
-- \`.agents/memory/raw/\` — append-only ingest: session transcripts, pasted findings, anything worth preserving verbatim. Keep one
-  file per task, \`raw/<yyyy-mm-dd>-<topic>.md\`: create it with ~{${WRITE_FILE_CONTENT_ID}} as soon as there is something worth
-  keeping and append later findings to it as new sections (~{${WRITE_FILE_REPLACEMENTS_ID}}, so you don't re-emit the whole file).
-  Only ever append to the current task's file — earlier files and a single shared log are both off limits.
-- \`.agents/memory/wiki/\` — the actual knowledge base: one short, single-concept \`.md\` article per topic (a project fact, a
-  convention, an environment quirk, a standing decision), cross-linked from \`.agents/memory/wiki/index.md\` and from related
-  articles. This is what you read from, not \`raw/\`.
-- Start of task: read \`.agents/memory/wiki/index.md\` (~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}} / ~{${FILE_CONTENT_FUNCTION_ID}})
-  and follow only the links relevant to the current task — browse the wiki, don't grep a diary. A workspace without
-  \`.agents/memory/\` simply has no memory yet: don't try to read it, and create it with a stub \`index.md\` the first time you have
-  something durable to record.
+That directory belongs to the current workspace but lies outside it, so what you learn about one project neither bleeds into
+the next nor shows up in the user's repository. Reach it with the ordinary file tools, prefixing every memory path with it.
+
+- \`${dir}/raw/\` — append-only ingest: session transcripts, pasted findings, anything worth preserving verbatim. Keep one
+  file per task, \`raw/<date>-<topic>.md\` with the \`yyyy-mm-dd\` prefix of {{today:inIso8601}} as the date: create it with
+  ~{${WRITE_FILE_CONTENT_ID}} as soon as there is something worth keeping and append later findings to it as new sections
+  (~{${WRITE_FILE_REPLACEMENTS_ID}}, so you don't re-emit the whole file). Only ever append to the current task's file — earlier
+  files and a single shared log are both off limits. Pruning \`raw/\` is the user's call, not yours.
+- \`${dir}/wiki/\` — the actual knowledge base: one short, single-concept \`.md\` article per topic (a project fact, a
+  convention, an environment quirk, a standing decision), cross-linked from \`wiki/index.md\` and from related articles. This is
+  what you read from, not \`raw/\`.
+- Start of task: read \`${dir}/wiki/index.md\` (~{${GET_WORKSPACE_FILE_LIST_FUNCTION_ID}} / ~{${FILE_CONTENT_FUNCTION_ID}})
+  and follow only the links relevant to the current task — browse the wiki, don't grep a diary. An empty memory directory simply
+  means this workspace has no memory yet: create \`wiki/index.md\` the first time you have something durable to record.
 - Compile, don't just log: when something durable comes up, fold it into the right existing article
   (~{${WRITE_FILE_REPLACEMENTS_ID}}) or create a new one linked from \`index.md\` and its related articles — don't leave it
   stranded only in \`raw/\`.
 - File outputs back in: substantial findings, decisions, or analysis produced during a task should be written into the wiki
   article they inform, so future queries benefit from this session's work too, not just the next session's memory of it.
 - Lint occasionally: when asked to clean up memory, or an article looks stale, use ~{${SEARCH_IN_WORKSPACE_FUNCTION_ID}} /
-  ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}} across \`.agents/memory/wiki/\` to find contradictions, duplicate articles, and
-  missing links, then merge or fix them.
+  ~{${FIND_FILES_BY_PATTERN_FUNCTION_ID}} across \`${dir}/wiki/\` to find contradictions, duplicate articles, and missing
+  links, then merge or fix them. Both take that directory as their search root.
 - Memory is yours to maintain unprompted — that is what separates it from the project info file described below, which is the
   user's own description of the project and is only updated when they ask for it. Record what you learn in the wiki instead of
   editing that file.
-- Memory lives in the workspace and is versioned with the code it describes, so it is shared project knowledge rather than scratch
-  space: your writes appear in the user's working tree and get reviewed and committed like any other change. Keep each write small
-  and self-contained, and leave \`.gitignore\` alone — whether memory is tracked is the project's decision, not yours.
+- Keep the knowledge base to what belongs in it: what you learned about this project and how to work in it. It is not a place for
+  secrets, credentials, or copies of the user's files.
 
 Use judgement on what's worth compiling — a small number of accurate, well-linked articles beats an exhaustive log.`;
     }

--- a/packages/ai-ide/src/browser/memory-directory-variable-contribution.spec.ts
+++ b/packages/ai-ide/src/browser/memory-directory-variable-contribution.spec.ts
@@ -1,0 +1,113 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { URI } from '@theia/core';
+import { Container } from '@theia/core/shared/inversify';
+import { WorkspaceMetadataStorageService, WorkspaceMetadataStore } from '@theia/workspace/lib/browser/metadata-storage';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { MEMORY_DIRECTORY_VARIABLE, MEMORY_METADATA_STORE_KEY, MemoryDirectoryVariableContribution } from './memory-directory-variable-contribution';
+
+describe('MemoryDirectoryVariableContribution', () => {
+
+    let contribution: MemoryDirectoryVariableContribution;
+    let location: URI;
+    let requestedKeys: string[];
+    let ensureExistsCalls: number;
+    let workspaceOpen: boolean;
+
+    beforeEach(() => {
+        location = new URI('file:///config/workspace-metadata/uuid/memory');
+        requestedKeys = [];
+        ensureExistsCalls = 0;
+        workspaceOpen = true;
+
+        const store = {
+            get location(): URI {
+                return location;
+            },
+            ensureExists: async () => {
+                ensureExistsCalls++;
+            }
+        } as unknown as WorkspaceMetadataStore;
+
+        const container = new Container();
+        container.bind(WorkspaceMetadataStorageService).toConstantValue({
+            getOrCreateStore: async (key: string) => {
+                requestedKeys.push(key);
+                if (!workspaceOpen) {
+                    throw new Error('Cannot create metadata store: no workspace is currently open');
+                }
+                return store;
+            }
+        } as WorkspaceMetadataStorageService);
+        container.bind(WorkspaceService).toConstantValue({
+            tryGetRoots: () => workspaceOpen ? [{ resource: new URI('file:///workspace') }] : []
+        } as unknown as WorkspaceService);
+        container.bind(MemoryDirectoryVariableContribution).toSelf();
+
+        contribution = container.get(MemoryDirectoryVariableContribution);
+    });
+
+    const resolve = (name: string = MEMORY_DIRECTORY_VARIABLE.name) =>
+        contribution.resolve({ variable: { ...MEMORY_DIRECTORY_VARIABLE, name } }, {});
+
+    it('resolves the variable to the memory store of the current workspace', async () => {
+        const resolved = await resolve();
+        expect(resolved?.value).to.equal(location.path.fsPath());
+        expect(requestedKeys).to.deep.equal([MEMORY_METADATA_STORE_KEY]);
+    });
+
+    it('creates the directory when the variable is resolved, but only once per location', async () => {
+        await resolve();
+        await resolve();
+        expect(ensureExistsCalls).to.equal(1);
+
+        location = new URI('file:///config/workspace-metadata/other/memory');
+        await resolve();
+        expect(ensureExistsCalls).to.equal(2);
+    });
+
+    it('contributes the memory directory as an accessible root', async () => {
+        expect((await contribution.getRoots()).map(root => root.toString())).to.deep.equal([location.toString()]);
+    });
+
+    it('follows the store location without needing invalidation', async () => {
+        await contribution.getRoots();
+        location = new URI('file:///config/workspace-metadata/other/memory');
+        expect((await contribution.getRoots())[0].toString()).to.equal(location.toString());
+    });
+
+    it('does not resolve other variables', async () => {
+        expect(await resolve('somethingElse')).to.be.undefined;
+    });
+
+    it('has neither a value nor a root without a workspace', async () => {
+        workspaceOpen = false;
+        expect(await resolve()).to.be.undefined;
+        expect(await contribution.getRoots()).to.be.empty;
+    });
+
+    it('drops the memory of a closed workspace instead of keeping the cached location', async () => {
+        // The store cannot compute a location without a workspace, so on close it keeps the one of the
+        // closed workspace. Nothing may be reachable through it any more.
+        expect((await resolve())?.value).to.equal(location.path.fsPath());
+
+        workspaceOpen = false;
+        expect(await resolve()).to.be.undefined;
+        expect(await contribution.getRoots()).to.be.empty;
+    });
+});

--- a/packages/ai-ide/src/browser/memory-directory-variable-contribution.ts
+++ b/packages/ai-ide/src/browser/memory-directory-variable-contribution.ts
@@ -1,0 +1,113 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import {
+    AIVariable, AIVariableContext, AIVariableContribution, AIVariableResolutionRequest, AIVariableResolver, AIVariableService, ResolvedAIVariable
+} from '@theia/ai-core/lib/common';
+import { MaybePromise, URI, nls } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { WorkspaceMetadataStorageService, WorkspaceMetadataStore } from '@theia/workspace/lib/browser/metadata-storage';
+import { WorkspaceService } from '@theia/workspace/lib/browser/workspace-service';
+import { AccessibleRootContribution } from './workspace-functions';
+
+/** Key under which the memory directory is requested from the workspace metadata storage. */
+export const MEMORY_METADATA_STORE_KEY = 'memory';
+
+export const MEMORY_DIRECTORY_VARIABLE: AIVariable = {
+    id: 'memory-directory',
+    name: 'memoryDirectory',
+    description: nls.localize('theia/ai/ide/memoryDirectoryVariable/description',
+        'The absolute path of the directory in which the agent keeps its memory for the current workspace.')
+};
+
+/**
+ * Resolves the memory directory of the current workspace and makes it reachable for the AI workspace
+ * tools. The directory is the workspace's metadata store, so every workspace has its own memory and none
+ * of it ends up in the user's repository.
+ *
+ * Its path is generated and changes with the workspace, which is why it is contributed as an accessible
+ * root instead of being configured in `ai-features.workspaceFunctions.allowedExternalPaths`: the user
+ * cannot name a path they do not know, and prompts learn it from {@link MEMORY_DIRECTORY_VARIABLE}.
+ *
+ * A window without a workspace has no metadata store and therefore no memory. The variable then resolves
+ * to nothing and no directory is made accessible.
+ */
+@injectable()
+export class MemoryDirectoryVariableContribution implements AIVariableContribution, AIVariableResolver, AccessibleRootContribution {
+
+    @inject(WorkspaceMetadataStorageService)
+    protected readonly metadataStorageService: WorkspaceMetadataStorageService;
+
+    @inject(WorkspaceService)
+    protected readonly workspaceService: WorkspaceService;
+
+    protected store: WorkspaceMetadataStore | undefined;
+    protected ensuredLocation: string | undefined;
+
+    registerVariables(service: AIVariableService): void {
+        service.registerResolver(MEMORY_DIRECTORY_VARIABLE, this);
+    }
+
+    canResolve(request: AIVariableResolutionRequest, context: AIVariableContext): MaybePromise<number> {
+        return request.variable.name === MEMORY_DIRECTORY_VARIABLE.name ? 1 : 0;
+    }
+
+    async resolve(request: AIVariableResolutionRequest, context: AIVariableContext): Promise<ResolvedAIVariable | undefined> {
+        if (request.variable.name !== MEMORY_DIRECTORY_VARIABLE.name) {
+            return undefined;
+        }
+        const store = await this.getStore();
+        if (!store) {
+            return undefined;
+        }
+        // Resolving the variable means a prompt is about to send the agent to this directory, so create
+        // it now: listing an empty memory is a clearer answer than a missing path.
+        if (this.ensuredLocation !== store.location.toString()) {
+            await store.ensureExists();
+            this.ensuredLocation = store.location.toString();
+        }
+        return { variable: request.variable, value: store.location.path.fsPath() };
+    }
+
+    async getRoots(): Promise<URI[]> {
+        const store = await this.getStore();
+        return store ? [store.location] : [];
+    }
+
+    /**
+     * The memory store of the current workspace, or undefined when there is no workspace to store
+     * memory for. The store instance is kept because it tracks the workspace itself: its `location`
+     * follows a workspace change, so nothing has to be invalidated when the workspace is replaced.
+     *
+     * Closing a workspace is the exception: the store cannot compute a location without one, so it
+     * keeps the location of the closed workspace. Whether a workspace is open is therefore checked on
+     * every call rather than only when the store is created.
+     */
+    protected async getStore(): Promise<WorkspaceMetadataStore | undefined> {
+        if (this.workspaceService.tryGetRoots().length === 0) {
+            return undefined;
+        }
+        try {
+            if (!this.store) {
+                this.store = await this.metadataStorageService.getOrCreateStore(MEMORY_METADATA_STORE_KEY);
+            }
+            return this.store;
+        } catch (error) {
+            // No workspace is open: memory is unavailable rather than shared between unrelated windows.
+            return undefined;
+        }
+    }
+}

--- a/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
@@ -74,8 +74,7 @@ describe('UserInteractionTool', () => {
 
         mockWorkspaceScope = {
             resolveRelativePath: sinon.stub().callsFake((path: string) => workspaceRoot.resolve(path)),
-            getContainingRoot: sinon.stub().returns(workspaceRoot),
-            ensureWithinWorkspace: sinon.stub()
+            getContainingRoot: sinon.stub().returns(workspaceRoot)
         };
 
         mockOpenerService = {

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -22,6 +22,7 @@ FrontendApplicationConfigProvider.set({});
 import { expect } from 'chai';
 import { CancellationTokenSource, OS, PreferenceService } from '@theia/core';
 import {
+    AccessibleRootContribution,
     GetWorkspaceDirectoryStructure,
     FileContentFunction,
     GetWorkspaceFileList,
@@ -29,6 +30,7 @@ import {
     WorkspaceFunctionScope,
     FindFilesByPattern
 } from './workspace-functions';
+import { bindRootContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { AiConfigurationService, ToolInvocationContext } from '@theia/ai-core';
 import { Container } from '@theia/core/shared/inversify';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
@@ -951,6 +953,23 @@ describe('FindFilesByPattern.findFiles', () => {
         expect(result.error).to.be.undefined;
         expect(result.files).to.deep.equal(['/external/data/x.ts']);
     });
+
+    describe('on Windows', () => {
+        let originalIsWindows: boolean;
+        beforeEach(() => { originalIsWindows = OS.backend.isWindows; });
+        afterEach(() => { OS.backend.isWindows = originalIsWindows; });
+
+        // The tool promises the returned paths can be passed back to the file tools, so an external
+        // hit must be rendered as a native path and not as the URI-style `/c:/...`.
+        it('returns native paths for an allow-listed external searchRoot', async () => {
+            OS.backend.isWindows = true;
+            allowedExternal = ['C:\\external\\data'];
+            searchResults = ['file:///c%3A/external/data/x.ts'];
+            const result = JSON.parse(await call({ pattern: '**/*.ts', searchRoot: 'C:\\external\\data' }));
+            expect(result.error).to.be.undefined;
+            expect(result.files).to.deep.equal(['C:\\external\\data\\x.ts']);
+        });
+    });
 });
 
 describe('WorkspaceFunctionScope gitignore caching', () => {
@@ -1241,7 +1260,7 @@ describe('FileContentFunction external paths', () => {
         allowedPaths = ['/external/configs'];
         const result = await callTool('/external/configs/../secrets.txt');
         const parsed = JSON.parse(result);
-        expect(parsed.error).to.include('Invalid file path');
+        expect(parsed.error).to.include('Invalid path');
     });
 
     it('expands ~ in allow-list entries', async () => {
@@ -1266,7 +1285,7 @@ describe('FileContentFunction external paths', () => {
         allowedPaths = ['/home/test/configs'];
         const result = await callTool('~/configs/../secrets.txt');
         const parsed = JSON.parse(result);
-        expect(parsed.error).to.include('Invalid file path');
+        expect(parsed.error).to.include('Invalid path');
     });
 
     it('still allows workspace-relative paths', async () => {
@@ -1298,6 +1317,104 @@ describe('FileContentFunction external paths', () => {
         const result = await callTool('/external/configs/myapp.json');
         const parsed = JSON.parse(result);
         expect(parsed.error).to.include('not allowed');
+    });
+});
+
+describe('WorkspaceFunctionScope accessible root contributions', () => {
+    let container: Container;
+    let fileContentFunction: FileContentFunction;
+    let contributedRoots: URI[];
+    let contributionFails: boolean;
+    let rootQueries: number;
+
+    let disableJSDOMInner: () => void;
+    before(() => { disableJSDOMInner = enableJSDOM(); });
+    after(() => { disableJSDOMInner(); });
+
+    beforeEach(() => {
+        container = new Container();
+        contributedRoots = [];
+        contributionFails = false;
+        rootQueries = 0;
+
+        const mockWorkspaceService = {
+            roots: [{ resource: new URI('file:///workspace') }],
+            tryGetRoots: () => [{ resource: new URI('file:///workspace') }],
+            onWorkspaceChanged: () => ({ dispose: () => { } })
+        } as unknown as WorkspaceService;
+
+        const mockFileService = {
+            exists: async () => true,
+            resolve: async (uri: URI) => ({ isFile: true, isDirectory: false, size: 1024, resource: uri }),
+            read: async (uri: URI) => ({ value: `content-of-${uri.path.toString()}` })
+        } as unknown as FileService;
+
+        const contribution: AccessibleRootContribution = {
+            getRoots: async () => {
+                rootQueries++;
+                if (contributionFails) {
+                    throw new Error('cannot resolve roots');
+                }
+                return contributedRoots;
+            }
+        };
+
+        container.bind(WorkspaceService).toConstantValue(mockWorkspaceService);
+        container.bind(FileService).toConstantValue(mockFileService);
+        container.bind(PreferenceService).toConstantValue({ get: <T>(_path: string, defaultValue: T) => defaultValue });
+        container.bind(MonacoWorkspace).toConstantValue({ getTextDocument: () => undefined } as unknown as MonacoWorkspace);
+        container.bind(AiConfigurationService).toConstantValue(makeTrustAwareReader());
+        container.bind(EnvVariablesServer).toConstantValue(makeEnvVariablesServer());
+        bindRootContributionProvider(container, AccessibleRootContribution);
+        container.bind(AccessibleRootContribution).toConstantValue(contribution);
+        container.bind(WorkspaceFunctionScope).toSelf();
+        container.bind(FileContentFunction).toSelf();
+
+        fileContentFunction = container.get(FileContentFunction);
+    });
+
+    const callTool = (file: string) =>
+        fileContentFunction.getTool().handler(JSON.stringify({ file }), undefined) as Promise<string>;
+
+    it('allows a file under a contributed root although the allow-list is empty', async () => {
+        contributedRoots = [new URI('file:///config/workspace-metadata/uuid/memory')];
+        const result = await callTool('/config/workspace-metadata/uuid/memory/wiki/index.md');
+        expect(result).to.equal('content-of-/config/workspace-metadata/uuid/memory/wiki/index.md');
+    });
+
+    it('rejects a sibling that only shares the contributed root\'s prefix', async () => {
+        contributedRoots = [new URI('file:///config/memory')];
+        const parsed = JSON.parse(await callTool('/config/memory-other/wiki/index.md'));
+        expect(parsed.error).to.include('not allowed');
+    });
+
+    it('matches a contributed root that carries a trailing separator', async () => {
+        contributedRoots = [new URI('file:///config/memory/')];
+        const result = await callTool('/config/memory/wiki/index.md');
+        expect(result).to.equal('content-of-/config/memory/wiki/index.md');
+    });
+
+    it('re-queries the contributions, so a root that moves needs no invalidation', async () => {
+        contributedRoots = [new URI('file:///config/first/memory')];
+        expect(await callTool('/config/first/memory/notes.md')).to.match(/^content-of-/);
+
+        contributedRoots = [new URI('file:///config/second/memory')];
+        expect(JSON.parse(await callTool('/config/first/memory/notes.md')).error).to.include('not allowed');
+        expect(await callTool('/config/second/memory/notes.md')).to.match(/^content-of-/);
+        expect(rootQueries).to.equal(3);
+    });
+
+    it('keeps checking the other sources when a contribution fails', async () => {
+        contributionFails = true;
+        const parsed = JSON.parse(await callTool('/config/memory/wiki/index.md'));
+        expect(parsed.error).to.include('not allowed');
+        // The workspace itself is unaffected by the broken contribution.
+        expect(await callTool('src/index.ts')).to.equal('content-of-/workspace/src/index.ts');
+    });
+
+    it('is not consulted for paths inside the workspace', async () => {
+        expect(await callTool('src/index.ts')).to.equal('content-of-/workspace/src/index.ts');
+        expect(rootQueries).to.equal(0);
     });
 });
 
@@ -1683,18 +1800,16 @@ describe('WorkspaceFunctionScope path-traversal hardening', () => {
         });
     });
 
-    // Item 6 — `ensureWithinWorkspace` is the gate used by getFileDiagnostics
-    // for relative path inputs. A sibling that merely shares the workspace
-    // root's string prefix must not pass.
+    // getFileDiagnostics goes through the same `resolveAccessiblePath` gate as every other tool, so a
+    // sibling that merely shares the workspace root's string prefix must not pass.
     it('FileDiagnosticProvider rejects sibling-prefix path outside the workspace', async () => {
         const diag = container.get(FileDiagnosticProvider);
         const handler = diag.getTool().handler;
-        // Workspace root is file:///workspace/project. With a raw string-prefix
-        // check the resolved URI file:///workspace/project-other/file.txt
-        // would be (incorrectly) admitted.
+        // Workspace root is file:///workspace/project, so file:///workspace/project-other/file.txt is
+        // outside it — and a `..` segment is refused before it can even be resolved.
         const result = await handler(JSON.stringify({ file: '../project-other/file.txt' }), undefined);
         const parsed = JSON.parse(result as string);
-        expect(parsed.error).to.include('outside of the workspace');
+        expect(parsed.error).to.include('Invalid path');
     });
 });
 

--- a/packages/ai-ide/src/browser/workspace-functions.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.spec.ts
@@ -822,6 +822,15 @@ describe('FindFilesByPattern.findFiles', () => {
     before(() => { disableJSDOMInner = enableJSDOM(); });
     after(() => { disableJSDOMInner(); });
 
+    // External hits are rendered with `Path.fsPath()`, which branches on the backend OS, so the POSIX
+    // fixtures below pin it instead of inheriting the OS the tests happen to run on.
+    let originalIsWindows: boolean;
+    beforeEach(() => {
+        originalIsWindows = OS.backend.isWindows;
+        OS.backend.isWindows = false;
+    });
+    afterEach(() => { OS.backend.isWindows = originalIsWindows; });
+
     beforeEach(() => {
         container = new Container();
         searchResults = [];
@@ -955,10 +964,6 @@ describe('FindFilesByPattern.findFiles', () => {
     });
 
     describe('on Windows', () => {
-        let originalIsWindows: boolean;
-        beforeEach(() => { originalIsWindows = OS.backend.isWindows; });
-        afterEach(() => { OS.backend.isWindows = originalIsWindows; });
-
         // The tool promises the returned paths can be passed back to the file tools, so an external
         // hit must be rendered as a native path and not as the URI-style `/c:/...`.
         it('returns native paths for an allow-listed external searchRoot', async () => {
@@ -1543,6 +1548,15 @@ describe('FindFilesByPattern with searchRoot', () => {
     let disableJSDOMInner: () => void;
     before(() => { disableJSDOMInner = enableJSDOM(); });
     after(() => { disableJSDOMInner(); });
+
+    // External hits are rendered with `Path.fsPath()`, which branches on the backend OS, so the POSIX
+    // fixtures below pin it instead of inheriting the OS the tests happen to run on.
+    let originalIsWindows: boolean;
+    beforeEach(() => {
+        originalIsWindows = OS.backend.isWindows;
+        OS.backend.isWindows = false;
+    });
+    afterEach(() => { OS.backend.isWindows = originalIsWindows; });
 
     beforeEach(() => {
         container = new Container();

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -643,8 +643,8 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
             name: GetWorkspaceDirectoryStructure.ID,
             description: 'Retrieves the directory tree structure as a nested JSON object. ' +
                 'By default returns all workspace roots with root names as keys. ' +
-                'Pass `root` to inspect a specific directory listed in the ' +
-                '`ai-features.workspaceFunctions.allowedExternalPaths` preference instead. ' +
+                'Pass `root` to inspect a specific directory the tools may access, such as one listed in the ' +
+                '`ai-features.workspaceFunctions.allowedExternalPaths` preference, instead. ' +
                 'Lists only directories (no files), excluding common non-essential directories (node_modules, hidden files, etc.). ' +
                 'Useful for getting a high-level overview of project organization. ' +
                 'For listing files within a specific directory, use getWorkspaceFileList instead. ' +
@@ -655,7 +655,7 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
                     root: {
                         type: 'string',
                         description: 'Optional absolute path or `file://` URI to inspect instead of the workspace. ' +
-                            'Must be inside, or equal to, an entry of the `allowedExternalPaths` preference. ' +
+                            'Must point to a directory the tools may access, such as one listed in the `allowedExternalPaths` preference. ' +
                             'When omitted, all workspace roots are returned.'
                     }
                 },
@@ -755,8 +755,8 @@ export class FileContentFunction implements ToolProvider {
             description: 'Returns the content of a specified file as a raw string. ' +
                 'File paths use the same format returned by other workspace tools ' +
                 '(e.g., "my-project/src/index.ts"). ' +
-                'Absolute paths and `file://` URIs are accepted when the target is inside the workspace ' +
-                'or covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference. ' +
+                'Absolute paths and `file://` URIs are accepted when the target is a location the tools may access, ' +
+                'such as a directory listed in the `ai-features.workspaceFunctions.allowedExternalPaths` preference. ' +
                 'If the file is currently open in an editor with unsaved changes, returns the editor\'s current content (not the saved file on disk). ' +
                 'Binary files may not be readable and will return an error. ' +
                 'Use this tool to read file contents before making any edits with replacement functions. ' +
@@ -773,8 +773,8 @@ export class FileContentFunction implements ToolProvider {
                         type: 'string',
                         description: 'Path to the target file. May be workspace-relative ' +
                             '(e.g., "my-project/src/index.ts"), an absolute path, or a `file://` URI. ' +
-                            'Absolute / URI forms must point inside the workspace ' +
-                            'or inside a directory listed in the `allowedExternalPaths` preference.',
+                            'Absolute / URI forms must point to a location the tools may access, such as a directory listed in the ' +
+                            '`allowedExternalPaths` preference.',
                     },
                     offset: {
                         type: 'number',
@@ -1034,7 +1034,8 @@ export class GetWorkspaceFileList implements ToolProvider {
                         description: 'Path to a directory. Workspace-relative paths use the format \'rootName/path\' ' +
                             '(e.g., \'my-project/src\', \'backend/src/components\'). ' +
                             'Use \'\' or \'.\' to list the workspace top-level directories. ' +
-                            'Absolute paths and `file://` URIs are accepted when covered by the `allowedExternalPaths` preference.'
+                            'Absolute paths and `file://` URIs are accepted when they point to a location the tools may access, ' +
+                            'such as a directory listed in the `allowedExternalPaths` preference.'
                     }
                 },
                 required: ['path']
@@ -1153,8 +1154,9 @@ export class FileDiagnosticProvider implements ToolProvider {
                 properties: {
                     file: {
                         type: 'string',
-                        description: 'The path to the target file within the workspace ' +
-                            '(e.g., "my-project/src/index.ts", "backend/src/main.ts").'
+                        description: 'The path to the target file. May be workspace-relative ' +
+                            '(e.g., "my-project/src/index.ts", "backend/src/main.ts"), an absolute path, or a `file://` URI ' +
+                            'pointing to a location the tools may access.'
                     }
                 },
                 required: ['file']
@@ -1287,8 +1289,8 @@ export class FindFilesByPattern implements ToolProvider {
             name: FindFilesByPattern.ID,
             description: 'Find files matching a given glob pattern. ' +
                 'By default searches across all workspace roots. ' +
-                'Pass `searchRoot` to search a directory listed in the ' +
-                '`ai-features.workspaceFunctions.allowedExternalPaths` preference instead. ' +
+                'Pass `searchRoot` to search a directory the tools may access, such as one listed in the ' +
+                '`ai-features.workspaceFunctions.allowedExternalPaths` preference, instead. ' +
                 'This function allows efficient discovery of files using patterns like \'**/*.ts\' for all TypeScript files or ' +
                 '\'src/**/*.js\' for JavaScript files in the src directory. The function respects gitignore patterns and user exclusions, ' +
                 'returns workspace-relative paths (e.g., "my-project/src/index.ts") or absolute paths for external roots, ' +
@@ -1313,7 +1315,7 @@ export class FindFilesByPattern implements ToolProvider {
                     searchRoot: {
                         type: 'string',
                         description: 'Optional absolute path or `file://` URI to search instead of the workspace. ' +
-                            'Must be inside, or equal to, an entry of the `allowedExternalPaths` preference. ' +
+                            'Must point to a directory the tools may access, such as one listed in the `allowedExternalPaths` preference. ' +
                             'When set, results are returned as absolute paths so they can be passed back to getFileContent. ' +
                             'When omitted (default), all workspace roots are searched and results are workspace-relative.'
                     }

--- a/packages/ai-ide/src/browser/workspace-functions.ts
+++ b/packages/ai-ide/src/browser/workspace-functions.ts
@@ -15,8 +15,9 @@
 // *****************************************************************************
 import { AiConfigurationService, ToolInvocationContext, ToolProvider, ToolRequest } from '@theia/ai-core';
 import { CancellationToken, Disposable, OS, PreferenceService, URI, Path } from '@theia/core';
+import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
-import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, named, optional, postConstruct } from '@theia/core/shared/inversify';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { FileStat, FileOperationError, FileOperationResult } from '@theia/filesystem/lib/common/files';
 import { FileSearchService } from '@theia/file-search/lib/common/file-search-service';
@@ -40,6 +41,22 @@ import { MonacoTextModelService } from '@theia/monaco/lib/browser/monaco-text-mo
 import { ProblemManager } from '@theia/markers/lib/browser';
 import { DiagnosticSeverity, Range } from '@theia/core/shared/vscode-languageserver-protocol';
 
+export const AccessibleRootContribution = Symbol('AccessibleRootContribution');
+
+/**
+ * Contributes directories outside the workspace roots that the AI workspace tools may access, in
+ * addition to the user-configured `ai-features.workspaceFunctions.allowedExternalPaths`. This is meant
+ * for locations Theia owns and resolves itself, such as the memory store of the current workspace,
+ * whose path is generated and can therefore not be named in a preference by the user.
+ */
+export interface AccessibleRootContribution {
+    /**
+     * The currently accessible roots. Queried on every check rather than once, so that a root which
+     * moves with the workspace is picked up without invalidation.
+     */
+    getRoots(): Promise<URI[]>;
+}
+
 @injectable()
 export class WorkspaceFunctionScope {
     protected readonly GITIGNORE_FILE_NAME = '.gitignore';
@@ -58,6 +75,9 @@ export class WorkspaceFunctionScope {
 
     @inject(EnvVariablesServer)
     protected readonly envVariablesServer: EnvVariablesServer;
+
+    @inject(ContributionProvider) @named(AccessibleRootContribution) @optional()
+    protected readonly accessibleRootContributions: ContributionProvider<AccessibleRootContribution> | undefined;
 
     private gitignoreMatchers = new Map<string, ReturnType<typeof ignore> | undefined>();
     private gitignoreWatchersInitialized = new Set<string>();
@@ -298,20 +318,27 @@ export class WorkspaceFunctionScope {
 
     // ── Access control ──────────────────────────────────────────────────
 
-    ensureWithinWorkspace(targetUri: URI, workspaceRootUri: URI): void {
-        const normalized = targetUri.normalizePath();
-        if (workspaceRootUri.scheme !== normalized.scheme
-            || !workspaceRootUri.isEqualOrParent(normalized, WorkspaceFunctionScope.pathCaseSensitive)) {
-            throw new Error('Access outside of the workspace is not allowed');
+    /**
+     * Resolves a tool argument and asserts that it may be accessed. This is the single entry point every
+     * tool uses, so that a path is subjected to the same parsing and the same boundary check no matter
+     * which tool received it.
+     *
+     * @throws if the path cannot be resolved or points outside the accessible roots.
+     */
+    async resolveAccessiblePath(pathOrUri: string): Promise<URI> {
+        const resolved = await this.resolveToUri(pathOrUri);
+        if (!resolved) {
+            throw new Error(`Invalid path: '${pathOrUri}'`);
         }
+        await this.ensureAccessible(resolved);
+        return resolved;
     }
 
     /**
-     * Asserts the target URI is reachable by AI tools that honor the external
-     * allow-list. Allowed when the URI is inside any workspace root, or when it
-     * is covered by an entry of the `ai-features.workspaceFunctions.allowedExternalPaths`
-     * preference. Workspace-scoped overrides of that preference are dropped when
-     * the workspace is not trusted.
+     * Asserts the target URI is reachable by the AI tools. Allowed when the URI is inside any workspace
+     * root, below a root contributed by an {@link AccessibleRootContribution}, or covered by an entry of
+     * the `ai-features.workspaceFunctions.allowedExternalPaths` preference. Workspace-scoped overrides of
+     * that preference are dropped when the workspace is not trusted.
      *
      * The target URI is normalized before the check so that literal `..`
      * segments and percent-encoded equivalents (e.g. `%2e%2e`) are resolved
@@ -322,21 +349,38 @@ export class WorkspaceFunctionScope {
      */
     async ensureAccessible(targetUri: URI): Promise<void> {
         const normalized = targetUri.normalizePath();
-        const caseSensitive = WorkspaceFunctionScope.pathCaseSensitive;
-        const roots = this.getAllRootUris();
-        for (const rootUri of roots) {
-            if (rootUri.scheme === normalized.scheme && rootUri.isEqualOrParent(normalized, caseSensitive)) {
-                return;
-            }
-        }
-        const allowed = await this.getAllowedExternalUris();
-        if (allowed.some(allowedUri => allowedUri.scheme === normalized.scheme && allowedUri.isEqualOrParent(normalized, caseSensitive))) {
+        if (this.isUnderAny(this.getAllRootUris(), normalized)
+            || this.isUnderAny(await this.getContributedRootUris(), normalized)
+            || this.isUnderAny(await this.getAllowedExternalUris(), normalized)) {
             return;
         }
         throw new Error(
             `Access to '${normalized.path.toString()}' is not allowed. ` +
             `Path is outside the workspace and not covered by the '${ALLOWED_EXTERNAL_PATHS_PREF}' preference.`
         );
+    }
+
+    protected isUnderAny(roots: URI[], normalizedTarget: URI): boolean {
+        const caseSensitive = WorkspaceFunctionScope.pathCaseSensitive;
+        return roots.some(root => root.scheme === normalizedTarget.scheme && root.isEqualOrParent(normalizedTarget, caseSensitive));
+    }
+
+    /**
+     * The roots contributed by {@link AccessibleRootContribution}s, normalized like the allow-list. A
+     * contribution that fails to resolve is skipped rather than allowed to fail every path check.
+     */
+    protected async getContributedRootUris(): Promise<URI[]> {
+        const roots: URI[] = [];
+        for (const contribution of this.accessibleRootContributions?.getContributions() ?? []) {
+            try {
+                for (const root of await contribution.getRoots()) {
+                    roots.push(WorkspaceFunctionScope.withoutTrailingSeparator(root.normalizePath()));
+                }
+            } catch (error) {
+                console.warn('Failed to resolve accessible roots from a contribution.', error);
+            }
+        }
+        return roots;
     }
 
     isInWorkspace(uri: URI): boolean {
@@ -643,11 +687,7 @@ export class GetWorkspaceDirectoryStructure implements ToolProvider {
 
         try {
             if (root) {
-                const resolved = await this.workspaceScope.resolveToUri(root);
-                if (!resolved) {
-                    return { error: `Invalid root: '${root}'` };
-                }
-                await this.workspaceScope.ensureAccessible(resolved);
+                const resolved = await this.workspaceScope.resolveAccessiblePath(root);
                 return this.buildDirectoryStructure(resolved, cancellationToken);
             } else {
                 const rootMapping = this.workspaceScope.getRootMapping();
@@ -800,14 +840,9 @@ export class FileContentFunction implements ToolProvider {
             return JSON.stringify({ error: 'limit must be a positive integer.' });
         }
 
-        let targetUri: URI | undefined;
+        let targetUri: URI;
         try {
-            const resolved = await this.workspaceScope.resolveToUri(file);
-            if (!resolved) {
-                return JSON.stringify({ error: `Invalid file path: '${file}'` });
-            }
-            targetUri = resolved;
-            await this.workspaceScope.ensureAccessible(targetUri);
+            targetUri = await this.workspaceScope.resolveAccessiblePath(file);
         } catch (error) {
             return JSON.stringify({ error: error.message });
         }
@@ -1044,12 +1079,7 @@ export class GetWorkspaceFileList implements ToolProvider {
 
             let targetUri: URI;
             try {
-                const resolved = await this.workspaceScope.resolveToUri(path);
-                if (!resolved) {
-                    return JSON.stringify({ error: `Invalid path: '${path}'` });
-                }
-                targetUri = resolved;
-                await this.workspaceScope.ensureAccessible(targetUri);
+                targetUri = await this.workspaceScope.resolveAccessiblePath(path);
             } catch (error) {
                 return JSON.stringify({ error: error.message });
             }
@@ -1132,12 +1162,7 @@ export class FileDiagnosticProvider implements ToolProvider {
             handler: async (arg: string, ctx?: ToolInvocationContext) => {
                 try {
                     const { file } = JSON.parse(arg);
-                    const targetUri = await this.workspaceScope.resolveRelativePath(file);
-                    const containingRoot = this.workspaceScope.getContainingRoot(targetUri);
-                    if (!containingRoot) {
-                        return JSON.stringify({ error: 'Access outside of the workspace is not allowed' });
-                    }
-                    this.workspaceScope.ensureWithinWorkspace(targetUri, containingRoot);
+                    const targetUri = await this.workspaceScope.resolveAccessiblePath(file);
 
                     return this.getDiagnosticsForFile(targetUri, ctx?.cancellationToken);
                 } catch (error) {
@@ -1337,11 +1362,7 @@ export class FindFilesByPattern implements ToolProvider {
             // Resolve the set of roots to search and how each root's results should be rendered.
             const targets: { rootUri: URI; rootName?: string; external: boolean }[] = [];
             if (searchRoot) {
-                const resolved = await this.workspaceScope.resolveToUri(searchRoot);
-                if (!resolved) {
-                    return JSON.stringify({ error: `Invalid searchRoot: '${searchRoot}'` });
-                }
-                await this.workspaceScope.ensureAccessible(resolved);
+                const resolved = await this.workspaceScope.resolveAccessiblePath(searchRoot);
                 targets.push({ rootUri: resolved, external: !this.workspaceScope.isInWorkspace(resolved) });
             } else {
                 const rootMapping = this.workspaceScope.getRootMapping();
@@ -1410,7 +1431,7 @@ export class FindFilesByPattern implements ToolProvider {
      */
     protected toDisplayPath(match: URI, target: { rootUri: URI; rootName?: string; external: boolean }): string | undefined {
         if (target.external) {
-            return match.path.toString();
+            return match.path.fsPath();
         }
         const relativePath = target.rootUri.relative(match)?.toString();
         if (relativePath === undefined) {

--- a/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.spec.ts
@@ -62,8 +62,7 @@ describe('Workspace Search Provider Cancellation Tests', () => {
         const mockWorkspaceScope = {
             getRootMapping: () => new Map([['workspace', new URI('file:///workspace')]]),
             getContainingRoot: () => new URI('file:///workspace'),
-            ensureWithinWorkspace: () => { },
-            resolveRelativePath: (path: string) => new URI(`file:///workspace/${path}`)
+            resolveAccessiblePath: async (path: string) => new URI(`file:///workspace/${path}`)
         } as unknown as WorkspaceFunctionScope;
 
         const mockPreferenceService = {

--- a/packages/ai-ide/src/browser/workspace-search-provider.ts
+++ b/packages/ai-ide/src/browser/workspace-search-provider.ts
@@ -75,8 +75,10 @@ export class WorkspaceSearchProvider implements ToolProvider {
                     },
                     subDirectoryPath: {
                         type: 'string',
-                        description: 'Optional subdirectory path to limit search scope ' +
+                        description: 'Optional directory to limit the search scope ' +
                             '(e.g., "frontend/src", "backend/packages/core/src/browser"). ' +
+                            'May also be an absolute path or `file://` URI of a directory the AI tools may access, ' +
+                            'such as one listed in the `ai-features.workspaceFunctions.allowedExternalPaths` preference. ' +
                             'If not specified, searches the entire workspace.'
                     }
                 },
@@ -96,12 +98,7 @@ export class WorkspaceSearchProvider implements ToolProvider {
             return Array.from(rootMapping.values()).map(uri => uri.toString());
         }
 
-        const subDirUri = await this.workspaceScope.resolveRelativePath(subDirectoryPath);
-        const containingRoot = this.workspaceScope.getContainingRoot(subDirUri);
-        if (!containingRoot) {
-            throw new Error(`Subdirectory '${subDirectoryPath}' is not within any workspace root`);
-        }
-        this.workspaceScope.ensureWithinWorkspace(subDirUri, containingRoot);
+        const subDirUri = await this.workspaceScope.resolveAccessiblePath(subDirectoryPath);
 
         try {
             const stat = await this.fileService.resolve(subDirUri);

--- a/packages/ai-ide/src/common/coder-replace-prompt-template.ts
+++ b/packages/ai-ide/src/common/coder-replace-prompt-template.ts
@@ -459,6 +459,8 @@ When review feedback is recorded in the task context (REVISE verdict): evaluate 
 
 {{capability:apptester default off}}
 
+{{capability:memory default off}}
+
 ## Final Review
 
 Confirm: works as intended, tests pass, code quality OK, no security issues. Then yield.

--- a/packages/ai-ide/src/common/workspace-preferences.ts
+++ b/packages/ai-ide/src/common/workspace-preferences.ts
@@ -108,9 +108,9 @@ export const WorkspacePreferencesSchema: PreferenceSchema = {
             type: 'array',
             title: nls.localize('theia/ai/workspace/allowedExternalPaths/title', 'Allowed External Paths'),
             description: nls.localize('theia/ai/workspace/allowedExternalPaths/description',
-                'List of absolute paths or file URIs (directories or files) outside the workspace that AI tools may read. ' +
+                'List of absolute paths or file URIs (directories or files) outside the workspace that AI tools may access. ' +
                 'Supports `~` to refer to the user home directory. Empty by default; opt-in only. ' +
-                'Honored by getFileContent, findFilesByPattern, getWorkspaceFileList, and getWorkspaceDirectoryStructure. ' +
+                'Honored by every tool that takes a path, including the tools that write files. ' +
                 'Workspace-scoped values are ignored when the workspace is not trusted. ' +
                 'Symbolic links inside allow-listed directories are followed and may point to files outside the allow-list; ' +
                 'only add directories whose contents you trust.'),

--- a/packages/ai-ide/src/common/workspace-search-provider-util.spec.ts
+++ b/packages/ai-ide/src/common/workspace-search-provider-util.spec.ts
@@ -1,0 +1,61 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { OS, URI } from '@theia/core';
+import { SearchInWorkspaceResult } from '@theia/search-in-workspace/lib/common/search-in-workspace-interface';
+import { optimizeSearchResults, WorkspacePathResolver } from './workspace-search-provider-util';
+
+const result = (fileUri: string): SearchInWorkspaceResult => ({
+    root: 'file:///workspace',
+    fileUri,
+    matches: [{ line: 3, character: 1, length: 4, lineText: '    hit  ' }]
+});
+
+/** Resolves paths below `file:///workspace` and treats everything else as external. */
+const workspaceResolver: WorkspacePathResolver = {
+    toWorkspaceRelativePath: (uri: URI) => {
+        const relative = new URI('file:///workspace').relative(uri)?.toString();
+        return relative === undefined ? undefined : `workspace/${relative}`;
+    }
+};
+
+describe('optimizeSearchResults', () => {
+
+    it('returns root-prefixed relative paths and trimmed line text for workspace hits', () => {
+        expect(optimizeSearchResults([result('file:///workspace/src/a.ts')], workspaceResolver)).to.deep.equal([
+            { file: 'workspace/src/a.ts', matches: [{ line: 3, text: 'hit' }] }
+        ]);
+    });
+
+    describe('paths outside the workspace roots', () => {
+        let originalIsWindows: boolean;
+        beforeEach(() => { originalIsWindows = OS.backend.isWindows; });
+        afterEach(() => { OS.backend.isWindows = originalIsWindows; });
+
+        it('falls back to the native path, so it can be passed back to the file tools', () => {
+            OS.backend.isWindows = true;
+            const [optimized] = optimizeSearchResults([result('file:///c%3A/external/data/x.ts')], workspaceResolver);
+            expect(optimized.file).to.equal('C:\\external\\data\\x.ts');
+        });
+
+        it('falls back to the absolute path on POSIX', () => {
+            OS.backend.isWindows = false;
+            const [optimized] = optimizeSearchResults([result('file:///external/data/x.ts')], workspaceResolver);
+            expect(optimized.file).to.equal('/external/data/x.ts');
+        });
+    });
+});

--- a/packages/ai-ide/src/common/workspace-search-provider-util.ts
+++ b/packages/ai-ide/src/common/workspace-search-provider-util.ts
@@ -29,7 +29,8 @@ export interface WorkspacePathResolver {
  * Optimizes search results for token efficiency while preserving all information.
  * - Groups matches by file to reduce repetition
  * - Trims leading/trailing whitespace from line text
- * - Uses root-prefixed relative file paths (e.g., "rootName/src/file.ts")
+ * - Uses root-prefixed relative file paths (e.g., "rootName/src/file.ts"), falling back to the absolute
+ *   path for hits outside the workspace roots
  * - Preserves all line numbers and content
  */
 export function optimizeSearchResults(
@@ -41,7 +42,7 @@ export function optimizeSearchResults(
         const relativePath = workspacePathResolver.toWorkspaceRelativePath(fileUri);
 
         return {
-            file: relativePath ?? result.fileUri,
+            file: relativePath ?? fileUri.path.fsPath(),
             matches: result.matches.map(match => {
                 let lineText: string;
                 if (typeof match.lineText === 'string') {


### PR DESCRIPTION
#### What it does

Introduces a new built-in "Memory" prompt capability that lets AI agents maintain a persistent, wiki-style knowledge base under `.agents/memory/` in the workspace, compiling raw session output into linked concept articles for reuse across tasks.

- `.agents/memory/raw/` — append-only ingest (session logs, verbatim findings)
- `.agents/memory/wiki/` — the compiled knowledge base: one short single-concept article per topic, cross-linked from `index.md`

It is contributed via `MemoryCapabilityContribution` and bound in the `ai-ide` frontend module, following the existing capability contributions (e.g. `github-capability-contribution.ts`). It is offered as an **opt-in** capability in the coder agent prompt template (`default off`), so we can field-test it before deciding on the default.

This was split out of #17815, which now only contains the coder prompt refinements.

##### Storage location

The knowledge base lives in `.agents/memory/` inside the workspace, matching the tiered convention already used for skills (`<workspace>/.agents/skills`, `<workspace>/.prompts/skills`). Rationale:

- The content the capability describes — project facts, conventions, environment quirks, standing decisions — is inherently project-scoped, so it belongs next to the code it describes.
- A dotfolder keeps the workspace root clean.
- The prompt asks the agent to keep the wiki under version control, which also removes the `git clean` risk of an ignored folder.

#### How to test

1. Start the browser example application.
2. Enable the "Memory" capability for the Coder agent (AI Configuration view → Coder → prompt capabilities).
3. Run a task and verify the agent creates/updates `.agents/memory/wiki/index.md` and articles, and reads them at the start of a follow-up task.

#### Follow-ups

- Decide on the default (on/off) after a field-test period.
- Consider a dedicated contribution point for prompt fragments instead of the current `FrontendApplicationContribution` boilerplate.

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the changelog has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the `nls` service

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with the review guidelines