### PR TITLE
[variable-resolver] Keep task input prompts open

### DIFF
--- a/packages/task/src/browser/process/process-task-resolver.spec.ts
+++ b/packages/task/src/browser/process/process-task-resolver.spec.ts
@@ -1,0 +1,65 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// http://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+FrontendApplicationConfigProvider.set({});
+
+import { expect } from 'chai';
+import { isCancelled } from '@theia/core/lib/common/cancellation';
+import { TaskScope } from '../../common/task-protocol';
+import { ProcessTaskConfiguration } from '../../common/process/task-protocol';
+import { ProcessTaskResolver } from './process-task-resolver';
+
+describe('ProcessTaskResolver', () => {
+    after(() => {
+        disableJSDOM();
+    });
+
+    it('cancels a task when resolving its arguments is cancelled', async () => {
+        const resolver = new ProcessTaskResolver();
+        (resolver as unknown as {
+            variableResolverService: { resolve: (value: unknown) => Promise<unknown> };
+            workspaceService: { getWorkspaceRootUri: () => undefined };
+        }).variableResolverService = {
+            resolve: async value => Array.isArray(value) ? undefined : value
+        };
+        (resolver as unknown as {
+            workspaceService: { getWorkspaceRootUri: () => undefined };
+        }).workspaceService = {
+            getWorkspaceRootUri: () => undefined
+        };
+
+        const task: ProcessTaskConfiguration = {
+            label: 'task with input variables',
+            type: 'shell',
+            command: 'node',
+            args: ['${input:task-argument}'],
+            _scope: TaskScope.Workspace
+        };
+
+        let error: Error | undefined;
+        try {
+            await resolver.resolveTask(task);
+        } catch (e) {
+            error = e as Error;
+        }
+
+        expect(isCancelled(error)).to.equal(true);
+    });
+});

--- a/packages/task/src/browser/process/process-task-resolver.ts
+++ b/packages/task/src/browser/process/process-task-resolver.ts
@@ -18,10 +18,11 @@ import { injectable, inject } from '@theia/core/shared/inversify';
 import { VariableResolverService } from '@theia/variable-resolver/lib/browser';
 import { TaskResolver } from '../task-contribution';
 import { TaskConfiguration } from '../../common/task-protocol';
-import { ProcessTaskConfiguration } from '../../common/process/task-protocol';
+import { CommandProperties, ProcessTaskConfiguration } from '../../common/process/task-protocol';
 import { TaskDefinitionRegistry } from '../task-definition-registry';
 import URI from '@theia/core/lib/common/uri';
 import { WorkspaceService } from '@theia/workspace/lib/browser';
+import { cancelled } from '@theia/core/lib/common/cancellation';
 
 @injectable()
 export class ProcessTaskResolver implements TaskResolver {
@@ -59,25 +60,13 @@ export class ProcessTaskResolver implements TaskResolver {
             }
         }
 
+        const commandProperties = await this.resolveCommandProperties(processTaskConfig, variableResolverOptions);
         const result: ProcessTaskConfiguration = {
             ...processTaskConfig,
-            command: await this.variableResolverService.resolve(processTaskConfig.command, variableResolverOptions),
-            args: processTaskConfig.args ? await this.variableResolverService.resolve(processTaskConfig.args, variableResolverOptions) : undefined,
-            windows: processTaskConfig.windows ? {
-                command: await this.variableResolverService.resolve(processTaskConfig.windows.command, variableResolverOptions),
-                args: processTaskConfig.windows.args ? await this.variableResolverService.resolve(processTaskConfig.windows.args, variableResolverOptions) : undefined,
-                options: processTaskConfig.windows.options
-            } : undefined,
-            osx: processTaskConfig.osx ? {
-                command: await this.variableResolverService.resolve(processTaskConfig.osx.command, variableResolverOptions),
-                args: processTaskConfig.osx.args ? await this.variableResolverService.resolve(processTaskConfig.osx.args, variableResolverOptions) : undefined,
-                options: processTaskConfig.osx.options
-            } : undefined,
-            linux: processTaskConfig.linux ? {
-                command: await this.variableResolverService.resolve(processTaskConfig.linux.command, variableResolverOptions),
-                args: processTaskConfig.linux.args ? await this.variableResolverService.resolve(processTaskConfig.linux.args, variableResolverOptions) : undefined,
-                options: processTaskConfig.linux.options
-            } : undefined,
+            ...commandProperties,
+            windows: await this.resolveCommandProperties(processTaskConfig.windows, variableResolverOptions),
+            osx: await this.resolveCommandProperties(processTaskConfig.osx, variableResolverOptions),
+            linux: await this.resolveCommandProperties(processTaskConfig.linux, variableResolverOptions),
             options: {
                 cwd: await this.variableResolverService.resolve(cwd, variableResolverOptions),
                 env: processTaskConfig.options?.env && await this.variableResolverService.resolve(processTaskConfig.options.env, variableResolverOptions),
@@ -85,5 +74,29 @@ export class ProcessTaskResolver implements TaskResolver {
             }
         };
         return result;
+    }
+
+    protected async resolveCommandProperties(
+        properties: CommandProperties | undefined,
+        variableResolverOptions: { context: URI | undefined; configurationSection: string }
+    ): Promise<CommandProperties | undefined> {
+        if (!properties) {
+            return undefined;
+        }
+        const command = properties.command === undefined
+            ? undefined
+            : await this.variableResolverService.resolve(properties.command, variableResolverOptions);
+        const args = properties.args === undefined
+            ? undefined
+            : await this.variableResolverService.resolve(properties.args, variableResolverOptions);
+        if ((properties.command !== undefined && command === undefined)
+            || (properties.args !== undefined && args === undefined)) {
+            throw cancelled();
+        }
+        return {
+            command,
+            args,
+            options: properties.options
+        };
     }
 }

