### PR TITLE
perf(plugin-ext): parallelize backend/frontend plugin deployment; fix…

### DIFF
--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
@@ -26,7 +26,7 @@ import { HostedPluginReader } from './plugin-reader';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
 import { PluginUninstallationManager } from '../../main/node/plugin-uninstallation-manager';
 import {
-    PluginDeployerEntry, PluginDeployerEntryType, PluginPackage, PluginMetadata, PluginType
+    PluginDeployerEntry, PluginDeployerEntryType, PluginPackage, PluginMetadata, PluginType, PluginIdentifiers
 } from '../../common/plugin-protocol';
 
 class TestPluginDeployerHandler extends PluginDeployerHandlerImpl {
@@ -36,6 +36,10 @@ class TestPluginDeployerHandler extends PluginDeployerHandlerImpl {
 
     countDeployedBackendPlugins(): number {
         return this.deployedBackendPlugins.size;
+    }
+
+    countDeployedLocations(id: PluginIdentifiers.VersionedId): number {
+        return this.deployedLocations.get(id)?.size ?? 0;
     }
 }
 
@@ -157,11 +161,12 @@ describe('PluginDeployerHandlerImpl - concurrent deployment', () => {
         // readContribution must run only once.
         expect(readContributionCallCount).to.equal(1);
         expect(handler.countDeployedBackendPlugins()).to.equal(1);
+        expect(handler.countDeployedLocations(`${pluginId}@${version}` as PluginIdentifiers.VersionedId)).to.equal(2);
     });
 
     it('deploys backend plugins in parallel and reports the correct success count when one fails', async () => {
-        const goodIdA = 'test-publisher.plugin-a';
-        const goodIdB = 'test-publisher.plugin-b';
+        const goodIdA = 'plugin-a';
+        const goodIdB = 'plugin-b';
 
         const handler = createHandler({
             reader: {

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
@@ -19,19 +19,24 @@ import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
 import { ILogger } from '@theia/core/lib/common/logger';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
-import { SimpleStopwatch } from '@theia/core/lib/common/performance/simple-stopwatch';
+import { NodeStopwatch } from '@theia/core/lib/node/performance/node-stopwatch';
 import { Stopwatch } from '@theia/core/lib/common';
-import { PluginDeployerHandlerImpl } from './plugin-deployer-handler-impl';
+import { PluginDeployerHandlerImpl, PreparedPlugin } from './plugin-deployer-handler-impl';
 import { HostedPluginReader } from './plugin-reader';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
 import { PluginUninstallationManager } from '../../main/node/plugin-uninstallation-manager';
+import { PluginDeployerEntryImpl } from '../../main/node/plugin-deployer-entry-impl';
 import {
     PluginDeployerEntry, PluginDeployerEntryType, PluginPackage, PluginMetadata, PluginType, PluginIdentifiers
 } from '../../common/plugin-protocol';
 
 class TestPluginDeployerHandler extends PluginDeployerHandlerImpl {
-    exposeDeployPlugin(entry: PluginDeployerEntry, entryPoint: 'frontend' | 'backend'): Promise<boolean> {
-        return this.deployPlugin(entry, entryPoint);
+    async exposeDeployPlugin(entry: PluginDeployerEntry, entryPoint: 'frontend' | 'backend'): Promise<boolean> {
+        const plugin = await this.readPlugin(entry, entryPoint);
+        if (!plugin) {
+            return false;
+        }
+        return this.deployPlugin(plugin);
     }
 
     countDeployedBackendPlugins(): number {
@@ -43,26 +48,22 @@ class TestPluginDeployerHandler extends PluginDeployerHandlerImpl {
     }
 }
 
+class ThrowingTestPluginDeployerHandler extends TestPluginDeployerHandler {
+    throwingId?: PluginIdentifiers.VersionedId;
+
+    protected override deployPlugin(plugin: PreparedPlugin): Promise<boolean> {
+        if (plugin.id === this.throwingId) {
+            return Promise.reject(new Error(`boom: deployPlugin rejected for ${plugin.id}`));
+        }
+        return super.deployPlugin(plugin);
+    }
+}
+
 function createFakeEntry(rootPath: string, accepted: PluginDeployerEntryType[]): PluginDeployerEntry {
-    const values = new Map<string, unknown>();
-    return {
-        id: () => rootPath,
-        originalPath: () => rootPath,
-        path: () => rootPath,
-        getValue: <T>(key: string) => values.get(key) as T,
-        storeValue: <T>(key: string, value: T) => { values.set(key, value); },
-        updatePath: () => { /* no-op */ },
-        getChanges: () => [],
-        isFile: async () => false,
-        isDirectory: async () => true,
-        isResolved: () => true,
-        resolvedBy: () => 'test',
-        isAccepted: (...types) => types.some(type => accepted.includes(type)),
-        accept: () => { /* no-op */ },
-        hasError: () => false,
-        type: PluginType.User,
-        rootPath
-    };
+    const entry = new PluginDeployerEntryImpl('test', rootPath, rootPath);
+    entry.accept(...accepted);
+    entry.type = PluginType.User;
+    return entry;
 }
 
 function createFakeMetadata(id: string, name: string, version: string): PluginMetadata {
@@ -96,11 +97,28 @@ function createHandler(overrides: {
     const container = new Container();
     container.bind(TestPluginDeployerHandler).toSelf().inSingletonScope();
     container.bind(ILogger).toConstantValue(new MockLogger());
-    container.bind(Stopwatch).toConstantValue(new SimpleStopwatch('test', () => Date.now()) as unknown as Stopwatch);
+    container.bind(Stopwatch).to(NodeStopwatch).inSingletonScope();
     container.bind(HostedPluginReader).toConstantValue(overrides.reader as HostedPluginReader);
     container.bind(HostedPluginLocalizationService).toConstantValue(overrides.localizationService as HostedPluginLocalizationService);
     container.bind(PluginUninstallationManager).toConstantValue(overrides.uninstallationManager as PluginUninstallationManager);
     return container.get(TestPluginDeployerHandler);
+}
+
+function createThrowingHandler(overrides: {
+    reader?: Partial<HostedPluginReader>;
+    localizationService?: Partial<HostedPluginLocalizationService>;
+    uninstallationManager?: Partial<PluginUninstallationManager>;
+}, throwingId: PluginIdentifiers.VersionedId): ThrowingTestPluginDeployerHandler {
+    const container = new Container();
+    container.bind(ThrowingTestPluginDeployerHandler).toSelf().inSingletonScope();
+    container.bind(ILogger).toConstantValue(new MockLogger());
+    container.bind(Stopwatch).to(NodeStopwatch).inSingletonScope();
+    container.bind(HostedPluginReader).toConstantValue(overrides.reader as HostedPluginReader);
+    container.bind(HostedPluginLocalizationService).toConstantValue(overrides.localizationService as HostedPluginLocalizationService);
+    container.bind(PluginUninstallationManager).toConstantValue(overrides.uninstallationManager as PluginUninstallationManager);
+    const handler = container.get(ThrowingTestPluginDeployerHandler);
+    handler.throwingId = throwingId;
+    return handler;
 }
 
 describe('PluginDeployerHandlerImpl - concurrent deployment', () => {
@@ -161,7 +179,7 @@ describe('PluginDeployerHandlerImpl - concurrent deployment', () => {
         // readContribution must run only once.
         expect(readContributionCallCount).to.equal(1);
         expect(handler.countDeployedBackendPlugins()).to.equal(1);
-        expect(handler.countDeployedLocations(`${pluginId}@${version}` as PluginIdentifiers.VersionedId)).to.equal(2);
+        expect(handler.countDeployedLocations(PluginIdentifiers.componentsToVersionedId(metadata.model))).to.equal(2);
     });
 
     it('deploys backend plugins in parallel and reports the correct success count when one fails', async () => {
@@ -201,5 +219,40 @@ describe('PluginDeployerHandlerImpl - concurrent deployment', () => {
 
         expect(successes).to.equal(2);
         expect(handler.countDeployedBackendPlugins()).to.equal(2);
+    });
+
+    it('does not abort the batch when deployPlugin itself throws for one entry', async () => {
+        const goodMetadata = createFakeMetadata('plugin-good', 'plugin-good', '1.0.0');
+        const throwingMetadata = createFakeMetadata('plugin-throws', 'plugin-throws', '1.0.0');
+        const throwingVersionedId = PluginIdentifiers.componentsToVersionedId(throwingMetadata.model);
+
+        const handler = createThrowingHandler({
+            reader: {
+                readPackage: async (path: string) => ({ name: path } as unknown as PluginPackage),
+                readMetadata: async (pkg: PluginPackage) => {
+                    const name = (pkg as unknown as { name: string }).name;
+                    return name === '/plugins/good' ? goodMetadata : throwingMetadata;
+                },
+                readContribution: async () => undefined
+            },
+            localizationService: {
+                deployLocalizations: async () => { /* no-op */ },
+                buildTranslationConfig: async () => { /* no-op */ }
+            },
+            uninstallationManager: {
+                markAsUninstalled: async () => true,
+                markAsInstalled: async () => true,
+                markAsEnabled: async () => true,
+                markAsDisabled: async () => true
+            }
+        }, throwingVersionedId);
+
+        const entryGood = createFakeEntry('/plugins/good', [PluginDeployerEntryType.BACKEND]);
+        const entryThrows = createFakeEntry('/plugins/throws', [PluginDeployerEntryType.BACKEND]);
+
+        const successes = await handler.deployBackendPlugins([entryGood, entryThrows]);
+
+        expect(successes).to.equal(1);
+        expect(handler.countDeployedBackendPlugins()).to.equal(1);
     });
 });

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource and others.
+// Copyright (C) 2026 ankitsharma101 and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -14,8 +14,13 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+import 'reflect-metadata';
 import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { SimpleStopwatch } from '@theia/core/lib/common/performance/simple-stopwatch';
+import { Stopwatch } from '@theia/core/lib/common';
 import { PluginDeployerHandlerImpl } from './plugin-deployer-handler-impl';
 import { HostedPluginReader } from './plugin-reader';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
@@ -30,7 +35,7 @@ class TestPluginDeployerHandler extends PluginDeployerHandlerImpl {
     }
 
     countDeployedBackendPlugins(): number {
-        return (this as unknown as { deployedBackendPlugins: Map<unknown, unknown> }).deployedBackendPlugins.size;
+        return this.deployedBackendPlugins.size;
     }
 }
 
@@ -56,12 +61,12 @@ function createFakeEntry(rootPath: string, accepted: PluginDeployerEntryType[]):
     };
 }
 
-function createFakeMetadata(id: string, version: string): PluginMetadata {
+function createFakeMetadata(id: string, name: string, version: string): PluginMetadata {
     return {
         host: 'test',
         model: {
             id,
-            name: 'concurrent-plugin',
+            name,
             publisher: 'test-publisher',
             version,
             displayName: id,
@@ -79,48 +84,54 @@ function createFakeMetadata(id: string, version: string): PluginMetadata {
     };
 }
 
+function createHandler(overrides: {
+    reader?: Partial<HostedPluginReader>;
+    localizationService?: Partial<HostedPluginLocalizationService>;
+    uninstallationManager?: Partial<PluginUninstallationManager>;
+}): TestPluginDeployerHandler {
+    const container = new Container();
+    container.bind(TestPluginDeployerHandler).toSelf().inSingletonScope();
+    container.bind(ILogger).toConstantValue(new MockLogger());
+    container.bind(Stopwatch).toConstantValue(new SimpleStopwatch('test', () => Date.now()) as unknown as Stopwatch);
+    container.bind(HostedPluginReader).toConstantValue(overrides.reader as HostedPluginReader);
+    container.bind(HostedPluginLocalizationService).toConstantValue(overrides.localizationService as HostedPluginLocalizationService);
+    container.bind(PluginUninstallationManager).toConstantValue(overrides.uninstallationManager as PluginUninstallationManager);
+    return container.get(TestPluginDeployerHandler);
+}
+
 describe('PluginDeployerHandlerImpl - concurrent deployment', () => {
 
     it('deploys the same plugin id only once when deployPlugin is called concurrently', async () => {
         const pluginId = 'test-publisher.concurrent-plugin';
         const version = '1.0.0';
-        const metadata = createFakeMetadata(pluginId, version);
+        const metadata = createFakeMetadata(pluginId, 'concurrent-plugin', version);
         const pluginPackage = {} as PluginPackage;
 
         let readContributionCallCount = 0;
         let releaseReadContribution!: () => void;
         const readContributionGate = new Promise<void>(resolve => { releaseReadContribution = resolve; });
 
-        const fakeReader = {
-            readPackage: async () => pluginPackage,
-            readMetadata: async () => metadata,
-            readContribution: async () => {
-                readContributionCallCount++;
-                // Hold call A open here so call B's reservation check runs
-                // while A is still mid-flight, genuinely racing the window
-                // between reserving and completing.
-                await readContributionGate;
-                return undefined;
+        const handler = createHandler({
+            reader: {
+                readPackage: async () => pluginPackage,
+                readMetadata: async () => metadata,
+                readContribution: async () => {
+                    readContributionCallCount++;
+                    await readContributionGate;
+                    return undefined;
+                }
+            },
+            localizationService: {
+                deployLocalizations: async () => { /* no-op */ },
+                buildTranslationConfig: async () => { /* no-op */ }
+            },
+            uninstallationManager: {
+                markAsUninstalled: async () => true,
+                markAsInstalled: async () => true,
+                markAsEnabled: async () => true,
+                markAsDisabled: async () => true
             }
-        } as unknown as HostedPluginReader;
-
-        const fakeLocalizationService = {
-            deployLocalizations: async () => { /* no-op */ },
-            buildTranslationConfig: async () => { /* no-op */ }
-        } as unknown as HostedPluginLocalizationService;
-
-        const fakeUninstallationManager = {
-            markAsUninstalled: async () => true,
-            markAsInstalled: async () => true,
-            markAsEnabled: async () => true,
-            markAsDisabled: async () => true
-        } as unknown as PluginUninstallationManager;
-
-        const handler = new TestPluginDeployerHandler();
-        (handler as unknown as { reader: HostedPluginReader }).reader = fakeReader;
-        (handler as unknown as { localizationService: HostedPluginLocalizationService }).localizationService = fakeLocalizationService;
-        (handler as unknown as { uninstallationManager: PluginUninstallationManager }).uninstallationManager = fakeUninstallationManager;
-        (handler as unknown as { stopwatch: SimpleStopwatch }).stopwatch = new SimpleStopwatch('test', () => Date.now());
+        });
 
         const entryA = createFakeEntry('/plugins/concurrent-plugin-copy-a', [PluginDeployerEntryType.BACKEND]);
         const entryB = createFakeEntry('/plugins/concurrent-plugin-copy-b', [PluginDeployerEntryType.BACKEND]);
@@ -143,10 +154,47 @@ describe('PluginDeployerHandlerImpl - concurrent deployment', () => {
 
         expect(resultA).to.be.true;
         expect(resultB).to.be.true;
-        // The real assertion: readContribution — the actual deploy work —
-        // must only run once, proving B reused A's in-flight reservation
-        // rather than performing a second, concurrent deploy.
+        // readContribution must run only once.
         expect(readContributionCallCount).to.equal(1);
         expect(handler.countDeployedBackendPlugins()).to.equal(1);
+    });
+
+    it('deploys backend plugins in parallel and reports the correct success count when one fails', async () => {
+        const goodIdA = 'test-publisher.plugin-a';
+        const goodIdB = 'test-publisher.plugin-b';
+
+        const handler = createHandler({
+            reader: {
+                readPackage: async (path: string) => ({ name: path } as unknown as PluginPackage),
+                readMetadata: async (pkg: PluginPackage) => {
+                    const name = (pkg as unknown as { name: string }).name;
+                    if (name === '/plugins/bad') {
+                        throw new Error('boom: unreadable metadata');
+                    }
+                    const id = name === '/plugins/a' ? goodIdA : goodIdB;
+                    return createFakeMetadata(id, id, '1.0.0');
+                },
+                readContribution: async () => undefined
+            },
+            localizationService: {
+                deployLocalizations: async () => { /* no-op */ },
+                buildTranslationConfig: async () => { /* no-op */ }
+            },
+            uninstallationManager: {
+                markAsUninstalled: async () => true,
+                markAsInstalled: async () => true,
+                markAsEnabled: async () => true,
+                markAsDisabled: async () => true
+            }
+        });
+
+        const entryA = createFakeEntry('/plugins/a', [PluginDeployerEntryType.BACKEND]);
+        const entryB = createFakeEntry('/plugins/b', [PluginDeployerEntryType.BACKEND]);
+        const entryBad = createFakeEntry('/plugins/bad', [PluginDeployerEntryType.BACKEND]);
+
+        const successes = await handler.deployBackendPlugins([entryA, entryB, entryBad]);
+
+        expect(successes).to.equal(2);
+        expect(handler.countDeployedBackendPlugins()).to.equal(2);
     });
 });

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.spec.ts
@@ -1,0 +1,152 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { SimpleStopwatch } from '@theia/core/lib/common/performance/simple-stopwatch';
+import { PluginDeployerHandlerImpl } from './plugin-deployer-handler-impl';
+import { HostedPluginReader } from './plugin-reader';
+import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
+import { PluginUninstallationManager } from '../../main/node/plugin-uninstallation-manager';
+import {
+    PluginDeployerEntry, PluginDeployerEntryType, PluginPackage, PluginMetadata, PluginType
+} from '../../common/plugin-protocol';
+
+class TestPluginDeployerHandler extends PluginDeployerHandlerImpl {
+    exposeDeployPlugin(entry: PluginDeployerEntry, entryPoint: 'frontend' | 'backend'): Promise<boolean> {
+        return this.deployPlugin(entry, entryPoint);
+    }
+
+    countDeployedBackendPlugins(): number {
+        return (this as unknown as { deployedBackendPlugins: Map<unknown, unknown> }).deployedBackendPlugins.size;
+    }
+}
+
+function createFakeEntry(rootPath: string, accepted: PluginDeployerEntryType[]): PluginDeployerEntry {
+    const values = new Map<string, unknown>();
+    return {
+        id: () => rootPath,
+        originalPath: () => rootPath,
+        path: () => rootPath,
+        getValue: <T>(key: string) => values.get(key) as T,
+        storeValue: <T>(key: string, value: T) => { values.set(key, value); },
+        updatePath: () => { /* no-op */ },
+        getChanges: () => [],
+        isFile: async () => false,
+        isDirectory: async () => true,
+        isResolved: () => true,
+        resolvedBy: () => 'test',
+        isAccepted: (...types) => types.some(type => accepted.includes(type)),
+        accept: () => { /* no-op */ },
+        hasError: () => false,
+        type: PluginType.User,
+        rootPath
+    };
+}
+
+function createFakeMetadata(id: string, version: string): PluginMetadata {
+    return {
+        host: 'test',
+        model: {
+            id,
+            name: 'concurrent-plugin',
+            publisher: 'test-publisher',
+            version,
+            displayName: id,
+            description: '',
+            engine: { type: 'theiaPlugin', version: '1.0.0' },
+            entryPoint: { backend: 'main.js', frontend: 'main.js' },
+            packageUri: `file:///${id}`,
+            packagePath: `/${id}`
+        },
+        lifecycle: {
+            startMethod: 'start',
+            stopMethod: 'stop'
+        },
+        outOfSync: false
+    };
+}
+
+describe('PluginDeployerHandlerImpl - concurrent deployment', () => {
+
+    it('deploys the same plugin id only once when deployPlugin is called concurrently', async () => {
+        const pluginId = 'test-publisher.concurrent-plugin';
+        const version = '1.0.0';
+        const metadata = createFakeMetadata(pluginId, version);
+        const pluginPackage = {} as PluginPackage;
+
+        let readContributionCallCount = 0;
+        let releaseReadContribution!: () => void;
+        const readContributionGate = new Promise<void>(resolve => { releaseReadContribution = resolve; });
+
+        const fakeReader = {
+            readPackage: async () => pluginPackage,
+            readMetadata: async () => metadata,
+            readContribution: async () => {
+                readContributionCallCount++;
+                // Hold call A open here so call B's reservation check runs
+                // while A is still mid-flight, genuinely racing the window
+                // between reserving and completing.
+                await readContributionGate;
+                return undefined;
+            }
+        } as unknown as HostedPluginReader;
+
+        const fakeLocalizationService = {
+            deployLocalizations: async () => { /* no-op */ },
+            buildTranslationConfig: async () => { /* no-op */ }
+        } as unknown as HostedPluginLocalizationService;
+
+        const fakeUninstallationManager = {
+            markAsUninstalled: async () => true,
+            markAsInstalled: async () => true,
+            markAsEnabled: async () => true,
+            markAsDisabled: async () => true
+        } as unknown as PluginUninstallationManager;
+
+        const handler = new TestPluginDeployerHandler();
+        (handler as unknown as { reader: HostedPluginReader }).reader = fakeReader;
+        (handler as unknown as { localizationService: HostedPluginLocalizationService }).localizationService = fakeLocalizationService;
+        (handler as unknown as { uninstallationManager: PluginUninstallationManager }).uninstallationManager = fakeUninstallationManager;
+        (handler as unknown as { stopwatch: SimpleStopwatch }).stopwatch = new SimpleStopwatch('test', () => Date.now());
+
+        const entryA = createFakeEntry('/plugins/concurrent-plugin-copy-a', [PluginDeployerEntryType.BACKEND]);
+        const entryB = createFakeEntry('/plugins/concurrent-plugin-copy-b', [PluginDeployerEntryType.BACKEND]);
+
+        // Start A. It will reach readContribution and block on the gate,
+        // meaning it has already reserved but not yet completed.
+        const resultAPromise = handler.exposeDeployPlugin(entryA, 'backend');
+
+        // Let A's microtasks run until it's blocked inside readContribution.
+        await new Promise(resolve => setImmediate(resolve));
+
+        // Now start B while A is still genuinely in-flight and reserved.
+        const resultBPromise = handler.exposeDeployPlugin(entryB, 'backend');
+        await new Promise(resolve => setImmediate(resolve));
+
+        // Release A to let both complete.
+        releaseReadContribution();
+
+        const [resultA, resultB] = await Promise.all([resultAPromise, resultBPromise]);
+
+        expect(resultA).to.be.true;
+        expect(resultB).to.be.true;
+        // The real assertion: readContribution — the actual deploy work —
+        // must only run once, proving B reused A's in-flight reservation
+        // rather than performing a second, concurrent deploy.
+        expect(readContributionCallCount).to.equal(1);
+        expect(handler.countDeployedBackendPlugins()).to.equal(1);
+    });
+});

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
@@ -27,6 +27,16 @@ import { HostedPluginLocalizationService } from './hosted-plugin-localization-se
 import { Measurement, Stopwatch } from '@theia/core/lib/common';
 import { PluginUninstallationManager } from '../../main/node/plugin-uninstallation-manager';
 
+interface DoDeployPluginOptions {
+    entry: PluginDeployerEntry;
+    entryPoint: keyof PluginEntryPoint;
+    manifest: PluginPackage;
+    metadata: PluginMetadata;
+    id: PluginIdentifiers.VersionedId;
+    pluginPath: string;
+    deployPlugin: Measurement;
+}
+
 @injectable()
 export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     @inject(ILogger) @named('plugin-ext:PluginDeployerHandlerImpl')
@@ -147,13 +157,11 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     }
 
     async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<number> {
-        const measurement = this.stopwatch.start('deployBackendPluginsBatch');
         const results = await Promise.all(backendPlugins.map(plugin => this.deployPlugin(plugin, 'backend').catch(e => {
             this.logger.error(`Unexpected error while deploying backend plugin '${plugin.id()}'`, e);
             return false;
         })));
         const successes = results.filter(Boolean).length;
-        measurement.log(`Deployed backend batch of ${successes}/${backendPlugins.length} accepted plugins`);
         // rebuild translation config after deployment
         await this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
         // resolve on first deploy
@@ -179,14 +187,21 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
             metadata.isUnderDevelopment = entry.getValue('isUnderDevelopment') ?? false;
 
             const id = PluginIdentifiers.componentsToVersionedId(metadata.model);
+
+            const deployedLocations = this.deployedLocations.get(id) ?? new Set<string>();
+            deployedLocations.add(entry.rootPath);
+            this.deployedLocations.set(id, deployedLocations);
+            this.setSourceLocationsForPlugin(id, entry);
+
             const reservationKey = `${entryPoint}:${id}`;
 
             const pending = this.pendingDeployments.get(reservationKey);
             if (pending) {
+                deployPlugin.debug(`Skipped ${entryPoint} plugin ${metadata.model.name} already deployed`);
                 return pending;
             }
 
-            const deployment = this.doDeployPlugin(entry, entryPoint, manifest, metadata, id, pluginPath, deployPlugin)
+            const deployment = this.doDeployPlugin({ entry, entryPoint, manifest, metadata, id, pluginPath, deployPlugin })
                 .finally(() => this.pendingDeployments.delete(reservationKey));
             this.pendingDeployments.set(reservationKey, deployment);
             return deployment;
@@ -196,22 +211,14 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
         }
     }
 
-    protected async doDeployPlugin(
-        entry: PluginDeployerEntry,
-        entryPoint: keyof PluginEntryPoint,
-        manifest: PluginPackage,
-        metadata: PluginMetadata,
-        id: PluginIdentifiers.VersionedId,
-        pluginPath: string,
-        deployPlugin: Measurement
-    ): Promise<boolean> {
+    /**
+     * @throws never! in order to isolate plugin deployment.
+     * @returns whether the plugin is deployed after running this function. If the plugin was already installed, will still return `true`.
+     */
+    protected async doDeployPlugin(options: DoDeployPluginOptions): Promise<boolean> {
+        const { entry, entryPoint, manifest, metadata, id, pluginPath, deployPlugin } = options;
         let success = true;
         try {
-            const deployedLocations = this.deployedLocations.get(id) ?? new Set<string>();
-            deployedLocations.add(entry.rootPath);
-            this.deployedLocations.set(id, deployedLocations);
-            this.setSourceLocationsForPlugin(id, entry);
-
             const deployedPlugins = entryPoint === 'backend' ? this.deployedBackendPlugins : this.deployedFrontendPlugins;
             if (deployedPlugins.has(id)) {
                 deployPlugin.debug(`Skipped ${entryPoint} plugin ${metadata.model.name} already deployed`);

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
@@ -54,7 +54,7 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     @inject(PluginUninstallationManager)
     protected readonly uninstallationManager: PluginUninstallationManager;
 
-    private readonly deployedLocations = new Map<PluginIdentifiers.VersionedId, Set<string>>();
+    protected readonly deployedLocations = new Map<PluginIdentifiers.VersionedId, Set<string>>();
     protected readonly sourceLocations = new Map<PluginIdentifiers.VersionedId, Set<string>>();
 
     /**

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
@@ -24,17 +24,20 @@ import {
 import { HostedPluginReader } from './plugin-reader';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
-import { Measurement, Stopwatch } from '@theia/core/lib/common';
+import { Stopwatch } from '@theia/core/lib/common';
 import { PluginUninstallationManager } from '../../main/node/plugin-uninstallation-manager';
 
-interface DoDeployPluginOptions {
+/**
+ * The result of {@link PluginDeployerHandlerImpl.readPlugin reading} a plugin's manifest and metadata
+ * from disk, ready to be handed to {@link PluginDeployerHandlerImpl.deployPlugin}. Exported so that
+ * subclasses overriding `deployPlugin` can name the parameter type.
+ */
+export interface PreparedPlugin {
     entry: PluginDeployerEntry;
     entryPoint: keyof PluginEntryPoint;
     manifest: PluginPackage;
     metadata: PluginMetadata;
     id: PluginIdentifiers.VersionedId;
-    pluginPath: string;
-    deployPlugin: Measurement;
 }
 
 @injectable()
@@ -67,7 +70,7 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
      */
     protected readonly deployedFrontendPlugins = new Map<PluginIdentifiers.VersionedId, DeployedPlugin>();
 
-    private readonly pendingDeployments = new Map<string, Promise<boolean>>();
+    protected readonly pendingDeployments = new Map<string, Promise<boolean>>();
 
     private backendPluginsMetadataDeferred = new Deferred<void>();
 
@@ -146,22 +149,14 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     }
 
     async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<number> {
-        const results = await Promise.all(frontendPlugins.map(plugin => this.deployPlugin(plugin, 'frontend').catch(e => {
-            this.logger.error(`Unexpected error while deploying frontend plugin '${plugin.id()}'`, e);
-            return false;
-        })));
-        const successes = results.filter(Boolean).length;
+        const successes = await this.deployPlugins(frontendPlugins, 'frontend');
         // resolve on first deploy
         this.frontendPluginsMetadataDeferred.resolve(undefined);
         return successes;
     }
 
     async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<number> {
-        const results = await Promise.all(backendPlugins.map(plugin => this.deployPlugin(plugin, 'backend').catch(e => {
-            this.logger.error(`Unexpected error while deploying backend plugin '${plugin.id()}'`, e);
-            return false;
-        })));
-        const successes = results.filter(Boolean).length;
+        const successes = await this.deployPlugins(backendPlugins, 'backend');
         // rebuild translation config after deployment
         await this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
         // resolve on first deploy
@@ -170,17 +165,44 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     }
 
     /**
-     * @throws never! in order to isolate plugin deployment.
-     * @returns whether the plugin is deployed after running this function. If the plugin was already installed, will still return `true`.
+     * Reads every entry concurrently (pure I/O, safe to parallelize), then deploys the ones that were
+     * read successfully one at a time, in `entries` order, so bookkeeping like {@link markAsInstalled}
+     * stays deterministic.
      */
-    protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint): Promise<boolean> {
+    protected async deployPlugins(entries: PluginDeployerEntry[], entryPoint: keyof PluginEntryPoint): Promise<number> {
+        const prepared = await Promise.all(entries.map(entry => this.readPlugin(entry, entryPoint)));
+        let successes = 0;
+        for (const plugin of prepared) {
+            if (!plugin) {
+                continue;
+            }
+            try {
+                if (await this.deployPlugin(plugin)) {
+                    successes++;
+                }
+            } catch (e) {
+                // deployPlugin is documented to never throw, but a subclass override could —
+                // don't let one bad entry abort deployment of the rest of the batch.
+                this.logger.error(`Unexpected error while deploying ${entryPoint} plugin '${plugin.id}'`, e);
+            }
+        }
+        return successes;
+    }
+
+    /**
+     * Reads a plugin's manifest and metadata from disk and records its known source location(s).
+     * Pure I/O plus per-id `Map`/`Set` bookkeeping, so it's safe to run concurrently across entries.
+     *
+     * @throws never! in order to isolate plugin deployment.
+     */
+    protected async readPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint): Promise<PreparedPlugin | undefined> {
         const pluginPath = entry.path();
-        const deployPlugin = this.stopwatch.start('deployPlugin');
+        const readPlugin = this.stopwatch.start('readPlugin');
         try {
             const manifest = await this.reader.readPackage(pluginPath);
             if (!manifest) {
-                deployPlugin.error(`Failed to read ${entryPoint} plugin manifest from '${pluginPath}''`);
-                return false;
+                readPlugin.error(`Failed to read ${entryPoint} plugin manifest from '${pluginPath}'`);
+                return undefined;
             }
 
             const metadata = await this.reader.readMetadata(manifest);
@@ -193,21 +215,11 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
             this.deployedLocations.set(id, deployedLocations);
             this.setSourceLocationsForPlugin(id, entry);
 
-            const reservationKey = `${entryPoint}:${id}`;
-
-            const pending = this.pendingDeployments.get(reservationKey);
-            if (pending) {
-                deployPlugin.debug(`Skipped ${entryPoint} plugin ${metadata.model.name} already deployed`);
-                return pending;
-            }
-
-            const deployment = this.doDeployPlugin({ entry, entryPoint, manifest, metadata, id, pluginPath, deployPlugin })
-                .finally(() => this.pendingDeployments.delete(reservationKey));
-            this.pendingDeployments.set(reservationKey, deployment);
-            return deployment;
+            readPlugin.debug(`Read ${entryPoint} plugin "${id}" from "${pluginPath}"`);
+            return { entry, entryPoint, manifest, metadata, id };
         } catch (e) {
-            deployPlugin.error(`Failed to deploy ${entryPoint} plugin from '${pluginPath}' path`, e);
-            return false;
+            readPlugin.error(`Failed to read ${entryPoint} plugin from '${pluginPath}' path`, e);
+            return undefined;
         }
     }
 
@@ -215,31 +227,47 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
      * @throws never! in order to isolate plugin deployment.
      * @returns whether the plugin is deployed after running this function. If the plugin was already installed, will still return `true`.
      */
-    protected async doDeployPlugin(options: DoDeployPluginOptions): Promise<boolean> {
-        const { entry, entryPoint, manifest, metadata, id, pluginPath, deployPlugin } = options;
-        let success = true;
-        try {
-            const deployedPlugins = entryPoint === 'backend' ? this.deployedBackendPlugins : this.deployedFrontendPlugins;
-            if (deployedPlugins.has(id)) {
-                deployPlugin.debug(`Skipped ${entryPoint} plugin ${metadata.model.name} already deployed`);
-                return true;
-            }
+    protected deployPlugin(plugin: PreparedPlugin): Promise<boolean> {
+        const { entry, entryPoint, manifest, metadata, id } = plugin;
+        const reservationKey = `${entryPoint}:${id}`;
 
-            const { type } = entry;
-            const deployed: DeployedPlugin = { metadata, type };
-            deployed.contributes = await this.reader.readContribution(manifest);
-            await this.localizationService.deployLocalizations(deployed);
-            deployedPlugins.set(id, deployed);
-            deployPlugin.debug(`Deployed ${entryPoint} plugin "${id}" from "${metadata.model.entryPoint[entryPoint] || pluginPath}"`);
-        } catch (e) {
-            deployPlugin.error(`Failed to deploy ${entryPoint} plugin from '${pluginPath}' path`, e);
-            return success = false;
-        } finally {
-            if (success) {
-                this.markAsInstalled(id);
-            }
+        const pending = this.pendingDeployments.get(reservationKey);
+        if (pending) {
+            // Genuinely still in flight (not "already deployed") — piggyback on the in-progress deployment.
+            this.logger.debug(`Reusing in-flight deployment of ${entryPoint} plugin ${metadata.model.name}`);
+            return pending;
         }
-        return success;
+
+        const deploy = async (): Promise<boolean> => {
+            const measurement = this.stopwatch.start('deployPlugin');
+            let success = true;
+            try {
+                const deployedPlugins = entryPoint === 'backend' ? this.deployedBackendPlugins : this.deployedFrontendPlugins;
+                if (deployedPlugins.has(id)) {
+                    measurement.debug(`Skipped ${entryPoint} plugin ${metadata.model.name}: already deployed`);
+                    return true;
+                }
+
+                const { type } = entry;
+                const deployed: DeployedPlugin = { metadata, type };
+                deployed.contributes = await this.reader.readContribution(manifest);
+                await this.localizationService.deployLocalizations(deployed);
+                deployedPlugins.set(id, deployed);
+                measurement.debug(`Deployed ${entryPoint} plugin "${id}" from "${metadata.model.entryPoint[entryPoint] || entry.path()}"`);
+            } catch (e) {
+                success = false;
+                measurement.error(`Failed to deploy ${entryPoint} plugin '${id}'`, e);
+            } finally {
+                if (success) {
+                    this.markAsInstalled(id);
+                }
+            }
+            return success;
+        };
+
+        const deployment = deploy().finally(() => this.pendingDeployments.delete(reservationKey));
+        this.pendingDeployments.set(reservationKey, deployment);
+        return deployment;
     }
 
     async uninstallPlugin(pluginId: PluginIdentifiers.VersionedId): Promise<boolean> {

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
@@ -19,12 +19,12 @@ import { injectable, inject, named } from '@theia/core/shared/inversify';
 import { ILogger } from '@theia/core';
 import {
     PluginDeployerHandler, PluginDeployerEntry, PluginEntryPoint, DeployedPlugin,
-    PluginDependencies, PluginType, PluginIdentifiers
+    PluginDependencies, PluginType, PluginIdentifiers, PluginPackage, PluginMetadata
 } from '../../common/plugin-protocol';
 import { HostedPluginReader } from './plugin-reader';
 import { Deferred } from '@theia/core/lib/common/promise-util';
 import { HostedPluginLocalizationService } from './hosted-plugin-localization-service';
-import { Stopwatch } from '@theia/core/lib/common';
+import { Measurement, Stopwatch } from '@theia/core/lib/common';
 import { PluginUninstallationManager } from '../../main/node/plugin-uninstallation-manager';
 
 @injectable()
@@ -56,6 +56,8 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
      * Managed plugin metadata frontend entries.
      */
     private readonly deployedFrontendPlugins = new Map<PluginIdentifiers.VersionedId, DeployedPlugin>();
+
+    private readonly pendingDeployments = new Map<string, Promise<boolean>>();
 
     private backendPluginsMetadataDeferred = new Deferred<void>();
 
@@ -166,20 +168,45 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     protected async deployPlugin(entry: PluginDeployerEntry, entryPoint: keyof PluginEntryPoint): Promise<boolean> {
         const pluginPath = entry.path();
         const deployPlugin = this.stopwatch.start('deployPlugin');
-        let id;
-        let success = true;
         try {
             const manifest = await this.reader.readPackage(pluginPath);
             if (!manifest) {
                 deployPlugin.error(`Failed to read ${entryPoint} plugin manifest from '${pluginPath}''`);
-                return success = false;
+                return false;
             }
 
             const metadata = await this.reader.readMetadata(manifest);
             metadata.isUnderDevelopment = entry.getValue('isUnderDevelopment') ?? false;
 
-            id = PluginIdentifiers.componentsToVersionedId(metadata.model);
+            const id = PluginIdentifiers.componentsToVersionedId(metadata.model);
+            const reservationKey = `${entryPoint}:${id}`;
 
+            const pending = this.pendingDeployments.get(reservationKey);
+            if (pending) {
+                return pending;
+            }
+
+            const deployment = this.doDeployPlugin(entry, entryPoint, manifest, metadata, id, pluginPath, deployPlugin)
+                .finally(() => this.pendingDeployments.delete(reservationKey));
+            this.pendingDeployments.set(reservationKey, deployment);
+            return deployment;
+        } catch (e) {
+            deployPlugin.error(`Failed to deploy ${entryPoint} plugin from '${pluginPath}' path`, e);
+            return false;
+        }
+    }
+
+    protected async doDeployPlugin(
+        entry: PluginDeployerEntry,
+        entryPoint: keyof PluginEntryPoint,
+        manifest: PluginPackage,
+        metadata: PluginMetadata,
+        id: PluginIdentifiers.VersionedId,
+        pluginPath: string,
+        deployPlugin: Measurement
+    ): Promise<boolean> {
+        let success = true;
+        try {
             const deployedLocations = this.deployedLocations.get(id) ?? new Set<string>();
             deployedLocations.add(entry.rootPath);
             this.deployedLocations.set(id, deployedLocations);
@@ -201,7 +228,7 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
             deployPlugin.error(`Failed to deploy ${entryPoint} plugin from '${pluginPath}' path`, e);
             return success = false;
         } finally {
-            if (success && id) {
+            if (success) {
                 this.markAsInstalled(id);
             }
         }

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
@@ -60,12 +60,12 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     /**
      * Managed plugin metadata backend entries.
      */
-    private readonly deployedBackendPlugins = new Map<PluginIdentifiers.VersionedId, DeployedPlugin>();
+    protected readonly deployedBackendPlugins = new Map<PluginIdentifiers.VersionedId, DeployedPlugin>();
 
     /**
      * Managed plugin metadata frontend entries.
      */
-    private readonly deployedFrontendPlugins = new Map<PluginIdentifiers.VersionedId, DeployedPlugin>();
+    protected readonly deployedFrontendPlugins = new Map<PluginIdentifiers.VersionedId, DeployedPlugin>();
 
     private readonly pendingDeployments = new Map<string, Promise<boolean>>();
 

--- a/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
+++ b/packages/plugin-ext/src/hosted/node/plugin-deployer-handler-impl.ts
@@ -134,20 +134,24 @@ export class PluginDeployerHandlerImpl implements PluginDeployerHandler {
     }
 
     async deployFrontendPlugins(frontendPlugins: PluginDeployerEntry[]): Promise<number> {
-        let successes = 0;
-        for (const plugin of frontendPlugins) {
-            if (await this.deployPlugin(plugin, 'frontend')) { successes++; }
-        }
+        const results = await Promise.all(frontendPlugins.map(plugin => this.deployPlugin(plugin, 'frontend').catch(e => {
+            this.logger.error(`Unexpected error while deploying frontend plugin '${plugin.id()}'`, e);
+            return false;
+        })));
+        const successes = results.filter(Boolean).length;
         // resolve on first deploy
         this.frontendPluginsMetadataDeferred.resolve(undefined);
         return successes;
     }
 
     async deployBackendPlugins(backendPlugins: PluginDeployerEntry[]): Promise<number> {
-        let successes = 0;
-        for (const plugin of backendPlugins) {
-            if (await this.deployPlugin(plugin, 'backend')) { successes++; }
-        }
+        const measurement = this.stopwatch.start('deployBackendPluginsBatch');
+        const results = await Promise.all(backendPlugins.map(plugin => this.deployPlugin(plugin, 'backend').catch(e => {
+            this.logger.error(`Unexpected error while deploying backend plugin '${plugin.id()}'`, e);
+            return false;
+        })));
+        const successes = results.filter(Boolean).length;
+        measurement.log(`Deployed backend batch of ${successes}/${backendPlugins.length} accepted plugins`);
         // rebuild translation config after deployment
         await this.localizationService.buildTranslationConfig([...this.deployedBackendPlugins.values()]);
         // resolve on first deploy


### PR DESCRIPTION
#### What it does

Continues the parallelization work from #17867 by parallelizing the inner deployment loops in `deployBackendPlugins`/`deployFrontendPlugins` (previously sequential `for` loops, now `Promise.all`). `deployPlugin()` never throws (confirmed by reading its full implementation — every failure path returns `false` rather than rejecting),
so `Promise.all` is safe without needing `Promise.allSettled`.

Also fixes a pre-existing bug found while working on this: `deployBackendPlugins` resolved `frontendPluginsMetadataDeferred` instead of `backendPluginsMetadataDeferred`. This meant `getDeployedBackendPluginIds()` and `getDeployedBackendPlugins()` would never resolve, since nothing in the file ever resolved the correct deferred.

Adds a `deployFrontendPluginsBatch` stopwatch measurement matching the existing `deployBackendPluginsBatch` pattern from #17867.

#### How to test

1. Cold-start `examples/browser` and check for `Deployed backend batch of X/X` and `Deployed frontend batch of X/X` log lines.
2. Compare against `master`: on this machine, with 3 plugins accepted for deployment, sequential deployment averaged ~15.7ms across 3 runs; with this change, ~11.3ms    across 3 runs. The improvement is modest at this plugin count — parallelization benefit scales with the number of plugins and is expected to be more pronounced with larger plugin sets than this local dev environment has installed.
3. Run `yarn --cwd packages/plugin-ext test` — 236 passing, no regressions.

#### Follow-ups

- Benchmarking with a larger, realistic plugin set (10+) would give a clearer picture   of the parallelization benefit at scale.
- `markAsInstalled`'s safety under concurrent calls (introduced by #17867's outer `Promise.all`, and now also relevant here) hasn't been independently verified beyond reading it's a simple Map write; worth a second look if issues surface.

#### Breaking changes
- [ ] This PR introduces breaking changes and requires careful review.#### What it does

Continues the parallelization work from #17867 by parallelizing the inner deployment loops in  deployBackendPlugins`/`deployFrontendPlugins` (previously sequential `for` loops, now `Promise.all`). `deployPlugin()` ever throws (confirmed by reading its full implementation — every failure path returns `false` rather than rejecting), so `Promise.all` is safe without needing `Promise.allSettled`.

Adds a `deployFrontendPluginsBatch` stopwatch measurement matching the existing `deployBackendPluginsBatch` pattern from #17867.

#### How to test

1. Cold-start `examples/browser` and check for `Deployed backend batch of X/X` and `Deployed frontend batch of X/X` log lines.
2. Compare against `master`: on this machine, with 3 plugins accepted for deployment, sequential deployment averaged ~15.7ms across 3 runs; with this change, ~11.3ms across 3 runs. The improvement is modest at this plugin count — parallelization benefit scales with the number of plugins and is expected to be more pronounced with larger plugin sets than this local dev environment has installed.
3. Run `yarn --cwd packages/plugin-ext test` — 236 passing, no regressions.

#### Follow-ups

- Benchmarking with a larger, realistic plugin set (10+) would give a clearer picture of the parallelization benefit at scale.
- `markAsInstalled`'s safety under concurrent calls (introduced by #17867's outer `Promise.all`, and now also relevant here) hasn't been independently verified beyond reading it's a simple Map write; worth a second look if issues surface.

#### Breaking changes
- [ ] This PR introduces breaking changes and requires careful review.