### PR TITLE
feat(ai-chatgpt): serve the models of a ChatGPT subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## 1.75.0 - tbd
 
+- [ai-chatgpt] added a new `@theia/ai-chatgpt` package which serves the models of your ChatGPT subscription instead of requiring an OpenAI API key [#PR]
 - [ai-ide] added an opt-in "Memory" prompt capability that lets agents maintain a wiki-style knowledge base per workspace, stored in the workspace metadata store and exposed to prompts via the new `{{memoryDirectory}}` variable [#17865](https://github.com/eclipse-theia/theia/pull/17865)
 - [core, monaco] fixed Monaco theme CSS, `SelectComponent` dropdown placement, and the OS font class in secondary windows [#17874](https://github.com/eclipse-theia/theia/pull/17874)
 - [scm-extra] deprecated `@theia/scm-extra` package [#17882](https://github.com/eclipse-theia/theia/pull/17882)

--- a/examples/browser/package.json
+++ b/examples/browser/package.json
@@ -26,6 +26,7 @@
     "@theia/ai-anthropic": "1.74.0",
     "@theia/ai-chat": "1.74.0",
     "@theia/ai-chat-ui": "1.74.0",
+    "@theia/ai-chatgpt": "1.74.0",
     "@theia/ai-claude-code": "1.74.0",
     "@theia/ai-code-completion": "1.74.0",
     "@theia/ai-codex": "1.74.0",

--- a/examples/browser/tsconfig.json
+++ b/examples/browser/tsconfig.json
@@ -18,6 +18,9 @@
       "path": "../../packages/ai-chat-ui"
     },
     {
+      "path": "../../packages/ai-chatgpt"
+    },
+    {
       "path": "../../packages/ai-claude-code"
     },
     {

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -31,6 +31,7 @@
     "@theia/ai-anthropic": "1.74.0",
     "@theia/ai-chat": "1.74.0",
     "@theia/ai-chat-ui": "1.74.0",
+    "@theia/ai-chatgpt": "1.74.0",
     "@theia/ai-claude-code": "1.74.0",
     "@theia/ai-code-completion": "1.74.0",
     "@theia/ai-codex": "1.74.0",

--- a/examples/electron/tsconfig.json
+++ b/examples/electron/tsconfig.json
@@ -21,6 +21,9 @@
       "path": "../../packages/ai-chat-ui"
     },
     {
+      "path": "../../packages/ai-chatgpt"
+    },
+    {
       "path": "../../packages/ai-claude-code"
     },
     {

--- a/package-lock.json
+++ b/package-lock.json
@@ -545,6 +545,7 @@
         "@theia/ai-anthropic": "1.74.0",
         "@theia/ai-chat": "1.74.0",
         "@theia/ai-chat-ui": "1.74.0",
+        "@theia/ai-chatgpt": "1.74.0",
         "@theia/ai-claude-code": "1.74.0",
         "@theia/ai-code-completion": "1.74.0",
         "@theia/ai-codex": "1.74.0",
@@ -691,6 +692,7 @@
         "@theia/ai-anthropic": "1.74.0",
         "@theia/ai-chat": "1.74.0",
         "@theia/ai-chat-ui": "1.74.0",
+        "@theia/ai-chatgpt": "1.74.0",
         "@theia/ai-claude-code": "1.74.0",
         "@theia/ai-code-completion": "1.74.0",
         "@theia/ai-codex": "1.74.0",
@@ -5819,9 +5821,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5836,9 +5835,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5853,9 +5849,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5870,9 +5863,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6221,9 +6211,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6243,9 +6230,6 @@
       "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6267,9 +6251,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6289,9 +6270,6 @@
       "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -6313,9 +6291,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6335,9 +6310,6 @@
       "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -7315,6 +7287,10 @@
     },
     "node_modules/@theia/ai-chat-ui": {
       "resolved": "packages/ai-chat-ui",
+      "link": true
+    },
+    "node_modules/@theia/ai-chatgpt": {
+      "resolved": "packages/ai-chatgpt",
       "link": true
     },
     "node_modules/@theia/ai-claude-code": {
@@ -8752,6 +8728,7 @@
       "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -31863,6 +31840,21 @@
         "@theia/workspace": "1.74.0",
         "date-fns": "^4.4.0",
         "mermaid": "^11.15.0",
+        "tslib": "^2.8.1"
+      },
+      "devDependencies": {
+        "@theia/ext-scripts": "1.74.0"
+      }
+    },
+    "packages/ai-chatgpt": {
+      "name": "@theia/ai-chatgpt",
+      "version": "1.74.0",
+      "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+      "dependencies": {
+        "@theia/ai-core": "1.74.0",
+        "@theia/ai-openai": "1.74.0",
+        "@theia/core": "1.74.0",
+        "openai": "^6.46.0",
         "tslib": "^2.8.1"
       },
       "devDependencies": {

--- a/packages/ai-chatgpt/.eslintrc.js
+++ b/packages/ai-chatgpt/.eslintrc.js
@@ -1,0 +1,10 @@
+/** @type {import('eslint').Linter.Config} */
+module.exports = {
+    extends: [
+        '../../configs/build.eslintrc.json'
+    ],
+    parserOptions: {
+        tsconfigRootDir: __dirname,
+        project: 'tsconfig.json'
+    }
+};

--- a/packages/ai-chatgpt/README.md
+++ b/packages/ai-chatgpt/README.md
@@ -1,0 +1,54 @@
+<div align='center'>
+
+<br />
+
+<img src='https://raw.githubusercontent.com/eclipse-theia/theia/master/logo/theia.svg?sanitize=true' alt='theia-ext-logo' width='100px' />
+
+<h2>ECLIPSE THEIA - CHATGPT EXTENSION</h2>
+
+<hr />
+
+</div>
+
+## Description
+
+The `@theia/ai-chatgpt` extension serves OpenAI models through your ChatGPT subscription instead of an OpenAI API key.
+The models appear as `chatgpt/<model>` in the model picker and coexist with the API-key based `openai/<model>` models contributed by `@theia/ai-openai`.
+
+By default the models your ChatGPT plan grants are queried from the endpoint once you are signed in. Set the `ai-features.chatGpt.models`
+preference to offer a fixed list of models instead. A built-in list is offered while the granted models cannot be determined, i.e. before the
+first sign in or when the endpoint cannot be reached.
+
+### Signing in
+
+Run the command _ChatGPT: Sign in_, or use the sign in link in the settings under _AI Features_ &rarr; _ChatGPT_. It opens the OpenAI authorization
+page in your browser. The browser returns the authorization code to a
+listener on `http://localhost:1455/auth/callback`, which is provided by the Theia backend. If the backend does not run on the same machine as
+your browser, or the port is already in use, you can paste the authorization code (or the full redirect URL) into the input box Theia offers
+instead. The credentials are stored in the credential store of your operating system and are removed again by the command _ChatGPT: Sign out_.
+
+While you are not signed in, the configured models are still listed, but reported as unavailable.
+
+### Limitations
+
+Requests are served by the ChatGPT endpoint `https://chatgpt.com/backend-api/codex`. That endpoint only supports the streaming Response API,
+does not retain responses, and only serves the models included in your ChatGPT plan, so models configured by hand need to be available for
+your plan. Because responses are not retained, server-side compaction is not offered for these models. The endpoint is not documented, so
+neither the web search tool it offers nor the listing of the granted models is a contract: web search can be deselected again in the chat
+capabilities, and the model listing is treated as a hint.
+
+## Additional Information
+
+- [API documentation for `@theia/ai-chatgpt`](https://eclipse-theia.github.io/theia/docs/next/modules/_theia_ai-chatgpt.html)
+- [Theia - GitHub](https://github.com/eclipse-theia/theia)
+- [Theia - Website](https://theia-ide.org/)
+
+## License
+
+- [Eclipse Public License 2.0](http://www.eclipse.org/legal/epl-2.0/)
+- [一 (Secondary) GNU General Public License, version 2 with the GNU Classpath Exception](https://projects.eclipse.org/license/secondary-gpl-2.0-cp)
+
+## Trademark
+
+"Theia" is a trademark of the Eclipse Foundation
+<https://www.eclipse.org/theia>

--- a/packages/ai-chatgpt/package.json
+++ b/packages/ai-chatgpt/package.json
@@ -1,0 +1,51 @@
+{
+  "name": "@theia/ai-chatgpt",
+  "version": "1.74.0",
+  "description": "Theia - ChatGPT Subscription Integration",
+  "dependencies": {
+    "@theia/ai-core": "1.74.0",
+    "@theia/ai-openai": "1.74.0",
+    "@theia/core": "1.74.0",
+    "openai": "^6.46.0",
+    "tslib": "^2.8.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "theiaExtensions": [
+    {
+      "frontend": "lib/browser/chatgpt-frontend-module",
+      "backend": "lib/node/chatgpt-backend-module"
+    }
+  ],
+  "keywords": [
+    "theia-extension"
+  ],
+  "license": "EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/eclipse-theia/theia.git"
+  },
+  "bugs": {
+    "url": "https://github.com/eclipse-theia/theia/issues"
+  },
+  "homepage": "https://github.com/eclipse-theia/theia",
+  "files": [
+    "lib",
+    "src"
+  ],
+  "scripts": {
+    "build": "theiaext build",
+    "clean": "theiaext clean",
+    "compile": "theiaext compile",
+    "lint": "theiaext lint",
+    "test": "theiaext test",
+    "watch": "theiaext watch"
+  },
+  "devDependencies": {
+    "@theia/ext-scripts": "1.74.0"
+  },
+  "nyc": {
+    "extends": "../../configs/nyc.json"
+  }
+}

--- a/packages/ai-chatgpt/src/browser/chatgpt-command-contribution.spec.ts
+++ b/packages/ai-chatgpt/src/browser/chatgpt-command-contribution.spec.ts
@@ -1,0 +1,211 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { Command, CommandHandler, CommandRegistry, Emitter, Event, MessageService } from '@theia/core';
+import { QuickInputService } from '@theia/core/lib/browser';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { AIActivationService } from '@theia/ai-core/lib/browser';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { ChatGptAuthService, ChatGptAuthState, ChatGptLoginSession, ChatGptPreferencesSchema, MODELS_PREF } from '../common';
+import { ChatGptCommandContribution, ChatGptCommands } from './chatgpt-command-contribution';
+
+disableJSDOM();
+
+class FakeAuthService implements ChatGptAuthService {
+    authState: ChatGptAuthState = { isAuthenticated: false };
+    session: ChatGptLoginSession = { authorizationUrl: 'https://auth.openai.com/oauth/authorize?code_challenge=x', callbackListening: true };
+    readonly login = new Deferred<boolean>();
+    readonly completed: string[] = [];
+    startLoginError: Error | undefined;
+    cancelledLogins = 0;
+    signOuts = 0;
+
+    protected readonly emitter = new Emitter<ChatGptAuthState>();
+    readonly onAuthStateChanged: Event<ChatGptAuthState> = this.emitter.event;
+
+    async startLogin(): Promise<ChatGptLoginSession> {
+        if (this.startLoginError) {
+            throw this.startLoginError;
+        }
+        return this.session;
+    }
+    waitForLogin(): Promise<boolean> {
+        return this.login.promise;
+    }
+    async completeLogin(codeOrRedirectUrl: string): Promise<boolean> {
+        this.completed.push(codeOrRedirectUrl);
+        return true;
+    }
+    async cancelLogin(): Promise<void> {
+        this.cancelledLogins++;
+    }
+    async getAuthState(): Promise<ChatGptAuthState> {
+        return this.authState;
+    }
+    async signOut(): Promise<void> {
+        this.signOuts++;
+    }
+    fireAuthStateChanged(state: ChatGptAuthState): void {
+        this.authState = state;
+        this.emitter.fire(state);
+    }
+}
+
+describe('ChatGptCommandContribution', () => {
+
+    let authService: FakeAuthService;
+    let contribution: ChatGptCommandContribution;
+    let openedUrls: string[];
+    let infoMessages: string[];
+    let errorMessages: string[];
+    let quickInput: string | undefined;
+    let quickInputRequests: number;
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    beforeEach(async () => {
+        authService = new FakeAuthService();
+        openedUrls = [];
+        infoMessages = [];
+        errorMessages = [];
+        quickInput = undefined;
+        quickInputRequests = 0;
+
+        const messageService = {
+            // An action message stays open until the user picks one, which the tests model as a pending promise.
+            info: (message: string, ...actions: string[]) => {
+                infoMessages.push(message);
+                return actions.length ? new Promise<string | undefined>(() => { }) : Promise.resolve(undefined);
+            },
+            error: (message: string) => {
+                errorMessages.push(message);
+                return Promise.resolve(undefined);
+            }
+        } as unknown as MessageService;
+        const windowService = { openNewWindow: (url: string) => { openedUrls.push(url); } } as unknown as WindowService;
+        const quickInputService = {
+            input: () => {
+                quickInputRequests++;
+                return Promise.resolve(quickInput);
+            }
+        } as unknown as QuickInputService;
+        const activationService = { isActive: true } as unknown as AIActivationService;
+
+        contribution = new ChatGptCommandContribution();
+        Object.assign(contribution, { authService, windowService, messageService, quickInputService, activationService });
+        (contribution as unknown as { init(): void }).init();
+        // The initial state is fetched asynchronously.
+        await Promise.resolve();
+    });
+
+    afterEach(() => {
+        contribution.dispose();
+    });
+
+    function registerCommands(): Map<string, CommandHandler> {
+        const handlers = new Map<string, CommandHandler>();
+        contribution.registerCommands({
+            registerCommand: (command: Command, handler: CommandHandler) => handlers.set(command.id, handler)
+        } as unknown as CommandRegistry);
+        return handlers;
+    }
+
+    it('offers signing in while there is no session and signing out once there is one', () => {
+        const handlers = registerCommands();
+        expect(handlers.get(ChatGptCommands.SIGN_IN.id)!.isEnabled!()).to.equal(true);
+        expect(handlers.get(ChatGptCommands.SIGN_OUT.id)!.isEnabled!()).to.equal(false);
+
+        authService.fireAuthStateChanged({ isAuthenticated: true, accountLabel: 'user@example.com' });
+
+        expect(handlers.get(ChatGptCommands.SIGN_IN.id)!.isEnabled!()).to.equal(false);
+        expect(handlers.get(ChatGptCommands.SIGN_OUT.id)!.isEnabled!()).to.equal(true);
+    });
+
+    it('hides both commands while the AI features are disabled', () => {
+        Object.assign(contribution, { activationService: { isActive: false } });
+        const handlers = registerCommands();
+        expect(handlers.get(ChatGptCommands.SIGN_IN.id)!.isVisible!()).to.equal(false);
+        expect(handlers.get(ChatGptCommands.SIGN_OUT.id)!.isVisible!()).to.equal(false);
+    });
+
+    it('opens the authorization page and reports the account once the browser completed the sign in', async () => {
+        const handlers = registerCommands();
+        const signingIn = handlers.get(ChatGptCommands.SIGN_IN.id)!.execute();
+
+        await Promise.resolve();
+        expect(openedUrls).to.deep.equal([authService.session.authorizationUrl]);
+
+        authService.authState = { isAuthenticated: true, accountLabel: 'user@example.com' };
+        authService.login.resolve(true);
+        await signingIn;
+
+        expect(infoMessages.pop()).to.contain('user@example.com');
+        expect(quickInputRequests).to.equal(0);
+    });
+
+    it('asks for the authorization code when the callback listener is not reachable', async () => {
+        authService.session = { authorizationUrl: 'https://auth.openai.com/oauth/authorize', callbackListening: false };
+        quickInput = 'the-code';
+
+        const handlers = registerCommands();
+        await handlers.get(ChatGptCommands.SIGN_IN.id)!.execute();
+
+        expect(quickInputRequests).to.equal(1);
+        expect(authService.completed).to.deep.equal(['the-code']);
+    });
+
+    it('abandons the sign in when the authorization code input is dismissed', async () => {
+        authService.session = { authorizationUrl: 'https://auth.openai.com/oauth/authorize', callbackListening: false };
+        quickInput = undefined;
+
+        const handlers = registerCommands();
+        await handlers.get(ChatGptCommands.SIGN_IN.id)!.execute();
+
+        expect(authService.completed).to.be.empty;
+        expect(authService.cancelledLogins).to.equal(1);
+        expect(infoMessages).to.be.empty;
+    });
+
+    it('cancels the sign in and reports the reason when it fails', async () => {
+        authService.startLoginError = new Error('the port is in use');
+
+        const handlers = registerCommands();
+        await handlers.get(ChatGptCommands.SIGN_IN.id)!.execute();
+
+        expect(errorMessages.pop()).to.contain('the port is in use');
+        expect(authService.cancelledLogins).to.equal(1);
+    });
+
+    it('offers both commands as links on the preference page', () => {
+        const description = ChatGptPreferencesSchema.properties[MODELS_PREF].markdownDescription!;
+        expect(description).to.contain(`(command:${ChatGptCommands.SIGN_IN.id})`);
+        expect(description).to.contain(`(command:${ChatGptCommands.SIGN_OUT.id})`);
+        // Four leading spaces would render the links as a code block instead.
+        expect(description).to.not.match(/\n {4}/);
+    });
+});

--- a/packages/ai-chatgpt/src/browser/chatgpt-command-contribution.ts
+++ b/packages/ai-chatgpt/src/browser/chatgpt-command-contribution.ts
@@ -1,0 +1,146 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Command, CommandContribution, CommandRegistry, Disposable, DisposableCollection, MessageService, nls } from '@theia/core';
+import { ConfirmDialog, Dialog, QuickInputService } from '@theia/core/lib/browser';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { AIActivationService } from '@theia/ai-core/lib/browser';
+import { inject, injectable, postConstruct } from '@theia/core/shared/inversify';
+import { ChatGptAuthService, ChatGptAuthState } from '../common';
+
+export namespace ChatGptCommands {
+    export const SIGN_IN: Command = Command.toLocalizedCommand(
+        { id: 'chatgpt.signIn', label: 'Sign in', category: 'ChatGPT' },
+        'theia/ai/chatgpt/commands/signIn',
+        'theia/ai/chatgpt/category'
+    );
+
+    export const SIGN_OUT: Command = Command.toLocalizedCommand(
+        { id: 'chatgpt.signOut', label: 'Sign out', category: 'ChatGPT' },
+        'theia/ai/chatgpt/commands/signOut',
+        'theia/ai/chatgpt/category'
+    );
+}
+
+/**
+ * Drives the "Sign in with ChatGPT" flow: the authorization page is opened in the user's browser and the
+ * authorization code is either delivered to the backend's loopback listener or entered manually.
+ */
+@injectable()
+export class ChatGptCommandContribution implements CommandContribution, Disposable {
+
+    @inject(ChatGptAuthService)
+    protected readonly authService: ChatGptAuthService;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(QuickInputService)
+    protected readonly quickInputService: QuickInputService;
+
+    @inject(AIActivationService)
+    protected readonly activationService: AIActivationService;
+
+    protected authState: ChatGptAuthState = { isAuthenticated: false };
+    protected readonly toDispose = new DisposableCollection();
+
+    @postConstruct()
+    protected init(): void {
+        this.authService.getAuthState().then(state => this.authState = state);
+        this.toDispose.push(this.authService.onAuthStateChanged(state => this.authState = state));
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    registerCommands(registry: CommandRegistry): void {
+        registry.registerCommand(ChatGptCommands.SIGN_IN, {
+            execute: () => this.signIn(),
+            isEnabled: () => !this.authState.isAuthenticated,
+            isVisible: () => this.activationService.isActive
+        });
+
+        registry.registerCommand(ChatGptCommands.SIGN_OUT, {
+            execute: () => this.signOut(),
+            isEnabled: () => this.authState.isAuthenticated,
+            isVisible: () => this.activationService.isActive
+        });
+    }
+
+    protected async signIn(): Promise<void> {
+        try {
+            const session = await this.authService.startLogin();
+            this.windowService.openNewWindow(session.authorizationUrl, { external: true });
+            const success = session.callbackListening ? await this.awaitAuthorization() : await this.requestAuthorizationCode();
+            if (success) {
+                this.authState = await this.authService.getAuthState();
+                this.messageService.info(this.authState.accountLabel
+                    ? nls.localize('theia/ai/chatgpt/signedInAs', 'Signed in to ChatGPT as {0}.', this.authState.accountLabel)
+                    : nls.localize('theia/ai/chatgpt/signedIn', 'Signed in to ChatGPT.'));
+            }
+        } catch (error) {
+            await this.authService.cancelLogin();
+            this.messageService.error(nls.localize('theia/ai/chatgpt/signInFailed', 'The ChatGPT sign in failed: {0}',
+                error instanceof Error ? error.message : String(error)));
+        }
+    }
+
+    /** Waits for the browser to complete the sign in while offering to enter the authorization code manually. */
+    protected async awaitAuthorization(): Promise<boolean> {
+        const enterCode = nls.localize('theia/ai/chatgpt/enterCode', 'Enter code manually');
+        const chosenAction = this.messageService.info(
+            nls.localize('theia/ai/chatgpt/waiting', 'Complete the ChatGPT sign in in your browser.'), enterCode);
+        const outcome = await Promise.race([
+            this.authService.waitForLogin().then(success => ({ success })),
+            chosenAction.then(action => ({ action }))
+        ]);
+        if ('success' in outcome) {
+            return outcome.success;
+        }
+        if (outcome.action === enterCode) {
+            return this.requestAuthorizationCode();
+        }
+        return this.authService.waitForLogin();
+    }
+
+    protected async requestAuthorizationCode(): Promise<boolean> {
+        const input = await this.quickInputService.input({
+            prompt: nls.localize('theia/ai/chatgpt/codePrompt', 'Paste the authorization code or the full redirect URL from your browser'),
+            ignoreFocusLost: true
+        });
+        if (input === undefined) {
+            await this.authService.cancelLogin();
+            return false;
+        }
+        return this.authService.completeLogin(input);
+    }
+
+    protected async signOut(): Promise<void> {
+        const confirmed = await new ConfirmDialog({
+            title: nls.localize('theia/ai/chatgpt/signOutTitle', 'Sign out of ChatGPT'),
+            msg: nls.localize('theia/ai/chatgpt/signOutConfirm', 'Are you sure you want to sign out of ChatGPT?'),
+            ok: Dialog.YES,
+            cancel: Dialog.NO
+        }).open();
+        if (confirmed) {
+            await this.authService.signOut();
+        }
+    }
+}

--- a/packages/ai-chatgpt/src/browser/chatgpt-frontend-application-contribution.spec.ts
+++ b/packages/ai-chatgpt/src/browser/chatgpt-frontend-application-contribution.spec.ts
@@ -1,0 +1,235 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+let disableJSDOM = enableJSDOM();
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { Emitter, Event, PreferenceChange, PreferenceService } from '@theia/core';
+import { Container } from '@theia/core/shared/inversify';
+import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES } from '@theia/ai-core/lib/common/ai-core-preferences';
+import { ChatGptAuthService, ChatGptAuthState, ChatGptLanguageModelsManager, ChatGptModelDescription, MODELS_PREF } from '../common';
+import { ChatGptFrontendApplicationContribution } from './chatgpt-frontend-application-contribution';
+
+disableJSDOM();
+
+class FakeManager implements ChatGptLanguageModelsManager {
+    readonly created: ChatGptModelDescription[][] = [];
+    readonly removed: string[][] = [];
+    proxyUrl: string | undefined;
+    available: string[] = [];
+    availableCalls = 0;
+
+    setProxyUrl(proxyUrl: string | undefined): void {
+        this.proxyUrl = proxyUrl;
+    }
+    async getAvailableModels(): Promise<string[]> {
+        this.availableCalls++;
+        return this.available;
+    }
+    async createOrUpdateLanguageModels(...models: ChatGptModelDescription[]): Promise<void> {
+        this.created.push(models);
+    }
+    removeLanguageModels(...modelIds: string[]): void {
+        this.removed.push(modelIds);
+    }
+}
+
+/** Only the parts of the preference service the contribution uses. */
+class FakePreferenceService {
+    readonly values = new Map<string, unknown>();
+    readonly ready = Promise.resolve();
+
+    protected readonly emitter = new Emitter<PreferenceChange>();
+    readonly onPreferenceChanged: Event<PreferenceChange> = this.emitter.event;
+
+    get<T>(preferenceName: string, defaultValue: T): T {
+        return (this.values.get(preferenceName) as T) ?? defaultValue;
+    }
+    set(preferenceName: string, value: unknown): void {
+        this.values.set(preferenceName, value);
+        this.emitter.fire({ preferenceName } as PreferenceChange);
+    }
+}
+
+function registeredIds(descriptions: ChatGptModelDescription[]): string[] {
+    return descriptions.map(description => description.id);
+}
+
+/** Lets the refresh triggered by the preceding change run to completion. */
+async function flush(): Promise<void> {
+    await new Promise(resolve => setImmediate(resolve));
+}
+
+describe('ChatGptFrontendApplicationContribution', () => {
+
+    let contribution: ChatGptFrontendApplicationContribution;
+    let manager: FakeManager;
+    let preferences: FakePreferenceService;
+    let aiCorePreferenceEmitter: Emitter<PreferenceChange>;
+    let authStateEmitter: Emitter<ChatGptAuthState>;
+    let maxRetries: number;
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    /** Runs `onStart` and the microtasks it defers to `preferenceService.ready`. */
+    async function start(): Promise<void> {
+        contribution.onStart();
+        await preferences.ready;
+        await new Promise(resolve => setImmediate(resolve));
+    }
+
+    beforeEach(() => {
+        manager = new FakeManager();
+        preferences = new FakePreferenceService();
+        aiCorePreferenceEmitter = new Emitter<PreferenceChange>();
+        authStateEmitter = new Emitter<ChatGptAuthState>();
+        maxRetries = 3;
+
+        const container = new Container();
+        container.bind(PreferenceService).toConstantValue(preferences as unknown as PreferenceService);
+        container.bind(ChatGptLanguageModelsManager).toConstantValue(manager);
+        container.bind(AICorePreferences).toConstantValue({
+            get: (name: string) => (name === PREFERENCE_NAME_MAX_RETRIES ? maxRetries : undefined),
+            onPreferenceChanged: aiCorePreferenceEmitter.event
+        } as unknown as AICorePreferences);
+        container.bind(ChatGptAuthService).toConstantValue({
+            onAuthStateChanged: authStateEmitter.event
+        } as unknown as ChatGptAuthService);
+        container.bind(ChatGptFrontendApplicationContribution).toSelf().inSingletonScope();
+        contribution = container.get(ChatGptFrontendApplicationContribution);
+    });
+
+    it('registers the configured models on startup, regardless of the sign in state', async () => {
+        preferences.values.set(MODELS_PREF, ['gpt-5.5', 'gpt-5.5-pro']);
+
+        await start();
+
+        expect(manager.created).to.have.lengthOf(1);
+        expect(registeredIds(manager.created[0])).to.deep.equal(['chatgpt/gpt-5.5', 'chatgpt/gpt-5.5-pro']);
+        expect(manager.created[0][0].maxRetries).to.equal(3);
+    });
+
+    it('offers the models the ChatGPT plan grants while none are configured', async () => {
+        manager.available = ['gpt-5.6-sol', 'gpt-5.5'];
+
+        await start();
+
+        expect(registeredIds(manager.created[0])).to.deep.equal(['chatgpt/gpt-5.6-sol', 'chatgpt/gpt-5.5']);
+    });
+
+    it('prefers the configured models over the ones the plan grants', async () => {
+        preferences.values.set(MODELS_PREF, ['gpt-5.5']);
+        manager.available = ['gpt-5.6-sol'];
+
+        await start();
+
+        expect(registeredIds(manager.created[0])).to.deep.equal(['chatgpt/gpt-5.5']);
+        expect(manager.availableCalls).to.equal(0);
+    });
+
+    it('registers the added models and removes the ones that were dropped', async () => {
+        preferences.values.set(MODELS_PREF, ['gpt-5.5']);
+        await start();
+
+        preferences.set(MODELS_PREF, ['gpt-5.5', 'gpt-5.6-sol']);
+        await flush();
+
+        expect(registeredIds(manager.created[1])).to.deep.equal(['chatgpt/gpt-5.5', 'chatgpt/gpt-5.6-sol']);
+        expect(manager.removed).to.be.empty;
+
+        preferences.set(MODELS_PREF, ['gpt-5.6-sol']);
+        await flush();
+
+        expect(manager.removed).to.deep.equal([['chatgpt/gpt-5.5']]);
+        expect(registeredIds(manager.created[2])).to.deep.equal(['chatgpt/gpt-5.6-sol']);
+    });
+
+    it('refreshes the models when the user signs in or out, so their status follows', async () => {
+        preferences.values.set(MODELS_PREF, ['gpt-5.5']);
+        await start();
+
+        authStateEmitter.fire({ isAuthenticated: true, accountLabel: 'user@example.com' });
+        await flush();
+
+        expect(registeredIds(manager.created[1])).to.deep.equal(['chatgpt/gpt-5.5']);
+    });
+
+    it('picks up the models the plan grants once the user is signed in', async () => {
+        await start();
+        expect(registeredIds(manager.created[0])).to.be.empty;
+
+        manager.available = ['gpt-5.6-sol'];
+        authStateEmitter.fire({ isAuthenticated: true });
+        await flush();
+
+        expect(registeredIds(manager.created[1])).to.deep.equal(['chatgpt/gpt-5.6-sol']);
+    });
+
+    it('applies overlapping refreshes one after the other', async () => {
+        const listings: ((models: string[]) => void)[] = [];
+        manager.getAvailableModels = () => new Promise<string[]>(resolve => listings.push(resolve));
+        await start();
+
+        authStateEmitter.fire({ isAuthenticated: true });
+        await flush();
+        expect(listings).to.have.lengthOf(1);
+
+        listings[0](['gpt-5.5']);
+        await flush();
+        expect(listings).to.have.lengthOf(2);
+
+        listings[1](['gpt-5.6-sol']);
+        await flush();
+
+        expect(registeredIds(manager.created[0])).to.deep.equal(['chatgpt/gpt-5.5']);
+        expect(registeredIds(manager.created[1])).to.deep.equal(['chatgpt/gpt-5.6-sol']);
+        expect(manager.removed).to.deep.equal([['chatgpt/gpt-5.5']]);
+    });
+
+    it('applies a changed retry count to the registered models', async () => {
+        preferences.values.set(MODELS_PREF, ['gpt-5.5']);
+        await start();
+
+        maxRetries = 7;
+        aiCorePreferenceEmitter.fire({ preferenceName: PREFERENCE_NAME_MAX_RETRIES } as PreferenceChange);
+        await flush();
+
+        expect(manager.created[1][0].maxRetries).to.equal(7);
+    });
+
+    it('forwards the proxy configuration and re-registers the models when it changes', async () => {
+        preferences.values.set(MODELS_PREF, ['gpt-5.5']);
+        preferences.values.set('http.proxy', 'http://proxy.example.com:3128');
+        await start();
+
+        expect(manager.proxyUrl).to.equal('http://proxy.example.com:3128');
+
+        preferences.set('http.proxy', 'http://other.example.com:3128');
+        await flush();
+
+        expect(manager.proxyUrl).to.equal('http://other.example.com:3128');
+        expect(registeredIds(manager.created[1])).to.deep.equal(['chatgpt/gpt-5.5']);
+    });
+});

--- a/packages/ai-chatgpt/src/browser/chatgpt-frontend-application-contribution.ts
+++ b/packages/ai-chatgpt/src/browser/chatgpt-frontend-application-contribution.ts
@@ -1,0 +1,98 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { AICorePreferences, PREFERENCE_NAME_MAX_RETRIES } from '@theia/ai-core/lib/common/ai-core-preferences';
+import { PreferenceService } from '@theia/core';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { CHATGPT_PROVIDER_ID, ChatGptAuthService, ChatGptLanguageModelsManager, ChatGptModelDescription, MODELS_PREF } from '../common';
+
+@injectable()
+export class ChatGptFrontendApplicationContribution implements FrontendApplicationContribution {
+
+    @inject(PreferenceService)
+    protected preferenceService: PreferenceService;
+
+    @inject(ChatGptLanguageModelsManager)
+    protected manager: ChatGptLanguageModelsManager;
+
+    @inject(AICorePreferences)
+    protected aiCorePreferences: AICorePreferences;
+
+    @inject(ChatGptAuthService)
+    protected authService: ChatGptAuthService;
+
+    protected registeredModels: string[] = [];
+    /** Serializes the refreshes, so a slow one cannot register models the next one already dropped. */
+    protected refreshes: Promise<unknown> = Promise.resolve();
+
+    onStart(): void {
+        this.preferenceService.ready.then(() => {
+            this.manager.setProxyUrl(this.preferenceService.get<string>('http.proxy', undefined));
+            this.refreshModels();
+
+            this.preferenceService.onPreferenceChanged(event => {
+                if (event.preferenceName === MODELS_PREF) {
+                    this.refreshModels();
+                } else if (event.preferenceName === 'http.proxy') {
+                    this.manager.setProxyUrl(this.preferenceService.get<string>('http.proxy', undefined));
+                    this.refreshModels();
+                }
+            });
+
+            this.aiCorePreferences.onPreferenceChanged(event => {
+                if (event.preferenceName === PREFERENCE_NAME_MAX_RETRIES) {
+                    this.refreshModels();
+                }
+            });
+
+            // Signing in or out changes the credentials, the availability of the models and which models are granted.
+            this.authService.onAuthStateChanged(() => this.refreshModels());
+        });
+    }
+
+    protected refreshModels(): Promise<void> {
+        const refresh = this.refreshes.then(() => this.doRefreshModels(), () => this.doRefreshModels());
+        this.refreshes = refresh.catch(() => undefined);
+        return refresh;
+    }
+
+    protected async doRefreshModels(): Promise<void> {
+        const models = await this.resolveModels();
+        const removed = this.registeredModels.filter(model => !models.includes(model));
+        this.registeredModels = models;
+        if (removed.length) {
+            this.manager.removeLanguageModels(...removed.map(model => `${CHATGPT_PROVIDER_ID}/${model}`));
+        }
+        // Registering a model that is already registered updates it, which is what a refresh is after.
+        await this.manager.createOrUpdateLanguageModels(...models.map(modelId => this.createModelDescription(modelId)));
+    }
+
+    /** The configured models, or the ones the ChatGPT plan grants while none are configured. */
+    protected resolveModels(): Promise<string[]> {
+        const configured = this.preferenceService.get<string[]>(MODELS_PREF, []);
+        return configured.length ? Promise.resolve(configured) : this.manager.getAvailableModels();
+    }
+
+    /** Per-model capabilities are resolved by the backend from the model id. */
+    protected createModelDescription(modelId: string): ChatGptModelDescription {
+        return {
+            id: `${CHATGPT_PROVIDER_ID}/${modelId}`,
+            model: modelId,
+            maxRetries: this.aiCorePreferences.get(PREFERENCE_NAME_MAX_RETRIES) ?? 3
+        };
+    }
+}

--- a/packages/ai-chatgpt/src/browser/chatgpt-frontend-module.ts
+++ b/packages/ai-chatgpt/src/browser/chatgpt-frontend-module.ts
@@ -1,0 +1,66 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { CommandContribution, Emitter, Event, PreferenceContribution } from '@theia/core';
+import { FrontendApplicationContribution, RemoteConnectionProvider, ServiceConnectionProvider } from '@theia/core/lib/browser';
+import { ContainerModule } from '@theia/core/shared/inversify';
+import {
+    CHATGPT_AUTH_SERVICE_PATH,
+    CHATGPT_LANGUAGE_MODELS_MANAGER_PATH,
+    ChatGptAuthService,
+    ChatGptAuthServiceClient,
+    ChatGptAuthState,
+    ChatGptLanguageModelsManager,
+    ChatGptPreferencesSchema
+} from '../common';
+import { ChatGptCommandContribution } from './chatgpt-command-contribution';
+import { ChatGptFrontendApplicationContribution } from './chatgpt-frontend-application-contribution';
+
+class ChatGptAuthServiceClientImpl implements ChatGptAuthServiceClient {
+    protected readonly onAuthStateChangedEmitter = new Emitter<ChatGptAuthState>();
+    readonly onAuthStateChangedEvent: Event<ChatGptAuthState> = this.onAuthStateChangedEmitter.event;
+    onAuthStateChanged(state: ChatGptAuthState): void {
+        this.onAuthStateChangedEmitter.fire(state);
+    }
+}
+
+export default new ContainerModule(bind => {
+    bind(PreferenceContribution).toConstantValue({ schema: ChatGptPreferencesSchema });
+    bind(ChatGptFrontendApplicationContribution).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(ChatGptFrontendApplicationContribution);
+    bind(ChatGptCommandContribution).toSelf().inSingletonScope();
+    bind(CommandContribution).toService(ChatGptCommandContribution);
+    bind(ChatGptLanguageModelsManager).toDynamicValue(ctx => {
+        const provider = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
+        return provider.createProxy<ChatGptLanguageModelsManager>(CHATGPT_LANGUAGE_MODELS_MANAGER_PATH);
+    }).inSingletonScope();
+    bind(ChatGptAuthServiceClientImpl).toConstantValue(new ChatGptAuthServiceClientImpl());
+    bind(ChatGptAuthServiceClient).toService(ChatGptAuthServiceClientImpl);
+    bind(ChatGptAuthService).toDynamicValue(ctx => {
+        const provider = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
+        const client = ctx.container.get(ChatGptAuthServiceClientImpl);
+        const proxy = provider.createProxy<ChatGptAuthService>(CHATGPT_AUTH_SERVICE_PATH, client);
+        // The RPC proxy cannot carry a Theia `Event`, so the client's local emitter is substituted for it.
+        return new Proxy(proxy, {
+            get(target: ChatGptAuthService, property: string | symbol, receiver: unknown): unknown {
+                if (property === 'onAuthStateChanged') {
+                    return client.onAuthStateChangedEvent;
+                }
+                return Reflect.get(target, property, receiver);
+            }
+        }) as ChatGptAuthService;
+    }).inSingletonScope();
+});

--- a/packages/ai-chatgpt/src/common/chatgpt-auth-service.ts
+++ b/packages/ai-chatgpt/src/common/chatgpt-auth-service.ts
@@ -1,0 +1,92 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core';
+
+export const CHATGPT_AUTH_SERVICE_PATH = '/services/chatgpt/auth';
+export const ChatGptAuthService = Symbol('ChatGptAuthService');
+export const ChatGptAuthServiceClient = Symbol('ChatGptAuthServiceClient');
+
+/** Endpoint serving OpenAI models to ChatGPT subscribers. It only implements the Response API. */
+export const CHATGPT_RESPONSES_BASE_URL = 'https://chatgpt.com/backend-api/codex';
+
+/** Current sign in state of the ChatGPT subscription. */
+export interface ChatGptAuthState {
+    /** Whether credentials for a ChatGPT subscription are available. */
+    isAuthenticated: boolean;
+    /** The email of the signed in account, if it is part of the token claims. */
+    accountLabel?: string;
+    /** The ChatGPT plan of the signed in account, e.g. `plus` or `pro`. */
+    planType?: string;
+}
+
+/** Information the user needs to complete the browser based sign in. */
+export interface ChatGptLoginSession {
+    /** The URL the user has to open to authorize Theia. */
+    authorizationUrl: string;
+    /**
+     * Whether the local callback listener was started successfully. If `false`, the browser cannot deliver the
+     * authorization code and the user has to paste the redirect URL via {@link ChatGptAuthService.completeLogin}.
+     */
+    callbackListening: boolean;
+}
+
+/** Credentials used to talk to the ChatGPT endpoint on behalf of the signed in user. */
+export interface ChatGptCredentials {
+    accessToken: string;
+    /** Sent as the `chatgpt-account-id` header, which the endpoint requires. */
+    accountId: string;
+}
+
+export interface ChatGptAuthServiceClient {
+    onAuthStateChanged(state: ChatGptAuthState): void;
+}
+
+/**
+ * Service handling the OAuth 2.0 authorization code flow (with PKCE) used to access OpenAI models
+ * with a ChatGPT subscription instead of an API key.
+ */
+export interface ChatGptAuthService {
+    /**
+     * Starts a new login attempt. Cancels a login attempt that is still pending.
+     * @returns the URL the user has to open and whether the local callback listener is available
+     */
+    startLogin(): Promise<ChatGptLoginSession>;
+
+    /**
+     * Waits for the browser to deliver the authorization code to the local callback listener.
+     * @returns `true` if the sign in completed, `false` if it was cancelled or timed out
+     */
+    waitForLogin(): Promise<boolean>;
+
+    /**
+     * Completes the pending login with a manually provided authorization code or the full redirect URL.
+     * @returns `true` if the sign in completed
+     */
+    completeLogin(codeOrRedirectUrl: string): Promise<boolean>;
+
+    /** Cancels the pending login attempt, if any. */
+    cancelLogin(): Promise<void>;
+
+    /** Returns the current sign in state. */
+    getAuthState(): Promise<ChatGptAuthState>;
+
+    /** Removes the stored credentials. */
+    signOut(): Promise<void>;
+
+    /** Emitted whenever the sign in state changes. */
+    readonly onAuthStateChanged: Event<ChatGptAuthState>;
+}

--- a/packages/ai-chatgpt/src/common/chatgpt-language-models-manager.ts
+++ b/packages/ai-chatgpt/src/common/chatgpt-language-models-manager.ts
@@ -1,0 +1,44 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+export const CHATGPT_LANGUAGE_MODELS_MANAGER_PATH = '/services/chatgpt/language-model-manager';
+export const ChatGptLanguageModelsManager = Symbol('ChatGptLanguageModelsManager');
+
+export const CHATGPT_PROVIDER_ID = 'chatgpt';
+
+/**
+ * Describes a model served by the ChatGPT subscription. The endpoint, the authentication and the request shape are
+ * fixed by the ChatGPT contract, so this carries no endpoint configuration.
+ */
+export interface ChatGptModelDescription {
+    /** The identifier of the model which will be shown in the UI, of the form `chatgpt/<model>`. */
+    id: string;
+    /** The model ID as used by the ChatGPT endpoint. */
+    model: string;
+    /** Maximum number of retry attempts when a request fails. */
+    maxRetries: number;
+}
+
+export interface ChatGptLanguageModelsManager {
+    setProxyUrl(proxyUrl: string | undefined): void;
+    /**
+     * The models the signed in ChatGPT plan grants. Falls back to a built-in list while they cannot be determined,
+     * i.e. before the first sign in or when the endpoint listing them cannot be reached.
+     */
+    getAvailableModels(): Promise<string[]>;
+    createOrUpdateLanguageModels(...models: ChatGptModelDescription[]): Promise<void>;
+    removeLanguageModels(...modelIds: string[]): void;
+}

--- a/packages/ai-chatgpt/src/common/chatgpt-preferences.ts
+++ b/packages/ai-chatgpt/src/common/chatgpt-preferences.ts
@@ -1,0 +1,59 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { AI_CORE_PREFERENCES_TITLE } from '@theia/ai-core/lib/common/ai-core-preferences';
+import { nls, PreferenceSchema } from '@theia/core';
+
+export const MODELS_PREF = 'ai-features.chatGpt.models';
+
+/**
+ * Models offered while the ones available to the account cannot be determined, i.e. before the first sign in or
+ * when the endpoint listing them cannot be reached.
+ */
+export const CHATGPT_FALLBACK_MODELS = [
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
+    'gpt-5.5',
+    'gpt-5.5-pro'
+];
+
+/**
+ * The preference page renders `command:` links of a markdown description through the `CommandOpenHandler`, so
+ * the sign in and sign out commands are reachable from the settings as well. Only the link labels are
+ * localized: a command id inside a translated string could be broken by a translation.
+ */
+const MODELS_DESCRIPTION = [
+    nls.localize('theia/ai/chatgpt/models/mdDescription',
+        'Models to serve through your ChatGPT subscription. They are only available while you are signed in. \
+Leave this empty to offer the models your ChatGPT plan actually grants, which are queried once you are signed in.'),
+    `[${nls.localize('theia/ai/chatgpt/models/signIn', 'Sign in with ChatGPT')}](command:chatgpt.signIn) \
+· [${nls.localizeByDefault('Sign Out')}](command:chatgpt.signOut)`
+].join('\n\n');
+
+export const ChatGptPreferencesSchema: PreferenceSchema = {
+    properties: {
+        [MODELS_PREF]: {
+            type: 'array',
+            markdownDescription: MODELS_DESCRIPTION,
+            title: AI_CORE_PREFERENCES_TITLE,
+            default: [],
+            items: {
+                type: 'string'
+            }
+        }
+    }
+};

--- a/packages/ai-chatgpt/src/common/index.ts
+++ b/packages/ai-chatgpt/src/common/index.ts
@@ -1,0 +1,18 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+export * from './chatgpt-auth-service';
+export * from './chatgpt-language-models-manager';
+export * from './chatgpt-preferences';

--- a/packages/ai-chatgpt/src/node/chatgpt-auth-service-impl.spec.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-auth-service-impl.spec.ts
@@ -1,0 +1,531 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as http from 'http';
+import * as sinon from 'sinon';
+import { Container } from '@theia/core/shared/inversify';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { KeyStoreService } from '@theia/core/lib/common/key-store';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { ChatGptAuthState } from '../common';
+import { ChatGptAuthServiceImpl, createRemoteAuthService } from './chatgpt-auth-service-impl';
+import { CHATGPT_REDIRECT_URI } from './chatgpt-oauth';
+
+/** Avoids binding the loopback callback port. The code hand over is exercised through {@link completeLogin} instead. */
+class TestAuthService extends ChatGptAuthServiceImpl {
+    protected override async startCallbackServer(): Promise<http.Server | undefined> {
+        return undefined;
+    }
+    get pendingState(): string | undefined {
+        return this.pendingLogin?.state;
+    }
+    callCallback(url: string): CallbackResponse {
+        const response = new CallbackResponse();
+        this.handleCallbackRequest(this.pendingLogin!, { url } as http.IncomingMessage, response as unknown as http.ServerResponse);
+        return response;
+    }
+}
+
+class CallbackResponse {
+    statusCode = 0;
+    body: string | undefined;
+    setHeader(): void { }
+    end(body: string): void {
+        this.body = body;
+    }
+}
+
+const REFRESHED_TOKEN = createAccessToken('refreshed-account');
+
+function createAccessToken(accountId: string): string {
+    const payload = {
+        exp: Math.floor(Date.now() / 1000) + 3600,
+        'https://api.openai.com/auth': { chatgpt_account_id: accountId, chatgpt_plan_type: 'plus' },
+        'https://api.openai.com/profile': { email: 'user@example.com' }
+    };
+    return `header.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`;
+}
+
+function tokenResponse(payload: Record<string, unknown>, status: number = 200): Response {
+    return {
+        ok: status < 400,
+        status,
+        json: async () => payload,
+        text: async () => JSON.stringify(payload)
+    } as Response;
+}
+
+function storedCredentials(expiresAt: number): string {
+    return JSON.stringify({
+        accessToken: 'stored-token',
+        refreshToken: 'stored-refresh-token',
+        expiresAt,
+        accountId: 'account-id',
+        accountLabel: 'user@example.com',
+        planType: 'plus'
+    });
+}
+
+async function expectRejection(promise: Promise<unknown>, message: RegExp): Promise<void> {
+    let error: unknown;
+    try {
+        await promise;
+    } catch (caught) {
+        error = caught;
+    }
+    expect(error).to.be.instanceOf(Error);
+    expect((error as Error).message).to.match(message);
+}
+
+/** Lets all pending microtasks run, so queued key store updates and generation changes are applied. */
+async function flush(): Promise<void> {
+    await new Promise(resolve => setImmediate(resolve));
+}
+
+async function waitFor(condition: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 100 && !condition(); attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+}
+
+describe('ChatGptAuthServiceImpl', () => {
+
+    let authService: TestAuthService;
+    let getPasswordStub: sinon.SinonStub;
+    let setPasswordStub: sinon.SinonStub;
+    let deletePasswordStub: sinon.SinonStub;
+    let fetchStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        getPasswordStub = sinon.stub().resolves(undefined);
+        setPasswordStub = sinon.stub().resolves();
+        deletePasswordStub = sinon.stub().resolves(true);
+        const keyStoreService = {
+            setPassword: setPasswordStub as KeyStoreService['setPassword'],
+            getPassword: getPasswordStub as KeyStoreService['getPassword'],
+            deletePassword: deletePasswordStub as KeyStoreService['deletePassword'],
+            findPassword: sinon.stub().resolves(undefined) as KeyStoreService['findPassword'],
+            findCredentials: sinon.stub().resolves([]) as KeyStoreService['findCredentials'],
+            keys: sinon.stub().resolves([]) as KeyStoreService['keys']
+        };
+
+        const container = new Container();
+        container.bind(KeyStoreService).toConstantValue(keyStoreService);
+        container.bind(ILogger).to(MockLogger).inSingletonScope();
+        container.bind(TestAuthService).toSelf().inSingletonScope();
+        authService = container.get(TestAuthService);
+
+        fetchStub = sinon.stub(globalThis, 'fetch');
+    });
+
+    afterEach(async () => {
+        // Abandoned login attempts keep a timer alive.
+        await authService.cancelLogin();
+        sinon.restore();
+    });
+
+    describe('getAuthState', () => {
+        it('reports no session when nothing is stored', async () => {
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('reports the account and plan of the stored session', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 3600_000));
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' });
+        });
+
+        it('reads the session from the ChatGPT key store entry', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 3600_000));
+            await authService.getAuthState();
+            expect(getPasswordStub.firstCall.args).to.deep.equal(['theia-chatgpt', 'default']);
+        });
+
+        it('reports no session when the stored credentials are malformed', async () => {
+            getPasswordStub.resolves('not-json');
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('reports no session for an empty stored object', async () => {
+            getPasswordStub.resolves('{}');
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('reports no session when the stored credentials have no ChatGPT account', async () => {
+            getPasswordStub.resolves(JSON.stringify({ accessToken: 'token', refreshToken: 'refresh', expiresAt: Date.now() + 3600_000 }));
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+            expect(await authService.getCredentials()).to.equal(undefined);
+        });
+
+        it('reports no session for blank stored values, which cannot authenticate a request', async () => {
+            getPasswordStub.resolves(JSON.stringify({ accessToken: 'token', refreshToken: 'refresh', expiresAt: Date.now() + 3600_000, accountId: '   ' }));
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('reports no session for a blank stored access token', async () => {
+            getPasswordStub.resolves(JSON.stringify({ accessToken: '  ', refreshToken: 'refresh', expiresAt: Date.now() + 3600_000, accountId: 'account-id' }));
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+    });
+
+    describe('completeLogin', () => {
+        it('rejects when no sign in is in progress', async () => {
+            await expectRejection(authService.completeLogin('the-code'), /no chatgpt sign in/i);
+        });
+
+        it('exchanges the code, stores the credentials and notifies the clients', async () => {
+            const states: ChatGptAuthState[] = [];
+            authService.addClient({ onAuthStateChanged: state => states.push(state) });
+            fetchStub.resolves(tokenResponse({ access_token: createAccessToken('account-id'), refresh_token: 'refresh-token', expires_in: 3600 }));
+
+            const session = await authService.startLogin();
+            expect(session.callbackListening).to.equal(false);
+            expect(await authService.completeLogin('the-code')).to.equal(true);
+
+            const body = fetchStub.firstCall.args[1].body as URLSearchParams;
+            expect(body.get('grant_type')).to.equal('authorization_code');
+            expect(body.get('code')).to.equal('the-code');
+            expect(body.get('code_verifier')).to.have.length.greaterThan(0);
+            expect(body.get('redirect_uri')).to.equal(CHATGPT_REDIRECT_URI);
+            expect(setPasswordStub.calledOnce).to.equal(true);
+            expect(setPasswordStub.firstCall.args.slice(0, 2)).to.deep.equal(['theia-chatgpt', 'default']);
+            expect(states).to.deep.equal([{ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' }]);
+        });
+
+        it('rejects a redirect URL that belongs to another sign in attempt', async () => {
+            await authService.startLogin();
+            await expectRejection(authService.completeLogin(`${CHATGPT_REDIRECT_URI}?code=the-code&state=other`), /state/);
+            expect(fetchStub.called).to.equal(false);
+        });
+
+        it('accepts the redirect URL of the pending sign in attempt', async () => {
+            fetchStub.resolves(tokenResponse({ access_token: createAccessToken('account-id'), refresh_token: 'refresh-token', expires_in: 3600 }));
+            await authService.startLogin();
+            expect(await authService.completeLogin(`${CHATGPT_REDIRECT_URI}?code=the-code&state=${authService.pendingState}`)).to.equal(true);
+        });
+
+        it('rejects a token response without a ChatGPT account', async () => {
+            fetchStub.resolves(tokenResponse({ access_token: 'not-a-jwt', refresh_token: 'refresh-token', expires_in: 3600 }));
+            await authService.startLogin();
+            await expectRejection(authService.completeLogin('the-code'), /account could not be determined/i);
+            expect(setPasswordStub.called).to.equal(false);
+        });
+
+        it('does not publish a session that could not be persisted', async () => {
+            setPasswordStub.rejects(new Error('key store unavailable'));
+            fetchStub.resolves(tokenResponse({ access_token: createAccessToken('account-id'), refresh_token: 'refresh-token', expires_in: 3600 }));
+
+            await authService.startLogin();
+            await expectRejection(authService.completeLogin('the-code'), /key store unavailable/);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('does not sign in a login attempt that was cancelled while the tokens were requested', async () => {
+            let respond: (response: Response) => void = () => { };
+            fetchStub.returns(new Promise<Response>(resolve => { respond = resolve; }));
+
+            await authService.startLogin();
+            const signingIn = authService.completeLogin('the-code');
+            await waitFor(() => fetchStub.called);
+            await authService.cancelLogin();
+            respond(tokenResponse({ access_token: createAccessToken('account-id'), refresh_token: 'refresh-token', expires_in: 3600 }));
+
+            expect(await signingIn).to.equal(false);
+            expect(setPasswordStub.called).to.equal(false);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('stops notifying a client whose registration was disposed', async () => {
+            const states: ChatGptAuthState[] = [];
+            authService.addClient({ onAuthStateChanged: state => states.push(state) }).dispose();
+            fetchStub.resolves(tokenResponse({ access_token: createAccessToken('account-id'), refresh_token: 'refresh-token', expires_in: 3600 }));
+
+            await authService.startLogin();
+            await authService.completeLogin('the-code');
+            expect(states).to.be.empty;
+        });
+    });
+
+    describe('getCredentials', () => {
+        it('returns undefined when there is no session', async () => {
+            expect(await authService.getCredentials()).to.equal(undefined);
+        });
+
+        it('uses the stored access token while it is valid', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 3600_000));
+            expect(await authService.getCredentials()).to.deep.equal({ accessToken: 'stored-token', accountId: 'account-id' });
+            expect(fetchStub.called).to.equal(false);
+        });
+
+        it('serves callers that arrive while the key store is still being read', async () => {
+            getPasswordStub.callsFake(async () => {
+                await new Promise(resolve => setImmediate(resolve));
+                return storedCredentials(Date.now() + 3600_000);
+            });
+
+            const [first, second] = await Promise.all([authService.getCredentials(), authService.getCredentials()]);
+            expect(first).to.deep.equal({ accessToken: 'stored-token', accountId: 'account-id' });
+            expect(second).to.deep.equal(first);
+            expect(getPasswordStub.calledOnce).to.equal(true);
+        });
+
+        it('refreshes an expiring access token and retains the refresh token when none is rotated in', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ access_token: REFRESHED_TOKEN, expires_in: 3600 }));
+
+            expect(await authService.getCredentials()).to.deep.equal({ accessToken: REFRESHED_TOKEN, accountId: 'refreshed-account' });
+
+            const body = fetchStub.firstCall.args[1].body as URLSearchParams;
+            expect(body.get('grant_type')).to.equal('refresh_token');
+            expect(body.get('refresh_token')).to.equal('stored-refresh-token');
+            expect(JSON.parse(setPasswordStub.firstCall.args[2]).refreshToken).to.equal('stored-refresh-token');
+        });
+
+        it('performs a single token request for concurrent refreshes', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ access_token: REFRESHED_TOKEN, refresh_token: 'rotated', expires_in: 3600 }));
+
+            const [first, second] = await Promise.all([authService.getCredentials(), authService.getCredentials()]);
+            expect(first).to.deep.equal(second);
+            expect(fetchStub.calledOnce).to.equal(true);
+        });
+
+        it('signs out when the refresh token is rejected', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ error: 'invalid_grant' }, 400));
+
+            await expectRejection(authService.getCredentials(), /session has expired/i);
+            expect(deletePasswordStub.calledOnce).to.equal(true);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('signs out when the refresh token is reported as spent under an OpenAI specific code', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ error: 'refresh_token_expired' }, 400));
+
+            await expectRejection(authService.getCredentials(), /session has expired/i);
+            expect(deletePasswordStub.calledOnce).to.equal(true);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('keeps the session when the refresh fails temporarily', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ error: 'server_error' }, 503));
+
+            await expectRejection(authService.getCredentials(), /503/);
+            expect(deletePasswordStub.called).to.equal(false);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' });
+        });
+
+        it('keeps the session when the refresh is rate limited, which does not reject the grant', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ error: 'rate_limit_exceeded' }, 429));
+
+            await expectRejection(authService.getCredentials(), /429/);
+            expect(deletePasswordStub.called).to.equal(false);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' });
+        });
+
+        it('keeps the session when the token endpoint answers without an OAuth error', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves({ ok: false, status: 400, text: async () => '<html>Bad Request</html>' } as Response);
+
+            await expectRejection(authService.getCredentials(), /400/);
+            expect(deletePasswordStub.called).to.equal(false);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' });
+        });
+
+        it('keeps the account of the session when a refreshed token does not restate it', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ access_token: 'not-a-jwt', refresh_token: 'rotated', expires_in: 3600 }));
+
+            expect(await authService.getCredentials()).to.deep.equal({ accessToken: 'not-a-jwt', accountId: 'account-id' });
+            expect(JSON.parse(setPasswordStub.firstCall.args[2])).to.include({ accountId: 'account-id', accountLabel: 'user@example.com', planType: 'plus' });
+        });
+
+        it('discards a refresh that completes after the user signed out', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            let respond: (response: Response) => void = () => { };
+            fetchStub.returns(new Promise<Response>(resolve => { respond = resolve; }));
+
+            const refreshing = authService.getCredentials();
+            await waitFor(() => fetchStub.called);
+            await authService.signOut();
+            respond(tokenResponse({ access_token: REFRESHED_TOKEN, refresh_token: 'rotated', expires_in: 3600 }));
+
+            expect(await refreshing).to.equal(undefined);
+            expect(setPasswordStub.called).to.equal(false);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('does not sign out the session of a new sign in when a stale refresh is rejected', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            const newToken = createAccessToken('new-account');
+            let respond: (response: Response) => void = () => { };
+            fetchStub.returns(new Promise<Response>(resolve => { respond = resolve; }));
+
+            const refreshing = authService.getCredentials();
+            await waitFor(() => fetchStub.called);
+            await authService.signOut();
+
+            fetchStub.resolves(tokenResponse({ access_token: newToken, refresh_token: 'new-refresh', expires_in: 3600 }));
+            await authService.startLogin();
+            expect(await authService.completeLogin('the-code')).to.equal(true);
+
+            respond(tokenResponse({ error: 'invalid_grant' }, 400));
+
+            expect(await refreshing).to.equal(undefined);
+            // Only the explicit sign out removed credentials, the rejected refresh left the new session alone.
+            expect(deletePasswordStub.calledOnce).to.equal(true);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' });
+            expect(await authService.getCredentials()).to.deep.equal({ accessToken: newToken, accountId: 'new-account' });
+        });
+
+        it('does not publish a session whose write outlived the sign out', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ access_token: REFRESHED_TOKEN, refresh_token: 'rotated', expires_in: 3600 }));
+            let completeWrite: () => void = () => { };
+            setPasswordStub.returns(new Promise<void>(resolve => { completeWrite = resolve; }));
+
+            const refreshing = authService.getCredentials();
+            await waitFor(() => setPasswordStub.called);
+            const signingOut = authService.signOut();
+            await flush();
+            completeWrite();
+            await signingOut;
+
+            expect(await refreshing).to.equal(undefined);
+            // The sign out is queued behind the stale write, so it removes what that write left behind.
+            expect(deletePasswordStub.calledOnce).to.equal(true);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('keeps the session of a sign in that happened while a stale write was still pending', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 1000));
+            fetchStub.resolves(tokenResponse({ access_token: REFRESHED_TOKEN, refresh_token: 'rotated', expires_in: 3600 }));
+            let completeStaleWrite: () => void = () => { };
+            setPasswordStub.onFirstCall().returns(new Promise<void>(resolve => { completeStaleWrite = resolve; }));
+            setPasswordStub.onSecondCall().resolves();
+
+            const refreshing = authService.getCredentials();
+            await waitFor(() => setPasswordStub.called);
+            const signingOut = authService.signOut();
+            await flush();
+
+            fetchStub.resolves(tokenResponse({ access_token: createAccessToken('new-account'), refresh_token: 'new-refresh', expires_in: 3600 }));
+            await authService.startLogin();
+            const signingIn = authService.completeLogin('the-code');
+            await flush();
+
+            completeStaleWrite();
+            await Promise.all([refreshing, signingOut, signingIn]);
+
+            expect(await signingIn).to.equal(true);
+            expect(JSON.parse(setPasswordStub.lastCall.args[2]).accountId).to.equal('new-account');
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' });
+        });
+    });
+
+    describe('loopback callback', () => {
+        beforeEach(async () => {
+            await authService.startLogin();
+        });
+
+        it('rejects a request to an unknown route', () => {
+            expect(authService.callCallback(`/elsewhere?code=the-code&state=${authService.pendingState}`).statusCode).to.equal(404);
+            expect(fetchStub.called).to.equal(false);
+        });
+
+        it('rejects a callback of another sign in attempt', () => {
+            expect(authService.callCallback('/auth/callback?code=the-code&state=other').statusCode).to.equal(400);
+            expect(fetchStub.called).to.equal(false);
+        });
+
+        it('rejects a callback without an authorization code', () => {
+            expect(authService.callCallback(`/auth/callback?state=${authService.pendingState}`).statusCode).to.equal(400);
+            expect(fetchStub.called).to.equal(false);
+        });
+
+        it('exchanges the code delivered by the browser', async () => {
+            fetchStub.resolves(tokenResponse({ access_token: createAccessToken('account-id'), refresh_token: 'refresh-token', expires_in: 3600 }));
+
+            expect(authService.callCallback(`/auth/callback?code=the-code&state=${authService.pendingState}`).statusCode).to.equal(200);
+
+            expect(await authService.waitForLogin()).to.equal(true);
+            expect((fetchStub.firstCall.args[1].body as URLSearchParams).get('code')).to.equal('the-code');
+        });
+    });
+
+    describe('signOut', () => {
+        it('deletes the stored credentials and notifies the clients', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 3600_000));
+            const states: ChatGptAuthState[] = [];
+            authService.addClient({ onAuthStateChanged: state => states.push(state) });
+
+            await authService.getAuthState();
+            await authService.signOut();
+
+            expect(deletePasswordStub.calledOnce).to.equal(true);
+            expect(deletePasswordStub.firstCall.args).to.deep.equal(['theia-chatgpt', 'default']);
+            expect(states).to.deep.equal([{ isAuthenticated: false }]);
+            expect(await authService.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+
+        it('abandons a pending sign in', async () => {
+            await authService.startLogin();
+            const pending = authService.waitForLogin();
+            await authService.signOut();
+            expect(await pending).to.equal(false);
+        });
+    });
+
+    describe('createRemoteAuthService', () => {
+        // The RPC proxy invokes `target[method](...args)`, so whatever the target carries is callable by a frontend.
+        function invoke(target: object, method: string, ...args: unknown[]): unknown {
+            const callable = (target as Record<string, unknown>)[method];
+            return typeof callable === 'function' ? (callable as (...parameters: unknown[]) => unknown).apply(target, args) : undefined;
+        }
+
+        it('does not expose the access token to the frontend', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 3600_000));
+            const remote = createRemoteAuthService(authService);
+
+            expect(invoke(remote, 'getCredentials')).to.equal(undefined);
+            expect(await authService.getCredentials()).to.deep.equal({ accessToken: 'stored-token', accountId: 'account-id' });
+        });
+
+        it('serves only the methods of the service interface', () => {
+            const remote = createRemoteAuthService(authService);
+            const served = Object.keys(remote).filter(key => typeof (remote as unknown as Record<string, unknown>)[key] === 'function');
+            // `onAuthStateChanged` is an event the frontend proxy resolves locally, it is never dispatched over RPC.
+            expect(served.sort()).to.deep.equal(
+                ['cancelLogin', 'completeLogin', 'getAuthState', 'onAuthStateChanged', 'signOut', 'startLogin', 'waitForLogin']
+            );
+            expect(invoke(remote, 'addClient', { onAuthStateChanged: () => { } })).to.equal(undefined);
+        });
+
+        it('delegates the served methods to the backend service', async () => {
+            getPasswordStub.resolves(storedCredentials(Date.now() + 3600_000));
+            const remote = createRemoteAuthService(authService);
+
+            expect(await remote.getAuthState()).to.deep.equal({ isAuthenticated: true, accountLabel: 'user@example.com', planType: 'plus' });
+            expect((await remote.startLogin()).authorizationUrl).to.match(/^https:\/\/auth\.openai\.com\/oauth\/authorize\?/);
+            await remote.signOut();
+            expect(deletePasswordStub.calledOnce).to.equal(true);
+            expect(await remote.getAuthState()).to.deep.equal({ isAuthenticated: false });
+        });
+    });
+});

