### PR TITLE
fix(core): replace deprecated unload event with pagehide

### DIFF
--- a/packages/core/src/browser/frontend-application-contribution.ts
+++ b/packages/core/src/browser/frontend-application-contribution.ts
@@ -52,7 +52,7 @@ export interface FrontendApplicationContribution {
     /**
      * Called when an application is stopped or unloaded.
      *
-     * Note that this is implemented using `window.beforeunload` which doesn't allow any asynchronous code anymore.
+     * Note that this is implemented using `window.pagehide` which doesn't allow any asynchronous code anymore.
      * I.e. this is the last tick.
      */
     onStop?(app: FrontendApplication): void;

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -124,7 +124,7 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
                     }
                 }, { capture: true });
 
-                newWindow.addEventListener('unload', () => {
+                newWindow.addEventListener('pagehide', () => {
                     focusRegistration.dispose();
                     const extIndex = this.secondaryWindows.indexOf(newWindow);
                     if (extIndex > -1) {
@@ -140,7 +140,7 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
     }
 
     protected windowCreated(newWindow: Window, widget: ExtractableWidget, shell: ApplicationShell): void {
-        newWindow.addEventListener('unload', () => {
+        newWindow.addEventListener('pagehide', () => {
             this.restoreWidgets(newWindow, widget, shell);
         });
     }

--- a/packages/core/src/browser/window/default-window-service.spec.ts
+++ b/packages/core/src/browser/window/default-window-service.spec.ts
@@ -77,6 +77,20 @@ describe('DefaultWindowService', () => {
         assert(windowService['collectContributionUnloadVetoes']().length > 0, 'there should be vetoes');
         assert(frontendContributions.every(contribution => contribution.onWillStopCalled), 'contributions should have been called');
     });
+    it('should reload unconditionally when restored from the back/forward cache', () => {
+        const frontendContributions: TestFrontendApplicationContribution[] = [
+            new TestFrontendApplicationContribution(true),
+        ];
+        const windowService = setupWindowService('always', frontendContributions);
+        let reloaded = 0;
+        windowService.reload = () => { reloaded++; };
+        windowService['handlePageShow']({ persisted: false } as PageTransitionEvent);
+        const reloadsBeforeRestore = reloaded;
+        windowService['handlePageShow']({ persisted: true } as PageTransitionEvent);
+        assert(reloadsBeforeRestore === 0, 'a regular page show should not reload');
+        assert(reloaded === 1, 'a restored page should reload');
+        assert(windowService['collectContributionUnloadVetoes']().length === 0, 'the recovery reload should not be vetoed');
+    });
     it('onUnload should fire at most once, even if `pagehide` fires repeatedly', () => {
         const windowService = setupWindowService('never', []);
         let fired = 0;

--- a/packages/core/src/browser/window/default-window-service.spec.ts
+++ b/packages/core/src/browser/window/default-window-service.spec.ts
@@ -77,4 +77,12 @@ describe('DefaultWindowService', () => {
         assert(windowService['collectContributionUnloadVetoes']().length > 0, 'there should be vetoes');
         assert(frontendContributions.every(contribution => contribution.onWillStopCalled), 'contributions should have been called');
     });
+    it('onUnload should fire at most once, even if `pagehide` fires repeatedly', () => {
+        const windowService = setupWindowService('never', []);
+        let fired = 0;
+        windowService.onUnload(() => fired++);
+        windowService['handlePageHide']();
+        windowService['handlePageHide']();
+        assert(fired === 1, `onUnload should have fired once, but fired ${fired} time(s)`);
+    });
 });

--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -109,6 +109,14 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
         // silently skipping the handler and thus e.g. losing the layout.
         // If `beforeunload` is cancelled and the user stays, `pagehide` is not fired.
         window.addEventListener('pagehide', () => this.onUnloadEmitter.fire());
+        // `pagehide` also fires when the page enters the back/forward cache, in which case the
+        // frontend has already shut down (state saved, connections closed). Reload to get a
+        // working application again if the page is restored from the cache.
+        window.addEventListener('pageshow', event => {
+            if (event.persisted) {
+                window.location.reload();
+            }
+        });
     }
 
     async isSafeToShutDown(stopReason: StopReason): Promise<boolean> {

--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -104,11 +104,11 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
      */
     protected registerUnloadListeners(): void {
         window.addEventListener('beforeunload', event => this.handleBeforeUnloadEvent(event));
-        // In a browser, `unload` is correctly fired when the page unloads, unlike Electron.
-        // If `beforeunload` is cancelled, the user will be prompted to leave or stay.
-        // If the user stays, the page won't be unloaded, so `unload` is not fired.
-        // If the user leaves, the page will be unloaded, so `unload` is fired.
-        window.addEventListener('unload', () => this.onUnloadEmitter.fire());
+        // `pagehide` is used instead of the deprecated `unload` event, which Chrome may block
+        // via permissions policy (https://developer.chrome.com/docs/web-platform/deprecating-unload),
+        // silently skipping the handler and thus e.g. losing the layout.
+        // If `beforeunload` is cancelled and the user stays, `pagehide` is not fired.
+        window.addEventListener('pagehide', () => this.onUnloadEmitter.fire());
     }
 
     async isSafeToShutDown(stopReason: StopReason): Promise<boolean> {

--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -30,6 +30,7 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
 
     protected frontendApplication: FrontendApplication;
     protected allowVetoes = true;
+    protected unloaded = false;
 
     protected onUnloadEmitter = new Emitter<void>();
     get onUnload(): Event<void> {
@@ -104,19 +105,38 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
      */
     protected registerUnloadListeners(): void {
         window.addEventListener('beforeunload', event => this.handleBeforeUnloadEvent(event));
-        // `pagehide` is used instead of the deprecated `unload` event, which Chrome may block
-        // via permissions policy (https://developer.chrome.com/docs/web-platform/deprecating-unload),
-        // silently skipping the handler and thus e.g. losing the layout.
-        // If `beforeunload` is cancelled and the user stays, `pagehide` is not fired.
-        window.addEventListener('pagehide', () => this.onUnloadEmitter.fire());
+        this.registerPageHideListener();
         // `pagehide` also fires when the page enters the back/forward cache, in which case the
         // frontend has already shut down (state saved, connections closed). Reload to get a
-        // working application again if the page is restored from the cache.
+        // working application again if the page is restored from the cache. The shutdown already
+        // happened, so the reload must not be vetoed again by the contributions.
         window.addEventListener('pageshow', event => {
             if (event.persisted) {
+                this.setSafeToShutDown();
                 window.location.reload();
             }
         });
+    }
+
+    /**
+     * `pagehide` is used instead of the deprecated `unload` event, which Chrome may block
+     * via permissions policy (https://developer.chrome.com/docs/web-platform/deprecating-unload),
+     * silently skipping the handler and thus e.g. losing the layout.
+     * If `beforeunload` is cancelled and the user stays, `pagehide` is not fired.
+     */
+    protected registerPageHideListener(): void {
+        window.addEventListener('pagehide', () => this.handlePageHide());
+    }
+
+    /**
+     * Fires {@link onUnload} at most once per document: `pagehide` fires again for the reload that
+     * recovers a page restored from the back/forward cache, but the application is already stopped.
+     */
+    protected handlePageHide(): void {
+        if (!this.unloaded) {
+            this.unloaded = true;
+            this.onUnloadEmitter.fire();
+        }
     }
 
     async isSafeToShutDown(stopReason: StopReason): Promise<boolean> {

--- a/packages/core/src/browser/window/default-window-service.ts
+++ b/packages/core/src/browser/window/default-window-service.ts
@@ -104,28 +104,32 @@ export class DefaultWindowService implements WindowService, FrontendApplicationC
      * Implement the mechanism to detect unloading of the page.
      */
     protected registerUnloadListeners(): void {
+        // If `beforeunload` is cancelled and the user stays, the page is not unloaded, so `pagehide` is not fired.
         window.addEventListener('beforeunload', event => this.handleBeforeUnloadEvent(event));
         this.registerPageHideListener();
-        // `pagehide` also fires when the page enters the back/forward cache, in which case the
-        // frontend has already shut down (state saved, connections closed). Reload to get a
-        // working application again if the page is restored from the cache. The shutdown already
-        // happened, so the reload must not be vetoed again by the contributions.
-        window.addEventListener('pageshow', event => {
-            if (event.persisted) {
-                this.setSafeToShutDown();
-                window.location.reload();
-            }
-        });
+        window.addEventListener('pageshow', event => this.handlePageShow(event));
     }
 
     /**
      * `pagehide` is used instead of the deprecated `unload` event, which Chrome may block
      * via permissions policy (https://developer.chrome.com/docs/web-platform/deprecating-unload),
      * silently skipping the handler and thus e.g. losing the layout.
-     * If `beforeunload` is cancelled and the user stays, `pagehide` is not fired.
      */
     protected registerPageHideListener(): void {
         window.addEventListener('pagehide', () => this.handlePageHide());
+    }
+
+    /**
+     * `pagehide` also fires when the page enters the back/forward cache, in which case the frontend
+     * has already shut down (state saved, connections closed). Reload to get a working application
+     * again if the page is restored from the cache. That shutdown already happened, so the reload
+     * must not be vetoed by the contributions.
+     */
+    protected handlePageShow(event: PageTransitionEvent): void {
+        if (event.persisted) {
+            this.setSafeToShutDown();
+            this.reload();
+        }
     }
 
     /**

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -56,7 +56,7 @@ export interface WindowService {
     focus(): void;
 
     /**
-     * Fires when the `window` unloads. The unload event is inevitable. On this event, the frontend application can save its state and release resource.
+     * Fires when the `window` is about to be unloaded (`pagehide`). On this event, the frontend application can save its state and release resource.
      * Saving the state and releasing any resources must be a synchronous call. Any asynchronous calls invoked after emitting this event might be ignored.
      */
     readonly onUnload: Event<void>;

--- a/packages/core/src/browser/window/window-service.ts
+++ b/packages/core/src/browser/window/window-service.ts
@@ -56,7 +56,7 @@ export interface WindowService {
     focus(): void;
 
     /**
-     * Fires when the `window` is about to be unloaded (`pagehide`). On this event, the frontend application can save its state and release resource.
+     * Fires when the application is shutting down. On this event, the frontend application can save its state and release resource.
      * Saving the state and releasing any resources must be a synchronous call. Any asynchronous calls invoked after emitting this event might be ignored.
      */
     readonly onUnload: Event<void>;

--- a/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
+++ b/packages/core/src/electron-browser/menu/electron-menu-contribution.ts
@@ -139,7 +139,7 @@ export class ElectronMenuContribution extends BrowserMenuBarContribution impleme
         const disposeHandler = window.electronTheiaCore.onWindowEvent('focus', () => {
             this.setMenu(app);
         });
-        window.addEventListener('unload', () => disposeHandler.dispose());
+        window.addEventListener('pagehide', () => disposeHandler.dispose());
     }
 
     protected attachMenuBarVisibilityListener(): void {

--- a/packages/core/src/electron-browser/window/electron-secondary-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-secondary-window-service.ts
@@ -61,7 +61,7 @@ export class ElectronSecondaryWindowService extends DefaultSecondaryWindowServic
             for (let i = this.secondaryWindows.length - 1; i >= 0; i--) {
                 const windowClosed = new Deferred<void>();
                 const win = this.secondaryWindows[i];
-                win.addEventListener('unload', () => {
+                win.addEventListener('pagehide', () => {
                     windowClosed.resolve();
                 });
                 promises.push(windowClosed.promise);

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -89,9 +89,7 @@ export class ElectronWindowService extends DefaultWindowService {
             }
             return willShutDown;
         });
-        window.addEventListener('pagehide', () => {
-            this.onUnloadEmitter.fire();
-        });
+        this.registerPageHideListener();
     }
 
     /**

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -89,6 +89,8 @@ export class ElectronWindowService extends DefaultWindowService {
             }
             return willShutDown;
         });
+        // Intentionally not calling `super`: in Electron the close request handler above takes the role of
+        // `beforeunload`, and there is no back/forward cache, so only the `pagehide` listener is shared.
         this.registerPageHideListener();
     }
 

--- a/packages/core/src/electron-browser/window/electron-window-service.ts
+++ b/packages/core/src/electron-browser/window/electron-window-service.ts
@@ -89,7 +89,7 @@ export class ElectronWindowService extends DefaultWindowService {
             }
             return willShutDown;
         });
-        window.addEventListener('unload', () => {
+        window.addEventListener('pagehide', () => {
             this.onUnloadEmitter.fire();
         });
     }


### PR DESCRIPTION
#### What it does

Fixes #17798.

Chrome is deprecating the `unload` event by disabling it via permissions policy (https://developer.chrome.com/docs/web-platform/deprecating-unload). Where the policy applies, `unload` handlers are silently skipped (`[Violation] Permissions policy violation: unload is not allowed in this document`), so `WindowService.onUnload` never fires and the layout is not saved on close.

Replaces all `unload` listeners with `pagehide`, which fires in the same situations (after an uncancelled `beforeunload`) and is not affected by the deprecation. The `WindowService.onUnload` API is unchanged; only the underlying DOM event differs.

#### How to test

1. Start the browser example, change the layout (e.g. open views/editors), reload — layout is restored as before.
2. Extract a widget into a secondary window, close it — the widget is restored to the main shell.
3. Same checks in the Electron example (close/reload, secondary windows, macOS menu after window switch).

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
