### PR TITLE
fix(ai-core): wait for preferences before the initial skill scan

### DIFF
--- a/packages/ai-core/src/browser/skill-service.spec.ts
+++ b/packages/ai-core/src/browser/skill-service.spec.ts
@@ -25,6 +25,7 @@ import * as sinon from 'sinon';
 import { parseSkillFile, combineSkillDirectories } from '../common/skill';
 import { Path } from '@theia/core/lib/common/path';
 import { Disposable, Emitter, ILogger, Logger, URI } from '@theia/core';
+import { Deferred } from '@theia/core/lib/common/promise-util';
 import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
 import { DefaultSkillService } from './skill-service';
 
@@ -365,6 +366,7 @@ description: Skill with no content
 
             preferencesMock = {
                 'ai-features.skills.skillDirectories': [],
+                ready: Promise.resolve(),
                 onPreferenceChanged: preferenceChangedEmitter.event
             };
         });
@@ -484,6 +486,41 @@ description: Skill with no content
             // Verify warning is logged for non-existent configured directory
             expect(loggerWarnSpy.calledWith(
                 sinon.match(/Configured skill directory.*does not exist/)
+            )).to.be.true;
+        });
+
+        it('should scan configured directories that only become known once the preferences are ready', async () => {
+            // The preference proxy serves defaults until its `ready` promise resolves, so a scan started before
+            // that point misses the configured directories.
+            const preferencesReady = new Deferred<void>();
+            preferencesMock.ready = preferencesReady.promise;
+
+            // Default skills directory exists and is empty, so the configured directory is the only source of warnings.
+            fileServiceMock.exists
+                .withArgs(sinon.match((uri: URI) => uri.path.toString() === '/home/testuser/.theia-ide/skills'))
+                .resolves(true);
+            fileServiceMock.resolve
+                .withArgs(sinon.match((uri: URI) => uri.path.toString() === '/home/testuser/.theia-ide/skills'))
+                .resolves({ children: [] });
+            fileServiceMock.exists
+                .withArgs(sinon.match((uri: URI) => uri.path.toString() === '/custom/configured/skills'))
+                .resolves(false);
+
+            const service = createService();
+            (service as unknown as { init: () => void }).init();
+            await workspaceServiceMock.ready;
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // Nothing may be scanned yet, the preference value is still the default one.
+            expect(fileServiceMock.exists.called).to.be.false;
+
+            (preferencesMock as Record<string, unknown>)['ai-features.skills.skillDirectories'] = ['/custom/configured/skills'];
+            preferencesReady.resolve();
+            await new Promise(resolve => setTimeout(resolve, 10));
+
+            // The scan picked up the configured directory instead of the default preference value.
+            expect(loggerWarnSpy.calledWith(
+                sinon.match(/Configured skill directory '\/custom\/configured\/skills' does not exist/)
             )).to.be.true;
         });
 

--- a/packages/ai-core/src/browser/skill-service.ts
+++ b/packages/ai-core/src/browser/skill-service.ts
@@ -131,27 +131,27 @@ export class DefaultSkillService implements SkillService {
             }
         });
 
-        // Wait for workspace to be ready before initial update
-        this.workspaceService.ready.then(() => {
-            this.update().then(() => {
-                this._ready.resolve();
-                // Only after initial update, start listening for changes
-                this.lastSkillDirectoriesValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
+        // The workspace contributes the workspace skill directories, the preferences the configured ones.
+        Promise.all([this.workspaceService.ready, this.preferences.ready]).catch(error => {
+            this.logger.error('Failed to resolve skill directory sources, scanning the already known directories', error);
+        }).then(() => this.update()).then(() => {
+            this._ready.resolve();
+            // Only after initial update, start listening for changes
+            this.lastSkillDirectoriesValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
 
-                this.preferences.onPreferenceChanged(event => {
-                    if (event.preferenceName === PREFERENCE_NAME_SKILL_DIRECTORIES) {
-                        const currentValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
-                        if (currentValue === this.lastSkillDirectoriesValue) {
-                            return;
-                        }
-                        this.lastSkillDirectoriesValue = currentValue;
-                        this.scheduleUpdate();
+            this.preferences.onPreferenceChanged(event => {
+                if (event.preferenceName === PREFERENCE_NAME_SKILL_DIRECTORIES) {
+                    const currentValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
+                    if (currentValue === this.lastSkillDirectoriesValue) {
+                        return;
                     }
-                });
-
-                this.workspaceService.onWorkspaceChanged(() => {
+                    this.lastSkillDirectoriesValue = currentValue;
                     this.scheduleUpdate();
-                });
+                }
+            });
+
+            this.workspaceService.onWorkspaceChanged(() => {
+                this.scheduleUpdate();
             });
         });
     }

--- a/packages/ai-core/src/browser/skill-service.ts
+++ b/packages/ai-core/src/browser/skill-service.ts
@@ -131,29 +131,43 @@ export class DefaultSkillService implements SkillService {
             }
         });
 
-        // The workspace contributes the workspace skill directories, the preferences the configured ones.
-        Promise.all([this.workspaceService.ready, this.preferences.ready]).catch(error => {
+        this.initializeSkills();
+    }
+
+    /** Runs the initial scan once the skill directory sources are known. {@link ready} always resolves, even if the scan failed. */
+    protected async initializeSkills(): Promise<void> {
+        try {
+            // The workspace contributes the workspace skill directories, the preferences the configured ones.
+            await Promise.all([this.workspaceService.ready, this.preferences.ready]);
+        } catch (error) {
             this.logger.error('Failed to resolve skill directory sources, scanning the already known directories', error);
-        }).then(() => this.update()).then(() => {
-            this._ready.resolve();
-            // Only after initial update, start listening for changes
-            this.lastSkillDirectoriesValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
+        }
 
-            this.preferences.onPreferenceChanged(event => {
-                if (event.preferenceName === PREFERENCE_NAME_SKILL_DIRECTORIES) {
-                    const currentValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
-                    if (currentValue === this.lastSkillDirectoriesValue) {
-                        return;
-                    }
-                    this.lastSkillDirectoriesValue = currentValue;
-                    this.scheduleUpdate();
+        // Listen for changes before the initial scan, otherwise a change landing while it runs is recorded as
+        // already applied by the snapshot below and dropped. update()'s in-progress guard coalesces the overlap.
+        this.lastSkillDirectoriesValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
+
+        this.preferences.onPreferenceChanged(event => {
+            if (event.preferenceName === PREFERENCE_NAME_SKILL_DIRECTORIES) {
+                const currentValue = JSON.stringify(this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES]);
+                if (currentValue === this.lastSkillDirectoriesValue) {
+                    return;
                 }
-            });
-
-            this.workspaceService.onWorkspaceChanged(() => {
+                this.lastSkillDirectoriesValue = currentValue;
                 this.scheduleUpdate();
-            });
+            }
         });
+
+        this.workspaceService.onWorkspaceChanged(() => {
+            this.scheduleUpdate();
+        });
+
+        try {
+            await this.update();
+        } catch (error) {
+            this.logger.error('Initial skill scan failed', error);
+        }
+        this._ready.resolve();
     }
 
     getSkills(): Skill[] {


### PR DESCRIPTION


<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

The initial scan started as soon as the workspace was ready, while the skillDirectories preference still held its default value, so configured skill directories were not scanned.

Waiting for the preference service in addition to the workspace makes both directory sources available for the initial scan.

#### How to test

1. Configure an external directory for skills in the preferences
2. Observe that skills are loaded
3. Restart Theia
4. Observe that skills are loaded (Without this fix, they were not loaded after restart)

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [X] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
