### PR TITLE
feat(scm): ref-role colors, current-commit indicator, and blame-style hover in history graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [ai-ide] added an opt-in "Memory" prompt capability that lets agents maintain a wiki-style knowledge base per workspace, stored in the workspace metadata store and exposed to prompts via the new `{{memoryDirectory}}` variable [#17865](https://github.com/eclipse-theia/theia/pull/17865)
 - [core, monaco] fixed Monaco theme CSS, `SelectComponent` dropdown placement, and the OS font class in secondary windows [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+- [scm] aligned the history graph with VS Code: ref-role lane and badge colors, a current-commit indicator, and a commit hover rendered from the content the history provider supplies [#17880](https://github.com/eclipse-theia/theia/pull/17880)
 - [scm-extra] deprecated `@theia/scm-extra` package [#17882](https://github.com/eclipse-theia/theia/pull/17882)
 
 <a name="breaking_changes_1.75.0">[Breaking Changes:](#breaking_changes_1.75.0)</a>
@@ -15,6 +16,7 @@
 - [ai-ide] removed `WorkspaceFunctionScope.ensureWithinWorkspace(targetUri, workspaceRootUri)`. Every path-taking AI tool now resolves and checks its argument through `WorkspaceFunctionScope.resolveAccessiblePath(pathOrUri)`, which in addition to the workspace roots accepts locations covered by the `ai-features.workspaceFunctions.allowedExternalPaths` preference or contributed via the new `AccessibleRootContribution`. Adopters that called `ensureWithinWorkspace`, or `resolveRelativePath` followed by their own boundary check, should call `resolveAccessiblePath` instead [#17865](https://github.com/eclipse-theia/theia/pull/17865)
 - [core] added `onWindowLoaded` to the `SecondaryWindowService` interface; adopters implementing the interface from scratch (rather than extending `DefaultSecondaryWindowService`) must provide it [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [monaco] removed the `protected secondaryWindowHandler` field from `MonacoFrontendApplicationContribution`; the Monaco theme stylesheet is now injected into every secondary window via `SecondaryWindowService.onWindowLoaded` [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+- [scm] widened `ScmHistoryItem.tooltip` from `string` to `string | MarkdownString | readonly MarkdownString[]`, so that hovers supplied by a history provider keep their `isTrusted` command allow-list and their multi-section form; adopters reading the field as a string must narrow it [#17880](https://github.com/eclipse-theia/theia/pull/17880)
 - [scm-extra] deprecated the `@theia/scm-extra` extension and stopped publishing it on npm; it has also been removed from the example applications, which drops its `SCM History` view, the `History` context menu items in the navigator and editor, and the `alt+h` keybinding. The view has been non-functional in the default application since the removal of `@theia/git`, as nothing implements `ScmHistorySupport` anymore. Please use the SCM history graph in `@theia/scm` for branch history and the Timeline view in `@theia/timeline` for per-file history instead [#17882](https://github.com/eclipse-theia/theia/pull/17882)
 
 ## 1.74.0 - 7/31/2026

--- a/packages/core/src/browser/markdown-rendering/markdown-link-handler.ts
+++ b/packages/core/src/browser/markdown-rendering/markdown-link-handler.ts
@@ -20,12 +20,27 @@ import URI from '../../common/uri';
 import { open, OpenerService } from '../opener-service';
 
 /**
+ * Marks an element whose markdown links are already routed through an {@link OpenerService}.
+ *
+ * Renderers that install their own link handling declare it with {@link markMarkdownLinksWired},
+ * so that {@link wireMarkdownLinkHandler} does not add a second handler and open every link twice.
+ */
+export const MARKDOWN_LINKS_WIRED_ATTRIBUTE = 'data-theia-markdown-links-wired';
+
+/** Declares that the element's markdown links are already routed through an {@link OpenerService}. */
+export function markMarkdownLinksWired(root: HTMLElement): void {
+    root.setAttribute(MARKDOWN_LINKS_WIRED_ATTRIBUTE, 'true');
+}
+
+/**
  * Wires up anchor clicks inside a rendered markdown element so that they are routed
  * through the {@link OpenerService} instead of relying on default browser navigation.
  * Honors {@link MarkdownString.isTrusted} for `command:` URIs.
  *
  * Also sets the `title` attribute on each anchor to its `href` (when no title is set)
  * so users can hover to see the link target.
+ *
+ * Does nothing if the element's links are already wired, see {@link markMarkdownLinksWired}.
  *
  * @returns a {@link Disposable} that removes the click listener.
  */
@@ -34,6 +49,10 @@ export function wireMarkdownLinkHandler(
     source: MarkdownString,
     openerService: OpenerService
 ): Disposable {
+    if (root.hasAttribute(MARKDOWN_LINKS_WIRED_ATTRIBUTE)) {
+        return Disposable.NULL;
+    }
+    markMarkdownLinksWired(root);
     for (const anchor of root.querySelectorAll('a')) {
         const href = anchor.getAttribute('href');
         if (href && !anchor.hasAttribute('title')) {
@@ -57,5 +76,8 @@ export function wireMarkdownLinkHandler(
         }
     };
     root.addEventListener('click', handleClick);
-    return Disposable.create(() => root.removeEventListener('click', handleClick));
+    return Disposable.create(() => {
+        root.removeEventListener('click', handleClick);
+        root.removeAttribute(MARKDOWN_LINKS_WIRED_ATTRIBUTE);
+    });
 }

--- a/packages/core/src/browser/markdown-rendering/markdown-renderer.spec.ts
+++ b/packages/core/src/browser/markdown-rendering/markdown-renderer.spec.ts
@@ -1,0 +1,88 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '../test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { Container } from 'inversify';
+import { expect } from 'chai';
+import { CommandService } from '../../common';
+import { MarkdownStringImpl } from '../../common/markdown-rendering/markdown-string';
+import { LabelParser } from '../label-parser';
+import { MarkdownRenderer, MarkdownRendererImpl } from './markdown-renderer';
+
+disableJSDOM();
+
+describe('MarkdownRendererImpl', () => {
+    let restoreJSDOM: () => void;
+    let renderer: MarkdownRenderer;
+
+    before(() => {
+        restoreJSDOM = enableJSDOM();
+        const container = new Container();
+        container.bind(LabelParser).toSelf().inSingletonScope();
+        container.bind(CommandService).toConstantValue({
+            executeCommand: <T>(): Promise<T | undefined> => Promise.resolve(undefined)
+        });
+        container.bind(MarkdownRendererImpl).toSelf().inSingletonScope();
+        container.bind(MarkdownRenderer).toService(MarkdownRendererImpl);
+        renderer = container.get<MarkdownRenderer>(MarkdownRenderer);
+    });
+
+    after(() => {
+        restoreJSDOM();
+    });
+
+    function renderImage(markdown: string): HTMLImageElement {
+        const { element } = renderer.render(new MarkdownStringImpl(markdown));
+        const image = element.querySelector('img');
+        expect(image, `image rendered for '${markdown}'`).to.not.be.null;
+        return image!;
+    }
+
+    it('applies the width and height of an image sizing suffix', () => {
+        const image = renderImage('![Jane](https://avatars.example.com/u/1|width=20,height=20)');
+        expect(image.getAttribute('src')).to.equal('https://avatars.example.com/u/1');
+        expect(image.getAttribute('width')).to.equal('20');
+        expect(image.getAttribute('height')).to.equal('20');
+    });
+
+    it('applies a suffix that sets only one dimension', () => {
+        const image = renderImage('![Jane](https://avatars.example.com/u/1|width=20)');
+        expect(image.getAttribute('src')).to.equal('https://avatars.example.com/u/1');
+        expect(image.getAttribute('width')).to.equal('20');
+        expect(image.hasAttribute('height')).to.be.false;
+    });
+
+    // markdown-it percent-encodes the link destination, so a pipe it keeps shows up as `%7C`.
+    it('keeps a literal pipe that is not a well-formed sizing suffix', () => {
+        const image = renderImage('![Jane](https://avatars.example.com/u/1|v=2)');
+        expect(image.getAttribute('src')).to.equal('https://avatars.example.com/u/1%7Cv=2');
+        expect(image.hasAttribute('width')).to.be.false;
+    });
+
+    it('ignores a non-numeric dimension', () => {
+        const image = renderImage('![Jane](https://avatars.example.com/u/1|width=20px)');
+        expect(image.getAttribute('src')).to.equal('https://avatars.example.com/u/1%7Cwidth=20px');
+        expect(image.hasAttribute('width')).to.be.false;
+    });
+
+    it('renders an image without a suffix unchanged', () => {
+        const image = renderImage('![Jane](https://avatars.example.com/u/1)');
+        expect(image.getAttribute('src')).to.equal('https://avatars.example.com/u/1');
+        expect(image.hasAttribute('width')).to.be.false;
+    });
+});

--- a/packages/core/src/browser/markdown-rendering/markdown-renderer.ts
+++ b/packages/core/src/browser/markdown-rendering/markdown-renderer.ts
@@ -101,5 +101,48 @@ export class MarkdownRendererImpl implements MarkdownRenderer {
                 return `<i class="${codicon(chunk.name)} ${chunk.animation ? `fa-${chunk.animation}` : ''} icon-inline"></i>`;
             }).join('');
         };
+
+        // Support VS Code's `![alt](src|width=W,height=H)` image sizing syntax, which markdown-it
+        // would otherwise fold into the `src` attribute, yielding a broken image.
+        const renderImage = this.markdownIt.renderer.rules.image;
+        this.markdownIt.renderer.rules.image = (tokens, idx, options, env, self) => {
+            const token = tokens[idx];
+            const srcIndex = token.attrIndex('src');
+            if (srcIndex >= 0 && token.attrs) {
+                const src = token.attrs[srcIndex][1];
+                // markdown-it percent-encodes the link destination, so the separator may have
+                // become `%7C` by the time the token reaches the renderer.
+                const separator = /(?:\||%7c)(?![\s\S]*(?:\||%7c))/i.exec(src);
+                if (separator) {
+                    const dimensions = this.parseImageDimensions(src.substring(separator.index + separator[0].length));
+                    if (dimensions) {
+                        token.attrs[srcIndex][1] = src.substring(0, separator.index);
+                        for (const [name, value] of Object.entries(dimensions)) {
+                            token.attrSet(name, value);
+                        }
+                    }
+                }
+            }
+            return renderImage ? renderImage(tokens, idx, options, env, self) : self.renderToken(tokens, idx, options);
+        };
+    }
+
+    /**
+     * Parses the `width=W,height=H` parameter list of an image's sizing suffix.
+     *
+     * @returns the recognized dimensions, or `undefined` if the suffix is not a well-formed
+     * parameter list — in which case it is left as part of the `src`, since it may be a literal
+     * `|` in the URL.
+     */
+    protected parseImageDimensions(params: string): { width?: string, height?: string } | undefined {
+        const dimensions: { width?: string, height?: string } = {};
+        for (const param of params.split(',')) {
+            const match = /^\s*(width|height)\s*=\s*(\d+)\s*$/.exec(param);
+            if (!match) {
+                return undefined;
+            }
+            dimensions[match[1] as 'width' | 'height'] = match[2];
+        }
+        return Object.keys(dimensions).length > 0 ? dimensions : undefined;
     }
 }

--- a/packages/monaco/src/browser/markdown-renderer/monaco-markdown-renderer.ts
+++ b/packages/monaco/src/browser/markdown-renderer/monaco-markdown-renderer.ts
@@ -24,6 +24,7 @@ import { IOpenerService, OpenExternalOptions, OpenInternalOptions } from '@theia
 import { HttpOpenHandlerOptions } from '@theia/core/lib/browser/http-open-handler';
 import { URI } from '@theia/core/lib/common/uri';
 import { MarkdownRenderer, MarkdownRenderOptions, MarkdownRenderResult } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { markMarkdownLinksWired } from '@theia/core/lib/browser/markdown-rendering/markdown-link-handler';
 import { MarkdownRenderOptions as MonacoMarkdownRenderOptions } from '@theia/monaco-editor-core/esm/vs/base/browser/markdownRenderer';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering';
 import { DisposableStore } from '@theia/monaco-editor-core/esm/vs/base/common/lifecycle';
@@ -39,7 +40,12 @@ export class MonacoMarkdownRenderer implements MarkdownRenderer {
     protected _openerService: OpenerService | undefined;
 
     render(markdown: MarkdownString, options?: MarkdownRenderOptions): MarkdownRenderResult {
-        return this.delegate.render(markdown, this.transformOptions(options));
+        const rendered = this.delegate.render(markdown, this.transformOptions(options));
+        // The delegate activates links through its own opener service, which `interceptOpen`
+        // routes to Theia's. Declaring that keeps callers from wiring a second handler, which
+        // would open every link twice.
+        markMarkdownLinksWired(rendered.element);
+        return rendered;
     }
 
     protected transformOptions(options?: MarkdownRenderOptions): MonacoMarkdownRenderOptions | undefined {

--- a/packages/plugin-ext/src/common/plugin-api-rpc.ts
+++ b/packages/plugin-ext/src/common/plugin-api-rpc.ts
@@ -1154,7 +1154,7 @@ export interface ScmHistoryItemDto {
     authorIcon?: UriComponents | { light: UriComponents; dark: UriComponents } | ThemeIcon;
     displayId?: string;
     timestamp?: number;
-    tooltip?: string | MarkdownString;
+    tooltip?: string | MarkdownString | MarkdownString[];
     statistics?: ScmHistoryItemStatisticsDto;
     references?: ScmHistoryItemRefDto[];
 }

--- a/packages/plugin-ext/src/main/browser/scm-main.ts
+++ b/packages/plugin-ext/src/main/browser/scm-main.ts
@@ -138,7 +138,9 @@ function historyItemFromDto(dto: ScmHistoryItemDto): ScmHistoryItem {
             'light' in dto.authorIcon ? vscodeURI.revive(dto.authorIcon.light).toString() : vscodeURI.revive(dto.authorIcon as UriComponents).toString()) : undefined,
         displayId: dto.displayId,
         timestamp: dto.timestamp,
-        tooltip: typeof dto.tooltip === 'string' ? dto.tooltip : dto.tooltip?.value,
+        // Passed through as-is so that the provider's own links, commands and `isTrusted`
+        // declaration survive; flattening to `value` would strip the command allow-list.
+        tooltip: dto.tooltip,
         statistics: dto.statistics ? {
             files: dto.statistics.files,
             insertions: dto.statistics.insertions,

--- a/packages/plugin-ext/src/plugin/scm.ts
+++ b/packages/plugin-ext/src/plugin/scm.ts
@@ -566,7 +566,7 @@ function historyItemToDto(item: theia.SourceControlHistoryItem): ScmHistoryItemD
         authorIcon: item.authorIcon,
         displayId: item.displayId,
         timestamp: item.timestamp,
-        tooltip: item.tooltip,
+        tooltip: Array.isArray(item.tooltip) ? [...item.tooltip] : item.tooltip,
         statistics: item.statistics ? {
             files: item.statistics.files,
             insertions: item.statistics.insertions,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -12751,7 +12751,12 @@ export module '@theia/plugin' {
         readonly timestamp?: number;
         readonly statistics?: SourceControlHistoryItemStatistics;
         readonly references?: readonly SourceControlHistoryItemRef[];
-        readonly tooltip?: string | MarkdownString;
+        /**
+         * Hover content for the history item. When several markdown strings are given, they are
+         * rendered as separate sections. `command:` links are only executed if the containing
+         * markdown string declares them via its `isTrusted` option.
+         */
+        readonly tooltip?: string | MarkdownString | MarkdownString[];
     }
 
     export interface SourceControlHistoryItemChange {

--- a/packages/scm/src/browser/scm-history-graph-helpers.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-helpers.spec.ts
@@ -1,0 +1,85 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { getRefBadgePresentation, getRefColorIndex } from './scm-history-graph-helpers';
+import { ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
+
+describe('getRefColorIndex', () => {
+
+    const mainRef: ScmHistoryItemRef = { id: 'refs/heads/main', name: 'main' };
+    const remoteRef: ScmHistoryItemRef = { id: 'refs/remotes/origin/main', name: 'origin/main' };
+    const baseRef: ScmHistoryItemRef = { id: 'refs/remotes/origin/develop', name: 'origin/develop' };
+    const otherRef: ScmHistoryItemRef = { id: 'refs/heads/feature', name: 'feature' };
+
+    const provider = {
+        currentHistoryItemRef: mainRef,
+        currentHistoryItemRemoteRef: remoteRef,
+        currentHistoryItemBaseRef: baseRef,
+    } as ScmHistoryProvider;
+
+    it('returns 0 for the current history item ref', () => {
+        expect(getRefColorIndex(mainRef, provider)).to.equal(0);
+    });
+
+    it('returns 1 for the current remote ref', () => {
+        expect(getRefColorIndex(remoteRef, provider)).to.equal(1);
+    });
+
+    it('returns 2 for the current base ref', () => {
+        expect(getRefColorIndex(baseRef, provider)).to.equal(2);
+    });
+
+    it('returns undefined for any other ref', () => {
+        expect(getRefColorIndex(otherRef, provider)).to.be.undefined;
+    });
+
+    it('returns undefined without a provider', () => {
+        expect(getRefColorIndex(mainRef, undefined)).to.be.undefined;
+    });
+});
+
+describe('getRefBadgePresentation', () => {
+
+    const mainRef: ScmHistoryItemRef = { id: 'refs/heads/main', name: 'main' };
+    const remoteRef: ScmHistoryItemRef = { id: 'refs/remotes/origin/main', name: 'origin/main' };
+
+    const provider = {
+        currentHistoryItemRef: mainRef,
+        currentHistoryItemRemoteRef: remoteRef,
+    } as ScmHistoryProvider;
+
+    it('prefers the codicon icon transferred from the provider', () => {
+        const ref: ScmHistoryItemRef = { ...mainRef, icon: 'codicon codicon-target' };
+        expect(getRefBadgePresentation(ref, undefined).iconClass).to.equal('codicon-target');
+    });
+
+    it('falls back to the target icon for the current ref', () => {
+        expect(getRefBadgePresentation(mainRef, provider).iconClass).to.equal('codicon-target');
+    });
+
+    it('falls back to category icons for remote, tag, and other local refs', () => {
+        expect(getRefBadgePresentation(remoteRef, provider).iconClass).to.equal('codicon-cloud');
+        expect(getRefBadgePresentation({ id: 'refs/tags/v1', name: 'v1' }, provider).iconClass).to.equal('codicon-tag');
+        expect(getRefBadgePresentation({ id: 'refs/heads/feature', name: 'feature' }, provider).iconClass).to.equal('codicon-git-branch');
+    });
+
+    it('carries the ref color index', () => {
+        expect(getRefBadgePresentation(mainRef, provider).colorIndex).to.equal(0);
+        expect(getRefBadgePresentation(remoteRef, provider).colorIndex).to.equal(1);
+        expect(getRefBadgePresentation({ id: 'refs/heads/feature', name: 'feature' }, provider).colorIndex).to.be.undefined;
+    });
+});

--- a/packages/scm/src/browser/scm-history-graph-helpers.ts
+++ b/packages/scm/src/browser/scm-history-graph-helpers.ts
@@ -14,16 +14,16 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { ScmHistoryItemRef, ScmHistoryItemChange } from './scm-provider';
+import { ScmHistoryItemRef, ScmHistoryItemChange, ScmHistoryProvider } from './scm-provider';
 
 /**
- * Returns the CSS color variable for the given lane index.
+ * Returns the CSS color variable for the given color index.
  * Uses Theia's `--theia-scmGraph-*` variables, mirroring the VS Code
  * scm graph color scheme:
- *   lane 0 (current ref)  → historyItemRefColor
- *   lane 1 (remote ref)   → historyItemRemoteRefColor
- *   lane 2 (base ref)     → historyItemBaseRefColor
- *   lane 3–7              → foreground1–5
+ *   0 (current ref)  → historyItemRefColor
+ *   1 (remote ref)   → historyItemRemoteRefColor
+ *   2 (base ref)     → historyItemBaseRefColor
+ *   3–7 (default rotation) → foreground1–5
  */
 export function laneColor(index: number): string {
     switch (index % 8) {
@@ -81,6 +81,56 @@ export function getRepoRelativePath(uri: string, rootUri: string | undefined): s
         return fullPath.slice(rootPrefix.length);
     }
     return fullPath;
+}
+
+/**
+ * Returns the ref-based color index of the given ref (0 = current ref,
+ * 1 = remote ref, 2 = base ref), or `undefined` when the ref is none of
+ * the provider's current history item refs. Mirrors VS Code's scm graph
+ * color map.
+ */
+export function getRefColorIndex(ref: ScmHistoryItemRef, provider: ScmHistoryProvider | undefined): number | undefined {
+    if (!provider) {
+        return undefined;
+    }
+    if (ref.id === provider.currentHistoryItemRef?.id) {
+        return 0;
+    }
+    if (ref.id === provider.currentHistoryItemRemoteRef?.id) {
+        return 1;
+    }
+    if (ref.id === provider.currentHistoryItemBaseRef?.id) {
+        return 2;
+    }
+    return undefined;
+}
+
+export interface RefBadgePresentation {
+    /** Icon class for the badge icon, e.g. 'codicon-git-branch'. */
+    iconClass: string;
+    /** Ref-based color index (0-2), or `undefined` to use the row color. */
+    colorIndex?: number;
+}
+
+/**
+ * Resolves how a ref badge is presented: the provider-supplied codicon icon
+ * when available (VS Code renders `ref.icon` unconditionally), otherwise a
+ * category fallback with the `target` icon marking the current ref; plus the
+ * ref-based color index.
+ */
+export function getRefBadgePresentation(ref: ScmHistoryItemRef, provider: ScmHistoryProvider | undefined): RefBadgePresentation {
+    const colorIndex = getRefColorIndex(ref, provider);
+    let iconClass: string;
+    if (ref.icon && ref.icon.startsWith('codicon ')) {
+        iconClass = ref.icon.substring('codicon '.length);
+    } else if (isTagRef(ref)) {
+        iconClass = 'codicon-tag';
+    } else if (isRemoteRef(ref)) {
+        iconClass = 'codicon-cloud';
+    } else {
+        iconClass = colorIndex === 0 ? 'codicon-target' : 'codicon-git-branch';
+    }
+    return { iconClass, colorIndex };
 }
 
 export function getRefBadgeClass(ref: ScmHistoryItemRef): string {

--- a/packages/scm/src/browser/scm-history-graph-lanes.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-lanes.spec.ts
@@ -37,9 +37,14 @@ describe('computeGraphRows', () => {
             expect(lanes(commits)).to.deep.equal([0, 0, 0]);
         });
 
-        it('colors are all 0', () => {
+        it('colors default to the first rotation color (foreground1 = index 3)', () => {
             const rows = computeGraphRows(commits);
-            expect(rows.map(r => r.color)).to.deep.equal([0, 0, 0]);
+            expect(rows.map(r => r.color)).to.deep.equal([3, 3, 3]);
+        });
+
+        it('topColor equals color when no ref color overrides the lane', () => {
+            const rows = computeGraphRows(commits);
+            rows.forEach(r => expect(r.topColor).to.equal(r.color));
         });
 
         it('first parent same-lane continuation emits no separate edge (handled by commit line)', () => {
@@ -201,9 +206,13 @@ describe('computeGraphRows', () => {
             expect(mergeIn.length).to.equal(0);
         });
 
-        it('lane colors are correct modulo 8', () => {
+        it('lane colors rotate through the default registry (indices 3-7)', () => {
             const rows = computeGraphRows(commits);
-            rows.forEach(r => expect(r.color).to.equal(r.lane % 8));
+            // O and P1 share lane 0 → first rotation color; P2/P3 opened new lanes
+            expect(rows[0].color).to.equal(3);
+            expect(rows[1].color).to.equal(3);
+            expect(rows[2].color).to.not.equal(rows[3].color);
+            rows.forEach(r => expect(r.color).to.be.within(3, 7));
         });
     });
 
@@ -387,25 +396,14 @@ describe('computeGraphRows', () => {
     });
 
     // -------------------------------------------------------------------------
-    // Lane color wraps at 8
+    // Default color rotation (VS Code cycles scmGraph.foreground1-5)
     // -------------------------------------------------------------------------
-    describe('color wrapping', () => {
-        it('lane color is always lane % 8', () => {
-            // 4 parallel chains so we have lanes 0, 1, 2, 3 occupied at once.
-            // Chain structure: X0→X1→X2, Y0→Y1→Y2, etc., interleaved.
-            const commits = [
-                { id: 'X0', parentIds: ['X1'] },
-                { id: 'Y0', parentIds: ['Y1'] },
-                { id: 'Z0', parentIds: ['Z1'] },
-                { id: 'W0', parentIds: ['W1'] },
-                { id: 'X1', parentIds: [] },
-                { id: 'Y1', parentIds: [] },
-                { id: 'Z1', parentIds: [] },
-                { id: 'W1', parentIds: [] },
-            ];
+    describe('default color rotation', () => {
+        it('cycles through indices 3-7 and wraps', () => {
+            // 6 independent tips → 6 lanes; the sixth wraps back to the first color
+            const commits = ['A', 'B', 'C', 'D', 'E', 'F'].map(id => ({ id, parentIds: [id.toLowerCase()] }));
             const rows = computeGraphRows(commits);
-            // Every row's color must equal lane % 8
-            rows.forEach(r => expect(r.color).to.equal(r.lane % 8));
+            expect(rows.map(r => r.color)).to.deep.equal([3, 4, 5, 6, 7, 3]);
         });
 
         it('assigns distinct lanes to 8 simultaneous branches', () => {
@@ -423,10 +421,57 @@ describe('computeGraphRows', () => {
             const rows = computeGraphRows(commits);
             const laneSet = new Set(rows.map(r => r.lane));
             expect(laneSet.size).to.equal(8); // all distinct lanes
-            // Color of lane 7 is 7, lane 0 is 0
-            const lane7 = rows.find(r => r.lane === 7);
-            expect(lane7).to.not.be.undefined;
-            expect(lane7!.color).to.equal(7);
+            // Default colors never use the reserved ref color indices 0-2
+            rows.forEach(r => expect(r.color).to.be.within(3, 7));
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // Ref-based colors (VS Code colorMap: current=0, remote=1, base=2)
+    // -------------------------------------------------------------------------
+    describe('ref-based colors', () => {
+        // Remote is one commit ahead: R (origin/main) → L (main = HEAD) → A
+        const behindCommits = [
+            { id: 'R', parentIds: ['L'], colorIndex: 1 },
+            { id: 'L', parentIds: ['A'], colorIndex: 0 },
+            { id: 'A', parentIds: [] },
+        ];
+
+        it('a tip with a color index colors its row', () => {
+            const rows = computeGraphRows(behindCommits);
+            expect(rows[0].color).to.equal(1);
+        });
+
+        it('an overriding commit recolors the chain from its row downward', () => {
+            const rows = computeGraphRows(behindCommits);
+            expect(rows[1].color).to.equal(0);
+            expect(rows[2].color).to.equal(0);
+        });
+
+        it('topColor keeps the inherited color for the segment above an overriding commit', () => {
+            const rows = computeGraphRows(behindCommits);
+            expect(rows[0].topColor).to.equal(1);
+            expect(rows[1].topColor).to.equal(1);
+            expect(rows[2].topColor).to.equal(0);
+        });
+
+        // Diverged: L (main = HEAD) and R (origin/main) both branched off A
+        const divergedCommits = [
+            { id: 'L', parentIds: ['A'], colorIndex: 0 },
+            { id: 'R', parentIds: ['A'], colorIndex: 1 },
+            { id: 'A', parentIds: [] },
+        ];
+
+        it('pass-through edges use the propagated ref color', () => {
+            const rows = computeGraphRows(divergedCommits);
+            const pass = rows[1].edges.find(e => e.type === 'pass-through');
+            expect(pass?.color).to.equal(0);
+        });
+
+        it('merge-in edges from a ref-colored lane keep that color', () => {
+            const rows = computeGraphRows(divergedCommits);
+            const mergeIn = rows[2].edges.find(e => e.type === 'merge-in');
+            expect(mergeIn?.color).to.equal(1);
         });
     });
 

--- a/packages/scm/src/browser/scm-history-graph-lanes.ts
+++ b/packages/scm/src/browser/scm-history-graph-lanes.ts
@@ -47,8 +47,14 @@ export interface GraphEdge {
 export interface GraphRow {
     /** Lane index where the commit node is rendered. */
     readonly lane: number;
-    /** Color index for the commit node dot. */
+    /** Color index for the commit node dot and the lane segment below it. */
     readonly color: number;
+    /**
+     * Color index for the lane segment above the commit node. Differs from
+     * `color` when this commit's ref color overrides the color inherited from
+     * the chain above (e.g. the current branch tip below remote-only commits).
+     */
+    readonly topColor: number;
     /** Edges crossing or originating on this row. */
     readonly edges: readonly GraphEdge[];
     /**
@@ -71,10 +77,28 @@ export interface GraphRow {
 interface MutableGraphRow {
     lane: number;
     color: number;
+    topColor: number;
     edges: GraphEdge[];
     hasContinuation: boolean;
     hasTopLine: boolean;
 }
+
+export interface GraphCommitInput {
+    id: string;
+    parentIds?: readonly string[];
+    /**
+     * Ref-based color index resolved from the commit's references
+     * (0 = current ref, 1 = remote ref, 2 = base ref). When set, it colors
+     * this row and propagates down the first-parent chain, mirroring
+     * VS Code's scm graph color map.
+     */
+    colorIndex?: number;
+}
+
+/** First color index of the default rotation (`scmGraph.foreground1`). */
+const DEFAULT_COLOR_FIRST = 3;
+/** Number of default rotation colors (`scmGraph.foreground1-5`). */
+const DEFAULT_COLOR_COUNT = 5;
 
 /**
  * Compute graph rows for an ordered list of commits (topological order,
@@ -84,13 +108,21 @@ interface MutableGraphRow {
  * @returns One `GraphRow` per commit in the same order.
  */
 export function computeGraphRows(
-    commits: ReadonlyArray<{ id: string; parentIds?: readonly string[] }>
+    commits: ReadonlyArray<GraphCommitInput>
 ): GraphRow[] {
     // lanes[i] = id of commit that "owns" lane i (i.e. we are waiting for this
     // commit to appear in the list so we can close the lane).
     const lanes: (string | undefined)[] = [];
-    // laneColors[i] = the color index permanently assigned to lane i
+    // laneColors[i] = the color index currently assigned to lane i
     const laneColors: (number | undefined)[] = [];
+
+    // Default lane colors rotate through foreground1-5, like VS Code's
+    // color registry; indices 0-2 are reserved for ref-based colors.
+    let rotation = -1;
+    const nextDefaultColor = (): number => {
+        rotation = (rotation + 1) % DEFAULT_COLOR_COUNT;
+        return DEFAULT_COLOR_FIRST + rotation;
+    };
 
     const rows: MutableGraphRow[] = [];
 
@@ -106,10 +138,15 @@ export function computeGraphRows(
             // Not yet tracked → open a new lane
             myLane = firstFreeLane(lanes);
             lanes[myLane] = commit.id;
-            laneColors[myLane] = myLane % 8;
+            laneColors[myLane] = commit.colorIndex ?? nextDefaultColor();
         }
 
-        const myColor = laneColors[myLane] ?? myLane % 8;
+        // The segment above the commit keeps the color inherited from the
+        // chain above; the commit's own ref color (if any) takes over from
+        // this row downward.
+        const topColor = laneColors[myLane] ?? DEFAULT_COLOR_FIRST;
+        const myColor = commit.colorIndex ?? topColor;
+        laneColors[myLane] = myColor;
 
         // Collect any duplicate lane occupants: other lanes that were kept
         // alive pointing at this same commit (sibling branch tips whose lane
@@ -120,7 +157,7 @@ export function computeGraphRows(
         if (hasTopLine) {
             for (let li = 0; li < lanes.length; li++) {
                 if (lanes[li] === commit.id && li !== myLane) {
-                    duplicateLanes.push({ lane: li, color: laneColors[li] ?? li % 8 });
+                    duplicateLanes.push({ lane: li, color: laneColors[li] ?? DEFAULT_COLOR_FIRST });
                     lanes[li] = undefined;
                     laneColors[li] = undefined;
                 }
@@ -170,7 +207,7 @@ export function computeGraphRows(
                     // Additional parents get new lanes — branch-out
                     const newLane = firstFreeLane(lanes);
                     lanes[newLane] = pid;
-                    laneColors[newLane] = newLane % 8;
+                    laneColors[newLane] = nextDefaultColor();
                     parentLanes.push(newLane);
                     parentIsExisting.push(false);
                 }
@@ -206,7 +243,7 @@ export function computeGraphRows(
             if (!occupant || occupant === commit.id) {
                 continue;
             }
-            const color = laneColors[li] ?? li % 8;
+            const color = laneColors[li] ?? DEFAULT_COLOR_FIRST;
             edges.push({ fromLane: li, toLane: li, color, type: 'pass-through' });
         }
 
@@ -225,11 +262,11 @@ export function computeGraphRows(
             if (isExisting) {
                 // Merge-in: an existing lane at the top of the row curves into
                 // the commit position at mid-row.
-                const color = laneColors[toLane] ?? toLane % 8;
+                const color = laneColors[toLane] ?? DEFAULT_COLOR_FIRST;
                 edges.push({ fromLane: toLane, toLane: myLane, color, type: 'merge-in' });
             } else {
                 // Branch-out: the commit spawns a new lane below mid-row.
-                const color = laneColors[toLane] ?? toLane % 8;
+                const color = laneColors[toLane] ?? DEFAULT_COLOR_FIRST;
                 edges.push({ fromLane: myLane, toLane, color, type: 'branch-out' });
             }
         }
@@ -245,7 +282,7 @@ export function computeGraphRows(
         // at the parent) so it persists as a pass-through to the parent row.
         const hasContinuation = parentIds.length > 0 && (parentLanes[0] === myLane || lanes[myLane] === parentIds[0]);
 
-        rows.push({ lane: myLane, color: myColor, edges, hasContinuation, hasTopLine });
+        rows.push({ lane: myLane, color: myColor, topColor, edges, hasContinuation, hasTopLine });
     }
 
     return rows;

--- a/packages/scm/src/browser/scm-history-graph-model.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.spec.ts
@@ -21,9 +21,9 @@ import { ScmHistoryItem, ScmHistoryItemRef, ScmHistoryItemChange, ScmHistoryOpti
 import { ScmRepository } from './scm-repository';
 
 class StubHistoryProvider implements ScmHistoryProvider {
-    readonly currentHistoryItemRef: ScmHistoryItemRef | undefined;
-    readonly currentHistoryItemRemoteRef: ScmHistoryItemRef | undefined;
-    readonly currentHistoryItemBaseRef: ScmHistoryItemRef | undefined;
+    currentHistoryItemRef: ScmHistoryItemRef | undefined;
+    currentHistoryItemRemoteRef: ScmHistoryItemRef | undefined;
+    currentHistoryItemBaseRef: ScmHistoryItemRef | undefined;
 
     readonly onDidChangeCurrentHistoryItemRefs = new Emitter<void>().event;
     readonly onDidChangeHistoryItemRefs = new Emitter<{
@@ -167,5 +167,65 @@ describe('ScmHistoryGraphModel - pagination', () => {
 
         await loadPage();
         expect(model.entries).to.have.length(PAGE_SIZE, 'should not grow when all items are duplicates');
+    });
+});
+
+describe('ScmHistoryGraphModel - ref colors and current item', () => {
+
+    const mainRef: ScmHistoryItemRef = { id: 'refs/heads/main', name: 'main', revision: 'c2' };
+    const originMainRef: ScmHistoryItemRef = { id: 'refs/remotes/origin/main', name: 'origin/main', revision: 'c1' };
+
+    /** Remote is one commit ahead: c1 (origin/main) → c2 (main = HEAD) → c3. */
+    function createBehindProvider(): StubHistoryProvider {
+        const provider = new StubHistoryProvider();
+        provider.currentHistoryItemRef = mainRef;
+        provider.currentHistoryItemRemoteRef = originMainRef;
+        provider.pages = [[
+            { id: 'c1', subject: 'remote only', parentIds: ['c2'], references: [originMainRef] },
+            { id: 'c2', subject: 'local head', parentIds: ['c3'], references: [mainRef] },
+            { id: 'c3', subject: 'base', parentIds: [] },
+        ]];
+        return provider;
+    }
+
+    it('colors the remote ref tip with the remote ref color', async () => {
+        const { model, loadPage } = createModel(createBehindProvider());
+        await loadPage();
+        expect(model.entries[0].graphRow.color).to.equal(1);
+    });
+
+    it('colors the current ref chain with the current ref color', async () => {
+        const { model, loadPage } = createModel(createBehindProvider());
+        await loadPage();
+        expect(model.entries[1].graphRow.color).to.equal(0);
+        expect(model.entries[2].graphRow.color).to.equal(0);
+    });
+
+    it('prefers the current ref color when a commit carries both local and remote refs', async () => {
+        const provider = new StubHistoryProvider();
+        const syncedMain: ScmHistoryItemRef = { ...mainRef, revision: 'c1' };
+        const syncedRemote: ScmHistoryItemRef = { ...originMainRef, revision: 'c1' };
+        provider.currentHistoryItemRef = syncedMain;
+        provider.currentHistoryItemRemoteRef = syncedRemote;
+        provider.pages = [[
+            { id: 'c1', subject: 'in sync', parentIds: [], references: [syncedRemote, syncedMain] },
+        ]];
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        expect(model.entries[0].graphRow.color).to.equal(0);
+    });
+
+    it('marks only the entry at the current ref revision as current', async () => {
+        const { model, loadPage } = createModel(createBehindProvider());
+        await loadPage();
+        expect(model.entries.map(e => e.isCurrent)).to.deep.equal([false, true, false]);
+    });
+
+    it('marks no entry as current when the provider has no current ref', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, 3)];
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        expect(model.entries.every(e => !e.isCurrent)).to.be.true;
     });
 });

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -21,12 +21,15 @@ import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { ScmService } from './scm-service';
 import { ScmHistoryItem, ScmHistoryProvider, ScmHistoryOptions } from './scm-provider';
 import { computeGraphRows, GraphRow } from './scm-history-graph-lanes';
+import { getRefColorIndex } from './scm-history-graph-helpers';
 
 export const PAGE_SIZE = 50;
 
 export interface HistoryGraphEntry {
     readonly item: ScmHistoryItem;
     readonly graphRow: GraphRow;
+    /** True when this item is the commit the current history item ref points at (HEAD). */
+    readonly isCurrent: boolean;
 }
 
 @injectable()
@@ -164,11 +167,14 @@ export class ScmHistoryGraphModel {
             const graphRows = computeGraphRows(allItems.map(i => ({
                 id: i.id,
                 parentIds: i.parentIds,
+                colorIndex: this.resolveColorIndex(i),
             })));
 
+            const currentRevision = this._provider.currentHistoryItemRef?.revision;
             this._entries = allItems.map((item, idx) => ({
                 item,
                 graphRow: graphRows[idx],
+                isCurrent: currentRevision !== undefined && item.id === currentRevision,
             }));
         } catch (err) {
             if (!token.isCancellationRequested) {
@@ -181,6 +187,21 @@ export class ScmHistoryGraphModel {
                 this.onDidChangeEmitter.fire();
             }
         }
+    }
+
+    /**
+     * Resolves the ref-based color index of an item from its references,
+     * preferring current (0) over remote (1) over base (2).
+     */
+    protected resolveColorIndex(item: ScmHistoryItem): number | undefined {
+        let result: number | undefined;
+        for (const ref of item.references ?? []) {
+            const index = getRefColorIndex(ref, this._provider);
+            if (index !== undefined && (result === undefined || index < result)) {
+                result = index;
+            }
+        }
+        return result;
     }
 
     /**

--- a/packages/scm/src/browser/scm-history-graph-tooltip.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-tooltip.spec.ts
@@ -1,0 +1,254 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { MarkdownString, MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import { OpenerService } from '@theia/core/lib/browser/opener-service';
+import { markMarkdownLinksWired } from '@theia/core/lib/browser/markdown-rendering/markdown-link-handler';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import URI from '@theia/core/lib/common/uri';
+import { ScmHistoryItem } from './scm-provider';
+import { HistoryGraphEntry } from './scm-history-graph-model';
+import { buildHtmlTooltip, buildProviderTooltip, HistoryTooltipActions } from './scm-history-graph-tooltip';
+
+disableJSDOM();
+
+function makeEntry(item: Partial<ScmHistoryItem>): HistoryGraphEntry {
+    return {
+        item: {
+            id: '1a56ba96fdc9b6df3a230df7b44e22e5785e3abd',
+            subject: 'fix something',
+            parentIds: [],
+            ...item,
+        },
+        graphRow: { lane: 0, color: 0, topColor: 0, edges: [], hasContinuation: false, hasTopLine: false },
+        isCurrent: false,
+    };
+}
+
+const markdownRenderer = {
+    render: () => ({ element: document.createElement('div'), dispose: () => { } })
+} as unknown as MarkdownRenderer;
+
+describe('buildHtmlTooltip', () => {
+    let restoreJSDOM: () => void;
+
+    before(() => {
+        restoreJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        restoreJSDOM();
+    });
+
+    it('renders the author as a bold mailto link when the email is known', () => {
+        const tooltip = buildHtmlTooltip(makeEntry({ author: 'Jane Doe', authorEmail: 'jane@example.com', timestamp: 1000 }), markdownRenderer);
+        const link = tooltip.querySelector('a[href="mailto:jane@example.com"]');
+        expect(link, 'mailto link').to.not.be.null;
+        expect(link!.textContent).to.contain('Jane Doe');
+        expect(link!.querySelector('strong'), 'bold author').to.not.be.null;
+    });
+
+    it('renders a plain bold author when no email is known', () => {
+        const tooltip = buildHtmlTooltip(makeEntry({ author: 'Jane Doe', timestamp: 1000 }), markdownRenderer);
+        expect(tooltip.querySelector('a[href^="mailto:"]')).to.be.null;
+        const strong = tooltip.querySelector('.scm-history-tooltip-header strong');
+        expect(strong).to.not.be.null;
+        expect(strong!.textContent).to.equal('Jane Doe');
+    });
+
+    it('renders the author avatar image when authorIcon is a URL', () => {
+        const tooltip = buildHtmlTooltip(makeEntry({ author: 'Jane Doe', authorIcon: 'https://avatars.example.com/u/1' }), markdownRenderer);
+        const img = tooltip.querySelector('img.scm-history-tooltip-avatar') as HTMLImageElement;
+        expect(img, 'avatar image').to.not.be.null;
+        expect(img.src).to.equal('https://avatars.example.com/u/1');
+    });
+
+    it('falls back to the account icon without an avatar', () => {
+        const tooltip = buildHtmlTooltip(makeEntry({ author: 'Jane Doe' }), markdownRenderer);
+        expect(tooltip.querySelector('img.scm-history-tooltip-avatar')).to.be.null;
+        expect(tooltip.querySelector('.scm-history-tooltip-header .codicon-account')).to.not.be.null;
+    });
+
+    it('renders an Open Commit action with the short hash', () => {
+        let opened = 0;
+        const actions: HistoryTooltipActions = { openCommit: () => { opened++; } };
+        const tooltip = buildHtmlTooltip(makeEntry({ displayId: '1a56ba9' }), markdownRenderer, undefined, actions);
+        const action = tooltip.querySelector('[title="Open Commit"]') as HTMLElement;
+        expect(action, 'open commit action').to.not.be.null;
+        expect(action.textContent).to.contain('1a56ba9');
+        action.click();
+        expect(opened).to.equal(1);
+    });
+
+    it('renders a Copy Commit Hash action', () => {
+        let copied = 0;
+        const actions: HistoryTooltipActions = { copyCommitHash: () => { copied++; } };
+        const tooltip = buildHtmlTooltip(makeEntry({}), markdownRenderer, undefined, actions);
+        const action = tooltip.querySelector('[title="Copy Commit Hash"]') as HTMLElement;
+        expect(action, 'copy hash action').to.not.be.null;
+        action.click();
+        expect(copied).to.equal(1);
+    });
+
+    it('shows the short hash as plain text when no actions are given', () => {
+        const tooltip = buildHtmlTooltip(makeEntry({ displayId: '1a56ba9' }), markdownRenderer);
+        expect(tooltip.querySelector('[title="Open Commit"]')).to.be.null;
+        expect(tooltip.querySelector('[title="Copy Commit Hash"]')).to.be.null;
+        expect(tooltip.textContent).to.contain('1a56ba9');
+    });
+});
+
+describe('buildProviderTooltip', () => {
+    let restoreJSDOM: () => void;
+    let opened: string[];
+    let toDispose: DisposableCollection;
+
+    /** Renders the markdown value as HTML, so that the wiring of the resulting links can be asserted. */
+    const htmlRenderer = {
+        render: (markdown: MarkdownString) => {
+            const element = document.createElement('div');
+            element.innerHTML = markdown.value;
+            return { element, dispose: () => { } };
+        }
+    } as unknown as MarkdownRenderer;
+
+    const openerService = {
+        getOpener: (uri: URI) => Promise.resolve({
+            canHandle: () => 1,
+            open: () => {
+                // decoded, as `HttpOpenHandler` does when opening the target externally
+                opened.push(uri.toString(true));
+                return Promise.resolve(undefined);
+            }
+        })
+    } as unknown as OpenerService;
+
+    /** Clicks the anchor and waits for the asynchronous opener lookup to settle. */
+    async function click(tooltip: HTMLElement, selector: string): Promise<void> {
+        const anchor = tooltip.querySelector(selector) as HTMLElement;
+        expect(anchor, selector).to.not.be.null;
+        anchor.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        await new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    before(() => {
+        restoreJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        restoreJSDOM();
+    });
+
+    beforeEach(() => {
+        opened = [];
+        toDispose = new DisposableCollection();
+    });
+
+    afterEach(() => {
+        toDispose.dispose();
+    });
+
+    it('renders each section in order', () => {
+        const tooltip = buildProviderTooltip(
+            [new MarkdownStringImpl('<span>first</span>'), new MarkdownStringImpl('<span>second</span>')],
+            htmlRenderer, openerService, toDispose)!;
+        expect(tooltip, 'tooltip').to.not.be.undefined;
+        expect(tooltip.textContent).to.equal('firstsecond');
+    });
+
+    // `vscode.git` ends its author and statistics sections with a horizontal rule of its own,
+    // so adding separators here would render every boundary as a double line.
+    it('adds no separators of its own between sections', () => {
+        const tooltip = buildProviderTooltip(
+            [new MarkdownStringImpl('<span>first</span><hr>'), new MarkdownStringImpl('<span>second</span>')],
+            htmlRenderer, openerService, toDispose)!;
+        expect(tooltip.querySelectorAll('hr').length, 'rules').to.equal(1);
+    });
+
+    it('renders a plain string tooltip', () => {
+        const tooltip = buildProviderTooltip('just text', htmlRenderer, openerService, toDispose)!;
+        expect(tooltip, 'tooltip').to.not.be.undefined;
+        expect(tooltip.textContent).to.equal('just text');
+    });
+
+    it('returns undefined when the provider supplies no usable content', () => {
+        expect(buildProviderTooltip('   ', htmlRenderer, openerService, toDispose)).to.be.undefined;
+        expect(buildProviderTooltip([], htmlRenderer, openerService, toDispose)).to.be.undefined;
+    });
+
+    it('routes an author mailto link through the opener service', async () => {
+        const tooltip = buildProviderTooltip(
+            new MarkdownStringImpl('<a href="mailto:jane@example.com">Jane Doe</a>'), htmlRenderer, openerService, toDispose)!;
+        await click(tooltip, 'a[href^="mailto:"]');
+        expect(opened).to.deep.equal(['mailto:jane@example.com']);
+    });
+
+    it('executes a command link that the section trusts', async () => {
+        const section = new MarkdownStringImpl('<a href="command:git.viewCommit">Open Commit</a>');
+        section.isTrusted = { enabledCommands: ['git.viewCommit'] };
+        const tooltip = buildProviderTooltip(section, htmlRenderer, openerService, toDispose)!;
+        await click(tooltip, 'a[href^="command:"]');
+        expect(opened).to.deep.equal(['command:git.viewCommit']);
+    });
+
+    it('blocks a command link that the section does not trust', async () => {
+        const section = new MarkdownStringImpl('<a href="command:git.viewCommit">Open Commit</a>');
+        section.isTrusted = { enabledCommands: ['git.copyContentToClipboard'] };
+        const tooltip = buildProviderTooltip(section, htmlRenderer, openerService, toDispose)!;
+        await click(tooltip, 'a[href^="command:"]');
+        expect(opened).to.be.empty;
+    });
+
+    it('does not open a link twice when the renderer already wired it', async () => {
+        // The Monaco-based renderer used at runtime routes link activation through the opener
+        // service itself, so wiring a second handler on top would open every link twice.
+        const wiringRenderer = {
+            render: (markdown: MarkdownString) => {
+                const element = document.createElement('div');
+                element.innerHTML = markdown.value;
+                markMarkdownLinksWired(element);
+                element.addEventListener('click', event => {
+                    event.preventDefault();
+                    opened.push((event.target as HTMLElement).getAttribute('href')!);
+                });
+                return { element, dispose: () => { } };
+            }
+        } as unknown as MarkdownRenderer;
+
+        const section = new MarkdownStringImpl('<a href="command:git.viewCommit">Open Commit</a>');
+        section.isTrusted = { enabledCommands: ['git.viewCommit'] };
+        const tooltip = buildProviderTooltip(section, wiringRenderer, openerService, toDispose)!;
+        await click(tooltip, 'a[href^="command:"]');
+        expect(opened).to.deep.equal(['command:git.viewCommit']);
+    });
+
+    it('does not let one section authorize another section\'s commands', async () => {
+        const untrusted = new MarkdownStringImpl('<a id="untrusted" href="command:git.viewCommit">Open Commit</a>');
+        const trusted = new MarkdownStringImpl('<a id="trusted" href="command:git.copyContentToClipboard">Copy</a>');
+        trusted.isTrusted = { enabledCommands: ['git.copyContentToClipboard'] };
+        const tooltip = buildProviderTooltip([untrusted, trusted], htmlRenderer, openerService, toDispose)!;
+
+        await click(tooltip, 'a#untrusted');
+        expect(opened, 'untrusted section').to.be.empty;
+        await click(tooltip, 'a#trusted');
+        expect(opened, 'trusted section').to.deep.equal(['command:git.copyContentToClipboard']);
+    });
+});

--- a/packages/scm/src/browser/scm-history-graph-tooltip.ts
+++ b/packages/scm/src/browser/scm-history-graph-tooltip.ts
@@ -15,10 +15,13 @@
 // *****************************************************************************
 
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
-import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import { wireMarkdownLinkHandler } from '@theia/core/lib/browser/markdown-rendering/markdown-link-handler';
+import { MarkdownString, MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import { OpenerService } from '@theia/core/lib/browser/opener-service';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { codicon } from '@theia/core/lib/browser/widgets/widget';
 import { nls } from '@theia/core/lib/common/nls';
-import { ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
+import { ScmHistoryItem, ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
 import { HistoryGraphEntry } from './scm-history-graph-model';
 import { laneColor, getRefBadgeClass, getRefBadgePresentation, deduplicateRefs, isTagRef, isRemoteRef } from './scm-history-graph-helpers';
 
@@ -75,6 +78,100 @@ export function createHoverHr(): HTMLElement {
     return document.createElement('hr');
 }
 
+export interface HistoryTooltipActions {
+    /** Invoked when the user clicks the commit hash (mirrors VS Code's "Open Commit" hover command). */
+    openCommit?: () => void;
+    /** Invoked when the user clicks the copy action (mirrors VS Code's "Copy Commit Hash" hover command). */
+    copyCommitHash?: () => void;
+}
+
+/**
+ * Renders the hover content supplied by the history provider, if any.
+ *
+ * Providers own their hover: `vscode.git`, for example, sends the same content as the blame
+ * editor decoration hover, including the author `mailto:` link and the "Open Commit",
+ * "Copy Commit Hash" and remote (e.g. "Open on GitHub") command links. Rendering it verbatim
+ * keeps those actions working without the graph having to know any provider-specific command.
+ *
+ * Each section is rendered and wired separately so that a section only authorizes the commands
+ * declared in its own {@link MarkdownString.isTrusted}. Sections are rendered as given, without
+ * separators of our own: a provider that owns its hover also owns how its sections are delimited,
+ * and `vscode.git` for one already ends them with a horizontal rule.
+ *
+ * @returns the rendered element, or `undefined` if the provider supplied no usable content.
+ */
+export function buildProviderTooltip(
+    tooltip: string | MarkdownString | readonly MarkdownString[],
+    markdownRenderer: MarkdownRenderer,
+    openerService: OpenerService,
+    disposables: DisposableCollection
+): HTMLElement | undefined {
+    const sections = (typeof tooltip === 'string' ? [new MarkdownStringImpl(tooltip)] : Array.isArray(tooltip) ? tooltip : [tooltip as MarkdownString])
+        .filter(section => section.value.trim().length > 0);
+    if (sections.length === 0) {
+        return undefined;
+    }
+
+    const container = document.createElement('div');
+    container.className = 'scm-history-tooltip';
+    for (const section of sections) {
+        const rendered = markdownRenderer.render(section);
+        disposables.push(rendered);
+        disposables.push(wireMarkdownLinkHandler(rendered.element, section, openerService));
+        container.appendChild(rendered.element);
+    }
+    return container;
+}
+
+/**
+ * Appends the author part of the tooltip header: the avatar image (or account
+ * icon) followed by the bold author name, linked via `mailto:` when the email
+ * is known — the same structure as the git blame editor decoration hover.
+ */
+function appendAuthor(container: HTMLElement, item: ScmHistoryItem): void {
+    if (item.authorIcon && (item.authorIcon.startsWith('http://') || item.authorIcon.startsWith('https://'))) {
+        const avatar = document.createElement('img');
+        avatar.className = 'scm-history-tooltip-avatar';
+        avatar.src = item.authorIcon;
+        container.appendChild(avatar);
+    } else {
+        const icon = document.createElement('i');
+        icon.className = codicon('account') + ' icon-inline';
+        container.appendChild(icon);
+    }
+    container.appendChild(document.createTextNode(' '));
+
+    const name = document.createElement('strong');
+    name.textContent = item.author!;
+    if (item.authorEmail) {
+        const link = document.createElement('a');
+        link.href = `mailto:${item.authorEmail}`;
+        link.appendChild(name);
+        container.appendChild(link);
+    } else {
+        container.appendChild(name);
+    }
+}
+
+/** Creates a clickable tooltip action (icon + optional label). */
+function createTooltipAction(title: string, iconName: string, label: string | undefined, onClick: () => void): HTMLElement {
+    const action = document.createElement('a');
+    action.className = 'scm-history-tooltip-action';
+    action.title = title;
+    action.setAttribute('role', 'button');
+    const icon = document.createElement('i');
+    icon.className = codicon(iconName) + ' icon-inline';
+    action.appendChild(icon);
+    if (label) {
+        action.appendChild(document.createTextNode(` ${label}`));
+    }
+    action.onclick = e => {
+        e.preventDefault();
+        onClick();
+    };
+    return action;
+}
+
 /** Creates a ref badge element for the HTML tooltip. */
 export function buildTooltipRefBadge(
     ref: ScmHistoryItemRef,
@@ -100,28 +197,32 @@ export function buildTooltipRefBadge(
     return badge;
 }
 
-export function buildHtmlTooltip(entry: HistoryGraphEntry, markdownRenderer: MarkdownRenderer, provider?: ScmHistoryProvider): HTMLElement {
+export function buildHtmlTooltip(
+    entry: HistoryGraphEntry,
+    markdownRenderer: MarkdownRenderer,
+    provider?: ScmHistoryProvider,
+    actions?: HistoryTooltipActions
+): HTMLElement {
     const { item } = entry;
     const badgeColor = laneColor(entry.graphRow.color);
     const container = document.createElement('div');
     container.className = 'scm-history-tooltip';
 
-    // Header
+    // Header - avatar/account icon, bold author (mailto link), relative + absolute date,
+    // matching the git blame editor decoration hover
     if (item.author || item.timestamp !== undefined) {
         const header = document.createElement('div');
         header.className = 'scm-history-tooltip-header';
-        header.style.fontWeight = 'bold';
-        header.style.marginBottom = '4px';
 
         if (item.author) {
-            appendIconText(header, 'account', item.author);
+            appendAuthor(header, item);
         }
         if (item.timestamp !== undefined) {
             if (item.author) {
-                header.appendChild(document.createTextNode('\u00a0\u00a0'));
+                header.appendChild(document.createTextNode(',\u00a0'));
             }
             const timeSpan = document.createElement('span');
-            appendIconText(timeSpan, 'clock', `${formatRelativeTime(item.timestamp)} (${formatAbsoluteDate(item.timestamp)})`);
+            appendIconText(timeSpan, 'history', `${formatRelativeTime(item.timestamp)} (${formatAbsoluteDate(item.timestamp)})`);
             header.appendChild(timeSpan);
         }
 
@@ -170,8 +271,10 @@ export function buildHtmlTooltip(entry: HistoryGraphEntry, markdownRenderer: Mar
     }
 
     // Refs + hash
+    const shortHash = item.displayId ?? item.id.substring(0, 7);
+    const hasActions = !!(actions?.openCommit || actions?.copyCommitHash);
     const hasRefs = item.references && item.references.length > 0;
-    if (hasRefs || item.displayId) {
+    if (hasRefs || (!hasActions && item.displayId)) {
         container.appendChild(createHoverHr());
 
         const refsRow = document.createElement('div');
@@ -195,13 +298,35 @@ export function buildHtmlTooltip(entry: HistoryGraphEntry, markdownRenderer: Mar
             }
         }
 
-        if (item.displayId) {
+        if (!hasActions && item.displayId) {
             const hash = document.createElement('code');
             hash.textContent = item.displayId;
             refsRow.appendChild(hash);
         }
 
         container.appendChild(refsRow);
+    }
+
+    // Actions — commit hash and copy, matching the git blame hover's command links
+    if (hasActions) {
+        container.appendChild(createHoverHr());
+
+        const actionsRow = document.createElement('div');
+        actionsRow.className = 'scm-history-tooltip-actions';
+
+        if (actions?.openCommit) {
+            actionsRow.appendChild(createTooltipAction(
+                nls.localize('theia/scm/openCommit', 'Open Commit'), 'git-commit', shortHash, actions.openCommit));
+        }
+        if (actions?.copyCommitHash) {
+            if (actions.openCommit) {
+                actionsRow.appendChild(document.createTextNode('  '));
+            }
+            actionsRow.appendChild(createTooltipAction(
+                nls.localize('theia/scm/copyCommitHash', 'Copy Commit Hash'), 'copy', undefined, actions.copyCommitHash));
+        }
+
+        container.appendChild(actionsRow);
     }
 
     return container;

--- a/packages/scm/src/browser/scm-history-graph-tooltip.ts
+++ b/packages/scm/src/browser/scm-history-graph-tooltip.ts
@@ -18,9 +18,9 @@ import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/mar
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
 import { codicon } from '@theia/core/lib/browser/widgets/widget';
 import { nls } from '@theia/core/lib/common/nls';
-import { ScmHistoryItemRef } from './scm-provider';
+import { ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
 import { HistoryGraphEntry } from './scm-history-graph-model';
-import { laneColor, getRefBadgeClass, deduplicateRefs, isTagRef, isRemoteRef } from './scm-history-graph-helpers';
+import { laneColor, getRefBadgeClass, getRefBadgePresentation, deduplicateRefs, isTagRef, isRemoteRef } from './scm-history-graph-helpers';
 
 export function formatRelativeTime(ms: number): string {
     const now = Date.now();
@@ -100,7 +100,7 @@ export function buildTooltipRefBadge(
     return badge;
 }
 
-export function buildHtmlTooltip(entry: HistoryGraphEntry, markdownRenderer: MarkdownRenderer): HTMLElement {
+export function buildHtmlTooltip(entry: HistoryGraphEntry, markdownRenderer: MarkdownRenderer, provider?: ScmHistoryProvider): HTMLElement {
     const { item } = entry;
     const badgeColor = laneColor(entry.graphRow.color);
     const container = document.createElement('div');
@@ -184,18 +184,13 @@ export function buildHtmlTooltip(entry: HistoryGraphEntry, markdownRenderer: Mar
         if (hasRefs) {
             const deduplicated = deduplicateRefs(item.references!);
             for (const { ref, hasBoth } of deduplicated) {
-                const isTag = isTagRef(ref);
-                const isRemote = isRemoteRef(ref);
+                // Current/remote/base refs are colored by role, others by the row's lane color
+                const { iconClass, colorIndex } = getRefBadgePresentation(ref, provider);
+                const bgColor = colorIndex !== undefined ? laneColor(colorIndex) : badgeColor;
 
-                if (isTag) {
-                    refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-tag', true, badgeColor));
-                } else if (isRemote) {
-                    refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-cloud', true, badgeColor));
-                } else {
-                    refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-git-branch', true, badgeColor));
-                    if (hasBoth) {
-                        refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-cloud', false, badgeColor, 'scm-history-ref-badge-cloud'));
-                    }
+                refsRow.appendChild(buildTooltipRefBadge(ref, iconClass, true, bgColor));
+                if (!isTagRef(ref) && !isRemoteRef(ref) && hasBoth) {
+                    refsRow.appendChild(buildTooltipRefBadge(ref, 'codicon-cloud', false, bgColor, 'scm-history-ref-badge-cloud'));
                 }
             }
         }

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -20,6 +20,7 @@ import { injectable, inject, postConstruct } from '@theia/core/shared/inversify'
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
 import { HoverService } from '@theia/core/lib/browser/hover-service';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { MarkdownRenderer, MarkdownRendererFactory } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { ScmHistoryGraphModel, HistoryGraphEntry } from './scm-history-graph-model';
 import { ScmHistoryItemRef, ScmHistoryItemChange } from './scm-provider';
@@ -28,6 +29,7 @@ import { GraphRow } from './scm-history-graph-lanes';
 import URI from '@theia/core/lib/common/uri';
 import { nls } from '@theia/core/lib/common/nls';
 import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import { MenuPath } from '@theia/core/lib/common/menu/menu-types';
 import { ContextMenuRenderer } from '@theia/core/lib/browser/context-menu-renderer';
 import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
@@ -37,7 +39,7 @@ import {
     laneColor, getChangeStatus, getFileName, getFilePath, getRepoRelativePath,
     getRefBadgeClass, getRefBadgePresentation, isTagRef, isRemoteRef, deduplicateRefs, DeduplicatedRef
 } from './scm-history-graph-helpers';
-import { buildHtmlTooltip } from './scm-history-graph-tooltip';
+import { buildHtmlTooltip, buildProviderTooltip } from './scm-history-graph-tooltip';
 
 /** Menu path matching the VS Code 'scm/history/title' contribution point (graph section toolbar). */
 export const SCM_HISTORY_TITLE_MENU: MenuPath = ['plugin_scm/history/title'];
@@ -87,6 +89,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
 
     @inject(ScmHistoryGraphModel) protected readonly model: ScmHistoryGraphModel;
     @inject(HoverService) protected readonly hoverService: HoverService;
+    @inject(ClipboardService) protected readonly clipboardService: ClipboardService;
     @inject(MarkdownRendererFactory) protected readonly markdownRendererFactory: MarkdownRendererFactory;
     @inject(ScmService) protected readonly scmService: ScmService;
     @inject(LabelProvider) protected readonly labelProvider: LabelProvider;
@@ -103,6 +106,8 @@ export class ScmHistoryGraphWidget extends ReactWidget {
     protected expandedIds = new Set<string>();
     /** Map from commit id → in-flight CancellationTokenSource for loadChanges. */
     protected loadChangesCts = new Map<string, CancellationTokenSource>();
+    /** Cleanup for the content of the hover currently being shown. */
+    protected readonly toDisposeOnHover = new DisposableCollection();
 
     constructor() {
         super();
@@ -131,6 +136,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
                 this.loadChangesCts.clear();
             }
         });
+        this.toDispose.push(this.toDisposeOnHover);
         this.update();
     }
 
@@ -246,13 +252,48 @@ export class ScmHistoryGraphWidget extends ReactWidget {
     }
 
     protected handleRowMouseEnter = (e: React.MouseEvent<HTMLDivElement>, entry: HistoryGraphEntry): void => {
+        this.toDisposeOnHover.dispose();
         this.hoverService.requestHover({
-            content: buildHtmlTooltip(entry, this.markdownRenderer, this.model.provider),
+            content: this.buildTooltip(entry),
             target: e.currentTarget,
             position: 'right',
             interactive: true,
         });
     };
+
+    /**
+     * Prefers the hover content supplied by the provider, so that its own links and commands
+     * (author `mailto:`, "Open Commit", remote actions) stay intact, and falls back to the hover
+     * derived from the history item's fields for providers that supply none.
+     */
+    protected buildTooltip(entry: HistoryGraphEntry): HTMLElement {
+        const { tooltip } = entry.item;
+        if (tooltip) {
+            const provided = buildProviderTooltip(tooltip, this.markdownRenderer, this.openerService, this.toDisposeOnHover);
+            if (provided) {
+                return provided;
+            }
+        }
+        return buildHtmlTooltip(entry, this.markdownRenderer, this.model.provider, {
+            openCommit: () => this.openCommitFromTooltip(entry),
+            copyCommitHash: () => this.clipboardService.writeText(entry.item.id),
+        });
+    }
+
+    /** Selects the commit and expands its changes, closing the hover first. */
+    protected openCommitFromTooltip(entry: HistoryGraphEntry): void {
+        this.hoverService.cancelHover();
+        const idx = this.model.entries.indexOf(entry);
+        if (idx < 0) {
+            return;
+        }
+        if (this.expandedIds.has(entry.item.id)) {
+            this.selectedIndex = idx;
+            this.update();
+        } else {
+            this.handleRowClick(idx, entry);
+        }
+    }
 
     protected renderChangesRows(
         itemId: string,

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -35,7 +35,7 @@ import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import { ScmContextKeyService } from './scm-context-key-service';
 import {
     laneColor, getChangeStatus, getFileName, getFilePath, getRepoRelativePath,
-    getRefBadgeClass, isTagRef, isRemoteRef, deduplicateRefs, DeduplicatedRef
+    getRefBadgeClass, getRefBadgePresentation, isTagRef, isRemoteRef, deduplicateRefs, DeduplicatedRef
 } from './scm-history-graph-helpers';
 import { buildHtmlTooltip } from './scm-history-graph-tooltip';
 
@@ -211,8 +211,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
         const isSelected = idx === this.selectedIndex;
         const isExpanded = this.expandedIds.has(item.id);
         const changes = this.expandedChanges.get(item.id);
-        // The first commit (idx === 0) on lane 0 is treated as HEAD/current
-        const isHead = idx === 0 && graphRow.lane === 0;
+        const isHead = entry.isCurrent;
 
         return (
             <React.Fragment key={item.id}>
@@ -248,7 +247,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
 
     protected handleRowMouseEnter = (e: React.MouseEvent<HTMLDivElement>, entry: HistoryGraphEntry): void => {
         this.hoverService.requestHover({
-            content: buildHtmlTooltip(entry, this.markdownRenderer),
+            content: buildHtmlTooltip(entry, this.markdownRenderer, this.model.provider),
             target: e.currentTarget,
             position: 'right',
             interactive: true,
@@ -465,7 +464,9 @@ export class ScmHistoryGraphWidget extends ReactWidget {
 
         // Commit lane lines — split at cy=11
         // Top segment: only drawn if there is an incoming line from above
-        // (i.e. this commit was referenced as a parent by an earlier row)
+        // (i.e. this commit was referenced as a parent by an earlier row).
+        // It keeps the color inherited from the chain above, which may differ
+        // from the commit's own (ref-based) color.
         if (row.hasTopLine) {
             elements.push(
                 <path
@@ -474,7 +475,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
                     strokeWidth='1px'
                     strokeLinecap='round'
                     d={`M ${commitX} 0 V ${cy}`}
-                    style={{ stroke: commitColor }}
+                    style={{ stroke: laneColor(row.topColor) }}
                 />
             );
         }
@@ -563,11 +564,10 @@ export class ScmHistoryGraphWidget extends ReactWidget {
             return undefined;
         }
 
+        const provider = this.model.provider;
         const laneColorValue = entry ? laneColor(entry.graphRow.color) : undefined;
         const deduplicated = deduplicateRefs(refs);
-        const style: React.CSSProperties = laneColorValue
-            ? { backgroundColor: laneColorValue, color: 'var(--theia-scmGraph-historyItemRefForeground, var(--theia-badge-foreground))' }
-            : {};
+        const badgeForeground = 'var(--theia-scmGraph-historyItemRefForeground, var(--theia-badge-foreground))';
 
         const badges: React.ReactElement[] = [];
         for (const info of deduplicated) {
@@ -579,24 +579,25 @@ export class ScmHistoryGraphWidget extends ReactWidget {
             const isRemote = isRemoteRef(ref);
             const onContextMenu = entry ? (e: React.MouseEvent) => this.handleRefBadgeContextMenu(e, entry, ref) : undefined;
 
-            if (isTag) {
-                badges.push(renderJsxRefBadge(ref, 'codicon-tag', false, style, ref.id, onContextMenu));
-            } else if (isRemote) {
-                badges.push(renderJsxRefBadge(ref, 'codicon-cloud', true, style, ref.id, onContextMenu));
-            } else {
-                badges.push(renderJsxRefBadge(ref, 'codicon-git-branch', true, style, ref.id, onContextMenu));
-                if (hasBoth && badges.length < 3) {
-                    badges.push(
-                        <span
-                            key={`${ref.id}-cloud`}
-                            className='scm-history-ref-badge scm-history-ref-badge-cloud'
-                            title={ref.description ?? ref.name}
-                            style={style}
-                        >
-                            <i className='codicon codicon-cloud scm-history-ref-icon' />
-                        </span>
-                    );
-                }
+            // Current/remote/base refs are colored by role, others by the row's lane color
+            const { iconClass, colorIndex } = getRefBadgePresentation(ref, provider);
+            const backgroundColor = colorIndex !== undefined ? laneColor(colorIndex) : laneColorValue;
+            const style: React.CSSProperties = backgroundColor
+                ? { backgroundColor, color: badgeForeground }
+                : {};
+
+            badges.push(renderJsxRefBadge(ref, iconClass, !isTag, style, ref.id, onContextMenu));
+            if (!isTag && !isRemote && hasBoth && badges.length < 3) {
+                badges.push(
+                    <span
+                        key={`${ref.id}-cloud`}
+                        className='scm-history-ref-badge scm-history-ref-badge-cloud'
+                        title={ref.description ?? ref.name}
+                        style={style}
+                    >
+                        <i className='codicon codicon-cloud scm-history-ref-icon' />
+                    </span>
+                );
             }
         }
         return badges;

--- a/packages/scm/src/browser/scm-provider.ts
+++ b/packages/scm/src/browser/scm-provider.ts
@@ -19,6 +19,7 @@
 import { Disposable, Event } from '@theia/core/lib/common';
 import URI from '@theia/core/lib/common/uri';
 import { CancellationToken } from '@theia/core/lib/common/cancellation';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdown-string';
 
 export interface ScmProvider extends Disposable {
     readonly id: string;
@@ -145,7 +146,14 @@ export interface ScmHistoryItem {
     readonly authorIcon?: string;
     readonly displayId?: string;
     readonly timestamp?: number;
-    readonly tooltip?: string;
+    /**
+     * Hover content supplied by the provider. When present, it is rendered instead of the
+     * hover the history graph derives from the other fields, so that providers stay in control
+     * of their own links and commands. May be split into sections, which are rendered separated
+     * by horizontal rules. Note that `command:` links are only executed if the containing
+     * {@link MarkdownString} declares them via {@link MarkdownString.isTrusted}.
+     */
+    readonly tooltip?: string | MarkdownString | readonly MarkdownString[];
     readonly statistics?: ScmHistoryItemStatistics;
     readonly references?: readonly ScmHistoryItemRef[];
 }

--- a/packages/scm/src/browser/style/scm-history-graph.css
+++ b/packages/scm/src/browser/style/scm-history-graph.css
@@ -286,18 +286,59 @@
     opacity: 0.6;
 }
 
+/* Markdown rendered into the tooltip keeps the browser's default paragraph margins,
+   which spaces the commit hover out far more than the git blame hover it mirrors. */
+.scm-history-tooltip p {
+    margin: 0;
+}
+
+.scm-history-tooltip p + p {
+    margin-top: 4px;
+}
+
 /* ── Tooltip header icon alignment ──────────────────────────────────────── */
+.scm-history-tooltip-header {
+    margin-bottom: 4px;
+}
+
 .scm-history-tooltip-header .icon-inline {
     vertical-align: middle;
 }
 
+.scm-history-tooltip-header a {
+    color: var(--theia-textLink-foreground);
+    text-decoration: none;
+}
+
+.scm-history-tooltip-header a:hover {
+    text-decoration: underline;
+}
+
+.scm-history-tooltip-avatar {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    vertical-align: middle;
+}
+
+/* ── Tooltip actions (aligned with the git blame hover command links) ───── */
+.scm-history-tooltip-actions a.scm-history-tooltip-action {
+    color: var(--theia-textLink-foreground);
+    cursor: pointer;
+    text-decoration: none;
+}
+
+.scm-history-tooltip-actions a.scm-history-tooltip-action:hover {
+    text-decoration: underline;
+}
+
 /* ── Tooltip stat colors (used inside .theia-hover) ─────────────────────── */
 .scm-history-stat-added {
-    color: var(--theia-gitDecoration-addedResourceForeground, #388a34);
+    color: var(--theia-scmGraph-historyItemHoverAdditionsForeground, var(--theia-gitDecoration-addedResourceForeground, #388a34));
 }
 
 .scm-history-stat-deleted {
-    color: var(--theia-gitDecoration-deletedResourceForeground, #a1260d);
+    color: var(--theia-scmGraph-historyItemHoverDeletionsForeground, var(--theia-gitDecoration-deletedResourceForeground, #a1260d));
 }
 
 /* ── Empty state ─────────────────────────────────────────────────────────── */


### PR DESCRIPTION
#### What it does

Addresses items 2 and 6 of #17457.

**Item 2 — ref-role colors and current-commit indicator.** Mirrors VS Code's scm graph color map: the current, remote, and base refs color their commit row, ref badge, and downstream first-parent chain with `scmGraph.historyItemRefColor` / `historyItemRemoteRefColor` / `historyItemBaseRefColor`, while unmapped lanes rotate through `scmGraph.foreground1-5` instead of positional lane colors. Diverged local and remote branches are now visually distinct. The HEAD double-circle indicator is keyed to the current history item ref's revision (previously it guessed "first row on lane 0", which marked the wrong commit when the remote was ahead), and ref badges use the provider-supplied icon — e.g. the `target` icon vscode.git sends for the current branch — with category fallbacks.

Note: this intentionally changes default lane colors for providers without current-ref information (rotation through `foreground1-5`, as in VS Code) — indices 0-2 are now reserved for ref-role colors.

**Item 6 — hover content supplied by the provider.** The graph now renders the hover the history provider sends, rather than deriving one from the history item's fields. Providers already own this content: vscode.git supplies the same hover as its blame editor decoration — author avatar with the name as a `mailto:` link, `$(history)` icon with relative and absolute date, insertion/deletion stats in the `scmGraph.historyItemHover*Foreground` colors, and an actionable footer with "Open Commit" (`git.viewCommit`), "Copy Commit Hash" and the remote commands such as "Open on GitHub".

That content was previously discarded: `historyItemFromDto` flattened `tooltip` to `.value`, dropping both the `isTrusted` command allow-list — without which every command link is silently refused — and the array form providers use for multiple sections. `ScmHistoryItem.tooltip` now carries `MarkdownString`s through. Sections are wired separately, so each authorizes only the commands declared in its own `isTrusted`. Providers that supply no tooltip still get the hover derived from the item's fields.

Two supporting fixes in `@theia/core`, both required by the above: the markdown renderer honors VS Code's `![alt](src|width=,height=)` image sizing syntax (used for the author avatar), and markdown link wiring is idempotent, so a caller can wire links unconditionally without double-opening them on the Monaco-based renderer, which activates links itself.


#### How to test

1. Open a workspace on a git repository whose branch has diverged from its remote (e.g. one local-only and one remote-only commit).
2. Open the Source Control view and expand the Graph section: the local branch badge/lane and the remote badge/lane render in different colors; the checked-out commit shows the double-circle indicator and the `target` icon on its badge.
3. Hover a commit row: the tooltip shows the avatar and author as a `mailto:` link, relative + absolute date, stats, and a footer with the commit hash, a copy action and "Open on GitHub". Clicking the hash opens the commit (`git.viewCommit`), the copy action copies the full hash, and the author link opens a mail composer.

Unit tests: `npx lerna run test --scope @theia/scm --scope @theia/core` (new/extended specs for the lane color map, model ref resolution, badge presentation, the tooltip DOM, per-section command trust, and the markdown image sizing suffix).

#### Follow-ups

- Ref filter picker and remaining toolbar actions (item 3 of #17457), which will feed the same color map ("Auto" filter semantics).
- `scm.graph.*` preferences (item 5 of #17457).

#### Breaking changes

`ScmHistoryItem.tooltip` widens from `string` to `string | MarkdownString | readonly MarkdownString[]`, so adopters reading it as a string need to narrow it. `SourceControlHistoryItem.tooltip` widens correspondingly in the plugin API, which is additive for plugins.

Also note that the graph hover no longer renders ref badges, matching VS Code, whose hover does not include them.

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)


