### PR TITLE
fix(ai-anthropic): drop unreplayable thinking blocks

### DIFF
--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -367,6 +367,141 @@ describe('AnthropicModel', () => {
 
             expect(thinkingBlocks(result)).to.deep.equal([{ type: 'thinking', thinking: 'some reasoning', signature: 'signature' }]);
         });
+
+        it('logs a debug message when dropping a thinking block', () => {
+            const originalDebug = console.debug;
+            const logged: string[] = [];
+            console.debug = (...args: unknown[]) => { logged.push(args.map(String).join(' ')); };
+            try {
+                transformToAnthropicParams([thinkingMessage('', 'signature'), userText('continue')], false);
+            } finally {
+                console.debug = originalDebug;
+            }
+            expect(logged.some(line => line.includes('thinking'))).to.be.true;
+        });
+    });
+
+    describe('tool loop thinking block replay', () => {
+        /**
+         * Mock client whose first stream() call yields the given events and whose follow-up calls yield none.
+         * All params passed to stream() are captured so the tool loop's follow-up request can be inspected.
+         */
+        function createToolLoopModel(firstCallEvents: object[], capturedParams: Anthropic.MessageCreateParams[]): AnthropicModel {
+            let call = 0;
+            return new class extends AnthropicModel {
+                protected override initializeAnthropic(): Anthropic {
+                    return {
+                        messages: {
+                            stream: (params: Anthropic.MessageCreateParams) => {
+                                capturedParams.push(params);
+                                const events = call++ === 0 ? firstCallEvents : [];
+                                async function* iterate(): AsyncGenerator<object> {
+                                    for (const event of events) {
+                                        yield event;
+                                    }
+                                }
+                                const iter = iterate();
+                                (iter as unknown as Record<string, unknown>).on = () => { /* no-op */ };
+                                (iter as unknown as Record<string, unknown>).abort = () => { /* no-op */ };
+                                return iter;
+                            }
+                        }
+                    } as unknown as Anthropic;
+                }
+            }('test-id', 'claude-opus-4-5', { status: 'ready' }, true, false, () => 'test-key', undefined);
+        }
+
+        function toolLoopEvents(thinkingBlock: { type: 'thinking'; thinking: string; signature: string }): object[] {
+            return [
+                // The SDK accumulates streamed content blocks into the message_start message in place, so by the
+                // time the tool loop replays it, its content holds the raw blocks exactly as streamed. The mock
+                // provides that end state up front.
+                {
+                    type: 'message_start',
+                    message: {
+                        role: 'assistant',
+                        content: [thinkingBlock, { type: 'tool_use', id: 'call_1', name: 'myTool', input: {} }],
+                        usage: { input_tokens: 10, output_tokens: 0 }
+                    }
+                },
+                { type: 'content_block_start', index: 0, content_block: thinkingBlock },
+                { type: 'content_block_stop', index: 0 },
+                { type: 'content_block_start', index: 1, content_block: { type: 'tool_use', id: 'call_1', name: 'myTool', input: {} } },
+                { type: 'content_block_delta', index: 1, delta: { type: 'input_json_delta', partial_json: '{}' } },
+                { type: 'content_block_stop', index: 1 },
+                { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 5 } },
+                { type: 'message_stop' },
+            ];
+        }
+
+        async function runToolLoop(firstCallEvents: object[]): Promise<Anthropic.MessageCreateParams[]> {
+            const capturedParams: Anthropic.MessageCreateParams[] = [];
+            const model = createToolLoopModel(firstCallEvents, capturedParams);
+            const request: UserRequest = {
+                messages: [{ actor: 'user', type: 'text', text: 'do something' }],
+                tools: [{ id: 'myTool', name: 'myTool', parameters: { type: 'object', properties: {} }, handler: async () => 'ok' }],
+                agentId: 'test', sessionId: 'session', requestId: 'req'
+            };
+            const response = await model.request(request);
+            if ('stream' in response) {
+                // eslint-disable-next-line @typescript-eslint/no-unused-vars
+                for await (const _part of response.stream) { /* drain */ }
+            }
+            return capturedParams;
+        }
+
+        function contentBlocks(params: Anthropic.MessageCreateParams): Anthropic.Messages.ContentBlockParam[] {
+            return params.messages.flatMap(message => Array.isArray(message.content) ? message.content : []);
+        }
+
+        it('drops an unreplayable thinking block from the tool loop follow-up request', async () => {
+            const params = await runToolLoop(toolLoopEvents({ type: 'thinking', thinking: '', signature: '' }));
+
+            expect(params).to.have.lengthOf(2);
+            const blocks = contentBlocks(params[1]);
+            expect(blocks.some(block => block.type === 'thinking')).to.be.false;
+            // The rest of the streamed assistant turn and the tool result still replay.
+            expect(blocks.some(block => block.type === 'tool_use' && block.id === 'call_1')).to.be.true;
+            expect(blocks.some(block => block.type === 'tool_result' && block.tool_use_id === 'call_1')).to.be.true;
+        });
+
+        it('replays a valid thinking block unchanged in the tool loop follow-up request', async () => {
+            const params = await runToolLoop(toolLoopEvents({ type: 'thinking', thinking: 'some reasoning', signature: 'sig' }));
+
+            expect(params).to.have.lengthOf(2);
+            const thinking = contentBlocks(params[1]).find(block => block.type === 'thinking');
+            expect(thinking).to.deep.equal({ type: 'thinking', thinking: 'some reasoning', signature: 'sig' });
+        });
+
+        it('drops a message left empty after filtering its only (unreplayable) thinking block', async () => {
+            // Two messages in one stream: the first holds only the invalid thinking block, the second the tool_use.
+            // After filtering, the first message has no content and must not be replayed at all.
+            const events = [
+                {
+                    type: 'message_start',
+                    message: { role: 'assistant', content: [{ type: 'thinking', thinking: '', signature: '' }], usage: { input_tokens: 10, output_tokens: 0 } }
+                },
+                { type: 'content_block_start', index: 0, content_block: { type: 'thinking', thinking: '', signature: '' } },
+                { type: 'content_block_stop', index: 0 },
+                { type: 'message_delta', delta: { stop_reason: 'end_turn' }, usage: { output_tokens: 1 } },
+                { type: 'message_stop' },
+                {
+                    type: 'message_start',
+                    message: { role: 'assistant', content: [{ type: 'tool_use', id: 'call_1', name: 'myTool', input: {} }], usage: { input_tokens: 10, output_tokens: 0 } }
+                },
+                { type: 'content_block_start', index: 0, content_block: { type: 'tool_use', id: 'call_1', name: 'myTool', input: {} } },
+                { type: 'content_block_delta', index: 0, delta: { type: 'input_json_delta', partial_json: '{}' } },
+                { type: 'content_block_stop', index: 0 },
+                { type: 'message_delta', delta: { stop_reason: 'tool_use' }, usage: { output_tokens: 5 } },
+                { type: 'message_stop' },
+            ];
+
+            const params = await runToolLoop(events);
+
+            expect(params).to.have.lengthOf(2);
+            const emptyMessages = params[1].messages.filter(message => Array.isArray(message.content) && message.content.length === 0);
+            expect(emptyMessages).to.be.empty;
+        });
     });
 
     describe('streaming token usage', () => {

--- a/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.spec.ts
@@ -320,6 +320,55 @@ describe('AnthropicModel', () => {
         });
     });
 