--- a/packages/variable-resolver/src/browser/common-variable-contribution.spec.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.spec.ts
@@ -19,8 +19,9 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 let disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';
-import { QuickInputService } from '@theia/core/lib/browser';
-import { InputOptions } from '@theia/core/lib/common/quick-pick-service';
+import { InputBox, QuickInputHideReason, QuickInputService } from '@theia/core/lib/browser';
+import { isCancelled } from '@theia/core/lib/common/cancellation';
+import { Emitter } from '@theia/core/lib/common/event';
 import URI from '@theia/core/lib/common/uri';
 import { CommonVariableContribution } from './common-variable-contribution';
 import { VariableRegistry } from './variable';
@@ -37,9 +38,22 @@ describe('CommonVariableContribution', () => {
         disableJSDOM();
     });
 
+    function createInputBox(): { inputBox: InputBox; accept: Emitter<void>; hide: Emitter<{ reason: QuickInputHideReason }> } {
+        const accept = new Emitter<void>();
+        const hide = new Emitter<{ reason: QuickInputHideReason }>();
+        const inputBox = {
+            onDidAccept: accept.event,
+            onDidHide: hide.event,
+            dispose: () => undefined,
+            hide: () => undefined,
+            show: () => undefined
+        } as unknown as InputBox;
+        return { inputBox, accept, hide };
+    }
+
     it('keeps task prompt string inputs open when focus is lost', async () => {
         const contribution = new CommonVariableContribution();
-        let inputOptions: InputOptions | undefined;
+        const { inputBox, accept } = createInputBox();
 
         (contribution as unknown as { env: { getExecPath: () => Promise<string> } }).env = {
             getExecPath: async () => ''
@@ -54,24 +68,96 @@ describe('CommonVariableContribution', () => {
                 }]
             })
         };