--- a/packages/ai-chatgpt/src/node/chatgpt-auth-service-impl.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-auth-service-impl.ts
@@ -1,0 +1,493 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as http from 'http';
+import { Disposable, Emitter, Event, ILogger } from '@theia/core';
+import { KeyStoreService } from '@theia/core/lib/common/key-store';
+import { Deferred } from '@theia/core/lib/common/promise-util';
+import { createProxyFetch, getProxyUrl } from '@theia/ai-core/lib/node';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import {
+    ChatGptAuthService,
+    ChatGptAuthServiceClient,
+    ChatGptAuthState,
+    ChatGptCredentials,
+    ChatGptLoginSession
+} from '../common';
+import {
+    buildAuthorizationUrl,
+    createLoginState,
+    createPkcePair,
+    decodeChatGptIdentity,
+    parseAuthorizationInput,
+    CHATGPT_CALLBACK_HOST,
+    CHATGPT_CALLBACK_PATH,
+    CHATGPT_CALLBACK_PORT,
+    CHATGPT_CLIENT_ID,
+    CHATGPT_REDIRECT_URI,
+    CHATGPT_TOKEN_URL
+} from './chatgpt-oauth';
+
+const KEYSTORE_SERVICE = 'theia-chatgpt';
+const KEYSTORE_ACCOUNT = 'default';
+/** A login attempt is abandoned when the user does not complete it within this time. */
+const LOGIN_TIMEOUT_MS = 10 * 60 * 1000;
+/** Access tokens are refreshed this long before they actually expire. */
+const TOKEN_REFRESH_MARGIN_MS = 60 * 1000;
+/**
+ * OAuth error codes with which the token endpoint reports a refresh token that can never be used again. Besides
+ * the `invalid_grant` of RFC 6749 section 5.2, OpenAI answers with codes of its own naming the actual reason.
+ */
+const SPENT_REFRESH_TOKEN_ERRORS = new Set([
+    'invalid_grant',
+    'refresh_token_expired',
+    'refresh_token_reused',
+    'refresh_token_invalidated'
+]);
+
+interface StoredCredentials {
+    accessToken: string;
+    refreshToken: string;
+    /** Expiration of the access token in epoch milliseconds. */
+    expiresAt: number;
+    /** The ChatGPT account the endpoint attributes the requests to. */
+    accountId: string;
+    accountLabel?: string;
+    planType?: string;
+}
+
+/** The parts of a token response that make up a session. The account is only conveyed by tokens that carry the claim. */
+interface TokenGrant extends Omit<StoredCredentials, 'accountId'> {
+    accountId?: string;
+}
+
+interface PendingLogin {
+    verifier: string;
+    state: string;
+    result: Deferred<boolean>;
+    settled: boolean;
+    server?: http.Server;
+    timeout?: NodeJS.Timeout;
+}
+
+class TokenRequestError extends Error {
+    /** @param oauthError the `error` code of an OAuth 2.0 error response (RFC 6749 section 5.2), if the endpoint sent one. */
+    constructor(message: string, readonly oauthError?: string) {
+        super(message);
+    }
+}
+
+/**
+ * Backend implementation of the "Sign in with ChatGPT" OAuth flow. The browser is sent to the OpenAI authorization
+ * page and returns the authorization code to a loopback listener. If that listener is not reachable, e.g. because
+ * the backend does not run on the user's machine, the code can be handed over manually instead.
+ */
+@injectable()
+export class ChatGptAuthServiceImpl implements ChatGptAuthService {
+
+    @inject(KeyStoreService)
+    protected readonly keyStoreService: KeyStoreService;
+
+    @inject(ILogger) @named('ai-chatgpt:ChatGptAuthServiceImpl')
+    protected readonly logger: ILogger;
+
+    protected readonly clients = new Set<ChatGptAuthServiceClient>();
+    protected pendingLogin: PendingLogin | undefined;
+    protected credentials: StoredCredentials | undefined;
+    protected credentialsLoaded = false;
+    protected credentialsLoading: Promise<StoredCredentials | undefined> | undefined;
+    protected refreshInProgress: Promise<ChatGptCredentials | undefined> | undefined;
+    /** Incremented whenever the credentials are invalidated, so results of requests started before that are discarded. */
+    protected credentialsGeneration = 0;
+    /** Serializes the key store updates, so a slow update cannot be applied on top of a later one. */
+    protected keyStoreUpdates: Promise<unknown> = Promise.resolve();
+
+    protected readonly onAuthStateChangedEmitter = new Emitter<ChatGptAuthState>();
+    readonly onAuthStateChanged: Event<ChatGptAuthState> = this.onAuthStateChangedEmitter.event;
+
+    /**
+     * Registers the client of a frontend connection. The credentials are shared by all frontends of this backend,
+     * hence this is not part of the service interface.
+     */
+    addClient(client: ChatGptAuthServiceClient): Disposable {
+        this.clients.add(client);
+        return Disposable.create(() => this.clients.delete(client));
+    }
+
+    async startLogin(): Promise<ChatGptLoginSession> {
+        await this.cancelLogin();
+        const { verifier, challenge } = createPkcePair();
+        const state = createLoginState();
+        const pending: PendingLogin = { verifier, state, result: new Deferred<boolean>(), settled: false };
+        // The result is only awaited when the browser callback is used, so failures must not surface as unhandled rejections.
+        pending.result.promise.catch(() => undefined);
+        this.pendingLogin = pending;
+        pending.server = await this.startCallbackServer(pending);
+        pending.timeout = setTimeout(() => this.settleLogin(pending, false), LOGIN_TIMEOUT_MS);
+        return {
+            authorizationUrl: buildAuthorizationUrl(challenge, state),
+            callbackListening: pending.server !== undefined
+        };
+    }
+
+    waitForLogin(): Promise<boolean> {
+        if (!this.pendingLogin) {
+            return Promise.resolve(false);
+        }
+        return this.pendingLogin.result.promise;
+    }
+
+    async completeLogin(codeOrRedirectUrl: string): Promise<boolean> {
+        const pending = this.pendingLogin;
+        if (!pending) {
+            throw new Error('No ChatGPT sign in is in progress.');
+        }
+        return this.exchangeCode(pending, parseAuthorizationInput(codeOrRedirectUrl, pending.state));
+    }
+
+    async cancelLogin(): Promise<void> {
+        if (this.pendingLogin) {
+            this.settleLogin(this.pendingLogin, false);
+        }
+    }
+
+    async getAuthState(): Promise<ChatGptAuthState> {
+        return this.toAuthState(await this.readCredentials());
+    }
+
+    /**
+     * Returns valid credentials for the ChatGPT endpoint, refreshing the access token when it is about to expire.
+     * Backend only: the tokens must not leave the backend, which is what {@link createRemoteAuthService} enforces.
+     */
+    async getCredentials(): Promise<ChatGptCredentials | undefined> {
+        const stored = await this.readCredentials();
+        if (!stored) {
+            return undefined;
+        }
+        if (stored.expiresAt - Date.now() > TOKEN_REFRESH_MARGIN_MS) {
+            return { accessToken: stored.accessToken, accountId: stored.accountId };
+        }
+        return this.refreshCredentials(stored);
+    }
+
+    async signOut(): Promise<void> {
+        await this.cancelLogin();
+        this.credentialsGeneration++;
+        this.credentials = undefined;
+        this.credentialsLoaded = true;
+        await this.enqueueKeyStoreUpdate(async () => {
+            try {
+                await this.keyStoreService.deletePassword(KEYSTORE_SERVICE, KEYSTORE_ACCOUNT);
+            } catch (error) {
+                this.logger.warn('Failed to delete the stored ChatGPT credentials:', error);
+            }
+        });
+        this.notifyAuthStateChanged();
+    }
+
+    protected enqueueKeyStoreUpdate<T>(update: () => Promise<T>): Promise<T> {
+        const result = this.keyStoreUpdates.then(update, update);
+        this.keyStoreUpdates = result.catch(() => undefined);
+        return result;
+    }
+
+    protected async startCallbackServer(pending: PendingLogin): Promise<http.Server | undefined> {
+        const server = http.createServer((request, response) => this.handleCallbackRequest(pending, request, response));
+
+        return new Promise<http.Server | undefined>(resolve => {
+            server.once('error', error => {
+                this.logger.info(`Could not listen on ${CHATGPT_REDIRECT_URI}, the authorization code has to be provided manually: ${error.message}`);
+                resolve(undefined);
+            });
+            server.listen(CHATGPT_CALLBACK_PORT, CHATGPT_CALLBACK_HOST, () => resolve(server));
+        });
+    }
+
+    protected handleCallbackRequest(pending: PendingLogin, request: http.IncomingMessage, response: http.ServerResponse): void {
+        const url = new URL(request.url ?? '', `http://${CHATGPT_CALLBACK_HOST}`);
+        if (url.pathname !== CHATGPT_CALLBACK_PATH) {
+            this.respond(response, 404, 'Unknown callback route.');
+            return;
+        }
+        if (url.searchParams.get('state') !== pending.state) {
+            this.respond(response, 400, 'The sign in could not be verified. Please start the sign in again from Theia.');
+            return;
+        }
+        const code = url.searchParams.get('code');
+        if (!code) {
+            this.respond(response, 400, 'The authorization code is missing. Please start the sign in again from Theia.');
+            return;
+        }
+        this.respond(response, 200, 'Sign in complete. You can close this tab and return to Theia.');
+        this.exchangeCode(pending, code).catch(error => this.logger.error('Failed to complete the ChatGPT sign in:', error));
+    }
+
+    /** The messages are application constants, so they need no escaping. */
+    protected respond(response: http.ServerResponse, statusCode: number, message: string): void {
+        response.statusCode = statusCode;
+        response.setHeader('Connection', 'close');
+        response.setHeader('Content-Type', 'text/html; charset=utf-8');
+        response.end(`<!DOCTYPE html><html><head><title>Theia</title></head><body><p>${message}</p></body></html>`);
+    }
+
+    protected async exchangeCode(pending: PendingLogin, code: string): Promise<boolean> {
+        if (pending.settled) {
+            return false;
+        }
+        const generation = this.credentialsGeneration;
+        try {
+            const grant = await this.requestTokens(new URLSearchParams({
+                grant_type: 'authorization_code',
+                client_id: CHATGPT_CLIENT_ID,
+                code,
+                code_verifier: pending.verifier,
+                redirect_uri: CHATGPT_REDIRECT_URI
+            }));
+            if (!grant.accountId) {
+                throw new Error('The ChatGPT account could not be determined from the token. Please try again.');
+            }
+            // The attempt may have been cancelled or replaced by a newer one while the tokens were being requested.
+            if (pending.settled || generation !== this.credentialsGeneration) {
+                return false;
+            }
+            const signedIn = await this.storeCredentials({ ...grant, accountId: grant.accountId });
+            this.settleLogin(pending, signedIn);
+            return signedIn;
+        } catch (error) {
+            this.settleLogin(pending, error instanceof Error ? error : new Error(String(error)));
+            throw error;
+        }
+    }
+
+    protected settleLogin(pending: PendingLogin, result: boolean | Error): void {
+        if (pending.settled) {
+            return;
+        }
+        pending.settled = true;
+        if (pending.timeout) {
+            clearTimeout(pending.timeout);
+        }
+        if (pending.server) {
+            pending.server.close();
+            pending.server.closeAllConnections();
+        }
+        if (this.pendingLogin === pending) {
+            this.pendingLogin = undefined;
+        }
+        if (result instanceof Error) {
+            pending.result.reject(result);
+        } else {
+            pending.result.resolve(result);
+        }
+    }
+
+    protected async refreshCredentials(stored: StoredCredentials): Promise<ChatGptCredentials | undefined> {
+        if (!this.refreshInProgress) {
+            this.refreshInProgress = this.doRefreshCredentials(stored).finally(() => this.refreshInProgress = undefined);
+        }
+        return this.refreshInProgress;
+    }
+
+    protected async doRefreshCredentials(stored: StoredCredentials): Promise<ChatGptCredentials | undefined> {
+        const generation = this.credentialsGeneration;
+        try {
+            const grant = await this.requestTokens(new URLSearchParams({
+                grant_type: 'refresh_token',
+                client_id: CHATGPT_CLIENT_ID,
+                refresh_token: stored.refreshToken
+            }));
+            if (generation !== this.credentialsGeneration) {
+                return undefined;
+            }
+            // The account, its label and its plan describe the session rather than the individual token, so they are
+            // carried over when a refreshed token does not restate them.
+            const credentials: StoredCredentials = {
+                ...grant,
+                refreshToken: grant.refreshToken || stored.refreshToken,
+                accountId: grant.accountId ?? stored.accountId,
+                accountLabel: grant.accountLabel ?? stored.accountLabel,
+                planType: grant.planType ?? stored.planType
+            };
+            if (!await this.storeCredentials(credentials)) {
+                return undefined;
+            }
+            return { accessToken: credentials.accessToken, accountId: credentials.accountId };
+        } catch (error) {
+            // Only a rejected grant proves that the session is gone. Other failures, e.g. rate limiting or a server
+            // error, must not cost the user their credentials.
+            if (error instanceof TokenRequestError && error.oauthError !== undefined && SPENT_REFRESH_TOKEN_ERRORS.has(error.oauthError)) {
+                // The rejection concerns the session this refresh started with. If that session has since been
+                // replaced, signing out would discard the credentials of whoever is signed in now.
+                if (generation !== this.credentialsGeneration) {
+                    return undefined;
+                }
+                this.logger.info('The stored ChatGPT credentials are no longer valid, signing out.');
+                await this.signOut();
+                throw new Error('The ChatGPT session has expired. Please sign in with ChatGPT again.');
+            }
+            throw error;
+        }
+    }
+
+    protected async requestTokens(body: URLSearchParams): Promise<TokenGrant> {
+        const proxyFetch = createProxyFetch(getProxyUrl(CHATGPT_TOKEN_URL)) ?? fetch;
+        const response = await proxyFetch(CHATGPT_TOKEN_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+            body
+        });
+        if (!response.ok) {
+            const errorBody = await response.text();
+            throw new TokenRequestError(`The OpenAI token request failed with status ${response.status}: ${errorBody}`, parseOAuthError(errorBody));
+        }
+        const payload = await response.json() as { access_token?: string, refresh_token?: string, expires_in?: number };
+        if (!payload.access_token) {
+            throw new TokenRequestError('The OpenAI token response did not contain an access token.');
+        }
+        const identity = decodeChatGptIdentity(payload.access_token);
+        const expiresIn = typeof payload.expires_in === 'number' ? Date.now() + payload.expires_in * 1000 : undefined;
+        return {
+            accessToken: payload.access_token,
+            refreshToken: payload.refresh_token ?? '',
+            expiresAt: expiresIn ?? identity.expiresAt ?? Date.now(),
+            accountId: identity.accountId,
+            accountLabel: identity.email,
+            planType: identity.planType
+        };
+    }
+
+    protected async readCredentials(): Promise<StoredCredentials | undefined> {
+        if (this.credentialsLoaded) {
+            return this.credentials;
+        }
+        // Callers arriving while the key store is being read have to see the loaded credentials, not the empty cache.
+        if (!this.credentialsLoading) {
+            this.credentialsLoading = this.loadCredentials().finally(() => this.credentialsLoading = undefined);
+        }
+        return this.credentialsLoading;
+    }
+
+    protected async loadCredentials(): Promise<StoredCredentials | undefined> {
+        const generation = this.credentialsGeneration;
+        let loaded: StoredCredentials | undefined;
+        try {
+            const stored = await this.keyStoreService.getPassword(KEYSTORE_SERVICE, KEYSTORE_ACCOUNT);
+            if (stored) {
+                loaded = this.toStoredCredentials(stored);
+                if (!loaded) {
+                    this.logger.warn('Ignoring the stored ChatGPT credentials because they are not a usable session.');
+                }
+            }
+        } catch (error) {
+            this.logger.warn('Failed to read the stored ChatGPT credentials:', error);
+        }
+        if (generation !== this.credentialsGeneration) {
+            return this.credentials;
+        }
+        this.credentials = loaded;
+        this.credentialsLoaded = true;
+        return this.credentials;
+    }
+
+    /** Parses a stored session, rejecting anything that could not be used to authenticate a request. */
+    protected toStoredCredentials(stored: string): StoredCredentials | undefined {
+        let parsed: Partial<StoredCredentials> | undefined;
+        try {
+            parsed = JSON.parse(stored) as Partial<StoredCredentials>;
+        } catch {
+            return undefined;
+        }
+        const accessToken = nonBlank(parsed?.accessToken);
+        const accountId = nonBlank(parsed?.accountId);
+        const refreshToken = parsed?.refreshToken;
+        const expiresAt = parsed?.expiresAt;
+        if (!accessToken || !accountId || typeof refreshToken !== 'string' || typeof expiresAt !== 'number') {
+            return undefined;
+        }
+        return {
+            accessToken,
+            refreshToken,
+            expiresAt,
+            accountId,
+            accountLabel: nonBlank(parsed?.accountLabel),
+            planType: nonBlank(parsed?.planType)
+        };
+    }
+
+    /**
+     * Persists the session before publishing it, so a failed write cannot leave the backend reporting a session that
+     * is not stored. Returns `false` if the session was ended while it was being obtained or written, in which case
+     * the sign out queued behind this update removes what was written.
+     */
+    protected async storeCredentials(credentials: StoredCredentials): Promise<boolean> {
+        const generation = this.credentialsGeneration;
+        return this.enqueueKeyStoreUpdate(async () => {
+            if (generation !== this.credentialsGeneration) {
+                return false;
+            }
+            await this.keyStoreService.setPassword(KEYSTORE_SERVICE, KEYSTORE_ACCOUNT, JSON.stringify(credentials));
+            if (generation !== this.credentialsGeneration) {
+                return false;
+            }
+            this.credentials = credentials;
+            this.credentialsLoaded = true;
+            this.notifyAuthStateChanged();
+            return true;
+        });
+    }
+
+    protected notifyAuthStateChanged(): void {
+        const state = this.toAuthState(this.credentials);
+        this.onAuthStateChangedEmitter.fire(state);
+        this.clients.forEach(client => client.onAuthStateChanged(state));
+    }
+
+    protected toAuthState(credentials: StoredCredentials | undefined): ChatGptAuthState {
+        return credentials
+            ? { isAuthenticated: true, accountLabel: credentials.accountLabel, planType: credentials.planType }
+            : { isAuthenticated: false };
+    }
+}
+
+/**
+ * Narrows the service down to what a frontend may invoke. The RPC proxy dispatches requests by method name on the
+ * object it serves, so handing out the service itself would let any client of the connection call
+ * {@link ChatGptAuthServiceImpl.getCredentials} and read the access token of the signed in account.
+ */
+export function createRemoteAuthService(service: ChatGptAuthServiceImpl): ChatGptAuthService {
+    return {
+        startLogin: () => service.startLogin(),
+        waitForLogin: () => service.waitForLogin(),
+        completeLogin: codeOrRedirectUrl => service.completeLogin(codeOrRedirectUrl),
+        cancelLogin: () => service.cancelLogin(),
+        getAuthState: () => service.getAuthState(),
+        signOut: () => service.signOut(),
+        onAuthStateChanged: service.onAuthStateChanged
+    };
+}
+
+function nonBlank(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+function parseOAuthError(errorBody: string): string | undefined {
+    try {
+        const parsed = JSON.parse(errorBody) as { error?: unknown };
+        return typeof parsed.error === 'string' ? parsed.error : undefined;
+    } catch {
+        return undefined;
+    }
+}

--- a/packages/ai-chatgpt/src/node/chatgpt-backend-module.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-backend-module.ts
@@ -1,0 +1,60 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ConnectionHandler, PreferenceContribution, RpcConnectionHandler } from '@theia/core';
+import { ConnectionContainerModule } from '@theia/core/lib/node/messaging/connection-container-module';
+import { ContainerModule } from '@theia/core/shared/inversify';
+import {
+    CHATGPT_AUTH_SERVICE_PATH,
+    CHATGPT_LANGUAGE_MODELS_MANAGER_PATH,
+    ChatGptAuthService,
+    ChatGptAuthServiceClient,
+    ChatGptLanguageModelsManager,
+    ChatGptPreferencesSchema
+} from '../common';
+import { ChatGptAuthServiceImpl, createRemoteAuthService } from './chatgpt-auth-service-impl';
+import { ChatGptLanguageModelsManagerImpl } from './chatgpt-language-models-manager-impl';
+import { ChatGptModelCatalog } from './chatgpt-model-catalog';
+import { ChatGptResponseApiUtils } from './chatgpt-response-api-utils';
+
+// The language model registry is scoped to a frontend connection, hence so is the manager driving it.
+const chatGptConnectionModule = ConnectionContainerModule.create(({ bind }) => {
+    bind(ChatGptLanguageModelsManagerImpl).toSelf().inSingletonScope();
+    bind(ChatGptLanguageModelsManager).toService(ChatGptLanguageModelsManagerImpl);
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler(CHATGPT_LANGUAGE_MODELS_MANAGER_PATH, () => ctx.container.get(ChatGptLanguageModelsManager))
+    ).inSingletonScope();
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler<ChatGptAuthServiceClient>(CHATGPT_AUTH_SERVICE_PATH, client => {
+            // The service is owned by the backend container because all frontends share the same stored credentials.
+            const authService = ctx.container.get<ChatGptAuthServiceImpl>(ChatGptAuthServiceImpl);
+            const registration = authService.addClient(client);
+            client.onDidCloseConnection(() => registration.dispose());
+            return createRemoteAuthService(authService);
+        })
+    ).inSingletonScope();
+});
+
+export default new ContainerModule(bind => {
+    bind(PreferenceContribution).toConstantValue({ schema: ChatGptPreferencesSchema });
+    bind(ChatGptAuthServiceImpl).toSelf().inSingletonScope();
+    bind(ChatGptAuthService).toService(ChatGptAuthServiceImpl);
+    // Owned by the backend container as well, so all frontends share one listing of the account's models.
+    bind(ChatGptModelCatalog).toSelf().inSingletonScope();
+    // Bound under its own symbol so that the OpenAI models keep using the unmodified `OpenAiResponseApiUtils`.
+    bind(ChatGptResponseApiUtils).toSelf().inSingletonScope();
+    bind(ConnectionContainerModule).toConstantValue(chatGptConnectionModule);
+});

