### PR TITLE
fix(core): import third-party base styles before Theia styles

### DIFF
--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -14,8 +14,8 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-// Base styles of third-party libraries must be imported before Theia's own styles
-// so that Theia rules of equal specificity override them (see GH-17872).
+// Import Lumino rules first because some conflict with Theia's styles.
+// This ensures Theia rules with equal specificity take precedence (see GH-17872).
 import '@lumino/widgets/style/index.css';
 import 'perfect-scrollbar/css/perfect-scrollbar.css';
 import '../../src/browser/style/index.css';

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -14,12 +14,14 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
+// Base styles of third-party libraries must be imported before Theia's own styles
+// so that Theia rules of equal specificity override them (see GH-17872).
+import '@lumino/widgets/style/index.css';
+import 'perfect-scrollbar/css/perfect-scrollbar.css';
 import '../../src/browser/style/index.css';
 import '../../src/browser/style/materialcolors.css';
-import '@lumino/widgets/style/index.css';
 import 'font-awesome/css/font-awesome.min.css';
 import 'file-icons-js/css/style.css';
-import 'perfect-scrollbar/css/perfect-scrollbar.css';
 import '@vscode/codicons/dist/codicon.css';
 
 import { ContainerModule } from 'inversify';


### PR DESCRIPTION
#### What it does

Fixes #17872: since #14414 (v1.72.0), the Lumino and perfect-scrollbar stylesheets are imported *after* Theia's own styles, so base rules such as `.lm-Widget { position: relative }` override Theia rules of equal specificity. Most visibly, the tree search box (`.theia-search-box-widget { position: absolute }`) is laid out in flow below the tree and clipped — it never appears when typing in a tree. The flipped order also dropped `.lm-SplitPanel-handle` from its intended `z-index: 6` to Lumino's `1`, and `.lm-DockPanel-overlay` from `2000` to `3`.

This restores the pre-1.72 cascade order (base library styles first). Audited all remaining equal-specificity overlaps: `.lm-Menu` z-index (10000 on both sides) and `.lm-MenuBar-content` display (`flex` on both sides) are value-identical, and no other bare `.lm-*`/`.ps*` class rules exist in the code base, so no further visual changes result.

#### How to test

1. Start the browser example and open the Explorer.
2. Focus the file tree and type a few characters.
3. Before: matches are filtered/highlighted but no search box appears. After: the search box overlays the top-right of the tree view.
4. Sanity-check context menus, tab bars, split handles, and scrollbars — unchanged.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
