### PR TITLE
fix(filesystem): report creation of watched paths that did not exist yet

### DIFF
--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
@@ -220,10 +220,13 @@ export class ParcelWatcher {
 
     /**
      * When starting a watcher, we'll first check and wait for the path to exists
-     * before running a parcel watcher.
+     * before running a parcel watcher. If the path only came into existence while we
+     * were waiting, its creation is reported synthetically once we are subscribed.
      */
     protected async start(): Promise<void> {
+        let createdWhileWaiting = false;
         while (await fsp.stat(this.fsPath).then(() => false, () => true)) {
+            createdWhileWaiting = true;
             await timeout(500);
             this.assertNotDisposed();
         }
@@ -263,6 +266,14 @@ export class ParcelWatcher {
             throw WatcherDisposal;
         }
         this.watcher = watcher;
+        if (createdWhileWaiting) {
+            // The path did not exist when we were asked to watch it, so the actual creation
+            // happened before parcel was subscribed and its event is lost. Report the creation
+            // synthetically, otherwise clients keep the state they observed while the path was
+            // still missing until the next change. VS Code behaves the same way when it resumes
+            // a watch request that was suspended because its path did not exist.
+            this.handleWatcherEvents([{ type: 'create', path: this.fsPath }]);
+        }
     }
 
     /**

--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
@@ -272,7 +272,18 @@ export class ParcelWatcher {
             // synthetically, otherwise clients keep the state they observed while the path was
             // still missing until the next change. VS Code behaves the same way when it resumes
             // a watch request that was suspended because its path did not exist.
-            this.handleWatcherEvents([{ type: 'create', path: this.fsPath }]);
+            //
+            // Use the resolved path: `createWatcher` subscribes to the realpath, so every real
+            // event of this watcher is reported realpath'd. Reporting the raw path here would
+            // make clients that key on the URI see two different resources for the same file.
+            //
+            // Note that only the watched path itself is reported. If the path is a directory
+            // that was populated within the same poll interval, its entries are not reported
+            // individually. Clients which refresh recursively on the directory event, like the
+            // file tree, still pick them up; clients which only react to concrete paths, like
+            // plugin file watchers, do not.
+            const createdPath = await fsp.realpath(this.fsPath).catch(() => this.fsPath);
+            this.handleWatcherEvents([{ type: 'create', path: createdPath }]);
         }
     }
 

--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
@@ -80,6 +80,14 @@ export class ParcelWatcher {
     protected watcher: AsyncSubscription | undefined;
 
     /**
+     * The realpath of {@link fsPath}, as resolved by {@link createWatcher}.
+     *
+     * Parcel is subscribed to the resolved path, so all of its events are reported realpath'd.
+     * {@link start} reuses this to report a synthetic creation under the very same path.
+     */
+    protected resolvedFsPath: string | undefined;
+
+    /**
      * When the ref count hits zero, we schedule this watch handle to be disposed.
      */
     protected deferredDisposalTimer: NodeJS.Timeout | undefined;
@@ -222,41 +230,19 @@ export class ParcelWatcher {
      * When starting a watcher, we'll first check and wait for the path to exists
      * before running a parcel watcher. If the path only came into existence while we
      * were waiting, its creation is reported synthetically once we are subscribed.
+     * Only the watched path itself is reported that way, not entries that were created
+     * underneath it within the same interval.
      */
     protected async start(): Promise<void> {
         let createdWhileWaiting = false;
-        while (await fsp.stat(this.fsPath).then(() => false, () => true)) {
-            createdWhileWaiting = true;
-            await timeout(500);
-            this.assertNotDisposed();
-        }
-        this.assertNotDisposed();
-        // This race is specific to Linux/inotify: parcel-watcher's inotify backend walks
-        // the tree and then calls inotify_add_watch on every subdirectory. If a subdirectory
-        // disappears between the walk and the add (common when watching dirs that contain
-        // auto-rotated log/temp folders), the syscall returns ENOENT and parcel-watcher fails
-        // the entire subscribe. Retry a few times: by the next walk the gone-but-not-forgotten
-        // dir is no longer present. Windows (ReadDirectoryChangesW) and macOS (FSEvents) watch
-        // the whole subtree from a single handle on the root and never register per-subdirectory
-        // watches, so they cannot hit this race; the retry is simply a no-op there.
         let watcher: AsyncSubscription | undefined;
-        let attempt = 0;
-        while (true) {
-            try {
-                watcher = await this.createWatcher();
-                break;
-            } catch (error) {
-                const message: string = (error && error.message) || '';
-                const isTransientEnoent = message.includes('No such file or directory')
-                    && await fsp.stat(this.fsPath).then(() => true, () => false);
-                if (!isTransientEnoent || attempt >= 4) {
-                    throw error;
-                }
-                attempt++;
-                this.assertNotDisposed();
-                await timeout(100 * attempt);
-                this.assertNotDisposed();
+        while (!watcher) {
+            if (await this.waitUntilPathExists()) {
+                createdWhileWaiting = true;
             }
+            // The path can vanish again while we are subscribing, in which case we have
+            // to wait for it to come back instead of failing the watcher for good.
+            watcher = await this.subscribeWithRetries();
         }
         this.assertNotDisposed();
         this.debug('STARTED', `disposed=${this.disposed}`);
@@ -266,25 +252,93 @@ export class ParcelWatcher {
             throw WatcherDisposal;
         }
         this.watcher = watcher;
-        if (createdWhileWaiting) {
-            // The path did not exist when we were asked to watch it, so the actual creation
-            // happened before parcel was subscribed and its event is lost. Report the creation
-            // synthetically, otherwise clients keep the state they observed while the path was
-            // still missing until the next change. VS Code behaves the same way when it resumes
-            // a watch request that was suspended because its path did not exist.
-            //
-            // Use the resolved path: `createWatcher` subscribes to the realpath, so every real
-            // event of this watcher is reported realpath'd. Reporting the raw path here would
-            // make clients that key on the URI see two different resources for the same file.
-            //
-            // Note that only the watched path itself is reported. If the path is a directory
-            // that was populated within the same poll interval, its entries are not reported
-            // individually. Clients which refresh recursively on the directory event, like the
-            // file tree, still pick them up; clients which only react to concrete paths, like
-            // plugin file watchers, do not.
-            const createdPath = await fsp.realpath(this.fsPath).catch(() => this.fsPath);
-            this.handleWatcherEvents([{ type: 'create', path: createdPath }]);
+        if (createdWhileWaiting && this.resolvedFsPath) {
+            // The path did not exist when we were asked to watch it, so its creation happened
+            // before parcel was subscribed and the event is lost. Report it synthetically under
+            // the path parcel resolved, so that it matches all subsequent events of this watcher.
+            // Otherwise clients keep the state they observed while the path was still missing.
+            // VS Code does the same when it resumes a watch request suspended for a missing path.
+            this.handleWatcherEvents([{ type: 'create', path: this.resolvedFsPath }]);
         }
+    }
+
+    /**
+     * Poll until {@link fsPath} exists.
+     *
+     * @returns `true` if the path was absent at least once, i.e. it came into existence while
+     * we were waiting for it.
+     * @throws with {@link WatcherDisposal} if this instance is disposed while waiting.
+     */
+    protected async waitUntilPathExists(): Promise<boolean> {
+        let wasAbsent = false;
+        while (true) {
+            const error = await fsp.stat(this.fsPath).then(() => undefined, (reason: NodeJS.ErrnoException) => reason);
+            if (!error) {
+                this.assertNotDisposed();
+                return wasAbsent;
+            }
+            // Only a genuinely absent path counts. Any other reason for `stat` to fail, e.g. a
+            // transient EACCES, must not end up reported as a creation.
+            if (this.isAbsenceError(error)) {
+                wasAbsent = true;
+            }
+            await timeout(500);
+            this.assertNotDisposed();
+        }
+    }
+
+    /**
+     * Subscribe to parcel, retrying transient failures.
+     *
+     * @returns the subscription, or `undefined` if {@link fsPath} disappeared again, in which
+     * case the caller has to wait for it to come back.
+     * @throws the underlying error if subscribing keeps failing for another reason.
+     */
+    protected async subscribeWithRetries(): Promise<AsyncSubscription | undefined> {
+        let attempt = 0;
+        while (true) {
+            try {
+                return await this.createWatcher();
+            } catch (error) {
+                const message: string = (error && error.message) || '';
+                // parcel reports this capitalized, Node's `fs` errors in lower case.
+                const isMissingPathError = message.toLowerCase().includes('no such file or directory');
+                if (isMissingPathError && await this.isPathAbsent()) {
+                    // This is not the subtree race handled below: the watched path itself is gone.
+                    return undefined;
+                }
+                // This race is specific to Linux/inotify: parcel-watcher's inotify backend walks
+                // the tree and then calls inotify_add_watch on every subdirectory. If a subdirectory
+                // disappears between the walk and the add (common when watching dirs that contain
+                // auto-rotated log/temp folders), the syscall returns ENOENT and parcel-watcher fails
+                // the entire subscribe. Retry a few times: by the next walk the gone-but-not-forgotten
+                // dir is no longer present. Windows (ReadDirectoryChangesW) and macOS (FSEvents) watch
+                // the whole subtree from a single handle on the root and never register per-subdirectory
+                // watches, so they cannot hit this race; the retry is simply a no-op there.
+                if (!isMissingPathError || attempt >= 4) {
+                    throw error;
+                }
+                attempt++;
+                this.assertNotDisposed();
+                await timeout(100 * attempt);
+                this.assertNotDisposed();
+            }
+        }
+    }
+
+    /**
+     * Whether {@link fsPath} is absent, as opposed to merely not being statable right now.
+     *
+     * Treating any `stat` failure as an absent path would turn a watcher that cannot be started
+     * at all, e.g. because of an EACCES, into an endless wait which never surfaces to the client.
+     */
+    protected async isPathAbsent(): Promise<boolean> {
+        const error = await fsp.stat(this.fsPath).then(() => undefined, (reason: NodeJS.ErrnoException) => reason);
+        return error !== undefined && this.isAbsenceError(error);
+    }
+
+    protected isAbsenceError(error: NodeJS.ErrnoException): boolean {
+        return error.code === 'ENOENT' || error.code === 'ENOTDIR';
     }
 
     /**
@@ -297,7 +351,11 @@ export class ParcelWatcher {
     }
 
     protected async createWatcher(): Promise<AsyncSubscription> {
-        let fsPath = await fsp.realpath(this.fsPath);
+        // Remember the resolved path so that `start()` can report a synthetic creation under the
+        // very same path. Overrides which subscribe to a different path have to update it as well,
+        // otherwise no creation is reported for a path that did not exist yet.
+        this.resolvedFsPath = await fsp.realpath(this.fsPath);
+        let fsPath = this.resolvedFsPath;
         if ((await fsp.stat(fsPath)).isFile()) {
             fsPath = path.dirname(fsPath);
         }

--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-service.ts
@@ -244,7 +244,6 @@ export class ParcelWatcher {
             // to wait for it to come back instead of failing the watcher for good.
             watcher = await this.subscribeWithRetries();
         }
-        this.assertNotDisposed();
         this.debug('STARTED', `disposed=${this.disposed}`);
         // The watcher could be disposed while it was starting, make sure to check for this:
         if (this.disposed) {

--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-watcher.spec.ts
@@ -21,7 +21,7 @@ import * as fs from '@theia/core/shared/fs-extra';
 import * as assert from 'assert';
 import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node';
-import { ParcelFileSystemWatcherService } from './parcel-filesystem-service';
+import { ParcelWatcherTestService } from './test/parcel-watcher-test-service';
 import { DidFilesChangedParams, FileChange, FileChangeType } from '../../common/filesystem-watcher-protocol';
 
 const expect = chai.expect;
@@ -30,7 +30,7 @@ const track = temp.track();
 describe('parcel-filesystem-watcher', function (): void {
 
     let root: URI;
-    let watcherService: ParcelFileSystemWatcherService;
+    let watcherService: ParcelWatcherTestService;
     let watcherId: number;
 
     this.timeout(100000);
@@ -52,6 +52,9 @@ describe('parcel-filesystem-watcher', function (): void {
     });
 
     afterEach(async () => {
+        // Unsubscribe before deleting the watched directories: deleting a still subscribed
+        // root strands parcel's shared macOS FSEvents backend, see ParcelWatcherTestService.
+        await watcherService.disposeAllWatchers();
         track.cleanupSync();
         watcherService.dispose();
     });
@@ -160,8 +163,8 @@ describe('parcel-filesystem-watcher', function (): void {
         }
     });
 
-    function createParcelFileSystemWatcherService(): ParcelFileSystemWatcherService {
-        return new ParcelFileSystemWatcherService({
+    function createParcelFileSystemWatcherService(): ParcelWatcherTestService {
+        return new ParcelWatcherTestService({
             verbose: true
         });
     }

--- a/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
@@ -54,8 +54,9 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
         root = FileUri.create(fs.realpathSync(tempPath));
         changes = [];
         service = new ParcelFileSystemWatcherService({ verbose: false });
-        // Bind the array itself instead of the variable: disposing a service is asynchronous, so
-        // events of a previous test may still arrive after `changes` was reassigned here.
+        // Bind the array itself instead of the variable: `dispose` is a no-op for the service and
+        // the tests never unwatch, so the watchers of a previous test are still live and would
+        // otherwise push into the array of the current one.
         const ownChanges = changes;
         service.setClient({
             onDidFilesChanged: event => ownChanges.push(...event.changes),
@@ -113,6 +114,25 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
         // synthetic creation has to use the same path, otherwise clients which key on the URI see
         // two different resources for the same file.
         expect([...new Set(changes.map(change => change.uri))]).to.deep.equal([resolved]);
+    });
+
+    it('reports the creation of a watched directory, but not the entries it was populated with', async () => {
+        const directory = root.resolve('config');
+
+        await service.watchFileChanges(0, directory.toString());
+        await sleep(200);
+        // Populate the directory within the same poll interval as its creation. Those entries
+        // predate the subscription just like the directory itself, but only the watched path is
+        // reported. Clients which refresh recursively on the directory event, like the file tree,
+        // still pick them up; clients which only react to concrete paths do not.
+        fs.mkdirpSync(FileUri.fsPath(directory.resolve('nested')));
+        fs.writeFileSync(FileUri.fsPath(directory.resolve('nested').resolve('settings.json')), '{}');
+        await waitFor(() => changes.some(change => change.uri === directory.toString() && change.type === FileChangeType.ADDED), 5000);
+        expect(changes.map(change => change.uri), 'only the watched directory should be reported').to.deep.equal([directory.toString()]);
+
+        // The watcher is nevertheless live and reports entries created from now on.
+        fs.writeFileSync(FileUri.fsPath(directory.resolve('keymaps.json')), '[]');
+        await waitFor(() => changes.some(change => change.uri === directory.resolve('keymaps.json').toString()), 5000);
     });
 
     it('does not report a creation for a watched file that already exists', async () => {

--- a/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
@@ -20,7 +20,7 @@ import * as temp from 'temp';
 import * as fs from '@theia/core/shared/fs-extra';
 import URI from '@theia/core/lib/common/uri';
 import { FileUri } from '@theia/core/lib/node';
-import { ParcelFileSystemWatcherService } from './parcel-filesystem-service';
+import { ParcelWatcherTestService } from './test/parcel-watcher-test-service';
 import { FileChange, FileChangeType } from '../../common/filesystem-watcher-protocol';
 
 const expect = chai.expect;
@@ -38,7 +38,7 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
     this.timeout(20000);
 
     let root: URI;
-    let service: ParcelFileSystemWatcherService;
+    let service: ParcelWatcherTestService;
     let changes: FileChange[];
 
     beforeEach(() => {
@@ -53,10 +53,9 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
         }
         root = FileUri.create(fs.realpathSync(tempPath));
         changes = [];
-        service = new ParcelFileSystemWatcherService({ verbose: false });
-        // Bind the array itself instead of the variable: `dispose` is a no-op for the service and
-        // the tests never unwatch, so the watchers of a previous test are still live and would
-        // otherwise push into the array of the current one.
+        service = new ParcelWatcherTestService({ verbose: false });
+        // Bind the array itself instead of the variable, so that events arriving while a
+        // test is torn down cannot leak into the array of the next one.
         const ownChanges = changes;
         service.setClient({
             onDidFilesChanged: event => ownChanges.push(...event.changes),
@@ -64,7 +63,10 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
         });
     });
 
-    afterEach(() => {
+    afterEach(async () => {
+        // Unsubscribe before deleting the watched directories: deleting a still subscribed
+        // root strands parcel's shared macOS FSEvents backend, see ParcelWatcherTestService.
+        await service.disposeAllWatchers();
         service.dispose();
         track.cleanupSync();
     });
@@ -144,9 +146,11 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
         await sleep(1000);
         expect(changes, 'no change should be reported for an already existing path').to.be.empty;
 
-        // The watcher is nevertheless live and reports actual changes.
+        // The watcher is nevertheless live and reports actual changes. Only the URI is
+        // checked: FSEvents on macOS coalesces flags per path, so parcel can legitimately
+        // report this write as a creation instead of an update.
         fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": true }');
-        await waitFor(() => changes.some(change => change.uri === file.toString() && change.type === FileChangeType.UPDATED), 5000);
+        await waitFor(() => changes.some(change => change.uri === file.toString()), 5000);
     });
 });
 

--- a/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
@@ -1,0 +1,98 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as chai from 'chai';
+import * as temp from 'temp';
+import * as fs from '@theia/core/shared/fs-extra';
+import URI from '@theia/core/lib/common/uri';
+import { FileUri } from '@theia/core/lib/node';
+import { ParcelFileSystemWatcherService } from './parcel-filesystem-service';
+import { FileChange, FileChangeType } from '../../common/filesystem-watcher-protocol';
+
+const expect = chai.expect;
+const track = temp.track();
+
+/**
+ * `ParcelWatcher.start()` waits for the watched path to exist before subscribing, so the
+ * creation itself happens while nobody is subscribed and its event is lost. Clients then keep
+ * the state they observed while the path was missing until the next change, e.g. the backend
+ * preference service never picks up a `settings.json` that was created after startup.
+ * See https://github.com/eclipse-theia/theia/issues/17842.
+ */
+describe('parcel-filesystem-watcher missing path handling', function (): void {
+
+    this.timeout(20000);
+
+    let root: URI;
+    let service: ParcelFileSystemWatcherService;
+    let changes: FileChange[];
+
+    beforeEach(() => {
+        root = FileUri.create(fs.realpathSync(temp.mkdirSync('parcel-missing-path-root')));
+        changes = [];
+        service = new ParcelFileSystemWatcherService({ verbose: false });
+        service.setClient({
+            onDidFilesChanged: event => changes.push(...event.changes),
+            onError: () => undefined
+        });
+    });
+
+    afterEach(() => {
+        service.dispose();
+        track.cleanupSync();
+    });
+
+    it('reports the creation of a watched file that did not exist when the watcher was requested', async () => {
+        const file = root.resolve('settings.json');
+
+        await service.watchFileChanges(0, file.toString());
+        // The watcher is now polling for the path: nothing can be reported yet.
+        await sleep(200);
+        expect(changes, 'no change should be reported while the path does not exist').to.be.empty;
+
+        fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": false }');
+
+        // The path is polled every 500ms, so allow a few intervals plus the subscribe.
+        await waitFor(() => changes.some(change => change.uri === file.toString() && change.type === FileChangeType.ADDED), 5000);
+    });
+
+    it('reports subsequent changes of a watched file that did not exist when the watcher was requested', async () => {
+        const file = root.resolve('settings.json');
+
+        await service.watchFileChanges(0, file.toString());
+        await sleep(200);
+        fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": false }');
+        await waitFor(() => changes.some(change => change.uri === file.toString()), 5000);
+
+        changes.length = 0;
+        fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": true }');
+        await waitFor(() => changes.some(change => change.uri === file.toString()), 5000);
+    });
+});
+
+function sleep(time: number): Promise<void> {
+    return new Promise<void>(resolve => setTimeout(resolve, time));
+}
+
+async function waitFor(condition: () => boolean, timeout: number): Promise<void> {
+    const deadline = Date.now() + timeout;
+    while (!condition()) {
+        if (Date.now() > deadline) {
+            expect.fail(`condition was not met within ${timeout}ms`);
+        }
+        await sleep(50);
+    }
+}

--- a/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-watcher-missing-path.spec.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import * as chai from 'chai';
+import * as cp from 'child_process';
 import * as temp from 'temp';
 import * as fs from '@theia/core/shared/fs-extra';
 import URI from '@theia/core/lib/common/uri';
@@ -41,11 +42,23 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
     let changes: FileChange[];
 
     beforeEach(() => {
-        root = FileUri.create(fs.realpathSync(temp.mkdirSync('parcel-missing-path-root')));
+        let tempPath = temp.mkdirSync('parcel-missing-path-root');
+        // Sometimes tempPath will use some Windows 8.3 short name in its path. This is a problem
+        // since parcel always returns paths with long names. We need to convert here.
+        // See: https://stackoverflow.com/a/34473971/7983255
+        if (process.platform === 'win32') {
+            tempPath = cp.execSync(`powershell "(Get-Item -LiteralPath '${tempPath}').FullName"`, {
+                encoding: 'utf8',
+            }).trim();
+        }
+        root = FileUri.create(fs.realpathSync(tempPath));
         changes = [];
         service = new ParcelFileSystemWatcherService({ verbose: false });
+        // Bind the array itself instead of the variable: disposing a service is asynchronous, so
+        // events of a previous test may still arrive after `changes` was reassigned here.
+        const ownChanges = changes;
         service.setClient({
-            onDidFilesChanged: event => changes.push(...event.changes),
+            onDidFilesChanged: event => ownChanges.push(...event.changes),
             onError: () => undefined
         });
     });
@@ -80,6 +93,40 @@ describe('parcel-filesystem-watcher missing path handling', function (): void {
         changes.length = 0;
         fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": true }');
         await waitFor(() => changes.some(change => change.uri === file.toString()), 5000);
+    });
+
+    // Creating symlinks on Windows requires elevated privileges or developer mode.
+    (process.platform === 'win32' ? it.skip : it)('reports the creation under the same resolved path as the subsequent changes', async () => {
+        const real = root.resolve('real');
+        const link = root.resolve('link');
+        fs.mkdirSync(FileUri.fsPath(real));
+        fs.symlinkSync(FileUri.fsPath(real), FileUri.fsPath(link));
+        const file = link.resolve('settings.json');
+        const resolved = real.resolve('settings.json').toString();
+
+        await service.watchFileChanges(0, file.toString());
+        await sleep(200);
+        fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": false }');
+        await waitFor(() => changes.some(change => change.type === FileChangeType.ADDED), 5000);
+
+        // Parcel subscribes to the resolved path, so all its events are reported realpath'd. The
+        // synthetic creation has to use the same path, otherwise clients which key on the URI see
+        // two different resources for the same file.
+        expect([...new Set(changes.map(change => change.uri))]).to.deep.equal([resolved]);
+    });
+
+    it('does not report a creation for a watched file that already exists', async () => {
+        const file = root.resolve('settings.json');
+        fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": false }');
+
+        await service.watchFileChanges(0, file.toString());
+        // Allow more than one poll interval so a synthetic event would have been delivered by now.
+        await sleep(1000);
+        expect(changes, 'no change should be reported for an already existing path').to.be.empty;
+
+        // The watcher is nevertheless live and reports actual changes.
+        fs.writeFileSync(FileUri.fsPath(file), '{ "breadcrumbs.enabled": true }');
+        await waitFor(() => changes.some(change => change.uri === file.toString() && change.type === FileChangeType.UPDATED), 5000);
     });
 });
 

--- a/packages/filesystem/src/node/parcel-watcher/parcel-watcher-retry.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-watcher-retry.spec.ts
@@ -101,6 +101,32 @@ describe('parcel-filesystem-watcher transient ENOENT handling', function (): voi
         expect(onError.called, 'error must be reported to the client').to.equal(true);
     });
 
+    it('waits for the path again instead of failing when the watched path itself vanished while subscribing', async () => {
+        const target = root.resolve('target');
+        const targetPath = FileUri.fsPath(target);
+        fs.mkdirSync(targetPath);
+
+        let attempts = 0;
+        subscribeStub = sinon.stub(parcel, 'subscribe').callsFake(async () => {
+            attempts++;
+            if (attempts === 1) {
+                // The watched path is gone again by the time parcel gets to subscribe. Node's `fs`
+                // reports this in lower case, unlike parcel's own message.
+                fs.rmdirSync(targetPath);
+                setTimeout(() => fs.mkdirSync(targetPath), 100);
+                throw new Error(`ENOENT: no such file or directory, realpath '${targetPath}'`);
+            }
+            return { unsubscribe: async () => undefined };
+        });
+
+        await service.watchFileChanges(0, target.toString());
+        // The path is polled every 500ms, so allow a few intervals plus the subscribe.
+        await new Promise(resolve => setTimeout(resolve, 1500));
+
+        expect(attempts, 'subscribe should have been repeated once the path came back').to.equal(2);
+        expect(onError.called, 'a path that vanished while subscribing must not fail the watcher').to.equal(false);
+    });
+
     it('gives up after the retry budget is exhausted on persistent ENOENT', async () => {
         subscribeStub = sinon.stub(parcel, 'subscribe').callsFake(async () => {
             throw new Error('No such file or directory at /tmp/rotated-log');

--- a/packages/filesystem/src/node/parcel-watcher/test/parcel-watcher-test-service.ts
+++ b/packages/filesystem/src/node/parcel-watcher/test/parcel-watcher-test-service.ts
@@ -1,0 +1,84 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Minimatch } from 'minimatch';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { AsyncSubscription } from '@theia/core/shared/@parcel/watcher';
+import { WatchOptions } from '../../../common/filesystem-watcher-protocol';
+import { ParcelFileSystemWatcherService, ParcelWatcher, ParcelWatcherOptions } from '../parcel-filesystem-service';
+
+/**
+ * A {@link ParcelWatcher} whose disposal can be awaited up to and including the native
+ * parcel unsubscribe, which the production disposal only fires and forgets.
+ */
+export class TrackedParcelWatcher extends ParcelWatcher {
+
+    protected readonly whenStopped = new Deferred<void>();
+
+    protected override async stopWatcher(watcher: AsyncSubscription): Promise<void> {
+        await super.stopWatcher(watcher);
+        this.whenStopped.resolve();
+    }
+
+    /**
+     * Dispose immediately, bypassing the reference counting and the deferred disposal
+     * timeout, and resolve only once the native parcel subscription is unsubscribed.
+     */
+    async disposeAndWait(): Promise<void> {
+        this._dispose();
+        // `false` also covers a disposal that raced the subscribe: in that case `start()`
+        // stops the just created subscription itself before settling `whenStarted`.
+        const started = await this.whenStarted.catch(() => false);
+        if (started) {
+            await this.whenStopped.promise;
+        }
+    }
+}
+
+/**
+ * Test variant of the watcher service that tracks every created watcher so tests can
+ * fully unsubscribe them before deleting the watched directories.
+ *
+ * This must happen before the temp directory cleanup: when a watched root is deleted
+ * while still subscribed, parcel's macOS FSEvents backend stops the stream in place
+ * without ever removing the subscription from its shared backend registry. The shared
+ * backend thread can then exit and every real subscription created afterwards in the
+ * same process silently receives no events anymore.
+ */
+export class ParcelWatcherTestService extends ParcelFileSystemWatcherService {
+
+    protected readonly trackedWatchers: TrackedParcelWatcher[] = [];
+
+    protected override createWatcher(clientId: number, fsPath: string, options: WatchOptions): ParcelWatcher {
+        const watcherOptions: ParcelWatcherOptions = {
+            ignored: options.ignored
+                .map(pattern => new Minimatch(pattern, { dot: true })),
+            ignorePatterns: options.ignored,
+        };
+        const watcher = new TrackedParcelWatcher(clientId, fsPath, watcherOptions, this.options, this.maybeClient);
+        this.trackedWatchers.push(watcher);
+        return watcher;
+    }
+
+    /**
+     * Dispose all watchers created by this service and wait until their native parcel
+     * subscriptions are unsubscribed.
+     */
+    async disposeAllWatchers(): Promise<void> {
+        await Promise.all(this.trackedWatchers.map(watcher => watcher.disposeAndWait()));
+        this.trackedWatchers.length = 0;
+    }
+}


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

`ParcelWatcher.start()` waits for the watched path to exist before subscribing, so the creation itself happens while nobody is subscribed and its event is lost. Report the creation synthetically once subscribed, like VS Code does when it resumes a suspended watch request.

Fixes #17842

#### How to test

1. Delete `~/.theia/settings.json` and start `examples/browser`.
2. Set `breadcrumbs.enabled` to `false` in the Settings UI. This creates `~/.theia/settings.json`.
3. Run `API Samples: Get Backend Preference` with key `breadcrumbs.enabled`.
   The backend now correctly reports `false`. Before this change it reported `true`

#### Follow-ups


#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