--- a/packages/ai-chatgpt/src/node/chatgpt-language-model.spec.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-language-model.spec.ts
@@ -1,0 +1,185 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { LanguageModelMessage, LanguageModelResponse, ReasoningSupport, UserRequest } from '@theia/ai-core';
+import { OpenAiModelUtils } from '@theia/ai-openai/lib/node/openai-language-model';
+import { OPENAI_WEB_SEARCH } from '@theia/ai-openai/lib/node/openai-server-tools';
+import { OpenAI } from 'openai';
+import { CHATGPT_RESPONSES_BASE_URL, ChatGptCredentials } from '../common';
+import { CHATGPT_ORIGINATOR } from './chatgpt-oauth';
+import { ChatGptModel } from './chatgpt-language-model';
+import { ChatGptResponseApiUtils, DEFAULT_CHATGPT_INSTRUCTIONS } from './chatgpt-response-api-utils';
+
+interface CapturedRequest {
+    openai: OpenAI;
+    settings: Record<string, unknown>;
+    model: string;
+    developerMessageSettings: string;
+    modelId: string;
+    isStreaming: boolean;
+}
+
+class CapturingResponseApiUtils extends ChatGptResponseApiUtils {
+    captured: CapturedRequest | undefined;
+
+    override async handleRequest(
+        openai: OpenAI,
+        request: UserRequest,
+        settings: Record<string, unknown>,
+        model: string,
+        modelUtils: OpenAiModelUtils,
+        developerMessageSettings: Parameters<ChatGptResponseApiUtils['handleRequest']>[5],
+        runnerOptions: Parameters<ChatGptResponseApiUtils['handleRequest']>[6],
+        modelId: string,
+        isStreaming: boolean
+    ): Promise<LanguageModelResponse> {
+        this.captured = { openai, settings, model, developerMessageSettings, modelId, isStreaming };
+        return { text: '' };
+    }
+}
+
+const CREDENTIALS: ChatGptCredentials = { accessToken: 'access-token', accountId: 'account-id' };
+
+const GPT5_REASONING_SUPPORT: ReasoningSupport = {
+    supportedLevels: ['off', 'minimal', 'low', 'medium', 'high', 'auto'],
+    defaultLevel: 'auto'
+};
+
+function createModel(
+    credentials: () => Promise<ChatGptCredentials | undefined> = async () => CREDENTIALS,
+    reasoningSupport?: ReasoningSupport
+): { model: ChatGptModel, utils: CapturingResponseApiUtils } {
+    const utils = new CapturingResponseApiUtils();
+    const model = new ChatGptModel(
+        'chatgpt/gpt-5.5', 'gpt-5.5', { status: 'ready' }, credentials, utils, new OpenAiModelUtils(), 3, undefined, reasoningSupport
+    );
+    return { model, utils };
+}
+
+function createRequest(settings?: Record<string, unknown>, messages: LanguageModelMessage[] = []): UserRequest {
+    return { messages, settings, sessionId: 'session', requestId: 'request' };
+}
+
+function defaultHeadersOf(openai: OpenAI): Record<string, string> {
+    return (openai as unknown as { _options: { defaultHeaders: Record<string, string> } })._options.defaultHeaders;
+}
+
+describe('ChatGptModel', () => {
+
+    it('rejects the request when the user is not signed in', async () => {
+        const { model } = createModel(async () => undefined);
+        let error: unknown;
+        try {
+            await model.request(createRequest());
+        } catch (caught) {
+            error = caught;
+        }
+        expect(error).to.be.instanceOf(Error);
+        expect((error as Error).message).to.match(/not signed in with chatgpt/i);
+    });
+
+    it('always requests an unstored, streamed response through the Response API', async () => {
+        const { model, utils } = createModel();
+        await model.request(createRequest());
+
+        expect(utils.captured!.settings.store).to.equal(false);
+        expect(utils.captured!.settings.stream).to.equal(true);
+        expect(utils.captured!.isStreaming).to.equal(true);
+        expect(utils.captured!.model).to.equal('gpt-5.5');
+        expect(utils.captured!.modelId).to.equal('chatgpt/gpt-5.5');
+    });
+
+    it('keeps the system messages available as instructions', async () => {
+        const { model, utils } = createModel();
+        await model.request(createRequest());
+        expect(utils.captured!.developerMessageSettings).to.equal('developer');
+    });
+
+    it('does not let request settings opt out of the endpoint invariants', async () => {
+        const { model, utils } = createModel();
+        await model.request(createRequest({ store: true, stream: false, temperature: 0.5 }));
+
+        expect(utils.captured!.settings.store).to.equal(false);
+        expect(utils.captured!.settings.stream).to.equal(true);
+        expect(utils.captured!.settings.temperature).to.equal(0.5);
+    });
+
+    it('translates the reasoning level for models that support reasoning', async () => {
+        const { model, utils } = createModel(async () => CREDENTIALS, GPT5_REASONING_SUPPORT);
+        await model.request({ ...createRequest(), reasoning: { level: 'high' } });
+        expect(utils.captured!.settings.reasoning).to.deep.equal({ effort: 'high' });
+    });
+
+    it('omits reasoning for models without reasoning support', async () => {
+        const { model, utils } = createModel();
+        await model.request({ ...createRequest(), reasoning: { level: 'high' } });
+        expect(utils.captured!.settings.reasoning).to.equal(undefined);
+    });
+
+    it('talks to the ChatGPT endpoint on behalf of the signed in account', async () => {
+        const { model, utils } = createModel();
+        await model.request(createRequest());
+
+        const openai = utils.captured!.openai;
+        expect(openai.baseURL).to.equal(CHATGPT_RESPONSES_BASE_URL);
+        const headers = defaultHeadersOf(openai);
+        expect(headers['chatgpt-account-id']).to.equal('account-id');
+        expect(headers['OpenAI-Beta']).to.equal('responses=experimental');
+        expect(headers.originator).to.equal(CHATGPT_ORIGINATOR);
+        expect(headers.session_id).to.have.length.greaterThan(0);
+    });
+
+    it('offers the server-side web search of the endpoint', () => {
+        const { model } = createModel();
+        expect(model.serverTools.map(tool => tool.id)).to.include(OPENAI_WEB_SEARCH);
+    });
+
+    it('resolves the access token per request, so a refreshed token is picked up', async () => {
+        const tokens = ['first-token', 'second-token'];
+        const { model, utils } = createModel(async () => ({ accessToken: tokens.shift() ?? 'exhausted', accountId: 'account-id' }));
+        await model.request(createRequest());
+
+        const apiKey = (utils.captured!.openai as unknown as { _options: { apiKey: () => Promise<string> } })._options.apiKey;
+        expect(await apiKey()).to.equal('second-token');
+    });
+});
+
+describe('ChatGptResponseApiUtils', () => {
+
+    const utils = new ChatGptResponseApiUtils();
+
+    it('substitutes default instructions when the request carries no system message', () => {
+        const result = utils.processMessages([{ actor: 'user', type: 'text', text: 'Hello' }], 'developer', 'gpt-5.5');
+        expect(result.instructions).to.equal(DEFAULT_CHATGPT_INSTRUCTIONS);
+    });
+
+    it('substitutes default instructions when the system message is blank', () => {
+        const result = utils.processMessages([{ actor: 'system', type: 'text', text: '   ' }], 'developer', 'gpt-5.5');
+        expect(result.instructions).to.equal(DEFAULT_CHATGPT_INSTRUCTIONS);
+    });
+
+    it('turns the system messages into instructions and keeps them out of the input', () => {
+        const result = utils.processMessages([
+            { actor: 'system', type: 'text', text: 'Be terse.' },
+            { actor: 'user', type: 'text', text: 'Hello' }
+        ], 'developer', 'gpt-5.5');
+
+        expect(result.instructions).to.equal('Be terse.');
+        expect(result.input).to.have.lengthOf(1);
+        expect(result.input.every(item => !('role' in item) || item.role !== 'system')).to.equal(true);
+    });
+});

