### PR TITLE
fix(ai-chat): prevent listener leak when streaming rebuilds response content

### DIFF
--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -3164,6 +3164,7 @@ class ChatResponseImpl implements ChatResponse {
     protected _content: ChatResponseContent[];
     protected _responseRepresentation: string;
     protected _responseRepresentationForDisplay: string;
+    protected readonly contentChangeListeners = new Map<ChatResponseContent, Disposable>();
 
     constructor() {
         this._content = [];
@@ -3174,6 +3175,8 @@ class ChatResponseImpl implements ChatResponse {
     }
 
     clearContent(): void {
+        this.contentChangeListeners.forEach(listener => listener.dispose());
+        this.contentChangeListeners.clear();
         this._content = [];
         this._updateResponseRepresentation();
         this._onDidChangeEmitter.fire();
@@ -3209,7 +3212,11 @@ class ChatResponseImpl implements ChatResponse {
                 // Forward content-level change events (e.g. partial-result updates from a
                 // renderer) so auto-save can persist them. Without this, mutations that
                 // don't go through addContent/merge are invisible to listeners.
-                nextContent.onDidChange(() => this._onDidChangeEmitter.fire());
+                // Track the subscription so re-adding the same content after clearContent()
+                // (as the stream parser does per token) doesn't stack up listeners (#17858).
+                if (!this.contentChangeListeners.has(nextContent)) {
+                    this.contentChangeListeners.set(nextContent, nextContent.onDidChange(() => this._onDidChangeEmitter.fire()));
+                }
             }
         } else if (ServerToolCallChatResponseContent.is(nextContent) && nextContent.id !== undefined) {
             // Server tool calls are matched by id (the start and result blocks arrive as separate stream parts).

--- a/packages/ai-chat/src/common/chat-model.ts
+++ b/packages/ai-chat/src/common/chat-model.ts
@@ -3212,11 +3212,11 @@ class ChatResponseImpl implements ChatResponse {
                 // Forward content-level change events (e.g. partial-result updates from a
                 // renderer) so auto-save can persist them. Without this, mutations that
                 // don't go through addContent/merge are invisible to listeners.
-                // Track the subscription so re-adding the same content after clearContent()
-                // (as the stream parser does per token) doesn't stack up listeners (#17858).
-                if (!this.contentChangeListeners.has(nextContent)) {
-                    this.contentChangeListeners.set(nextContent, nextContent.onDidChange(() => this._onDidChangeEmitter.fire()));
-                }
+                // The subscription is tracked so that clearContent() can dispose it: the stream
+                // parser clears and re-adds the content per token, which would otherwise stack
+                // up one listener per token on the same content object (#17858).
+                this.contentChangeListeners.get(nextContent)?.dispose();
+                this.contentChangeListeners.set(nextContent, nextContent.onDidChange(() => this._onDidChangeEmitter.fire()));
             }
         } else if (ServerToolCallChatResponseContent.is(nextContent) && nextContent.id !== undefined) {
             // Server tool calls are matched by id (the start and result blocks arrive as separate stream parts).

--- a/packages/ai-chat/src/common/chat-response-model.spec.ts
+++ b/packages/ai-chat/src/common/chat-response-model.spec.ts
@@ -59,6 +59,22 @@ describe('MutableChatResponseModel', () => {
             // content array was rebuilt during streaming (see #17858).
             expect(fireCount).to.equal(1);
         });
+
+        it('should stop propagating changes of content that was cleared and not re-added', () => {
+            const response = new MutableChatResponseModel('req-1');
+            const toolCall = new ToolCallChatResponseContentImpl('tool-1', 'tool', '{}', false);
+            response.response.addContent(toolCall);
+            response.response.clearContent();
+
+            let fireCount = 0;
+            response.onDidChange(() => { fireCount++; });
+
+            toolCall.updateResult('result');
+
+            // Content that is no longer part of the response must not trigger response changes
+            // (and with that auto-save) anymore.
+            expect(fireCount).to.equal(0);
+        });
     });
 
     describe('setTokenUsage', () => {

--- a/packages/ai-chat/src/common/chat-response-model.spec.ts
+++ b/packages/ai-chat/src/common/chat-response-model.spec.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { MutableChatResponseModel, ToolCallChatResponseContentImpl } from './chat-model';
+import { MarkdownChatResponseContentImpl, MutableChatResponseModel, ToolCallChatResponseContentImpl } from './chat-model';
 
 describe('MutableChatResponseModel', () => {
     describe('content change propagation', () => {
@@ -33,6 +33,30 @@ describe('MutableChatResponseModel', () => {
             // intermediate state. Without this propagation, mutations that don't go
             // through addContent/merge (e.g. renderer-side partial results) would be
             // lost on reload.
+            expect(fireCount).to.equal(1);
+        });
+
+        it('should not accumulate duplicate listeners when content is cleared and re-added', () => {
+            const response = new MutableChatResponseModel('req-1');
+            const toolCall = new ToolCallChatResponseContentImpl('tool-1', 'tool', '{}', false);
+            response.response.addContent(toolCall);
+
+            // Simulate AbstractStreamParsingChatAgent.addStreamResponse: for every streamed
+            // text token, the whole content is cleared and re-added, tool call included.
+            for (let i = 0; i < 10; i++) {
+                const contentBeforeMarker = response.response.content.slice(0, 1);
+                response.response.clearContent();
+                response.response.addContents(contentBeforeMarker);
+                response.response.addContents([new MarkdownChatResponseContentImpl(`token ${i}`)]);
+            }
+
+            let fireCount = 0;
+            response.onDidChange(() => { fireCount++; });
+
+            toolCall.updateResult('result');
+
+            // A single tool call change must fire exactly once, no matter how often the
+            // content array was rebuilt during streaming (see #17858).
             expect(fireCount).to.equal(1);
         });
     });


### PR DESCRIPTION
#### What it does

Fixes #17858.

`ChatResponseImpl.doAddContent` subscribes to a tool call content's `onDidChange` without keeping the disposable, and `clearContent()` never disposes it. `AbstractStreamParsingChatAgent.addStreamResponse` clears and re-adds the content for every streamed text token, so each token after a tool call re-subscribed the same content — one leaked listener per token, triggering the emitter leak warning and firing the response's `onDidChange` once per duplicate listener on every subsequent tool call change.

The fix tracks the subscriptions per content in a `Map`, disposes them in `clearContent()`, and skips re-subscribing for already-tracked content, so each content object has at most one live listener.

#### How to test

- New regression test in `chat-response-model.spec.ts` simulates the streaming clear/re-add cycle and asserts a single tool call change fires `onDidChange` exactly once (fails with `expected 11 to equal 1` without the fix).
- Manual: with a streaming LLM, ask a tool-using agent something that produces a tool call followed by a long prose answer (>175 stream chunks, e.g. "read package.json, then explain each dependency in detail") and watch the frontend dev tools console — without the fix, the `Possible Emitter memory leak detected` warning from #17858 appears.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
