### PR TITLE
fix(cli): don't hard-exit `download:plugins` after fetching

### DIFF
--- a/dev-packages/cli/src/theia.ts
+++ b/dev-packages/cli/src/theia.ts
@@ -432,13 +432,16 @@ async function theiaCli(): Promise<void> {
                 if (!client) {
                     client = new OVSXHttpClient(apiUrl, requestService, rateLimiter);
                 }
+                // This handler must not call `process.exit`: on Windows that aborts the
+                // process, because Node calls `uv_async_send` on an already-closing handle
+                // while undici tears down the connections used to fetch the plugins
+                // (nodejs/node#56645). Let the event loop drain instead.
                 try {
                     await downloadPlugins(client, rateLimiter, requestService, options);
                 } catch (error) {
                     console.error(error);
-                    process.exit(1);
+                    process.exitCode = 1;
                 }
-                process.exit(0);
             },
         })
         .command<{


### PR DESCRIPTION
#### What it does

`theia download:plugins` calls `process.exit()` on both its success and failure paths, the moment `downloadPlugins` settles. On Windows that aborts the process rather than exiting it:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), file src\win\async.c, line 76
[ELIFECYCLE] Command failed with exit code 3221226505.
```

`3221226505` is `0xC0000409`, the Windows fast-fail signature. Node calls `uv_async_send` on a handle `uv_close` has already flagged `UV_HANDLE_CLOSING` while undici tears down the sockets the OVSX requests ran on, and libuv asserts. This is [nodejs/node#56645](https://github.com/nodejs/node/issues/56645), fixed by [nodejs/node#61999](https://github.com/nodejs/node/pull/61999) — merged to `main` on 2026-07-24, but in no released Node version at the time of writing (no `61999` in `CHANGELOG_V24/V25/V26`, and it is not an ancestor of `v24.19.0`).

Because it is a race between the exit and the socket teardown, it is intermittent, and it fires *after* every plugin has resolved and downloaded — the command has done its work and only the teardown fails. In a downstream CI job the Windows packaging leg aborted on 4 of 6 runs on Node 24.15.0, every time at the tail of a `download:plugins` whose plugins were all already downloaded. The same job ran 36 Windows legs on Node 22.23.2 with zero aborts, which matches the upstream report that Node 23 is where this starts.

Node 24 is what Electron 42 embeds, so adopting a current Electron makes this reachable for any downstream that packages on Windows.

The fix sets `process.exitCode` and lets the event loop drain, which is what the `.fail()` handler further down this same file already does. Nothing here needs a hard exit: the command exits on its own once its work is done.

#### How to test

On any platform, to confirm the command still terminates promptly and reports the right code — the only real risk in dropping a hard exit is that something keeps the loop alive and the command hangs instead:

1. Create a scratch directory with a `package.json` declaring `theiaPluginsDir` and a couple of `theiaPlugins` entries.
2. Run `theia download:plugins` there, cold (empty plugins dir) and again warm (everything already downloaded).

Measured on Node 24.15.0, Linux x64, with this branch built:

| Path | Result |
| --- | --- |
| Cold, 2 plugins over the network | exits `0` in 4.5s, both plugins present |
| Fully cached | exits `0` in under 1s |
| Download failure (bogus plugin URL) | exits `1`, error printed |

On Windows with Node 23+, the abort itself reproduces only intermittently, so absence over a handful of runs is weak evidence either way — the downstream sample above needed six runs to show four aborts.

#### Follow-ups

Once a Node release carries nodejs/node#61999, the underlying fault is gone and this change is no longer load-bearing on Windows. It is worth keeping regardless: a CLI command that has finished its work has no reason to hard-exit, and the same pattern (`process.exit` immediately after `fetch`) appears elsewhere in this file's commands, which may deserve the same treatment if they turn out to be reachable after network I/O.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

This contribution was drafted with AI assistance (Claude Code), working under my direction. I set the investigation, reviewed the change, and ran and checked the verification reported above; the measurements in the table are from runs I monitored, not model output taken on trust. The sign-off, and responsibility for the contribution, are mine.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#requesting-a-review)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/eclipse-theia/theia/blob/master/doc/pull-requests.md#reviewing-a-pull-request)