--- a/packages/ai-chatgpt/src/node/chatgpt-language-model.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-language-model.ts
@@ -1,0 +1,111 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LanguageModel, LanguageModelResponse, LanguageModelStatus, ReasoningSupport, UserRequest } from '@theia/ai-core';
+import { createProxyFetch } from '@theia/ai-core/lib/node';
+import { CancellationToken, generateUuid } from '@theia/core';
+import { OpenAiModelUtils } from '@theia/ai-openai/lib/node/openai-language-model';
+import { openAiReasoningFor } from '@theia/ai-openai/lib/node/openai-reasoning';
+import { OPENAI_SERVER_TOOLS } from '@theia/ai-openai/lib/node/openai-server-tools';
+import { OpenAI } from 'openai';
+import type { RunnerOptions } from 'openai/lib/AbstractChatCompletionRunner';
+import { CHATGPT_RESPONSES_BASE_URL, ChatGptCredentials } from '../common';
+import { CHATGPT_ORIGINATOR } from './chatgpt-oauth';
+import { ChatGptResponseApiUtils } from './chatgpt-response-api-utils';
+
+/**
+ * A model served by the ChatGPT subscription of the signed in user. The endpoint only implements the streaming
+ * Response API, so unlike the plain OpenAI model there is no Chat Completions path and no fallback to one.
+ */
+export class ChatGptModel implements LanguageModel {
+
+    readonly vendor = 'chatgpt';
+
+    /**
+     * The endpoint serves Codex, which offers the same server-side web search, so it is offered for every model
+     * rather than derived from the endpoint the way the plain OpenAI model does.
+     */
+    readonly serverTools = OPENAI_SERVER_TOOLS;
+
+    /** Mirrors the OpenAI model: each tool call counts as a completion, so the limit has to accommodate long tool chains. */
+    protected readonly runnerOptions: RunnerOptions = {
+        maxChatCompletions: 100
+    };
+
+    /**
+     * @param id the unique id for this language model. It will be used to identify the model in the UI.
+     * @param model the model id as it is used by the ChatGPT endpoint
+     * @param credentials returns the credentials of the signed in user, refreshing the access token when needed
+     * @param maxRetries the maximum number of retry attempts when a request fails
+     */
+    constructor(
+        public readonly id: string,
+        public model: string,
+        public status: LanguageModelStatus,
+        public credentials: () => Promise<ChatGptCredentials | undefined>,
+        public responseApiUtils: ChatGptResponseApiUtils,
+        public modelUtils: OpenAiModelUtils,
+        public maxRetries: number = 3,
+        public proxy?: string,
+        public reasoningSupport?: ReasoningSupport,
+        public maxInputTokens?: number
+    ) { }
+
+    async request(request: UserRequest, cancellationToken?: CancellationToken): Promise<LanguageModelResponse> {
+        const openai = await this.initializeOpenAi();
+        const settings = {
+            ...request.settings,
+            ...openAiReasoningFor(request.reasoning?.level, true, !!this.reasoningSupport),
+            // The endpoint rejects anything else with 400 'Store must be set to false' / 'Stream must be set to true'.
+            store: false,
+            stream: true
+        };
+        return this.responseApiUtils.handleRequest(
+            openai,
+            request,
+            settings,
+            this.model,
+            this.modelUtils,
+            // System messages have to become the top level `instructions`, which only this setting preserves them for.
+            'developer',
+            this.runnerOptions,
+            this.id,
+            true,
+            cancellationToken
+        );
+    }
+
+    protected async initializeOpenAi(): Promise<OpenAI> {
+        const credentials = await this.credentials();
+        if (!credentials) {
+            throw new Error('Not signed in with ChatGPT. Use the "ChatGPT: Sign in" command to use your ChatGPT subscription.');
+        }
+        return new OpenAI({
+            // The function form is invoked before each request, including the SDK's own retries, so an access token
+            // that expires mid-conversation is refreshed transparently.
+            apiKey: async () => (await this.credentials())?.accessToken ?? '',
+            baseURL: CHATGPT_RESPONSES_BASE_URL,
+            maxRetries: this.maxRetries,
+            fetch: createProxyFetch(this.proxy),
+            defaultHeaders: {
+                'chatgpt-account-id': credentials.accountId,
+                'OpenAI-Beta': 'responses=experimental',
+                originator: CHATGPT_ORIGINATOR,
+                session_id: generateUuid()
+            }
+        });
+    }
+}