+    describe('transformToAnthropicParams thinking blocks', () => {
+        function thinkingMessage(thinking: string, signature: string): LanguageModelMessage {
+            return { actor: 'ai', type: 'thinking', thinking, signature };
+        }
+
+        function userText(text: string): LanguageModelMessage {
+            return { actor: 'user', type: 'text', text };
+        }
+
+        function thinkingBlocks(messages: MessageParam[]): Anthropic.Messages.ContentBlockParam[] {
+            return messages.flatMap(message => Array.isArray(message.content) ? message.content : [])
+                .filter(block => block.type === 'thinking');
+        }
+
+        it('drops a thinking block with empty thinking text, which Anthropic rejects on replay', () => {
+            const messages = [userText('do something'), thinkingMessage('', 'signature'), userText('continue')];
+
+            const { messages: result } = transformToAnthropicParams(messages, false);
+
+            expect(thinkingBlocks(result)).to.be.empty;
+            expect(JSON.stringify(result)).to.contain('do something');
+            expect(JSON.stringify(result)).to.contain('continue');
+        });
+
+        it('drops a thinking block whose thinking text is only whitespace', () => {
+            const messages = [thinkingMessage('  \n', 'signature'), userText('continue')];
+
+            const { messages: result } = transformToAnthropicParams(messages, false);
+
+            expect(thinkingBlocks(result)).to.be.empty;
+        });
+
+        it('drops a thinking block without a signature', () => {
+            const messages = [thinkingMessage('some reasoning', ''), userText('continue')];
+
+            const { messages: result } = transformToAnthropicParams(messages, false);
+
+            expect(thinkingBlocks(result)).to.be.empty;
+        });
+
+        it('keeps a signed thinking block that has content', () => {
+            const messages = [thinkingMessage('some reasoning', 'signature'), userText('continue')];
+
+            const { messages: result } = transformToAnthropicParams(messages, false);
+
+            expect(thinkingBlocks(result)).to.deep.equal([{ type: 'thinking', thinking: 'some reasoning', signature: 'signature' }]);
+        });
+    });
+
     describe('streaming token usage', () => {
         /**
          * Builds a mock Anthropic client whose messages.stream() yields

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -72,6 +72,13 @@ const createMessageContent = (message: LanguageModelMessage, compactionEnabled: 
     } else if (LanguageModelMessage.isTextMessage(message)) {
         return [{ type: 'text', text: message.text }];
     } else if (LanguageModelMessage.isThinkingMessage(message)) {
+        // Anthropic rejects replayed thinking blocks without content ('each thinking block must contain thinking')
+        // or without a signature. Both can reach us from API-compatible endpoints that omit thinking text or
+        // signature deltas, and from streams cancelled before the signature arrived. Returning [] drops the block
+        // so the surrounding history still replays.
+        if (!message.thinking.trim() || !message.signature) {
+            return [];
+        }
         return [{ signature: message.signature, thinking: message.thinking, type: 'thinking' }];
     } else if (LanguageModelMessage.isToolUseMessage(message)) {
         return [{ id: message.id, input: message.input, name: message.name, type: 'tool_use' }];

--- a/packages/ai-anthropic/src/node/anthropic-language-model.ts
+++ b/packages/ai-anthropic/src/node/anthropic-language-model.ts
@@ -60,6 +60,24 @@ interface ToolCallback {
     args: string;
 }
 
+/**
+ * Anthropic rejects replayed thinking blocks without content ('each thinking block must contain thinking')
+ * or without a signature. Both can reach us from API-compatible endpoints that omit thinking text or
+ * signature deltas, and from streams cancelled before the signature arrived.
+ */
+const isReplayableThinking = (thinking: string | undefined, signature: string | undefined): boolean =>
+    !!thinking?.trim() && !!signature;
+
+/** The tool loop replays streamed messages raw (bypassing {@link createMessageContent}); drop thinking blocks Anthropic would reject. */
+const dropUnreplayableThinking = (content: Message['content']): Message['content'] =>
+    content.filter(block => {
+        if (block.type === 'thinking' && !isReplayableThinking(block.thinking, block.signature)) {
+            console.debug('Anthropic: dropping thinking block from tool loop replay that cannot be replayed (missing thinking text or signature)');
+            return false;
+        }
+        return true;
+    });
+
 const createMessageContent = (message: LanguageModelMessage, compactionEnabled: boolean): MessageParam['content'] => {
     if (LanguageModelMessage.isCompactionMessage(message)) {
         // Only replay our own provider's compaction blocks, and only when the request will use the beta endpoint.
@@ -72,11 +90,9 @@ const createMessageContent = (message: LanguageModelMessage, compactionEnabled: 
     } else if (LanguageModelMessage.isTextMessage(message)) {
         return [{ type: 'text', text: message.text }];
     } else if (LanguageModelMessage.isThinkingMessage(message)) {
-        // Anthropic rejects replayed thinking blocks without content ('each thinking block must contain thinking')
-        // or without a signature. Both can reach us from API-compatible endpoints that omit thinking text or
-        // signature deltas, and from streams cancelled before the signature arrived. Returning [] drops the block
-        // so the surrounding history still replays.
-        if (!message.thinking.trim() || !message.signature) {
+        // Returning [] drops an unreplayable thinking block so the surrounding history still replays.
+        if (!isReplayableThinking(message.thinking, message.signature)) {
+            console.debug('Anthropic: dropping thinking block from history that cannot be replayed (missing thinking text or signature)');
             return [];
         }
         return [{ signature: message.signature, thinking: message.thinking, type: 'thinking' }];
@@ -618,7 +634,8 @@ export class AnthropicModel implements LanguageModel {
                         cancellationToken,
                         [
                             ...(toolMessages ?? []),
-                            ...currentMessages.map(m => ({ role: m.role, content: m.content })),
+                            ...currentMessages.map(m => ({ role: m.role, content: dropUnreplayableThinking(m.content) }))
+                                .filter(m => m.content.length > 0),
                             toolResponseMessage
                         ]
                     );


### PR DESCRIPTION
#### What it does

Fixes #17904.

Anthropic rejects a replayed thinking block with no thinking text (`each thinking block must contain thinking`) or no signature, failing the whole request with a 400 before anything is generated. The invalid block stays in the conversation, so every retry fails identically and agent tool loops cannot advance. Such blocks reach us from API-compatible endpoints, e.g. a gateway that forwards block boundaries and signatures but strips thinking text.

`createMessageContent` now returns `[]` for these blocks, reusing the existing mechanism that drops messages whose content converts to empty, so the surrounding history still replays.

The fix is in the Anthropic provider rather than in the vendor-agnostic guard in `AbstractChatAgent.getMessages` (which only covers unsigned blocks): Gemini legitimately emits empty-text thought parts whose signature must be replayed, and the provider-level check also covers non-chat entry points.

#### How to test

`packages/ai-anthropic`: 4 unit tests in `anthropic-language-model.spec.ts` (`transformToAnthropicParams thinking blocks`) cover empty, whitespace-only, and unsigned thinking blocks being dropped while a signed block with content is kept.

```
cd packages/ai-anthropic && npm run compile && npm test
```

End-to-end: configure a custom Anthropic-compatible model whose endpoint returns thinking blocks without thinking text, then ask an agent something requiring a tool call. Before this change the second request fails with `400 ... each thinking block must contain thinking` and never recovers; after it, the conversation continues.

#### Follow-ups

Custom endpoints also fall back to `DEFAULT_MAX_TOKENS` (4096) whenever the `/v1/models` lookup is unavailable, which is common for gateways that only proxy `/v1/messages`. There is no way to configure the limit per custom model. I intend to file that separately.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
