### PR TITLE
feat(scm): add reveal and view mode actions to the history graph toolbar

### DIFF
--- a/packages/scm/src/browser/scm-history-graph-contribution.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-contribution.spec.ts
@@ -21,7 +21,7 @@ import { expect } from 'chai';
 import { Command, CommandHandler, CommandRegistry } from '@theia/core/lib/common/command';
 import { Disposable } from '@theia/core/lib/common/disposable';
 import { ScmHistoryGraphContribution, ScmHistoryGraphCommands } from './scm-history-graph-contribution';
-import { ScmHistoryGraphModel } from './scm-history-graph-model';
+import { ScmHistoryGraphModel, ScmHistoryViewMode } from './scm-history-graph-model';
 import { ScmHistoryProvider } from './scm-provider';
 
 disableJSDOM();
@@ -30,23 +30,44 @@ interface ContributionInternals {
     scmService: { selectedRepository: { provider: { historyProvider?: ScmHistoryProvider } } | undefined };
     modelProvider: () => ScmHistoryGraphModel;
     quickInputService: unknown;
+    scmContextKeys: unknown;
 }
 
-function createContribution(historyProvider: ScmHistoryProvider | undefined): {
+const ALL_COMMANDS = [
+    ScmHistoryGraphCommands.REFRESH,
+    ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS,
+    ScmHistoryGraphCommands.REVEAL_CURRENT_HISTORY_ITEM,
+    ScmHistoryGraphCommands.SET_LIST_VIEW_MODE,
+    ScmHistoryGraphCommands.SET_TREE_VIEW_MODE,
+];
+
+function createContribution(historyProvider: ScmHistoryProvider | undefined, currentRefInFilter = true): {
     handlers: Map<string, CommandHandler>;
     modelResolved(): boolean;
+    revealCount(): number;
+    viewMode(): ScmHistoryViewMode;
 } {
     const contribution = new ScmHistoryGraphContribution();
     let resolved = false;
+    let reveals = 0;
+    let viewMode: ScmHistoryViewMode = 'list';
     const internals = contribution as unknown as ContributionInternals;
     internals.scmService = {
         selectedRepository: historyProvider ? { provider: { historyProvider } } : undefined,
     };
     internals.modelProvider = () => {
         resolved = true;
-        return { historyItemRefFilter: undefined } as unknown as ScmHistoryGraphModel;
+        return {
+            historyItemRefFilter: undefined,
+            revealCurrentHistoryItem: async () => { reveals++; return undefined; },
+            get viewMode(): ScmHistoryViewMode { return viewMode; },
+            setViewMode: (mode: ScmHistoryViewMode) => { viewMode = mode; },
+        } as unknown as ScmHistoryGraphModel;
     };
     internals.quickInputService = {};
+    internals.scmContextKeys = {
+        scmCurrentHistoryItemRefInFilter: { get: () => currentRefInFilter },
+    };
 
     const handlers = new Map<string, CommandHandler>();
     const registry = {
@@ -56,14 +77,14 @@ function createContribution(historyProvider: ScmHistoryProvider | undefined): {
         },
     } as unknown as CommandRegistry;
     contribution.registerCommands(registry);
-    return { handlers, modelResolved: () => resolved };
+    return { handlers, modelResolved: () => resolved, revealCount: () => reveals, viewMode: () => viewMode };
 }
 
 describe('ScmHistoryGraphContribution', () => {
 
     it('does not resolve the graph model for enablement and visibility checks', () => {
         const { handlers, modelResolved } = createContribution({} as ScmHistoryProvider);
-        for (const command of [ScmHistoryGraphCommands.REFRESH, ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS]) {
+        for (const command of ALL_COMMANDS) {
             const handler = handlers.get(command.id)!;
             expect(handler.isEnabled!()).to.be.true;
             expect(handler.isVisible!()).to.be.true;
@@ -73,11 +94,55 @@ describe('ScmHistoryGraphContribution', () => {
 
     it('disables the commands when the selected repository has no history provider', () => {
         const { handlers, modelResolved } = createContribution(undefined);
-        for (const command of [ScmHistoryGraphCommands.REFRESH, ScmHistoryGraphCommands.PICK_HISTORY_ITEM_REFS]) {
+        for (const command of ALL_COMMANDS) {
             const handler = handlers.get(command.id)!;
             expect(handler.isEnabled!()).to.be.false;
             expect(handler.isVisible!()).to.be.false;
         }
         expect(modelResolved()).to.be.false;
+    });
+
+    it('disables revealing the current history item when the filter excludes the current ref', () => {
+        const { handlers } = createContribution({} as ScmHistoryProvider, false);
+        const handler = handlers.get(ScmHistoryGraphCommands.REVEAL_CURRENT_HISTORY_ITEM.id)!;
+        expect(handler.isEnabled!()).to.be.false;
+    });
+
+    it('keeps revealing the current history item visible when the filter excludes the current ref', () => {
+        const { handlers } = createContribution({} as ScmHistoryProvider, false);
+        const handler = handlers.get(ScmHistoryGraphCommands.REVEAL_CURRENT_HISTORY_ITEM.id)!;
+        expect(handler.isVisible!()).to.be.true;
+    });
+
+    it('asks the model to reveal the current history item when executed', async () => {
+        const { handlers, revealCount } = createContribution({} as ScmHistoryProvider);
+        await handlers.get(ScmHistoryGraphCommands.REVEAL_CURRENT_HISTORY_ITEM.id)!.execute();
+        expect(revealCount()).to.equal(1);
+    });
+
+    it('switches the model to the tree view mode', async () => {
+        const { handlers, viewMode } = createContribution({} as ScmHistoryProvider);
+        await handlers.get(ScmHistoryGraphCommands.SET_TREE_VIEW_MODE.id)!.execute();
+        expect(viewMode()).to.equal('tree');
+    });
+
+    it('switches the model back to the list view mode', async () => {
+        const { handlers, viewMode } = createContribution({} as ScmHistoryProvider);
+        await handlers.get(ScmHistoryGraphCommands.SET_TREE_VIEW_MODE.id)!.execute();
+        await handlers.get(ScmHistoryGraphCommands.SET_LIST_VIEW_MODE.id)!.execute();
+        expect(viewMode()).to.equal('list');
+    });
+
+    it('toggles the view mode command matching the current view mode', async () => {
+        const { handlers } = createContribution({} as ScmHistoryProvider);
+        const list = handlers.get(ScmHistoryGraphCommands.SET_LIST_VIEW_MODE.id)!;
+        const tree = handlers.get(ScmHistoryGraphCommands.SET_TREE_VIEW_MODE.id)!;
+        expect(list.isToggled!()).to.be.true;
+        expect(tree.isToggled!()).to.be.false;
+
+        await tree.execute();
+
+        expect(list.isToggled!()).to.be.false;
+        expect(tree.isToggled!()).to.be.true;
     });
 });

--- a/packages/scm/src/browser/scm-history-graph-contribution.ts
+++ b/packages/scm/src/browser/scm-history-graph-contribution.ts
@@ -25,6 +25,7 @@ import { QuickPickItem, QuickPickSeparator } from '@theia/core/lib/common/quick-
 import { codicon } from '@theia/core/lib/browser/widgets/widget';
 import { ScmHistoryGraphModel, ScmHistoryGraphModelProvider } from './scm-history-graph-model';
 import { ScmService } from './scm-service';
+import { ScmContextKeyService } from './scm-context-key-service';
 import { ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
 import { SCM_HISTORY_TITLE_MENU } from './scm-history-graph-widget';
 import { getRefBadgeClass } from './scm-history-graph-helpers';
@@ -42,6 +43,22 @@ export namespace ScmHistoryGraphCommands {
         label: 'Pick History Item Reference...',
         iconClass: codicon('git-branch')
     }, 'theia/scm/pickHistoryItemRefs');
+    export const REVEAL_CURRENT_HISTORY_ITEM = Command.toDefaultLocalizedCommand({
+        id: 'scmHistoryGraph.revealCurrentHistoryItem',
+        category: 'Source Control',
+        label: 'Go to Current History Item',
+        iconClass: codicon('target')
+    });
+    export const SET_LIST_VIEW_MODE = Command.toDefaultLocalizedCommand({
+        id: 'scmHistoryGraph.setListViewMode',
+        category: 'Source Control',
+        label: 'View as List'
+    });
+    export const SET_TREE_VIEW_MODE = Command.toDefaultLocalizedCommand({
+        id: 'scmHistoryGraph.setTreeViewMode',
+        category: 'Source Control',
+        label: 'View as Tree'
+    });
 }
 
 type RefPickItem = QuickPickItem & { refId?: string; auto?: boolean };
@@ -59,6 +76,7 @@ export class ScmHistoryGraphContribution implements CommandContribution, MenuCon
     @inject(ScmHistoryGraphModelProvider) protected readonly modelProvider: ScmHistoryGraphModelProvider;
     @inject(QuickInputService) @optional() protected readonly quickInputService: QuickInputService;
     @inject(ILogger) @named('scm:ScmHistoryGraphContribution') protected readonly logger: ILogger;
+    @inject(ScmContextKeyService) protected readonly scmContextKeys: ScmContextKeyService;
 
     /**
      * The graph model, resolved lazily: instantiating it starts loading
@@ -87,6 +105,25 @@ export class ScmHistoryGraphContribution implements CommandContribution, MenuCon
             isToggled: () => !!this.model.historyItemRefFilter,
             execute: () => this.pickHistoryItemRefs()
         });
+        commands.registerCommand(ScmHistoryGraphCommands.REVEAL_CURRENT_HISTORY_ITEM, {
+            // There is nothing to reveal while the filter excludes the current ref,
+            // mirroring VS Code's precondition for this action.
+            isEnabled: () => !!this.historyProvider && this.scmContextKeys.scmCurrentHistoryItemRefInFilter.get() === true,
+            isVisible: () => !!this.historyProvider,
+            execute: () => this.model.revealCurrentHistoryItem()
+        });
+        commands.registerCommand(ScmHistoryGraphCommands.SET_LIST_VIEW_MODE, {
+            isEnabled: () => !!this.historyProvider,
+            isVisible: () => !!this.historyProvider,
+            isToggled: () => this.model.viewMode === 'list',
+            execute: () => this.model.setViewMode('list')
+        });
+        commands.registerCommand(ScmHistoryGraphCommands.SET_TREE_VIEW_MODE, {
+            isEnabled: () => !!this.historyProvider,
+            isVisible: () => !!this.historyProvider,
+            isToggled: () => this.model.viewMode === 'tree',
+            execute: () => this.model.setViewMode('tree')
+        });
     }
 
     registerMenus(menus: MenuModelRegistry): void {
@@ -97,8 +134,22 @@ export class ScmHistoryGraphContribution implements CommandContribution, MenuCon
             order: '100'
         });
         menus.registerMenuAction([...SCM_HISTORY_TITLE_MENU, 'navigation'], {
+            commandId: ScmHistoryGraphCommands.REVEAL_CURRENT_HISTORY_ITEM.id,
+            order: '200'
+        });
+        menus.registerMenuAction([...SCM_HISTORY_TITLE_MENU, 'navigation'], {
             commandId: ScmHistoryGraphCommands.REFRESH.id,
             order: '999'
+        });
+        // Groups other than 'navigation' are rendered in the toolbar's overflow menu,
+        // which is where VS Code places the view mode toggles as well.
+        menus.registerMenuAction([...SCM_HISTORY_TITLE_MENU, '9_viewmode'], {
+            commandId: ScmHistoryGraphCommands.SET_LIST_VIEW_MODE.id,
+            order: '1'
+        });
+        menus.registerMenuAction([...SCM_HISTORY_TITLE_MENU, '9_viewmode'], {
+            commandId: ScmHistoryGraphCommands.SET_TREE_VIEW_MODE.id,
+            order: '2'
         });
     }
 

--- a/packages/scm/src/browser/scm-history-graph-helpers.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-helpers.spec.ts
@@ -15,8 +15,10 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { filterRefsForBadges, getRefBadgePresentation, getRefColorIndex } from './scm-history-graph-helpers';
-import { ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
+import {
+    buildChangeTreeRows, ChangeTreeFileRow, ChangeTreeRow, filterRefsForBadges, getFileName, getRefBadgePresentation, getRefColorIndex
+} from './scm-history-graph-helpers';
+import { ScmHistoryItemChange, ScmHistoryItemRef, ScmHistoryProvider } from './scm-provider';
 
 describe('getRefColorIndex', () => {
 
@@ -114,5 +116,78 @@ describe('filterRefsForBadges', () => {
 
     it("ignores an explicit filter in 'all' mode", () => {
         expect(filterRefsForBadges(refs, provider, 'all', ['refs/heads/feature'])).to.deep.equal(refs);
+    });
+});
+
+describe('buildChangeTreeRows', () => {
+
+    const rootUri = 'file:///repo';
+
+    function change(path: string): ScmHistoryItemChange {
+        return { uri: `${rootUri}/${path}`, modifiedUri: `${rootUri}/${path}` };
+    }
+
+    /** Renders the rows as indented lines, so the expectations read like a tree. */
+    function describeRows(rows: readonly ChangeTreeRow[]): string[] {
+        return rows.map(row => `${'  '.repeat(row.depth)}${row.type === 'folder' ? row.label + '/' : getFileName(row.path)}`);
+    }
+
+    it('keeps files at the root at depth 0', () => {
+        const rows = buildChangeTreeRows([change('a.ts'), change('b.ts')], rootUri, new Set());
+        expect(describeRows(rows)).to.deep.equal(['a.ts', 'b.ts']);
+    });
+
+    it('groups files under their folder', () => {
+        const rows = buildChangeTreeRows([change('src/a.ts'), change('src/b.ts')], rootUri, new Set());
+        expect(describeRows(rows)).to.deep.equal(['src/', '  a.ts', '  b.ts']);
+    });
+
+    it('compacts folder chains that hold a single child folder', () => {
+        const rows = buildChangeTreeRows([change('src/browser/a.ts')], rootUri, new Set());
+        expect(describeRows(rows)).to.deep.equal(['src/browser/', '  a.ts']);
+    });
+
+    it('stops compacting where a folder chain branches', () => {
+        const rows = buildChangeTreeRows([change('src/browser/a.ts'), change('src/node/b.ts')], rootUri, new Set());
+        expect(describeRows(rows)).to.deep.equal(['src/', '  browser/', '    a.ts', '  node/', '    b.ts']);
+    });
+
+    it('does not compact a folder that also holds files', () => {
+        const rows = buildChangeTreeRows([change('src/a.ts'), change('src/browser/b.ts')], rootUri, new Set());
+        expect(describeRows(rows)).to.deep.equal(['src/', '  browser/', '    b.ts', '  a.ts']);
+    });
+
+    it('sorts folders before files, each alphabetically', () => {
+        const rows = buildChangeTreeRows([change('z.ts'), change('a.ts'), change('src/b.ts')], rootUri, new Set());
+        expect(describeRows(rows)).to.deep.equal(['src/', '  b.ts', 'a.ts', 'z.ts']);
+    });
+
+    it('hides the descendants of a collapsed folder', () => {
+        const rows = buildChangeTreeRows([change('src/a.ts'), change('b.ts')], rootUri, new Set(['src']));
+        expect(describeRows(rows)).to.deep.equal(['src/', 'b.ts']);
+    });
+
+    it('addresses a compacted folder by its full path', () => {
+        const rows = buildChangeTreeRows([change('src/browser/a.ts')], rootUri, new Set(['src/browser']));
+        expect(describeRows(rows)).to.deep.equal(['src/browser/']);
+    });
+
+    it('carries the original change on each file row', () => {
+        const first = change('src/a.ts');
+        const rows = buildChangeTreeRows([first], rootUri, new Set());
+        expect(rows[1].type).to.equal('file');
+        expect((rows[1] as ChangeTreeFileRow).change).to.equal(first);
+    });
+
+    it('keeps the index of the change in the original list, so row keys stay stable', () => {
+        const rows = buildChangeTreeRows([change('z.ts'), change('src/a.ts')], rootUri, new Set());
+        // Sorted as: src/, src/a.ts (index 1), z.ts (index 0).
+        expect(rows.filter(row => row.type === 'file').map(row => (row as ChangeTreeFileRow).index)).to.deep.equal([1, 0]);
+    });
+
+    it('falls back to the full path when the change is outside the repository root', () => {
+        const outside: ScmHistoryItemChange = { uri: 'file:///elsewhere/x.ts', modifiedUri: 'file:///elsewhere/x.ts' };
+        const rows = buildChangeTreeRows([outside], rootUri, new Set());
+        expect(describeRows(rows)).to.deep.equal(['elsewhere/', '  x.ts']);
     });
 });

--- a/packages/scm/src/browser/scm-history-graph-helpers.ts
+++ b/packages/scm/src/browser/scm-history-graph-helpers.ts
@@ -83,6 +83,105 @@ export function getRepoRelativePath(uri: string, rootUri: string | undefined): s
     return fullPath;
 }
 
+export interface ChangeTreeRowBase {
+    /** Repo-relative path of the row; the expansion key for folders. */
+    readonly path: string;
+    /** Nesting level, used for indentation. */
+    readonly depth: number;
+}
+
+export interface ChangeTreeFolderRow extends ChangeTreeRowBase {
+    readonly type: 'folder';
+    /** Segments rendered for this row; a compacted chain shows `browser/model`. */
+    readonly label: string;
+}
+
+export interface ChangeTreeFileRow extends ChangeTreeRowBase {
+    readonly type: 'file';
+    readonly change: ScmHistoryItemChange;
+    /** Position of the change in the list it came from, so row keys stay stable. */
+    readonly index: number;
+}
+
+export type ChangeTreeRow = ChangeTreeFolderRow | ChangeTreeFileRow;
+
+interface ChangeTreeFolder {
+    readonly folders: Map<string, ChangeTreeFolder>;
+    readonly files: { change: ScmHistoryItemChange; index: number; name: string }[];
+}
+
+/**
+ * Arranges history item changes into the rows of a file tree: folders before
+ * files, each sorted by name, with single-child folder chains compacted into
+ * one row (`src/browser`) the way VS Code's SCM tree renders them. Folders
+ * listed in `collapsedFolders` (by their full path) hide their descendants.
+ */
+export function buildChangeTreeRows(
+    changes: readonly ScmHistoryItemChange[],
+    rootUri: string | undefined,
+    collapsedFolders: ReadonlySet<string>
+): ChangeTreeRow[] {
+    const root: ChangeTreeFolder = { folders: new Map(), files: [] };
+    changes.forEach((change, index) => {
+        const relativePath = getRepoRelativePath(change.modifiedUri ?? change.originalUri ?? change.uri, rootUri);
+        const segments = relativePath.split('/').filter(segment => segment.length > 0);
+        const name = segments.pop() ?? relativePath;
+        let folder = root;
+        for (const segment of segments) {
+            let child = folder.folders.get(segment);
+            if (!child) {
+                child = { folders: new Map(), files: [] };
+                folder.folders.set(segment, child);
+            }
+            folder = child;
+        }
+        folder.files.push({ change, index, name });
+    });
+
+    const rows: ChangeTreeRow[] = [];
+    collectChangeTreeRows(root, '', '', 0, collapsedFolders, rows);
+    return rows;
+}
+
+function collectChangeTreeRows(
+    folder: ChangeTreeFolder,
+    path: string,
+    label: string,
+    depth: number,
+    collapsedFolders: ReadonlySet<string>,
+    rows: ChangeTreeRow[]
+): void {
+    for (const name of [...folder.folders.keys()].sort(compareNames)) {
+        let child = folder.folders.get(name)!;
+        let childPath = path ? `${path}/${name}` : name;
+        let childLabel = label ? `${label}/${name}` : name;
+        // Compact a chain of folders that each hold nothing but one folder.
+        while (child.files.length === 0 && child.folders.size === 1) {
+            const [onlyName, onlyChild] = [...child.folders][0];
+            child = onlyChild;
+            childPath = `${childPath}/${onlyName}`;
+            childLabel = `${childLabel}/${onlyName}`;
+        }
+        rows.push({ type: 'folder', path: childPath, label: childLabel, depth });
+        if (!collapsedFolders.has(childPath)) {
+            collectChangeTreeRows(child, childPath, '', depth + 1, collapsedFolders, rows);
+        }
+    }
+    for (const file of [...folder.files].sort((left, right) => compareNames(left.name, right.name))) {
+        rows.push({
+            type: 'file',
+            path: path ? `${path}/${file.name}` : file.name,
+            depth,
+            change: file.change,
+            index: file.index
+        });
+    }
+}
+
+function compareNames(left: string, right: string): number {
+    return left.localeCompare(right);
+}
+
 /**
  * Returns the ref-based color index of the given ref (0 = current ref,
  * 1 = remote ref, 2 = base ref), or `undefined` when the ref is none of

--- a/packages/scm/src/browser/scm-history-graph-model.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.spec.ts
@@ -404,3 +404,134 @@ describe('ScmHistoryGraphModel - ref colors and current item', () => {
         expect(model.entries.every(e => !e.isCurrent)).to.be.true;
     });
 });
+
+describe('ScmHistoryGraphModel - view mode', () => {
+
+    it('shows the changes of a history item as a list by default', () => {
+        const { model } = createModel(new StubHistoryProvider());
+        expect(model.viewMode).to.equal('list');
+    });
+
+    it('switches the view mode', () => {
+        const { model } = createModel(new StubHistoryProvider());
+        model.setViewMode('tree');
+        expect(model.viewMode).to.equal('tree');
+    });
+
+    it('notifies listeners when the view mode changes', () => {
+        const { model } = createModel(new StubHistoryProvider());
+        let changes = 0;
+        model.onDidChange(() => changes++);
+
+        model.setViewMode('tree');
+
+        expect(changes).to.equal(1);
+    });
+
+    it('does not notify listeners when the view mode is unchanged', () => {
+        const { model } = createModel(new StubHistoryProvider());
+        model.setViewMode('tree');
+        let changes = 0;
+        model.onDidChange(() => changes++);
+
+        model.setViewMode('tree');
+
+        expect(changes).to.equal(0);
+    });
+
+    it('does not reload history when the view mode changes', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, 10)];
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        const requestsBefore = provider.receivedOptions.length;
+
+        model.setViewMode('tree');
+        await nextTick();
+
+        expect(provider.receivedOptions).to.have.length(requestsBefore);
+    });
+});
+
+describe('ScmHistoryGraphModel - revealing the current history item', () => {
+
+    function createProviderAt(revision: string): StubHistoryProvider {
+        const provider = new StubHistoryProvider();
+        provider.currentHistoryItemRef = { id: 'refs/heads/main', name: 'main', revision };
+        return provider;
+    }
+
+    it('requests a reveal of the index of the current history item', async () => {
+        const provider = createProviderAt('c3');
+        provider.pages = [makeItems(1, 10)];
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        const revealed: number[] = [];
+        model.onDidRequestReveal(revealedIndex => revealed.push(revealedIndex));
+
+        const index = await model.revealCurrentHistoryItem();
+
+        expect(index).to.equal(2);
+        expect(revealed).to.deep.equal([2]);
+    });
+
+    it('loads further pages until the current history item is found', async () => {
+        const provider = createProviderAt('c55');
+        provider.pages = [makeItems(1, PAGE_SIZE), makeItems(PAGE_SIZE + 1, PAGE_SIZE)];
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        expect(model.entries).to.have.length(PAGE_SIZE);
+
+        const index = await model.revealCurrentHistoryItem();
+
+        expect(index).to.equal(54);
+        expect(model.entries).to.have.length(2 * PAGE_SIZE);
+    });
+
+    it('does not request a reveal when the current history item is not in the history', async () => {
+        const provider = createProviderAt('not-loaded');
+        provider.pages = [makeItems(1, 10)];
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        const revealed: number[] = [];
+        model.onDidRequestReveal(revealedIndex => revealed.push(revealedIndex));
+
+        const index = await model.revealCurrentHistoryItem();
+
+        expect(index).to.be.undefined;
+        expect(revealed).to.be.empty;
+    });
+
+    it('does not request a reveal when the provider has no current history item ref', async () => {
+        const provider = new StubHistoryProvider();
+        provider.pages = [makeItems(1, 10)];
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        const revealed: number[] = [];
+        model.onDidRequestReveal(revealedIndex => revealed.push(revealedIndex));
+
+        const index = await model.revealCurrentHistoryItem();
+
+        expect(index).to.be.undefined;
+        expect(revealed).to.be.empty;
+    });
+
+    it('stops paging when further pages add no new items', async () => {
+        const provider = createProviderAt('never-returned');
+        const page = makeItems(1, PAGE_SIZE);
+        // A provider that keeps returning the same full page: `hasMore` stays true
+        // forever, so only a no-progress guard can end the search.
+        provider.provideHistoryItems = async options => {
+            provider.receivedOptions.push(options);
+            return page;
+        };
+        const { model, loadPage } = createModel(provider);
+        await loadPage();
+        expect(model.hasMore).to.be.true;
+
+        const index = await model.revealCurrentHistoryItem();
+
+        expect(index).to.be.undefined;
+        expect(model.entries).to.have.length(PAGE_SIZE);
+    });
+});

--- a/packages/scm/src/browser/scm-history-graph-model.ts
+++ b/packages/scm/src/browser/scm-history-graph-model.ts
@@ -16,7 +16,7 @@
 
 import { injectable, inject, postConstruct, named } from '@theia/core/shared/inversify';
 import { Disposable, DisposableCollection } from '@theia/core/lib/common/disposable';
-import { Emitter } from '@theia/core/lib/common/event';
+import { Emitter, Event } from '@theia/core/lib/common/event';
 import { CancellationTokenSource } from '@theia/core/lib/common/cancellation';
 import { ScmService } from './scm-service';
 import { ScmHistoryItem, ScmHistoryItemRef, ScmHistoryProvider, ScmHistoryOptions } from './scm-provider';
@@ -26,6 +26,9 @@ import { getRefColorIndex } from './scm-history-graph-helpers';
 import { ScmPreferences } from '../common/scm-preferences';
 
 export const PAGE_SIZE = 50;
+
+/** How the changes of an expanded history item are laid out. */
+export type ScmHistoryViewMode = 'list' | 'tree';
 
 export const ScmHistoryGraphModelProvider = Symbol('ScmHistoryGraphModelProvider');
 /**
@@ -63,9 +66,14 @@ export class ScmHistoryGraphModel {
     protected _provider: ScmHistoryProvider | undefined;
     /** Explicitly picked ref ids to filter the graph by; `undefined` = auto (current/remote/base). */
     protected _historyItemRefFilter: string[] | undefined;
+    protected _viewMode: ScmHistoryViewMode = 'list';
 
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange = this.onDidChangeEmitter.event;
+
+    protected readonly onDidRequestRevealEmitter = new Emitter<number>();
+    /** Fired with the index of an entry the view should scroll to and select. */
+    readonly onDidRequestReveal: Event<number> = this.onDidRequestRevealEmitter.event;
 
     protected cancelSource = new CancellationTokenSource();
 
@@ -74,6 +82,7 @@ export class ScmHistoryGraphModel {
         this.toDispose.pushAll([
             Disposable.create(() => this.toDisposeOnProviderChange.dispose()),
             this.onDidChangeEmitter,
+            this.onDidRequestRevealEmitter,
             this.scmService.onDidChangeSelectedRepository(() => this.refresh()),
             this.scmPreferences.onPreferenceChanged(e => {
                 if (e.preferenceName === 'scm.graph.pageSize') {
@@ -96,6 +105,23 @@ export class ScmHistoryGraphModel {
     /** The explicitly picked ref ids filtering the graph, or `undefined` in auto mode. */
     get historyItemRefFilter(): readonly string[] | undefined {
         return this._historyItemRefFilter;
+    }
+
+    /** How the changes of an expanded history item are laid out. */
+    get viewMode(): ScmHistoryViewMode {
+        return this._viewMode;
+    }
+
+    /**
+     * Switches how the changes of an expanded history item are laid out. This
+     * only affects rendering, so the loaded history is kept as is.
+     */
+    setViewMode(viewMode: ScmHistoryViewMode): void {
+        if (this._viewMode === viewMode) {
+            return;
+        }
+        this._viewMode = viewMode;
+        this.onDidChangeEmitter.fire();
     }
 
     /**
@@ -198,6 +224,35 @@ export class ScmHistoryGraphModel {
         this._hasMore = false;
 
         this.loadPage();
+    }
+
+    /**
+     * Locates the commit the current history item ref points at, loading
+     * further pages while it is outside the loaded range, and asks the view to
+     * reveal it. Returns its index, or `undefined` when there is no current
+     * history item ref or the commit is not part of the graph (e.g. the ref is
+     * excluded by the filter).
+     */
+    async revealCurrentHistoryItem(): Promise<number | undefined> {
+        let index = this.indexOfCurrentHistoryItem();
+        while (index === undefined && this._hasMore) {
+            const loadedBefore = this._entries.length;
+            await this.loadMore();
+            if (this._entries.length === loadedBefore) {
+                // The page added nothing new; paging further cannot find the item.
+                break;
+            }
+            index = this.indexOfCurrentHistoryItem();
+        }
+        if (index !== undefined) {
+            this.onDidRequestRevealEmitter.fire(index);
+        }
+        return index;
+    }
+
+    protected indexOfCurrentHistoryItem(): number | undefined {
+        const index = this._entries.findIndex(entry => entry.isCurrent);
+        return index === -1 ? undefined : index;
     }
 
     async loadMore(): Promise<void> {

--- a/packages/scm/src/browser/scm-history-graph-widget.spec.ts
+++ b/packages/scm/src/browser/scm-history-graph-widget.spec.ts
@@ -18,10 +18,13 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJSDOM = enableJSDOM();
 
 import { expect } from 'chai';
+import * as React from '@theia/core/shared/react';
+import { Emitter } from '@theia/core/lib/common/event';
 import { ContextKey, ContextKeyServiceDummyImpl, ContextKeyValue } from '@theia/core/lib/browser/context-key-service';
 import { ScmContextKeyService } from './scm-context-key-service';
 import { ScmHistoryGraphWidget } from './scm-history-graph-widget';
-import { ScmHistoryProvider } from './scm-provider';
+import { GraphRow } from './scm-history-graph-lanes';
+import { ScmHistoryItemChange, ScmHistoryProvider } from './scm-provider';
 
 disableJSDOM();
 
@@ -108,5 +111,200 @@ describe('ScmHistoryGraphWidget context keys', () => {
         };
         updateContextKeys();
         expect(scmContextKeys.scmCurrentHistoryItemRefHasRemote.get()).to.equal(true);
+    });
+});
+
+describe('ScmHistoryGraphWidget reveal', () => {
+    let restoreJSDOM: () => void;
+    let widget: ScmHistoryGraphWidget;
+    let requestReveal: Emitter<number>;
+    let scrolledTo: { index: number; align?: string }[];
+
+    beforeEach(() => {
+        restoreJSDOM = enableJSDOM();
+        requestReveal = new Emitter<number>();
+        scrolledTo = [];
+
+        widget = new ScmHistoryGraphWidget();
+        const raw = widget as unknown as Record<string, unknown>;
+        raw.scmContextKeys = createScmContextKeyService();
+        raw.scmPreferences = { onPreferenceChanged: new Emitter<{ preferenceName: string }>().event };
+        raw.model = {
+            provider: undefined,
+            entries: [],
+            hasMore: false,
+            loading: false,
+            hasAttemptedLoad: true,
+            isCurrentRefInFilter: () => true,
+            onDidChange: new Emitter<void>().event,
+            onDidRequestReveal: requestReveal.event
+        };
+        raw.listRef = { current: { scrollToIndex: (location: { index: number; align?: string }) => scrolledTo.push(location) } };
+        // Rendering is out of scope here and would otherwise run asynchronously,
+        // after JSDOM has been torn down again.
+        raw.update = () => { };
+        (widget as unknown as { init(): void }).init();
+    });
+
+    afterEach(() => {
+        widget.dispose();
+        restoreJSDOM();
+    });
+
+    function selectedIndex(): number {
+        return (widget as unknown as { selectedIndex: number }).selectedIndex;
+    }
+
+    it('should scroll to the entry the model asks to reveal', () => {
+        requestReveal.fire(4);
+        expect(scrolledTo).to.deep.equal([{ index: 4, align: 'center' }]);
+    });
+
+    it('should select the entry the model asks to reveal', () => {
+        requestReveal.fire(4);
+        expect(selectedIndex()).to.equal(4);
+    });
+
+    it('should stop revealing once disposed', () => {
+        widget.dispose();
+        requestReveal.fire(4);
+        expect(scrolledTo).to.be.empty;
+    });
+});
+
+const ROOT_URI = 'file:///repo';
+
+/** Builds the change rows of `commit-1` in the given view mode. */
+function renderChanges(widget: ScmHistoryGraphWidget, viewMode: 'list' | 'tree', paths: string[]): React.ReactElement {
+    const raw = widget as unknown as Record<string, unknown>;
+    raw.model = { viewMode };
+    raw.scmService = { selectedRepository: { provider: { rootUri: ROOT_URI } } };
+    raw.labelProvider = { getIcon: () => 'file-icon' };
+    const changes: ScmHistoryItemChange[] = paths.map(path => ({
+        uri: `${ROOT_URI}/${path}`,
+        modifiedUri: `${ROOT_URI}/${path}`,
+        originalUri: `${ROOT_URI}/${path}`
+    }));
+    const graphRow: GraphRow = { lane: 0, color: 0, topColor: 0, edges: [], hasContinuation: false, hasTopLine: false };
+    const render = widget as unknown as {
+        renderChangesRows(itemId: string, svgWidth: number, graphRow: GraphRow, changes: ScmHistoryItemChange[]): React.ReactElement;
+    };
+    return render.renderChangesRows('commit-1', 22, graphRow, changes);
+}
+
+function allElements(node: React.ReactNode): React.ReactElement[] {
+    const result: React.ReactElement[] = [];
+    const visit = (candidate: React.ReactNode): void => {
+        if (Array.isArray(candidate)) {
+            candidate.forEach(visit);
+        } else if (React.isValidElement(candidate)) {
+            result.push(candidate);
+            visit((candidate.props as { children?: React.ReactNode }).children);
+        }
+    };
+    visit(node);
+    return result;
+}
+
+function elementsWithClass(node: React.ReactNode, className: string): React.ReactElement[] {
+    return allElements(node).filter(element => {
+        const elementClass = (element.props as { className?: unknown }).className;
+        return typeof elementClass === 'string' && elementClass.includes(className);
+    });
+}
+
+/** The rendered name of a row — the `name scm-history-change-name` span it holds. */
+function nameOf(row: React.ReactElement): string {
+    const name = allElements(row).find(element => (element.props as { className?: unknown }).className === 'name scm-history-change-name');
+    return String((name?.props as { children?: unknown })?.children ?? '');
+}
+
+function folderLabels(rows: React.ReactElement): string[] {
+    return elementsWithClass(rows, 'scm-history-change-folder-row').map(nameOf);
+}
+
+function fileNames(rows: React.ReactElement): string[] {
+    return elementsWithClass(rows, 'scm-history-change-row')
+        .filter(row => !((row.props as { className: string }).className.includes('scm-history-change-folder-row')))
+        .map(nameOf);
+}
+
+describe('ScmHistoryGraphWidget change tree folders', () => {
+    let restoreJSDOM: () => void;
+    let widget: ScmHistoryGraphWidget;
+
+    beforeEach(() => {
+        restoreJSDOM = enableJSDOM();
+        widget = new ScmHistoryGraphWidget();
+        const raw = widget as unknown as Record<string, unknown>;
+        raw.update = () => { };
+    });
+
+    afterEach(() => {
+        widget.dispose();
+        restoreJSDOM();
+    });
+
+    function internals(): {
+        isFolderCollapsed(itemId: string, path: string): boolean;
+        toggleFolder(itemId: string, path: string): void;
+        collapsedFolders: Map<string, Set<string>>;
+    } {
+        return widget as unknown as ReturnType<typeof internals>;
+    }
+
+    it('should show folders expanded by default', () => {
+        expect(internals().isFolderCollapsed('commit-1', 'src')).to.be.false;
+    });
+
+    it('should collapse a folder on toggle', () => {
+        internals().toggleFolder('commit-1', 'src');
+        expect(internals().isFolderCollapsed('commit-1', 'src')).to.be.true;
+    });
+
+    it('should expand a collapsed folder on toggle', () => {
+        internals().toggleFolder('commit-1', 'src');
+        internals().toggleFolder('commit-1', 'src');
+        expect(internals().isFolderCollapsed('commit-1', 'src')).to.be.false;
+    });
+
+    it('should keep folder state separate per history item', () => {
+        internals().toggleFolder('commit-1', 'src');
+        expect(internals().isFolderCollapsed('commit-2', 'src')).to.be.false;
+    });
+
+    it('should render a folder row per folder of the change tree', () => {
+        const rows = renderChanges(widget, 'tree', ['src/browser/a.ts', 'src/node/b.ts']);
+        expect(folderLabels(rows)).to.deep.equal(['src', 'browser', 'node']);
+        expect(fileNames(rows)).to.deep.equal(['a.ts', 'b.ts']);
+    });
+
+    it('should render expanded folders with a down twistie', () => {
+        const rows = renderChanges(widget, 'tree', ['src/a.ts']);
+        expect(elementsWithClass(rows, 'codicon-chevron-down')).to.have.length(1);
+    });
+
+    it('should render a flat list of files without folder rows in list mode', () => {
+        const rows = renderChanges(widget, 'list', ['src/browser/a.ts', 'src/node/b.ts']);
+        expect(folderLabels(rows)).to.be.empty;
+        expect(fileNames(rows)).to.deep.equal(['a.ts', 'b.ts']);
+    });
+
+    it('should drop the files of a collapsed folder and turn its twistie', () => {
+        internals().toggleFolder('commit-1', 'src');
+        const rows = renderChanges(widget, 'tree', ['src/browser/a.ts', 'src/node/b.ts']);
+        expect(folderLabels(rows)).to.deep.equal(['src']);
+        expect(fileNames(rows)).to.be.empty;
+        expect(elementsWithClass(rows, 'codicon-chevron-right')).to.have.length(1);
+    });
+
+    it('should forget folder state when the history item is collapsed again', () => {
+        const raw = widget as unknown as { expandedIds: Set<string>; handleRowClick(idx: number, entry: unknown): void };
+        raw.expandedIds.add('commit-1');
+        internals().toggleFolder('commit-1', 'src');
+
+        raw.handleRowClick(0, { item: { id: 'commit-1' } });
+
+        expect(internals().collapsedFolders.has('commit-1')).to.be.false;
     });
 });

--- a/packages/scm/src/browser/scm-history-graph-widget.tsx
+++ b/packages/scm/src/browser/scm-history-graph-widget.tsx
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import * as React from '@theia/core/shared/react';
-import { Virtuoso } from '@theia/core/shared/react-virtuoso';
+import { Virtuoso, VirtuosoHandle } from '@theia/core/shared/react-virtuoso';
 import { injectable, inject, postConstruct, named } from '@theia/core/shared/inversify';
 import { ReactWidget } from '@theia/core/lib/browser/widgets/react-widget';
 import { LabelProvider } from '@theia/core/lib/browser/label-provider';
@@ -40,7 +40,8 @@ import { ScmContextKeyService } from './scm-context-key-service';
 import { ScmPreferences } from '../common/scm-preferences';
 import {
     laneColor, filterRefsForBadges, getChangeStatus, getFileName, getFilePath, getRepoRelativePath,
-    getRefBadgeClass, getRefBadgePresentation, isTagRef, isRemoteRef, deduplicateRefs, DeduplicatedRef
+    getRefBadgeClass, getRefBadgePresentation, isTagRef, isRemoteRef, deduplicateRefs, DeduplicatedRef,
+    buildChangeTreeRows, ChangeTreeFolderRow
 } from './scm-history-graph-helpers';
 import { ILogger } from '@theia/core';
 import { buildHtmlTooltip, buildProviderTooltip } from './scm-history-graph-tooltip';
@@ -59,6 +60,19 @@ const ROW_HEIGHT = 22;
 const LANE_WIDTH = 22;
 /** Y position of the commit dot — vertically centered in the row. */
 const DOT_CY = 11;
+
+/** Indentation of one level of the change tree, in pixels. */
+const TREE_INDENT = 8;
+/** Shared empty set for history items whose change tree is fully expanded. */
+const EMPTY_FOLDER_SET: ReadonlySet<string> = new Set<string>();
+
+/**
+ * Indentation for a row of the change tree. Like Theia's tree widget, the depth
+ * is applied as padding rather than through a class, as it is not known upfront.
+ */
+function indentStyle(depth: number): React.CSSProperties | undefined {
+    return depth > 0 ? { paddingLeft: `${4 + depth * TREE_INDENT}px` } : undefined;
+}
 
 /** Renders a ref badge as a JSX element for the commit row. */
 function renderJsxRefBadge(
@@ -106,12 +120,16 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
     protected readonly logger: ILogger;
 
     protected selectedIndex = -1;
+    /** Handle on the virtualized list, used to scroll an entry into view. */
+    protected readonly listRef = React.createRef<VirtuosoHandle>();
     /** Currently selected change row key (`${itemId}-${ci}`), or undefined. */
     protected selectedChangeKey: string | undefined;
     /** Map from commit id → loaded changes (undefined = not loaded yet). */
     protected expandedChanges = new Map<string, ScmHistoryItemChange[] | 'loading'>();
     /** Set of commit ids that are currently expanded. */
     protected expandedIds = new Set<string>();
+    /** Map from commit id → folder paths collapsed in its change tree. */
+    protected collapsedFolders = new Map<string, Set<string>>();
     /** Map from commit id → in-flight CancellationTokenSource for loadChanges. */
     protected loadChangesCts = new Map<string, CancellationTokenSource>();
     /** Cleanup for the content of the hover currently being shown. */
@@ -142,6 +160,9 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
             })
         );
         this.toDispose.push(
+            this.model.onDidRequestReveal(index => this.revealIndex(index))
+        );
+        this.toDispose.push(
             this.scmPreferences.onPreferenceChanged(e => {
                 if (e.preferenceName.startsWith('scm.graph.')) {
                     this.update();
@@ -158,6 +179,14 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
             }
         });
         this.toDispose.push(this.toDisposeOnHover);
+        this.update();
+    }
+
+    /** Scrolls the entry at `index` into view and selects it. */
+    protected revealIndex(index: number): void {
+        this.selectedIndex = index;
+        this.selectedChangeKey = undefined;
+        this.listRef.current?.scrollToIndex({ index, align: 'center' });
         this.update();
     }
 
@@ -215,6 +244,7 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
 
         return (
             <Virtuoso
+                ref={this.listRef}
                 className='scm-history-graph-list'
                 data={entries as HistoryGraphEntry[]}
                 itemContent={(idx, entry) => this.renderRow(entry, idx, svgWidth)}
@@ -337,6 +367,18 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
             );
         }
 
+        if (this.model.viewMode === 'tree') {
+            const rootUri = this.scmService.selectedRepository?.provider.rootUri;
+            const rows = buildChangeTreeRows(changes, rootUri, this.collapsedFolders.get(itemId) ?? EMPTY_FOLDER_SET);
+            return (
+                <React.Fragment key={`${itemId}-changes`}>
+                    {rows.map(row => row.type === 'folder'
+                        ? this.renderChangeFolderRow(row, itemId, svgWidth, graphRow)
+                        : this.renderChangeRow(row.change, row.index, itemId, svgWidth, graphRow, row.depth))}
+                </React.Fragment>
+            );
+        }
+
         return (
             <React.Fragment key={`${itemId}-changes`}>
                 {changes.map((change, ci) =>
@@ -346,18 +388,66 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
         );
     }
 
+    protected renderChangeFolderRow(
+        row: ChangeTreeFolderRow,
+        itemId: string,
+        svgWidth: number,
+        graphRow: GraphRow
+    ): React.ReactElement {
+        const collapsed = this.isFolderCollapsed(itemId, row.path);
+        return (
+            <div
+                key={`${itemId}-folder-${row.path}`}
+                className='scm-history-change-row scm-history-change-folder-row'
+                onClick={e => this.handleFolderClick(e, itemId, row.path)}
+                role='treeitem'
+                aria-expanded={!collapsed}
+                tabIndex={-1}
+            >
+                {this.renderChangeRowSvg(graphRow, svgWidth)}
+                <div className='scm-history-change-info' style={indentStyle(row.depth)}>
+                    <span className={`codicon ${collapsed ? 'codicon-chevron-right' : 'codicon-chevron-down'} scm-history-change-twistie`} />
+                    <span className='name scm-history-change-name' title={row.path}>{row.label}</span>
+                </div>
+            </div>
+        );
+    }
+
+    protected isFolderCollapsed(itemId: string, path: string): boolean {
+        return !!this.collapsedFolders.get(itemId)?.has(path);
+    }
+
+    protected toggleFolder(itemId: string, path: string): void {
+        let collapsed = this.collapsedFolders.get(itemId);
+        if (!collapsed) {
+            collapsed = new Set<string>();
+            this.collapsedFolders.set(itemId, collapsed);
+        }
+        if (!collapsed.delete(path)) {
+            collapsed.add(path);
+        }
+        this.update();
+    }
+
+    protected handleFolderClick = (e: React.MouseEvent, itemId: string, path: string): void => {
+        e.stopPropagation();
+        this.toggleFolder(itemId, path);
+    };
+
     protected renderChangeRow(
         change: ScmHistoryItemChange,
         ci: number,
         itemId: string,
         svgWidth: number,
-        graphRow: GraphRow
+        graphRow: GraphRow,
+        depth = 0
     ): React.ReactElement {
         const rootUri = this.scmService.selectedRepository?.provider.rootUri;
         const uri = change.modifiedUri ?? change.originalUri ?? change.uri;
         const relativePath = getRepoRelativePath(uri, rootUri);
         const fileName = getFileName(relativePath);
-        const dirPath = relativePath.includes('/')
+        // In tree mode the folder rows already carry the directory.
+        const dirPath = this.model.viewMode === 'list' && relativePath.includes('/')
             ? relativePath.slice(0, relativePath.lastIndexOf('/'))
             : '';
         const status = getChangeStatus(change);
@@ -376,7 +466,7 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
                 tabIndex={-1}
             >
                 {this.renderChangeRowSvg(graphRow, svgWidth)}
-                <div className='scm-history-change-info'>
+                <div className='scm-history-change-info' style={indentStyle(depth)}>
                     <span className={`${fileIcon} file-icon scm-history-change-file-icon`} />
                     <div className='scm-history-change-name-container'>
                         <span className='name scm-history-change-name' title={relativePath}>{fileName}</span>
@@ -719,6 +809,7 @@ export class ScmHistoryGraphWidget extends ReactWidget implements DynamicToolbar
 
         if (this.expandedIds.has(item.id)) {
             this.expandedIds.delete(item.id);
+            this.collapsedFolders.delete(item.id);
             const cts = this.loadChangesCts.get(item.id);
             if (cts) {
                 cts.cancel();

--- a/packages/scm/src/browser/style/scm-history-graph.css
+++ b/packages/scm/src/browser/style/scm-history-graph.css
@@ -200,6 +200,16 @@
     flex-shrink: 0;
 }
 
+/* Folder rows of the change tree ('View as Tree'). */
+.scm-history-change-twistie {
+    flex-shrink: 0;
+    opacity: 0.8;
+}
+
+.scm-history-change-folder-row .scm-history-change-name {
+    flex: 1;
+}
+
 .scm-history-change-name-container {
     flex: 1;
     display: flex;


### PR DESCRIPTION
#### What it does

Completes item 3 of #17457 by adding the two toolbar actions still missing from VS Code's Source Control Graph:

- **Go to Current History Item** (`target` icon) scrolls the graph to the commit the current history item ref points at and selects it, paging further history in when that commit is outside the loaded range. Disabled while the ref filter excludes the current ref, mirroring VS Code's precondition.
- **View as List** / **View as Tree** switch how the changes of an expanded commit are laid out. The tree groups files by folder, sorts folders before files and compacts single-child folder chains, as VS Code's SCM tree does. Both sit in the toolbar's overflow menu, where VS Code places them.

The graph toolbar now matches VS Code's: ref picker, go to current, fetch, pull, push, refresh, and the overflow with the view modes.

With this the follow-ups of #17457 are done, so the issue can be closed — provided the two deliberate exclusions are acceptable:

- the **repository picker** (item 3), since Theia's SCM view has its own repositories section;
- `scm.graph.showIncomingChanges` / `scm.graph.showOutgoingChanges` (item 5), which gate incoming/outgoing nodes the graph does not render yet. The item allows implementing a subset.

#### How to test

1. Open a git repository and expand the **Graph** section of the Source Control view.
2. Scroll away from the current commit, then click the `target` icon: the graph scrolls back to it and selects it. Pick a ref that excludes the current branch via the `Auto` picker — the action is disabled.
3. Expand a commit, then choose **View as Tree** from the toolbar's `...` menu: the changes are grouped into folders. Click a folder to collapse it, and switch back with **View as List**.

#### Follow-ups

Incoming/outgoing changes nodes, together with the two `scm.graph.*` settings that gate them, are the remaining gap against VS Code's graph.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