--- a/packages/ai-chatgpt/src/node/chatgpt-language-models-manager-impl.spec.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-language-models-manager-impl.spec.ts
@@ -1,0 +1,166 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Emitter, Event } from '@theia/core';
+import { Container } from '@theia/core/shared/inversify';
+import { LanguageModel, LanguageModelRegistry, LanguageModelSelector } from '@theia/ai-core';
+import { OpenAiModelUtils } from '@theia/ai-openai/lib/node/openai-language-model';
+import { ChatGptAuthState } from '../common';
+import { ChatGptAuthServiceImpl } from './chatgpt-auth-service-impl';
+import { ChatGptModel } from './chatgpt-language-model';
+import { ChatGptLanguageModelsManagerImpl } from './chatgpt-language-models-manager-impl';
+import { ChatGptModelCatalog } from './chatgpt-model-catalog';
+import { ChatGptResponseApiUtils } from './chatgpt-response-api-utils';
+
+class FakeLanguageModelRegistry implements LanguageModelRegistry {
+    readonly models = new Map<string, LanguageModel>();
+    readonly patches: { id: string, patch: Partial<LanguageModel> }[] = [];
+    readonly removed: string[][] = [];
+
+    protected readonly emitter = new Emitter<{ models: LanguageModel[] }>();
+    readonly onChange: Event<{ models: LanguageModel[] }> = this.emitter.event;
+
+    addLanguageModels(models: LanguageModel[]): void {
+        models.forEach(model => this.models.set(model.id, model));
+    }
+    async getLanguageModels(): Promise<LanguageModel[]> {
+        return [...this.models.values()];
+    }
+    async getLanguageModel(id: string): Promise<LanguageModel | undefined> {
+        return this.models.get(id);
+    }
+    removeLanguageModels(ids: string[]): void {
+        this.removed.push(ids);
+        ids.forEach(id => this.models.delete(id));
+    }
+    async selectLanguageModel(request: LanguageModelSelector): Promise<LanguageModel | undefined> {
+        return undefined;
+    }
+    async selectLanguageModels(request: LanguageModelSelector): Promise<LanguageModel[] | undefined> {
+        return undefined;
+    }
+    async patchLanguageModel<T extends LanguageModel = LanguageModel>(id: string, patch: Partial<T>): Promise<void> {
+        this.patches.push({ id, patch });
+        Object.assign(this.models.get(id)!, patch);
+    }
+}
+
+const UNAVAILABLE = { status: 'unavailable', message: 'Not signed in with ChatGPT' };
+
+describe('ChatGptLanguageModelsManagerImpl', () => {
+
+    let manager: ChatGptLanguageModelsManagerImpl;
+    let registry: FakeLanguageModelRegistry;
+    let authState: ChatGptAuthState;
+
+    beforeEach(() => {
+        registry = new FakeLanguageModelRegistry();
+        authState = { isAuthenticated: false };
+
+        const container = new Container();
+        container.bind(LanguageModelRegistry).toConstantValue(registry);
+        container.bind(ChatGptAuthServiceImpl).toConstantValue({
+            getAuthState: async () => authState,
+            getCredentials: async () => ({ accessToken: 'token', accountId: 'account-id' })
+        } as unknown as ChatGptAuthServiceImpl);
+        container.bind(ChatGptResponseApiUtils).toSelf().inSingletonScope();
+        container.bind(OpenAiModelUtils).toSelf().inSingletonScope();
+        container.bind(ChatGptModelCatalog).toConstantValue({
+            getAvailableModels: async () => ['gpt-5.6-sol']
+        } as unknown as ChatGptModelCatalog);
+        container.bind(ChatGptLanguageModelsManagerImpl).toSelf().inSingletonScope();
+        manager = container.get(ChatGptLanguageModelsManagerImpl);
+    });
+
+    it('registers the configured models while nobody is signed in, stating why they are unavailable', async () => {
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        const model = registry.models.get('chatgpt/gpt-5.5') as ChatGptModel;
+        expect(model).to.be.instanceOf(ChatGptModel);
+        expect(model.status).to.deep.equal(UNAVAILABLE);
+        expect(model.vendor).to.equal('chatgpt');
+        expect(model.model).to.equal('gpt-5.5');
+        expect(model.maxRetries).to.equal(3);
+    });
+
+    it('reports the models as ready once the user is signed in', async () => {
+        authState = { isAuthenticated: true, accountLabel: 'user@example.com' };
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        expect((registry.models.get('chatgpt/gpt-5.5') as ChatGptModel).status).to.deep.equal({ status: 'ready' });
+    });
+
+    it('flips the status of the already registered models on sign out instead of removing them', async () => {
+        authState = { isAuthenticated: true };
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        authState = { isAuthenticated: false };
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        expect(registry.models.size).to.equal(1);
+        expect(registry.patches).to.have.lengthOf(1);
+        expect((registry.models.get('chatgpt/gpt-5.5') as ChatGptModel).status).to.deep.equal(UNAVAILABLE);
+    });
+
+    it('patches an already registered model instead of replacing it', async () => {
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+        const registered = registry.models.get('chatgpt/gpt-5.5');
+
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5-pro', maxRetries: 5 });
+
+        expect(registry.models.get('chatgpt/gpt-5.5')).to.equal(registered);
+        expect(registry.patches[0].patch).to.include({ model: 'gpt-5.5-pro', maxRetries: 5 });
+    });
+
+    it('applies the OpenAI capabilities of the model', async () => {
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        const model = registry.models.get('chatgpt/gpt-5.5') as ChatGptModel;
+        expect(model.reasoningSupport).to.not.equal(undefined);
+        expect(model.maxInputTokens).to.be.a('number');
+    });
+
+    it('leaves a model of another provider alone', async () => {
+        const foreign = { id: 'chatgpt/gpt-5.5', vendor: 'openai' } as unknown as LanguageModel;
+        registry.addLanguageModels([foreign]);
+
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        expect(registry.models.get('chatgpt/gpt-5.5')).to.equal(foreign);
+        expect(registry.patches).to.be.empty;
+    });
+
+    it('passes the configured proxy on to the models', async () => {
+        manager.setProxyUrl('http://proxy.example.com:3128');
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        expect((registry.models.get('chatgpt/gpt-5.5') as ChatGptModel).proxy).to.equal('http://proxy.example.com:3128');
+    });
+
+    it('serves the models of the plan to the frontend, which decides what to register', async () => {
+        expect(await manager.getAvailableModels()).to.deep.equal(['gpt-5.6-sol']);
+    });
+
+    it('removes the models it is asked to remove', async () => {
+        await manager.createOrUpdateLanguageModels({ id: 'chatgpt/gpt-5.5', model: 'gpt-5.5', maxRetries: 3 });
+
+        manager.removeLanguageModels('chatgpt/gpt-5.5');
+
+        expect(registry.removed).to.deep.equal([['chatgpt/gpt-5.5']]);
+        expect(registry.models.size).to.equal(0);
+    });
+});

