### PR TITLE
feat(scm-extra): deprecate @theia/scm-extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@
 ## 1.75.0 - tbd
 
 - [core, monaco] fixed Monaco theme CSS, `SelectComponent` dropdown placement, and the OS font class in secondary windows [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+- [scm-extra] deprecated `@theia/scm-extra` package [#17882](https://github.com/eclipse-theia/theia/pull/17882)
 
 <a name="breaking_changes_1.75.0">[Breaking Changes:](#breaking_changes_1.75.0)</a>
 
 - [core] added `onWindowLoaded` to the `SecondaryWindowService` interface; adopters implementing the interface from scratch (rather than extending `DefaultSecondaryWindowService`) must provide it [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [monaco] removed the `protected secondaryWindowHandler` field from `MonacoFrontendApplicationContribution`; the Monaco theme stylesheet is now injected into every secondary window via `SecondaryWindowService.onWindowLoaded` [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+- [scm-extra] deprecated the `@theia/scm-extra` extension and stopped publishing it on npm; it has also been removed from the example applications, which drops its `SCM History` view, the `History` context menu items in the navigator and editor, and the `alt+h` keybinding. The view has been non-functional in the default application since the removal of `@theia/git`, as nothing implements `ScmHistorySupport` anymore. Please use the SCM history graph in `@theia/scm` for branch history and the Timeline view in `@theia/timeline` for per-file history instead [#17882](https://github.com/eclipse-theia/theia/pull/17882)
 
 ## 1.74.0 - 7/31/2026
 

--- a/examples/api-tests/src/menus.spec.js
+++ b/examples/api-tests/src/menus.spec.js
@@ -33,7 +33,6 @@ describe('Menus', function () {
     const { EXPLORER_VIEW_CONTAINER_ID } = require('@theia/navigator/lib/browser/navigator-widget-factory');
     const { FileNavigatorContribution } = require('@theia/navigator/lib/browser/navigator-contribution');
     const { ScmContribution } = require('@theia/scm/lib/browser/scm-contribution');
-    const { ScmHistoryContribution } = require('@theia/scm-extra/lib/browser/history/scm-history-contribution');
     const { OutlineViewContribution } = require('@theia/outline-view/lib/browser/outline-view-contribution');
     const { OutputContribution } = require('@theia/output/lib/browser/output-contribution');
     const { PluginFrontendViewContribution } = require('@theia/plugin-ext/lib/main/browser/plugin-frontend-view-contribution');
@@ -66,7 +65,6 @@ describe('Menus', function () {
         container.get(CallHierarchyContribution),
         container.get(FileNavigatorContribution),
         container.get(ScmContribution),
-        container.get(ScmHistoryContribution),
         container.get(OutlineViewContribution),
         container.get(OutputContribution),
         container.get(PluginFrontendViewContribution),

--- a/examples/browser-only/package.json
+++ b/examples/browser-only/package.json
@@ -55,7 +55,6 @@
     "@theia/property-view": "1.74.0",
     "@theia/scanoss": "1.74.0",
     "@theia/scm": "1.74.0",
-    "@theia/scm-extra": "1.74.0",
     "@theia/search-in-workspace": "1.74.0",
     "@theia/secondary-window": "1.74.0",
     "@theia/task": "1.74.0",

--- a/examples/browser-only/tsconfig.json
+++ b/examples/browser-only/tsconfig.json
@@ -126,9 +126,6 @@
       "path": "../../packages/scm"
     },
     {
-      "path": "../../packages/scm-extra"
-    },
-    {
       "path": "../../packages/search-in-workspace"
     },
     {

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -83,7 +83,6 @@
     "@theia/remote": "1.74.0",
     "@theia/scanoss": "1.74.0",
     "@theia/scm": "1.74.0",
-    "@theia/scm-extra": "1.74.0",
     "@theia/search-in-workspace": "1.74.0",
     "@theia/secondary-window": "1.74.0",
     "@theia/task": "1.74.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -183,9 +183,6 @@
       "path": "../../packages/scm"
     },
     {
-      "path": "../../packages/scm-extra"
-    },
-    {
       "path": "../../packages/search-in-workspace"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -89,7 +89,6 @@
     "@theia/remote-wsl": "1.74.0",
     "@theia/scanoss": "1.74.0",
     "@theia/scm": "1.74.0",
-    "@theia/scm-extra": "1.74.0",
     "@theia/search-in-workspace": "1.74.0",
     "@theia/secondary-window": "1.74.0",
     "@theia/task": "1.74.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -186,9 +186,6 @@
       "path": "../../packages/scm"
     },
     {
-      "path": "../../packages/scm-extra"
-    },
-    {
       "path": "../../packages/search-in-workspace"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -379,6 +379,7 @@
     "dev-packages/ffmpeg": {
       "name": "@theia/ffmpeg",
       "version": "1.74.0",
+      "hasInstallScript": true,
       "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
       "dependencies": {
         "@electron/get": "^2.0.3",
@@ -601,7 +602,6 @@
         "@theia/remote": "1.74.0",
         "@theia/scanoss": "1.74.0",
         "@theia/scm": "1.74.0",
-        "@theia/scm-extra": "1.74.0",
         "@theia/search-in-workspace": "1.74.0",
         "@theia/secondary-window": "1.74.0",
         "@theia/task": "1.74.0",
@@ -666,7 +666,6 @@
         "@theia/property-view": "1.74.0",
         "@theia/scanoss": "1.74.0",
         "@theia/scm": "1.74.0",
-        "@theia/scm-extra": "1.74.0",
         "@theia/search-in-workspace": "1.74.0",
         "@theia/secondary-window": "1.74.0",
         "@theia/task": "1.74.0",
@@ -750,7 +749,6 @@
         "@theia/remote-wsl": "1.74.0",
         "@theia/scanoss": "1.74.0",
         "@theia/scm": "1.74.0",
-        "@theia/scm-extra": "1.74.0",
         "@theia/search-in-workspace": "1.74.0",
         "@theia/secondary-window": "1.74.0",
         "@theia/task": "1.74.0",

--- a/packages/scm-extra/README.md
+++ b/packages/scm-extra/README.md
@@ -5,6 +5,7 @@
 <img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
 
 <h2>ECLIPSE THEIA - SCM-EXTRA EXTENSION</h2>
+<h2>This extension is DEPRECATED!</h2>
 
 <hr />
 

--- a/packages/scm-extra/README.md
+++ b/packages/scm-extra/README.md
@@ -12,6 +12,14 @@
 
 ## Description
 
+> [!WARNING]
+> **Deprecated since 1.75.0** — this package is superseded by the SCM history graph in
+> [`@theia/scm`](../scm) (branch history) and the Timeline view in
+> [`@theia/timeline`](../timeline) (per-file history) and will be removed in a future
+> release. See [eclipse-theia/theia#17457](https://github.com/eclipse-theia/theia/issues/17457).
+> Note that its `SCM History` view requires an `ScmHistorySupport` implementation, which no
+> longer ships with Theia since the removal of `@theia/git`.
+
 The `@theia/scm-extra` extension contributes additional functionality compared to the base `@theia/scm` extension.
 This includes:
 

--- a/packages/scm-extra/package.json
+++ b/packages/scm-extra/package.json
@@ -2,6 +2,7 @@
   "name": "@theia/scm-extra",
   "version": "1.74.0",
   "description": "Theia - Source control extras Extension (deprecated, superseded by the SCM history graph in @theia/scm and the Timeline view)",
+  "private": true,
   "dependencies": {
     "@theia/core": "1.74.0",
     "@theia/editor": "1.74.0",

--- a/packages/scm-extra/package.json
+++ b/packages/scm-extra/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@theia/scm-extra",
   "version": "1.74.0",
-  "description": "Theia - Source control extras Extension",
+  "description": "Theia - Source control extras Extension (deprecated, superseded by the SCM history graph in @theia/scm and the Timeline view)",
   "dependencies": {
     "@theia/core": "1.74.0",
     "@theia/editor": "1.74.0",

--- a/packages/scm-extra/src/browser/history/scm-history-constants.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-constants.ts
@@ -18,11 +18,36 @@ import { Command, Event, nls } from '@theia/core';
 import { OpenViewArguments } from '@theia/core/lib/browser';
 import { ScmFileChangeNode, ScmHistoryCommit } from '../scm-file-change-node';
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export const SCM_HISTORY_ID = 'scm-history';
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export const SCM_HISTORY_LABEL = nls.localizeByDefault('History');
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export const SCM_HISTORY_TOGGLE_KEYBINDING = 'alt+h';
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export const SCM_HISTORY_MAX_COUNT = 100;
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export namespace ScmHistoryCommands {
     export const OPEN_FILE_HISTORY: Command = {
         id: 'scm-history:open-file-history',
@@ -33,16 +58,36 @@ export namespace ScmHistoryCommands {
     };
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface ScmHistoryOpenViewArguments extends OpenViewArguments {
     uri: string | undefined;
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export const ScmHistorySupport = Symbol('scm-history-support');
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface ScmHistorySupport {
     getCommitHistory(options?: HistoryWidgetOptions): Promise<ScmHistoryCommit[]>;
     readonly onDidChangeHistory: Event<void>;
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface ScmCommitNode {
     commitDetails: ScmHistoryCommit;
     authorAvatar: string;
@@ -51,12 +96,22 @@ export interface ScmCommitNode {
     selected: boolean;
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export namespace ScmCommitNode {
     export function is(node: unknown): node is ScmCommitNode {
         return !!node && typeof node === 'object' && 'commitDetails' in node && 'expanded' in node && 'selected' in node;
     }
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface HistoryWidgetOptions {
     range?: {
         toRevision?: string;
@@ -66,4 +121,9 @@ export interface HistoryWidgetOptions {
     maxCount?: number;
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export type ScmHistoryListNode = (ScmCommitNode | ScmFileChangeNode);

--- a/packages/scm-extra/src/browser/history/scm-history-contribution.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-contribution.ts
@@ -27,6 +27,11 @@ import { SCM_HISTORY_ID, SCM_HISTORY_LABEL, ScmHistoryCommands, SCM_HISTORY_TOGG
 export { SCM_HISTORY_ID, SCM_HISTORY_LABEL, ScmHistoryCommands, SCM_HISTORY_TOGGLE_KEYBINDING, ScmHistoryOpenViewArguments };
 
 @injectable()
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export class ScmHistoryContribution extends AbstractViewContribution<ScmHistoryWidget> {
 
     @inject(SelectionService)

--- a/packages/scm-extra/src/browser/history/scm-history-frontend-module.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-frontend-module.ts
@@ -22,6 +22,11 @@ import { ScmExtraLayoutVersion4Migration } from '../scm-extra-layout-migrations'
 
 import '../../../src/browser/style/history.css';
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export function bindScmHistoryModule(bind: interfaces.Bind): void {
 
     bind(ScmHistoryWidget).toSelf();

--- a/packages/scm-extra/src/browser/history/scm-history-provider.ts
+++ b/packages/scm-extra/src/browser/history/scm-history-provider.ts
@@ -17,9 +17,19 @@
 import { ScmProvider } from '@theia/scm/lib/browser/scm-provider';
 import { ScmHistorySupport } from './scm-history-constants';
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface ScmHistoryProvider extends ScmProvider {
     historySupport?: ScmHistorySupport;
 }
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export namespace ScmHistoryProvider {
     export function is(scmProvider: ScmProvider | undefined): scmProvider is ScmHistoryProvider {
         return !!scmProvider && 'historySupport' in scmProvider;

--- a/packages/scm-extra/src/browser/history/scm-history-widget.tsx
+++ b/packages/scm-extra/src/browser/history/scm-history-widget.tsx
@@ -34,6 +34,11 @@ import { HistoryWidgetOptions, ScmCommitNode, ScmHistoryListNode, ScmHistorySupp
 export { HistoryWidgetOptions, ScmCommitNode, ScmHistoryListNode, ScmHistorySupport };
 
 @injectable()
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode> implements StatefulWidget {
     protected options: HistoryWidgetOptions;
     protected singleFileMode: boolean;
@@ -517,6 +522,11 @@ export class ScmHistoryWidget extends ScmNavigableListWidget<ScmHistoryListNode>
     }
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export namespace ScmHistoryList {
     export interface Props {
         readonly rows: ScmHistoryListNode[]
@@ -526,6 +536,11 @@ export namespace ScmHistoryList {
         readonly renderFileChangeList: (fileChange: ScmFileChangeNode) => React.ReactNode
     }
 }
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export class ScmHistoryList extends React.Component<ScmHistoryList.Props> {
     list: VirtuosoHandle | undefined;
 

--- a/packages/scm-extra/src/browser/scm-extra-contribution.ts
+++ b/packages/scm-extra/src/browser/scm-extra-contribution.ts
@@ -15,4 +15,9 @@
 // *****************************************************************************
 import { EDITOR_CONTEXT_MENU } from '@theia/editor/lib/browser';
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export const EDITOR_CONTEXT_MENU_SCM = [...EDITOR_CONTEXT_MENU, '3_scm'];

--- a/packages/scm-extra/src/browser/scm-extra-layout-migrations.ts
+++ b/packages/scm-extra/src/browser/scm-extra-layout-migrations.ts
@@ -19,6 +19,11 @@ import { ApplicationShellLayoutMigration, WidgetDescription, ApplicationShellLay
 import { SCM_HISTORY_ID } from './history/scm-history-contribution';
 
 @injectable()
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export class ScmExtraLayoutVersion4Migration implements ApplicationShellLayoutMigration {
     readonly layoutVersion = 4.0;
     onWillInflateWidget(desc: WidgetDescription, { parent }: ApplicationShellLayoutMigrationContext): WidgetDescription | undefined {

--- a/packages/scm-extra/src/browser/scm-file-change-label-provider.ts
+++ b/packages/scm-extra/src/browser/scm-file-change-label-provider.ts
@@ -21,6 +21,11 @@ import URI from '@theia/core/lib/common/uri';
 import { ScmService } from '@theia/scm/lib/browser/scm-service';
 
 @injectable()
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export class ScmFileChangeLabelProvider implements LabelProviderContribution {
 
     @inject(LabelProvider)

--- a/packages/scm-extra/src/browser/scm-file-change-node.ts
+++ b/packages/scm-extra/src/browser/scm-file-change-node.ts
@@ -18,23 +18,43 @@ import { ScmCommit } from '@theia/scm/lib/browser/scm-provider';
 import URI from '@theia/core/lib/common/uri';
 import { isObject } from '@theia/core/lib/common';
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface ScmFileChangeNode {
     readonly fileChange: ScmFileChange;
     readonly commitId: string;
     selected?: boolean;
 }
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export namespace ScmFileChangeNode {
     export function is(node: unknown): node is ScmFileChangeNode {
         return isObject(node) && 'fileChange' in node && 'commitId' in node;
     }
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface ScmHistoryCommit extends ScmCommit {
     readonly commitDetailUri: URI;
     readonly fileChanges: ScmFileChange[];
     readonly commitDetailOptions: {};
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export interface ScmFileChange {
     readonly uri: string;
     getCaption(): string;

--- a/packages/scm-extra/src/browser/scm-navigable-list-widget.tsx
+++ b/packages/scm-extra/src/browser/scm-navigable-list-widget.tsx
@@ -27,6 +27,11 @@ import { ScmFileChangeLabelProvider } from './scm-file-change-label-provider';
 import { ScmFileChangeNode } from './scm-file-change-node';
 
 @injectable()
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export abstract class ScmNavigableListWidget<T extends { selected?: boolean }> extends ReactWidget {
 
     protected scmNodes: T[] = [];
@@ -158,6 +163,11 @@ export abstract class ScmNavigableListWidget<T extends { selected?: boolean }> e
     }
 }
 
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export namespace ScmItemComponent {
     export interface Props {
         labelProvider: LabelProvider;
@@ -167,6 +177,11 @@ export namespace ScmItemComponent {
         selectNode: (change: ScmFileChangeNode) => void
     }
 }
+/**
+ * @deprecated since 1.75.0 - superseded by the SCM history graph in `@theia/scm`
+ * and the Timeline view in `@theia/timeline`. This package will be removed in a
+ * future release - see https://github.com/eclipse-theia/theia/issues/17457.
+ */
 export class ScmItemComponent extends React.Component<ScmItemComponent.Props> {
 
     override render(): React.JSX.Element {


### PR DESCRIPTION
#### What it does

Addresses item 4 of #17457: deprecates `@theia/scm-extra`.

Its SCM History view is superseded by the SCM history graph in `@theia/scm` (branch history) and the Timeline view in `@theia/timeline` (per-file history). It has also been effectively non-functional in the default application since the removal of `@theia/git`: nothing implements `ScmHistorySupport` anymore, so opening the view only shows "History is not supported for … source control", while its "History" context menu items (navigator/editor) and `alt+h` keybinding remain visible whenever a repository exists.

- Tags all exported APIs with `@deprecated since 1.75.0`, pointing to the replacements (per [api-management.md](https://github.com/eclipse-theia/theia/blob/master/doc/api-management.md#deprecation)).
- Adds a deprecation notice to the README and the package description.
- Marks the package `"private": true` so it is no longer published on npm.
- Removes the package from the example applications — this also removes the dead "History" menu items/keybinding from the examples, and drops `ScmHistoryContribution` from the api-tests menu spec.

Removal from the code base can follow in a later release.

#### How to test

1. Build and start the browser example: the SCM view no longer offers the old History view, and no "History" entries appear in the navigator/editor context menus.
2. API docs/IDE hovers show the deprecation notice for `@theia/scm-extra` exports.

#### Follow-ups

- Remove the package in a future release.

#### Breaking changes

- [x] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
