### PR TITLE
feat(ai-registry): auto-update installed skills and MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [core, monaco] fixed Monaco theme CSS, `SelectComponent` dropdown placement, and the OS font class in secondary windows [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [scm] aligned the history graph with VS Code: ref-role lane and badge colors, a current-commit indicator, and a commit hover rendered from the content the history provider supplies [#17880](https://github.com/eclipse-theia/theia/pull/17880)
 - [scm-extra] deprecated `@theia/scm-extra` package [#17882](https://github.com/eclipse-theia/theia/pull/17882)
+- [vsx-registry] fixed missing counter badges in the Extensions view when no contribution changes after a section is created, for example when the application is started offline [#17887](https://github.com/eclipse-theia/theia/pull/17887)
 
 <a name="breaking_changes_1.75.0">[Breaking Changes:](#breaking_changes_1.75.0)</a>
 
@@ -18,6 +19,7 @@
 - [monaco] removed the `protected secondaryWindowHandler` field from `MonacoFrontendApplicationContribution`; the Monaco theme stylesheet is now injected into every secondary window via `SecondaryWindowService.onWindowLoaded` [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [scm] widened `ScmHistoryItem.tooltip` from `string` to `string | MarkdownString | readonly MarkdownString[]`, so that hovers supplied by a history provider keep their `isTrusted` command allow-list and their multi-section form; adopters reading the field as a string must narrow it [#17880](https://github.com/eclipse-theia/theia/pull/17880)
 - [scm-extra] deprecated the `@theia/scm-extra` extension and stopped publishing it on npm; it has also been removed from the example applications, which drops its `SCM History` view, the `History` context menu items in the navigator and editor, and the `alt+h` keybinding. The view has been non-functional in the default application since the removal of `@theia/git`, as nothing implements `ScmHistorySupport` anymore. Please use the SCM history graph in `@theia/scm` for branch history and the Timeline view in `@theia/timeline` for per-file history instead [#17882](https://github.com/eclipse-theia/theia/pull/17882)
+- [vsx-registry] `VSXExtensionsWidget.resolveCount()` is now synchronous (`number | undefined` instead of `Promise<number | undefined>`) and counts the resolved tree nodes instead of re-resolving the source's elements; adopters overriding it must adapt the signature [#17887](https://github.com/eclipse-theia/theia/pull/17887)
 
 ## 1.74.0 - 7/31/2026
 

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -18,13 +18,14 @@ import '../../src/browser/style/mcp-entries.css';
 import '../../src/browser/style/skill-entries.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
-import { PreferenceContribution } from '@theia/core';
-import { RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
+import { CommandContribution, MenuContribution, PreferenceContribution } from '@theia/core';
+import { FrontendApplicationContribution, RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
 import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ExtensionsSourceContribution } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
+import { AIRegistryPreferencesSchema } from '../common/ai-registry-preferences';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../common/mcp/mcp-registry-entry-resolver';
 import { RegistryFetchService, RegistryFetchServiceImpl } from '../common/registry-fetch-service';
 import { RegistrySearchFilter } from '../common/registry-search-filter';
@@ -40,6 +41,10 @@ import { SkillExtensionsContribution } from './skill/skill-extensions-contributi
 import { InstallSkillUriConfiguration } from './skill/install-skill-uri-configuration';
 import { InstallSkillUriHandler } from './skill/install-skill-uri-handler';
 import { AIRegistryToolbarContribution } from './ai-registry-toolbar-contribution';
+import { AIRegistryMenuContribution } from './ai-registry-menu-contribution';
+import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from './auto-update/registry-auto-update-policy';
+import { RegistryAutoUpdateService } from './auto-update/registry-auto-update-service';
+import { RegistryAutoUpdateContribution } from './auto-update/registry-auto-update-contribution';
 
 export default new ContainerModule(bind => {
     bind(AIRegistryConfiguration).toSelf().inSingletonScope();
@@ -78,4 +83,15 @@ export default new ContainerModule(bind => {
 
     bind(AIRegistryToolbarContribution).toSelf().inSingletonScope();
     bind(TabBarToolbarContribution).toService(AIRegistryToolbarContribution);
+
+    bind(PreferenceContribution).toConstantValue({ schema: AIRegistryPreferencesSchema });
+    bind(RegistryAutoUpdatePolicyImpl).toSelf().inSingletonScope();
+    bind(RegistryAutoUpdatePolicy).toService(RegistryAutoUpdatePolicyImpl);
+    bind(RegistryAutoUpdateService).toSelf().inSingletonScope();
+    bind(RegistryAutoUpdateContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(RegistryAutoUpdateContribution);
+
+    bind(AIRegistryMenuContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(AIRegistryMenuContribution);
+    bind(MenuContribution).toService(AIRegistryMenuContribution);
 });

--- a/packages/ai-registry/src/browser/ai-registry-menu-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/ai-registry-menu-contribution.spec.ts
@@ -1,0 +1,190 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Command, CommandHandler, CommandRegistry, PreferenceService } from '@theia/core';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
+import { Container } from '@theia/core/shared/inversify';
+import { AUTO_UPDATE_OVERRIDES_PREF, AUTO_UPDATE_PREF } from '../common/ai-registry-preferences';
+import { AIRegistryCommands, AIRegistryMenuContribution } from './ai-registry-menu-contribution';
+import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from './auto-update/registry-auto-update-policy';
+import { RegistryEntryContext } from './registry-entry-context';
+
+/** Collects the handlers the contribution registers so the tests can invoke them directly. */
+class StubCommandRegistry {
+    readonly handlers = new Map<string, CommandHandler>();
+    registerCommand(command: Command, handler: CommandHandler): void {
+        this.handlers.set(command.id, handler);
+    }
+}
+
+class FakePreferenceService {
+    private readonly store = new Map<string, unknown>();
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return (this.store.has(key) ? this.store.get(key) : defaultValue) as T | undefined;
+    }
+    async set(key: string, value: unknown): Promise<void> {
+        this.store.set(key, value);
+    }
+    snapshot<T>(key: string): T | undefined {
+        return this.store.get(key) as T | undefined;
+    }
+}
+
+/** An entry that is installed and linked to a live registry entry, so it can take a policy. */
+const eligible: RegistryEntryContext = {
+    artifactKind: 'skill',
+    copyableId: 'io.github.example/example-skill',
+    autoUpdateId: 'io.github.example/example-skill'
+};
+
+/** A card that cannot receive updates - drifted, unlinked, stale-linked or not installed. */
+const notEligible: RegistryEntryContext = {
+    artifactKind: 'skill',
+    copyableId: 'io.github.example/example-skill',
+    autoUpdateId: undefined
+};
+
+describe('AIRegistryMenuContribution', () => {
+
+    /** The mode items shown when their mode is not the current global default. */
+    const plainIds = [
+        AIRegistryCommands.AUTO_UPDATE_OFF.id,
+        AIRegistryCommands.AUTO_UPDATE_ASK.id,
+        AIRegistryCommands.AUTO_UPDATE_ON.id
+    ];
+    /** The mode items shown when their mode is the current global default. */
+    const defaultIds = [
+        AIRegistryCommands.AUTO_UPDATE_OFF_DEFAULT.id,
+        AIRegistryCommands.AUTO_UPDATE_ASK_DEFAULT.id,
+        AIRegistryCommands.AUTO_UPDATE_ON_DEFAULT.id
+    ];
+    const autoUpdateCommandIds = [...plainIds, ...defaultIds];
+
+    let prefs: FakePreferenceService;
+    let copied: string[];
+    let registry: StubCommandRegistry;
+
+    beforeEach(() => {
+        const container = new Container();
+        prefs = new FakePreferenceService();
+        copied = [];
+        container.bind(PreferenceService).toConstantValue(prefs);
+        container.bind(ClipboardService).toConstantValue({
+            readText: () => '',
+            writeText: (value: string) => { copied.push(value); }
+        } as ClipboardService);
+        container.bind(RegistryAutoUpdatePolicyImpl).toSelf().inSingletonScope();
+        container.bind(RegistryAutoUpdatePolicy).toService(RegistryAutoUpdatePolicyImpl);
+        container.bind(AIRegistryMenuContribution).toSelf().inSingletonScope();
+        registry = new StubCommandRegistry();
+        container.get(AIRegistryMenuContribution).registerCommands(registry as unknown as CommandRegistry);
+    });
+
+    function handler(command: Command | string): CommandHandler {
+        return registry.handlers.get(typeof command === 'string' ? command : command.id)!;
+    }
+
+    function isVisible(command: Command | string, ...args: unknown[]): boolean {
+        return !!handler(command).isVisible?.(...args);
+    }
+
+    /** The mode items the menu actually renders. */
+    function visibleModes(...args: unknown[]): string[] {
+        return autoUpdateCommandIds.filter(id => isVisible(id, ...args));
+    }
+
+    /** The mode items the menu renders with a check mark. */
+    function checkedModes(...args: unknown[]): string[] {
+        return visibleModes(...args).filter(id => handler(id).isToggled?.(...args));
+    }
+
+    it('registers a command per auto-update mode variant plus Copy ID', () => {
+        expect([...registry.handlers.keys()]).to.have.members([...autoUpdateCommandIds, AIRegistryCommands.COPY_ID.id]);
+    });
+
+    it('offers every mode exactly once, as the variant that names the current default', () => {
+        expect(visibleModes(eligible)).to.have.members([
+            AIRegistryCommands.AUTO_UPDATE_OFF.id,
+            AIRegistryCommands.AUTO_UPDATE_ASK_DEFAULT.id,
+            AIRegistryCommands.AUTO_UPDATE_ON.id
+        ]);
+    });
+
+    it('moves the default variant along when the global default changes', async () => {
+        await prefs.set(AUTO_UPDATE_PREF, 'on');
+        expect(visibleModes(eligible)).to.have.members([
+            AIRegistryCommands.AUTO_UPDATE_OFF.id,
+            AIRegistryCommands.AUTO_UPDATE_ASK.id,
+            AIRegistryCommands.AUTO_UPDATE_ON_DEFAULT.id
+        ]);
+    });
+
+    it('hides the auto-update modes for an entry that cannot receive updates', () => {
+        expect(visibleModes(notEligible)).to.be.empty;
+    });
+
+    it('hides every command when invoked without an entry, as from the command palette', () => {
+        for (const id of [...autoUpdateCommandIds, AIRegistryCommands.COPY_ID.id]) {
+            expect(isVisible(id), id).to.be.false;
+        }
+    });
+
+    it('checks the default variant when the entry has no override, so the mode reads as inherited', () => {
+        expect(checkedModes(eligible)).to.deep.equal([AIRegistryCommands.AUTO_UPDATE_ASK_DEFAULT.id]);
+    });
+
+    it('checks a plain variant once an override is set, so the mode reads as explicitly set', async () => {
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, { [`skill:${eligible.autoUpdateId}`]: 'on' });
+        expect(checkedModes(eligible)).to.deep.equal([AIRegistryCommands.AUTO_UPDATE_ON.id]);
+    });
+
+    it('checks nothing for an entry the menu cannot apply a policy to', () => {
+        expect(checkedModes(notEligible)).to.be.empty;
+    });
+
+    it('writes an override for the picked mode', async () => {
+        await handler(AIRegistryCommands.AUTO_UPDATE_ON).execute(eligible);
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ [`skill:${eligible.autoUpdateId}`]: 'on' });
+    });
+
+    it('picking the default variant clears the override instead of pinning it', async () => {
+        await prefs.set(AUTO_UPDATE_PREF, 'ask');
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, { [`skill:${eligible.autoUpdateId}`]: 'on' });
+
+        await handler(AIRegistryCommands.AUTO_UPDATE_ASK_DEFAULT).execute(eligible);
+
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({});
+    });
+
+    it('does nothing when a mode is picked without an entry', async () => {
+        await handler(AIRegistryCommands.AUTO_UPDATE_ON).execute();
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.be.undefined;
+    });
+
+    it('copies the entry id to the clipboard', async () => {
+        await handler(AIRegistryCommands.COPY_ID).execute(eligible);
+        expect(copied).to.deep.equal(['io.github.example/example-skill']);
+    });
+
+    it('hides Copy ID for an entry without any identifier', () => {
+        expect(isVisible(AIRegistryCommands.COPY_ID, { artifactKind: 'mcp', copyableId: undefined, autoUpdateId: undefined })).to.be.false;
+    });
+
+    it('offers Copy ID for an entry that has no auto-update policy but does have an id', () => {
+        expect(isVisible(AIRegistryCommands.COPY_ID, notEligible)).to.be.true;
+    });
+});

--- a/packages/ai-registry/src/browser/ai-registry-menu-contribution.ts
+++ b/packages/ai-registry/src/browser/ai-registry-menu-contribution.ts
@@ -1,0 +1,155 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Command, CommandContribution, CommandRegistry, MenuContribution, MenuModelRegistry, nls } from '@theia/core';
+import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { AutoUpdateMode } from '../common/ai-registry-preferences';
+import { RegistryAutoUpdatePolicy } from './auto-update/registry-auto-update-policy';
+import { AIRegistryEntryContextMenu, RegistryEntryContext } from './registry-entry-context';
+
+export namespace AIRegistryCommands {
+    export const AUTO_UPDATE_OFF: Command = { id: 'ai-registry.auto-update.off' };
+    export const AUTO_UPDATE_ASK: Command = { id: 'ai-registry.auto-update.ask' };
+    export const AUTO_UPDATE_ON: Command = { id: 'ai-registry.auto-update.on' };
+    export const AUTO_UPDATE_OFF_DEFAULT: Command = { id: 'ai-registry.auto-update.off-default' };
+    export const AUTO_UPDATE_ASK_DEFAULT: Command = { id: 'ai-registry.auto-update.ask-default' };
+    export const AUTO_UPDATE_ON_DEFAULT: Command = { id: 'ai-registry.auto-update.on-default' };
+    export const COPY_ID: Command = { id: 'ai-registry.copy-id' };
+}
+
+/** One auto-update mode as offered in the submenu, in its plain and its "is the default" variant. */
+interface AutoUpdateModeItem {
+    readonly mode: AutoUpdateMode;
+    readonly order: string;
+    readonly command: Command;
+    readonly label: string;
+    readonly defaultCommand: Command;
+    readonly defaultLabel: string;
+}
+
+function modeItem(mode: AutoUpdateMode, order: string, command: Command, defaultCommand: Command, label: string): AutoUpdateModeItem {
+    return {
+        mode, order, command, label, defaultCommand,
+        defaultLabel: nls.localizeByDefault('{0} (Default)', label)
+    };
+}
+
+const AUTO_UPDATE_MODE_ITEMS: readonly AutoUpdateModeItem[] = [
+    modeItem('off', '0', AIRegistryCommands.AUTO_UPDATE_OFF, AIRegistryCommands.AUTO_UPDATE_OFF_DEFAULT,
+        nls.localizeByDefault('Off')),
+    modeItem('ask', '1', AIRegistryCommands.AUTO_UPDATE_ASK, AIRegistryCommands.AUTO_UPDATE_ASK_DEFAULT,
+        nls.localizeByDefault('Ask')),
+    modeItem('on', '2', AIRegistryCommands.AUTO_UPDATE_ON, AIRegistryCommands.AUTO_UPDATE_ON_DEFAULT,
+        nls.localizeByDefault('On'))
+];
+
+/**
+ * Commands and menu items behind the gear icon on skill and MCP entry cards.
+ *
+ * The auto-update items are only offered for artifacts that can actually receive an update
+ * - installed and linked to a live registry entry. Drifted, unlinked, stale-linked and
+ * not-yet-installed cards expose Copy ID alone, so the gear is never an empty menu.
+ */
+@injectable()
+export class AIRegistryMenuContribution implements CommandContribution, MenuContribution {
+
+    @inject(RegistryAutoUpdatePolicy)
+    protected readonly policy: RegistryAutoUpdatePolicy;
+
+    @inject(ClipboardService)
+    protected readonly clipboardService: ClipboardService;
+
+    registerCommands(commands: CommandRegistry): void {
+        for (const item of AUTO_UPDATE_MODE_ITEMS) {
+            this.registerAutoUpdateCommand(commands, item.command, item.mode, false);
+            this.registerAutoUpdateCommand(commands, item.defaultCommand, item.mode, true);
+        }
+        commands.registerCommand(AIRegistryCommands.COPY_ID, {
+            isVisible: (...args) => this.copyableId(args) !== undefined,
+            execute: (...args) => {
+                const id = this.copyableId(args);
+                if (id !== undefined) {
+                    this.clipboardService.writeText(id);
+                }
+            }
+        });
+    }
+
+    registerMenus(menus: MenuModelRegistry): void {
+        menus.registerSubmenu(
+            AIRegistryEntryContextMenu.AUTO_UPDATE_SUBMENU,
+            nls.localizeByDefault('Auto Update')
+        );
+        for (const item of AUTO_UPDATE_MODE_ITEMS) {
+            menus.registerMenuAction(AIRegistryEntryContextMenu.AUTO_UPDATE_SUBMENU, {
+                commandId: item.command.id,
+                label: item.label,
+                order: `${item.order}a`
+            });
+            menus.registerMenuAction(AIRegistryEntryContextMenu.AUTO_UPDATE_SUBMENU, {
+                commandId: item.defaultCommand.id,
+                label: item.defaultLabel,
+                order: `${item.order}b`
+            });
+        }
+        menus.registerMenuAction(AIRegistryEntryContextMenu.COPY, {
+            commandId: AIRegistryCommands.COPY_ID.id,
+            label: nls.localize('theia/ai-registry/action/copyId', 'Copy ID'),
+            order: '0'
+        });
+    }
+
+    /**
+     * Each mode is a command of its own so the menu can render the three of them as a toggle
+     * group, with a check mark on the effective mode.
+     *
+     * Each mode also comes in two variants - plain and suffixed "(Default)" - of which only
+     * the one matching the current global default is visible. That makes the source of the
+     * effective mode readable at a glance: a check mark on the "(Default)" item means the
+     * artifact inherits the mode, a check mark on a plain item means it was set for this
+     * artifact. The two can never be confused, because {@link RegistryAutoUpdatePolicy.setMode}
+     * drops an override equal to the default instead of writing it.
+     */
+    protected registerAutoUpdateCommand(commands: CommandRegistry, command: Command, mode: AutoUpdateMode, isDefaultVariant: boolean): void {
+        commands.registerCommand(command, {
+            isVisible: (...args) => !!this.autoUpdateContext(args) && (this.policy.getDefault() === mode) === isDefaultVariant,
+            isToggled: (...args) => {
+                const context = this.autoUpdateContext(args);
+                return !!context && this.policy.getMode(context.artifactKind, context.autoUpdateId) === mode;
+            },
+            execute: (...args) => {
+                const context = this.autoUpdateContext(args);
+                if (context) {
+                    return this.policy.setMode(context.artifactKind, context.autoUpdateId, mode);
+                }
+            }
+        });
+    }
+
+    /** The entry the menu was opened on, if it is eligible for an auto-update policy. */
+    protected autoUpdateContext(args: unknown[]): { artifactKind: RegistryEntryContext['artifactKind']; autoUpdateId: string } | undefined {
+        const entry = args.find(RegistryEntryContext.is);
+        if (!entry?.autoUpdateId) {
+            return undefined;
+        }
+        return { artifactKind: entry.artifactKind, autoUpdateId: entry.autoUpdateId };
+    }
+
+    protected copyableId(args: unknown[]): string | undefined {
+        return args.find(RegistryEntryContext.is)?.copyableId;
+    }
+}

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-contribution.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-contribution.ts
@@ -1,0 +1,46 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ILogger, PreferenceService } from '@theia/core';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { RegistryAutoUpdateService } from './registry-auto-update-service';
+
+/**
+ * Runs the AI registry update check once per window load, after the layout is up so it never
+ * competes with application start-up. There is deliberately no polling: an update landing
+ * mid-session is picked up on the next window load.
+ */
+@injectable()
+export class RegistryAutoUpdateContribution implements FrontendApplicationContribution {
+
+    @inject(RegistryAutoUpdateService)
+    protected readonly autoUpdateService: RegistryAutoUpdateService;
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    @inject(ILogger) @named('ai-registry:RegistryAutoUpdateContribution')
+    protected readonly logger: ILogger;
+
+    onDidInitializeLayout(): void {
+        this.preferenceService.ready
+            .then(() => this.autoUpdateService.check())
+            .catch(error => {
+                this.logger.error('AI registry auto-update check failed.', error);
+            });
+    }
+}

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-policy.spec.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-policy.spec.ts
@@ -1,0 +1,156 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { PreferenceService } from '@theia/core';
+import { AUTO_UPDATE_OVERRIDES_PREF, AUTO_UPDATE_PREF, AutoUpdateMode } from '../../common/ai-registry-preferences';
+import { RegistryAutoUpdatePolicyImpl } from './registry-auto-update-policy';
+
+/** Minimal in-memory stand-in for the two preferences the policy reads and writes. */
+class TestPolicy extends RegistryAutoUpdatePolicyImpl {
+    readonly values: Record<string, unknown> = {};
+    writes = 0;
+
+    constructor(defaultMode?: string, overrides?: Record<string, string>) {
+        super();
+        if (defaultMode !== undefined) {
+            this.values[AUTO_UPDATE_PREF] = defaultMode;
+        }
+        if (overrides !== undefined) {
+            this.values[AUTO_UPDATE_OVERRIDES_PREF] = overrides;
+        }
+        // Object.assign rather than a direct write: `preferenceService` is declared readonly
+        // on the base class, so it can only be assigned in that class's own constructor.
+        Object.assign(this, {
+            preferenceService: {
+                get: (name: string, defaultValue: unknown) => this.values[name] ?? defaultValue,
+                // Mirrors the real service: `globalValue` is only set once someone has written
+                // the preference, which is what distinguishes a chosen default from the schema one.
+                inspect: (name: string) => ({ globalValue: this.values[name] }),
+                set: async (name: string, value: unknown) => {
+                    this.writes++;
+                    this.values[name] = value;
+                }
+            } as unknown as PreferenceService
+        });
+    }
+
+    get overrides(): Record<string, AutoUpdateMode> {
+        return (this.values[AUTO_UPDATE_OVERRIDES_PREF] ?? {}) as Record<string, AutoUpdateMode>;
+    }
+}
+
+describe('RegistryAutoUpdatePolicy', () => {
+
+    it('namespaces override keys by artifact kind', () => {
+        const policy = new TestPolicy();
+        expect(policy.key('skill', 'io.github.example/skill')).to.equal('skill:io.github.example/skill');
+        expect(policy.key('mcp', 'io.github.example/server')).to.equal('mcp:io.github.example/server');
+    });
+
+    it('defaults to ask when the preference is unset or holds an unknown value', () => {
+        expect(new TestPolicy().getDefault()).to.equal('ask');
+        expect(new TestPolicy('bogus').getDefault()).to.equal('ask');
+    });
+
+    it('falls back to the default for an artifact without an override', () => {
+        const policy = new TestPolicy('on');
+        expect(policy.getMode('skill', 'unknown-skill')).to.equal('on');
+    });
+
+    it('prefers the artifact override over the default', () => {
+        const policy = new TestPolicy('on', { 'skill:pinned': 'off' });
+        expect(policy.getMode('skill', 'pinned')).to.equal('off');
+        expect(policy.getMode('skill', 'other')).to.equal('on');
+    });
+
+    it('keeps artifact kinds apart when the same id exists for both', () => {
+        const policy = new TestPolicy('ask', { 'skill:shared': 'on', 'mcp:shared': 'off' });
+        expect(policy.getMode('skill', 'shared')).to.equal('on');
+        expect(policy.getMode('mcp', 'shared')).to.equal('off');
+    });
+
+    it('falls back to the default for an artifact with no registry id', () => {
+        const policy = new TestPolicy('off');
+        expect(policy.getMode('mcp', undefined)).to.equal('off');
+    });
+
+    it('writes an override that differs from the default', async () => {
+        const policy = new TestPolicy('ask');
+        await policy.setMode('skill', 'example', 'on');
+        expect(policy.overrides).to.deep.equal({ 'skill:example': 'on' });
+    });
+
+    it('removes the override when the chosen mode equals the default', async () => {
+        const policy = new TestPolicy('ask', { 'skill:example': 'on', 'mcp:other': 'off' });
+        await policy.setMode('skill', 'example', 'ask');
+        expect(policy.overrides).to.deep.equal({ 'mcp:other': 'off' });
+    });
+
+    it('does not write when the artifact already follows the default', async () => {
+        const policy = new TestPolicy('ask');
+        await policy.setMode('skill', 'example', 'ask');
+        expect(policy.writes).to.equal(0);
+        expect(policy.overrides).to.deep.equal({});
+    });
+
+    it('does not write when the override is already the chosen mode', async () => {
+        const policy = new TestPolicy('ask', { 'skill:example': 'off' });
+        await policy.setMode('skill', 'example', 'off');
+        expect(policy.writes).to.equal(0);
+    });
+
+    it('clears the override of an uninstalled artifact and keeps the others', async () => {
+        const policy = new TestPolicy('ask', { 'skill:example': 'on', 'mcp:other': 'off' });
+        await policy.clearMode('skill', 'example');
+        expect(policy.overrides).to.deep.equal({ 'mcp:other': 'off' });
+    });
+
+    it('does not write when clearing an artifact that has no override', async () => {
+        const policy = new TestPolicy('ask', { 'mcp:other': 'off' });
+        await policy.clearMode('skill', 'example');
+        expect(policy.writes).to.equal(0);
+    });
+
+    it('reports no explicit default until one is written', async () => {
+        const policy = new TestPolicy();
+        expect(policy.hasExplicitDefault()).to.be.false;
+        await policy.setDefault('on');
+        expect(policy.hasExplicitDefault()).to.be.true;
+        expect(policy.getDefault()).to.equal('on');
+    });
+
+    it('reports an explicit default even when it equals the schema default', async () => {
+        const policy = new TestPolicy();
+        await policy.setDefault('ask');
+        expect(policy.hasExplicitDefault()).to.be.true;
+        expect(policy.getDefault()).to.equal('ask');
+    });
+
+    it('leaves existing overrides alone when the default changes', async () => {
+        const policy = new TestPolicy('ask', { 'skill:example': 'on' });
+        await policy.setDefault('on');
+        expect(policy.overrides).to.deep.equal({ 'skill:example': 'on' });
+        expect(policy.getMode('skill', 'example')).to.equal('on');
+    });
+
+    it('lets an artifact follow a changed default once its override is removed', async () => {
+        const policy = new TestPolicy('ask', { 'skill:example': 'on' });
+        await policy.setMode('skill', 'example', 'ask');
+        policy.values[AUTO_UPDATE_PREF] = 'off';
+        expect(policy.getMode('skill', 'example')).to.equal('off');
+    });
+});

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-policy.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-policy.ts
@@ -1,0 +1,116 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceScope, PreferenceService } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import {
+    AUTO_UPDATE_OVERRIDES_PREF,
+    AUTO_UPDATE_PREF,
+    AutoUpdateMode,
+    RegistryArtifactKind
+} from '../../common/ai-registry-preferences';
+
+type Overrides = Record<string, AutoUpdateMode>;
+
+export const RegistryAutoUpdatePolicy = Symbol('RegistryAutoUpdatePolicy');
+
+/**
+ * Resolves the effective auto-update mode for a registry artifact and maintains the
+ * per-artifact override map.
+ *
+ * An artifact without an override follows the global default. Setting an artifact to the value
+ * that currently *is* the default removes its override rather than writing a redundant one, so
+ * the artifact keeps following the default if the user later changes it. An artifact therefore
+ * cannot be pinned to the current default value; that is intentional, and it is what lets the
+ * gear menu show whether a mode is inherited or explicitly set.
+ */
+export interface RegistryAutoUpdatePolicy {
+    /** Override key for an artifact, e.g. `skill:my-skill-id` or `mcp:io.github.foo/bar`. */
+    key(kind: RegistryArtifactKind, id: string): string;
+    /** The configured default, or `ask` while none has been chosen. */
+    getDefault(): AutoUpdateMode;
+    /**
+     * True once the user has explicitly chosen a default, as opposed to inheriting the schema
+     * default. Gates the one-time "should this happen automatically?" prompt.
+     */
+    hasExplicitDefault(): boolean;
+    setDefault(mode: AutoUpdateMode): Promise<void>;
+    /** The effective mode for an artifact: its override if it has one, the default otherwise. */
+    getMode(kind: RegistryArtifactKind, id: string | undefined): AutoUpdateMode;
+    /** Writes the artifact's override, or removes it when `mode` equals the current default. */
+    setMode(kind: RegistryArtifactKind, id: string, mode: AutoUpdateMode): Promise<void>;
+    /** Drops the artifact's override, if it has one. */
+    clearMode(kind: RegistryArtifactKind, id: string): Promise<void>;
+}
+
+@injectable()
+export class RegistryAutoUpdatePolicyImpl implements RegistryAutoUpdatePolicy {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    key(kind: RegistryArtifactKind, id: string): string {
+        return `${kind}:${id}`;
+    }
+
+    getDefault(): AutoUpdateMode {
+        const value = this.preferenceService.get<string>(AUTO_UPDATE_PREF, 'ask');
+        return AutoUpdateMode.is(value) ? value : 'ask';
+    }
+
+    hasExplicitDefault(): boolean {
+        return this.preferenceService.inspect<string>(AUTO_UPDATE_PREF)?.globalValue !== undefined;
+    }
+
+    async setDefault(mode: AutoUpdateMode): Promise<void> {
+        await this.preferenceService.set(AUTO_UPDATE_PREF, mode, PreferenceScope.User);
+    }
+
+    getMode(kind: RegistryArtifactKind, id: string | undefined): AutoUpdateMode {
+        if (id === undefined) {
+            return this.getDefault();
+        }
+        const override = this.readOverrides()[this.key(kind, id)];
+        return AutoUpdateMode.is(override) ? override : this.getDefault();
+    }
+
+    async setMode(kind: RegistryArtifactKind, id: string, mode: AutoUpdateMode): Promise<void> {
+        if (mode === this.getDefault()) {
+            return this.clearMode(kind, id);
+        }
+        const overrides = this.readOverrides();
+        const key = this.key(kind, id);
+        if (overrides[key] === mode) {
+            return;
+        }
+        await this.preferenceService.set(AUTO_UPDATE_OVERRIDES_PREF, { ...overrides, [key]: mode }, PreferenceScope.User);
+    }
+
+    async clearMode(kind: RegistryArtifactKind, id: string): Promise<void> {
+        const overrides = this.readOverrides();
+        const key = this.key(kind, id);
+        if (!(key in overrides)) {
+            return;
+        }
+        const next: Overrides = { ...overrides };
+        delete next[key];
+        await this.preferenceService.set(AUTO_UPDATE_OVERRIDES_PREF, next, PreferenceScope.User);
+    }
+
+    protected readOverrides(): Overrides {
+        return this.preferenceService.get<Overrides>(AUTO_UPDATE_OVERRIDES_PREF, {}) ?? {};
+    }
+}

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.spec.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.spec.ts
@@ -1,0 +1,468 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// The service references the Extensions view command, which pulls in browser-side modules,
+// so a DOM is required at import time.
+const disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { ILogger, MessageService, PreferenceService } from '@theia/core';
+import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { AUTO_UPDATE_OVERRIDES_PREF, AUTO_UPDATE_PREF, AutoUpdateMode } from '../../common/ai-registry-preferences';
+import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { InstalledSkillInfo, ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { MCPInstallService, MCPInstallServiceImpl } from '../mcp/mcp-install-service';
+import { SkillInstallService, SkillInstallServiceImpl } from '../skill/skill-install-service';
+import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from './registry-auto-update-policy';
+import { RegistryAutoUpdateService } from './registry-auto-update-service';
+
+after(() => disableJSDOM());
+
+const skillEntry: ResolvedSkillEntry = {
+    skillId: 'io.github.example/skill-a',
+    name: 'Skill A',
+    description: 'A skill',
+    sourceUrl: 'https://github.com/example/skills',
+    contentHash: 'hash-v2'
+};
+
+const otherSkillEntry: ResolvedSkillEntry = {
+    skillId: 'io.github.example/skill-b',
+    name: 'Skill B',
+    description: 'Another skill',
+    sourceUrl: 'https://github.com/example/skills',
+    contentHash: 'hash-v2'
+};
+
+const mcpEntry: ResolvedRegistryEntry = {
+    serverId: 'io.github.example/server-a',
+    name: 'Server A',
+    description: 'A server',
+    localName: 'server-a',
+    config: { command: 'npx', args: ['-y', 'server-a'] },
+    configHash: 'hash-v2',
+    mcpRegistryVerified: true
+};
+
+/** Installed skill whose recorded hash is behind the registry, i.e. an update is available. */
+function outdatedSkill(entry: ResolvedSkillEntry, drifted = false): InstalledSkillInfo {
+    return { name: entry.name, skillId: entry.skillId, contentHash: 'hash-v1', drifted };
+}
+
+/** Locally stored server linked to the registry entry but carrying an older config hash. */
+function outdatedServer(entry: ResolvedRegistryEntry, drifted = false): MCPServerDescription {
+    return {
+        name: entry.localName,
+        command: drifted ? 'tampered' : entry.config.command,
+        args: entry.config.args,
+        registryMetadata: { serverId: entry.serverId, configHash: 'hash-v1' }
+    } as MCPServerDescription;
+}
+
+interface RecordedMessage {
+    kind: 'info' | 'warn';
+    text: string;
+    actions: string[];
+}
+
+interface TestOptions {
+    defaultMode?: AutoUpdateMode;
+    overrides?: Record<string, AutoUpdateMode>;
+    skillEntries?: ResolvedSkillEntry[];
+    mcpEntries?: ResolvedRegistryEntry[];
+    installedSkills?: InstalledSkillInfo[];
+    installedServers?: MCPServerDescription[];
+    /** Registry ids whose update should throw. */
+    failing?: string[];
+    /** Action label the user "clicks" on any notification offering it. */
+    answer?: string;
+    /** When set, the registry fetch rejects. */
+    fetchFails?: boolean;
+    /** False when the user has never chosen a default, so the one-time policy prompt is due. */
+    explicitDefault?: boolean;
+}
+
+class TestAutoUpdateService extends RegistryAutoUpdateService {
+    readonly messages: RecordedMessage[] = [];
+    readonly attempted: string[] = [];
+    shown = 0;
+
+    protected override async showInstalled(): Promise<void> {
+        this.shown++;
+    }
+
+    /** Deterministic text: the real hints embed a command URI that is irrelevant here. */
+    protected override settingsHint(): string {
+        return '<settings>';
+    }
+
+    protected override settingsChangeHint(): string {
+        return '<settings>';
+    }
+}
+
+/**
+ * @param explicitDefault whether the user has chosen the default, i.e. whether the one-time
+ * policy prompt still has a question to ask.
+ */
+function createPolicy(defaultMode: AutoUpdateMode, overrides: Record<string, AutoUpdateMode>, explicitDefault = true): RegistryAutoUpdatePolicy {
+    const values: Record<string, unknown> = {
+        [AUTO_UPDATE_PREF]: defaultMode,
+        [AUTO_UPDATE_OVERRIDES_PREF]: overrides
+    };
+    let userSetDefault = explicitDefault;
+    const policy = new RegistryAutoUpdatePolicyImpl();
+    Object.assign(policy, {
+        preferenceService: {
+            get: (name: string, defaultValue: unknown) => values[name] ?? defaultValue,
+            inspect: (name: string) => ({
+                globalValue: name === AUTO_UPDATE_PREF && !userSetDefault ? undefined : values[name]
+            }),
+            set: async (name: string, value: unknown) => {
+                if (name === AUTO_UPDATE_PREF) {
+                    userSetDefault = true;
+                }
+                values[name] = value;
+            }
+        } as unknown as PreferenceService
+    });
+    return policy;
+}
+
+function createService(options: TestOptions = {}): { service: TestAutoUpdateService; policy: RegistryAutoUpdatePolicy } {
+    const skillEntries = options.skillEntries ?? [skillEntry, otherSkillEntry];
+    const mcpEntries = options.mcpEntries ?? [mcpEntry];
+    const installedSkills = options.installedSkills ?? [];
+    const installedServers = options.installedServers ?? [];
+    const failing = new Set(options.failing ?? []);
+    const policy = createPolicy(options.defaultMode ?? 'ask', options.overrides ?? {}, options.explicitDefault ?? true);
+    const service = new TestAutoUpdateService();
+
+    // Classification is exercised through the real implementations so the drift rules stay
+    // pinned end to end; only the I/O around them is faked.
+    const realSkillService = new SkillInstallServiceImpl();
+    const realMcpService = new MCPInstallServiceImpl();
+
+    const record = async (id: string): Promise<void> => {
+        service.attempted.push(id);
+        if (failing.has(id)) {
+            throw new Error(`update of ${id} failed`);
+        }
+    };
+    const respond = async (kind: 'info' | 'warn', text: string, actions: string[]): Promise<string | undefined> => {
+        service.messages.push({ kind, text, actions });
+        return options.answer !== undefined && actions.includes(options.answer) ? options.answer : undefined;
+    };
+
+    Object.assign(service, {
+        policy,
+        fetchService: {
+            getEntries: async () => {
+                if (options.fetchFails) {
+                    throw new Error('registry unreachable');
+                }
+                return mcpEntries;
+            },
+            getSkillEntries: async () => skillEntries
+        } as unknown as RegistryFetchService,
+        skillInstallService: {
+            listInstalledSkills: async () => installedSkills,
+            classifyInstalledSkill: (info: InstalledSkillInfo, entries: ResolvedSkillEntry[]) => realSkillService.classifyInstalledSkill(info, entries),
+            update: (entry: ResolvedSkillEntry) => record(entry.skillId)
+        } as unknown as SkillInstallService,
+        mcpInstallService: {
+            listInstalledServers: () => installedServers,
+            classifyLocalServer: (local: MCPServerDescription, entries: ResolvedRegistryEntry[]) => realMcpService.classifyLocalServer(local, entries),
+            update: (entry: ResolvedRegistryEntry) => record(entry.serverId)
+        } as unknown as MCPInstallService,
+        messageService: {
+            info: (text: string, ...actions: string[]) => respond('info', text, actions),
+            warn: (text: string, ...actions: string[]) => respond('warn', text, actions)
+        } as unknown as MessageService,
+        logger: {
+            warn: () => { },
+            error: () => { }
+        } as unknown as ILogger
+    });
+    return { service, policy };
+}
+
+describe('RegistryAutoUpdateService', () => {
+
+    describe('mode routing', () => {
+
+        it('neither updates nor notifies when the mode is off', async () => {
+            const { service } = createService({ defaultMode: 'off', installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+            expect(service.messages).to.be.empty;
+        });
+
+        it('updates without asking when the mode is on', async () => {
+            const { service } = createService({ defaultMode: 'on', installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(service.attempted).to.deep.equal([skillEntry.skillId]);
+            expect(service.messages).to.have.lengthOf(1);
+            expect(service.messages[0].kind).to.equal('info');
+            expect(service.messages[0].text).to.contain('Skill A');
+            expect(service.messages[0].actions).to.be.empty;
+        });
+
+        it('reports one batched message when several artifacts update automatically', async () => {
+            const { service } = createService({
+                defaultMode: 'on',
+                installedSkills: [outdatedSkill(skillEntry), outdatedSkill(otherSkillEntry)],
+                installedServers: [outdatedServer(mcpEntry)]
+            });
+            await service.check();
+            expect(service.attempted).to.have.lengthOf(3);
+            expect(service.messages).to.have.lengthOf(1);
+            expect(service.messages[0].text).to.contain('3');
+        });
+
+        it('applies a per-artifact override over the default', async () => {
+            const { service } = createService({
+                defaultMode: 'off',
+                overrides: { [`skill:${skillEntry.skillId}`]: 'on' },
+                installedSkills: [outdatedSkill(skillEntry), outdatedSkill(otherSkillEntry)]
+            });
+            await service.check();
+            expect(service.attempted).to.deep.equal([skillEntry.skillId]);
+        });
+
+        it('does nothing when nothing has an update available', async () => {
+            const current: InstalledSkillInfo = { name: 'Skill A', skillId: skillEntry.skillId, contentHash: skillEntry.contentHash, drifted: false };
+            const { service } = createService({ defaultMode: 'on', installedSkills: [current] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+            expect(service.messages).to.be.empty;
+        });
+    });
+
+    describe('drift', () => {
+
+        it('skips a drifted skill in on mode', async () => {
+            const { service } = createService({ defaultMode: 'on', installedSkills: [outdatedSkill(skillEntry, true)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+            expect(service.messages).to.be.empty;
+        });
+
+        it('skips a drifted skill in ask mode', async () => {
+            const { service } = createService({ defaultMode: 'ask', installedSkills: [outdatedSkill(skillEntry, true)] });
+            await service.check();
+            expect(service.messages).to.be.empty;
+        });
+
+        it('skips a drifted MCP server in on mode', async () => {
+            const { service } = createService({ defaultMode: 'on', installedServers: [outdatedServer(mcpEntry, true)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+        });
+    });
+
+    describe('update notification', () => {
+
+        it('offers exactly Update and Show for a single pending update', async () => {
+            const { service } = createService({ installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(service.messages).to.have.lengthOf(1);
+            expect(service.messages[0].actions).to.deep.equal(['Update', 'Show']);
+            expect(service.messages[0].text).to.contain('Skill A');
+            expect(service.messages[0].text).to.contain('<settings>');
+        });
+
+        it('keeps the same action set for several pending updates, pluralizing only the label', async () => {
+            const { service } = createService({ installedSkills: [outdatedSkill(skillEntry), outdatedSkill(otherSkillEntry)] });
+            await service.check();
+            expect(service.messages).to.have.lengthOf(1);
+            expect(service.messages[0].actions).to.deep.equal(['Update All', 'Show']);
+            expect(service.messages[0].text).to.contain('2');
+        });
+
+        it('offers no per-artifact policy actions', async () => {
+            const { service } = createService({ installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            const actions = service.messages[0].actions.join(' ');
+            expect(actions).to.not.contain('Never');
+            expect(actions).to.not.contain('Auto Update');
+        });
+
+        it('updates the single pending artifact for Update', async () => {
+            const { service, policy } = createService({ installedSkills: [outdatedSkill(skillEntry)], answer: 'Update' });
+            await service.check();
+            expect(service.attempted).to.deep.equal([skillEntry.skillId]);
+            // The notification never sets policy; the artifact keeps following the default.
+            expect(policy.getMode('skill', skillEntry.skillId)).to.equal('ask');
+        });
+
+        it('updates everything for Update All', async () => {
+            const { service } = createService({
+                installedSkills: [outdatedSkill(skillEntry), outdatedSkill(otherSkillEntry)],
+                answer: 'Update All'
+            });
+            await service.check();
+            expect(service.attempted).to.have.lengthOf(2);
+        });
+
+        it('opens the installed view for Show', async () => {
+            const { service } = createService({
+                installedSkills: [outdatedSkill(skillEntry), outdatedSkill(otherSkillEntry)],
+                answer: 'Show'
+            });
+            await service.check();
+            expect(service.shown).to.equal(1);
+            expect(service.attempted).to.be.empty;
+        });
+
+        it('updates nothing and persists nothing when dismissed', async () => {
+            const { service, policy } = createService({ installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+            expect(policy.getMode('skill', skillEntry.skillId)).to.equal('ask');
+        });
+    });
+
+    describe('one-time policy prompt', () => {
+
+        it('is not shown once the user has chosen a default', async () => {
+            const { service } = createService({ installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(service.messages).to.have.lengthOf(1);
+        });
+
+        it('follows the update notification when no default has been chosen', async () => {
+            const { service } = createService({ explicitDefault: false, installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(service.messages).to.have.lengthOf(2);
+            expect(service.messages[1].actions).to.deep.equal(['Enable Auto Update', 'Keep Asking', 'Never']);
+            expect(service.messages[1].text).to.contain('<settings>');
+        });
+
+        it('follows a dismissed update notification too', async () => {
+            const { service } = createService({ explicitDefault: false, installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+            expect(service.messages).to.have.lengthOf(2);
+        });
+
+        it('turns the default on for Enable Auto Update', async () => {
+            const { service, policy } = createService({
+                explicitDefault: false,
+                installedSkills: [outdatedSkill(skillEntry)],
+                answer: 'Enable Auto Update'
+            });
+            await service.check();
+            expect(policy.getDefault()).to.equal('on');
+            expect(policy.hasExplicitDefault()).to.be.true;
+        });
+
+        it('applies the updates the user left outstanding when they enable auto update', async () => {
+            // The update notification was dismissed, so nothing has been applied when the policy
+            // prompt appears; saying "yes, automatically" must not defer them to the next reload.
+            const { service } = createService({
+                explicitDefault: false,
+                installedSkills: [outdatedSkill(skillEntry), outdatedSkill(otherSkillEntry)],
+                answer: 'Enable Auto Update'
+            });
+            await service.check();
+            expect(service.attempted).to.deep.equal([skillEntry.skillId, otherSkillEntry.skillId]);
+        });
+
+        it('does not re-apply updates the user already ran from the notification', async () => {
+            // "Update" answers the first notification, so nothing is left outstanding for the
+            // policy prompt to carry over.
+            const { service } = createService({
+                explicitDefault: false,
+                installedSkills: [outdatedSkill(skillEntry)],
+                answer: 'Update'
+            });
+            await service.check();
+            expect(service.attempted).to.deep.equal([skillEntry.skillId]);
+        });
+
+        it('turns the default off for Never', async () => {
+            const { service, policy } = createService({ explicitDefault: false, installedSkills: [outdatedSkill(skillEntry)], answer: 'Never' });
+            await service.check();
+            expect(policy.getDefault()).to.equal('off');
+        });
+
+        it('pins the default to ask for Keep Asking, so it is never asked again', async () => {
+            const { service, policy } = createService({
+                explicitDefault: false,
+                installedSkills: [outdatedSkill(skillEntry)],
+                answer: 'Keep Asking'
+            });
+            await service.check();
+            expect(policy.getDefault()).to.equal('ask');
+            expect(policy.hasExplicitDefault()).to.be.true;
+        });
+
+        it('persists nothing when dismissed, so it is asked again next window', async () => {
+            const { service, policy } = createService({ explicitDefault: false, installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            expect(policy.hasExplicitDefault()).to.be.false;
+        });
+
+        it('is not shown when there was nothing to notify about', async () => {
+            const { service } = createService({ explicitDefault: false, defaultMode: 'on', installedSkills: [outdatedSkill(skillEntry)] });
+            await service.check();
+            // The artifact updated silently, so the user was never asked anything to follow up on.
+            expect(service.messages.map(message => message.actions)).to.deep.equal([[]]);
+        });
+    });
+
+    describe('failures', () => {
+
+        it('warns once and still reports the successes when part of a batch fails', async () => {
+            const { service } = createService({
+                defaultMode: 'on',
+                installedSkills: [outdatedSkill(skillEntry), outdatedSkill(otherSkillEntry)],
+                failing: [otherSkillEntry.skillId]
+            });
+            await service.check();
+            expect(service.attempted).to.have.lengthOf(2);
+            expect(service.messages.map(message => message.kind)).to.deep.equal(['info', 'warn']);
+            expect(service.messages[0].text).to.contain('Skill A');
+            expect(service.messages[1].text).to.contain('1');
+        });
+
+        it('reports only the warning when every update fails', async () => {
+            const { service } = createService({
+                defaultMode: 'on',
+                installedSkills: [outdatedSkill(skillEntry)],
+                failing: [skillEntry.skillId]
+            });
+            await service.check();
+            expect(service.messages.map(message => message.kind)).to.deep.equal(['warn']);
+        });
+
+        it('stays silent when the registry cannot be fetched', async () => {
+            const { service } = createService({ defaultMode: 'on', installedSkills: [outdatedSkill(skillEntry)], fetchFails: true });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+            expect(service.messages).to.be.empty;
+        });
+    });
+});

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
@@ -1,0 +1,277 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CommandService, ILogger, MessageService, nls } from '@theia/core';
+import { CommonCommands } from '@theia/core/lib/browser/common-commands';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { VSXExtensionsCommands } from '@theia/vsx-registry/lib/browser/vsx-extension-commands';
+import { AUTO_UPDATE_PREF, AutoUpdateMode, RegistryArtifactKind } from '../../common/ai-registry-preferences';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { MCPInstallService } from '../mcp/mcp-install-service';
+import { SkillInstallService } from '../skill/skill-install-service';
+import { RegistryAutoUpdatePolicy } from './registry-auto-update-policy';
+
+/** A single artifact that has a newer registry entry and is not opted out of updating. */
+export interface PendingUpdate {
+    kind: RegistryArtifactKind;
+    label: string;
+    mode: AutoUpdateMode;
+    /** Message shown when this artifact alone is offered for update. */
+    promptMessage: string;
+    /** Message shown when this artifact alone was updated. */
+    successMessage: string;
+    apply(): Promise<void>;
+}
+
+/**
+ * Checks the registry for updates to installed skills and MCP servers and applies or
+ * offers them according to the effective {@link RegistryAutoUpdatePolicy}.
+ *
+ * Drifted artifacts are deliberately excluded in every mode: they classify as `fix-skill` /
+ * `fix-config` rather than `installed-from-registry`, so they never reach
+ * {@link collectPending} and the user resolves them with Fix in the Extensions view.
+ *
+ * Updates go through the install services directly rather than the contributions' action
+ * handlers, so a batch reports one summary message instead of one message per artifact.
+ */
+@injectable()
+export class RegistryAutoUpdateService {
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    @inject(SkillInstallService)
+    protected readonly skillInstallService: SkillInstallService;
+
+    @inject(MCPInstallService)
+    protected readonly mcpInstallService: MCPInstallService;
+
+    @inject(RegistryAutoUpdatePolicy)
+    protected readonly policy: RegistryAutoUpdatePolicy;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(CommandService)
+    protected readonly commandService: CommandService;
+
+    @inject(ILogger) @named('ai-registry:RegistryAutoUpdateService')
+    protected readonly logger: ILogger;
+
+    /**
+     * Runs one update pass. Never rejects - a registry that cannot be reached is logged and
+     * otherwise ignored, since a failed fetch is not evidence that anything needs updating.
+     */
+    async check(): Promise<void> {
+        let pending: PendingUpdate[];
+        try {
+            pending = await this.collectPending();
+        } catch (error) {
+            this.logger.warn('AI registry auto-update check skipped: could not resolve registry entries.', error);
+            return;
+        }
+        const automatic = pending.filter(update => update.mode === 'on');
+        const toAsk = pending.filter(update => update.mode === 'ask');
+        if (automatic.length > 0) {
+            await this.applyAll(automatic);
+        }
+        if (toAsk.length > 0) {
+            const applied = await this.promptPending(toAsk);
+            // Only once the user has dealt with that notification, so the two decisions never
+            // compete for attention. Anything still outstanding is carried over, so turning auto
+            // update on there applies it instead of leaving it for the next window load.
+            await this.promptForDefault(applied ? [] : toAsk);
+        }
+    }
+
+    /**
+     * Resolves every installed artifact that has an update available and is not set to `off`.
+     * Forces a registry refresh first - the cached response would not surface anything new.
+     */
+    protected async collectPending(): Promise<PendingUpdate[]> {
+        // One refresh serves both slices: `getEntries(true)` refetches the shared response
+        // and invalidates both caches, so the skill call below resolves against it.
+        const mcpEntries = await this.fetchService.getEntries(true);
+        const skillEntries = await this.fetchService.getSkillEntries();
+        const pending: PendingUpdate[] = [];
+
+        for (const info of await this.skillInstallService.listInstalledSkills()) {
+            const state = this.skillInstallService.classifyInstalledSkill(info, skillEntries);
+            if (state.kind !== 'installed-from-registry' || !state.updateAvailable) {
+                continue;
+            }
+            const entry = skillEntries.find(candidate => candidate.skillId === info.skillId);
+            if (!entry) {
+                continue;
+            }
+            const mode = this.policy.getMode('skill', entry.skillId);
+            if (mode === 'off') {
+                continue;
+            }
+            pending.push({
+                kind: 'skill',
+                label: entry.name,
+                mode,
+                promptMessage: nls.localize('theia/ai-registry/autoUpdate/skillAvailable', 'Skill "{0}" has an update available.', entry.name),
+                successMessage: nls.localize('theia/ai-registry/skill/updated', 'Updated skill "{0}".', entry.name),
+                apply: () => this.skillInstallService.update(entry)
+            });
+        }
+
+        for (const local of this.mcpInstallService.listInstalledServers()) {
+            const state = this.mcpInstallService.classifyLocalServer(local, mcpEntries);
+            if (state.kind !== 'installed-from-registry' || !state.updateAvailable) {
+                continue;
+            }
+            const entry = mcpEntries.find(candidate => candidate.serverId === local.registryMetadata?.serverId);
+            if (!entry) {
+                continue;
+            }
+            const mode = this.policy.getMode('mcp', entry.serverId);
+            if (mode === 'off') {
+                continue;
+            }
+            pending.push({
+                kind: 'mcp',
+                label: entry.name,
+                mode,
+                promptMessage: nls.localize('theia/ai-registry/autoUpdate/mcpAvailable', 'MCP server "{0}" has an update available.', entry.name),
+                successMessage: nls.localize('theia/ai-registry/mcp/updated', 'Updated MCP server "{0}".', entry.name),
+                apply: () => this.mcpInstallService.update(entry)
+            });
+        }
+        return pending;
+    }
+
+    /**
+     * Applies a batch, reporting one info message for the successes and one warning if
+     * anything failed. Each update is isolated so one failure does not abort the rest.
+     */
+    protected async applyAll(updates: PendingUpdate[]): Promise<void> {
+        const succeeded: PendingUpdate[] = [];
+        let failed = 0;
+        for (const update of updates) {
+            try {
+                await update.apply();
+                succeeded.push(update);
+            } catch (error) {
+                failed++;
+                this.logger.error(`Failed to auto-update ${update.kind} "${update.label}".`, error);
+            }
+        }
+        if (succeeded.length === 1) {
+            this.messageService.info(succeeded[0].successMessage);
+        } else if (succeeded.length > 1) {
+            this.messageService.info(nls.localize('theia/ai-registry/autoUpdate/updatedMany', 'Updated {0} AI registry items.', succeeded.length));
+        }
+        if (failed > 0) {
+            const show = nls.localizeByDefault('Show');
+            // Deliberately not awaited: a notification with an action stays until the user acts
+            // on it, and waiting here would hold back a pending "ask" prompt indefinitely.
+            this.messageService.warn(
+                nls.localize('theia/ai-registry/autoUpdate/updateFailed', 'Could not auto-update {0} AI registry items.', failed),
+                show
+            ).then(
+                answer => answer === show ? this.showInstalled() : undefined,
+                error => this.logger.error('Failed to report AI registry auto-update failures.', error)
+            );
+        }
+    }
+
+    /**
+     * Offers the pending updates. There is deliberately no "don't update" action: closing the
+     * notification already means "not now", and the pass runs again on the next window load.
+     * Per-artifact policy is not offered here either; it lives in the gear menu, where it can
+     * name its target.
+     */
+    protected async promptPending(updates: PendingUpdate[]): Promise<boolean> {
+        const doUpdate = updates.length === 1
+            ? nls.localizeByDefault('Update')
+            : nls.localize('theia/ai-registry/autoUpdate/updateAll', 'Update All');
+        const show = nls.localizeByDefault('Show');
+        const message = updates.length === 1
+            ? updates[0].promptMessage
+            : nls.localize('theia/ai-registry/autoUpdate/summary', '{0} AI registry updates are available.', updates.length);
+        const answer = await this.messageService.info(`${message} ${this.settingsHint()}`, doUpdate, show);
+        if (answer === doUpdate) {
+            await this.applyAll(updates);
+            return true;
+        }
+        if (answer === show) {
+            await this.showInstalled();
+        }
+        return false;
+    }
+
+    /**
+     * Asks once, ever, whether updates should be applied automatically from now on. "Once" is
+     * anchored on the preference rather than on separate bookkeeping, so setting it by hand in
+     * Settings counts as answering. Dismissing writes nothing and the prompt returns on the
+     * next window load.
+     *
+     * @param outstanding updates the user has not already applied. Turning auto update on
+     * applies them right away, since a user who just asked for automatic updates would
+     * otherwise watch the ones that prompted the question sit untouched until the next reload.
+     */
+    protected async promptForDefault(outstanding: PendingUpdate[]): Promise<void> {
+        if (this.policy.hasExplicitDefault()) {
+            return;
+        }
+        const enable = nls.localize('theia/ai-registry/autoUpdate/enableDefault', 'Enable Auto Update');
+        const keepAsking = nls.localize('theia/ai-registry/autoUpdate/keepAsking', 'Keep Asking');
+        const never = nls.localizeByDefault('Never');
+        const answer = await this.messageService.info(
+            `${nls.localize(
+                'theia/ai-registry/autoUpdate/defaultPrompt',
+                'Update skills and MCP servers from the AI registry automatically from now on?'
+            )} ${this.settingsChangeHint()}`,
+            enable, keepAsking, never
+        );
+        if (answer === enable) {
+            await this.policy.setDefault('on');
+            if (outstanding.length > 0) {
+                await this.applyAll(outstanding);
+            }
+        } else if (answer === keepAsking) {
+            await this.policy.setDefault('ask');
+        } else if (answer === never) {
+            await this.policy.setDefault('off');
+        }
+    }
+
+    /** Opens the Extensions view on the installed artifacts, where updates surface per card. */
+    protected async showInstalled(): Promise<void> {
+        await this.commandService.executeCommand(VSXExtensionsCommands.SHOW_INSTALLED.id);
+    }
+
+    protected settingsHint(): string {
+        return nls.localize('theia/ai-registry/autoUpdate/configureDefault', 'Configure the default in {0}.', this.settingsLink());
+    }
+
+    protected settingsChangeHint(): string {
+        return nls.localize('theia/ai-registry/autoUpdate/changeLater', 'You can change this later in {0}.', this.settingsLink());
+    }
+
+    /**
+     * Markdown link opening the default preference. Notification messages are rendered as
+     * inline markdown and their links are opened through the `OpenerService`, where core's
+     * `CommandOpenHandler` picks up the `command:` scheme.
+     */
+    protected settingsLink(): string {
+        const args = encodeURIComponent(JSON.stringify([AUTO_UPDATE_PREF]));
+        return `[${nls.localizeByDefault('Settings')}](command:${CommonCommands.OPEN_PREFERENCES.id}?${args})`;
+    }
+}

--- a/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
+++ b/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
@@ -16,13 +16,16 @@
 
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { TypeBadge } from '@theia/vsx-registry/lib/browser/type-badge';
 import { ExtensionCard, ExtensionCardTrust } from '@theia/vsx-registry/lib/browser/extension-card';
 import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { RegistryArtifactKind } from '../../common/ai-registry-preferences';
 import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { RegistryEntryContext } from '../registry-entry-context';
+import { RegistryEntryGear, RegistryEntryMenuEvent, showEntryMenu } from '../registry-entry-menu';
 
 /**
  * Per-entry action callbacks provided by the contribution. Entries close over
@@ -39,18 +42,28 @@ export interface MCPEntryHandlers {
 }
 
 /** An entry surfacing a locally installed MCP server in the Installed section. */
-export class MCPInstalledEntry implements TreeElement {
+export class MCPInstalledEntry implements TreeElement, RegistryEntryContext {
 
     readonly id: string;
+    readonly artifactKind: RegistryArtifactKind = 'mcp';
 
     constructor(
         readonly local: MCPServerDescription,
         readonly matchedEntry: ResolvedRegistryEntry | undefined,
         readonly state: ClassificationResult,
         readonly handlers: MCPEntryHandlers,
-        readonly hoverService: HoverService
+        readonly hoverService: HoverService,
+        readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         this.id = `mcp-installed-${local.name}`;
+    }
+
+    get copyableId(): string | undefined {
+        return this.matchedEntry?.serverId ?? this.local.registryMetadata?.serverId ?? this.local.name;
+    }
+
+    get autoUpdateId(): string | undefined {
+        return autoUpdateId(this.state, this.matchedEntry?.serverId);
     }
 
     render(): React.ReactNode {
@@ -67,6 +80,7 @@ export class MCPInstalledEntry implements TreeElement {
                 identifier={this.matchedEntry?.serverId ?? this.local.registryMetadata?.serverId}
                 verified={this.matchedEntry?.mcpRegistryVerified}
                 hoverService={this.hoverService}
+                onManage={event => showEntryMenu(event, this, this.contextMenuRenderer)}
                 actions={renderActions(this.state, this.matchedEntry, this.local.name, this.handlers, localVersion)}
             />
         );
@@ -74,17 +88,27 @@ export class MCPInstalledEntry implements TreeElement {
 }
 
 /** An entry surfacing a registry-resolved MCP server in the Search Results section. */
-export class MCPSearchResultEntry implements TreeElement {
+export class MCPSearchResultEntry implements TreeElement, RegistryEntryContext {
 
     readonly id: string;
+    readonly artifactKind: RegistryArtifactKind = 'mcp';
 
     constructor(
         readonly entry: ResolvedRegistryEntry,
         readonly state: ClassificationResult,
         readonly handlers: MCPEntryHandlers,
-        readonly hoverService: HoverService
+        readonly hoverService: HoverService,
+        readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         this.id = `mcp-search-${entry.serverId}`;
+    }
+
+    get copyableId(): string | undefined {
+        return this.entry.serverId;
+    }
+
+    get autoUpdateId(): string | undefined {
+        return autoUpdateId(this.state, this.entry.serverId);
     }
 
     render(): React.ReactNode {
@@ -96,10 +120,19 @@ export class MCPSearchResultEntry implements TreeElement {
                 identifier={this.entry.serverId}
                 verified={this.entry.mcpRegistryVerified}
                 hoverService={this.hoverService}
+                onManage={event => showEntryMenu(event, this, this.contextMenuRenderer)}
                 actions={renderActions(this.state, this.entry, this.entry.localName, this.handlers)}
             />
         );
     }
+}
+
+/**
+ * An auto-update policy is only meaningful for a server that is installed and linked to a live
+ * registry entry - which excludes drifted servers, as the auto-updater does.
+ */
+function autoUpdateId(state: ClassificationResult, serverId: string | undefined): string | undefined {
+    return state.kind === 'installed-from-registry' ? serverId : undefined;
 }
 
 interface MCPCardProps {
@@ -111,6 +144,7 @@ interface MCPCardProps {
     /** Drives the trust icon next to `identifier`: verified -> filled check, otherwise question mark. */
     verified?: boolean;
     hoverService: HoverService;
+    onManage: (event: RegistryEntryMenuEvent) => void;
     actions?: React.ReactNode;
 }
 
@@ -135,8 +169,8 @@ function buildHoverContent(props: MCPCardProps): MarkdownStringImpl {
  * trust icon and hover tooltip. The MCP-specific bits are the codicon icon, the type
  * badge, the derived trust state and the action set.
  *
- * The trailing invisible settings-gear element reserves the same layout space VSX cards
- * use for their context-menu gear, so MCP and VSX action bars align across the view.
+ * The trailing settings-gear opens the shared entry context menu, occupying the same layout
+ * slot VSX cards use for theirs so MCP and VSX action bars align across the view.
  */
 const MCPCard: React.FC<MCPCardProps> = props => {
     const trust: ExtensionCardTrust = props.verified === true ? 'verified' : 'unknown';
@@ -158,13 +192,11 @@ const MCPCard: React.FC<MCPCardProps> = props => {
             publisherTitle={props.identifier}
             trust={trust}
             hover={{ content: buildHoverContent(props), hoverService: props.hoverService }}
+            onContextMenu={props.onManage}
             actions={
                 <div className="theia-mcp-extension-actions">
                     {props.actions}
-                    <div
-                        className="codicon codicon-settings-gear action theia-mcp-extension-gear-placeholder"
-                        aria-hidden="true"
-                    />
+                    <RegistryEntryGear className="theia-mcp-extension-gear" onManage={props.onManage} />
                 </div>
             }
         />

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -28,7 +28,7 @@ try {
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
 import { Emitter, MessageService, PreferenceService } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCPServerEditor, MCPServerEditorImpl, MCPServerEditDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
@@ -37,6 +37,7 @@ import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { RegistrySearchFilter } from '../../common/registry-search-filter';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../../common/mcp/mcp-registry-entry-resolver';
+import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from '../auto-update/registry-auto-update-policy';
 import { MCPInstallService, MCPInstallServiceImpl } from './mcp-install-service';
 import { MCPExtensionsContribution } from './mcp-extensions-contribution';
 import { MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
@@ -82,6 +83,8 @@ function buildContainer(prefs: FakePreferenceService, fetch: StubRegistryFetchSe
     container.bind(MessageService).toConstantValue({ error: () => undefined } as unknown as MessageService);
     container.bind(MCPFrontendService).toConstantValue({} as unknown as MCPFrontendService);
     container.bind(HoverService).toConstantValue({ requestHover: () => undefined } as unknown as HoverService);
+    // Entries take the renderer to open their gear menu; these tests never click it.
+    container.bind(ContextMenuRenderer).toConstantValue({ render: () => undefined } as unknown as ContextMenuRenderer);
     // The contribution doesn't open dialogs in these tests; bind factories that fail loudly if used.
     container.bind(MCPServerEditDialogFactory).toConstantValue(() => {
         throw new Error('MCPServerEditDialogFactory should not be invoked in these tests');
@@ -91,6 +94,9 @@ function buildContainer(prefs: FakePreferenceService, fetch: StubRegistryFetchSe
     });
     container.bind(MCPServerEditorImpl).toSelf().inSingletonScope();
     container.bind(MCPServerEditor).toService(MCPServerEditorImpl);
+    // The install service clears an artifact's auto-update override when it is uninstalled.
+    container.bind(RegistryAutoUpdatePolicyImpl).toSelf().inSingletonScope();
+    container.bind(RegistryAutoUpdatePolicy).toService(RegistryAutoUpdatePolicyImpl);
     container.bind(MCPInstallServiceImpl).toSelf().inSingletonScope();
     container.bind(MCPInstallService).toService(MCPInstallServiceImpl);
     container.bind(MCPExtensionsContribution).toSelf().inSingletonScope();

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -16,20 +16,16 @@
 
 import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
 import { Disposable, DisposableCollection, Emitter, Event, nls, PreferenceChange, PreferenceService } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
-import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
-import { MCPServersPreference, MCPServersPreferenceValue } from '@theia/ai-mcp/lib/common/mcp-server-preference-validator';
 import { MCPServerInstallDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-install-dialog';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { RegistrySearchFilter } from '../../common/registry-search-filter';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
 import { MCPInstallService } from './mcp-install-service';
 import { MCPEntryHandlers, MCPInstalledEntry, MCPSearchResultEntry } from './mcp-entries';
-
-type StoredServer = MCPServersPreferenceValue;
 
 @injectable()
 export class MCPExtensionsContribution implements ExtensionsSourceContribution, Disposable {
@@ -50,6 +46,9 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
 
     @inject(HoverService)
     protected readonly hoverService: HoverService;
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
 
     @inject(MCPServerInstallDialogFactory)
     protected readonly installDialogFactory: MCPServerInstallDialogFactory;
@@ -87,16 +86,11 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
     }
 
     async resolveInstalled(): Promise<Iterable<TreeElement>> {
-        const stored = this.readStoredServers();
         const registryEntries = await this.safeGetRegistryEntries();
         const byServerId = new Map(registryEntries.map(e => [e.serverId, e]));
         const byName = new Map(registryEntries.map(e => [e.localName, e]));
         const result: TreeElement[] = [];
-        for (const [name, config] of Object.entries(stored)) {
-            const local = this.toServerDescription(name, config);
-            if (!local) {
-                continue;
-            }
+        for (const local of this.installService.listInstalledServers()) {
             const state = this.installService.classifyLocalServer(local, registryEntries);
             // Hand-added local servers belong to the MCP configuration widget, not this view.
             // Stale-linked entries (registryMetadata.serverId set but registry no longer lists
@@ -106,7 +100,7 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             }
             const linkedId = local.registryMetadata?.serverId;
             const matchedEntry = (linkedId && byServerId.get(linkedId)) || byName.get(local.name);
-            result.push(new MCPInstalledEntry(local, matchedEntry, state, this.handlers, this.hoverService));
+            result.push(new MCPInstalledEntry(local, matchedEntry, state, this.handlers, this.hoverService, this.contextMenuRenderer));
         }
         return result;
     }
@@ -116,13 +110,7 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             return [];
         }
         const registryEntries = await this.safeGetRegistryEntries();
-        const localDescriptions: MCPServerDescription[] = [];
-        for (const [name, cfg] of Object.entries(this.readStoredServers())) {
-            const local = this.toServerDescription(name, cfg);
-            if (local) {
-                localDescriptions.push(local);
-            }
-        }
+        const localDescriptions = this.installService.listInstalledServers();
         const result: SearchResult[] = [];
         for (const entry of registryEntries) {
             // `verifiedOnly` comes from the OVSX-named `extensions.onlyShowVerifiedExtensions`
@@ -141,7 +129,7 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             const searchableText = `${entry.name} ${entry.serverId} ${entry.description}`;
             const state = this.installService.classifyRegistryEntry(entry, localDescriptions, registryEntries);
             result.push({
-                element: new MCPSearchResultEntry(entry, state, this.handlers, this.hoverService),
+                element: new MCPSearchResultEntry(entry, state, this.handlers, this.hoverService, this.contextMenuRenderer),
                 searchableText
             });
         }
@@ -150,15 +138,6 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
 
     async refresh(): Promise<void> {
         await this.fetchService.getEntries(true);
-    }
-
-    /**
-     * Returns the raw (untyped) servers preference; per-entry validation happens in
-     * `toServerDescription`, which uses the shared `MCPServersPreference.isValue` guard
-     * so this view and `McpFrontendApplicationContribution` apply the same value checks.
-     */
-    protected readStoredServers(): Record<string, unknown> {
-        return this.preferenceService.get<Record<string, unknown>>(MCP_SERVERS_PREF, {}) ?? {};
     }
 
     protected async safeGetRegistryEntries(): Promise<ResolvedRegistryEntry[]> {
@@ -171,17 +150,6 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             console.warn('AI registry fetch failed; MCP entries unavailable.', error);
             return [];
         }
-    }
-
-    protected toServerDescription(name: string, stored: unknown): MCPServerDescription | undefined {
-        // Reuse the same value guard the MCP frontend contribution applies to the
-        // preference, so a `command: 42` (or any non-string) entry is rejected here too
-        // instead of being cast straight to `MCPServerDescription`.
-        if (!MCPServersPreference.isValue(stored)) {
-            console.warn(`Ignoring malformed MCP server "${name}": value does not match the MCP servers preference schema.`);
-            return undefined;
-        }
-        return { name, ...(stored as StoredServer) } as MCPServerDescription;
     }
 
     /**

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.spec.ts
@@ -20,7 +20,9 @@ import { MessageService, PreferenceService } from '@theia/core';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
 import { MCPFrontendService } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCPServerEditor, MCPServerEditorImpl, MCPServerEditDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
+import { AUTO_UPDATE_OVERRIDES_PREF } from '../../common/ai-registry-preferences';
 import { ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from '../auto-update/registry-auto-update-policy';
 import { MCPInstallService, MCPInstallServiceImpl } from './mcp-install-service';
 
 class FakePreferenceService {
@@ -370,6 +372,8 @@ describe('MCPInstallService actions', () => {
         });
         container.bind(MCPServerEditorImpl).toSelf().inSingletonScope();
         container.bind(MCPServerEditor).toService(MCPServerEditorImpl);
+        container.bind(RegistryAutoUpdatePolicyImpl).toSelf().inSingletonScope();
+        container.bind(RegistryAutoUpdatePolicy).toService(RegistryAutoUpdatePolicyImpl);
         container.bind(MCPInstallServiceImpl).toSelf().inSingletonScope();
         container.bind(MCPInstallService).toService(MCPInstallServiceImpl);
         service = container.get(MCPInstallService);
@@ -431,6 +435,33 @@ describe('MCPInstallService actions', () => {
         });
     });
 
+    it('uninstall drops the server auto-update override so it does not linger in the settings', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryMetadata: { serverId: 'io.github.example/example-mcp' }
+            }
+        });
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, {
+            'mcp:io.github.example/example-mcp': 'on',
+            'mcp:io.github.other/other-mcp': 'off'
+        });
+
+        await service.uninstall('example');
+
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ 'mcp:io.github.other/other-mcp': 'off' });
+    });
+
+    it('uninstall leaves the overrides untouched for a server that was never linked to the registry', async () => {
+        await prefs.set(MCP_SERVERS_PREF, { example: { command: 'npx', args: ['-y', 'example-mcp'] } });
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, { 'mcp:io.github.other/other-mcp': 'off' });
+
+        await service.uninstall('example');
+
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ 'mcp:io.github.other/other-mcp': 'off' });
+    });
+
     it('unlink removes the registryMetadata block while leaving the server config intact', async () => {
         await prefs.set(MCP_SERVERS_PREF, {
             example: {
@@ -456,6 +487,24 @@ describe('MCPInstallService actions', () => {
                 autostart: true
             }
         });
+    });
+
+    it('unlink drops the server auto-update override, since the server stops being registry-managed', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryMetadata: { serverId: 'io.github.example/example-mcp' }
+            }
+        });
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, {
+            'mcp:io.github.example/example-mcp': 'on',
+            'mcp:io.github.other/other-mcp': 'off'
+        });
+
+        await service.unlink('example');
+
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ 'mcp:io.github.other/other-mcp': 'off' });
     });
 
     it('unlink is a no-op on entries that have no registryMetadata block', async () => {

--- a/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-install-service.ts
@@ -24,8 +24,10 @@ import {
     MCPServerDescription
 } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { MCPServersPreference } from '@theia/ai-mcp/lib/common/mcp-server-preference-validator';
 import { MCPInstallOverrides, MCPServerEditor } from '@theia/ai-mcp/lib/browser/mcp-server-editor';
 import { ClassificationResult, ResolvedRegistryEntry } from '../../common/mcp/mcp-registry-types';
+import { RegistryAutoUpdatePolicy } from '../auto-update/registry-auto-update-policy';
 
 export { MCPInstallOverrides };
 
@@ -50,6 +52,8 @@ export interface MCPInstallService {
     unlink(name: string): Promise<void>;
     /** Removes an installed server entry by its local preference key. */
     uninstall(name: string): Promise<void>;
+    /** Lists every locally stored server, skipping entries that do not match the servers preference schema. */
+    listInstalledServers(): MCPServerDescription[];
     /** Classifies a locally stored server against the registry (for the Installed view). */
     classifyLocalServer(local: MCPServerDescription, registryEntries: ResolvedRegistryEntry[]): ClassificationResult;
     /** Classifies a registry entry against the locally stored servers (for the Search view). */
@@ -64,6 +68,9 @@ export class MCPInstallServiceImpl implements MCPInstallService {
 
     @inject(MCPServerEditor)
     protected readonly editor: MCPServerEditor;
+
+    @inject(RegistryAutoUpdatePolicy)
+    protected readonly autoUpdatePolicy: RegistryAutoUpdatePolicy;
 
     /** Delegates to the generic editor so both registry installs and `install-mcp` URL handlers go through the same code path. */
     async install(entry: ResolvedRegistryEntry, overrides?: MCPInstallOverrides): Promise<void> {
@@ -154,9 +161,15 @@ export class MCPInstallServiceImpl implements MCPInstallService {
         if (!existing || existing.registryMetadata === undefined) {
             return;
         }
+        const serverId = existing.registryMetadata.serverId;
         const next: StoredEntry = { ...existing };
         delete next.registryMetadata;
         await this.writeServers({ ...current, [name]: next });
+        if (serverId) {
+            // Unlinking is the other way a server stops being registry-managed, so it drops the
+            // override for the same reason uninstall does. Re-linking starts from the default again.
+            await this.autoUpdatePolicy.clearMode('mcp', serverId);
+        }
     }
 
     async uninstall(name: string): Promise<void> {
@@ -164,9 +177,29 @@ export class MCPInstallServiceImpl implements MCPInstallService {
         if (!(name in current)) {
             return;
         }
+        const serverId = current[name].registryMetadata?.serverId;
         const next: StoredServers = { ...current };
         delete next[name];
         await this.writeServers(next);
+        if (serverId) {
+            // The server is gone, so its override would linger with nothing left to apply it to.
+            await this.autoUpdatePolicy.clearMode('mcp', serverId);
+        }
+    }
+
+    listInstalledServers(): MCPServerDescription[] {
+        const result: MCPServerDescription[] = [];
+        for (const [name, value] of Object.entries(this.readServers())) {
+            // `StoredServers` is the expected shape of the preference, not a guarantee. Reuse the
+            // same guard `McpFrontendApplicationContribution` applies, so a `command: 42` entry is
+            // rejected here too instead of being cast straight to a description.
+            if (!MCPServersPreference.isValue(value)) {
+                console.warn(`Ignoring malformed MCP server "${name}": value does not match the MCP servers preference schema.`);
+                continue;
+            }
+            result.push({ name, ...value } as MCPServerDescription);
+        }
+        return result;
     }
 
     protected readServers(): StoredServers {

--- a/packages/ai-registry/src/browser/registry-entry-context.ts
+++ b/packages/ai-registry/src/browser/registry-entry-context.ts
@@ -1,0 +1,44 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MenuPath } from '@theia/core';
+import { RegistryArtifactKind } from '../common/ai-registry-preferences';
+
+export const AI_REGISTRY_ENTRY_CONTEXT_MENU: MenuPath = ['ai_registry_entry_context_menu'];
+
+export namespace AIRegistryEntryContextMenu {
+    export const AUTO_UPDATE = [...AI_REGISTRY_ENTRY_CONTEXT_MENU, '1_auto_update'];
+    export const COPY = [...AI_REGISTRY_ENTRY_CONTEXT_MENU, '2_copy'];
+    export const AUTO_UPDATE_SUBMENU = [...AUTO_UPDATE, 'auto_update_submenu'];
+}
+
+/**
+ * The slice of a skill or MCP entry the shared gear context menu operates on, so the menu
+ * commands stay agnostic of which artifact family they were invoked from.
+ */
+export interface RegistryEntryContext {
+    readonly artifactKind: RegistryArtifactKind;
+    /** The "Copy ID" payload: the registry identifier, or the local name for an unlinked artifact. */
+    readonly copyableId: string | undefined;
+    /** The override key, set only while the artifact is installed and linked to a registry entry. */
+    readonly autoUpdateId: string | undefined;
+}
+
+export namespace RegistryEntryContext {
+    export function is(arg: unknown): arg is RegistryEntryContext {
+        return !!arg && typeof arg === 'object' && 'artifactKind' in arg && 'autoUpdateId' in arg;
+    }
+}

--- a/packages/ai-registry/src/browser/registry-entry-menu.spec.ts
+++ b/packages/ai-registry/src/browser/registry-entry-menu.spec.ts
@@ -1,0 +1,68 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { ContextMenuRenderer, RenderContextMenuOptions } from '@theia/core/lib/browser';
+import { AI_REGISTRY_ENTRY_CONTEXT_MENU, RegistryEntryContext } from './registry-entry-context';
+import { RegistryEntryMenuEvent, showEntryMenu } from './registry-entry-menu';
+
+const entry: RegistryEntryContext = {
+    artifactKind: 'skill',
+    copyableId: 'io.github.example/example-skill',
+    autoUpdateId: 'io.github.example/example-skill'
+};
+
+/** Stands in for the gear element, which is the only thing the anchor needs from the DOM. */
+const gear = {
+    getBoundingClientRect: () => ({ left: 40, bottom: 90 })
+} as unknown as HTMLElement;
+
+function pointerEvent(clientX: number, clientY: number): RegistryEntryMenuEvent {
+    return { preventDefault: () => { }, stopPropagation: () => { }, clientX, clientY, currentTarget: gear } as unknown as RegistryEntryMenuEvent;
+}
+
+function keyboardEvent(): RegistryEntryMenuEvent {
+    return { preventDefault: () => { }, stopPropagation: () => { }, key: 'Enter', currentTarget: gear } as unknown as RegistryEntryMenuEvent;
+}
+
+describe('showEntryMenu', () => {
+
+    let rendered: RenderContextMenuOptions | undefined;
+    let contextMenuRenderer: ContextMenuRenderer;
+
+    beforeEach(() => {
+        rendered = undefined;
+        contextMenuRenderer = {
+            render: (options: RenderContextMenuOptions) => { rendered = options; }
+        } as unknown as ContextMenuRenderer;
+    });
+
+    it('passes the entry to the shared menu as its argument', () => {
+        showEntryMenu(pointerEvent(12, 34), entry, contextMenuRenderer);
+        expect(rendered!.menuPath).to.deep.equal(AI_REGISTRY_ENTRY_CONTEXT_MENU);
+        expect(rendered!.args).to.deep.equal([entry]);
+    });
+
+    it('anchors the menu at the pointer for a mouse interaction', () => {
+        showEntryMenu(pointerEvent(12, 34), entry, contextMenuRenderer);
+        expect(rendered!.anchor).to.deep.equal({ x: 12, y: 34 });
+    });
+
+    it('anchors the menu below the activated element for a keyboard interaction, which has no pointer position', () => {
+        showEntryMenu(keyboardEvent(), entry, contextMenuRenderer);
+        expect(rendered!.anchor).to.deep.equal({ x: 40, y: 90 });
+    });
+});

--- a/packages/ai-registry/src/browser/registry-entry-menu.tsx
+++ b/packages/ai-registry/src/browser/registry-entry-menu.tsx
@@ -1,0 +1,74 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { Anchor, ContextMenuRenderer } from '@theia/core/lib/browser';
+import { buttonKeyboardProps, isActivationKey } from '@theia/core/lib/browser/keyboard/keyboard-utils';
+import { AI_REGISTRY_ENTRY_CONTEXT_MENU, RegistryEntryContext } from './registry-entry-context';
+
+/** The pointer or keyboard interaction that opens the entry context menu. */
+export type RegistryEntryMenuEvent = React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>;
+
+/**
+ * Opens the shared entry context menu, passing the entry along as the menu argument so the
+ * commands can read its artifact kind and registry id.
+ */
+export function showEntryMenu(
+    event: RegistryEntryMenuEvent,
+    entry: RegistryEntryContext,
+    contextMenuRenderer: ContextMenuRenderer
+): void {
+    event.preventDefault();
+    event.stopPropagation();
+    const target = event.currentTarget;
+    contextMenuRenderer.render({
+        menuPath: AI_REGISTRY_ENTRY_CONTEXT_MENU,
+        anchor: menuAnchor(event, target),
+        args: [entry],
+        context: target
+    });
+}
+
+/**
+ * Keyboard activation has no pointer position - `clientX`/`clientY` would both be 0 - so the
+ * menu opens below the activated element instead, as core's tab bar toolbar does.
+ */
+function menuAnchor(event: RegistryEntryMenuEvent, target: HTMLElement): Anchor {
+    if ('clientX' in event) {
+        return { x: event.clientX, y: event.clientY };
+    }
+    const { left, bottom } = target.getBoundingClientRect();
+    return { x: left, y: bottom };
+}
+
+/** The gear that opens {@link showEntryMenu}. */
+export const RegistryEntryGear: React.FC<{ className: string; onManage: (event: RegistryEntryMenuEvent) => void }> = props => {
+    const label = nls.localizeByDefault('Manage');
+    return (
+        <div
+            className={`codicon codicon-settings-gear action ${props.className}`}
+            {...buttonKeyboardProps(label)}
+            title={label}
+            onClick={props.onManage}
+            onKeyDown={event => {
+                if (isActivationKey(event)) {
+                    props.onManage(event);
+                }
+            }}
+        />
+    );
+};

--- a/packages/ai-registry/src/browser/skill/skill-entries.tsx
+++ b/packages/ai-registry/src/browser/skill/skill-entries.tsx
@@ -16,12 +16,15 @@
 
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { TypeBadge } from '@theia/vsx-registry/lib/browser/type-badge';
 import { ExtensionCard } from '@theia/vsx-registry/lib/browser/extension-card';
+import { RegistryArtifactKind } from '../../common/ai-registry-preferences';
 import { InstalledSkillInfo, ResolvedSkillEntry, SkillClassificationResult } from '../../common/skill/skill-registry-types';
+import { RegistryEntryContext } from '../registry-entry-context';
+import { RegistryEntryGear, RegistryEntryMenuEvent, showEntryMenu } from '../registry-entry-menu';
 
 /**
  * Per-entry action callbacks provided by the contribution. Entries close over these so
@@ -38,18 +41,28 @@ export interface SkillEntryHandlers {
 }
 
 /** An entry surfacing a locally installed skill in the Installed section. */
-export class SkillInstalledEntry implements TreeElement {
+export class SkillInstalledEntry implements TreeElement, RegistryEntryContext {
 
     readonly id: string;
+    readonly artifactKind: RegistryArtifactKind = 'skill';
 
     constructor(
         readonly local: InstalledSkillInfo,
         readonly matchedEntry: ResolvedSkillEntry | undefined,
         readonly state: SkillClassificationResult,
         readonly handlers: SkillEntryHandlers,
-        readonly hoverService: HoverService
+        readonly hoverService: HoverService,
+        readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         this.id = `skill-installed-${local.name}`;
+    }
+
+    get copyableId(): string | undefined {
+        return this.matchedEntry?.skillId ?? this.local.skillId ?? this.local.name;
+    }
+
+    get autoUpdateId(): string | undefined {
+        return autoUpdateId(this.state, this.matchedEntry?.skillId);
     }
 
     render(): React.ReactNode {
@@ -59,6 +72,7 @@ export class SkillInstalledEntry implements TreeElement {
                 description={this.matchedEntry?.description}
                 identifier={this.matchedEntry?.skillId ?? this.local.skillId}
                 hoverService={this.hoverService}
+                onManage={event => showEntryMenu(event, this, this.contextMenuRenderer)}
                 actions={renderActions(this.state, this.matchedEntry, this.local.name, this.handlers)}
             />
         );
@@ -66,17 +80,27 @@ export class SkillInstalledEntry implements TreeElement {
 }
 
 /** An entry surfacing a registry-resolved skill in the Search Results section. */
-export class SkillSearchResultEntry implements TreeElement {
+export class SkillSearchResultEntry implements TreeElement, RegistryEntryContext {
 
     readonly id: string;
+    readonly artifactKind: RegistryArtifactKind = 'skill';
 
     constructor(
         readonly entry: ResolvedSkillEntry,
         readonly state: SkillClassificationResult,
         readonly handlers: SkillEntryHandlers,
-        readonly hoverService: HoverService
+        readonly hoverService: HoverService,
+        readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         this.id = `skill-search-${entry.skillId}`;
+    }
+
+    get copyableId(): string | undefined {
+        return this.entry.skillId;
+    }
+
+    get autoUpdateId(): string | undefined {
+        return autoUpdateId(this.state, this.entry.skillId);
     }
 
     render(): React.ReactNode {
@@ -86,10 +110,19 @@ export class SkillSearchResultEntry implements TreeElement {
                 description={this.entry.description}
                 identifier={this.entry.skillId}
                 hoverService={this.hoverService}
+                onManage={event => showEntryMenu(event, this, this.contextMenuRenderer)}
                 actions={renderActions(this.state, this.entry, this.entry.name, this.handlers)}
             />
         );
     }
+}
+
+/**
+ * An auto-update policy is only meaningful for a skill that is installed and linked to a live
+ * registry entry - which excludes drifted skills, as the auto-updater does.
+ */
+function autoUpdateId(state: SkillClassificationResult, skillId: string | undefined): string | undefined {
+    return state.kind === 'installed-from-registry' ? skillId : undefined;
 }
 
 interface SkillCardProps {
@@ -98,6 +131,7 @@ interface SkillCardProps {
     /** Stable identifier shown in the publisher-row slot - the registry skillId. */
     identifier?: string;
     hoverService: HoverService;
+    onManage: (event: RegistryEntryMenuEvent) => void;
     actions?: React.ReactNode;
 }
 
@@ -117,6 +151,8 @@ function buildHoverContent(props: SkillCardProps): MarkdownStringImpl {
  * Skill entry card. Renders against the shared {@link ExtensionCard} shell so skill
  * entries sit visually alongside extensions and MCP servers in the unified Extensions
  * view, sharing the layout and hover tooltip.
+ *
+ * The trailing settings-gear opens the shared entry context menu.
  */
 const SkillCard: React.FC<SkillCardProps> = props => (
     <ExtensionCard
@@ -135,13 +171,11 @@ const SkillCard: React.FC<SkillCardProps> = props => (
         publisherTitle={props.identifier}
         trust="verified"
         hover={{ content: buildHoverContent(props), hoverService: props.hoverService }}
+        onContextMenu={props.onManage}
         actions={
             <div className="theia-skill-extension-actions">
                 {props.actions}
-                <div
-                    className="codicon codicon-settings-gear action theia-skill-extension-gear-placeholder"
-                    aria-hidden="true"
-                />
+                <RegistryEntryGear className="theia-skill-extension-gear" onManage={props.onManage} />
             </div>
         }
     />

--- a/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/skill/skill-extensions-contribution.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { Disposable, DisposableCollection, Emitter, Event, ILogger, MessageService, nls } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
@@ -44,6 +44,9 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
 
     @inject(HoverService)
     protected readonly hoverService: HoverService;
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
 
     @inject(MessageService)
     protected readonly messageService: MessageService;
@@ -122,7 +125,7 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
                 continue;
             }
             const matchedEntry = (info.skillId && bySkillId.get(info.skillId)) || byName.get(info.name);
-            result.push(new SkillInstalledEntry(info, matchedEntry, state, this.handlers, this.hoverService));
+            result.push(new SkillInstalledEntry(info, matchedEntry, state, this.handlers, this.hoverService, this.contextMenuRenderer));
         }
         return result;
     }
@@ -143,7 +146,7 @@ export class SkillExtensionsContribution implements ExtensionsSourceContribution
             }
             const state = this.installService.classifyRegistryEntry(entry, installed);
             result.push({
-                element: new SkillSearchResultEntry(entry, state, this.handlers, this.hoverService),
+                element: new SkillSearchResultEntry(entry, state, this.handlers, this.hoverService, this.contextMenuRenderer),
                 searchableText: `${entry.name} ${entry.skillId} ${entry.description}`
             });
         }

--- a/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.spec.ts
@@ -15,7 +15,12 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { PreferenceService } from '@theia/core';
+import { AUTO_UPDATE_OVERRIDES_PREF } from '../../common/ai-registry-preferences';
+import { SkillInstallBackendService } from '../../common/skill/skill-install-protocol';
 import { InstalledSkillInfo, ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from '../auto-update/registry-auto-update-policy';
 import { SkillInstallService, SkillInstallServiceImpl } from './skill-install-service';
 
 const entry: ResolvedSkillEntry = {
@@ -55,9 +60,9 @@ describe('SkillInstallService.classifyInstalledSkill', () => {
         expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'fix-skill' });
     });
 
-    it('prefers Update over Fix when the registry hash differs even if the local files have also drifted', () => {
+    it('prefers Fix over Update when the local files have drifted even though the registry hash also differs', () => {
         const info: InstalledSkillInfo = { name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v0', drifted: true };
-        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+        expect(service.classifyInstalledSkill(info, [entry])).to.deep.equal({ kind: 'fix-skill' });
     });
 
     it('returns installed-from-registry with no update when the recorded hash matches the registry hash', () => {
@@ -98,13 +103,91 @@ describe('SkillInstallService.classifyRegistryEntry', () => {
         expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'fix-skill' });
     });
 
-    it('prefers Update over Fix when the registry hash differs even if a linked folder has also drifted', () => {
+    it('prefers Fix over Update when a linked folder has drifted even though the registry hash also differs', () => {
         const installed: InstalledSkillInfo[] = [{ name: 'Example Skill', skillId: entry.skillId, contentHash: 'hash-v0', drifted: true }];
-        expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+        expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'fix-skill' });
     });
 
     it('returns installed-manually when a folder of the same name exists but is not linked to this skill', () => {
         const installed: InstalledSkillInfo[] = [{ name: 'Example Skill', drifted: false }];
         expect(service.classifyRegistryEntry(entry, installed)).to.deep.equal({ kind: 'installed-manually' });
+    });
+});
+
+describe('SkillInstallService override cleanup', () => {
+
+    class FakePreferenceService {
+        private readonly store = new Map<string, unknown>();
+        get<T>(key: string, defaultValue?: T): T | undefined {
+            return (this.store.has(key) ? this.store.get(key) : defaultValue) as T | undefined;
+        }
+        async set(key: string, value: unknown): Promise<void> {
+            this.store.set(key, value);
+        }
+        snapshot<T>(key: string): T | undefined {
+            return this.store.get(key) as T | undefined;
+        }
+    }
+
+    /** A linked folder and a hand-placed one, so both the with- and without-id paths are covered. */
+    const installed: InstalledSkillInfo[] = [
+        { name: 'Example Skill', skillId: entry.skillId, contentHash: entry.contentHash, drifted: false },
+        { name: 'hand-placed', drifted: false }
+    ];
+
+    let prefs: FakePreferenceService;
+    let uninstalled: string[];
+    let unlinked: string[];
+    let service: SkillInstallService;
+
+    beforeEach(() => {
+        const container = new Container();
+        prefs = new FakePreferenceService();
+        uninstalled = [];
+        unlinked = [];
+        container.bind(PreferenceService).toConstantValue(prefs);
+        container.bind(SkillInstallBackendService).toConstantValue({
+            uninstall: async (name: string) => { uninstalled.push(name); },
+            unlink: async (name: string) => { unlinked.push(name); },
+            listInstalledSkills: async () => installed
+        } as unknown as SkillInstallBackendService);
+        container.bind(RegistryAutoUpdatePolicyImpl).toSelf().inSingletonScope();
+        container.bind(RegistryAutoUpdatePolicy).toService(RegistryAutoUpdatePolicyImpl);
+        container.bind(SkillInstallServiceImpl).toSelf().inSingletonScope();
+        container.bind(SkillInstallService).toService(SkillInstallServiceImpl);
+        service = container.get(SkillInstallService);
+    });
+
+    it('resolves the registry id itself, so uninstall drops the override without being told it', async () => {
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, {
+            [`skill:${entry.skillId}`]: 'on',
+            'skill:io.github.other/other-skill': 'off'
+        });
+
+        await service.uninstall('Example Skill');
+
+        expect(uninstalled).to.deep.equal(['Example Skill']);
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ 'skill:io.github.other/other-skill': 'off' });
+    });
+
+    it('leaves the overrides untouched when the uninstalled folder has no registry identity', async () => {
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, { 'skill:io.github.other/other-skill': 'off' });
+
+        await service.uninstall('hand-placed');
+
+        expect(uninstalled).to.deep.equal(['hand-placed']);
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ 'skill:io.github.other/other-skill': 'off' });
+    });
+
+    it('drops the override on unlink too, since the skill stops being registry-managed', async () => {
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, {
+            [`skill:${entry.skillId}`]: 'on',
+            'skill:io.github.other/other-skill': 'off'
+        });
+
+        await service.unlink('Example Skill');
+
+        expect(unlinked).to.deep.equal(['Example Skill']);
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ 'skill:io.github.other/other-skill': 'off' });
     });
 });

--- a/packages/ai-registry/src/browser/skill/skill-install-service.ts
+++ b/packages/ai-registry/src/browser/skill/skill-install-service.ts
@@ -17,6 +17,7 @@
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { SkillInstallBackendService } from '../../common/skill/skill-install-protocol';
 import { InstalledSkillInfo, ResolvedSkillEntry, SkillClassificationResult } from '../../common/skill/skill-registry-types';
+import { RegistryAutoUpdatePolicy } from '../auto-update/registry-auto-update-policy';
 
 export const SkillInstallService = Symbol('SkillInstallService');
 export interface SkillInstallService {
@@ -30,7 +31,10 @@ export interface SkillInstallService {
     link(entry: ResolvedSkillEntry): Promise<void>;
     /** Removes the registry metadata file from a skill folder while keeping its other files. */
     unlink(name: string): Promise<void>;
-    /** Removes an installed (registry-managed) skill folder. */
+    /**
+     * Removes an installed (registry-managed) skill folder, dropping any auto-update override
+     * kept for it.
+     */
     uninstall(name: string): Promise<void>;
     /** Lists every skill folder under `~/.agents/skills`. */
     listInstalledSkills(): Promise<InstalledSkillInfo[]>;
@@ -45,6 +49,9 @@ export class SkillInstallServiceImpl implements SkillInstallService {
 
     @inject(SkillInstallBackendService)
     protected readonly backend: SkillInstallBackendService;
+
+    @inject(RegistryAutoUpdatePolicy)
+    protected readonly autoUpdatePolicy: RegistryAutoUpdatePolicy;
 
     install(entry: ResolvedSkillEntry): Promise<void> {
         return this.backend.install(entry);
@@ -62,12 +69,25 @@ export class SkillInstallServiceImpl implements SkillInstallService {
         return this.backend.link(entry);
     }
 
-    unlink(name: string): Promise<void> {
-        return this.backend.unlink(name);
+    async unlink(name: string): Promise<void> {
+        // Unlinking is the other way a skill stops being registry-managed, so it drops the
+        // override for the same reason uninstall does. Re-linking starts from the default again.
+        const skillId = (await this.listInstalledSkills()).find(info => info.name === name)?.skillId;
+        await this.backend.unlink(name);
+        if (skillId) {
+            await this.autoUpdatePolicy.clearMode('skill', skillId);
+        }
     }
 
-    uninstall(name: string): Promise<void> {
-        return this.backend.uninstall(name);
+    async uninstall(name: string): Promise<void> {
+        // Resolve the registry identity before the folder goes away, so callers don't have to
+        // thread it in - one that passed only the name would silently leak the override.
+        const skillId = (await this.listInstalledSkills()).find(info => info.name === name)?.skillId;
+        await this.backend.uninstall(name);
+        if (skillId) {
+            // The skill is gone, so its override would linger with nothing left to apply it to.
+            await this.autoUpdatePolicy.clearMode('skill', skillId);
+        }
     }
 
     listInstalledSkills(): Promise<InstalledSkillInfo[]> {
@@ -81,14 +101,15 @@ export class SkillInstallServiceImpl implements SkillInstallService {
                 // The registry metadata file points at a skillId the registry no longer lists.
                 return { kind: 'installed-link-stale' };
             }
-            // Update takes precedence: a changed registry content hash always means an
-            // Update is available, even if the local files have also drifted. Only when the
-            // registry hash still matches do local edits surface as a Fix.
-            if (matched.contentHash !== info.contentHash) {
-                return { kind: 'installed-from-registry', updateAvailable: true };
-            }
+            // Drift takes precedence, mirroring the MCP classifier: a skill whose files no longer
+            // match what was installed must be fixed before it is considered updatable. Nothing is
+            // lost by fixing first - `fixSkill` and `update` are the same clean replace, so a
+            // single Fix already lands the current registry content.
             if (info.drifted) {
                 return { kind: 'fix-skill' };
+            }
+            if (matched.contentHash !== info.contentHash) {
+                return { kind: 'installed-from-registry', updateAvailable: true };
             }
             return { kind: 'installed-from-registry', updateAvailable: false };
         }
@@ -100,12 +121,12 @@ export class SkillInstallServiceImpl implements SkillInstallService {
     classifyRegistryEntry(entry: ResolvedSkillEntry, installed: InstalledSkillInfo[]): SkillClassificationResult {
         const linked = installed.find(info => info.skillId === entry.skillId);
         if (linked) {
-            // Update takes precedence over Fix, mirroring classifyInstalledSkill.
-            if (entry.contentHash !== linked.contentHash) {
-                return { kind: 'installed-from-registry', updateAvailable: true };
-            }
+            // Fix takes precedence over Update, mirroring classifyInstalledSkill.
             if (linked.drifted) {
                 return { kind: 'fix-skill' };
+            }
+            if (entry.contentHash !== linked.contentHash) {
+                return { kind: 'installed-from-registry', updateAvailable: true };
             }
             return { kind: 'installed-from-registry', updateAvailable: false };
         }

--- a/packages/ai-registry/src/browser/style/mcp-entries.css
+++ b/packages/ai-registry/src/browser/style/mcp-entries.css
@@ -35,11 +35,9 @@
     flex-shrink: 0;
 }
 
-/* Invisible spacer reserving the same width VSX cards use for their context-menu gear,
-   so MCP and VSX action bars line up across the unified Extensions view. */
-.theia-mcp-extension-gear-placeholder {
-    visibility: hidden;
-    pointer-events: none;
+/* Occupies the same slot VSX cards use for their gear, so the action bars line up. */
+.theia-mcp-extension-gear {
+    cursor: pointer;
 }
 
 .theia-mcp-extension-warning {

--- a/packages/ai-registry/src/browser/style/skill-entries.css
+++ b/packages/ai-registry/src/browser/style/skill-entries.css
@@ -35,9 +35,8 @@
     flex-shrink: 0;
 }
 
-.theia-skill-extension-gear-placeholder {
-    visibility: hidden;
-    pointer-events: none;
+.theia-skill-extension-gear {
+    cursor: pointer;
 }
 
 .theia-skill-extension-warning {

--- a/packages/ai-registry/src/common/ai-registry-preferences.ts
+++ b/packages/ai-registry/src/common/ai-registry-preferences.ts
@@ -1,0 +1,73 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
+import { nls, PreferenceSchema, PreferenceScope } from '@theia/core';
+
+export const AUTO_UPDATE_PREF = 'ai-features.registry.autoUpdate';
+export const AUTO_UPDATE_OVERRIDES_PREF = 'ai-features.registry.autoUpdateOverrides';
+
+/** How registry-managed artifacts (skills, MCP servers) react to a newer registry entry. */
+export type AutoUpdateMode = 'off' | 'ask' | 'on';
+
+export const AUTO_UPDATE_MODES: readonly AutoUpdateMode[] = ['off', 'ask', 'on'];
+
+export namespace AutoUpdateMode {
+    export function is(value: unknown): value is AutoUpdateMode {
+        return typeof value === 'string' && (AUTO_UPDATE_MODES as readonly string[]).includes(value);
+    }
+}
+
+/** Artifact families the registry can auto-update. Namespaces the override keys. */
+export type RegistryArtifactKind = 'skill' | 'mcp';
+
+/**
+ * Both preferences are `User`-scoped on purpose: a workspace-settable policy would let a cloned
+ * repository turn auto-update on and download skill content into `~/.agents/skills` at startup
+ * without the user ever being asked.
+ */
+export const AIRegistryPreferencesSchema: PreferenceSchema = {
+    properties: {
+        [AUTO_UPDATE_PREF]: {
+            type: 'string',
+            enum: [...AUTO_UPDATE_MODES],
+            default: 'ask',
+            scope: PreferenceScope.User,
+            enumDescriptions: [
+                nls.localize('theia/ai-registry/autoUpdate/off', 'Never update installed skills and MCP servers, and never notify about available updates.'),
+                nls.localize('theia/ai-registry/autoUpdate/ask', 'Notify when an update is available for an installed skill or MCP server.'),
+                nls.localize('theia/ai-registry/autoUpdate/on', 'Update installed skills and MCP servers automatically.')
+            ],
+            description: nls.localize('theia/ai-registry/autoUpdate/description',
+                'Default update behavior for skills and MCP servers installed from the AI registry. Updates are checked once per window load. \
+Individual skills and MCP servers can override this from the gear menu in the Extensions view.'),
+            title: AI_CORE_PREFERENCES_TITLE
+        },
+        [AUTO_UPDATE_OVERRIDES_PREF]: {
+            type: 'object',
+            default: {},
+            scope: PreferenceScope.User,
+            additionalProperties: {
+                type: 'string',
+                enum: [...AUTO_UPDATE_MODES]
+            },
+            markdownDescription: nls.localize('theia/ai-registry/autoUpdateOverrides/mdDescription',
+                'Per-artifact overrides of `#ai-features.registry.autoUpdate#`, keyed by `skill:<skillId>` or `mcp:<serverId>`. \
+Entries are normally maintained through the gear menu in the Extensions view; an artifact without an entry follows the default.'),
+            title: AI_CORE_PREFERENCES_TITLE
+        }
+    }
+};

--- a/packages/ai-registry/src/common/registry-fetch-service.spec.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.spec.ts
@@ -24,19 +24,41 @@ import { RegistryFetchService, RegistryFetchServiceImpl } from './registry-fetch
 
 class FakeRequestService implements RequestService {
     public lastUrl: string | undefined;
+    public lastTimeout: number | undefined;
     public callCount = 0;
+    /** When set, every request rejects with this error instead of responding. */
+    public failWith: Error | undefined;
+    /** When `true`, every request stays pending forever, mimicking a network that drops packets. */
+    public hang = false;
     constructor(private readonly responseBody: string, private readonly statusCode = 200) { }
     async configure(): Promise<void> { /* no-op */ }
     async resolveProxy(): Promise<string | undefined> { return undefined; }
     async request(options: RequestOptions): Promise<RequestContext> {
         this.lastUrl = options.url;
+        this.lastTimeout = options.timeout;
         this.callCount += 1;
+        if (this.hang) {
+            return new Promise<RequestContext>(() => { /* never settles */ });
+        }
+        if (this.failWith) {
+            throw this.failWith;
+        }
         return {
             url: options.url,
             res: { headers: {}, statusCode: this.statusCode },
             buffer: new TextEncoder().encode(this.responseBody)
         };
     }
+}
+
+/** Exposes the timing knobs so the tests don't have to wait out the production values. */
+class TestRegistryFetchService extends RegistryFetchServiceImpl {
+    public timeout = 10;
+    public delay = 1000;
+    public currentTime = 0;
+    protected override get fetchTimeout(): number { return this.timeout; }
+    protected override get retryDelay(): number { return this.delay; }
+    protected override now(): number { return this.currentTime; }
 }
 
 class FakeConfiguration extends AIRegistryConfiguration {
@@ -172,6 +194,82 @@ describe('RegistryFetchService', () => {
         await service.getEntries(true);
 
         expect(request.callCount).to.equal(2);
+    });
+
+    function buildTestService(requestService: RequestService): TestRegistryFetchService {
+        const container = buildContainer(requestService, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/'));
+        container.rebind(RegistryFetchServiceImpl).to(TestRegistryFetchService).inSingletonScope();
+        return container.get(RegistryFetchServiceImpl) as TestRegistryFetchService;
+    }
+
+    async function expectRejection(promise: Promise<unknown>): Promise<Error> {
+        try {
+            await promise;
+        } catch (error) {
+            return error as Error;
+        }
+        throw new Error('Expected the fetch to be rejected.');
+    }
+
+    it('issues a single request for callers that ask concurrently', async () => {
+        const request = new FakeRequestService(payload());
+        const service = buildTestService(request);
+
+        // The Extensions view resolves its sections in parallel, and the auto-update check adds
+        // another caller, so the requests overlap in practice.
+        await Promise.all([service.getEntries(), service.getSkillEntries(), service.getEntries()]);
+
+        expect(request.callCount).to.equal(1);
+    });
+
+    it('gives up on a request that never settles', async () => {
+        const request = new FakeRequestService(payload());
+        request.hang = true;
+        const service = buildTestService(request);
+
+        const error = await expectRejection(service.getEntries());
+
+        expect(error.message).to.match(/Timed out fetching the AI registry/);
+        expect(request.lastTimeout).to.equal(service.timeout);
+    });
+
+    it('backs off instead of re-attempting a failed fetch on every call', async () => {
+        const request = new FakeRequestService(payload());
+        request.failWith = new Error('getaddrinfo ENOTFOUND example.test');
+        const service = buildTestService(request);
+
+        await expectRejection(service.getEntries());
+        const second = await expectRejection(service.getSkillEntries());
+
+        expect(request.callCount).to.equal(1);
+        expect(second.message).to.match(/ENOTFOUND/);
+    });
+
+    it('attempts the network again once the backoff window has passed', async () => {
+        const request = new FakeRequestService(payload());
+        request.failWith = new Error('offline');
+        const service = buildTestService(request);
+
+        await expectRejection(service.getEntries());
+        service.currentTime += service.delay;
+        request.failWith = undefined;
+        const entries = await service.getEntries();
+
+        expect(request.callCount).to.equal(2);
+        expect(entries).to.have.length(1);
+    });
+
+    it('ignores the backoff window on an explicit refresh', async () => {
+        const request = new FakeRequestService(payload());
+        request.failWith = new Error('offline');
+        const service = buildTestService(request);
+
+        await expectRejection(service.getEntries());
+        request.failWith = undefined;
+        const entries = await service.getEntries(true);
+
+        expect(request.callCount).to.equal(2);
+        expect(entries).to.have.length(1);
     });
 
     it('throws a descriptive error when the server returns a non-success status', async () => {

--- a/packages/ai-registry/src/common/registry-fetch-service.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.ts
@@ -28,6 +28,21 @@ interface RegistryResponse {
     skills?: RegistrySkill[];
 }
 
+/**
+ * Upper bound on a single registry request. An unreachable network does not necessarily fail
+ * fast - packets can be dropped silently (VPN, captive portal), in which case the request only
+ * settles after the OS-level TCP timeout, minutes later. The Extensions view resolves its
+ * entries through this service, so an unbounded request keeps whole sections unresolved.
+ */
+export const REGISTRY_FETCH_TIMEOUT = 10_000;
+
+/**
+ * How long a failed fetch is remembered before the next call attempts the network again. Without
+ * it, every caller - one per Extensions view section, plus the auto-update check - re-attempts the
+ * same doomed request on every change event.
+ */
+export const REGISTRY_FETCH_RETRY_DELAY = 30_000;
+
 export const RegistryFetchService = Symbol('RegistryFetchService');
 export interface RegistryFetchService {
     /** Fires whenever the cached set of resolved entries changes (initial load, manual refresh). */
@@ -60,6 +75,10 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
     protected cachedResponse: RegistryResponse | undefined;
     protected cachedEntries: ResolvedRegistryEntry[] | undefined;
     protected cachedSkills: ResolvedSkillEntry[] | undefined;
+    /** Shared while a request is in flight so concurrent callers issue a single request. */
+    protected pendingResponse: Promise<RegistryResponse> | undefined;
+    /** The last failure and when it happened, used to back off from a registry that is unreachable. */
+    protected lastFailure: { error: unknown, timestamp: number } | undefined;
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     /** Fires whenever the cached set of resolved entries changes (initial load, manual refresh). */
@@ -94,17 +113,86 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
         if (this.cachedResponse && !forceRefresh) {
             return this.cachedResponse;
         }
-        const url = this.buildEndpointUrl();
-        const context = await this.requestService.request({ url });
-        if (!RequestContext.isSuccess(context)) {
-            throw new Error(`Failed to fetch AI registry from ${url}: HTTP ${context.res.statusCode ?? 'unknown'}`);
+        if (forceRefresh) {
+            // An explicit refresh is a deliberate decision to hit the network, so it ignores the
+            // backoff window left behind by an earlier failure.
+            this.lastFailure = undefined;
+        } else if (this.lastFailure && this.now() - this.lastFailure.timestamp < this.retryDelay) {
+            throw this.lastFailure.error;
         }
-        const data = RequestContext.asJson<RegistryResponse>(context);
-        this.cachedResponse = data;
-        this.cachedEntries = undefined;
-        this.cachedSkills = undefined;
-        this.onDidChangeEmitter.fire();
-        return data;
+        if (!this.pendingResponse) {
+            // A request that is already in flight is as fresh as a new one, so `forceRefresh` joins
+            // it instead of opening a second connection.
+            const pending = this.doFetchResponse();
+            // Release the shared slot once it settles, either way, so the next call can retry. The
+            // identity check keeps a settling request from clearing a newer one.
+            const clear = () => {
+                if (this.pendingResponse === pending) {
+                    this.pendingResponse = undefined;
+                }
+            };
+            pending.then(clear, clear);
+            this.pendingResponse = pending;
+        }
+        return this.pendingResponse;
+    }
+
+    protected async doFetchResponse(): Promise<RegistryResponse> {
+        const url = this.buildEndpointUrl();
+        try {
+            const context = await this.requestWithTimeout(url);
+            if (!RequestContext.isSuccess(context)) {
+                throw new Error(`Failed to fetch AI registry from ${url}: HTTP ${context.res.statusCode ?? 'unknown'}`);
+            }
+            const data = RequestContext.asJson<RegistryResponse>(context);
+            this.lastFailure = undefined;
+            this.cachedResponse = data;
+            this.cachedEntries = undefined;
+            this.cachedSkills = undefined;
+            this.onDidChangeEmitter.fire();
+            return data;
+        } catch (error) {
+            this.lastFailure = { error, timestamp: this.now() };
+            throw error;
+        }
+    }
+
+    /**
+     * Issues the request under a hard deadline. The `timeout` option is passed on to the transport,
+     * but the request travels through a JSON-RPC hop to the backend request service, so the deadline
+     * is enforced here as well. A request abandoned this way settles later and is then ignored.
+     */
+    protected async requestWithTimeout(url: string): Promise<RequestContext> {
+        const timeout = this.fetchTimeout;
+        const pending = this.requestService.request({ url, timeout });
+        // If the deadline wins the race, `pending` may still reject afterwards; keep that from
+        // surfacing as an unhandled rejection.
+        pending.catch(() => undefined);
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        try {
+            return await Promise.race([
+                pending,
+                new Promise<never>((_, reject) => {
+                    timer = setTimeout(() => reject(new Error(`Timed out fetching the AI registry from ${url} after ${timeout}ms.`)), timeout);
+                })
+            ]);
+        } finally {
+            if (timer !== undefined) {
+                clearTimeout(timer);
+            }
+        }
+    }
+
+    protected get fetchTimeout(): number {
+        return REGISTRY_FETCH_TIMEOUT;
+    }
+
+    protected get retryDelay(): number {
+        return REGISTRY_FETCH_RETRY_DELAY;
+    }
+
+    protected now(): number {
+        return Date.now();
     }
 
     protected buildEndpointUrl(): string {

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.spec.ts
@@ -29,7 +29,8 @@ try { FrontendApplicationConfigProvider.set({}); } catch { /* already set by a s
 
 import { expect } from 'chai';
 import { Container } from '@theia/core/shared/inversify';
-import { Emitter } from '@theia/core';
+import { Emitter, ILogger } from '@theia/core';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
 import { FuzzySearch } from '@theia/core/lib/common/fuzzy-search';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
@@ -60,8 +61,28 @@ class StubContribution implements ExtensionsSourceContribution {
     }
 }
 
+/** Minimal contribution stub for the section modes (installed / built-in / recommended). */
+class StubSectionContribution implements ExtensionsSourceContribution {
+    readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange = this.onDidChangeEmitter.event;
+    constructor(
+        readonly type: string,
+        readonly displayName: string,
+        readonly searchToken: string,
+        private readonly installed: () => Promise<Iterable<TreeElement>>,
+        readonly priority = 0
+    ) { }
+    resolveInstalled(): Promise<Iterable<TreeElement>> {
+        return this.installed();
+    }
+}
+
 interface TaggedElement extends TreeElement {
     readonly id: string;
+}
+
+function makeElement(id: string): TaggedElement {
+    return { id, render: () => undefined };
 }
 
 function makeResult(id: string, searchableText: string): SearchResult {
@@ -79,9 +100,10 @@ class StubPreferenceService {
     }
 }
 
-function buildSource(contributions: ExtensionsSourceContribution[], query: string): VSXExtensionsSource {
+function buildSource(contributions: ExtensionsSourceContribution[], query: string, sectionId = VSXExtensionsSourceOptions.SEARCH_RESULT): VSXExtensionsSource {
     const container = new Container();
-    container.bind(VSXExtensionsSourceOptions).toConstantValue({ id: VSXExtensionsSourceOptions.SEARCH_RESULT });
+    container.bind(ILogger).toConstantValue(new MockLogger());
+    container.bind(VSXExtensionsSourceOptions).toConstantValue({ id: sectionId });
     container.bind(VSXExtensionsModel).toConstantValue({
         onDidChange: new Emitter<void>().event
     } as unknown as VSXExtensionsModel);
@@ -166,6 +188,20 @@ describe('VSXExtensionsSource.collectSearchResults', () => {
         expect(elements.map(e => e.id)).to.deep.equal(['mcp-1']);
     });
 
+    it('keeps the hits of the other contributions when one rejects', async () => {
+        const failing = new StubContribution('extension', 'Extensions', '@extensions', []);
+        failing.resolveSearchResults = () => { throw new Error('registry unreachable'); };
+        const working = new StubContribution('mcp-server', 'MCP Servers', '@mcp', [
+            makeResult('mcp-1', 'alpha')
+        ], 100);
+
+        const source = buildSource([failing, working], '');
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id)).to.deep.equal(['mcp-1']);
+    });
+
     it('composes @-tokens, including multiple type tokens', async () => {
         const extensions = new StubContribution('extension', 'Extensions', '@extensions', [
             makeResult('ext-1', 'ext alpha')
@@ -182,5 +218,40 @@ describe('VSXExtensionsSource.collectSearchResults', () => {
         const elements = [...(await source.getElements())] as TaggedElement[];
 
         expect(elements.map(e => e.id).sort()).to.deep.equal(['mcp-1', 'skill-1']);
+    });
+});
+
+describe('VSXExtensionsSource section entries', () => {
+
+    it('keeps the entries of the other contributions when one rejects', async () => {
+        const failing = new StubSectionContribution('extension', 'Extensions', '@extensions', () => Promise.reject(new Error('registry unreachable')));
+        const working = new StubSectionContribution('mcp-server', 'MCP Servers', '@mcp', async () => [makeElement('mcp-1')], 100);
+
+        const source = buildSource([failing, working], '', VSXExtensionsSourceOptions.INSTALLED);
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id)).to.deep.equal(['mcp-1']);
+    });
+
+    it('resolves the contributions concurrently, in priority order', async () => {
+        let markSecondStarted: () => void = () => { };
+        const secondStarted = new Promise<void>(resolve => { markSecondStarted = resolve; });
+        // The first contribution only completes once the second one has started, so this test times
+        // out if the section resolves its contributions one after the other.
+        const first = new StubSectionContribution('extension', 'Extensions', '@extensions', async () => {
+            await secondStarted;
+            return [makeElement('first')];
+        });
+        const second = new StubSectionContribution('mcp-server', 'MCP Servers', '@mcp', async () => {
+            markSecondStarted();
+            return [makeElement('second')];
+        }, 100);
+
+        const source = buildSource([first, second], '', VSXExtensionsSourceOptions.INSTALLED);
+
+        const elements = [...(await source.getElements())] as TaggedElement[];
+
+        expect(elements.map(e => e.id)).to.deep.equal(['first', 'second']);
     });
 });

--- a/packages/vsx-registry/src/browser/vsx-extensions-source.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-source.ts
@@ -15,12 +15,13 @@
 // *****************************************************************************
 
 import { injectable, inject, postConstruct, named } from '@theia/core/shared/inversify';
+import { ILogger } from '@theia/core/lib/common/logger';
 import { TreeElement, TreeSource } from '@theia/core/lib/browser/source-tree';
 import { ContributionProvider } from '@theia/core/lib/common/contribution-provider';
 import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
 import { FuzzySearch } from '@theia/core/lib/common/fuzzy-search';
 import { VSXExtensionsModel } from './vsx-extensions-model';
-import { ExtensionsSourceContribution, SearchContext } from './extensions-source-contribution';
+import { ExtensionsSourceContribution, SearchContext, SearchResult } from './extensions-source-contribution';
 import { VSXExtensionsSearchModel } from './vsx-extensions-search-model';
 import debounce = require('@theia/core/shared/lodash.debounce');
 
@@ -54,6 +55,9 @@ export class VSXExtensionsSource extends TreeSource {
     @inject(FuzzySearch)
     protected readonly fuzzySearch: FuzzySearch;
 
+    @inject(ILogger) @named('vsx-registry:VSXExtensionsSource')
+    protected readonly logger: ILogger;
+
     @postConstruct()
     protected init(): void {
         this.fireDidChange();
@@ -82,9 +86,12 @@ export class VSXExtensionsSource extends TreeSource {
             return this.collectSearchResults(enabled);
         }
 
+        // Resolve concurrently and isolate each contribution: a section is shared between all of
+        // them, so one that is slow (e.g. waiting on a remote registry) must not hold up the
+        // others, and one that rejects must not empty the whole section.
+        const resolved = await Promise.all(enabled.map(contribution => this.safeResolveForSection(contribution)));
         const entries: TreeElement[] = [];
-        for (const contribution of enabled) {
-            const iter = await this.resolveForSection(contribution);
+        for (const iter of resolved) {
             if (!iter) {
                 continue;
             }
@@ -107,7 +114,7 @@ export class VSXExtensionsSource extends TreeSource {
         const ctx: SearchContext = {
             verifiedOnly: this.preferenceService.get<boolean>('extensions.onlyShowVerifiedExtensions', false)
         };
-        const results = await Promise.all(contributions.map(c => c.resolveSearchResults?.(freeText, ctx) ?? []));
+        const results = await Promise.all(contributions.map(c => this.safeResolveSearchResults(c, freeText, ctx)));
         const all = results.flatMap(r => [...r]);
         const trimmed = freeText.trim();
         if (!trimmed || all.length <= 1) {
@@ -119,6 +126,24 @@ export class VSXExtensionsSource extends TreeSource {
             transform: r => r.searchableText
         });
         return matches.map(m => m.item.element).values();
+    }
+
+    protected async safeResolveForSection(contribution: ExtensionsSourceContribution): Promise<Iterable<TreeElement> | undefined> {
+        try {
+            return await this.resolveForSection(contribution);
+        } catch (error) {
+            this.logger.warn(`Failed to resolve '${this.options.id}' entries of contribution '${contribution.type}'.`, error);
+            return undefined;
+        }
+    }
+
+    protected async safeResolveSearchResults(contribution: ExtensionsSourceContribution, query: string, context: SearchContext): Promise<Iterable<SearchResult>> {
+        try {
+            return await (contribution.resolveSearchResults?.(query, context) ?? []);
+        } catch (error) {
+            this.logger.warn(`Failed to resolve search results of contribution '${contribution.type}'.`, error);
+            return [];
+        }
     }
 
     protected async resolveForSection(contribution: ExtensionsSourceContribution): Promise<Iterable<TreeElement> | undefined> {

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.spec.ts
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.spec.ts
@@ -1,0 +1,137 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+// xterm.js (pulled in transitively via plugin-ext from VSXExtensionsModel) calls
+// HTMLCanvasElement.prototype.getContext at module-load time. JSDOM's default impl
+// throws 'Not implemented' without the optional `canvas` package; replace it with a
+// no-op so the module graph evaluates. The tests below never render xterm itself.
+const canvasProto = (globalThis as { HTMLCanvasElement?: { prototype: { getContext?: unknown } } }).HTMLCanvasElement?.prototype;
+if (canvasProto) {
+    canvasProto.getContext = () => undefined;
+}
+try { FrontendApplicationConfigProvider.set({}); } catch { /* already set by a sibling spec */ }
+
+import { expect } from 'chai';
+import { Container } from '@theia/core/shared/inversify';
+import { Disposable, Event, ILogger, SelectionService } from '@theia/core';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { ContextMenuRenderer, LabelProvider } from '@theia/core/lib/browser';
+import { CorePreferences } from '@theia/core/lib/common/core-preferences';
+import { PreferenceService } from '@theia/core/lib/common/preferences/preference-service';
+import { SourceTreeWidget, TreeElement, TreeSource } from '@theia/core/lib/browser/source-tree';
+import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
+import { VSXExtensionsWidget, VSXExtensionsWidgetOptions } from './vsx-extensions-widget';
+
+after(() => disableJSDOM());
+
+/**
+ * Stands in for `VSXExtensionsSource`: yields a controllable set of elements and never fires a
+ * change event of its own unless a test asks for one.
+ */
+class StubSource extends TreeSource {
+    elements: TreeElement[] = [];
+    override async getElements(): Promise<IterableIterator<TreeElement>> {
+        return this.elements.values();
+    }
+    change(): void {
+        this.fireDidChange();
+    }
+}
+
+function makeElement(id: string): TreeElement {
+    return { id, render: () => undefined };
+}
+
+function createWidget(source: TreeSource, id: string): VSXExtensionsWidget {
+    const parent = new Container();
+    parent.bind(ILogger).to(MockLogger).inSingletonScope();
+    parent.bind(SelectionService).toSelf().inSingletonScope();
+    parent.bind(PreferenceService).toConstantValue({
+        get: <T>(_preferenceName: string, defaultValue?: T) => defaultValue,
+        onPreferenceChanged: () => Disposable.NULL
+    } as unknown as PreferenceService);
+    parent.bind(CorePreferences).toConstantValue({
+        onPreferenceChanged: () => Disposable.NULL
+    } as unknown as CorePreferences);
+    parent.bind(LabelProvider).toConstantValue({ onDidChange: Event.None } as unknown as LabelProvider);
+    parent.bind(ContextMenuRenderer).toConstantValue({} as ContextMenuRenderer);
+
+    // Mirrors `VSXExtensionsWidget.createWidget`, with the source replaced by the stub.
+    const child = SourceTreeWidget.createContainer(parent, {
+        virtualized: false,
+        scrollIfActive: true
+    });
+    const options = { id };
+    child.bind(VSXExtensionsSourceOptions).toConstantValue(options);
+    child.bind(VSXExtensionsSource).toConstantValue(source as VSXExtensionsSource);
+    child.unbind(SourceTreeWidget);
+    child.bind(VSXExtensionsWidgetOptions).toConstantValue(options);
+    child.bind(VSXExtensionsWidget).toSelf();
+    return child.get(VSXExtensionsWidget);
+}
+
+/** Waits for the tree to resolve, i.e. until `condition` holds or the attempts run out. */
+async function waitFor(condition: () => boolean, attempts = 100): Promise<void> {
+    for (let i = 0; i < attempts && !condition(); i++) {
+        await new Promise<void>(resolve => setTimeout(resolve, 1));
+    }
+}
+
+describe('VSXExtensionsWidget badge', () => {
+
+    it('counts the entries without waiting for a source change event', async () => {
+        // Regression test: the source fires its initial change while the widget is still being
+        // constructed, so a badge that is only assigned from that event stays unset for sections
+        // whose contributions never change again - which is what happens when the application
+        // starts offline and the registry-backed contributions fail without firing.
+        const source = new StubSource();
+        source.elements = [makeElement('a'), makeElement('b')];
+
+        const widget = createWidget(source, VSXExtensionsSourceOptions.INSTALLED);
+        await waitFor(() => widget.badge === 2);
+
+        expect(widget.badge).to.equal(2);
+        widget.dispose();
+    });
+
+    it('updates the count when the source changes', async () => {
+        const source = new StubSource();
+        source.elements = [makeElement('a')];
+        const widget = createWidget(source, VSXExtensionsSourceOptions.BUILT_IN);
+        await waitFor(() => widget.badge === 1);
+
+        source.elements = [makeElement('a'), makeElement('b'), makeElement('c')];
+        source.change();
+        await waitFor(() => widget.badge === 3);
+
+        expect(widget.badge).to.equal(3);
+        widget.dispose();
+    });
+
+    it('leaves the badge unset for the search result section', async () => {
+        const source = new StubSource();
+        source.elements = [makeElement('a'), makeElement('b')];
+
+        const widget = createWidget(source, VSXExtensionsSourceOptions.SEARCH_RESULT);
+        await waitFor(() => false, 10);
+
+        expect(widget.badge).to.equal(undefined);
+        widget.dispose();
+    });
+});

--- a/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
+++ b/packages/vsx-registry/src/browser/vsx-extensions-widget.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { injectable, interfaces, postConstruct, inject } from '@theia/core/shared/inversify';
-import { Message, TreeModel, TreeNode } from '@theia/core/lib/browser';
+import { CompositeTreeNode, Message, TreeModel, TreeNode } from '@theia/core/lib/browser';
 import { SourceTreeWidget } from '@theia/core/lib/browser/source-tree';
 import { VSXExtensionsSource, VSXExtensionsSourceOptions } from './vsx-extensions-source';
 import { nls } from '@theia/core/lib/common/nls';
@@ -75,9 +75,15 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
         this.title.label = title;
         this.title.caption = title;
 
-        this.toDispose.push(this.source.onDidChange(async () => {
-            this.badge = await this.resolveCount();
-        }));
+        // The badge is derived from the tree, not from a source change event: the source fires its
+        // initial change while this widget is still being constructed, so a section whose
+        // contributions never change again afterwards - e.g. when the application starts offline and
+        // the registry fetch backing some of them fails without ever firing - would keep an unset
+        // badge. `TreeModel.onChanged` covers both the initial resolution of the root's children
+        // (triggered by assigning `this.source` above) and every later refresh, and counting the
+        // resolved nodes avoids resolving the same elements a second time just to count them.
+        this.toDispose.push(this.model.onChanged(() => this.updateBadge()));
+        this.updateBadge();
     }
 
     get onDidChangeBadge(): Event<void> {
@@ -121,12 +127,19 @@ export class VSXExtensionsWidget extends SourceTreeWidget implements BadgeWidget
         }
     }
 
-    protected async resolveCount(): Promise<number | undefined> {
-        if (this.options.id !== VSXExtensionsSourceOptions.SEARCH_RESULT) {
-            const elements = await this.source?.getElements() || [];
-            return [...elements].length;
+    protected updateBadge(): void {
+        const count = this.resolveCount();
+        if (count !== this.badge) {
+            this.badge = count;
         }
-        return undefined;
+    }
+
+    protected resolveCount(): number | undefined {
+        if (this.options.id === VSXExtensionsSourceOptions.SEARCH_RESULT) {
+            return undefined;
+        }
+        const root = this.model.root;
+        return CompositeTreeNode.is(root) ? root.children.length : undefined;
     }
 
     protected override tapNode(node?: TreeNode): void {


### PR DESCRIPTION

<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does
Check the registry once per window load and apply or offer updates following a User-scoped default preference with per-artifact overrides. Overrides are set from a new gear context menu on the skill and MCP entry cards, which also marks whether the effective mode is inherited from the default or set for that artifact.

<!-- Include relevant issues and describe how they are addressed. -->

#### How to test
The check runs once per window load, so reload after every state change. Settings are in
`~/.theia/settings.json`, skills in `~/.agents/skills/<name>/.registry.json`.

1. Install one skill (`@skills`) and two MCP servers (`@mcp`): fresh installs show no Update.
2. `ai-features.registry` in the settings editor: three modes with descriptions, documented
   override keys, User scope only (absent from the Workspace tab).
3. Set a server's `registryMetadata.configHash` to `"stale"`, leaving `command`/`args` alone: the
   card shows **Update**, not **Fix Config** — the hash alone decides update availability.
4. Reload: one notification, `MCP server "<name>" has an update available. Configure the default
   in Settings.`, with exactly **Update** and **Show**.
5. Close it: only then does the one-time policy prompt appear (**Enable Auto Update** / **Keep
   Asking** / **Never**) — the two questions never compete.
6. Answer **Keep Asking**: `"autoUpdate": "ask"` is written and the prompt never returns.
7. Close the update notification: nothing is written, and it returns on the next reload.
8. Click `Settings` in the notification: the settings editor opens on `ai-features.registry.autoUpdate`.
9. Click **Show**: the Extensions view opens, filtered to `@installed`, and updates nothing.
10. Click **Update**: `Updated MCP server "<name>".`, `configHash` restored, Update button gone
    without a manual refresh.
11. Make it stale again without reloading: nothing happens — no polling.
12. Both servers stale, reload: one notification, `2 AI registry updates are available.`,
    **Update All** reports `Updated 2 AI registry items.`
13. Mode `on`, both stale, reload: updated silently, single message, no actions.
14. Mode `off`, one stale, reload: no update, no notification; the card still offers Update.
15. Mode `on`, offline, one stale, reload: nothing updated, no notification, console logs
    `AI registry auto-update check skipped: ...`
16. Rename the installed skill's folder to an uninstalled registry skill's name and repoint
    `skillId` in its `.registry.json` (keep `contentHash`): no drift, hash behind the entry, so the
    card shows **Update**.
17. Mode `ask`, reload, **Update**: `Updated skill "<name>".`, folder content replaced, view
    refreshed from the folder watcher.
18. Append a line to that skill's `SKILL.md`: the card switches to **Fix Skill**, not Update —
    local edits win over a newer registry hash.
19. Mode `on` with that drifted skill, reload: never auto-updated, stays on **Fix Skill**.
20. Mode `ask`, no override, gear ▸ `Auto Update`: `Off`, `Ask (Default)`, `On`, check on
    `Ask (Default)` — the mode is inherited.
21. Pick `On`: `autoUpdateOverrides` gains `"mcp:<serverId>"`/`"skill:<skillId>"`, and the check
    moves to plain `On` — the mode was set for this artifact.
22. Pick `Ask (Default)`: the override is removed, not written as `"ask"` — the default value can
    never be an explicit setting.
23. Change the default to `on`: the suffix moves to `On (Default)`, still three items.
24. Default `off`, one artifact overridden to `on`, both stale, reload: only that one updates.
25. Gear on a drifted, unlinked, stale-linked and not-installed card: **Copy ID** only, never an
    empty menu.
26. Open the menu by gear click, right-click on the card, and Tab + Enter: same menu, anchored at
    the pointer or below the gear.
27. **Copy ID**: registry id for a linked card, local name for a hand-placed folder.
28. Uninstall a skill and a server that have overrides: both keys disappear from
    `autoUpdateOverrides`.
<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