-        (contribution as unknown as { quickInputService: Pick<QuickInputService, 'input'> }).quickInputService = {
-            input: async options => {
-                inputOptions = options;
-                return 'task-argument';
-            }
+        (contribution as unknown as { quickInputService: Pick<QuickInputService, 'createInputBox'> }).quickInputService = {
+            createInputBox: () => inputBox
         };
 
         const variables = new VariableRegistry();
         await contribution.registerVariables(variables);
 
         const input = variables.getVariable('input');
-        const resolved = await input?.resolve(new URI('file:///workspace'), 'task-argument', 'tasks');
+        const resolving = input?.resolve(new URI('file:///workspace'), 'task-argument', 'tasks');
+        expect(inputBox.prompt).to.equal('Enter a task argument');
+        expect(inputBox.value).to.equal('default-value');
+        expect(inputBox.ignoreFocusOut).to.equal(true);
+        inputBox.value = 'task-argument';
+        accept.fire();
+        const resolved = await resolving;
 
         expect(resolved).to.equal('task-argument');
-        expect(inputOptions).to.deep.equal({
-            prompt: 'Enter a task argument',
-            value: 'default-value',
-            ignoreFocusLost: true
+    });
+
+    it('cancels task prompt string inputs when dismissed', async () => {
+        const contribution = new CommonVariableContribution();
+        const { inputBox, hide } = createInputBox();
+
+        (contribution as unknown as { env: { getExecPath: () => Promise<string> } }).env = {
+            getExecPath: async () => ''
+        };
+        (contribution as unknown as { preferences: { get: () => unknown } }).preferences = {
+            get: () => ({
+                inputs: [{
+                    id: 'task-argument',
+                    type: 'promptString',
+                    description: 'Enter a task argument'
+                }]
+            })
+        };
+        (contribution as unknown as { quickInputService: Pick<QuickInputService, 'createInputBox'> }).quickInputService = {
+            createInputBox: () => inputBox
+        };
+
+        const variables = new VariableRegistry();
+        await contribution.registerVariables(variables);
+
+        let error: Error | undefined;
+        try {
+            const resolving = variables.getVariable('input')?.resolve(new URI('file:///workspace'), 'task-argument', 'tasks');
+            hide.fire({ reason: QuickInputHideReason.Gesture });
+            await resolving;
+        } catch (e) {
+            error = e as Error;
+        }
+        expect(isCancelled(error)).to.equal(true);
+    });
+
+    it('cancels task pick string inputs when dismissed', async () => {
+        const contribution = new CommonVariableContribution();
+        let pickOptions: { placeholder?: string; ignoreFocusOut?: boolean } | undefined;
+
+        (contribution as unknown as { env: { getExecPath: () => Promise<string> } }).env = {
+            getExecPath: async () => ''
+        };
+        (contribution as unknown as { preferences: { get: () => unknown } }).preferences = {
+            get: () => ({
+                inputs: [{
+                    id: 'task-argument-choice',
+                    type: 'pickString',
+                    description: 'Choose a task argument',
+                    options: ['first', 'second']
+                }]
+            })
+        };
+        (contribution as unknown as { quickInputService: Pick<QuickInputService, 'showQuickPick'> }).quickInputService = {
+            showQuickPick: async (_items, options) => {
+                pickOptions = options;
+                return undefined;
+            }
+        };
+
+        const variables = new VariableRegistry();
+        await contribution.registerVariables(variables);
+
+        let error: Error | undefined;
+        try {
+            await variables.getVariable('input')?.resolve(new URI('file:///workspace'), 'task-argument-choice', 'tasks');
+        } catch (e) {
+            error = e as Error;
+        }
+        expect(isCancelled(error)).to.equal(true);
+        expect(pickOptions).to.deep.equal({
+            placeholder: 'Choose a task argument',
+            ignoreFocusOut: true
         });
     });
 });

--- a/packages/variable-resolver/src/browser/common-variable-contribution.spec.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.spec.ts
@@ -1,0 +1,77 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+
+let disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { QuickInputService } from '@theia/core/lib/browser';
+import { InputOptions } from '@theia/core/lib/common/quick-pick-service';
+import URI from '@theia/core/lib/common/uri';
+import { CommonVariableContribution } from './common-variable-contribution';
+import { VariableRegistry } from './variable';
+
+disableJSDOM();
+
+describe('CommonVariableContribution', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    it('keeps task prompt string inputs open when focus is lost', async () => {
+        const contribution = new CommonVariableContribution();
+        let inputOptions: InputOptions | undefined;
+
+        (contribution as unknown as { env: { getExecPath: () => Promise<string> } }).env = {
+            getExecPath: async () => ''
+        };
+        (contribution as unknown as { preferences: { get: () => unknown } }).preferences = {
+            get: () => ({
+                inputs: [{
+                    id: 'task-argument',
+                    type: 'promptString',
+                    description: 'Enter a task argument',
+                    default: 'default-value'
+                }]
+            })
+        };
+        (contribution as unknown as { quickInputService: Pick<QuickInputService, 'input'> }).quickInputService = {
+            input: async options => {
+                inputOptions = options;
+                return 'task-argument';
+            }
+        };
+
+        const variables = new VariableRegistry();
+        await contribution.registerVariables(variables);
+
+        const input = variables.getVariable('input');
+        const resolved = await input?.resolve(new URI('file:///workspace'), 'task-argument', 'tasks');
+
+        expect(resolved).to.equal('task-argument');
+        expect(inputOptions).to.deep.equal({
+            prompt: 'Enter a task argument',
+            value: 'default-value',
+            ignoreFocusLost: true
+        });
+    });
+});

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -26,6 +26,7 @@ import { VariableInput } from './variable-input';
 import { QuickInputService, QuickPickValue } from '@theia/core/lib/browser';
 import { MaybeArray, RecursivePartial } from '@theia/core/lib/common/types';
 import { cancelled } from '@theia/core/lib/common/cancellation';
+import { DisposableCollection } from '@theia/core/lib/common/disposable';
 import URI from '@theia/core/lib/common/uri';
 
 @injectable()
