### PR TITLE
fix(ai-chat-ui): force chat input suggest widget to open upwards

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -49,6 +49,7 @@ import { ContextVariablePicker } from './context-variable-picker';
 import { TASK_CONTEXT_VARIABLE } from '@theia/ai-chat/lib/browser/task-context-variable';
 import { IModelDeltaDecoration } from '@theia/monaco-editor-core/esm/vs/editor/common/model';
 import { EditorOption } from '@theia/monaco-editor-core/esm/vs/editor/common/config/editorOptions';
+import { SuggestController } from '@theia/monaco-editor-core/esm/vs/editor/contrib/suggest/browser/suggestController';
 import { ChatInputHistoryService, ChatInputNavigationState } from './chat-input-history';
 import { ContextFileValidationService, FileValidationResult, FileValidationState } from '@theia/ai-chat/lib/browser/context-file-validation-service';
 import { PendingImageRegistry } from '@theia/ai-chat/lib/browser/pending-image-registry';
@@ -1400,6 +1401,15 @@ export class AIChatInputWidget extends ReactWidget {
             }
             this.scheduleUpdateReceivingAgent();
         }));
+
+        // Force the suggest widget above the input, otherwise Monaco measures the available
+        // space against the document body and opens it downward behind the bottom panel when
+        // the chat is in the main area. Assert this on every trigger because the inline
+        // completions controller resets the flag whenever there is no ghost text.
+        const suggestController = SuggestController.get(editor);
+        if (suggestController) {
+            this.toDispose.push(suggestController.model.onDidTrigger(() => suggestController.forceRenderingAbove()));
+        }
 
         if (editor.hasWidgetFocus()) {
             this.chatInputFocusKey.set(true);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- force the suggest widget above the chat input so it is not hidden behind the bottom panel when the chat is in the main area
- Monaco decides above/below against the document body bounds, which ignores the bottom panel and wrongly opens downward
- re-assert forceRenderingAbove on every suggest trigger, since the inline completions controller resets the flag when there is no ghost text

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- Open the AI chat and move it to the main area (drag the tab into the editor area) or switch to the experimental AI First perspective (command: `View: Switch perspective (Experimental)`)
- Open the bottom panel (e.g. the Terminal) so it sits below the chat widget.
- In the chat input, type `/` (or `@`) to trigger the inline suggest widget.
- Verify the suggest widget opens upwards, above the input, and is fully visible rather than clipped behind the bottom panel.
- Type a few more characters, dismiss the widget (Esc), then trigger it again; confirm it still opens upwards every time.
- Move the chat back to the right/left side panel or switch to the default perspective and confirm the suggest widget still behaves correctly there.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
