### PR TITLE
fix(ai-chat, ai-core): improve slash command parsing

### DIFF
--- a/packages/ai-chat/src/browser/chat-request-command-resolution.spec.ts
+++ b/packages/ai-chat/src/browser/chat-request-command-resolution.spec.ts
@@ -1,0 +1,117 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import 'reflect-metadata';
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { CommandService, ILogger, Logger } from '@theia/core';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { DefaultAIVariableService, PromptService, PromptServiceImpl, ToolInvocationRegistryImpl } from '@theia/ai-core';
+import { PromptVariableContribution } from '@theia/ai-core/lib/browser/prompt-variable-contribution';
+import { ChatAgentServiceImpl } from '../common/chat-agent-service';
+import { ChatAgentLocation } from '../common/chat-agents';
+import { ChatRequestParserImpl } from '../common/chat-request-parser';
+
+disableJSDOM();
+
+/**
+ * End-to-end coverage for slash commands: a request is parsed into parts and those parts are
+ * resolved by the real prompt variable resolver, so that the text finally sent to the language
+ * model is asserted rather than just the intermediate `#prompt:command|args` representation.
+ */
+describe('slash command parsing and resolution', () => {
+    before(() => disableJSDOM = enableJSDOM());
+    after(() => disableJSDOM());
+
+    let promptService: PromptService;
+    let parser: ChatRequestParserImpl;
+
+    beforeEach(() => {
+        promptService = new PromptServiceImpl();
+        promptService.addBuiltInPromptFragment({
+            id: 'command-hello',
+            template: 'Greet $ARGUMENTS warmly.',
+            isCommand: true,
+            commandName: 'hello'
+        });
+
+        const variableService = new DefaultAIVariableService({ getContributions: () => [] });
+        (variableService as unknown as Record<string, unknown>)['logger'] = new MockLogger();
+
+        const promptVariableContribution = new PromptVariableContribution();
+        (promptVariableContribution as unknown as Record<string, unknown>)['promptService'] = promptService;
+        (promptVariableContribution as unknown as Record<string, unknown>)['logger'] = new MockLogger();
+        (promptVariableContribution as unknown as Record<string, unknown>)['commandService'] = {} as CommandService;
+        promptVariableContribution.registerVariables(variableService);
+
+        parser = new ChatRequestParserImpl(
+            sinon.createStubInstance(ChatAgentServiceImpl),
+            variableService,
+            sinon.createStubInstance(ToolInvocationRegistryImpl),
+            sinon.createStubInstance(Logger) as ILogger
+        );
+        (parser as unknown as { promptService: PromptService }).promptService = promptService;
+    });
+
+    /** The text that is finally sent to the language model. */
+    const resolve = async (text: string): Promise<string> => {
+        const parsed = await parser.parseChatRequest({ text }, ChatAgentLocation.Panel, { variables: [] });
+        return parsed.parts.map(part => part.promptText).join('');
+    };
+
+    it('resolves a single command with an argument', async () => {
+        expect(await resolve('/hello Klaus')).to.equal('Greet Klaus warmly.');
+    });
+
+    it('resolves the same command twice on one line, keeping the arguments apart', async () => {
+        expect(await resolve('/hello Klaus /hello Maria')).to.equal('Greet Klaus warmly. Greet Maria warmly.');
+    });
+
+    it('resolves the same command on two lines, preserving the line break', async () => {
+        expect(await resolve('/hello Klaus\n/hello Maria')).to.equal('Greet Klaus warmly.\nGreet Maria warmly.');
+    });
+
+    it('resolves a command repeated three times', async () => {
+        expect(await resolve('/hello Klaus /hello Maria /hello Bob')).to.equal('Greet Klaus warmly. Greet Maria warmly. Greet Bob warmly.');
+    });
+
+    it('does not let a command consume the next line', async () => {
+        expect(await resolve('/hello Klaus\nand please be brief')).to.equal('Greet Klaus warmly.\nand please be brief');
+    });
+
+    it('keeps surrounding text around a command', async () => {
+        expect(await resolve('please /hello Klaus now')).to.equal('please Greet Klaus now warmly.');
+    });
+
+    it('does not resolve a path as a command and keeps the message intact', async () => {
+        const text = 'please look at /home/user/notes.txt and fix the bug';
+        expect(await resolve(text)).to.equal(text);
+    });
+
+    it('does not resolve an unknown command and keeps the message intact', async () => {
+        const text = '/goodbye Klaus';
+        expect(await resolve(text)).to.equal(text);
+    });
+
+    it('uses a path argument of a known command without dropping it', async () => {
+        expect(await resolve('/hello /home/user/notes.txt')).to.equal('Greet /home/user/notes.txt warmly.');
+    });
+});

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -26,11 +26,23 @@ import { ParsedChatRequestAgentPart, ParsedChatRequestFunctionPart, ParsedChatRe
 import { AgentDelegationTool } from '../browser/agent-delegation-tool';
 
 describe('ChatRequestParserImpl', () => {
+    /** Command names the stubbed `PromptService` knows about. Anything else is not a command. */
+    const KNOWN_COMMANDS = ['hello', 'explain', 'compare', 'cmd', 'summarize', 'skill-one', 'skill-two'];
+    /** Prompt fragments that are not marked as commands, but can still be invoked by their id. */
+    const KNOWN_FRAGMENT_IDS = ['coder-system'];
+
+    const promptService = {
+        isKnownCommand: (name: string) => KNOWN_COMMANDS.includes(name) || KNOWN_FRAGMENT_IDS.includes(name),
+        getCommands: () => KNOWN_COMMANDS.map(name => ({ id: `command-${name}`, template: '', isCommand: true, commandName: name }))
+    } as unknown as PromptService;
+
     const chatAgentService = sinon.createStubInstance(ChatAgentServiceImpl);
     const variableService = sinon.createStubInstance(DefaultAIVariableService);
     const toolInvocationRegistry = sinon.createStubInstance(ToolInvocationRegistryImpl);
     const logger: ILogger = sinon.createStubInstance(Logger);
     const parser = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry, logger);
+    // The parser injects the PromptService as a property, so it has to be assigned manually here.
+    (parser as unknown as { promptService: PromptService }).promptService = promptService;
 
     beforeEach(() => {
         // Reset our stubs before each test
@@ -324,24 +336,16 @@ describe('ChatRequestParserImpl', () => {
         expect(varPart.variableArg).to.equal('explain|/path/to/file');
     });
 
-    it('uses known command names to disambiguate slash command arguments', async () => {
-        const promptService = {
-            getCommands: () => [
-                { id: 'command-skill-one', template: '', isCommand: true, commandName: 'skill-one' },
-                { id: 'command-skill-two', template: '', isCommand: true, commandName: 'skill-two' },
-            ]
-        } as unknown as PromptService;
-        const parserWithPromptService = new ChatRequestParserImpl(chatAgentService, variableService, toolInvocationRegistry, logger);
-        (parserWithPromptService as unknown as { promptService: PromptService }).promptService = promptService;
+    it('does not treat path segments as commands', async () => {
+        const req: ChatRequest = {
+            text: 'please look at /home/user/notes.txt and fix the bug'
+        };
         const context: ChatContext = { variables: [] };
+        const result = await parser.parseChatRequest(req, ChatAgentLocation.Panel, context);
 
-        const multipleCommands = await parserWithPromptService.parseChatRequest({ text: '/skill-one /skill-two' }, ChatAgentLocation.Panel, context);
-        expect((multipleCommands.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-one');
-        expect((multipleCommands.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-two');
-
-        const pathArgument = await parserWithPromptService.parseChatRequest({ text: '/skill-one /tmp' }, ChatAgentLocation.Panel, context);
-        expect(pathArgument.parts.length).to.equal(1);
-        expect((pathArgument.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-one|/tmp');
+        expect(result.parts.length).to.equal(1);
+        expect(result.parts[0].kind).to.equal('text');
+        expect(result.parts[0].text).to.equal(req.text);
     });
 
     it('treats the first @agent mention as the selector and does not allow later mentions to override it', async () => {
@@ -522,6 +526,334 @@ describe('ChatRequestParserImpl', () => {
             expect(result.deferredToolIds?.size).to.equal(1);
             expect(result.deferredToolIds?.has('deferredTool')).to.be.true;
             expect(result.deferredToolIds?.has('eagerTool')).to.be.false;
+        });
+    });
+
+    describe('slash command disambiguation', () => {
+        const parse = (text: string) => parser.parseChatRequest({ text }, ChatAgentLocation.Panel, { variables: [] });
+
+        /** Every character of the input has to be covered by exactly one part, in order and without gaps. */
+        const expectFullCoverage = (parts: ReadonlyArray<{ range: { start: number, endExclusive: number } }>, text: string): void => {
+            let expectedStart = 0;
+            for (const part of parts) {
+                expect(part.range.start, `part starting at ${part.range.start} does not continue at ${expectedStart}`).to.equal(expectedStart);
+                expectedStart = part.range.endExclusive;
+            }
+            expect(expectedStart, 'parts do not cover the whole message').to.equal(text.length);
+        };
+
+        const expectPlainText = async (text: string) => {
+            const result = await parse(text);
+            expect(result.parts.map(p => p.kind), `expected only text parts for ${JSON.stringify(text)}`).to.deep.equal(['text']);
+            expect(result.parts[0].text).to.equal(text);
+            expectFullCoverage(result.parts, text);
+        };
+
+        describe('unknown commands stay plain text', () => {
+            const unknownCommandInputs = [
+                'please look at /home/user/notes.txt and fix the bug',
+                '/home/user/notes.txt is broken',
+                'read /usr/local/bin/theia',
+                'the file is at /etc/hosts',
+                'compare /tmp/a.txt with /tmp/b.txt',
+                'run cd /home && ls',
+                'see /usr/lib/node/foo.js:12 for the stack trace',
+                'what does the option --foo /bar do?',
+                '/does-not-exist do something',
+                '/tmp',
+                'move it to /tmp',
+                'the separator is / on Unix'
+            ];
+
+            unknownCommandInputs.forEach(text => {
+                it(`keeps ${JSON.stringify(text)} as plain text`, () => expectPlainText(text));
+            });
+
+            it('does not drop any user text when a path follows a known command name prefix', async () => {
+                // `/summarizes` is not a known command, even though `/summarize` is.
+                await expectPlainText('/summarizes the file');
+            });
+
+            it('does not treat a known command name as a command when it is a path segment', async () => {
+                // `summarize` is known, but `/summarize/foo` is a path, not a command invocation.
+                await expectPlainText('/summarize/foo is a path');
+            });
+
+            it('does not treat a known command name followed by punctuation as a command', async () => {
+                await expectPlainText('did you mean /summarize?');
+            });
+        });
+
+        describe('slashes that are not command leaders', () => {
+            const nonLeaderInputs = [
+                'A: 10/20 and B: 30/40',
+                'use and/or here',
+                '2026/08/04 is the date',
+                'see https://example.com/foo/bar for details',
+                'the regex is a\\/b'
+            ];
+
+            nonLeaderInputs.forEach(text => {
+                it(`keeps ${JSON.stringify(text)} as plain text`, () => expectPlainText(text));
+            });
+        });
+
+        describe('known commands still parse', () => {
+            it('parses a known command without arguments', async () => {
+                const text = '/summarize';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                const command = result.parts[0] as ParsedChatRequestVariablePart;
+                expect(command.variableName).to.equal('prompt');
+                expect(command.variableArg).to.equal('summarize');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses a known command with arguments', async () => {
+                const text = '/summarize foo bar';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo bar');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('keeps a path as the argument of a known command', async () => {
+                const text = '/summarize /home/user/notes.txt';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|/home/user/notes.txt');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('keeps an unknown slash token inside the arguments of a known command', async () => {
+                const text = '/summarize foo /unknown bar';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo /unknown bar');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses a known command in the middle of a message', async () => {
+                const text = 'please /summarize this';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['text', 'var']);
+                expect(result.parts[0].text).to.equal('please ');
+                expect((result.parts[1] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|this');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses two adjacent known commands', async () => {
+                const text = '/skill-one /skill-two';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-one');
+                expect(result.parts[1].text).to.equal(' ');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('skill-two');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('separates two argument-taking known commands', async () => {
+                const text = '/summarize foo /explain bar';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo');
+                expect(result.parts[1].text).to.equal(' ');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('explain|bar');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses the same command twice, each with its own argument', async () => {
+                const text = '/hello Klaus /hello Maria';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Klaus');
+                expect(result.parts[1].text).to.equal(' ');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Maria');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses the same command three times', async () => {
+                const text = '/hello Klaus /hello Maria /hello Bob';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Klaus');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Maria');
+                expect((result.parts[4] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Bob');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses the same command twice without arguments', async () => {
+                const text = '/hello /hello';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('hello');
+                expect(result.parts[1].text).to.equal(' ');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('hello');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('accepts a prompt fragment id as a command', async () => {
+                const text = '/coder-system';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('coder-system');
+            });
+
+            it('keeps trailing whitespace out of the command part', async () => {
+                const text = '/summarize   ';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize');
+                expect(result.parts[1].text).to.equal('   ');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('trims whitespace around arguments', async () => {
+                const text = '/summarize \t foo \t ';
+                const result = await parse(text);
+
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo');
+                expectFullCoverage(result.parts, text);
+            });
+        });
+
+        describe('arguments do not span multiple lines', () => {
+            it('does not consume the following line for a command without arguments', async () => {
+                const text = '/summarize\nsecond line';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize');
+                expect(result.parts[1].text).to.equal('\nsecond line');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('does not consume the following line for a command with arguments', async () => {
+                const text = '/summarize foo\nsecond line\nthird line';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo');
+                expect(result.parts[1].text).to.equal('\nsecond line\nthird line');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('handles CRLF line endings', async () => {
+                const text = '/summarize foo\r\nsecond line';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo');
+                expect(result.parts[1].text).to.equal('\r\nsecond line');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses a command on a later line', async () => {
+                const text = 'first line\n/summarize foo\nthird line';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['text', 'var', 'text']);
+                expect(result.parts[0].text).to.equal('first line\n');
+                expect((result.parts[1] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo');
+                expect(result.parts[2].text).to.equal('\nthird line');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses one command per line', async () => {
+                const text = '/summarize foo\n/explain bar';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('summarize|foo');
+                expect(result.parts[1].text).to.equal('\n');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('explain|bar');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses the same command on consecutive lines', async () => {
+                const text = '/hello Klaus\n/hello Maria';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Klaus');
+                expect(result.parts[1].text).to.equal('\n');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Maria');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('keeps a blank line between two commands', async () => {
+                const text = '/hello Klaus\n\n/hello Maria';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Klaus');
+                expect(result.parts[1].text).to.equal('\n\n');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Maria');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('mixes a line break with a repetition on the same line', async () => {
+                const text = '/hello Klaus\n/hello Maria and /hello Bob';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text', 'var', 'text', 'var']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Klaus');
+                expect(result.parts[1].text).to.equal('\n');
+                expect((result.parts[2] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Maria and');
+                expect(result.parts[3].text).to.equal(' ');
+                expect((result.parts[4] as ParsedChatRequestVariablePart).variableArg).to.equal('hello|Bob');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('keeps a multi-line paste containing paths untouched', async () => {
+                await expectPlainText('here is a stack trace:\n at /usr/lib/node/foo.js:12\nplease fix it');
+            });
+        });
+
+        describe('interaction with other request parts', () => {
+            it('does not turn a path into a command when it follows a variable', async () => {
+                const text = '#file:/path/to/file.ext look at /home/user/notes.txt';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['var', 'text']);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableName).to.equal('file');
+                expect(result.parts[1].text).to.equal(' look at /home/user/notes.txt');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('does not turn a path into a command when it follows an agent mention', async () => {
+                chatAgentService.getAgents.returns([{
+                    id: 'agentA',
+                    name: 'agentA',
+                    description: '',
+                    tags: [],
+                    variables: [],
+                    prompts: [],
+                    agentSpecificVariables: [],
+                    functions: [],
+                    languageModelRequirements: [],
+                    locations: [ChatAgentLocation.Panel],
+                    invoke: async () => undefined
+                } as ChatAgent]);
+                const text = '@agentA please read /etc/hosts';
+                const result = await parse(text);
+
+                expect(result.parts.map(p => p.kind)).to.deep.equal(['agent', 'text']);
+                expect(result.parts[1].text).to.equal(' please read /etc/hosts');
+                expectFullCoverage(result.parts, text);
+            });
         });
     });
 

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -19,7 +19,7 @@
  *--------------------------------------------------------------------------------------------*/
 // Partially copied from https://github.com/microsoft/vscode/blob/a2cab7255c0df424027be05d58e1b7b941f4ea60/src/vs/workbench/contrib/chat/common/chatRequestParser.ts
 
-import { inject, injectable, optional } from '@theia/core/shared/inversify';
+import { inject, injectable } from '@theia/core/shared/inversify';
 import { ChatAgentService } from './chat-agent-service';
 import { ChatAgentLocation } from './chat-agents';
 import { ChatContext, ChatRequest } from './chat-model';
@@ -47,7 +47,10 @@ const agentReg = /^@([\w_\-\.]+)(?=(\s|$|\b))/i; // An @-agent
 const functionReg = /^~(\??[\w_\-\.]+)(?=(\s|$|\b))/i;
 const functionPromptFormatReg = /^\~\{\s*(.*?)\s*\}/i;
 const variableReg = /^#([\w_\-]+)(?::([\w_\-_\/\\.:]+))?(?=(\s|$|\b))/i; // A #-variable with an optional : arg (#file:workspace/path/name.ext)
-const commandReg = /^\/([\w_\-]+)/; // A /-command (/commandname) with optional arguments parsed separately
+// A /-command (/commandname) with optional arguments parsed separately. The command name must be
+// terminated by whitespace or the end of the input, so that path segments such as `/home/user` are
+// not mistaken for a command.
+const commandReg = /^\/([\w_\-]+)(?=\s|$)/;
 const nextCommandReg = /\s+\/([\w_\-]+)(?=\s|$)/g;
 
 export const ChatRequestParser = Symbol('ChatRequestParser');
@@ -64,8 +67,8 @@ function offsetRange(start: number, endExclusive: number): OffsetRange {
 @injectable()
 export class ChatRequestParserImpl implements ChatRequestParser {
 
-    @inject(PromptService) @optional()
-    protected readonly promptService?: PromptService;
+    @inject(PromptService)
+    protected readonly promptService: PromptService;
 
     constructor(
         @inject(ChatAgentService) private readonly agentService: ChatAgentService,
@@ -299,11 +302,20 @@ export class ChatRequestParserImpl implements ChatRequestParser {
         }
 
         const [commandText, commandName] = nextCommandMatch;
+        if (!this.isCommandCandidate(commandName)) {
+            // Not a command we know about, so leave the text alone. Otherwise anything the user
+            // types after a `/word` token, e.g. a Unix path, would be swallowed as command
+            // arguments and silently dropped when the non-existing command fails to resolve.
+            return;
+        }
         let commandEnd = commandText.length;
         let commandArgs: string | undefined;
 
-        const nextCommandOffset = this.findNextCommandOffset(message, commandEnd);
-        const argsEnd = nextCommandOffset ?? message.length;
+        // Arguments never span multiple lines: a command only consumes the remainder of its own line.
+        const lineBreakOffset = message.indexOf('\n', commandEnd);
+        const lineEnd = lineBreakOffset === -1 ? message.length : lineBreakOffset;
+        const nextCommandOffset = this.findNextCommandOffset(message, commandEnd, lineEnd);
+        const argsEnd = nextCommandOffset ?? lineEnd;
         const rawArgs = message.slice(commandEnd, argsEnd);
         const args = rawArgs.trim();
         if (args) {
@@ -321,16 +333,11 @@ export class ChatRequestParserImpl implements ChatRequestParser {
         return new ParsedChatRequestVariablePart(commandRange, 'prompt', variableArg);
     }
 
-    private findNextCommandOffset(message: string, startOffset: number): number | undefined {
+    private findNextCommandOffset(message: string, startOffset: number, endOffset: number): number | undefined {
         nextCommandReg.lastIndex = startOffset;
         let match = nextCommandReg.exec(message);
-        while (match) {
-            const commandName = match[1];
-            // Deliberate behavior difference: without a PromptService we cannot tell commands from
-            // path-like arguments, so any `/word` token is treated as a command boundary. With a
-            // PromptService we only break on known command names and keep unknown `/word` tokens
-            // (e.g. `/tmp`, `/path/to/file`) as part of the current command's arguments.
-            if (!this.promptService || this.isKnownCommand(commandName)) {
+        while (match && match.index < endOffset) {
+            if (this.isCommandCandidate(match[1])) {
                 return match.index + match[0].indexOf(chatSubcommandLeader);
             }
             match = nextCommandReg.exec(message);
@@ -338,10 +345,13 @@ export class ChatRequestParserImpl implements ChatRequestParser {
         return undefined;
     }
 
-    private isKnownCommand(commandName: string): boolean {
-        return this.promptService?.getCommands().some(command =>
-            (command.commandName ?? command.id) === commandName
-        ) ?? false;
+    /**
+     * Whether a `/name` token should be treated as a command. Only names that actually resolve to a
+     * command or prompt fragment are accepted, which keeps unknown `/word` tokens (e.g. `/tmp`,
+     * `/path/to/file`) as plain text.
+     */
+    protected isCommandCandidate(commandName: string): boolean {
+        return this.promptService.isKnownCommand(commandName);
     }
 
     private tryToParseFunction(message: string, offset: number): ParsedChatRequestFunctionPart | undefined {

--- a/packages/ai-core/src/browser/prompt-variable-contribution.spec.ts
+++ b/packages/ai-core/src/browser/prompt-variable-contribution.spec.ts
@@ -225,13 +225,61 @@ describe('PromptVariableContribution', () => {
             expect(result?.variable).to.deep.equal(PROMPT_VARIABLE);
         });
 
-        it('returns empty string for non-existent prompts', async () => {
+        // Resolving to `undefined` instead of an empty string makes callers keep the original text
+        // (the literal `#prompt:...` / `{{prompt:...}}` placeholder) rather than silently dropping it.
+        it('returns undefined for a non-existent prompt with arguments', async () => {
             const result = await contribution.resolve(
                 { variable: PROMPT_VARIABLE, arg: 'non-existent|args' },
                 {}
             );
 
-            expect(result?.value).to.equal('');
+            expect(result).to.be.undefined;
+        });
+
+        it('returns undefined for a non-existent prompt without arguments', async () => {
+            const result = await contribution.resolve(
+                { variable: PROMPT_VARIABLE, arg: 'non-existent' },
+                {}
+            );
+
+            expect(result).to.be.undefined;
+        });
+
+        it('returns undefined for a path-like argument', async () => {
+            promptService.addBuiltInPromptFragment({
+                id: 'hello-cmd',
+                template: 'Hello, world!',
+                isCommand: true,
+                commandName: 'hello'
+            });
+
+            const result = await contribution.resolve(
+                { variable: PROMPT_VARIABLE, arg: 'home|/user/notes.txt and fix the bug' },
+                {}
+            );
+
+            expect(result).to.be.undefined;
+        });
+
+        it('returns undefined when no argument is given', async () => {
+            expect(await contribution.resolve({ variable: PROMPT_VARIABLE, arg: undefined }, {})).to.be.undefined;
+            expect(await contribution.resolve({ variable: PROMPT_VARIABLE, arg: '   ' }, {})).to.be.undefined;
+        });
+
+        it('resolves a command referenced by its fragment id without arguments', async () => {
+            promptService.addBuiltInPromptFragment({
+                id: 'hello-cmd',
+                template: 'Hello, world!',
+                isCommand: true,
+                commandName: 'hello'
+            });
+
+            const result = await contribution.resolve(
+                { variable: PROMPT_VARIABLE, arg: 'hello' },
+                {}
+            );
+
+            expect(result?.value).to.equal('Hello, world!');
         });
     });
 });

--- a/packages/ai-core/src/browser/prompt-variable-contribution.spec.ts
+++ b/packages/ai-core/src/browser/prompt-variable-contribution.spec.ts
@@ -225,6 +225,44 @@ describe('PromptVariableContribution', () => {
             expect(result?.variable).to.deep.equal(PROMPT_VARIABLE);
         });
 
+        describe('customized (file-based) commands, whose fragment id differs from the command name', () => {
+            const customized = {
+                id: 'my-file',
+                customizationId: 'customization-1',
+                priority: 1,
+                template: 'Deploy $ARGUMENTS now.',
+                isCommand: true,
+                commandName: 'deploy'
+            };
+
+            beforeEach(() => {
+                (promptService as unknown as Record<string, unknown>)['customizationService'] = {
+                    isPromptFragmentCustomized: (id: string) => id === customized.id,
+                    getActivePromptFragmentCustomization: (id: string) => (id === customized.id ? customized : undefined),
+                    getCustomizedPromptFragmentIds: () => [customized.id]
+                };
+            });
+
+            it('resolves the command with arguments', async () => {
+                const result = await contribution.resolve({ variable: PROMPT_VARIABLE, arg: 'deploy|prod' }, {});
+                expect(result?.value).to.equal('Deploy prod now.');
+            });
+
+            it('resolves the command without arguments', async () => {
+                const result = await contribution.resolve({ variable: PROMPT_VARIABLE, arg: 'deploy' }, {});
+                expect(result?.value).to.equal('Deploy $ARGUMENTS now.');
+            });
+
+            it('is accepted by isKnownCommand for both invocations', () => {
+                expect(promptService.isKnownCommand('deploy')).to.be.true;
+            });
+
+            it('still resolves the command by its fragment id', async () => {
+                const result = await contribution.resolve({ variable: PROMPT_VARIABLE, arg: 'my-file' }, {});
+                expect(result?.value).to.equal('Deploy $ARGUMENTS now.');
+            });
+        });
+
         // Resolving to `undefined` instead of an empty string makes callers keep the original text
         // (the literal `#prompt:...` / `{{prompt:...}}` placeholder) rather than silently dropping it.
         it('returns undefined for a non-existent prompt with arguments', async () => {

--- a/packages/ai-core/src/browser/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/browser/prompt-variable-contribution.ts
@@ -76,11 +76,13 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
                 const promptIdOrCommandName = pipeIndex >= 0 ? arg.substring(0, pipeIndex) : arg;
                 const commandArgs = pipeIndex >= 0 ? arg.substring(pipeIndex + 1) : '';
 
-                // Determine the actual fragment ID
-                // If this is a command invocation (has args), try to find by command name first
-                let fragment = commandArgs
-                    ? this.promptService.getPromptFragmentByCommandName(promptIdOrCommandName)
-                    : undefined;
+                // Determine the actual fragment ID by looking up the command name first.
+                // This must not be conditional on arguments being present: a customized (file-based)
+                // command has a fragment id that differs from its command name, so `/deploy` without
+                // arguments would otherwise not resolve even though `/deploy prod` does. It also keeps
+                // this lookup aligned with `PromptService.isKnownCommand`, which the chat request
+                // parser uses to decide whether `/deploy` is a command at all.
+                let fragment = this.promptService.getPromptFragmentByCommandName(promptIdOrCommandName);
 
                 // Fall back to looking up by fragment ID if not found by command name
                 if (!fragment) {

--- a/packages/ai-core/src/browser/prompt-variable-contribution.ts
+++ b/packages/ai-core/src/browser/prompt-variable-contribution.ts
@@ -90,11 +90,7 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
                 // If we still don't have a fragment, we can't resolve
                 if (!fragment) {
                     this.logger.debug(`Could not find prompt fragment or command '${promptIdOrCommandName}'`);
-                    return {
-                        variable: request.variable,
-                        value: '',
-                        allResolvedDependencies: []
-                    };
+                    return undefined;
                 }
 
                 const fragmentId = fragment.id;
@@ -124,12 +120,11 @@ export class PromptVariableContribution implements AIVariableContribution, AIVar
                 }
             }
         }
-        this.logger.debug(`Could not resolve prompt variable '${request.variable.name}' with arg '${request.arg}'. Returning empty string.`);
-        return {
-            variable: request.variable,
-            value: '',
-            allResolvedDependencies: []
-        };
+        // Returning `undefined` rather than an empty resolution keeps the original text in place:
+        // callers fall back to the literal `#prompt:...` / `{{prompt:...}}` placeholder instead of
+        // silently dropping it, which is also how every other unresolvable variable behaves.
+        this.logger.debug(`Could not resolve prompt variable '${request.variable.name}' with arg '${request.arg}'.`);
+        return undefined;
     }
 
     private substituteCommandArguments(template: string, commandName: string, commandArgs: string): string {

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -562,6 +562,62 @@ describe('PromptService', () => {
             expect(fragment).to.be.undefined;
         });
     });
+
+    describe('isKnownCommand', () => {
+        it('accepts a registered command name', () => {
+            promptService.addBuiltInPromptFragment({
+                id: 'sample-debug',
+                template: 'Help debug: $ARGUMENTS',
+                isCommand: true,
+                commandName: 'debug'
+            });
+
+            expect(promptService.isKnownCommand('debug')).to.be.true;
+        });
+
+        it('accepts a command fragment referenced by its id', () => {
+            promptService.addBuiltInPromptFragment({
+                id: 'sample-debug',
+                template: 'Help debug: $ARGUMENTS',
+                isCommand: true,
+                commandName: 'debug'
+            });
+
+            expect(promptService.isKnownCommand('sample-debug')).to.be.true;
+        });
+
+        it('accepts the id of a fragment that is not marked as a command', () => {
+            // The `prompt` variable falls back to a plain fragment lookup, so `/normal-fragment`
+            // resolves and must therefore be recognized here as well.
+            promptService.addBuiltInPromptFragment({
+                id: 'normal-fragment',
+                template: 'Not a command'
+            });
+
+            expect(promptService.isKnownCommand('normal-fragment')).to.be.true;
+        });
+
+        it('rejects unknown names', () => {
+            promptService.addBuiltInPromptFragment({
+                id: 'sample-debug',
+                template: 'Help debug: $ARGUMENTS',
+                isCommand: true,
+                commandName: 'debug'
+            });
+
+            expect(promptService.isKnownCommand('home')).to.be.false;
+            expect(promptService.isKnownCommand('usr')).to.be.false;
+            expect(promptService.isKnownCommand('debugger')).to.be.false;
+        });
+
+        it('rejects the empty name', () => {
+            expect(promptService.isKnownCommand('')).to.be.false;
+        });
+
+        it('rejects names when nothing is registered', () => {
+            expect(promptService.isKnownCommand('anything')).to.be.false;
+        });
+    });
 });
 
 describe('CustomAgentDescription', () => {

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -468,6 +468,19 @@ export interface PromptService {
     getPromptFragmentByCommandName(commandName: string): PromptFragment | undefined;
 
     /**
+     * Checks whether `/name` can be resolved as a slash command.
+     *
+     * This mirrors the lookup performed when resolving the `prompt` variable: the name may either be
+     * the command name of a fragment marked as a command, or the id of any existing prompt fragment.
+     * Use this before interpreting a `/name` token as a command, so that unrelated text such as Unix
+     * paths is not mistaken for a command.
+     *
+     * @param name The command name or prompt fragment id
+     * @returns `true` if a matching command or prompt fragment exists
+     */
+    isKnownCommand(name: string): boolean;
+
+    /**
      * Resolves a prompt fragment by replacing variables and function references
      * @param fragmentId The prompt fragment ID
      * @param args Optional object with values for variable replacement
@@ -756,6 +769,15 @@ export class PromptServiceImpl implements PromptService {
         return this._builtInFragments.find(fragment =>
             fragment.isCommand && fragment.commandName === commandName
         );
+    }
+
+    isKnownCommand(name: string): boolean {
+        if (!name) {
+            return false;
+        }
+        // Both lookups are needed because the `prompt` variable resolves a command either by its
+        // command name or, as a fallback, by prompt fragment id.
+        return this.getPromptFragmentByCommandName(name) !== undefined || this.getRawPromptFragment(name) !== undefined;
     }
 
     /**


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- ChatRequestParserImpl only accepts `/word` if the name resolves to a command or prompt fragment
- command names must be terminated by whitespace or end of input
- command arguments stop at the end of their own line
- PromptService.isKnownCommand() mirrors what the `prompt` variable accepts, so parser and resolver cannot drift apart
- PromptVariableContribution.resolve() returns undefined instead of an empty resolution for unknown fragments, so callers keep the original text

Follow-up to #17661

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

In the chat input, with any agent:

1. `please look at /home/user/notes.txt and fix the bug` reaches the model unchanged. Before, everything from `/home` onwards was dropped and shown as a `#prompt:home|...` chip.
2. Paste a stack trace whose second line contains a path, e.g. ` at /usr/lib/node/foo.js:12`. All lines are preserved.
3. `/tmp is full` and `run cd /home && ls` stay plain text.
4. `/goodbye Klaus` stays plain text, because no such command exists.
5. `/hello Klaus` still expands to the sample template.
6. `/hello Klaus /hello Maria` expands both, each with its own name.
7. `/hello Klaus` on line one plus arbitrary text on line two: only `Klaus` is used as the argument, line two is left alone. Previously the second line was swallowed into the argument.
8. `/hello /home/user/notes.txt` passes the path through as the argument.
9. Run the additinally added unit tests (or check CI runs for their results)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
