### PR TITLE
fix(scm): enable pull/push toolbar actions in history graph

### DIFF
--- a/packages/scm/src/browser/scm-context-key-service.spec.ts
+++ b/packages/scm/src/browser/scm-context-key-service.spec.ts
@@ -69,6 +69,15 @@ describe('ScmContextKeyService', () => {
         scmContextKeyService.scmProviderCount.reset();
         expect(scmContextKeyService.scmProviderCount.get()).to.equal(0);
     });
+
+    it('should initialize scmCurrentHistoryItemRefInFilter to false', () => {
+        expect(scmContextKeyService.scmCurrentHistoryItemRefInFilter.get()).to.equal(false);
+    });
+
+    it('should update scmCurrentHistoryItemRefInFilter when set is called', () => {
+        scmContextKeyService.scmCurrentHistoryItemRefInFilter.set(true);
+        expect(scmContextKeyService.scmCurrentHistoryItemRefInFilter.get()).to.equal(true);
+    });
 });
 
 describe('ScmContribution scm.providerCount wiring', () => {

--- a/packages/scm/src/browser/scm-context-key-service.ts
+++ b/packages/scm/src/browser/scm-context-key-service.ts
@@ -63,6 +63,11 @@ export class ScmContextKeyService {
         return this._scmCurrentHistoryItemRefHasBase;
     }
 
+    protected _scmCurrentHistoryItemRefInFilter: ContextKey<boolean>;
+    get scmCurrentHistoryItemRefInFilter(): ContextKey<boolean> {
+        return this._scmCurrentHistoryItemRefInFilter;
+    }
+
     @postConstruct()
     protected init(): void {
         this._scmProvider = this.contextKeyService.createKey<string | undefined>('scmProvider', undefined);
@@ -73,6 +78,7 @@ export class ScmContextKeyService {
         this._scmHistoryItemRef = this.contextKeyService.createKey<string | undefined>('scmHistoryItemRef', undefined);
         this._scmCurrentHistoryItemRefHasRemote = this.contextKeyService.createKey<boolean>('scmCurrentHistoryItemRefHasRemote', false);
         this._scmCurrentHistoryItemRefHasBase = this.contextKeyService.createKey<boolean>('scmCurrentHistoryItemRefHasBase', false);
+        this._scmCurrentHistoryItemRefInFilter = this.contextKeyService.createKey<boolean>('scmCurrentHistoryItemRefInFilter', false);
     }
 
     match(expression: string | undefined): boolean {

--- a/packages/scm/src/browser/scm-history-graph-widget.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-widget.spec.ts
@@ -1,0 +1,101 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { ContextKey, ContextKeyServiceDummyImpl, ContextKeyValue } from '@theia/core/lib/browser/context-key-service';
+import { ScmContextKeyService } from './scm-context-key-service';
+import { ScmHistoryGraphWidget } from './scm-history-graph-widget';
+import { ScmHistoryProvider } from './scm-provider';
+
+disableJSDOM();
+
+class MockContextKeyService extends ContextKeyServiceDummyImpl {
+    override createKey<T extends ContextKeyValue>(key: string, defaultValue: T | undefined): ContextKey<T> {
+        let value: T | undefined = defaultValue;
+        return {
+            set: (v: T | undefined) => { value = v; },
+            reset: () => { value = defaultValue; },
+            get: () => value
+        };
+    }
+}
+
+function createScmContextKeyService(): ScmContextKeyService {
+    const service = new ScmContextKeyService();
+    (service as unknown as { contextKeyService: MockContextKeyService }).contextKeyService = new MockContextKeyService();
+    (service as unknown as { init(): void }).init();
+    return service;
+}
+
+describe('ScmHistoryGraphWidget context keys', () => {
+    let restoreJSDOM: () => void;
+    let widget: ScmHistoryGraphWidget;
+    let scmContextKeys: ScmContextKeyService;
+    let provider: Partial<ScmHistoryProvider> | undefined;
+
+    beforeEach(() => {
+        restoreJSDOM = enableJSDOM();
+        scmContextKeys = createScmContextKeyService();
+        widget = new ScmHistoryGraphWidget();
+        const raw = widget as unknown as Record<string, unknown>;
+        raw.scmContextKeys = scmContextKeys;
+        Object.defineProperty(raw, 'model', {
+            get: () => ({ provider })
+        });
+    });
+
+    afterEach(() => {
+        restoreJSDOM();
+    });
+
+    function updateContextKeys(): void {
+        (widget as unknown as { updateContextKeys(): void }).updateContextKeys();
+    }
+
+    it('should set scmCurrentHistoryItemRefInFilter when the provider has a current ref', () => {
+        provider = {
+            currentHistoryItemRef: { id: 'refs/heads/main', name: 'main' }
+        };
+        updateContextKeys();
+        expect(scmContextKeys.scmCurrentHistoryItemRefInFilter.get()).to.equal(true);
+    });
+
+    it('should clear scmCurrentHistoryItemRefInFilter when the provider has no current ref', () => {
+        scmContextKeys.scmCurrentHistoryItemRefInFilter.set(true);
+        provider = {};
+        updateContextKeys();
+        expect(scmContextKeys.scmCurrentHistoryItemRefInFilter.get()).to.equal(false);
+    });
+
+    it('should clear scmCurrentHistoryItemRefInFilter when there is no provider', () => {
+        scmContextKeys.scmCurrentHistoryItemRefInFilter.set(true);
+        provider = undefined;
+        updateContextKeys();
+        expect(scmContextKeys.scmCurrentHistoryItemRefInFilter.get()).to.equal(false);
+    });
+
+    it('should set scmCurrentHistoryItemRefHasRemote when the provider has a remote ref', () => {
+        provider = {
+            currentHistoryItemRef: { id: 'refs/heads/main', name: 'main' },
+            currentHistoryItemRemoteRef: { id: 'refs/remotes/origin/main', name: 'origin/main' }
+        };
+        updateContextKeys();
+        expect(scmContextKeys.scmCurrentHistoryItemRefHasRemote.get()).to.equal(true);
+    });
+});

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -138,6 +138,9 @@ export class ScmHistoryGraphWidget extends ReactWidget {
         const provider = this.model.provider;
         this.scmContextKeys.scmCurrentHistoryItemRefHasRemote.set(!!provider?.currentHistoryItemRemoteRef);
         this.scmContextKeys.scmCurrentHistoryItemRefHasBase.set(!!provider?.currentHistoryItemBaseRef);
+        // The graph has no ref filter yet, so the current ref is always considered part of it.
+        // Commands like git.pullRef/git.pushRef gate their enablement on this key.
+        this.scmContextKeys.scmCurrentHistoryItemRefInFilter.set(!!provider?.currentHistoryItemRef);
     }
 
     protected render(): React.ReactNode {


### PR DESCRIPTION
#### What it does

Fixes item 1 of #17457: the Pull / Push toolbar actions in the SCM history graph failed with `Error: The command 'git.pullRef' cannot be executed. There are no active handlers available for the command.`

`git.pullRef` and `git.pushRef` (contributed by `vscode.git` to `scm/history/title`) gate their enablement on the `scmCurrentHistoryItemRefInFilter` context key, which Theia never set. This PR registers the key in `ScmContextKeyService` and sets it from the graph widget whenever the provider has a current history item ref. Since the graph has no ref filter yet, the current ref is always considered part of it, matching VS Code's default "Auto" filter behavior.

#### How to test

1. Open a workspace on a git repository whose current branch tracks a remote that has new commits (e.g. a local clone that is one commit behind).
2. Open the Source Control view and expand the Graph section.
3. Click the Pull toolbar action: the remote commit is fetched and merged, and the graph updates. Previously this threw the "no active handlers" error. Same for Push.

Unit tests: `npx lerna run test --scope @theia/scm` (new specs in `scm-context-key-service.spec.ts` and `scm-history-graph-widget.spec.ts`).

#### Follow-ups

- Remaining items of #17457, in particular the ref filter picker (item 3), which will give this context key its full semantics.
- The tab bar toolbar renders plugin-contributed items as clickable even when their `enablement` clause is false; VS Code disables/hides them instead.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
