### PR TITLE
chore(electron): upgrade Electron to 42.8.1

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   build-and-test-playwright:
-    name: Playwright Tests (ubuntu-22.04,  Node.js 22.x)
+    name: Playwright Tests (ubuntu-22.04,  Node.js 24.x)
 
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Use Node.js "22.x"
+      - name: Use Node.js "24.x"
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.13

--- a/.github/workflows/production-smoke-test.yml
+++ b/.github/workflows/production-smoke-test.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build-and-test-playwright:
-    name: Smoke Test for Browser Example Production Build on ubuntu-22.04 with Node.js 22.x
+    name: Smoke Test for Browser Example Production Build on ubuntu-22.04 with Node.js 24.x
 
     runs-on: ubuntu-22.04
     timeout-minutes: 60
@@ -28,10 +28,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: Use Node.js "22.x"
+      - name: Use Node.js "24.x"
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          node-version: "22.x"
+          node-version: "24.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Use Python 3.13

--- a/examples/electron/package.json
+++ b/examples/electron/package.json
@@ -120,6 +120,6 @@
   },
   "devDependencies": {
     "@theia/cli": "1.74.0",
-    "electron": "42.3.0"
+    "electron": "42.8.1"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -642,7 +642,7 @@
       },
       "devDependencies": {
         "@theia/cli": "1.74.0",
-        "electron": "42.3.0"
+        "electron": "42.8.1"
       }
     },
     "examples/playwright": {
@@ -2618,6 +2618,15 @@
       "license": "EPL-2.0",
       "bin": {
         "dash-licenses-wrapper": "src/dash-licenses-wrapper.js"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/get": {
@@ -8541,17 +8550,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "license": "MIT"
     },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.18.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.18.0.tgz",
@@ -13720,6 +13718,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/decompress-unzip/node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/dedent": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -14441,14 +14449,14 @@
       }
     },
     "node_modules/electron": {
-      "version": "42.3.0",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-42.3.0.tgz",
-      "integrity": "sha512-9ZiLdRXk+WDxW1OgIUz8J2rIQ5TYU9o629gCOjU48Q3dQiOmym7osWsH5Ubs/Jh4uuFLn6m6SBD2rmRXLAPz9g==",
+      "version": "42.8.1",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-42.8.1.tgz",
+      "integrity": "sha512-zQnW4hKUyxzdsw3gvtBszEfZ0d5SGqkAsfdaVFVdHDmzRsgw3rR5so/gB7LS9TLlewoIC0wg0sTIjtn3ilICuA==",
       "license": "MIT",
       "dependencies": {
+        "@electron-internal/extract-zip": "^1.0.1",
         "@electron/get": "^5.0.0",
-        "@types/node": "^24.9.0",
-        "extract-zip": "^2.0.1"
+        "@types/node": "^24.9.0"
       },
       "bin": {
         "electron": "cli.js",
@@ -15959,41 +15967,6 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -16085,6 +16058,15 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -31863,9 +31845,10 @@
       }
     },
     "node_modules/yauzl": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.3.2.tgz",
-      "integrity": "sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.4.0.tgz",
+      "integrity": "sha512-jIH9yLR9wqr0wOS0TpBvo/g/2UgZH5qePVbjgRliiF0BYvOZyaBknKsF+x9Iht0O6sqgnB93rCICdOZFecJuDw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pend": "~1.2.0"
@@ -32704,7 +32687,7 @@
         "@theia/re-exports": "1.74.0"
       },
       "peerDependencies": {
-        "electron": "42.3.0"
+        "electron": "42.8.1"
       }
     },
     "packages/external-terminal": {

--- a/package.json
+++ b/package.json
@@ -18,8 +18,7 @@
     "perfect-scrollbar": "1.5.5",
     "serialize-javascript": "^7.1.0",
     "tar": "^7.5.22",
-    "uuid": "^11.1.1",
-    "yauzl": "~3.3.2"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@eclipse-dash/nodejs-wrapper": "^0.0.1",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -72,7 +72,7 @@ export class SomeClass {
 
 - `@theia/core/electron-shared/...`
   - `native-keymap` (from [`native-keymap@^2.5.0`](https://www.npmjs.com/package/native-keymap))
-  - `electron` (from [`electron@42.3.0`](https://www.npmjs.com/package/electron/v/42.3.0))
+  - `electron` (from [`electron@42.8.1`](https://www.npmjs.com/package/electron/v/42.8.1))
   - `electron-store` (from [`electron-store@^8.2.0`](https://www.npmjs.com/package/electron-store))
 - `@theia/core/shared/...`
   - `@lumino/algorithm` (from [`@lumino/algorithm@^2.0.5`](https://www.npmjs.com/package/@lumino/algorithm))

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -18,7 +18,7 @@ The `@theia/electron` extension bundles all Electron-specific dependencies and c
 
 - `@theia/electron/shared/...`
   - `native-keymap` (from [`native-keymap@^2.5.0`](https://www.npmjs.com/package/native-keymap))
-  - `electron` (from [`electron@42.3.0`](https://www.npmjs.com/package/electron/v/42.3.0))
+  - `electron` (from [`electron@42.8.1`](https://www.npmjs.com/package/electron/v/42.8.1))
   - `electron-store` (from [`electron-store@^8.2.0`](https://www.npmjs.com/package/electron-store))
 
 ## Additional Information

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -12,7 +12,7 @@
     "@theia/re-exports": "1.74.0"
   },
   "peerDependencies": {
-    "electron": "42.3.0"
+    "electron": "42.8.1"
   },
   "theiaReExports": {
     "shared": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Upgrades Electron from 42.3.0 to 42.8.1 and removes the `yauzl` override that is now no longer needed.

Electron 42.4.0 replaced `extract-zip` with `@electron-internal/extract-zip` (Rust, no JS dependencies), which removes the postinstall stream race that caused sporadic `ENOENT: node_modules/electron/dist/version` failures on Node 24. `electron` was the only package pulling `extract-zip`, so the `"yauzl": "~3.3.2"` override added in #17575 has nothing left to pin and is dropped.

Also moves both Playwright workflows back to Node 24. `playwright-core` dropped the bundled `extract-zip@2.0.1` in 1.60.0 in favour of its own extractor on yauzl 3.x, so with 1.62.1 in the lockfile the race is unreachable there too, the workflow pin from #17575 was only needed because an npm override could not reach that bundled copy. Together with the override removal this covers the last two open items of #17570.

Resolves #17570

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

- `npm install && npm run compile` (all 92 projects compile against the 42.8.1 typings)
- `npm ls yauzl` is clean: `decompress-unzip` on 2.10.0, `@vscode/vsce` on 3.4.0
- `node scripts/verify-lockfile-platforms.js` passes
- `npm run start:electron` starts as before
- CI on the Node 22/24 matrix exercises the Electron install path that this fixes
- Playwright workflows:
  - Forced a cold browser install on Node 24 to exercise the extraction path that caused the Node 22 pin (`GH-17570`): deleted the `Linux-playwright-*` caches holding the current Chromium build, then dispatched [Playwright Tests on `nd/electron-42.8.1`](https://github.com/eclipse-theia/theia/actions/runs/31675280928/job/94368404450). The cache fell back to a stale entry (Chromium 1228) via `restore-keys`, so `playwright install chromium` downloaded and extracted Chromium 1234 plus the headless shell on Node 24: `Build Playwright` took 14s with no hang (the `GH-17570` symptom), job was successful.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