--- a/packages/ai-chatgpt/src/node/chatgpt-language-models-manager-impl.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-language-models-manager-impl.ts
@@ -1,0 +1,105 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LanguageModelRegistry, LanguageModelStatus } from '@theia/ai-core';
+import { getProxyUrl } from '@theia/ai-core/lib/node';
+import { nls } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { OpenAiModelUtils } from '@theia/ai-openai/lib/node/openai-language-model';
+import { getOpenAiModelDefaults } from '@theia/ai-openai/lib/node/openai-model-defaults';
+import { CHATGPT_RESPONSES_BASE_URL, ChatGptLanguageModelsManager, ChatGptModelDescription } from '../common';
+import { ChatGptAuthServiceImpl } from './chatgpt-auth-service-impl';
+import { ChatGptModel } from './chatgpt-language-model';
+import { ChatGptModelCatalog } from './chatgpt-model-catalog';
+import { ChatGptResponseApiUtils } from './chatgpt-response-api-utils';
+
+@injectable()
+export class ChatGptLanguageModelsManagerImpl implements ChatGptLanguageModelsManager {
+
+    @inject(LanguageModelRegistry)
+    protected readonly languageModelRegistry: LanguageModelRegistry;
+
+    @inject(ChatGptAuthServiceImpl)
+    protected readonly authService: ChatGptAuthServiceImpl;
+
+    @inject(ChatGptResponseApiUtils)
+    protected readonly responseApiUtils: ChatGptResponseApiUtils;
+
+    @inject(OpenAiModelUtils)
+    protected readonly modelUtils: OpenAiModelUtils;
+
+    @inject(ChatGptModelCatalog)
+    protected readonly modelCatalog: ChatGptModelCatalog;
+
+    protected proxyUrl: string | undefined;
+
+    setProxyUrl(proxyUrl: string | undefined): void {
+        this.proxyUrl = proxyUrl || undefined;
+    }
+
+    getAvailableModels(): Promise<string[]> {
+        return this.modelCatalog.getAvailableModels();
+    }
+
+    async createOrUpdateLanguageModels(...modelDescriptions: ChatGptModelDescription[]): Promise<void> {
+        const status = await this.calculateStatus();
+        const proxy = getProxyUrl(CHATGPT_RESPONSES_BASE_URL, this.proxyUrl);
+        for (const description of modelDescriptions) {
+            // The ChatGPT plan serves OpenAI models, so their published capabilities apply.
+            const defaults = getOpenAiModelDefaults(description.model);
+            const existing = await this.languageModelRegistry.getLanguageModel(description.id);
+            if (existing) {
+                if (!(existing instanceof ChatGptModel)) {
+                    console.warn(`ChatGPT: model ${description.id} is not a ChatGPT model`);
+                    continue;
+                }
+                await this.languageModelRegistry.patchLanguageModel<ChatGptModel>(description.id, {
+                    model: description.model,
+                    status,
+                    maxRetries: description.maxRetries,
+                    proxy,
+                    reasoningSupport: defaults.reasoningSupport,
+                    maxInputTokens: defaults.contextWindow
+                });
+            } else {
+                this.languageModelRegistry.addLanguageModels([
+                    new ChatGptModel(
+                        description.id,
+                        description.model,
+                        status,
+                        () => this.authService.getCredentials(),
+                        this.responseApiUtils,
+                        this.modelUtils,
+                        description.maxRetries,
+                        proxy,
+                        defaults.reasoningSupport,
+                        defaults.contextWindow
+                    )
+                ]);
+            }
+        }
+    }
+
+    protected async calculateStatus(): Promise<LanguageModelStatus> {
+        return (await this.authService.getAuthState()).isAuthenticated
+            ? { status: 'ready' }
+            : { status: 'unavailable', message: nls.localize('theia/ai/chatgpt/notSignedIn', 'Not signed in with ChatGPT') };
+    }
+
+    removeLanguageModels(...modelIds: string[]): void {
+        this.languageModelRegistry.removeLanguageModels(modelIds);
+    }
+}

