### PR TITLE
fix(core): cancel superseded activation checks

### DIFF
--- a/packages/core/src/browser/shell/application-shell.spec.ts
+++ b/packages/core/src/browser/shell/application-shell.spec.ts
@@ -1,0 +1,62 @@
+// *****************************************************************************
+// Copyright (C) 2026 Alec Timison.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '../test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { Widget } from '@theia/core/shared/@lumino/widgets';
+import * as sinon from 'sinon';
+import { DisposableCollection } from '../../common/disposable';
+import { ApplicationShell } from './application-shell';
+disableJSDOM();
+
+describe('ApplicationShell', () => {
+    let toTearDown: () => void;
+
+    beforeEach(() => {
+        toTearDown = enableJSDOM();
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        toTearDown();
+    });
+
+    it('cancels the previous activation check', () => {
+        const shell = Object.create(ApplicationShell.prototype) as ApplicationShell;
+        Object.assign(shell, {
+            toDisposeOnActivationCheck: new DisposableCollection(),
+            logger: { warn: sinon.stub() }
+        });
+        const assertActivated = (shell as unknown as { assertActivated(widget: Widget): void }).assertActivated.bind(shell);
+        const firstWidget = new Widget();
+        const secondWidget = new Widget();
+        const request = {} as ReturnType<typeof window.setTimeout>;
+        sinon.stub(globalThis, 'setTimeout').returns(request);
+        sinon.stub(window, 'setTimeout').returns(request);
+        const clearTimeout = sinon.stub(window, 'clearTimeout');
+        window.cancelAnimationFrame = sinon.stub();
+
+        assertActivated(firstWidget);
+        assertActivated(secondWidget);
+
+        expect(clearTimeout.callCount).to.equal(1);
+        expect(clearTimeout.firstCall.args[0]).to.equal(request);
+        firstWidget.dispose();
+        secondWidget.dispose();
+    });
+});

--- a/packages/core/src/browser/shell/application-shell.ts
+++ b/packages/core/src/browser/shell/application-shell.ts
@@ -1438,7 +1438,7 @@ export class ApplicationShell extends Widget {
         this.toDisposeOnActivationCheck.push(Disposable.create(() => widget.disposed.disconnect(onDispose)));
 
         let start = 0;
-        const step: FrameRequestCallback = () => {
+        const step = (): void => {
             const activeElement = widget.node.ownerDocument.activeElement;
             if (activeElement && widget.node.contains(activeElement)) {
                 return;
@@ -1449,13 +1449,13 @@ export class ApplicationShell extends Widget {
             }
             const delta = now - start;
             if (delta < this.activationTimeout) {
-                request = setTimeout(step, 0);
+                request = window.setTimeout(step, 0);
             } else {
                 this.logger.warn(`Widget was activated, but did not accept focus after ${this.activationTimeout}ms: ${widget.id}`);
             }
         };
-        let request = setTimeout(step, 0);
-        this.toDisposeOnActivationCheck.push(Disposable.create(() => window.cancelAnimationFrame(request)));
+        let request = window.setTimeout(step, 0);
+        this.toDisposeOnActivationCheck.push(Disposable.create(() => window.clearTimeout(request)));
     }
 
     /**


### PR DESCRIPTION
#### What it does

Uses matching `window.setTimeout` and `window.clearTimeout` APIs in `ApplicationShell.assertActivated`, so starting a new activation check cancels the previous polling loop. It also removes the stale `FrameRequestCallback` type and adds focused regression coverage for the timer handle.

Closes #17884.

#### How to test

1. Run `npx tsc --build packages/core`.
2. Run `npm run test --workspace @theia/core -- --grep=cancels.*previous.*activation.*check`.
3. Optionally run all core tests with `npm run test --workspace @theia/core`.

The focused test activates two widgets through the diagnostic method and verifies that the second activation clears the first timeout handle.

Local validation:

- core TypeScript build passed
- core lint passed
- core tests: 1022 passing, 1 pending

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed by Alec Timison.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (no user-facing text was added)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
