### PR TITLE
fix(core): drop stale tree refreshes when the node no longer belongs to the tree

### DIFF
--- a/packages/core/src/browser/tree/tree-consistency.spec.ts
+++ b/packages/core/src/browser/tree/tree-consistency.spec.ts
@@ -21,6 +21,10 @@ import { TreeImpl, CompositeTreeNode, TreeNode } from './tree';
 import { TreeModel } from './tree-model';
 import { ExpandableTreeNode } from './tree-expansion';
 import { TreeLabelProvider } from './tree-label-provider';
+import { MockTreeModel } from './test/mock-tree-model';
+import { MockLogger } from '../../common/test/mock-logger';
+import { ILogger } from '../../common';
+import { Deferred, timeout } from '../../common/promise-util';
 
 @injectable()
 class ConsistencyTestTree extends TreeImpl {
@@ -69,6 +73,22 @@ function createConsistencyTestRoot(rootName: string): CompositeTreeNode {
     return root;
 }
 
+/**
+ * A `TreeImpl` whose `resolveChildren` can be stalled per node id, to simulate
+ * slow child resolution (e.g. a file system request) in tests.
+ */
+@injectable()
+class StallingTestTree extends TreeImpl {
+
+    readonly resolveRequests = new Map<string, Deferred<TreeNode[]>>();
+
+    protected override resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+        const pending = this.resolveRequests.get(parent.id);
+        return pending ? pending.promise : super.resolveChildren(parent);
+    }
+
+}
+
 describe('Tree Consistency', () => {
 
     it('setting different tree roots should finish', async () => {
@@ -100,6 +120,61 @@ describe('Tree Consistency', () => {
             resolveCounter = tree.resolveCounter;
         }
         assert.ok(false, 'Resolving does not stop, attempts: ' + tree.resolveCounter);
+    });
+
+    describe('stale refreshes', () => {
+
+        let tree: StallingTestTree;
+        let model: TreeModel;
+        let loggedErrors: unknown[][];
+
+        beforeEach(async () => {
+            const container = createTreeTestContainer();
+            container.bind(StallingTestTree).toSelf();
+            container.rebind(TreeImpl).toService(StallingTestTree);
+            tree = container.get(StallingTestTree);
+            model = container.get<TreeModel>(TreeModel);
+            loggedErrors = [];
+            const logger = container.get<MockLogger>(ILogger);
+            logger.error = async (...args: unknown[]) => { loggedErrors.push(args); };
+            model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
+            // let the refresh cascade triggered by setting the root settle
+            await timeout(0);
+        });
+
+        it('drops an in-flight refresh when the root is replaced meanwhile', async () => {
+            const stale = model.getNode('1.2') as CompositeTreeNode;
+            const gate = new Deferred<TreeNode[]>();
+            tree.resolveRequests.set('1.2', gate);
+            const pendingRefresh = tree.refresh(stale);
+            tree.resolveRequests.delete('1.2');
+
+            model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
+            gate.resolve(Array.from(stale.children));
+
+            assert.strictEqual(await pendingRefresh, undefined);
+            assert.deepStrictEqual(loggedErrors, []);
+            const fresh = model.getNode('1.2');
+            assert.ok(fresh);
+            assert.notStrictEqual(fresh, stale);
+        });
+
+        it('does not resurrect a removed subtree when a stale refresh completes', async () => {
+            const target = model.getNode('1.2') as CompositeTreeNode;
+            const gate = new Deferred<TreeNode[]>();
+            tree.resolveRequests.set('1.2', gate);
+            const pendingRefresh = tree.refresh(target);
+            tree.resolveRequests.delete('1.2');
+
+            CompositeTreeNode.removeChild(target.parent as CompositeTreeNode, target, tree);
+            assert.strictEqual(model.getNode('1.2'), undefined);
+            gate.resolve(Array.from(target.children));
+
+            assert.strictEqual(await pendingRefresh, undefined);
+            assert.strictEqual(model.getNode('1.2'), undefined);
+            assert.strictEqual(model.getNode('1.2.1'), undefined);
+        });
+
     });
 
 });

--- a/packages/core/src/browser/tree/tree-consistency.spec.ts
+++ b/packages/core/src/browser/tree/tree-consistency.spec.ts
@@ -23,7 +23,7 @@ import { ExpandableTreeNode } from './tree-expansion';
 import { TreeLabelProvider } from './tree-label-provider';
 import { MockTreeModel } from './test/mock-tree-model';
 import { MockLogger } from '../../common/test/mock-logger';
-import { ILogger } from '../../common';
+import { Disposable, ILogger } from '../../common';
 import { Deferred, timeout } from '../../common/promise-util';
 
 @injectable()
@@ -74,17 +74,40 @@ function createConsistencyTestRoot(rootName: string): CompositeTreeNode {
 }
 
 /**
- * A `TreeImpl` whose `resolveChildren` can be stalled per node id, to simulate
- * slow child resolution (e.g. a file system request) in tests.
+ * A `TreeImpl` whose `resolveChildren` can be stalled or overridden per node id, to
+ * simulate slow child resolution (e.g. a file system request) in tests.
  */
 @injectable()
 class StallingTestTree extends TreeImpl {
 
-    readonly resolveRequests = new Map<string, Deferred<TreeNode[]>>();
+    protected readonly stalled = new Map<string, Deferred<TreeNode[]>>();
+    protected readonly overrides = new Map<string, () => TreeNode[]>();
+
+    /**
+     * Stall the *next* `resolveChildren` for `id` on the returned deferred. Later
+     * resolutions for the same id proceed normally, so the stall cannot leak into
+     * unrelated refreshes (e.g. the cascade of a newly set root).
+     */
+    stallNextResolve(id: string): Deferred<TreeNode[]> {
+        const gate = new Deferred<TreeNode[]>();
+        this.stalled.set(id, gate);
+        return gate;
+    }
+
+    /** Make `resolveChildren` for `id` return `children()` instead of the current child nodes. */
+    overrideResolve(id: string, children: () => TreeNode[]): Disposable {
+        this.overrides.set(id, children);
+        return Disposable.create(() => this.overrides.delete(id));
+    }
 
     protected override resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
-        const pending = this.resolveRequests.get(parent.id);
-        return pending ? pending.promise : super.resolveChildren(parent);
+        const gate = this.stalled.get(parent.id);
+        if (gate) {
+            this.stalled.delete(parent.id);
+            return gate.promise;
+        }
+        const override = this.overrides.get(parent.id);
+        return override ? Promise.resolve(override()) : super.resolveChildren(parent);
     }
 
 }