--- a/packages/ai-chatgpt/src/node/chatgpt-model-catalog.spec.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-model-catalog.spec.ts
@@ -1,0 +1,189 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { Emitter } from '@theia/core';
+import { ILogger } from '@theia/core/lib/common/logger';
+import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
+import { Container } from '@theia/core/shared/inversify';
+import { CHATGPT_FALLBACK_MODELS, ChatGptAuthState, ChatGptCredentials } from '../common';
+import { ChatGptAuthServiceImpl } from './chatgpt-auth-service-impl';
+import { ChatGptModelCatalog } from './chatgpt-model-catalog';
+import { CHATGPT_ORIGINATOR } from './chatgpt-oauth';
+
+function listing(payload: Record<string, unknown>, status: number = 200): Response {
+    return {
+        ok: status < 400,
+        status,
+        json: async () => payload,
+        text: async () => JSON.stringify(payload)
+    } as Response;
+}
+
+const MODELS = {
+    models: [
+        { slug: 'gpt-5.6-sol', supported_in_api: true, visibility: 'list' },
+        { slug: 'gpt-5.5', supported_in_api: true, visibility: 'list' },
+        { slug: 'gpt-5.5-internal', supported_in_api: true, visibility: 'hidden' },
+        { slug: 'gpt-image-2', supported_in_api: false, visibility: 'list' },
+        { supported_in_api: true, visibility: 'list' }
+    ]
+};
+
+async function waitFor(condition: () => boolean): Promise<void> {
+    for (let attempt = 0; attempt < 100 && !condition(); attempt++) {
+        await new Promise(resolve => setImmediate(resolve));
+    }
+}
+
+describe('ChatGptModelCatalog', () => {
+
+    let catalog: ChatGptModelCatalog;
+    let credentials: ChatGptCredentials | undefined;
+    let credentialsError: Error | undefined;
+    let authStateEmitter: Emitter<ChatGptAuthState>;
+    let fetchStub: sinon.SinonStub;
+
+    beforeEach(() => {
+        credentials = { accessToken: 'the-token', accountId: 'account-id' };
+        credentialsError = undefined;
+        authStateEmitter = new Emitter<ChatGptAuthState>();
+
+        const container = new Container();
+        container.bind(ChatGptAuthServiceImpl).toConstantValue({
+            getCredentials: async () => {
+                if (credentialsError) {
+                    throw credentialsError;
+                }
+                return credentials;
+            },
+            onAuthStateChanged: authStateEmitter.event
+        } as unknown as ChatGptAuthServiceImpl);
+        container.bind(ILogger).to(MockLogger).inSingletonScope();
+        container.bind(ChatGptModelCatalog).toSelf().inSingletonScope();
+        catalog = container.get(ChatGptModelCatalog);
+
+        fetchStub = sinon.stub(globalThis, 'fetch');
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('lists the models the signed in account may request', async () => {
+        fetchStub.resolves(listing(MODELS));
+
+        expect(await catalog.getAvailableModels()).to.deep.equal(['gpt-5.6-sol', 'gpt-5.5']);
+    });
+
+    it('identifies the client and the account of the listing request', async () => {
+        fetchStub.resolves(listing(MODELS));
+        await catalog.getAvailableModels();
+
+        const url = new URL(fetchStub.firstCall.args[0]);
+        expect(url.origin + url.pathname).to.equal('https://chatgpt.com/backend-api/codex/models');
+        expect(url.searchParams.get('client_version')).to.have.length.greaterThan(0);
+
+        const { headers } = fetchStub.firstCall.args[1];
+        expect(headers.Authorization).to.equal('Bearer the-token');
+        expect(headers['chatgpt-account-id']).to.equal('account-id');
+        expect(headers.originator).to.equal(CHATGPT_ORIGINATOR);
+    });
+
+    it('offers the built-in models while nobody is signed in', async () => {
+        credentials = undefined;
+
+        expect(await catalog.getAvailableModels()).to.deep.equal(CHATGPT_FALLBACK_MODELS);
+        expect(fetchStub.called).to.equal(false);
+    });
+
+    it('offers the built-in models when the listing is rejected', async () => {
+        fetchStub.resolves(listing({ error: 'unsupported client' }, 400));
+
+        expect(await catalog.getAvailableModels()).to.deep.equal(CHATGPT_FALLBACK_MODELS);
+    });
+
+    it('offers the built-in models when the response is not a model listing', async () => {
+        fetchStub.resolves(listing({ object: 'list' }));
+
+        expect(await catalog.getAvailableModels()).to.deep.equal(CHATGPT_FALLBACK_MODELS);
+    });
+
+    it('offers the built-in models when the credentials cannot be refreshed', async () => {
+        credentialsError = new Error('The ChatGPT session has expired.');
+
+        expect(await catalog.getAvailableModels()).to.deep.equal(CHATGPT_FALLBACK_MODELS);
+        expect(fetchStub.called).to.equal(false);
+    });
+
+    it('requests the listing once and serves it to later callers', async () => {
+        fetchStub.resolves(listing(MODELS));
+
+        const [first, second] = await Promise.all([catalog.getAvailableModels(), catalog.getAvailableModels()]);
+        expect(second).to.deep.equal(first);
+        expect(await catalog.getAvailableModels()).to.deep.equal(first);
+        expect(fetchStub.calledOnce).to.equal(true);
+    });
+
+    it('lists the models again once a different account is signed in', async () => {
+        fetchStub.resolves(listing(MODELS));
+        await catalog.getAvailableModels();
+
+        fetchStub.resolves(listing({ models: [{ slug: 'gpt-5.5-pro', supported_in_api: true, visibility: 'list' }] }));
+        authStateEmitter.fire({ isAuthenticated: true, accountLabel: 'other@example.com' });
+
+        expect(await catalog.getAvailableModels()).to.deep.equal(['gpt-5.5-pro']);
+    });
+
+    it('does not serve the models of the account that was replaced while they were listed', async () => {
+        let respond: (response: Response) => void = () => { };
+        fetchStub.returns(new Promise<Response>(resolve => { respond = resolve; }));
+
+        const listed = catalog.getAvailableModels();
+        await waitFor(() => fetchStub.called);
+        authStateEmitter.fire({ isAuthenticated: true, accountLabel: 'other@example.com' });
+        fetchStub.resolves(listing({ models: [{ slug: 'gpt-5.5-pro', supported_in_api: true, visibility: 'list' }] }));
+        respond(listing(MODELS));
+
+        expect(await listed).to.deep.equal(['gpt-5.5-pro']);
+    });
+
+    it('keeps the listing of the current account when the one of a former account fails', async () => {
+        let fail: (error: Error) => void = () => { };
+        fetchStub.returns(new Promise<Response>((resolve, reject) => { fail = reject; }));
+
+        const stale = catalog.getAvailableModels();
+        await waitFor(() => fetchStub.called);
+        authStateEmitter.fire({ isAuthenticated: true, accountLabel: 'other@example.com' });
+        fetchStub.resolves(listing(MODELS));
+        expect(await catalog.getAvailableModels()).to.deep.equal(['gpt-5.6-sol', 'gpt-5.5']);
+
+        fail(new Error('the connection was reset'));
+        expect(await stale).to.deep.equal(['gpt-5.6-sol', 'gpt-5.5']);
+
+        expect(await catalog.getAvailableModels()).to.deep.equal(['gpt-5.6-sol', 'gpt-5.5']);
+        expect(fetchStub.callCount).to.equal(2);
+    });
+
+    it('retries a listing that failed instead of serving the built-in models for good', async () => {
+        fetchStub.resolves(listing({}, 503));
+        expect(await catalog.getAvailableModels()).to.deep.equal(CHATGPT_FALLBACK_MODELS);
+
+        fetchStub.resolves(listing(MODELS));
+        expect(await catalog.getAvailableModels()).to.deep.equal(['gpt-5.6-sol', 'gpt-5.5']);
+    });
+});

--- a/packages/ai-chatgpt/src/node/chatgpt-model-catalog.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-model-catalog.ts
@@ -1,0 +1,115 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ILogger } from '@theia/core';
+import { createProxyFetch, getProxyUrl } from '@theia/ai-core/lib/node';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { CHATGPT_FALLBACK_MODELS, CHATGPT_RESPONSES_BASE_URL } from '../common';
+import { ChatGptAuthServiceImpl } from './chatgpt-auth-service-impl';
+import { CHATGPT_CLIENT_VERSION, CHATGPT_ORIGINATOR } from './chatgpt-oauth';
+
+/** Lists the models the endpoint serves to the signed in account. The client version is required. */
+const CHATGPT_MODELS_URL = `${CHATGPT_RESPONSES_BASE_URL}/models?client_version=${encodeURIComponent(CHATGPT_CLIENT_VERSION)}`;
+
+/**
+ * The models a ChatGPT plan grants, as reported by the endpoint. The listing is not part of OpenAI's documented
+ * API, so the result is treated as a hint: whenever it cannot be obtained, {@link CHATGPT_FALLBACK_MODELS} is
+ * served instead, which keeps the feature usable while signed out or offline.
+ */
+@injectable()
+export class ChatGptModelCatalog {
+
+    @inject(ChatGptAuthServiceImpl)
+    protected readonly authService: ChatGptAuthServiceImpl;
+
+    @inject(ILogger) @named('ai-chatgpt:ChatGptModelCatalog')
+    protected readonly logger: ILogger;
+
+    protected discovery: Promise<string[] | undefined> | undefined;
+    /** Incremented whenever the granted models may have changed, so listings started earlier are discarded. */
+    protected generation = 0;
+
+    @postConstruct()
+    protected init(): void {
+        // A different account, or none at all, grants different models.
+        this.authService.onAuthStateChanged(() => {
+            this.generation++;
+            this.discovery = undefined;
+        });
+    }
+
+    async getAvailableModels(): Promise<string[]> {
+        // A sign in or out while the models are being listed invalidates the result, so it is looked up again for
+        // the account that is signed in now. One retry, because the fallback is an acceptable answer either way.
+        for (let attempt = 0; attempt < 2; attempt++) {
+            const generation = this.generation;
+            if (!this.discovery) {
+                this.discovery = this.discoverModels();
+            }
+            const discovery = this.discovery;
+            const discovered = await discovery;
+            if (generation !== this.generation) {
+                continue;
+            }
+            if (discovered?.length) {
+                return discovered;
+            }
+            // Nothing was learned, so the next call retries instead of serving the fallback for good. A listing
+            // that has been replaced in the meantime is left alone.
+            if (this.discovery === discovery) {
+                this.discovery = undefined;
+            }
+            break;
+        }
+        return [...CHATGPT_FALLBACK_MODELS];
+    }
+
+    protected async discoverModels(): Promise<string[] | undefined> {
+        try {
+            const credentials = await this.authService.getCredentials();
+            if (!credentials) {
+                return undefined;
+            }
+            const proxyFetch = createProxyFetch(getProxyUrl(CHATGPT_MODELS_URL)) ?? fetch;
+            const response = await proxyFetch(CHATGPT_MODELS_URL, {
+                headers: {
+                    Authorization: `Bearer ${credentials.accessToken}`,
+                    'chatgpt-account-id': credentials.accountId,
+                    originator: CHATGPT_ORIGINATOR
+                }
+            });
+            if (!response.ok) {
+                throw new Error(`The model listing failed with status ${response.status}: ${await response.text()}`);
+            }
+            return toModelSlugs(await response.json());
+        } catch (error) {
+            this.logger.warn('Could not list the models of the ChatGPT plan, offering the built-in models instead:', error);
+            return undefined;
+        }
+    }
+}
+
+/** Keeps the models that are offered for selection and can actually be requested through the API. */
+function toModelSlugs(payload: unknown): string[] {
+    const models = (payload as { models?: unknown } | undefined)?.models;
+    if (!Array.isArray(models)) {
+        return [];
+    }
+    return models
+        .filter((model: { supported_in_api?: unknown, visibility?: unknown }) => model?.supported_in_api === true && model.visibility === 'list')
+        .map((model: { slug?: unknown }) => typeof model.slug === 'string' ? model.slug.trim() : '')
+        .filter(slug => slug.length > 0);
+}

--- a/packages/ai-chatgpt/src/node/chatgpt-oauth.spec.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-oauth.spec.ts
@@ -1,0 +1,115 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { createHash } from 'crypto';
+import {
+    buildAuthorizationUrl,
+    createPkcePair,
+    decodeChatGptIdentity,
+    parseAuthorizationInput,
+    CHATGPT_CLIENT_ID,
+    CHATGPT_ORIGINATOR,
+    CHATGPT_REDIRECT_URI
+} from './chatgpt-oauth';
+
+function encodeJwt(payload: Record<string, unknown>): string {
+    return `header.${Buffer.from(JSON.stringify(payload)).toString('base64url')}.signature`;
+}
+
+describe('ChatGPT OAuth helpers', () => {
+
+    describe('createPkcePair', () => {
+        it('derives the challenge as the base64url encoded SHA-256 of the verifier', () => {
+            const { verifier, challenge } = createPkcePair();
+            expect(challenge).to.equal(createHash('sha256').update(verifier).digest('base64url'));
+        });
+
+        it('creates a new verifier on each call', () => {
+            expect(createPkcePair().verifier).to.not.equal(createPkcePair().verifier);
+        });
+    });
+
+    describe('buildAuthorizationUrl', () => {
+        it('requests an authorization code for the ChatGPT client using PKCE', () => {
+            const url = new URL(buildAuthorizationUrl('challenge', 'state'));
+            expect(url.origin + url.pathname).to.equal('https://auth.openai.com/oauth/authorize');
+            expect(url.searchParams.get('response_type')).to.equal('code');
+            expect(url.searchParams.get('client_id')).to.equal(CHATGPT_CLIENT_ID);
+            expect(url.searchParams.get('redirect_uri')).to.equal(CHATGPT_REDIRECT_URI);
+            expect(url.searchParams.get('scope')).to.equal('openid profile email offline_access');
+            expect(url.searchParams.get('code_challenge')).to.equal('challenge');
+            expect(url.searchParams.get('code_challenge_method')).to.equal('S256');
+            expect(url.searchParams.get('state')).to.equal('state');
+        });
+
+        it('identifies Theia as the client instead of an OpenAI first party client', () => {
+            const url = new URL(buildAuthorizationUrl('challenge', 'state'));
+            expect(CHATGPT_ORIGINATOR).to.equal('theia');
+            expect(url.searchParams.get('originator')).to.equal(CHATGPT_ORIGINATOR);
+            expect(url.searchParams.has('codex_cli_simplified_flow')).to.be.false;
+        });
+    });
+
+    describe('parseAuthorizationInput', () => {
+        it('accepts a bare authorization code', () => {
+            expect(parseAuthorizationInput('  the-code  ', 'state')).to.equal('the-code');
+        });
+
+        it('extracts the code from a redirect URL', () => {
+            expect(parseAuthorizationInput(`${CHATGPT_REDIRECT_URI}?code=the-code&state=state`, 'state')).to.equal('the-code');
+        });
+
+        it('rejects a redirect URL with a mismatching state', () => {
+            expect(() => parseAuthorizationInput(`${CHATGPT_REDIRECT_URI}?code=the-code&state=other`, 'state')).to.throw(/state/);
+        });
+
+        it('rejects a redirect URL without a state', () => {
+            expect(() => parseAuthorizationInput(`${CHATGPT_REDIRECT_URI}?code=the-code`, 'state')).to.throw(/state/);
+        });
+
+        it('rejects a URL that is not the sign in callback', () => {
+            expect(() => parseAuthorizationInput('https://evil.example.com/auth?code=the-code&state=state', 'state')).to.throw(/callback/);
+        });
+
+        it('rejects a redirect URL without a code', () => {
+            expect(() => parseAuthorizationInput(`${CHATGPT_REDIRECT_URI}?state=state`, 'state')).to.throw(/authorization code/);
+        });
+
+        it('rejects empty input', () => {
+            expect(() => parseAuthorizationInput('   ', 'state')).to.throw(/authorization code/);
+        });
+    });
+
+    describe('decodeChatGptIdentity', () => {
+        it('reads the account, plan and email from the token claims', () => {
+            const identity = decodeChatGptIdentity(encodeJwt({
+                exp: 1700000000,
+                'https://api.openai.com/auth': { chatgpt_account_id: 'account-id', chatgpt_plan_type: 'plus' },
+                'https://api.openai.com/profile': { email: 'user@example.com' }
+            }));
+            expect(identity.accountId).to.equal('account-id');
+            expect(identity.planType).to.equal('plus');
+            expect(identity.email).to.equal('user@example.com');
+            expect(identity.expiresAt).to.equal(1700000000000);
+        });
+
+        it('returns an empty identity for tokens that are no readable JWT', () => {
+            expect(decodeChatGptIdentity('not-a-jwt')).to.deep.equal({});
+            expect(decodeChatGptIdentity('header.not-json.signature')).to.deep.equal({});
+        });
+    });
+});

--- a/packages/ai-chatgpt/src/node/chatgpt-oauth.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-oauth.ts
@@ -1,0 +1,143 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { createHash, randomBytes } from 'crypto';
+
+/** Public client id OpenAI registered for clients authenticating with a ChatGPT subscription. */
+export const CHATGPT_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+export const CHATGPT_AUTHORIZE_URL = 'https://auth.openai.com/oauth/authorize';
+export const CHATGPT_TOKEN_URL = 'https://auth.openai.com/oauth/token';
+export const CHATGPT_SCOPE = 'openid profile email offline_access';
+/**
+ * The port and path are registered with the OAuth application and cannot be chosen freely.
+ */
+export const CHATGPT_CALLBACK_PORT = 1455;
+export const CHATGPT_CALLBACK_HOST = 'localhost';
+export const CHATGPT_CALLBACK_PATH = '/auth/callback';
+export const CHATGPT_REDIRECT_URI = `http://${CHATGPT_CALLBACK_HOST}:${CHATGPT_CALLBACK_PORT}${CHATGPT_CALLBACK_PATH}`;
+/** Identifies Theia as the client of the ChatGPT endpoint. */
+export const CHATGPT_ORIGINATOR = 'theia';
+/** Version of this client. The endpoint requires the model listing to state one, the completion endpoint does not. */
+export const CHATGPT_CLIENT_VERSION = '1.0.0';
+
+/** Claim namespaces used by OpenAI to convey the ChatGPT account of the signed in user. */
+const AUTH_CLAIM = 'https://api.openai.com/auth';
+const PROFILE_CLAIM = 'https://api.openai.com/profile';
+
+export interface PkcePair {
+    verifier: string;
+    challenge: string;
+}
+
+export interface ChatGptIdentity {
+    accountId?: string;
+    planType?: string;
+    email?: string;
+    /** Expiration of the token in epoch milliseconds. */
+    expiresAt?: number;
+}
+
+export function createPkcePair(): PkcePair {
+    const verifier = randomBytes(32).toString('base64url');
+    return { verifier, challenge: createHash('sha256').update(verifier).digest('base64url') };
+}
+
+export function createLoginState(): string {
+    return randomBytes(16).toString('hex');
+}
+
+export function buildAuthorizationUrl(challenge: string, state: string, redirectUri: string = CHATGPT_REDIRECT_URI): string {
+    const url = new URL(CHATGPT_AUTHORIZE_URL);
+    url.searchParams.set('response_type', 'code');
+    url.searchParams.set('client_id', CHATGPT_CLIENT_ID);
+    url.searchParams.set('redirect_uri', redirectUri);
+    url.searchParams.set('scope', CHATGPT_SCOPE);
+    url.searchParams.set('code_challenge', challenge);
+    url.searchParams.set('code_challenge_method', 'S256');
+    url.searchParams.set('state', state);
+    url.searchParams.set('id_token_add_organizations', 'true');
+    url.searchParams.set('originator', CHATGPT_ORIGINATOR);
+    return url.toString();
+}
+
+/**
+ * Extracts the authorization code from user input, which is either the bare code or the full redirect URL
+ * the browser was sent to.
+ *
+ * @throws if no code can be extracted, if the redirect URL is not the sign in callback or if its state does not match
+ */
+export function parseAuthorizationInput(input: string, expectedState: string): string {
+    const trimmed = input.trim();
+    if (!trimmed) {
+        throw new Error('No authorization code provided.');
+    }
+    if (/^https?:\/\//i.test(trimmed)) {
+        const url = new URL(trimmed);
+        if (url.pathname !== CHATGPT_CALLBACK_PATH) {
+            throw new Error('The provided URL is not the sign in callback URL.');
+        }
+        // The state correlates the redirect with this login attempt, so it is required rather than merely compared.
+        if (url.searchParams.get('state') !== expectedState) {
+            throw new Error('The state of the provided redirect URL does not match the pending sign in.');
+        }
+        const code = url.searchParams.get('code');
+        if (!code) {
+            throw new Error('The provided redirect URL does not contain an authorization code.');
+        }
+        return code;
+    }
+    return trimmed;
+}
+
+/**
+ * Reads the ChatGPT account information from the claims of an OpenAI access token.
+ * Returns an empty identity if the token is not a readable JWT.
+ */
+export function decodeChatGptIdentity(accessToken: string): ChatGptIdentity {
+    const payload = decodeJwtPayload(accessToken);
+    if (!payload) {
+        return {};
+    }
+    const auth = asRecord(payload[AUTH_CLAIM]);
+    const profile = asRecord(payload[PROFILE_CLAIM]);
+    const expiration = typeof payload.exp === 'number' ? payload.exp * 1000 : undefined;
+    return {
+        accountId: asNonEmptyString(auth?.chatgpt_account_id),
+        planType: asNonEmptyString(auth?.chatgpt_plan_type),
+        email: asNonEmptyString(profile?.email) ?? asNonEmptyString(payload.email),
+        expiresAt: expiration
+    };
+}
+
+function decodeJwtPayload(token: string): Record<string, unknown> | undefined {
+    const parts = token.split('.');
+    if (parts.length !== 3) {
+        return undefined;
+    }
+    try {
+        return asRecord(JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')));
+    } catch {
+        return undefined;
+    }
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+    return typeof value === 'object' && value ? value as Record<string, unknown> : undefined;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}

--- a/packages/ai-chatgpt/src/node/chatgpt-response-api-utils.ts
+++ b/packages/ai-chatgpt/src/node/chatgpt-response-api-utils.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { LanguageModelMessage } from '@theia/ai-core';
+import { injectable } from '@theia/core/shared/inversify';
+import { DeveloperMessageSettings } from '@theia/ai-openai/lib/node/openai-language-model';
+import { OpenAiResponseApiUtils } from '@theia/ai-openai/lib/node/openai-response-api-utils';
+import type { ResponseInputItem } from 'openai/resources/responses/responses';
+
+/** Used when a request carries no system message, which the ChatGPT endpoint rejects with `Instructions are required`. */
+export const DEFAULT_CHATGPT_INSTRUCTIONS = 'You are a helpful assistant.';
+
+/**
+ * Adapts the OpenAI Response API request to the additional constraints of the ChatGPT endpoint.
+ * Bound under its own symbol so the plain OpenAI models keep using {@link OpenAiResponseApiUtils}.
+ */
+@injectable()
+export class ChatGptResponseApiUtils extends OpenAiResponseApiUtils {
+
+    override processMessages(
+        messages: LanguageModelMessage[],
+        developerMessageSettings: DeveloperMessageSettings,
+        model: string
+    ): { instructions?: string; input: ResponseInputItem[] } {
+        const processed = super.processMessages(messages, developerMessageSettings, model);
+        return processed.instructions?.trim()
+            ? processed
+            : { ...processed, instructions: DEFAULT_CHATGPT_INSTRUCTIONS };
+    }
+}

--- a/packages/ai-chatgpt/tsconfig.json
+++ b/packages/ai-chatgpt/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../configs/base.tsconfig",
+  "compilerOptions": {
+    "composite": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ],
+  "references": [
+    {
+      "path": "../ai-core"
+    },
+    {
+      "path": "../ai-openai"
+    },
+    {
+      "path": "../core"
+    }
+  ]
+}

--- a/packages/preferences/src/browser/util/preference-layout.spec.ts
+++ b/packages/preferences/src/browser/util/preference-layout.spec.ts
@@ -1,0 +1,33 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { PreferenceLayoutProvider } from './preference-layout';
+
+describe('preference-layout', () => {
+
+    const provider = new PreferenceLayoutProvider();
+
+    it('assigns the ChatGPT preferences a section with the brand spelling', () => {
+        const layout = provider.getLayoutForPreference('ai-features.chatGpt.models');
+        expect(layout?.id).eq('ai-features.chatGpt');
+        expect(layout?.label).eq('ChatGPT');
+    });
+
+    it('keeps the chat preferences in their own section despite the shared prefix', () => {
+        expect(provider.getLayoutForPreference('ai-features.chat.defaultChatAgent')?.id).eq('ai-features.chat');
+    });
+});

--- a/packages/preferences/src/browser/util/preference-layout.ts
+++ b/packages/preferences/src/browser/util/preference-layout.ts
@@ -323,6 +323,11 @@ export const DEFAULT_LAYOUT: PreferenceLayout[] = [
                 settings: ['ai-features.chat.*']
             },
             {
+                id: 'ai-features.chatGpt',
+                label: 'ChatGPT',
+                settings: ['ai-features.chatGpt.*']
+            },
+            {
                 id: 'ai-features.copilot',
                 label: 'GitHub Copilot',
                 settings: ['ai-features.copilot.*']

--- a/packages/preferences/src/browser/views/components/preference-markdown-renderer.spec.ts
+++ b/packages/preferences/src/browser/views/components/preference-markdown-renderer.spec.ts
@@ -1,0 +1,70 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+/* eslint-disable no-unsanitized/property */
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import URI from '@theia/core/lib/common/uri';
+import * as DOMPurify from '@theia/core/shared/dompurify';
+import { PreferenceMarkdownRenderer } from './preference-markdown-renderer';
+
+disableJSDOM();
+
+describe('preference-markdown-renderer', () => {
+
+    let renderer: PreferenceMarkdownRenderer;
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+        renderer = new PreferenceMarkdownRenderer();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    /**
+     * Renders a markdown description the way the preference node renderer displays it.
+     */
+    function renderDescription(markdown: string): HTMLElement {
+        const wrapper = document.createElement('div');
+        wrapper.innerHTML = DOMPurify.sanitize(renderer.render(markdown), { ALLOW_UNKNOWN_PROTOCOLS: true });
+        return wrapper;
+    }
+
+    it('keeps a command link of a description intact', () => {
+        const link = renderDescription('[Do something](command:my.extension.doSomething)').querySelector('a');
+
+        expect(link?.textContent).eq('Do something');
+        const uri = new URI(link!.getAttribute('href')!);
+        expect(uri.scheme).eq('command');
+        expect(uri.path.toString()).eq('my.extension.doSomething');
+    });
+
+    it('drops a scripting link of a description', () => {
+        // eslint-disable-next-line no-script-url
+        const wrapper = renderDescription('[Do something](javascript:alert(1))');
+
+        expect(wrapper.querySelector('a[href]')).to.not.exist;
+    });
+});

--- a/packages/preferences/src/browser/views/components/preference-node-renderer.ts
+++ b/packages/preferences/src/browser/views/components/preference-node-renderer.ts
@@ -193,7 +193,8 @@ export abstract class PreferenceLeafNodeRenderer<ValueType extends JSONValue, In
             // Exclude right click
             if (event.button < 2) {
                 const uri = new URI(event.target.href);
-                open(this.openerService, uri);
+                // A `command:` link of a description may point at a command that is disabled in the current state.
+                open(this.openerService, uri).catch(error => console.warn(`Could not open the link ${uri.toString()}:`, error));
             }
         }
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->
Using OpenAI models in Theia required an OpenAI API key, which is billed separately from a ChatGPT subscription most users already pay for. The new @theia/ai-chatgpt package signs the user in with their ChatGPT account and serves the models their plan grants, alongside the API-key based openai/* models rather than replacing them.

Sign in runs the OAuth 2.0 authorization code flow with PKCE against auth.openai.com, using the client id, scope and redirect URI OpenAI has registered for this flow; none of them can be chosen freely. The authorization page opens in the user's browser and the code is returned to a loopback listener the backend runs on localhost:1455. For remote backends, or when the port is taken, the user pastes the code or the full redirect URL instead. Tokens are kept in the OS credential store via KeyStoreService and refreshed transparently before each request, including the SDK's own retries.

Models are registered regardless of the sign-in state and carry their status, so they stay discoverable while signed out and signing out is a status flip rather than a disappearance.

- serve requests through https://chatgpt.com/backend-api/codex, which only implements the streaming Response API: responses are never stored, streaming is unconditional, system messages become the top level instructions, and a default instructions string is substituted when a request carries none
- reuse the Responses-API engine of @theia/ai-openai by deep import and extend it through a subclass bound under our own symbol; rebinding OpenAiResponseApiUtils would be process-global and would corrupt every plain OpenAI model in the same application. @theia/ai-openai is not modified
- discover the granted models from the endpoint's model listing once signed in, falling back to a built-in list whenever it cannot be obtained. The ai-features.chatGpt.models preference pins the list explicitly
- offer OpenAI's server-side web search as a selectable capability
- identify Theia as the client through the originator header rather than impersonating a first-party OpenAI client
- serve a narrow facade over the RPC connection instead of the auth service itself, so getCredentials is not reachable from the frontend: RpcProxyFactory dispatches by method name without consulting the TypeScript interface
- sign the user out only when the token endpoint reports a spent refresh token, so a rate limit or a malformed error body does not discard a valid session, and guard that decision with a generation counter so a stale rejection cannot delete a session the user has meanwhile signed back into
#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Go to preferences and sign in or use the Chat GPT command.
Then you can select a chatgpt/* model for an agent and it should answer.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
