### PR TITLE
[tasks] Update test-resources task examples

### DIFF
--- a/packages/task/test-resources/.theia/tasks.json
+++ b/packages/task/test-resources/.theia/tasks.json
@@ -1,5 +1,23 @@
 {
     // comment
+    "inputs": [
+        {
+            "id": "task-argument",
+            "type": "promptString",
+            "description": "Enter the second task argument",
+            "default": "b"
+        },
+        {
+            "id": "task-argument-choice",
+            "type": "pickString",
+            "description": "Choose the third task argument",
+            "options": [
+                "c",
+                "not-c"
+            ],
+            "default": "c"
+        }
+    ],
     "tasks": [
         {
             "label": "test task",
@@ -54,6 +72,48 @@
                     "/c",
                     "dir"
                 ]
+            }
+        },
+        {
+            "label": "task with input variables",
+            "type": "shell",
+            "command": "node",
+            "args": [
+                "test-arguments-0.js",
+                "Unexpected task arguments:",
+                "a",
+                "${input:task-argument}",
+                "${input:task-argument-choice}"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "task with custom problem matcher",
+            "type": "shell",
+            "command": "node",
+            "args": [
+                "test-arguments-0.js",
+                "test-arguments-0.js:1:1: error:",
+                "invalid"
+            ],
+            "options": {
+                "cwd": "${workspaceFolder}"
+            },
+            "problemMatcher": {
+                "owner": "task-test",
+                "source": "task-test",
+                "fileLocation": "relative",
+                "pattern": {
+                    "regexp": "^(.+):(\\d+):(\\d+):\\s+(error|warning|info):\\s+(.+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                }
             }
         }
     ]


### PR DESCRIPTION
#### What it does

Closes #6348.

- Adds `promptString` and `pickString` input definitions to the task test resources.
- Adds a task demonstrating `${input:...}` variable resolution.
- Adds a self-contained task demonstrating a custom problem matcher with file, line, column, severity, and message captures.
- Keeps all existing task examples unchanged.

These examples exercise currently supported task features and provide reusable fixtures for manual and automated task testing.

#### How to test

1. Build and start the browser example, then open `packages/task/test-resources` as the workspace.
2. Run **Task: Run Task...** and select **task with input variables**.
3. Accept the default `b` prompt value and select the default `c` choice. The task should complete successfully with arguments `a b c` and produce no Problems entry.
4. Run **task with custom problem matcher**. The task intentionally exits with code 1.
5. Open the Problems view and verify that it contains exactly one error for `test-arguments-0.js`: `["invalid"]` at line 1, column 1, with source `task-test`.

Validation performed:

- `git diff --check`
- `npm run compile`
- `npm test --workspace=@theia/task` (38 passing)
- `npm test --workspace=@theia/variable-resolver` (9 passing)
- `npm run lint --workspace=@theia/task`
- `npm run lint --workspace=@theia/variable-resolver`
- `npm run build:browser`
- Manual browser verification of both added tasks on Windows with Node.js 22

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Not applicable.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (not applicable: this change only updates task test fixtures)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing)
