### PR TITLE
fix: Monaco theme CSS and select dropdowns in secondary windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - [Previous Changelogs](https://github.com/eclipse-theia/theia/tree/master/doc/changelogs/)
 
+## 1.75.0 - tbd
+
+- [core, monaco] fixed Monaco theme CSS, `SelectComponent` dropdown placement, and the OS font class in secondary windows [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+
+<a name="breaking_changes_1.75.0">[Breaking Changes:](#breaking_changes_1.75.0)</a>
+
+- [core] added `onWindowLoaded` to the `SecondaryWindowService` interface; adopters implementing the interface from scratch (rather than extending `DefaultSecondaryWindowService`) must provide it [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+- [monaco] removed the `protected secondaryWindowHandler` field from `MonacoFrontendApplicationContribution`; the Monaco theme stylesheet is now injected into every secondary window via `SecondaryWindowService.onWindowLoaded` [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+
 ## 1.74.0 - 7/31/2026
 
 - [ai] support for server-side compaction [#17746](https://github.com/eclipse-theia/theia/pull/17746)

--- a/packages/core/src/browser/common-frontend-contribution.spec.ts
+++ b/packages/core/src/browser/common-frontend-contribution.spec.ts
@@ -51,39 +51,20 @@ describe('CommonFrontendContribution', () => {
 
     describe('setOsClass', () => {
 
-        let onWindowOpenedEmitter: Emitter<Window>;
+        let onWindowLoadedEmitter: Emitter<Window>;
         let contribution: CommonFrontendContribution;
 
         beforeEach(() => {
             document.body.classList.remove(...OS_CLASSNAMES);
-            onWindowOpenedEmitter = new Emitter<Window>();
-            /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-            const unused = undefined as any;
-            contribution = new CommonFrontendContribution(unused, unused, unused, unused, unused, unused, unused);
+            onWindowLoadedEmitter = new Emitter<Window>();
+            // Bypass the constructor: setOsClass only uses the secondary window service,
+            // and this keeps the test independent of the constructor's parameter list.
+            contribution = Object.create(CommonFrontendContribution.prototype);
             /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
             (contribution as any).secondaryWindowService = <Partial<SecondaryWindowService>>{
-                onWindowOpened: onWindowOpenedEmitter.event
+                onWindowLoaded: onWindowLoadedEmitter.event
             };
         });
-
-        /** Fake secondary window: a bare body plus DOMContentLoaded listener registration. */
-        function fakeSecondaryWindow(): { win: Window, body: HTMLElement, loadDocument: () => void } {
-            const body = document.createElement('body');
-            const loadListeners: EventListener[] = [];
-            const win = <Partial<Window>>{
-                document: <Partial<Document>>{ body },
-                addEventListener: (type: string, listener: EventListener) => {
-                    if (type === 'DOMContentLoaded') {
-                        loadListeners.push(listener);
-                    }
-                }
-            };
-            return {
-                win: win as Window,
-                body,
-                loadDocument: () => loadListeners.splice(0).forEach(listener => listener(new Event('DOMContentLoaded')))
-            };
-        }
 
         it('adds the OS class to the main window body', () => {
             contribution['setOsClass']();
@@ -94,14 +75,10 @@ describe('CommonFrontendContribution', () => {
             contribution['setOsClass']();
             const osClass = OS_CLASSNAMES.find(c => document.body.classList.contains(c))!;
 
-            const { win, body, loadDocument } = fakeSecondaryWindow();
-            onWindowOpenedEmitter.fire(win);
-            // The initial about:blank document is replaced by secondary-window.html,
-            // so the class must only be added to the final document.
-            expect(body.classList.contains(osClass), 'class must not be added before DOMContentLoaded').to.be.false;
-
-            loadDocument();
-            expect(body.classList.contains(osClass), 'class must be added after DOMContentLoaded').to.be.true;
+            const body = document.createElement('body');
+            const win = <Partial<Window>>{ document: <Partial<Document>>{ body } };
+            onWindowLoadedEmitter.fire(win as Window);
+            expect(body.classList.contains(osClass), 'class must be added to the loaded window').to.be.true;
         });
     });
 });

--- a/packages/core/src/browser/common-frontend-contribution.spec.ts
+++ b/packages/core/src/browser/common-frontend-contribution.spec.ts
@@ -1,0 +1,107 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from './test/jsdom';
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+// jsdom does not implement queryCommandSupported, which common-frontend-contribution
+// evaluates at module load to determine cut/copy/paste support.
+document.queryCommandSupported = () => false;
+
+import * as chai from 'chai';
+import { Emitter } from '../common/event';
+// Initialize the common barrel before common-frontend-contribution: its import graph contains
+// cycles through the barrel (e.g. shell/tab-bar-toolbar) that leave injection tokens undefined
+// when the contribution module itself is the entry point.
+import '../common';
+import { CLASSNAME_OS_LINUX, CLASSNAME_OS_MAC, CLASSNAME_OS_WINDOWS, CommonFrontendContribution } from './common-frontend-contribution';
+import { SecondaryWindowService } from './window/secondary-window-service';
+
+disableJSDOM();
+
+const expect = chai.expect;
+const OS_CLASSNAMES = [CLASSNAME_OS_MAC, CLASSNAME_OS_WINDOWS, CLASSNAME_OS_LINUX];
+
+describe('CommonFrontendContribution', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+        document.queryCommandSupported = () => false;
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    describe('setOsClass', () => {
+
+        let onWindowOpenedEmitter: Emitter<Window>;
+        let contribution: CommonFrontendContribution;
+
+        beforeEach(() => {
+            document.body.classList.remove(...OS_CLASSNAMES);
+            onWindowOpenedEmitter = new Emitter<Window>();
+            /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+            const unused = undefined as any;
+            contribution = new CommonFrontendContribution(unused, unused, unused, unused, unused, unused, unused);
+            /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+            (contribution as any).secondaryWindowService = <Partial<SecondaryWindowService>>{
+                onWindowOpened: onWindowOpenedEmitter.event
+            };
+        });
+
+        /** Fake secondary window: a bare body plus DOMContentLoaded listener registration. */
+        function fakeSecondaryWindow(): { win: Window, body: HTMLElement, loadDocument: () => void } {
+            const body = document.createElement('body');
+            const loadListeners: EventListener[] = [];
+            const win = <Partial<Window>>{
+                document: <Partial<Document>>{ body },
+                addEventListener: (type: string, listener: EventListener) => {
+                    if (type === 'DOMContentLoaded') {
+                        loadListeners.push(listener);
+                    }
+                }
+            };
+            return {
+                win: win as Window,
+                body,
+                loadDocument: () => loadListeners.splice(0).forEach(listener => listener(new Event('DOMContentLoaded')))
+            };
+        }
+
+        it('adds the OS class to the main window body', () => {
+            contribution['setOsClass']();
+            expect(OS_CLASSNAMES.filter(c => document.body.classList.contains(c))).to.have.lengthOf(1);
+        });
+
+        it('adds the OS class to a secondary window body once its document is loaded', () => {
+            contribution['setOsClass']();
+            const osClass = OS_CLASSNAMES.find(c => document.body.classList.contains(c))!;
+
+            const { win, body, loadDocument } = fakeSecondaryWindow();
+            onWindowOpenedEmitter.fire(win);
+            // The initial about:blank document is replaced by secondary-window.html,
+            // so the class must only be added to the final document.
+            expect(body.classList.contains(osClass), 'class must not be added before DOMContentLoaded').to.be.false;
+
+            loadDocument();
+            expect(body.classList.contains(osClass), 'class must be added after DOMContentLoaded').to.be.true;
+        });
+    });
+});

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -61,6 +61,7 @@ import { nls } from '../common/nls';
 import { CurrentWidgetCommandAdapter } from './shell/current-widget-command-adapter';
 import { ConfirmDialog, confirmExit, ConfirmSaveDialog, Dialog } from './dialogs';
 import { WindowService } from './window/window-service';
+import { SecondaryWindowService } from './window/secondary-window-service';
 import { FrontendApplicationConfigProvider } from './frontend-application-config-provider';
 import { DecorationStyle } from './decoration-style';
 import { codicon, isPinned, Title, togglePinned, Widget } from './widgets';
@@ -147,6 +148,9 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     @inject(WindowService)
     protected readonly windowService: WindowService;
 
+    @inject(SecondaryWindowService)
+    protected readonly secondaryWindowService: SecondaryWindowService;
+
     @inject(UserWorkingDirectoryProvider)
     protected readonly workingDirProvider: UserWorkingDirectoryProvider;
 
@@ -218,12 +222,24 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
     }
 
     protected setOsClass(): void {
+        const osClass = this.getOsClass();
+        document.body.classList.add(osClass);
+        // The OS class selects the platform-specific font stacks in os.css. Secondary windows
+        // have their own document, so apply it there as well. Wait for the secondary window's
+        // final document: anything added to the initial about:blank document is discarded when
+        // secondary-window.html replaces it.
+        this.secondaryWindowService.onWindowOpened(win => {
+            win.addEventListener('DOMContentLoaded', () => win.document.body.classList.add(osClass), { once: true });
+        });
+    }
+
+    protected getOsClass(): string {
         if (isOSX) {
-            document.body.classList.add(CLASSNAME_OS_MAC);
+            return CLASSNAME_OS_MAC;
         } else if (isWindows) {
-            document.body.classList.add(CLASSNAME_OS_WINDOWS);
+            return CLASSNAME_OS_WINDOWS;
         } else {
-            document.body.classList.add(CLASSNAME_OS_LINUX);
+            return CLASSNAME_OS_LINUX;
         }
     }
 

--- a/packages/core/src/browser/common-frontend-contribution.ts
+++ b/packages/core/src/browser/common-frontend-contribution.ts
@@ -225,12 +225,8 @@ export class CommonFrontendContribution implements FrontendApplicationContributi
         const osClass = this.getOsClass();
         document.body.classList.add(osClass);
         // The OS class selects the platform-specific font stacks in os.css. Secondary windows
-        // have their own document, so apply it there as well. Wait for the secondary window's
-        // final document: anything added to the initial about:blank document is discarded when
-        // secondary-window.html replaces it.
-        this.secondaryWindowService.onWindowOpened(win => {
-            win.addEventListener('DOMContentLoaded', () => win.document.body.classList.add(osClass), { once: true });
-        });
+        // have their own document, so apply it there as well.
+        this.secondaryWindowService.onWindowLoaded(win => win.document.body.classList.add(osClass));
     }
 
     protected getOsClass(): string {

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -61,6 +61,8 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
     protected optimalWidth = 0;
     protected optimalHeight = 0;
     protected resizeObserver: ResizeObserver | undefined;
+    /** Window the scroll/wheel/resize listeners are attached to; may differ from the main window in secondary windows. */
+    protected listenersWindow: Window | undefined;
 
     constructor(props: SelectComponentProps) {
         super(props);
@@ -71,14 +73,28 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             hover: selected
         };
 
-        let list = document.getElementById(SELECT_COMPONENT_CONTAINER);
+        this.dropdownElement = this.resolveDropdownContainer(document);
+    }
+
+    /**
+     * The document that currently hosts this component. Falls back to the main document before
+     * the first render. Widgets can be moved to secondary windows, so this must be re-queried
+     * instead of captured once.
+     */
+    protected getHostDocument(): Document {
+        return this.fieldRef.current?.ownerDocument ?? document;
+    }
+
+    /** Finds or creates the dropdown portal container in the given document. */
+    protected resolveDropdownContainer(hostDocument: Document): HTMLElement {
+        let list = hostDocument.getElementById(SELECT_COMPONENT_CONTAINER);
         if (!list) {
-            list = document.createElement('div');
+            list = hostDocument.createElement('div');
             list.id = SELECT_COMPONENT_CONTAINER;
             list.className = 'theia-select-component-container';
-            document.body.appendChild(list);
+            hostDocument.body.appendChild(list);
         }
-        this.dropdownElement = list;
+        return list;
     }
 
     protected getInitialSelectedIndex(props: SelectComponentProps): number {
@@ -183,8 +199,9 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             parent = parent.parentElement;
         }
 
+        this.listenersWindow = this.getHostDocument().defaultView ?? window;
         for (const [key, listener] of this.mountedListeners.entries()) {
-            window.addEventListener(key, listener);
+            this.listenersWindow.addEventListener(key, listener);
         }
 
         // Catch Lumino sash drags globally - observe the closest lm-Widget panel
@@ -222,7 +239,12 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
     }
 
     override componentWillUnmount(): void {
+        this.detachListeners();
+    }
+
+    protected detachListeners(): void {
         this.resizeObserver?.disconnect();
+        this.resizeObserver = undefined;
         if (this.mountedListeners.size > 0) {
             const eventListener = this.mountedListeners.get('scroll')!;
             let parent = this.fieldRef.current?.parentElement;
@@ -231,9 +253,11 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
                 parent = parent.parentElement;
             }
             for (const [key, listener] of this.mountedListeners.entries()) {
-                window.removeEventListener(key, listener);
+                (this.listenersWindow ?? window).removeEventListener(key, listener);
             }
+            this.mountedListeners.clear();
         }
+        this.listenersWindow = undefined;
     }
 
     override render(): React.ReactNode {
@@ -345,6 +369,14 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             return;
         }
         if (!this.state.dimensions) {
+            // Re-resolve the portal container and listener window against the document that
+            // currently hosts the field: the widget may have been moved to a secondary window
+            // (or back to the main window) since the last time the dropdown was opened.
+            const hostDocument = this.getHostDocument();
+            this.dropdownElement = this.resolveDropdownContainer(hostDocument);
+            if (this.listenersWindow && this.listenersWindow !== hostDocument.defaultView) {
+                this.detachListeners();
+            }
             const rect = this.fieldRef.current.getBoundingClientRect();
             this.setState({ dimensions: rect });
         } else {
@@ -361,7 +393,8 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             hover: selectedIndex
         });
         // Force releasing focus of the select element to allow closing via escape later on
-        if (releaseFocus && document.activeElement && document.activeElement === this.fieldRef.current) {
+        const hostDocument = this.getHostDocument();
+        if (releaseFocus && hostDocument.activeElement && hostDocument.activeElement === this.fieldRef.current) {
             this.fieldRef.current.blur();
         }
     }
@@ -371,7 +404,9 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             return;
         }
 
-        const shellArea = document.getElementById('theia-app-shell')!.getBoundingClientRect();
+        // Secondary windows have no 'theia-app-shell' element; use the document element as the boundary there.
+        const hostDocument = this.getHostDocument();
+        const shellArea = (hostDocument.getElementById('theia-app-shell') ?? hostDocument.documentElement).getBoundingClientRect();
         const maxWidth = this.alignLeft ? shellArea.width - this.state.dimensions.left : this.state.dimensions.right;
         if (this.mountedListeners.size === 0) {
             // Only attach our listeners once we render our dropdown menu

--- a/packages/core/src/browser/widgets/select-component.tsx
+++ b/packages/core/src/browser/widgets/select-component.tsx
@@ -63,6 +63,8 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
     protected resizeObserver: ResizeObserver | undefined;
     /** Window the scroll/wheel/resize listeners are attached to; may differ from the main window in secondary windows. */
     protected listenersWindow: Window | undefined;
+    /** Perfect-scrollbar ancestors the `ps-scroll-y` listener was attached to. The field may have moved to another window since, so the elements are remembered. */
+    protected psScrollListenerTargets: HTMLElement[] = [];
 
     constructor(props: SelectComponentProps) {
         super(props);
@@ -195,6 +197,7 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
             // neither triggers the `scroll`, `wheel` nor `blur` event
             if (parent.classList.contains('ps')) {
                 parent.addEventListener('ps-scroll-y', hide);
+                this.psScrollListenerTargets.push(parent);
             }
             parent = parent.parentElement;
         }
@@ -247,16 +250,15 @@ export class SelectComponent extends React.Component<SelectComponentProps, Selec
         this.resizeObserver = undefined;
         if (this.mountedListeners.size > 0) {
             const eventListener = this.mountedListeners.get('scroll')!;
-            let parent = this.fieldRef.current?.parentElement;
-            while (parent) {
-                parent.removeEventListener('ps-scroll-y', eventListener);
-                parent = parent.parentElement;
+            for (const target of this.psScrollListenerTargets) {
+                target.removeEventListener('ps-scroll-y', eventListener);
             }
             for (const [key, listener] of this.mountedListeners.entries()) {
                 (this.listenersWindow ?? window).removeEventListener(key, listener);
             }
             this.mountedListeners.clear();
         }
+        this.psScrollListenerTargets = [];
         this.listenersWindow = undefined;
     }
 

--- a/packages/core/src/browser/window/default-secondary-window-service.ts
+++ b/packages/core/src/browser/window/default-secondary-window-service.ts
@@ -28,6 +28,8 @@ import { WindowFocusService } from './window-focus-service';
 export class DefaultSecondaryWindowService implements SecondaryWindowService {
     protected readonly onWindowOpenedEmitter = new Emitter<Window>;
     readonly onWindowOpened: Event<Window> = this.onWindowOpenedEmitter.event;
+    protected readonly onWindowLoadedEmitter = new Emitter<Window>;
+    readonly onWindowLoaded: Event<Window> = this.onWindowLoadedEmitter.event;
     protected readonly onWindowClosedEmitter = new Emitter<Window>;
     readonly onWindowClosed: Event<Window> = this.onWindowClosedEmitter.event;
     protected readonly beforeWidgetRestoreEmitter = new Emitter<[Widget, Window]>;
@@ -110,6 +112,10 @@ export class DefaultSecondaryWindowService implements SecondaryWindowService {
             this.secondaryWindows.push(newWindow);
             this.onWindowOpenedEmitter.fire(newWindow);
             newWindow.addEventListener('DOMContentLoaded', () => {
+                // This fires for the final secondary-window.html document, not for the initial
+                // about:blank document the window starts out with, so onWindowLoaded listeners
+                // can safely modify the document.
+                this.onWindowLoadedEmitter.fire(newWindow);
                 const focusRegistration = this.windowFocusService.registerWindow(newWindow);
                 newWindow.addEventListener('beforeunload', evt => {
                     const widgets = getAllWidgetsFromSecondaryWindow(newWindow) ?? [widget];

--- a/packages/core/src/browser/window/secondary-window-service.ts
+++ b/packages/core/src/browser/window/secondary-window-service.ts
@@ -55,6 +55,13 @@ export interface SecondaryWindowService {
      */
     createSecondaryWindow(widget: ExtractableWidget, shell: ApplicationShell): SecondaryWindow | Window | undefined;
     readonly onWindowOpened: Event<Window>;
+    /**
+     * Emitted once a secondary window's final document has finished loading. Listeners can safely
+     * modify the window's document, unlike with {@link onWindowOpened}: at that point the window
+     * still shows the initial `about:blank` document, and anything added to it is discarded when
+     * the final document replaces it.
+     */
+    readonly onWindowLoaded: Event<Window>;
     readonly onWindowClosed: Event<Window>;
     readonly beforeWidgetRestore: Event<[Widget, Window]>;
 

--- a/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
+++ b/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
@@ -24,12 +24,9 @@ import { MonacoTextModelService } from './monaco-text-model-service';
 import { MonacoThemingService } from './monaco-theming-service';
 import { isHighContrast } from '@theia/core/lib/common/theme';
 import { editorOptionsRegistry, IEditorOption } from '@theia/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
-import { MAX_SAFE_INTEGER, PreferenceSchemaService } from '@theia/core';
+import { DisposableCollection, MAX_SAFE_INTEGER, PreferenceSchemaService } from '@theia/core';
 import { editorGeneratedPreferenceProperties } from '@theia/editor/lib/common/editor-generated-preference-schema';
 import { WorkspaceFileService } from '@theia/workspace/lib/common/workspace-file-service';
-import { SecondaryWindowHandler } from '@theia/core/lib/browser/secondary-window-handler';
-import { EditorWidget } from '@theia/editor/lib/browser';
-import { MonacoEditor } from './monaco-editor';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
 import { StandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneThemeService';
 import { IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
@@ -60,9 +57,6 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
     @inject(MonacoThemingService) protected readonly monacoThemingService: MonacoThemingService;
 
     @inject(WorkspaceFileService) protected readonly workspaceFileService: WorkspaceFileService;
-
-    @inject(SecondaryWindowHandler)
-    protected readonly secondaryWindowHandler: SecondaryWindowHandler;
 
     @inject(SecondaryWindowService)
     protected readonly secondaryWindowService: SecondaryWindowService;
@@ -110,17 +104,25 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
         // are available document-wide from launch; `_updateCSS` keeps the stylesheet in sync on theme changes.
         (StandaloneServices.get(IStandaloneThemeService) as StandaloneThemeService).registerEditorContainer(document.body);
 
-        this.secondaryWindowHandler.onDidAddWidget(([widget, window]) => {
-            if (widget instanceof EditorWidget && widget.editor instanceof MonacoEditor) {
-                const themeService = StandaloneServices.get(IStandaloneThemeService) as StandaloneThemeService;
-                themeService.registerEditorContainer(widget.node);
-            }
-        });
         this.secondaryWindowService.onWindowOpened(window => {
             const codeWindow: CodeWindow = window as CodeWindow;
             codeWindow.vscodeWindowId = this.nextWindowId++;
 
-            this.windowsById.set(codeWindow.vscodeWindowId, registerWindow(codeWindow));
+            const toDispose = new DisposableCollection();
+            // Wait for the secondary window's final document: anything added to the initial
+            // about:blank document is discarded when secondary-window.html replaces it.
+            codeWindow.addEventListener('DOMContentLoaded', () => {
+                toDispose.push(registerWindow(codeWindow));
+                // Inject Monaco's theme stylesheet (`monaco-colors`, defining the `--vscode-*`
+                // variables and token colors) into the new window's document. Without it, Monaco
+                // editors in secondary windows have no theme colors: invisible cursor and
+                // selection, unstyled suggest widget. Registering the document body covers all
+                // widgets moved to this window, e.g. the AI chat view with its input editor.
+                // See https://github.com/eclipse-theia/theia/issues/15164
+                const themeService = StandaloneServices.get(IStandaloneThemeService) as StandaloneThemeService;
+                toDispose.push(themeService.registerEditorContainer(codeWindow.document.body));
+            }, { once: true });
+            this.windowsById.set(codeWindow.vscodeWindowId, toDispose);
         });
 
         this.secondaryWindowService.onWindowClosed(window => {

--- a/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
+++ b/packages/monaco/src/browser/monaco-frontend-application-contribution.ts
@@ -28,8 +28,8 @@ import { DisposableCollection, MAX_SAFE_INTEGER, PreferenceSchemaService } from 
 import { editorGeneratedPreferenceProperties } from '@theia/editor/lib/common/editor-generated-preference-schema';
 import { WorkspaceFileService } from '@theia/workspace/lib/common/workspace-file-service';
 import { StandaloneServices } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneServices';
-import { StandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/browser/standaloneThemeService';
 import { IStandaloneThemeService } from '@theia/monaco-editor-core/esm/vs/editor/standalone/common/standaloneTheme';
+import { MonacoStandaloneThemeService } from './monaco-standalone-theme-service';
 import { SecondaryWindowService } from '@theia/core/lib/browser/window/secondary-window-service';
 import { registerWindow } from '@theia/monaco-editor-core/esm/vs/base/browser/dom';
 
@@ -102,33 +102,40 @@ export class MonacoFrontendApplicationContribution implements FrontendApplicatio
         // when the first standalone editor is opened, so popups that rely on those variables (e.g. the chat
         // input's suggest widget) are unstyled until then. Register the main window up front so the variables
         // are available document-wide from launch; `_updateCSS` keeps the stylesheet in sync on theme changes.
-        (StandaloneServices.get(IStandaloneThemeService) as StandaloneThemeService).registerEditorContainer(document.body);
+        this.standaloneThemeService.registerEditorContainer(document.body);
 
-        this.secondaryWindowService.onWindowOpened(window => {
+        this.secondaryWindowService.onWindowLoaded(window => {
             const codeWindow: CodeWindow = window as CodeWindow;
             codeWindow.vscodeWindowId = this.nextWindowId++;
 
             const toDispose = new DisposableCollection();
-            // Wait for the secondary window's final document: anything added to the initial
-            // about:blank document is discarded when secondary-window.html replaces it.
-            codeWindow.addEventListener('DOMContentLoaded', () => {
-                toDispose.push(registerWindow(codeWindow));
-                // Inject Monaco's theme stylesheet (`monaco-colors`, defining the `--vscode-*`
-                // variables and token colors) into the new window's document. Without it, Monaco
-                // editors in secondary windows have no theme colors: invisible cursor and
-                // selection, unstyled suggest widget. Registering the document body covers all
-                // widgets moved to this window, e.g. the AI chat view with its input editor.
-                // See https://github.com/eclipse-theia/theia/issues/15164
-                const themeService = StandaloneServices.get(IStandaloneThemeService) as StandaloneThemeService;
-                toDispose.push(themeService.registerEditorContainer(codeWindow.document.body));
-            }, { once: true });
+            toDispose.push(registerWindow(codeWindow));
+            // Inject Monaco's theme stylesheet (`monaco-colors`, defining the `--vscode-*`
+            // variables and token colors) into the new window's document. Without it, Monaco
+            // editors in secondary windows have no theme colors: invisible cursor and
+            // selection, unstyled suggest widget. Registering the document body covers all
+            // widgets moved to this window, e.g. the AI chat view with its input editor.
+            // See https://github.com/eclipse-theia/theia/issues/15164
+            toDispose.push(this.standaloneThemeService.registerEditorContainer(codeWindow.document.body));
             this.windowsById.set(codeWindow.vscodeWindowId, toDispose);
         });
 
         this.secondaryWindowService.onWindowClosed(window => {
             const codeWindow: CodeWindow = window as CodeWindow;
             this.windowsById.get(codeWindow.vscodeWindowId)?.dispose();
+            this.windowsById.delete(codeWindow.vscodeWindowId);
         });
+    }
+
+    /**
+     * Theia's {@link MonacoStandaloneThemeService} override, which creates the `monaco-colors`
+     * stylesheet in the target node's own document. The upstream `StandaloneThemeService` would
+     * only ever create a single global stylesheet in the main document and silently no-op for
+     * nodes in other documents, so this contribution depends on the Theia override being bound
+     * (see `monaco-init.ts`).
+     */
+    protected get standaloneThemeService(): MonacoStandaloneThemeService {
+        return StandaloneServices.get(IStandaloneThemeService) as MonacoStandaloneThemeService;
     }
 
     registerThemeStyle(theme: ColorTheme, collector: CssStyleCollector): void {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md
-->

#### What it does

Fixes [#15164](https://github.com/eclipse-theia/theia/issues/15164)

Addresses the Monaco styling and dropdown placement problems of #15164 (chat UI in a secondary window).

Three independent fixes:

1. **`@theia/monaco`: inject Monaco's theme CSS into secondary windows.** Monaco exposes its theme colors (`--vscode-*` variables and token colors) only through the dynamically created `monaco-colors` stylesheet (`MonacoStandaloneThemeService.registerEditorContainer`, which creates it per document). For extracted widgets this was only done for `EditorWidget`s (#13493), so other widgets containing Monaco editors — e.g. the AI chat view with its input editor — had no theme colors in secondary windows: invisible cursor, invisible selection, unstyled/unhighlighted suggest widget. The contribution now registers the secondary window's `document.body` once per window (via the new `SecondaryWindowService.onWindowLoaded` event, which fires for the final document and covers every widget moved there) and disposes the registration when the window closes. The now-redundant `EditorWidget` special case is removed; note this also removes the protected `secondaryWindowHandler` field from `MonacoFrontendApplicationContribution` and adds `onWindowLoaded` to the `SecondaryWindowService` interface (both listed in the changelog).

2. **`@theia/core`: render the `SelectComponent` dropdown in its owning window.** The dropdown portal container, the positioning boundary (`theia-app-shell` rect), the scroll/resize auto-hide listeners, and the focus check were all bound to the main window. Opening e.g. the chat input's model or reasoning selector in a secondary window rendered the dropdown into the main window's DOM at popup-relative coordinates. The component now resolves the portal container, boundary rect (falling back to `documentElement` where no `theia-app-shell` exists), and listener window from the field's `ownerDocument` at the moment the dropdown opens, so it follows the widget when it moves between windows (and back).

3. **`@theia/core`: apply the OS class to secondary windows.** The `mac`/`windows`/`linux` class that selects the platform-specific font stacks in `os.css` was only set on the main window's `document.body`, so UI text in secondary windows fell back to the generic default font (found in review by @ndoschek). The class is now applied to each secondary window's body via the same `onWindowLoaded` event. Covered by a new unit test.

Not addressed here: the file/context variable picker still opens in the main window, because quick inputs are attached to the main window's DOM — that is the general limitation tracked in #11647.

#### How to test

1. Open the AI Chat view (AI features enabled) and click "Move View to Secondary Window".
2. Type in the chat input: the cursor is visible and blinking, selecting text highlights it.
3. Type `@` or `#`: the completion list shows the focused-row background and match highlighting.
4. Open the model / reasoning dropdowns in the chat input: they open inside the secondary window, anchored to the control.
5. UI text in the secondary window renders with the platform font (e.g. the system font on macOS), matching the main window.
6. Move the view back to the main window and repeat 2–5 to verify unchanged behavior there.
7. Extract a text editor to a secondary window: cursor/selection/syntax highlighting still work (previously covered by the removed `EditorWidget` special case).

#### Follow-ups

- Quick inputs (e.g. the file variable picker) still open in the main window: #11647.

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
