### PR TITLE
feat(scm): history graph ref filter picker, refresh action, and scm.graph preferences

### DIFF
--- a/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
+++ b/packages/core/src/browser/shell/tab-bar-toolbar/tab-bar-toolbar-menu-adapters.tsx
@@ -96,8 +96,9 @@ abstract class AbstractToolbarMenuWrapper {
         const icon = this.icon || 'ellipsis';
         const contextMatcher: ContextMatcher = this.contextKeyService;
         const className = `${icon} ${ACTION_ITEM}`;
+        const itemClassName = TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled menu' + (this.isToggled(widget) ? ' toggled' : '');
         if (CompoundMenuNode.is(this.menuNode) && !this.menuNode.isEmpty(this.effectiveMenuPath, this.contextKeyService, widget.node, widget)) {
-            return <div key={this.id} className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled menu'}>
+            return <div key={this.id} className={itemClassName}>
                 <div id={this.id} className={className}
                     title={this.tooltip || this.text}
                     onClick={e => this.executeCommand(widget, e)}
@@ -107,7 +108,7 @@ abstract class AbstractToolbarMenuWrapper {
                 </div>
             </div>;
         } else {
-            return <div key={this.id} className={TabBarToolbar.Styles.TAB_BAR_TOOLBAR_ITEM + ' enabled menu'}>
+            return <div key={this.id} className={itemClassName}>
                 <div id={this.id} className={className}
                     title={this.tooltip || this.text}
                     onClick={e => this.executeCommand(widget, e)}

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -46,7 +46,7 @@ import { bindScmPreferences } from '../common/scm-preferences';
 import { bindMergeEditor } from './merge-editor/merge-editor-module';
 import { ScmRepositoriesWidget } from './scm-repositories-widget';
 import { ScmHistoryGraphWidget } from './scm-history-graph-widget';
-import { ScmHistoryGraphModel } from './scm-history-graph-model';
+import { ScmHistoryGraphModel, ScmHistoryGraphModelProvider } from './scm-history-graph-model';
 import { ScmHistoryGraphContribution } from './scm-history-graph-contribution';
 import { CommandContribution, MenuContribution } from '@theia/core';
 
@@ -93,6 +93,7 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
 
     bind(ScmHistoryGraphModel).toSelf().inSingletonScope();
+    bind(ScmHistoryGraphModelProvider).toFactory(ctx => () => ctx.container.get(ScmHistoryGraphModel));
     bind(ScmHistoryGraphContribution).toSelf().inSingletonScope();
     bind(CommandContribution).toService(ScmHistoryGraphContribution);
     bind(MenuContribution).toService(ScmHistoryGraphContribution);

--- a/packages/scm/src/browser/scm-frontend-module.ts
+++ b/packages/scm/src/browser/scm-frontend-module.ts
@@ -47,6 +47,8 @@ import { bindMergeEditor } from './merge-editor/merge-editor-module';
 import { ScmRepositoriesWidget } from './scm-repositories-widget';
 import { ScmHistoryGraphWidget } from './scm-history-graph-widget';
 import { ScmHistoryGraphModel } from './scm-history-graph-model';
+import { ScmHistoryGraphContribution } from './scm-history-graph-contribution';
+import { CommandContribution, MenuContribution } from '@theia/core';
 
 export default new ContainerModule(bind => {
     bind(ScmContextKeyService).toSelf().inSingletonScope();
@@ -91,6 +93,9 @@ export default new ContainerModule(bind => {
     })).inSingletonScope();
 
     bind(ScmHistoryGraphModel).toSelf().inSingletonScope();
+    bind(ScmHistoryGraphContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(ScmHistoryGraphContribution);
+    bind(MenuContribution).toService(ScmHistoryGraphContribution);
     bind(ScmHistoryGraphWidget).toSelf();
     bind(WidgetFactory).toDynamicValue(({ container }) => ({
         id: ScmHistoryGraphWidget.ID,

--- a/packages/scm/src/browser/scm-history-graph-contribution.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-contribution.spec.ts
@@ -1,0 +1,83 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { Command, CommandHandler, CommandRegistry } from '@theia/core/lib/common/command';
+import { Disposable } from '@theia/core/lib/common/disposable';
+import { ScmHistoryGraphContribution, ScmHistoryGraphCommands } from './scm-history-graph-contribution';
+import { ScmHistoryGraphModel } from './scm-history-graph-model';
+import { ScmHistoryProvider } from './scm-provider';
+
+disableJSDOM();
+
+interface ContributionInternals {
+    scmService: { selectedRepository: { provider: { historyProvider?: ScmHistoryProvider } } | undefined };
+    modelProvider: () => ScmHistoryGraphModel;
+    quickInputService: unknown;
+}
+
+function createContribution(historyProvider: ScmHistoryProvider | undefined): {
+    handlers: Map<string, CommandHandler>;
+    modelResolved(): boolean;
+} {
+    const contribution = new ScmHistoryGraphContribution();
+    let resolved = false;
+    const internals = contribution as unknown as ContributionInternals;
+    internals.scmService = {
+        selectedRepository: historyProvider ? { provider: { historyProvider } } : undefined,
+    };
+    internals.modelProvider = () => {
+        resolved = true;
+        return { historyItemRefFilter: undefined } as unknown as ScmHistoryGraphModel;
+    };
+    internals.quickInputService = {};
+
+    const handlers = new Map<string, CommandHandler>();
+    const registry = {
+        registerCommand: (command: Command, handler: CommandHandler): Disposable => {
+            handlers.set(command.id, handler);
+            return Disposable.NULL;
+        },
+    } as unknown as CommandRegistry;
+    contribution.registerCommands(registry);
+    return { handlers, modelResolved: () => resolved };
+}
+
+describe('ScmHistoryGraphContribution', () => {
+
+    it('does not resolve the graph model for enablement and visibility checks', () => {
+        const { handlers, modelResolved } = createContribution({} as ScmHistoryProvider);
+        for (const command of [ScmHistoryGraphCommands.REFRESH, ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS]) {
+            const handler = handlers.get(command.id)!;
+            expect(handler.isEnabled!()).to.be.true;
+            expect(handler.isVisible!()).to.be.true;
+        }
+        expect(modelResolved()).to.be.false;
+    });
+
+    it('disables the commands when the selected repository has no history provider', () => {
+        const { handlers, modelResolved } = createContribution(undefined);
+        for (const command of [ScmHistoryGraphCommands.REFRESH, ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS]) {
+            const handler = handlers.get(command.id)!;
+            expect(handler.isEnabled!()).to.be.false;
+            expect(handler.isVisible!()).to.be.false;
+        }
+        expect(modelResolved()).to.be.false;
+    });
+});

--- a/packages/scm/src/browser/scm-history-graph-contribution.ts
+++ b/packages/scm/src/browser/scm-history-graph-contribution.ts
@@ -1,0 +1,172 @@
+// *****************************************************************************
+// Copyright (C) 2026 Safi Seid-Ahmad, K2view and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable, inject, optional } from '@theia/core/shared/inversify';
+import { Command, CommandContribution, CommandRegistry } from '@theia/core/lib/common/command';
+import { MenuContribution, MenuModelRegistry } from '@theia/core/lib/common/menu';
+import { nls } from '@theia/core/lib/common/nls';
+import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
+import { QuickInputService } from '@theia/core/lib/browser';
+import { QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
+import { codicon } from '@theia/core/lib/browser/widgets/widget';
+import { ScmHistoryGraphModel } from './scm-history-graph-model';
+import { ScmHistoryItemRef } from './scm-provider';
+import { SCM_HISTORY_TITLE_MENU } from './scm-history-graph-widget';
+import { getRefBadgeClass } from './scm-history-graph-helpers';
+
+export namespace ScmHistoryGraphCommands {
+    export const REFRESH = Command.toDefaultLocalizedCommand({
+        id: 'scmHistoryGraph.refresh',
+        category: 'Source Control',
+        label: 'Refresh',
+        iconClass: codicon('refresh')
+    });
+    export const PICK_HISTORY_ITEM_REFS = Command.toLocalizedCommand({
+        id: 'scmHistoryGraph.pickHistoryItemRefs',
+        category: 'Source Control',
+        label: 'Pick History Item Reference...',
+        iconClass: codicon('git-branch')
+    }, 'theia/scm/pickHistoryItemRefs');
+}
+
+type RefPickItem = QuickPickItem & { refId?: string; auto?: boolean };
+
+/**
+ * Contributes the native toolbar actions of the SCM history graph: the
+ * history item reference filter picker (VS Code's "Auto" dropdown) and the
+ * refresh action. Extension actions (e.g. fetch/pull/push from vscode.git)
+ * are contributed separately via the `scm/history/title` menu.
+ */
+@injectable()
+export class ScmHistoryGraphContribution implements CommandContribution, MenuContribution {
+
+    @inject(ScmHistoryGraphModel) protected readonly model: ScmHistoryGraphModel;
+    @inject(QuickInputService) @optional() protected readonly quickInputService: QuickInputService;
+
+    registerCommands(commands: CommandRegistry): void {
+        commands.registerCommand(ScmHistoryGraphCommands.REFRESH, {
+            isEnabled: () => !!this.model.provider,
+            isVisible: () => !!this.model.provider,
+            execute: () => this.model.refresh()
+        });
+        commands.registerCommand(ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS, {
+            isEnabled: () => !!this.model.provider && !!this.quickInputService,
+            isVisible: () => !!this.model.provider,
+            execute: () => this.pickHistoryItemRefs()
+        });
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        // Extension actions from vscode.git sit at order 900-902; the picker
+        // goes before them and refresh last, matching VS Code's graph toolbar.
+        menus.registerMenuAction([...SCM_HISTORY_TITLE_MENU, 'navigation'], {
+            commandId: ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS.id,
+            order: '100'
+        });
+        menus.registerMenuAction([...SCM_HISTORY_TITLE_MENU, 'navigation'], {
+            commandId: ScmHistoryGraphCommands.REFRESH.id,
+            order: '999'
+        });
+    }
+
+    protected async pickHistoryItemRefs(): Promise<void> {
+        const provider = this.model.provider;
+        if (!provider || !this.quickInputService) {
+            return;
+        }
+        const cts = new CancellationTokenSource();
+        const refs = await provider.provideHistoryItemRefs(undefined, cts.token) ?? [];
+
+        const currentFilter = this.model.historyItemRefFilter;
+        const items = this.createRefPickItems(refs);
+
+        const picker = this.quickInputService.createQuickPick<RefPickItem>();
+        picker.placeholder = nls.localize('theia/scm/pickHistoryItemRefsPlaceholder', 'Select one or more history item references');
+        picker.canSelectMany = true;
+        picker.matchOnDescription = true;
+        picker.items = items;
+        picker.selectedItems = items.filter((item): item is RefPickItem => !QuickPickSeparator.is(item)
+            && (currentFilter ? !!item.refId && currentFilter.includes(item.refId) : item.auto === true));
+
+        // "Auto" is exclusive: checking it unchecks everything else and vice versa
+        let lastSelection: readonly RefPickItem[] = picker.selectedItems;
+        picker.onDidChangeSelection(newSelection => {
+            const autoNow = newSelection.some(item => item.auto);
+            if (autoNow && newSelection.length > 1) {
+                const autoBefore = lastSelection.some(item => item.auto);
+                picker.selectedItems = autoBefore ? newSelection.filter(item => !item.auto) : newSelection.filter(item => item.auto);
+            }
+            lastSelection = picker.selectedItems;
+        });
+
+        const selection = await new Promise<readonly RefPickItem[] | undefined>(resolve => {
+            picker.onDidAccept(() => {
+                resolve(picker.selectedItems);
+                picker.hide();
+            });
+            picker.onDidHide(() => resolve(undefined));
+            picker.show();
+        });
+        picker.dispose();
+
+        if (!selection) {
+            return;
+        }
+        const refIds = selection.filter(item => item.refId !== undefined).map(item => item.refId!);
+        const auto = selection.some(item => item.auto) || refIds.length === 0;
+        this.model.setHistoryItemRefFilter(auto ? undefined : refIds);
+    }
+
+    protected createRefPickItems(refs: readonly ScmHistoryItemRef[]): (RefPickItem | QuickPickSeparator)[] {
+        const provider = this.model.provider;
+        const autoRefs = [provider?.currentHistoryItemRef, provider?.currentHistoryItemRemoteRef, provider?.currentHistoryItemBaseRef]
+            .filter((ref): ref is ScmHistoryItemRef => !!ref);
+        const items: (RefPickItem | QuickPickSeparator)[] = [{
+            label: nls.localizeByDefault('Auto'),
+            description: autoRefs.map(ref => ref.name).join(', '),
+            auto: true
+        }];
+
+        const groups: { label: string; badgeClass: string }[] = [
+            { label: nls.localize('theia/scm/refPickerBranches', 'branches'), badgeClass: 'head' },
+            { label: nls.localize('theia/scm/refPickerRemoteBranches', 'remote branches'), badgeClass: 'remote' },
+            { label: nls.localize('theia/scm/refPickerTags', 'tags'), badgeClass: 'tag' }
+        ];
+        const grouped = new Set<ScmHistoryItemRef>();
+        for (const group of groups) {
+            const groupRefs = refs.filter(ref => getRefBadgeClass(ref) === group.badgeClass);
+            if (groupRefs.length > 0) {
+                groupRefs.forEach(ref => grouped.add(ref));
+                items.push({ type: 'separator', label: group.label });
+                items.push(...groupRefs.map(ref => this.toRefPickItem(ref)));
+            }
+        }
+        const remaining = refs.filter(ref => !grouped.has(ref));
+        if (remaining.length > 0) {
+            items.push({ type: 'separator' });
+            items.push(...remaining.map(ref => this.toRefPickItem(ref)));
+        }
+        return items;
+    }
+
+    protected toRefPickItem(ref: ScmHistoryItemRef): RefPickItem {
+        return {
+            label: ref.name,
+            description: ref.description,
+            refId: ref.id
+        };
+    }
+}

--- a/packages/scm/src/browser/scm-history-graph-contribution.ts
+++ b/packages/scm/src/browser/scm-history-graph-contribution.ts
@@ -22,8 +22,9 @@ import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { QuickInputService } from '@theia/core/lib/browser';
 import { QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-pick-service';
 import { codicon } from '@theia/core/lib/browser/widgets/widget';
-import { ScmHistoryGraphModel } from './scm-history-graph-model';
-import { ScmHistoryItemRef } from './scm-provider';
+import { ScmHistoryGraphModel, ScmHistoryGraphModelProvider } from './scm-history-graph-model';
+import { ScmService } from './scm-service';
+import { ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
 import { SCM_HISTORY_TITLE_MENU } from './scm-history-graph-widget';
 import { getRefBadgeClass } from './scm-history-graph-helpers';
 
@@ -53,18 +54,35 @@ type RefPickItem = QuickPickItem & { refId?: string; auto?: boolean };
 @injectable()
 export class ScmHistoryGraphContribution implements CommandContribution, MenuContribution {
 
-    @inject(ScmHistoryGraphModel) protected readonly model: ScmHistoryGraphModel;
+    @inject(ScmService) protected readonly scmService: ScmService;
+    @inject(ScmHistoryGraphModelProvider) protected readonly modelProvider: ScmHistoryGraphModelProvider;
     @inject(QuickInputService) @optional() protected readonly quickInputService: QuickInputService;
+
+    /**
+     * The graph model, resolved lazily: instantiating it starts loading
+     * history, so it must only be resolved when a graph command actually
+     * runs or the graph toolbar renders (the widget has created the model
+     * by then). In particular, `isEnabled`/`isVisible` are also queried by
+     * the command palette and therefore consult the `ScmService` instead.
+     */
+    protected get model(): ScmHistoryGraphModel {
+        return this.modelProvider();
+    }
+
+    protected get historyProvider(): ScmHistoryProvider | undefined {
+        return this.scmService.selectedRepository?.provider.historyProvider;
+    }
 
     registerCommands(commands: CommandRegistry): void {
         commands.registerCommand(ScmHistoryGraphCommands.REFRESH, {
-            isEnabled: () => !!this.model.provider,
-            isVisible: () => !!this.model.provider,
+            isEnabled: () => !!this.historyProvider,
+            isVisible: () => !!this.historyProvider,
             execute: () => this.model.refresh()
         });
         commands.registerCommand(ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS, {
-            isEnabled: () => !!this.model.provider && !!this.quickInputService,
-            isVisible: () => !!this.model.provider,
+            isEnabled: () => !!this.historyProvider && !!this.quickInputService,
+            isVisible: () => !!this.historyProvider,
+            isToggled: () => !!this.model.historyItemRefFilter,
             execute: () => this.pickHistoryItemRefs()
         });
     }
@@ -83,56 +101,86 @@ export class ScmHistoryGraphContribution implements CommandContribution, MenuCon
     }
 
     protected async pickHistoryItemRefs(): Promise<void> {
-        const provider = this.model.provider;
-        if (!provider || !this.quickInputService) {
+        if (!this.quickInputService) {
             return;
         }
-        const cts = new CancellationTokenSource();
-        const refs = await provider.provideHistoryItemRefs(undefined, cts.token) ?? [];
-
-        const currentFilter = this.model.historyItemRefFilter;
-        const items = this.createRefPickItems(refs);
-
+        const model = this.model;
+        const provider = model.provider;
+        if (!provider) {
+            return;
+        }
         const picker = this.quickInputService.createQuickPick<RefPickItem>();
-        picker.placeholder = nls.localize('theia/scm/pickHistoryItemRefsPlaceholder', 'Select one or more history item references');
-        picker.canSelectMany = true;
-        picker.matchOnDescription = true;
-        picker.items = items;
-        picker.selectedItems = items.filter((item): item is RefPickItem => !QuickPickSeparator.is(item)
-            && (currentFilter ? !!item.refId && currentFilter.includes(item.refId) : item.auto === true));
+        const cts = new CancellationTokenSource();
+        try {
+            picker.placeholder = nls.localize('theia/scm/pickHistoryItemRefsPlaceholder', 'Select one or more history item references');
+            picker.canSelectMany = true;
+            picker.matchOnDescription = true;
+            // Show the picker right away and populate it once the refs arrive,
+            // so that a slow ref lookup surfaces as a busy picker instead of a
+            // command that appears to do nothing.
+            picker.busy = true;
 
-        // "Auto" is exclusive: checking it unchecks everything else and vice versa
-        let lastSelection: readonly RefPickItem[] = picker.selectedItems;
-        picker.onDidChangeSelection(newSelection => {
-            const autoNow = newSelection.some(item => item.auto);
-            if (autoNow && newSelection.length > 1) {
-                const autoBefore = lastSelection.some(item => item.auto);
-                picker.selectedItems = autoBefore ? newSelection.filter(item => !item.auto) : newSelection.filter(item => item.auto);
-            }
-            lastSelection = picker.selectedItems;
-        });
+            const selection = await new Promise<readonly RefPickItem[] | undefined>(resolve => {
+                picker.onDidAccept(() => {
+                    resolve(picker.selectedItems);
+                    picker.hide();
+                });
+                // Also cancels a still-running ref lookup when the picker is dismissed.
+                picker.onDidHide(() => {
+                    cts.cancel();
+                    resolve(undefined);
+                });
+                picker.show();
 
-        const selection = await new Promise<readonly RefPickItem[] | undefined>(resolve => {
-            picker.onDidAccept(() => {
-                resolve(picker.selectedItems);
-                picker.hide();
+                provider.provideHistoryItemRefs(undefined, cts.token).then(refs => {
+                    if (cts.token.isCancellationRequested) {
+                        return;
+                    }
+                    const currentFilter = model.historyItemRefFilter;
+                    const items = this.createRefPickItems(refs ?? [], provider);
+                    picker.items = items;
+                    picker.selectedItems = items.filter((item): item is RefPickItem => !QuickPickSeparator.is(item)
+                        && (currentFilter ? !!item.refId && currentFilter.includes(item.refId) : item.auto === true));
+
+                    // "Auto" is exclusive: checking it unchecks everything else and vice versa
+                    let lastSelection: readonly RefPickItem[] = picker.selectedItems;
+                    picker.onDidChangeSelection(newSelection => {
+                        const autoNow = newSelection.some(item => item.auto);
+                        if (autoNow && newSelection.length > 1) {
+                            const autoBefore = lastSelection.some(item => item.auto);
+                            picker.selectedItems = autoBefore ? newSelection.filter(item => !item.auto) : newSelection.filter(item => item.auto);
+                        }
+                        lastSelection = picker.selectedItems;
+                    });
+                    picker.busy = false;
+                }, err => {
+                    if (!cts.token.isCancellationRequested) {
+                        console.error('ScmHistoryGraphContribution: failed to load history item refs', err);
+                    }
+                    picker.hide();
+                });
             });
-            picker.onDidHide(() => resolve(undefined));
-            picker.show();
-        });
-        picker.dispose();
 
-        if (!selection) {
-            return;
+            if (!selection) {
+                return;
+            }
+            // The selected repository may have changed while the picker was open;
+            // the picked refs belong to the old provider and must not be applied
+            // to the new one.
+            if (model.provider !== provider) {
+                return;
+            }
+            const refIds = selection.filter(item => item.refId !== undefined).map(item => item.refId!);
+            const auto = selection.some(item => item.auto) || refIds.length === 0;
+            model.setHistoryItemRefFilter(auto ? undefined : refIds);
+        } finally {
+            picker.dispose();
+            cts.dispose();
         }
-        const refIds = selection.filter(item => item.refId !== undefined).map(item => item.refId!);
-        const auto = selection.some(item => item.auto) || refIds.length === 0;
-        this.model.setHistoryItemRefFilter(auto ? undefined : refIds);
     }
 
-    protected createRefPickItems(refs: readonly ScmHistoryItemRef[]): (RefPickItem | QuickPickSeparator)[] {
-        const provider = this.model.provider;
-        const autoRefs = [provider?.currentHistoryItemRef, provider?.currentHistoryItemRemoteRef, provider?.currentHistoryItemBaseRef]
+    protected createRefPickItems(refs: readonly ScmHistoryItemRef[], provider: ScmHistoryProvider): (RefPickItem | QuickPickSeparator)[] {
+        const autoRefs = [provider.currentHistoryItemRef, provider.currentHistoryItemRemoteRef, provider.currentHistoryItemBaseRef]
             .filter((ref): ref is ScmHistoryItemRef => !!ref);
         const items: (RefPickItem | QuickPickSeparator)[] = [{
             label: nls.localizeByDefault('Auto'),

--- a/packages/scm/src/browser/scm-history-graph-helpers.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-helpers.spec.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { getRefBadgePresentation, getRefColorIndex } from './scm-history-graph-helpers';
+import { filterRefsForBadges, getRefBadgePresentation, getRefColorIndex } from './scm-history-graph-helpers';
 import { ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
 
 describe('getRefColorIndex', () => {
@@ -81,5 +81,38 @@ describe('getRefBadgePresentation', () => {
         expect(getRefBadgePresentation(mainRef, provider).colorIndex).to.equal(0);
         expect(getRefBadgePresentation(remoteRef, provider).colorIndex).to.equal(1);
         expect(getRefBadgePresentation({ id: 'refs/heads/feature', name: 'feature' }, provider).colorIndex).to.be.undefined;
+    });
+});
+
+describe('filterRefsForBadges', () => {
+
+    const mainRef: ScmHistoryItemRef = { id: 'refs/heads/main', name: 'main' };
+    const remoteRef: ScmHistoryItemRef = { id: 'refs/remotes/origin/main', name: 'origin/main' };
+    const featureRef: ScmHistoryItemRef = { id: 'refs/heads/feature', name: 'feature' };
+    const refs = [mainRef, remoteRef, featureRef];
+
+    const provider = {
+        currentHistoryItemRef: mainRef,
+        currentHistoryItemRemoteRef: remoteRef,
+    } as ScmHistoryProvider;
+
+    it("returns all refs in 'all' mode", () => {
+        expect(filterRefsForBadges(refs, provider, 'all')).to.deep.equal(refs);
+    });
+
+    it("keeps only the refs used as a filter in 'filter' mode", () => {
+        expect(filterRefsForBadges(refs, provider, 'filter')).to.deep.equal([mainRef, remoteRef]);
+    });
+
+    it("returns all refs in 'filter' mode when no provider is available", () => {
+        expect(filterRefsForBadges(refs, undefined, 'filter')).to.deep.equal(refs);
+    });
+
+    it("keeps only the explicitly picked refs in 'filter' mode with an explicit filter", () => {
+        expect(filterRefsForBadges(refs, provider, 'filter', ['refs/heads/feature'])).to.deep.equal([featureRef]);
+    });
+
+    it("ignores an explicit filter in 'all' mode", () => {
+        expect(filterRefsForBadges(refs, provider, 'all', ['refs/heads/feature'])).to.deep.equal(refs);
     });
 });

--- a/packages/scm/src/browser/scm-history-graph-helpers.ts
+++ b/packages/scm/src/browser/scm-history-graph-helpers.ts
@@ -105,6 +105,31 @@ export function getRefColorIndex(ref: ScmHistoryItemRef, provider: ScmHistoryPro
     return undefined;
 }
 
+/**
+ * Filters which refs get badges in the graph, following VS Code's
+ * `scm.graph.badges` setting: `'all'` shows every ref, `'filter'` shows only
+ * the refs used as the graph's filter — the explicitly picked ref ids, or,
+ * without an explicit filter (auto mode), the current, remote, and base refs.
+ * Without provider information all refs are kept.
+ */
+export function filterRefsForBadges(
+    refs: readonly ScmHistoryItemRef[],
+    provider: ScmHistoryProvider | undefined,
+    badges: 'all' | 'filter',
+    filter?: readonly string[]
+): readonly ScmHistoryItemRef[] {
+    if (badges === 'all') {
+        return refs;
+    }
+    if (filter) {
+        return refs.filter(ref => filter.includes(ref.id));
+    }
+    if (!provider) {
+        return refs;
+    }
+    return refs.filter(ref => getRefColorIndex(ref, provider) !== undefined);
+}
+
 export interface RefBadgePresentation {
     /** Icon class for the badge icon, e.g. 'codicon-git-branch'. */
     iconClass: string;

--- a/packages/scm/src/browser/scm-history-graph-model.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.spec.ts
@@ -17,7 +17,7 @@
 import { expect } from 'chai';
 import { Emitter } from '@theia/core/lib/common/event';
 import { ScmHistoryGraphModel, PAGE_SIZE } from './scm-history-graph-model';
-import { ScmHistoryItem, ScmHistoryItemRef, ScmHistoryItemChange, ScmHistoryOptions, ScmHistoryProvider } from './scm-provider';
+import { ScmHistoryItem, ScmHistoryItemRef, ScmHistoryItemRefsChangeEvent, ScmHistoryItemChange, ScmHistoryOptions, ScmHistoryProvider } from './scm-provider';
 import { ScmRepository } from './scm-repository';
 
 class StubHistoryProvider implements ScmHistoryProvider {
@@ -26,11 +26,12 @@ class StubHistoryProvider implements ScmHistoryProvider {
     currentHistoryItemBaseRef: ScmHistoryItemRef | undefined;
 
     readonly onDidChangeCurrentHistoryItemRefs = new Emitter<void>().event;
-    readonly onDidChangeHistoryItemRefs = new Emitter<{
-        readonly added: readonly ScmHistoryItemRef[];
-        readonly removed: readonly ScmHistoryItemRef[];
-        readonly modified: readonly ScmHistoryItemRef[];
-    }>().event;
+    protected readonly onDidChangeHistoryItemRefsEmitter = new Emitter<ScmHistoryItemRefsChangeEvent>();
+    readonly onDidChangeHistoryItemRefs = this.onDidChangeHistoryItemRefsEmitter.event;
+
+    fireHistoryItemRefsChanged(event: ScmHistoryItemRefsChangeEvent): void {
+        this.onDidChangeHistoryItemRefsEmitter.fire(event);
+    }
 
     /** Pages this provider will return on consecutive calls (FIFO). */
     pages: ScmHistoryItem[][] = [];
@@ -75,11 +76,14 @@ function makeItems(start: number, count: number): ScmHistoryItem[] {
 /**
  * Instantiates the model with a stub provider, bypassing inversify and the
  * SCM service so tests can drive pagination directly via loadPage().
+ * When `wireRepository` is set, the provider is instead wired through a stub
+ * selected repository and refresh(), so provider event subscriptions are live.
  */
 function createModel(
     provider: ScmHistoryProvider,
-    preferences: Record<string, unknown> = {}
-): { model: ScmHistoryGraphModel; loadPage(): Promise<void> } {
+    preferences: Record<string, unknown> = {},
+    wireRepository = false
+): { model: ScmHistoryGraphModel; loadPage(): Promise<void>; firePreferenceChanged(preferenceName: string): void } {
     const model = new ScmHistoryGraphModel();
     const internals = model as unknown as {
         scmService: {
@@ -91,17 +95,25 @@ function createModel(
         init(): void;
         loadPage(): Promise<void>;
     };
+    const preferenceEmitter = new Emitter<{ preferenceName: string }>();
     internals.scmService = {
         onDidChangeSelectedRepository: new Emitter<ScmRepository | undefined>().event,
-        selectedRepository: undefined,
+        selectedRepository: wireRepository ? { provider: { historyProvider: provider } } as unknown as ScmRepository : undefined,
     };
-    internals.scmPreferences = preferences;
+    internals.scmPreferences = Object.assign(preferences, { onPreferenceChanged: preferenceEmitter.event });
     internals.init();
-    internals._provider = provider;
+    if (!wireRepository) {
+        internals._provider = provider;
+    }
     return {
         model,
         loadPage: () => internals.loadPage(),
+        firePreferenceChanged: preferenceName => preferenceEmitter.fire({ preferenceName }),
     };
+}
+
+async function nextTick(): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, 0));
 }
 
 describe('ScmHistoryGraphModel - pagination', () => {
@@ -198,6 +210,23 @@ describe('ScmHistoryGraphModel - page size preference', () => {
 
         expect(provider.receivedOptions[0].limit).to.equal(PAGE_SIZE);
     });
+
+    it('reloads from the start when scm.graph.pageSize changes', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, 10), makeItems(1, 5)];
+        const preferences: Record<string, unknown> = { 'scm.graph.pageSize': 10 };
+        const { loadPage, firePreferenceChanged } = createModel(provider, preferences);
+
+        await loadPage();
+        expect(provider.receivedOptions[0].limit).to.equal(10);
+
+        preferences['scm.graph.pageSize'] = 5;
+        firePreferenceChanged('scm.graph.pageSize');
+        await nextTick();
+
+        expect(provider.receivedOptions[1].limit).to.equal(5);
+        expect(provider.receivedOptions[1].skip).to.equal(0);
+    });
 });
 
 describe('ScmHistoryGraphModel - history item ref filter', () => {
@@ -209,10 +238,6 @@ describe('ScmHistoryGraphModel - history item ref filter', () => {
         provider.currentHistoryItemRef = mainRef;
         provider.pages = [makeItems(1, 3), makeItems(1, 3), makeItems(1, 3)];
         return provider;
-    }
-
-    async function nextTick(): Promise<void> {
-        return new Promise(resolve => setTimeout(resolve, 0));
     }
 
     it('is in auto mode by default: current ref revisions are requested and the current ref is in the filter', async () => {
@@ -265,6 +290,58 @@ describe('ScmHistoryGraphModel - history item ref filter', () => {
         model.setHistoryItemRefFilter(['refs/heads/feature']);
         await nextTick();
         expect(model.entries[0].graphRow.color).to.not.equal(0);
+    });
+});
+
+describe('ScmHistoryGraphModel - ref filter pruning', () => {
+
+    const mainRef: ScmHistoryItemRef = { id: 'refs/heads/main', name: 'main', revision: 'c1' };
+    const featureRef: ScmHistoryItemRef = { id: 'refs/heads/feature', name: 'feature', revision: 'c5' };
+
+    function createWiredProvider(): StubHistoryProvider {
+        const provider = new StubHistoryProvider();
+        provider.currentHistoryItemRef = mainRef;
+        return provider;
+    }
+
+    it('drops a removed ref from the filter and keeps the remaining ones', async () => {
+        const provider = createWiredProvider();
+        const { model } = createModel(provider, {}, true);
+        model.setHistoryItemRefFilter([featureRef.id, mainRef.id]);
+        await nextTick();
+
+        provider.fireHistoryItemRefsChanged({ added: [], removed: [featureRef], modified: [] });
+        await nextTick();
+
+        expect(model.historyItemRefFilter).to.deep.equal([mainRef.id]);
+        const last = provider.receivedOptions[provider.receivedOptions.length - 1];
+        expect(last.historyItemRefs).to.deep.equal([mainRef.id]);
+    });
+
+    it('falls back to auto mode when all filtered refs are removed', async () => {
+        const provider = createWiredProvider();
+        const { model } = createModel(provider, {}, true);
+        model.setHistoryItemRefFilter([featureRef.id]);
+        await nextTick();
+
+        provider.fireHistoryItemRefsChanged({ added: [], removed: [featureRef], modified: [] });
+        await nextTick();
+
+        expect(model.historyItemRefFilter).to.be.undefined;
+        const last = provider.receivedOptions[provider.receivedOptions.length - 1];
+        expect(last.historyItemRefs).to.deep.equal(['c1']);
+    });
+
+    it('keeps the filter when unrelated refs are removed', async () => {
+        const provider = createWiredProvider();
+        const { model } = createModel(provider, {}, true);
+        model.setHistoryItemRefFilter([mainRef.id]);
+        await nextTick();
+
+        provider.fireHistoryItemRefsChanged({ added: [], removed: [featureRef], modified: [] });
+        await nextTick();
+
+        expect(model.historyItemRefFilter).to.deep.equal([mainRef.id]);
     });
 });
 

--- a/packages/scm/src/browser/scm-history-graph-model.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.spec.ts
@@ -76,13 +76,17 @@ function makeItems(start: number, count: number): ScmHistoryItem[] {
  * Instantiates the model with a stub provider, bypassing inversify and the
  * SCM service so tests can drive pagination directly via loadPage().
  */
-function createModel(provider: ScmHistoryProvider): { model: ScmHistoryGraphModel; loadPage(): Promise<void> } {
+function createModel(
+    provider: ScmHistoryProvider,
+    preferences: Record<string, unknown> = {}
+): { model: ScmHistoryGraphModel; loadPage(): Promise<void> } {
     const model = new ScmHistoryGraphModel();
     const internals = model as unknown as {
         scmService: {
             onDidChangeSelectedRepository: Emitter<ScmRepository | undefined>['event'];
             selectedRepository: ScmRepository | undefined;
         };
+        scmPreferences: Record<string, unknown>;
         _provider: ScmHistoryProvider | undefined;
         init(): void;
         loadPage(): Promise<void>;
@@ -91,6 +95,7 @@ function createModel(provider: ScmHistoryProvider): { model: ScmHistoryGraphMode
         onDidChangeSelectedRepository: new Emitter<ScmRepository | undefined>().event,
         selectedRepository: undefined,
     };
+    internals.scmPreferences = preferences;
     internals.init();
     internals._provider = provider;
     return {
@@ -167,6 +172,99 @@ describe('ScmHistoryGraphModel - pagination', () => {
 
         await loadPage();
         expect(model.entries).to.have.length(PAGE_SIZE, 'should not grow when all items are duplicates');
+    });
+});
+
+describe('ScmHistoryGraphModel - page size preference', () => {
+
+    it('requests the configured page size and paginates by it', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, 10)];
+        const { model, loadPage } = createModel(provider, { 'scm.graph.pageSize': 10 });
+
+        await loadPage();
+
+        expect(provider.receivedOptions[0].limit).to.equal(10);
+        expect(model.entries).to.have.length(10);
+        expect(model.hasMore).to.be.true;
+    });
+
+    it('falls back to the default page size without a preference value', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, 10)];
+        const { loadPage } = createModel(provider);
+
+        await loadPage();
+
+        expect(provider.receivedOptions[0].limit).to.equal(PAGE_SIZE);
+    });
+});
+
+describe('ScmHistoryGraphModel - history item ref filter', () => {
+
+    const mainRef: ScmHistoryItemRef = { id: 'refs/heads/main', name: 'main', revision: 'c1' };
+
+    function createFilterProvider(): StubHistoryProvider {
+        const provider = new StubHistoryProvider();
+        provider.currentHistoryItemRef = mainRef;
+        provider.pages = [makeItems(1, 3), makeItems(1, 3), makeItems(1, 3)];
+        return provider;
+    }
+
+    async function nextTick(): Promise<void> {
+        return new Promise(resolve => setTimeout(resolve, 0));
+    }
+
+    it('is in auto mode by default: current ref revisions are requested and the current ref is in the filter', async () => {
+        const provider = createFilterProvider();
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        expect(provider.receivedOptions[0].historyItemRefs).to.deep.equal(['c1']);
+        expect(model.historyItemRefFilter).to.be.undefined;
+        expect(model.isCurrentRefInFilter()).to.be.true;
+    });
+
+    it('passes the picked ref ids to the provider and reloads', async () => {
+        const provider = createFilterProvider();
+        const { model } = createModel(provider);
+        model.setHistoryItemRefFilter(['refs/heads/feature']);
+        await nextTick();
+        expect(provider.receivedOptions[0].historyItemRefs).to.deep.equal(['refs/heads/feature']);
+        expect(model.historyItemRefFilter).to.deep.equal(['refs/heads/feature']);
+    });
+
+    it('reports whether the current ref is part of the filter', async () => {
+        const provider = createFilterProvider();
+        const { model } = createModel(provider);
+        model.setHistoryItemRefFilter(['refs/heads/feature']);
+        await nextTick();
+        expect(model.isCurrentRefInFilter()).to.be.false;
+        model.setHistoryItemRefFilter(['refs/heads/feature', 'refs/heads/main']);
+        await nextTick();
+        expect(model.isCurrentRefInFilter()).to.be.true;
+    });
+
+    it('returns to auto mode when the filter is cleared', async () => {
+        const provider = createFilterProvider();
+        const { model } = createModel(provider);
+        model.setHistoryItemRefFilter(['refs/heads/feature']);
+        await nextTick();
+        model.setHistoryItemRefFilter(undefined);
+        await nextTick();
+        expect(model.historyItemRefFilter).to.be.undefined;
+        expect(provider.receivedOptions[1].historyItemRefs).to.deep.equal(['c1']);
+    });
+
+    it('does not apply ref role colors to refs excluded by the filter', async () => {
+        const provider = createFilterProvider();
+        provider.pages = [[
+            { id: 'c1', subject: 'head', parentIds: ['c2'], references: [mainRef] },
+            { id: 'c2', subject: 'base', parentIds: [] },
+        ]];
+        const { model } = createModel(provider);
+        model.setHistoryItemRefFilter(['refs/heads/feature']);
+        await nextTick();
+        expect(model.entries[0].graphRow.color).to.not.equal(0);
     });
 });
 

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -19,12 +19,22 @@ import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposa
 import { Emitter } from '@theia/core/lib/common/event';
 import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { ScmService } from './scm-service';
-import { ScmHistoryItem, ScmHistoryProvider, ScmHistoryOptions } from './scm-provider';
+import { ScmHistoryItem, ScmHistoryItemRef, ScmHistoryProvider, ScmHistoryOptions } from './scm-provider';
 import { computeGraphRows, GraphRow } from './scm-history-graph-lanes';
 import { getRefColorIndex } from './scm-history-graph-helpers';
 import { ScmPreferences } from '../common/scm-preferences';
 
 export const PAGE_SIZE = 50;
+
+export const ScmHistoryGraphModelProvider = Symbol('ScmHistoryGraphModelProvider');
+/**
+ * Resolves the {@link ScmHistoryGraphModel} singleton on first use. The model
+ * starts loading history and subscribing to provider events as soon as it is
+ * instantiated, so clients that may not need it (e.g. command contributions
+ * instantiated at application start) must inject this provider instead of the
+ * model itself.
+ */
+export type ScmHistoryGraphModelProvider = () => ScmHistoryGraphModel;
 
 export interface HistoryGraphEntry {
     readonly item: ScmHistoryItem;
@@ -61,6 +71,11 @@ export class ScmHistoryGraphModel {
             Disposable.create(() => this.toDisposeOnProviderChange.dispose()),
             this.onDidChangeEmitter,
             this.scmService.onDidChangeSelectedRepository(() => this.refresh()),
+            this.scmPreferences.onPreferenceChanged(e => {
+                if (e.preferenceName === 'scm.graph.pageSize') {
+                    this.reload();
+                }
+            }),
         ]);
         this.refresh();
     }
@@ -137,7 +152,10 @@ export class ScmHistoryGraphModel {
                 this._provider.onDidChangeCurrentHistoryItemRefs(() => this.refresh())
             );
             this.toDisposeOnProviderChange.push(
-                this._provider.onDidChangeHistoryItemRefs(() => this.refresh())
+                this._provider.onDidChangeHistoryItemRefs(e => {
+                    this.pruneHistoryItemRefFilter(e.removed);
+                    this.refresh();
+                })
             );
         } else if (repo) {
             // historyProvider is not yet available; listen for provider changes
@@ -148,6 +166,23 @@ export class ScmHistoryGraphModel {
         }
 
         this.reload();
+    }
+
+    /**
+     * Drops refs that no longer exist from the explicit filter, so that
+     * deleting or renaming a filtered ref does not leave the graph stuck
+     * requesting history for it. When the last filtered ref is removed,
+     * the filter falls back to auto mode.
+     */
+    protected pruneHistoryItemRefFilter(removed: readonly ScmHistoryItemRef[]): void {
+        if (!this._historyItemRefFilter || removed.length === 0) {
+            return;
+        }
+        const removedIds = new Set(removed.map(ref => ref.id));
+        const remaining = this._historyItemRefFilter.filter(id => !removedIds.has(id));
+        if (remaining.length !== this._historyItemRefFilter.length) {
+            this._historyItemRefFilter = remaining.length > 0 ? remaining : undefined;
+        }
     }
 
     /** Clears the loaded entries and loads the first page again from the current provider. */

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -22,6 +22,7 @@ import { ScmService } from './scm-service';
 import { ScmHistoryItem, ScmHistoryProvider, ScmHistoryOptions } from './scm-provider';
 import { computeGraphRows, GraphRow } from './scm-history-graph-lanes';
 import { getRefColorIndex } from './scm-history-graph-helpers';
+import { ScmPreferences } from '../common/scm-preferences';
 
 export const PAGE_SIZE = 50;
 
@@ -36,6 +37,7 @@ export interface HistoryGraphEntry {
 export class ScmHistoryGraphModel {
 
     @inject(ScmService) protected readonly scmService: ScmService;
+    @inject(ScmPreferences) protected readonly scmPreferences: ScmPreferences;
 
     protected readonly toDispose = new DisposableCollection();
     protected readonly toDisposeOnProviderChange = new DisposableCollection();
@@ -45,6 +47,8 @@ export class ScmHistoryGraphModel {
     protected _loading = false;
     protected _hasAttemptedLoad = false;
     protected _provider: ScmHistoryProvider | undefined;
+    /** Explicitly picked ref ids to filter the graph by; `undefined` = auto (current/remote/base). */
+    protected _historyItemRefFilter: string[] | undefined;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange = this.onDidChangeEmitter.event;
@@ -70,6 +74,32 @@ export class ScmHistoryGraphModel {
         return this._provider;
     }
 
+    /** The explicitly picked ref ids filtering the graph, or `undefined` in auto mode. */
+    get historyItemRefFilter(): readonly string[] | undefined {
+        return this._historyItemRefFilter;
+    }
+
+    /**
+     * Sets the ref ids to filter the graph by (`undefined` returns to auto
+     * mode) and reloads the graph.
+     */
+    setHistoryItemRefFilter(refIds: readonly string[] | undefined): void {
+        this._historyItemRefFilter = refIds && refIds.length > 0 ? [...refIds] : undefined;
+        this.reload();
+    }
+
+    /**
+     * Whether the current history item ref is part of the graph's filter.
+     * Always true in auto mode, which includes the current ref.
+     */
+    isCurrentRefInFilter(): boolean {
+        if (!this._historyItemRefFilter) {
+            return true;
+        }
+        const currentId = this._provider?.currentHistoryItemRef?.id;
+        return currentId !== undefined && this._historyItemRefFilter.includes(currentId);
+    }
+
     get entries(): readonly HistoryGraphEntry[] {
         return this._entries;
     }
@@ -92,13 +122,14 @@ export class ScmHistoryGraphModel {
     }
 
     refresh(): void {
-        this.cancelSource.cancel();
-        this.cancelSource = new CancellationTokenSource();
-
         this.toDisposeOnProviderChange.dispose();
 
         const repo = this.scmService.selectedRepository;
         const hp = repo?.provider.historyProvider;
+        if (hp !== this._provider) {
+            // The repository changed — a filter picked for the old provider does not apply.
+            this._historyItemRefFilter = undefined;
+        }
         this._provider = hp;
 
         if (this._provider) {
@@ -115,6 +146,14 @@ export class ScmHistoryGraphModel {
                 repo.provider.onDidChange(() => this.refresh())
             );
         }
+
+        this.reload();
+    }
+
+    /** Clears the loaded entries and loads the first page again from the current provider. */
+    protected reload(): void {
+        this.cancelSource.cancel();
+        this.cancelSource = new CancellationTokenSource();
 
         this._entries = [];
         this._hasMore = false;
@@ -144,10 +183,11 @@ export class ScmHistoryGraphModel {
 
         const token = this.cancelSource.token;
         try {
+            const pageSize = this.pageSize;
             const historyItemRefs = this.getCurrentHistoryItemRefs();
             const options: ScmHistoryOptions = {
                 skip: this._entries.length,
-                limit: PAGE_SIZE,
+                limit: pageSize,
                 historyItemRefs: historyItemRefs.length > 0 ? historyItemRefs : undefined,
             };
             const items = await this._provider.provideHistoryItems(options, token);
@@ -157,7 +197,7 @@ export class ScmHistoryGraphModel {
             }
 
             const fetchedItems: ScmHistoryItem[] = items ?? [];
-            this._hasMore = fetchedItems.length >= PAGE_SIZE;
+            this._hasMore = fetchedItems.length >= pageSize;
 
             // Filter out any items already loaded so the graph does not show duplicates.
             const existingIds = new Set(this._entries.map(e => e.item.id));
@@ -189,13 +229,22 @@ export class ScmHistoryGraphModel {
         }
     }
 
+    /** The configured page size (`scm.graph.pageSize`). */
+    protected get pageSize(): number {
+        return this.scmPreferences['scm.graph.pageSize'] ?? PAGE_SIZE;
+    }
+
     /**
      * Resolves the ref-based color index of an item from its references,
-     * preferring current (0) over remote (1) over base (2).
+     * preferring current (0) over remote (1) over base (2). Refs excluded by
+     * an explicit filter get no role color, mirroring VS Code's color map.
      */
     protected resolveColorIndex(item: ScmHistoryItem): number | undefined {
         let result: number | undefined;
         for (const ref of item.references ?? []) {
+            if (this._historyItemRefFilter && !this._historyItemRefFilter.includes(ref.id)) {
+                continue;
+            }
             const index = getRefColorIndex(ref, this._provider);
             if (index !== undefined && (result === undefined || index < result)) {
                 result = index;
@@ -205,11 +254,15 @@ export class ScmHistoryGraphModel {
     }
 
     /**
-     * Returns the revisions of the current branch ref, its remote tracking ref,
-     * and the merge-base ref to pass to `provideHistoryItems`. Providers walk
-     * history starting from these revisions.
+     * Returns the refs to pass to `provideHistoryItems`: the explicitly picked
+     * ref ids when a filter is active, otherwise (auto mode) the revisions of
+     * the current branch ref, its remote tracking ref, and the merge-base ref.
+     * Providers walk history starting from these refs.
      */
     protected getCurrentHistoryItemRefs(): string[] {
+        if (this._historyItemRefFilter) {
+            return [...this._historyItemRefFilter];
+        }
         if (!this._provider) {
             return [];
         }

--- a/packages/scm/src/browser/scm-history-graph-widget.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-widget.spec.ts
@@ -48,15 +48,17 @@ describe('ScmHistoryGraphWidget context keys', () => {
     let widget: ScmHistoryGraphWidget;
     let scmContextKeys: ScmContextKeyService;
     let provider: Partial<ScmHistoryProvider> | undefined;
+    let currentRefInFilter: boolean;
 
     beforeEach(() => {
         restoreJSDOM = enableJSDOM();
         scmContextKeys = createScmContextKeyService();
+        currentRefInFilter = true;
         widget = new ScmHistoryGraphWidget();
         const raw = widget as unknown as Record<string, unknown>;
         raw.scmContextKeys = scmContextKeys;
         Object.defineProperty(raw, 'model', {
-            get: () => ({ provider })
+            get: () => ({ provider, isCurrentRefInFilter: () => currentRefInFilter })
         });
     });
 
@@ -86,6 +88,15 @@ describe('ScmHistoryGraphWidget context keys', () => {
     it('should clear scmCurrentHistoryItemRefInFilter when there is no provider', () => {
         scmContextKeys.scmCurrentHistoryItemRefInFilter.set(true);
         provider = undefined;
+        updateContextKeys();
+        expect(scmContextKeys.scmCurrentHistoryItemRefInFilter.get()).to.equal(false);
+    });
+
+    it('should clear scmCurrentHistoryItemRefInFilter when the filter excludes the current ref', () => {
+        provider = {
+            currentHistoryItemRef: { id: 'refs/heads/main', name: 'main' }
+        };
+        currentRefInFilter = false;
         updateContextKeys();
         expect(scmContextKeys.scmCurrentHistoryItemRefInFilter.get()).to.equal(false);
     });

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -35,8 +35,9 @@ import { ContextMenuRenderer } from '@theia/core/lib/browser/context-menu-render
 import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
 import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import { ScmContextKeyService } from './scm-context-key-service';
+import { ScmPreferences } from '../common/scm-preferences';
 import {
-    laneColor, getChangeStatus, getFileName, getFilePath, getRepoRelativePath,
+    laneColor, filterRefsForBadges, getChangeStatus, getFileName, getFilePath, getRepoRelativePath,
     getRefBadgeClass, getRefBadgePresentation, isTagRef, isRemoteRef, deduplicateRefs, DeduplicatedRef
 } from './scm-history-graph-helpers';
 import { buildHtmlTooltip, buildProviderTooltip } from './scm-history-graph-tooltip';
@@ -96,6 +97,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
     @inject(ContextMenuRenderer) protected readonly contextMenuRenderer: ContextMenuRenderer;
     @inject(OpenerService) protected readonly openerService: OpenerService;
     @inject(ScmContextKeyService) protected readonly scmContextKeys: ScmContextKeyService;
+    @inject(ScmPreferences) protected readonly scmPreferences: ScmPreferences;
 
     protected selectedIndex = -1;
     /** Currently selected change row key (`${itemId}-${ci}`), or undefined. */
@@ -127,6 +129,13 @@ export class ScmHistoryGraphWidget extends ReactWidget {
                 this.update();
             })
         );
+        this.toDispose.push(
+            this.scmPreferences.onPreferenceChanged(e => {
+                if (e.preferenceName.startsWith('scm.graph.')) {
+                    this.update();
+                }
+            })
+        );
         this.toDispose.push({
             dispose: () => {
                 for (const cts of this.loadChangesCts.values()) {
@@ -144,9 +153,8 @@ export class ScmHistoryGraphWidget extends ReactWidget {
         const provider = this.model.provider;
         this.scmContextKeys.scmCurrentHistoryItemRefHasRemote.set(!!provider?.currentHistoryItemRemoteRef);
         this.scmContextKeys.scmCurrentHistoryItemRefHasBase.set(!!provider?.currentHistoryItemBaseRef);
-        // The graph has no ref filter yet, so the current ref is always considered part of it.
         // Commands like git.pullRef/git.pushRef gate their enablement on this key.
-        this.scmContextKeys.scmCurrentHistoryItemRefInFilter.set(!!provider?.currentHistoryItemRef);
+        this.scmContextKeys.scmCurrentHistoryItemRefInFilter.set(!!provider?.currentHistoryItemRef && this.model.isCurrentRefInFilter());
     }
 
     protected render(): React.ReactNode {
@@ -198,7 +206,7 @@ export class ScmHistoryGraphWidget extends ReactWidget {
                 className='scm-history-graph-list'
                 data={entries as HistoryGraphEntry[]}
                 itemContent={(idx, entry) => this.renderRow(entry, idx, svgWidth)}
-                endReached={hasMore && !loading ? this.handleEndReached : undefined}
+                endReached={hasMore && !loading && this.scmPreferences['scm.graph.pageOnScroll'] !== false ? this.handleEndReached : undefined}
                 overscan={500}
                 components={footer ? { Footer: footer } : {}}
                 style={{ overflowX: 'hidden' }}
@@ -606,8 +614,12 @@ export class ScmHistoryGraphWidget extends ReactWidget {
         }
 
         const provider = this.model.provider;
+        const visibleRefs = filterRefsForBadges(refs, provider, this.scmPreferences['scm.graph.badges'] ?? 'filter', this.model.historyItemRefFilter);
+        if (visibleRefs.length === 0) {
+            return undefined;
+        }
         const laneColorValue = entry ? laneColor(entry.graphRow.color) : undefined;
-        const deduplicated = deduplicateRefs(refs);
+        const deduplicated = deduplicateRefs(visibleRefs);
         const badgeForeground = 'var(--theia-scmGraph-historyItemRefForeground, var(--theia-badge-foreground))';
 
         const badges: React.ReactElement[] = [];

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -30,6 +30,8 @@ import URI from '@theia/core/lib/common/uri';
 import { nls } from '@theia/core/lib/common/nls';
 import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { DisposableCollection } from '@theia/core/lib/common/disposable';
+import { Emitter, Event } from '@theia/core/lib/common/event';
+import { DynamicToolbarWidget } from '@theia/core/lib/browser/view-container';
 import { MenuPath } from '@theia/core/lib/common/menu/menu-types';
 import { ContextMenuRenderer } from '@theia/core/lib/browser/context-menu-renderer';
 import { OpenerService, open } from '@theia/core/lib/browser/opener-service';
@@ -83,7 +85,7 @@ function renderJsxRefBadge(
 // ── Widget ──────────────────────────────────────────────────────────────────
 
 @injectable()
-export class ScmHistoryGraphWidget extends ReactWidget {
+export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbarWidget {
 
     static readonly ID = 'scm-history-graph-widget';
     static readonly LABEL = nls.localizeByDefault('Graph');
@@ -111,6 +113,10 @@ export class ScmHistoryGraphWidget extends ReactWidget {
     /** Cleanup for the content of the hover currently being shown. */
     protected readonly toDisposeOnHover = new DisposableCollection();
 
+    protected readonly onDidChangeToolbarItemsEmitter = new Emitter<void>();
+    /** Re-renders the part toolbar on model changes, e.g. to reflect the toggled state of the ref filter picker. */
+    readonly onDidChangeToolbarItems: Event<void> = this.onDidChangeToolbarItemsEmitter.event;
+
     constructor() {
         super();
         this.id = ScmHistoryGraphWidget.ID;
@@ -123,10 +129,12 @@ export class ScmHistoryGraphWidget extends ReactWidget {
 
     @postConstruct()
     protected init(): void {
+        this.toDispose.push(this.onDidChangeToolbarItemsEmitter);
         this.toDispose.push(
             this.model.onDidChange(() => {
                 this.updateContextKeys();
                 this.update();
+                this.onDidChangeToolbarItemsEmitter.fire();
             })
         );
         this.toDispose.push(

--- a/packages/scm/src/common/scm-preferences.ts
+++ b/packages/scm/src/common/scm-preferences.ts
@@ -35,12 +35,39 @@ export const scmPreferenceSchema: PreferenceSchema = {
             ],
             description: nls.localizeByDefault('Controls the default Source Control repository view mode.'),
             default: 'list'
+        },
+        'scm.graph.badges': {
+            type: 'string',
+            enum: ['all', 'filter'],
+            enumDescriptions: [
+                nls.localizeByDefault('Show badges of all history item groups in the Source Control Graph view.'),
+                nls.localizeByDefault('Show only the badges of history item groups used as a filter in the Source Control Graph view.')
+            ],
+            description: nls.localizeByDefault(
+                // eslint-disable-next-line max-len
+                'Controls which badges are shown in the Source Control Graph view. The badges are shown on the right side of the graph indicating the names of history item groups.'),
+            default: 'filter'
+        },
+        'scm.graph.pageOnScroll': {
+            type: 'boolean',
+            description: nls.localizeByDefault('Controls whether the Source Control Graph view will load the next page of items when you scroll to the end of the list.'),
+            default: true
+        },
+        'scm.graph.pageSize': {
+            type: 'number',
+            minimum: 1,
+            maximum: 1000,
+            description: nls.localizeByDefault('The number of items to show in the Source Control Graph view by default and when loading more items.'),
+            default: 50
         }
     }
 };
 
 export interface ScmConfiguration {
     'scm.defaultViewMode': 'tree' | 'list'
+    'scm.graph.badges': 'all' | 'filter'
+    'scm.graph.pageOnScroll': boolean
+    'scm.graph.pageSize': number
 }
 
 export const ScmPreferenceContribution = Symbol('ScmPreferenceContribution');


### PR DESCRIPTION
#### What it does

Addresses items 3 and 5 of #17457.

> **Depends on #17880** — this branch is stacked on it; only the last commit (`feat(scm): graph ref filter picker...`) is new here. Rebased onto master now that #17876 has merged; will rebase again once #17880 merges.

**Item 3 — missing toolbar actions.** Adds the native actions of VS Code's Source Control Graph toolbar:
- A **history item reference filter picker** (VS Code's "Auto" dropdown): a multi-select quick pick over the provider's refs, grouped into branches / remote branches / tags, with an exclusive "Auto" entry (current + remote + base refs). The picked refs feed `provideHistoryItems`, the ref role colors, badge visibility, and the `scmCurrentHistoryItemRefInFilter` context key — so `git.pullRef`/`git.pushRef` enablement now follows the actual filter instead of the placeholder introduced with #17876.
- A **refresh** action.

The repository picker is intentionally not ported: Theia's SCM view has its own repositories section driving `ScmService.selectedRepository`, which the graph follows.

**Item 5 — `scm.graph.*` preferences**, matching VS Code's schema:
- `scm.graph.badges` (`'all' | 'filter'`, default `'filter'`): which ref badges are shown; `'filter'` shows only refs in the graph filter (Auto = current/remote/base).
- `scm.graph.pageOnScroll` (default `true`): gates automatic paging when scrolling to the end.
- `scm.graph.pageSize` (1-1000, default 50): page size for initial load and load-more.

`scm.graph.showIncomingChanges`/`showOutgoingChanges` are left out — the graph has no incoming/outgoing nodes yet.

#### How to test

1. Open a workspace on a git repository with several branches/tags whose current branch has a remote.
2. Graph section toolbar: a branch icon (Pick History Item Reference...) appears before fetch/pull/push and a refresh icon after them.
3. Click the picker: "Auto" is pre-selected; pick a branch instead — the graph reloads showing only that ref's history, only its badge is shown, and checking "Auto" again restores the default view. Checking "Auto" unchecks other refs and vice versa.
4. Preferences: search `scm.graph` in Settings; set `scm.graph.badges` to `all` — badges of all refs appear without reloading; set `scm.graph.pageSize` to a small value and verify paging; disable `scm.graph.pageOnScroll` and verify only the "Load more" footer pages.

Unit tests: `npx lerna run test --scope @theia/scm`.

#### Follow-ups

- Persist the picked filter per repository across sessions (VS Code stores it in workspace state).
- Incoming/outgoing change nodes in the graph, then the corresponding `scm.graph.show*Changes` settings.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