@@ -108,11 +109,7 @@ export class CommonVariableContribution implements VariableContribution {
                     if (typeof input.description !== 'string') {
                         return undefined;
                     }
-                    return this.quickInputService?.input({
-                        prompt: input.description,
-                        value: input.default,
-                        ignoreFocusLost: true
-                    });
+                    return this.resolvePromptStringInput(input.description, input.default);
                 }
                 if (input.type === 'pickString') {
                     if (typeof input.description !== 'string' || !Array.isArray(input.options)) {
@@ -136,8 +133,14 @@ export class CommonVariableContribution implements VariableContribution {
                             });
                         }
                     }
-                    const selectedPick = await this.quickInputService?.showQuickPick(elements, { placeholder: input.description });
-                    return selectedPick?.value;
+                    const selectedPick = await this.quickInputService?.showQuickPick(elements, {
+                        placeholder: input.description,
+                        ignoreFocusOut: true
+                    });
+                    if (!selectedPick) {
+                        throw cancelled();
+                    }
+                    return selectedPick.value;
                 }
                 if (input.type === 'command') {
                     if (typeof input.command !== 'string') {
@@ -147,6 +150,36 @@ export class CommonVariableContribution implements VariableContribution {
                 }
                 return undefined;
             }
+        });
+    }
+
+    protected resolvePromptStringInput(description: string, defaultValue: string | undefined): Promise<string> {
+        const inputBox = this.quickInputService?.createInputBox();
+        if (!inputBox) {
+            throw cancelled();
+        }
+        return new Promise((resolve, reject) => {
+            const toDispose = new DisposableCollection();
+            toDispose.push(inputBox.onDidAccept(() => {
+                const value = inputBox.value;
+                toDispose.dispose();
+                inputBox.hide();
+                inputBox.dispose();
+                if (value === undefined) {
+                    reject(cancelled());
+                } else {
+                    resolve(value);
+                }
+            }));
+            toDispose.push(inputBox.onDidHide(() => {
+                toDispose.dispose();
+                inputBox.dispose();
+                reject(cancelled());
+            }));
+            inputBox.prompt = description;
+            inputBox.value = defaultValue;
+            inputBox.ignoreFocusOut = true;
+            inputBox.show();
         });
     }
 }

--- a/packages/variable-resolver/src/browser/common-variable-contribution.ts
+++ b/packages/variable-resolver/src/browser/common-variable-contribution.ts
@@ -110,7 +110,8 @@ export class CommonVariableContribution implements VariableContribution {
                     }
                     return this.quickInputService?.input({
                         prompt: input.description,
-                        value: input.default
+                        value: input.default,
+                        ignoreFocusLost: true
                     });
                 }
                 if (input.type === 'pickString') {


### PR DESCRIPTION
Closes #17894.

## Summary

Task input prompts were closing when focus moved away, for example after clicking in the Explorer. That is disruptive because the task is still waiting for a value.

This change keeps both `promptString` and `pickString` task inputs open when focus moves elsewhere. A task now proceeds only after the user selects a value or confirms the text input. Pressing Escape cancels the task cleanly instead of leaving a partially resolved task running.

While testing the cancellation path, I also found that cancelling an input could leave a shell task without its arguments. With the example task, that meant starting `node` by itself and leaving a Node prompt running. The process task resolver now stops task resolution when a command or its arguments are cancelled.

## Manual testing

Using `packages/task/test-resources/.theia/tasks.json` and **Task: Run Task**:

- Started **task with input variables**, clicked elsewhere in the Explorer while the text prompt was open, and confirmed that the prompt remained open.
- Entered `b`, selected `c`, and confirmed the task completed with the expected arguments: `a b c`.
- Pressed Escape at the text prompt and verified that the task was cancelled rather than started.
- Started the same task again immediately after cancellation and confirmed that it opened normally; no "already running" task was left behind.
- Repeated the focus-loss and Escape checks for the choice input.

## Automated checks

Passed locally:

- `npm run compile --workspace=@theia/task`
- `npm run compile --workspace=@theia/variable-resolver`
- `npm test --workspace=@theia/variable-resolver` (12 passing)
- `./node_modules/.bin/mocha --config ./configs/mocharc.yml ./packages/task/lib/browser/process/process-task-resolver.spec.js` (1 passing)
- `npm run lint --workspace=@theia/task`
- `npm run lint --workspace=@theia/variable-resolver`
- `git diff --check`
- JSONC validation for `packages/task/test-resources/.theia/tasks.json`

The complete `@theia/task` suite could not be started locally because the current Node 24 environment is missing the unrelated native `drivelist` binding. The modified packages compile cleanly, and the focused regression tests pass.