@@ -144,10 +167,8 @@ describe('Tree Consistency', () => {
 
         it('drops an in-flight refresh when the root is replaced meanwhile', async () => {
             const stale = model.getNode('1.2') as CompositeTreeNode;
-            const gate = new Deferred<TreeNode[]>();
-            tree.resolveRequests.set('1.2', gate);
+            const gate = tree.stallNextResolve('1.2');
             const pendingRefresh = tree.refresh(stale);
-            tree.resolveRequests.delete('1.2');
 
             model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
             gate.resolve(Array.from(stale.children));
@@ -161,10 +182,8 @@ describe('Tree Consistency', () => {
 
         it('does not resurrect a removed subtree when a stale refresh completes', async () => {
             const target = model.getNode('1.2') as CompositeTreeNode;
-            const gate = new Deferred<TreeNode[]>();
-            tree.resolveRequests.set('1.2', gate);
+            const gate = tree.stallNextResolve('1.2');
             const pendingRefresh = tree.refresh(target);
-            tree.resolveRequests.delete('1.2');
 
             CompositeTreeNode.removeChild(target.parent as CompositeTreeNode, target, tree);
             assert.strictEqual(model.getNode('1.2'), undefined);
@@ -172,6 +191,29 @@ describe('Tree Consistency', () => {
 
             assert.strictEqual(await pendingRefresh, undefined);
             assert.strictEqual(model.getNode('1.2'), undefined);
+            assert.strictEqual(model.getNode('1.2.1'), undefined);
+        });
+
+        it('does not re-index a node object that a concurrent ancestor refresh replaced', async () => {
+            const stale = model.getNode('1.2') as CompositeTreeNode;
+            const gate = tree.stallNextResolve('1.2');
+            const pendingRefresh = tree.refresh(stale);
+
+            // an ancestor refresh yields a *fresh* object for the same id, as trees whose
+            // `resolveChildren` builds new nodes do
+            const parent = model.getNode('1') as CompositeTreeNode;
+            const replacement: CompositeTreeNode = { id: '1.2', name: '1.2', parent, children: [] };
+            const override = tree.overrideResolve('1', () => parent.children.map(child => child.id === '1.2' ? replacement : child));
+            await tree.refresh(parent);
+            override.dispose();
+            assert.strictEqual(model.getNode('1.2'), replacement);
+
+            gate.resolve(Array.from(stale.children));
+
+            assert.strictEqual(await pendingRefresh, undefined);
+            assert.deepStrictEqual(loggedErrors, []);
+            // the stale object must not take the replacement's place in the index, nor bring its children back
+            assert.strictEqual(model.getNode('1.2'), replacement);
             assert.strictEqual(model.getNode('1.2.1'), undefined);
         });
 

--- a/packages/core/src/browser/tree/tree-consistency.spec.ts
+++ b/packages/core/src/browser/tree/tree-consistency.spec.ts
@@ -23,7 +23,7 @@ import { ExpandableTreeNode } from './tree-expansion';
 import { TreeLabelProvider } from './tree-label-provider';
 import { MockTreeModel } from './test/mock-tree-model';
 import { MockLogger } from '../../common/test/mock-logger';
-import { Disposable, ILogger } from '../../common';
+import { ILogger } from '../../common';
 import { Deferred, timeout } from '../../common/promise-util';
 
 @injectable()
@@ -94,10 +94,9 @@ class StallingTestTree extends TreeImpl {
         return gate;
     }
 
-    /** Make `resolveChildren` for `id` return `children()` instead of the current child nodes. */
-    overrideResolve(id: string, children: () => TreeNode[]): Disposable {
+    /** Make the *next* `resolveChildren` for `id` return `children()` instead of the current child nodes. */
+    overrideNextResolve(id: string, children: () => TreeNode[]): void {
         this.overrides.set(id, children);
-        return Disposable.create(() => this.overrides.delete(id));
     }
 
     protected override resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
@@ -107,7 +106,11 @@ class StallingTestTree extends TreeImpl {
             return gate.promise;
         }
         const override = this.overrides.get(parent.id);
-        return override ? Promise.resolve(override()) : super.resolveChildren(parent);
+        if (override) {
+            this.overrides.delete(parent.id);
+            return Promise.resolve(override());
+        }
+        return super.resolveChildren(parent);
     }
 
 }
@@ -203,9 +206,8 @@ describe('Tree Consistency', () => {
             // `resolveChildren` builds new nodes do
             const parent = model.getNode('1') as CompositeTreeNode;
             const replacement: CompositeTreeNode = { id: '1.2', name: '1.2', parent, children: [] };
-            const override = tree.overrideResolve('1', () => parent.children.map(child => child.id === '1.2' ? replacement : child));
+            tree.overrideNextResolve('1', () => parent.children.map(child => child.id === '1.2' ? replacement : child));
             await tree.refresh(parent);
-            override.dispose();
             assert.strictEqual(model.getNode('1.2'), replacement);
 
             gate.resolve(Array.from(stale.children));

--- a/packages/core/src/browser/tree/tree.spec.ts
+++ b/packages/core/src/browser/tree/tree.spec.ts
@@ -15,11 +15,30 @@
 // *****************************************************************************
 
 import * as assert from 'assert';
-import { TreeNode, CompositeTreeNode } from './tree';
+import { injectable } from 'inversify';
+import { TreeNode, CompositeTreeNode, TreeImpl } from './tree';
 import { TreeModel } from './tree-model';
 import { MockTreeModel } from './test/mock-tree-model';
 import { expect } from 'chai';
 import { createTreeTestContainer } from './test/tree-test-container';
+import { Deferred, timeout } from '../../common/promise-util';
+import { ILogger } from '../../common';
+import { MockLogger } from '../../common/test/mock-logger';
+
+/**
+ * A `TreeImpl` whose `resolveChildren` can be stalled per node id, to simulate
+ * slow child resolution (e.g. a file system request) in tests.
+ */
+@injectable()
+class ControllableTree extends TreeImpl {
+
+    readonly resolveRequests = new Map<string, Deferred<TreeNode[]>>();
+
+    protected override resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
+        const pending = this.resolveRequests.get(parent.id);
+        return pending ? pending.promise : super.resolveChildren(parent);
+    }
+}
 
 describe('Tree', () => {
 
@@ -225,6 +244,58 @@ describe('Tree', () => {
                 expect(expectedRefreshedNodes.size).to.be.equal(0);
                 done();
             });
+        });
+    });
+
+    describe('refresh - stale refreshes', () => {
+
+        let tree: ControllableTree;
+        let loggedErrors: unknown[][];
+
+        beforeEach(async () => {
+            const container = createTreeTestContainer();
+            container.rebind(TreeImpl).to(ControllableTree);
+            model = container.get(TreeModel);
+            tree = container.get(TreeImpl) as ControllableTree;
+            loggedErrors = [];
+            const logger = container.get<MockLogger>(ILogger);
+            logger.error = async (...args: unknown[]) => { loggedErrors.push(args); };
+            model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
+            // let the refresh cascade triggered by setting the root settle
+            await timeout(0);
+        });
+
+        it('drops an in-flight refresh when the root is replaced meanwhile', async () => {
+            const stale = retrieveNode<CompositeTreeNode>('1.2');
+            const gate = new Deferred<TreeNode[]>();
+            tree.resolveRequests.set('1.2', gate);
+            const pendingRefresh = tree.refresh(stale);
+            tree.resolveRequests.delete('1.2');
+
+            model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
+            gate.resolve(Array.from(stale.children));
+
+            expect(await pendingRefresh).to.be.undefined;
+            expect(loggedErrors).to.have.lengthOf(0);
+            const fresh = model.getNode('1.2');
+            expect(fresh).to.not.be.undefined;
+            expect(fresh).to.not.equal(stale);
+        });
+
+        it('does not resurrect a removed subtree when a stale refresh completes', async () => {
+            const target = retrieveNode<CompositeTreeNode>('1.2');
+            const gate = new Deferred<TreeNode[]>();
+            tree.resolveRequests.set('1.2', gate);
+            const pendingRefresh = tree.refresh(target);
+            tree.resolveRequests.delete('1.2');
+
+            CompositeTreeNode.removeChild(target.parent as CompositeTreeNode, target, tree);
+            expect(model.getNode('1.2')).to.be.undefined;
+            gate.resolve(Array.from(target.children));
+
+            expect(await pendingRefresh).to.be.undefined;
+            expect(model.getNode('1.2')).to.be.undefined;
+            expect(model.getNode('1.2.1')).to.be.undefined;
         });
     });
 

--- a/packages/core/src/browser/tree/tree.spec.ts
+++ b/packages/core/src/browser/tree/tree.spec.ts
@@ -15,30 +15,11 @@
 // *****************************************************************************
 
 import * as assert from 'assert';
-import { injectable } from 'inversify';
-import { TreeNode, CompositeTreeNode, TreeImpl } from './tree';
+import { TreeNode, CompositeTreeNode } from './tree';
 import { TreeModel } from './tree-model';
 import { MockTreeModel } from './test/mock-tree-model';
 import { expect } from 'chai';
 import { createTreeTestContainer } from './test/tree-test-container';
-import { Deferred, timeout } from '../../common/promise-util';
-import { ILogger } from '../../common';
-import { MockLogger } from '../../common/test/mock-logger';
-
-/**
- * A `TreeImpl` whose `resolveChildren` can be stalled per node id, to simulate
- * slow child resolution (e.g. a file system request) in tests.
- */
-@injectable()
-class ControllableTree extends TreeImpl {
-
-    readonly resolveRequests = new Map<string, Deferred<TreeNode[]>>();
-
-    protected override resolveChildren(parent: CompositeTreeNode): Promise<TreeNode[]> {
-        const pending = this.resolveRequests.get(parent.id);
-        return pending ? pending.promise : super.resolveChildren(parent);
-    }
-}
 
 describe('Tree', () => {
 
@@ -244,58 +225,6 @@ describe('Tree', () => {
                 expect(expectedRefreshedNodes.size).to.be.equal(0);
                 done();
             });
-        });
-    });
-
-    describe('refresh - stale refreshes', () => {
-
-        let tree: ControllableTree;
-        let loggedErrors: unknown[][];
-
-        beforeEach(async () => {
-            const container = createTreeTestContainer();
-            container.rebind(TreeImpl).to(ControllableTree);
-            model = container.get(TreeModel);
-            tree = container.get(TreeImpl) as ControllableTree;
-            loggedErrors = [];
-            const logger = container.get<MockLogger>(ILogger);
-            logger.error = async (...args: unknown[]) => { loggedErrors.push(args); };
-            model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
-            // let the refresh cascade triggered by setting the root settle
-            await timeout(0);
-        });
-
-        it('drops an in-flight refresh when the root is replaced meanwhile', async () => {
-            const stale = retrieveNode<CompositeTreeNode>('1.2');
-            const gate = new Deferred<TreeNode[]>();
-            tree.resolveRequests.set('1.2', gate);
-            const pendingRefresh = tree.refresh(stale);
-            tree.resolveRequests.delete('1.2');
-
-            model.root = MockTreeModel.HIERARCHICAL_MOCK_ROOT();
-            gate.resolve(Array.from(stale.children));
-
-            expect(await pendingRefresh).to.be.undefined;
-            expect(loggedErrors).to.have.lengthOf(0);
-            const fresh = model.getNode('1.2');
-            expect(fresh).to.not.be.undefined;
-            expect(fresh).to.not.equal(stale);
-        });
-
-        it('does not resurrect a removed subtree when a stale refresh completes', async () => {
-            const target = retrieveNode<CompositeTreeNode>('1.2');
-            const gate = new Deferred<TreeNode[]>();
-            tree.resolveRequests.set('1.2', gate);
-            const pendingRefresh = tree.refresh(target);
-            tree.resolveRequests.delete('1.2');
-
-            CompositeTreeNode.removeChild(target.parent as CompositeTreeNode, target, tree);
-            expect(model.getNode('1.2')).to.be.undefined;
-            gate.resolve(Array.from(target.children));
-
-            expect(await pendingRefresh).to.be.undefined;
-            expect(model.getNode('1.2')).to.be.undefined;
-            expect(model.getNode('1.2.1')).to.be.undefined;
         });
     });
 

--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -354,6 +354,11 @@ export class TreeImpl implements Tree {
                 result = parent;
                 const children = await this.resolveChildren(parent);
                 if (cancellationToken?.isCancellationRequested) { return; }
+                if (this.getNode(parent.id) !== parent) {
+                    // the tree changed while children were being resolved (e.g. a new root was
+                    // set or the node was removed): drop the stale refresh
+                    return undefined;
+                }
                 result = await this.setChildren(parent, children);
                 if (cancellationToken?.isCancellationRequested) { return; }
             } finally {

--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -357,6 +357,7 @@ export class TreeImpl implements Tree {
                 if (this.validateNode(parent) !== parent) {
                     // the tree changed while children were being resolved (e.g. a new root was
                     // set or the node was removed): drop the stale refresh
+                    this.logger.debug(`Refresh of node '${parent.id}' dropped, it no longer belongs to the tree.`);
                     return undefined;
                 }
                 result = await this.setChildren(parent, children);

--- a/packages/core/src/browser/tree/tree.ts
+++ b/packages/core/src/browser/tree/tree.ts
@@ -354,7 +354,7 @@ export class TreeImpl implements Tree {
                 result = parent;
                 const children = await this.resolveChildren(parent);
                 if (cancellationToken?.isCancellationRequested) { return; }
-                if (this.getNode(parent.id) !== parent) {
+                if (this.validateNode(parent) !== parent) {
                     // the tree changed while children were being resolved (e.g. a new root was
                     // set or the node was removed): drop the stale refresh
                     return undefined;


### PR DESCRIPTION
#### What it does

Fixes #17885.

`TreeImpl.refresh` now drops an in-flight refresh if the node no longer belongs to the tree after `resolveChildren` resolves (the tree's id→node index no longer maps the node's id to that node). This re-asserts the same invariant `validateNode` establishes at the start of `refresh`.

This fixes two problems caused by stale refreshes:
- Since 1.74, `restorePerspectiveLayouts` inflates every persisted perspective layout at startup, calling `restoreState()` repeatedly on the same navigator widget. Each call replaces `model.root`, and the expansion service's un-cancellable nested refresh from the previous root then hits the guard in `setChildren`, logging `Child node '<path>' does not belong to this 'WorkspaceNodeId' tree.` on every startup.
- A stale refresh of a *removed* node passed the root-consistency guard in `setChildren` and re-inserted the removed subtree into the id→node index.

Both cases are covered by new specs in `tree-consistency.spec.ts`.

#### How to test

1. Open a workspace with the Explorer visible, switch to the AI-First perspective and back, then reload: without the fix, the error above is logged during layout restore; with the fix it is not, and the Explorer restores normally.
2. `npx mocha --config configs/mocharc.yml "packages/core/lib/**/*.spec.js"` — the two new specs fail without the `tree.ts` change and pass with it.

#### Follow-ups

Perspective layout inflation could avoid calling `restoreState()` on the same widget once per perspective (only the active perspective's layout needs it eagerly), which would also save the redundant file-system requests at startup.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (not applicable — no user-facing text)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

