### PR TITLE
feat(ai-registry): install and manage agent plugins from the AI registry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32042,7 +32042,9 @@
         "@theia/ai-core": "1.74.0",
         "@theia/ai-mcp": "1.74.0",
         "@theia/core": "1.74.0",
-        "@theia/vsx-registry": "1.74.0"
+        "@theia/vsx-registry": "1.74.0",
+        "filenamify": "^4.3.0",
+        "tar-fs": "^3.1.3"
       },
       "devDependencies": {
         "@theia/ext-scripts": "1.74.0"

--- a/packages/ai-chat-ui/src/browser/chat-capabilities-service.ts
+++ b/packages/ai-chat-ui/src/browser/chat-capabilities-service.ts
@@ -129,8 +129,9 @@ export class ChatCapabilitiesServiceImpl implements ChatCapabilitiesService {
         const variableMatches = matchVariablesRegEx(template);
         for (const match of variableMatches) {
             const variableAndArg = match[1];
-            const parts = variableAndArg.split(':', 2);
-            const variableName = parts[0];
+            // First colon only, as the prompt service does: `{{file:C:\some\path}}`.
+            const separatorIndex = variableAndArg.indexOf(':');
+            const variableName = separatorIndex >= 0 ? variableAndArg.substring(0, separatorIndex) : variableAndArg;
 
             // Exclude capability and selected_* variables (they're meta-variables)
             if (variableName !== 'capability' &&

--- a/packages/ai-chat-ui/src/browser/generic-capabilities-service.spec.ts
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-service.spec.ts
@@ -244,8 +244,8 @@ describe('GenericCapabilitiesServiceImpl', () => {
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (service as any).skillService = {
                 getSkills: () => [
-                    { name: 'git-best-practices', description: 'Git tips', location: '/path' },
-                    { name: 'code-review', description: 'Code review', location: '/path2' }
+                    { name: 'git-best-practices', qualifiedName: 'git-best-practices', description: 'Git tips', location: '/path' },
+                    { name: 'code-review', qualifiedName: 'code-review', description: 'Code review', location: '/path2' }
                 ] as Skill[]
             };
 
@@ -254,6 +254,24 @@ describe('GenericCapabilitiesServiceImpl', () => {
             expect(result).to.have.length(2);
             expect(result[0]).to.deep.equal({ id: 'git-best-practices', name: 'git-best-practices', description: 'Git tips' });
             expect(result[1]).to.deep.equal({ id: 'code-review', name: 'code-review', description: 'Code review' });
+        });
+
+        it('identifies a skill owned by a plugin by its qualified name, which is what the user has to type', () => {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (service as any).skillService = {
+                getSkills: () => [
+                    {
+                        name: 'query-builder',
+                        qualifiedName: 'bigquery:query-builder',
+                        description: 'Build SQL',
+                        location: '/path'
+                    }
+                ] as Skill[]
+            };
+
+            expect(service.getAvailableSkills()).to.deep.equal([
+                { id: 'bigquery:query-builder', name: 'bigquery:query-builder', description: 'Build SQL' }
+            ]);
         });
     });
 });

--- a/packages/ai-chat-ui/src/browser/generic-capabilities-service.ts
+++ b/packages/ai-chat-ui/src/browser/generic-capabilities-service.ts
@@ -143,8 +143,8 @@ export class GenericCapabilitiesServiceImpl implements GenericCapabilitiesServic
         }
 
         return this.skillService.getSkills().map(skill => ({
-            id: skill.name,
-            name: skill.name,
+            id: skill.qualifiedName,
+            name: skill.qualifiedName,
             description: skill.description
         }));
     }

--- a/packages/ai-chat/src/common/chat-request-parser.spec.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.spec.ts
@@ -27,7 +27,7 @@ import { AgentDelegationTool } from '../browser/agent-delegation-tool';
 
 describe('ChatRequestParserImpl', () => {
     /** Command names the stubbed `PromptService` knows about. Anything else is not a command. */
-    const KNOWN_COMMANDS = ['hello', 'explain', 'compare', 'cmd', 'summarize', 'skill-one', 'skill-two'];
+    const KNOWN_COMMANDS = ['hello', 'explain', 'compare', 'cmd', 'summarize', 'skill-one', 'skill-two', 'bigquery:query-builder', 'io.github.acme_tools:my-skill'];
     /** Prompt fragments that are not marked as commands, but can still be invoked by their id. */
     const KNOWN_FRAGMENT_IDS = ['coder-system'];
 
@@ -708,6 +708,44 @@ describe('ChatRequestParserImpl', () => {
 
                 expect(result.parts.length).to.equal(1);
                 expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('coder-system');
+            });
+
+            it('parses a qualified command name containing a colon as one command', async () => {
+                // A skill supplied by an installed artifact is addressed as `<qualifier>:<skill>`, so
+                // the colon has to be part of the command name rather than terminate it.
+                const text = '/bigquery:query-builder';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('bigquery:query-builder');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses a qualified command name with arguments', async () => {
+                const text = '/bigquery:query-builder count the rows';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('bigquery:query-builder|count the rows');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('parses a qualified command name whose qualifier contains periods', async () => {
+                // The qualifier is the plugin's directory name, which is derived from its identifier -
+                // `io.github.acme/tools` becomes `io.github.acme_tools`, periods and all. Without them
+                // in the charset the token falls through to the model as plain text, with no error.
+                const text = '/io.github.acme_tools:my-skill';
+                const result = await parse(text);
+
+                expect(result.parts.length).to.equal(1);
+                expect((result.parts[0] as ParsedChatRequestVariablePart).variableArg).to.equal('io.github.acme_tools:my-skill');
+                expectFullCoverage(result.parts, text);
+            });
+
+            it('leaves an unknown colon-separated slash token as plain text', async () => {
+                // Widening the command charset must not turn arbitrary text into a command.
+                await expectPlainText('/unknown:thing');
+                await expectPlainText('/io.github.other_tools:my-skill');
             });
 
             it('keeps trailing whitespace out of the command part', async () => {

--- a/packages/ai-chat/src/common/chat-request-parser.ts
+++ b/packages/ai-chat/src/common/chat-request-parser.ts
@@ -50,8 +50,10 @@ const variableReg = /^#([\w_\-]+)(?::([\w_\-_\/\\.:]+))?(?=(\s|$|\b))/i; // A #-
 // A /-command (/commandname) with optional arguments parsed separately. The command name must be
 // terminated by whitespace or the end of the input, so that path segments such as `/home/user` are
 // not mistaken for a command.
-const commandReg = /^\/([\w_\-]+)(?=\s|$)/;
-const nextCommandReg = /\s+\/([\w_\-]+)(?=\s|$)/g;
+// The colon and the period are in the charset so a qualified skill is invocable as
+// `/<qualifier>:<skill>`; the qualifier comes from a plugin identifier, so it usually has periods.
+const commandReg = /^\/([\w_\-.:]+)(?=\s|$)/;
+const nextCommandReg = /\s+\/([\w_\-.:]+)(?=\s|$)/g;
 
 export const ChatRequestParser = Symbol('ChatRequestParser');
 export interface ChatRequestParser {

--- a/packages/ai-core-ui/src/browser/ai-configuration/ai-configuration-category.ts
+++ b/packages/ai-core-ui/src/browser/ai-configuration/ai-configuration-category.ts
@@ -15,6 +15,8 @@
 // *****************************************************************************
 
 import { Event } from '@theia/core';
+// Type-only, so this contribution point stays free of a runtime dependency on the rendering component.
+import type { AiConfigurationOrigin } from './components/ai-configuration-origin-badge';
 
 /**
  * Contribution point for a category shown in the AI Configuration view.
@@ -178,10 +180,16 @@ export interface AiConfigurationTreeItem {
     readonly label: string;
     /**
      * Short labels shown as badges next to the item's name, for what it *is* rather than what it is doing
-     * (which is {@link status}): where it came from, for instance "From registry". The item detail can state
-     * the same thing in a richer way, e.g. as a link back to the registry entry.
+     * (which is {@link status}). Use {@link origins} for where the item came from, which is a badge of its
+     * own kind: it carries an icon and leads somewhere.
      */
     readonly tags?: string[];
+    /**
+     * Where the item came from, when that is not the user - an AI registry entry, an Agent Plugin. Shown
+     * next to the item's name on the overview and, unchanged, on the item's detail header, so that
+     * provenance reads the same in both places.
+     */
+    readonly origins?: AiConfigurationOrigin[];
     /** Status badge shown on the overview card and the item detail header. */
     readonly status?: AiConfigurationItemStatus;
     /** Short text for the overview card. */

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-components.spec.ts
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-components.spec.ts
@@ -31,6 +31,7 @@ import { flushSync } from '@theia/core/shared/react-dom';
 import { createRoot } from '@theia/core/shared/react-dom/client';
 import { AiConfigurationItemRow } from './ai-configuration-item-row';
 import { AiConfigurationEmptyState, AiConfigurationItemDetailHeader, AiConfigurationSection } from './ai-configuration-primitives';
+import { AiConfigurationOrigin, AiConfigurationOriginBadge, AiConfigurationOriginBadges } from './ai-configuration-origin-badge';
 import { AiConfigurationSettingRow } from './ai-configuration-setting-row';
 import { AiArrayInput, AiNumberStepper } from './ai-configuration-controls';
 import { ConfirmDialog } from '@theia/core/lib/browser';
@@ -210,6 +211,70 @@ describe('AI Configuration primitives', () => {
     it('AiConfigurationItemDetailHeader renders title and subtitle', async () => {
         const tree = await AiConfigurationItemDetailHeader({ title: 'Coder', subtitle: 'agent-id-1' });
         expect(textOf(tree)).to.include('Coder').and.to.include('agent-id-1');
+    });
+
+    it('AiConfigurationOriginBadge is a button that activates its origin, and does not open the row it sits in', () => {
+        let activated = 0;
+        let rowOpened = 0;
+        const { container, dispose } = mount(React.createElement('div', { onClick: () => { rowOpened++; } },
+            React.createElement(AiConfigurationOriginBadge, {
+                origin: { label: 'From registry', iconClass: 'codicon-link-external', tooltip: 'Open in AI registry: x', activate: () => { activated++; } }
+            })));
+        try {
+            const badge = container.querySelector('button.ai-configuration-origin-badge') as HTMLButtonElement;
+            expect(badge.getAttribute('title')).to.equal('Open in AI registry: x');
+            expect(badge.textContent).to.include('From registry');
+
+            flushSync(() => badge.click());
+            expect(activated).to.equal(1);
+            // The surrounding row and detail header are clickable themselves; following the badge must
+            // not also open them.
+            expect(rowOpened).to.equal(0);
+        } finally {
+            dispose();
+        }
+    });
+
+    it('AiConfigurationOriginBadge is not focusable when the origin leads nowhere', () => {
+        const { container, dispose } = mount(React.createElement(AiConfigurationOriginBadge, {
+            origin: { label: 'via Acme', iconClass: 'codicon-extensions', tooltip: 'Acme' }
+        }));
+        try {
+            expect(container.querySelector('button')).to.be.null;
+            expect(container.querySelector('span.ai-configuration-origin-badge')?.textContent).to.include('via Acme');
+        } finally {
+            dispose();
+        }
+    });
+
+    it('AiConfigurationOriginBadges renders one badge per origin, in order, and nothing without any', () => {
+        const origin = (label: string) => ({ label, iconClass: 'codicon-link-external', tooltip: label, activate: () => { } });
+        const { container, dispose } = mount(React.createElement(AiConfigurationOriginBadges,
+            { origins: [origin('From registry'), origin('via Acme Devtools')] }));
+        try {
+            expect(Array.from(container.querySelectorAll('.ai-configuration-origin-badge')).map(badge => badge.textContent))
+                .to.deep.equal(['From registry', 'via Acme Devtools']);
+        } finally {
+            dispose();
+        }
+        const empty = mount(React.createElement('div', {}, React.createElement(AiConfigurationOriginBadges, { origins: [] })));
+        try {
+            expect(empty.container.querySelector('.ai-configuration-origin-badges')).to.be.null;
+        } finally {
+            empty.dispose();
+        }
+    });
+
+    it('AiConfigurationOrigin builds the same registry and Agent Plugin badges for every page to use', () => {
+        const registry = AiConfigurationOrigin.registry('io.github.acme/validator', () => { });
+        expect(registry.label).to.equal('From registry');
+        expect(registry.iconClass).to.contain('codicon-link-external');
+        expect(registry.tooltip).to.contain('io.github.acme/validator');
+
+        const plugin = AiConfigurationOrigin.agentPlugin({ pluginId: 'io.github.acme/devtools', name: 'Acme Devtools' }, () => { });
+        expect(plugin.label).to.equal('via Acme Devtools');
+        expect(plugin.iconClass).to.contain('codicon-extensions');
+        expect(plugin.tooltip).to.contain('Acme Devtools');
     });
 
     it('AiConfigurationSettingRow renders title and control, marks modified rows, and hides the raw id', () => {

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-components.spec.ts
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-components.spec.ts
@@ -237,7 +237,7 @@ describe('AI Configuration primitives', () => {
 
     it('AiConfigurationOriginBadge is not focusable when the origin leads nowhere', () => {
         const { container, dispose } = mount(React.createElement(AiConfigurationOriginBadge, {
-            origin: { label: 'via Acme', iconClass: 'codicon-extensions', tooltip: 'Acme' }
+            origin: { label: 'via Acme', iconClass: 'codicon-package', tooltip: 'Acme' }
         }));
         try {
             expect(container.querySelector('button')).to.be.null;
@@ -273,7 +273,7 @@ describe('AI Configuration primitives', () => {
 
         const plugin = AiConfigurationOrigin.agentPlugin({ pluginId: 'io.github.acme/devtools', name: 'Acme Devtools' }, () => { });
         expect(plugin.label).to.equal('via Acme Devtools');
-        expect(plugin.iconClass).to.contain('codicon-extensions');
+        expect(plugin.iconClass).to.contain('codicon-package');
         expect(plugin.tooltip).to.contain('Acme Devtools');
     });
 

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-item-row.tsx
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-item-row.tsx
@@ -18,6 +18,7 @@ import { codicon } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
 import { AiConfigurationItemStatus } from '../ai-configuration-category';
 import { AiConfigurationKindBadge, AiConfigurationStatusBadge } from './ai-configuration-primitives';
+import { AiConfigurationOrigin, AiConfigurationOriginBadges } from './ai-configuration-origin-badge';
 import { AiSettingGearButton } from './ai-configuration-setting-row';
 
 export interface AiConfigurationItemRowProps {
@@ -32,8 +33,10 @@ export interface AiConfigurationItemRowProps {
     /** `codicon(...)` class shown before the label. */
     readonly iconClass?: string;
     readonly description?: string;
-    /** Short badges shown after the label, e.g. an item's provenance ("From registry"). */
+    /** Short badges shown after the label, for what the item *is*. Use {@link origins} for where it came from. */
     readonly tags?: string[];
+    /** Where the item came from, shown after the tags as {@link AiConfigurationOriginBadge}s. */
+    readonly origins?: AiConfigurationOrigin[];
     /** Status badge shown on the right (e.g. an alias' resolved model). */
     readonly status?: AiConfigurationItemStatus;
     /** `true` reveals the modified edge (left indicator bar), matching {@link AiConfigurationSettingRow}. */
@@ -72,7 +75,7 @@ export interface AiConfigurationItemRowProps {
  * alternative to a card grid, matching the Settings and extensions lists; every non-label slot is optional.
  */
 export const AiConfigurationItemRow: React.FC<AiConfigurationItemRowProps> = ({
-    label, rowId, tags, monospaceLabel, iconClass, description, status, modified, trailing, onOpenMenu, onSelect, onActivateLabel, labelTooltip
+    label, rowId, tags, origins, monospaceLabel, iconClass, description, status, modified, trailing, onOpenMenu, onSelect, onActivateLabel, labelTooltip
 }) => {
     const navigable = onSelect !== undefined;
     const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
@@ -111,6 +114,7 @@ export const AiConfigurationItemRow: React.FC<AiConfigurationItemRowProps> = ({
                 {tags && tags.length > 0 && <span className='ai-configuration-item-row-tags'>
                     {tags.map(tag => <AiConfigurationKindBadge key={tag} label={tag} variant='outline' />)}
                 </span>}
+                <AiConfigurationOriginBadges origins={origins} />
             </div>
             {description && <span className='ai-configuration-item-row-description'>{description}</span>}
         </div>

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-origin-badge.tsx
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-origin-badge.tsx
@@ -63,7 +63,9 @@ export namespace AiConfigurationOrigin {
     export function agentPlugin(plugin: InstalledAgentPluginInfo, reveal: () => void): AiConfigurationOrigin {
         return {
             label: nls.localize('theia/ai/core/aiConfiguration/origin/viaAgentPlugin', 'via {0}', plugin.name),
-            iconClass: codicon('extensions'),
+            // `package`, matching the Agent Plugin cards in the Extensions view; `extensions` is the icon
+            // that view's VS Code extension section owns.
+            iconClass: codicon('package'),
             tooltip: nls.localize('theia/ai/core/aiConfiguration/origin/openAgentPlugin', 'Open the Agent Plugin that provides this: {0}', plugin.name),
             activate: reveal
         };

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-origin-badge.tsx
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-origin-badge.tsx
@@ -1,0 +1,112 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { codicon } from '@theia/core/lib/browser';
+import { InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
+import * as React from '@theia/core/shared/react';
+
+/**
+ * Where a configuration entry came from, when that is not the user: an AI registry entry, or an Agent
+ * Plugin that contributed it. Built through {@link AiConfigurationOrigin.registry} or
+ * {@link AiConfigurationOrigin.agentPlugin} rather than by hand, so that the same origin reads the same
+ * on every page - an entry's provenance is surfaced in an overview list, on a detail header and in a
+ * collapsible row, and those diverged while each page phrased it for itself.
+ */
+export interface AiConfigurationOrigin {
+    /** Short, on one line next to the entry's name; the {@link tooltip} carries the detail. */
+    readonly label: string;
+    /** `codicon(...)` class shown before the label. */
+    readonly iconClass: string;
+    readonly tooltip: string;
+    /** Opens or reveals the origin. Omit for an origin with nothing to navigate to; the badge is then static. */
+    readonly activate?: () => void;
+}
+
+export namespace AiConfigurationOrigin {
+
+    /**
+     * An entry installed from, or linked to, an AI registry approval.
+     *
+     * @param open reveals the entry in the registry UI. Omit it where no registry UI is bound: the entry
+     * still came from the registry, which is worth stating, so the badge is shown - just not as a link.
+     */
+    export function registry(entryId: string, open?: () => void): AiConfigurationOrigin {
+        return {
+            label: nls.localize('theia/ai/core/aiConfiguration/origin/fromRegistry', 'From registry'),
+            iconClass: codicon('link-external'),
+            tooltip: open
+                ? nls.localize('theia/ai/core/aiConfiguration/origin/openInRegistry', 'Open in AI registry: {0}', entryId)
+                : nls.localize('theia/ai/core/aiConfiguration/origin/registryEntry', 'AI registry entry: {0}', entryId),
+            activate: open
+        };
+    }
+
+    /**
+     * An entry contributed by an installed Agent Plugin. Takes the resolved plugin rather than its
+     * identifier: a bare identifier is not worth showing, so a caller that cannot resolve one renders no
+     * badge at all.
+     */
+    export function agentPlugin(plugin: InstalledAgentPluginInfo, reveal: () => void): AiConfigurationOrigin {
+        return {
+            label: nls.localize('theia/ai/core/aiConfiguration/origin/viaAgentPlugin', 'via {0}', plugin.name),
+            iconClass: codicon('extensions'),
+            tooltip: nls.localize('theia/ai/core/aiConfiguration/origin/openAgentPlugin', 'Open the Agent Plugin that provides this: {0}', plugin.name),
+            activate: reveal
+        };
+    }
+}
+
+export interface AiConfigurationOriginBadgeProps {
+    readonly origin: AiConfigurationOrigin;
+}
+
+/**
+ * One {@link AiConfigurationOrigin} as a pill next to an entry's name: a `<button>` when the origin can
+ * be opened, a plain `<span>` when it cannot, so that only what is actually navigable is focusable.
+ * The click never bubbles - these sit inside rows and headers that are themselves clickable, and
+ * following the badge must not also open the row.
+ */
+export const AiConfigurationOriginBadge: React.FC<AiConfigurationOriginBadgeProps> = ({ origin }) => {
+    const content = <>
+        <span aria-hidden='true' className={`ai-configuration-origin-badge-icon ${origin.iconClass}`}></span>
+        <span className='ai-configuration-origin-badge-label'>{origin.label}</span>
+    </>;
+    return origin.activate
+        ? <button
+            type='button'
+            className='ai-configuration-origin-badge activatable'
+            title={origin.tooltip}
+            aria-label={origin.tooltip}
+            onClick={event => {
+                event.stopPropagation();
+                origin.activate!();
+            }}
+        >{content}</button>
+        : <span className='ai-configuration-origin-badge' title={origin.tooltip}>{content}</span>;
+};
+
+export interface AiConfigurationOriginBadgesProps {
+    readonly origins?: AiConfigurationOrigin[];
+}
+
+/** The origins of one entry, in the order given; nothing at all when it has none, which is the common case. */
+export const AiConfigurationOriginBadges: React.FC<AiConfigurationOriginBadgesProps> = ({ origins }) =>
+    origins && origins.length > 0
+        ? <span className='ai-configuration-origin-badges'>
+            {origins.map(origin => <AiConfigurationOriginBadge key={origin.label} origin={origin} />)}
+        </span>
+        : undefined;

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-primitives.tsx
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/ai-configuration-primitives.tsx
@@ -18,6 +18,7 @@ import { nls } from '@theia/core';
 import { codicon } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
 import { AiConfigurationItemStatus } from '../ai-configuration-category';
+import { AiConfigurationOrigin, AiConfigurationOriginBadges } from './ai-configuration-origin-badge';
 
 /**
  * Presentational, DI-free display primitives shared across the AI configuration pages: badges, the
@@ -323,20 +324,28 @@ export interface AiConfigurationItemDetailHeaderProps {
     readonly subtitle?: string;
     /** Status badge shown next to the title. */
     readonly status?: AiConfigurationItemStatus;
-    /** Optional inline content shown right after the title (e.g. an origin link). */
+    /**
+     * Where the item came from, shown right after the title - the same badges the overview list shows,
+     * so provenance does not get a second look on the detail page.
+     */
+    readonly origins?: AiConfigurationOrigin[];
+    /** Optional inline content shown after the title and the origin badges. */
     readonly titleSuffix?: React.ReactNode;
     /** Trailing slot for header actions and toggles (buttons, switches). */
     readonly actions?: React.ReactNode;
 }
 
 /** Header of a collection item's detail page: icon, title, subtitle, status badge and an actions slot. */
-export const AiConfigurationItemDetailHeader: React.FC<AiConfigurationItemDetailHeaderProps> = ({ title, iconClass, subtitle, status, titleSuffix, actions }) => (
+export const AiConfigurationItemDetailHeader: React.FC<AiConfigurationItemDetailHeaderProps> = ({
+    title, iconClass, subtitle, status, origins, titleSuffix, actions
+}) => (
     <div className='ai-configuration-item-detail-header'>
         <div className='ai-configuration-item-detail-header-heading'>
             {iconClass && <span className={`ai-configuration-item-detail-header-icon ${iconClass}`}></span>}
             <div className='ai-configuration-item-detail-header-titles'>
                 <span className='ai-configuration-item-detail-header-title-row'>
                     <span className='ai-configuration-item-detail-header-title'>{title}</span>
+                    <AiConfigurationOriginBadges origins={origins} />
                     {titleSuffix}
                 </span>
                 {subtitle !== undefined && <span className='ai-configuration-item-detail-header-subtitle'>{subtitle}</span>}

--- a/packages/ai-core-ui/src/browser/ai-configuration/components/collapsible-list.tsx
+++ b/packages/ai-core-ui/src/browser/ai-configuration/components/collapsible-list.tsx
@@ -17,6 +17,7 @@
 import { codicon } from '@theia/core/lib/browser';
 import * as React from '@theia/core/shared/react';
 import { AiConfigurationEmptyState, AiConfigurationFilterInput, AiConfigurationSection } from './ai-configuration-primitives';
+import { AiConfigurationOrigin, AiConfigurationOriginBadges } from './ai-configuration-origin-badge';
 
 /** One expandable row of a {@link CollapsibleList}. */
 export interface CollapsibleRow {
@@ -27,6 +28,12 @@ export interface CollapsibleRow {
     readonly description?: string;
     /** Short badges shown before the actions, e.g. an argument count or the single agent using the row. */
     readonly pills?: string[];
+    /**
+     * Where the row's entry came from, when that is not the user. Shown after the pills as the same
+     * {@link AiConfigurationOriginBadge}s a collection item carries, and reachable while the row is
+     * collapsed - provenance is something you scan a list for, not something you expand rows to find.
+     */
+    readonly origins?: AiConfigurationOrigin[];
     /**
      * Actions rendered at the row's trailing edge, after the pills, and available whether the row is
      * expanded or not. Use {@link CollapsibleRowAction}, which stops the click from toggling the row.
@@ -183,8 +190,9 @@ const CollapsibleRowView: React.FC<CollapsibleRowViewProps> = ({ row, expanded, 
             {expanded
                 ? <span className='ai-config-collapsible-inline-description-spacer' aria-hidden='true'></span>
                 : <span className='ai-config-collapsible-inline-description' title={row.description || undefined}>{row.description}</span>}
-            {row.pills && row.pills.length > 0 && <div className='ai-config-collapsible-row-meta'>
-                {row.pills.map((pill, index) => <span key={index} className='ai-config-collapsible-count-pill'>{pill}</span>)}
+            {((row.pills && row.pills.length > 0) || (row.origins && row.origins.length > 0)) && <div className='ai-config-collapsible-row-meta'>
+                {row.pills?.map((pill, index) => <span key={index} className='ai-config-collapsible-count-pill'>{pill}</span>)}
+                <AiConfigurationOriginBadges origins={row.origins} />
             </div>}
             {/* Trailing edge, after the pills: the row's actions stay reachable while the row is collapsed. */}
             {row.actions && <div className='ai-config-collapsible-row-actions'>{row.actions}</div>}

--- a/packages/ai-core-ui/src/browser/ai-configuration/renderers/collection-category-renderer.tsx
+++ b/packages/ai-core-ui/src/browser/ai-configuration/renderers/collection-category-renderer.tsx
@@ -65,6 +65,7 @@ export abstract class CollectionCategoryRenderer implements AiConfigurationCateg
                         iconClass={item.iconClass}
                         description={item.description}
                         tags={item.tags}
+                        origins={item.origins}
                         status={item.status}
                         onSelect={() => ctx.navigate({ categoryId: this.categoryId, itemId: item.id })}
                     />)}
@@ -138,9 +139,15 @@ export abstract class CollectionCategoryRenderer implements AiConfigurationCateg
         return undefined;
     }
 
-    /** Header of an item detail page; icon/title/subtitle from the item by default. */
+    /** Header of an item detail page; icon/title/subtitle/origins from the item by default. */
     protected renderItemHeader(item: AiConfigurationTreeItem, ctx: AiConfigurationRenderContext): React.ReactNode {
-        return <AiConfigurationItemDetailHeader title={item.label} iconClass={item.iconClass} subtitle={item.description} status={item.status} />;
+        return <AiConfigurationItemDetailHeader
+            title={item.label}
+            iconClass={item.iconClass}
+            subtitle={item.description}
+            status={item.status}
+            origins={item.origins}
+        />;
     }
 
     /** Body of an item detail page: typically {@link AiConfigurationSection}s of rows. */

--- a/packages/ai-core-ui/src/browser/style/ai-configuration-components.css
+++ b/packages/ai-core-ui/src/browser/style/ai-configuration-components.css
@@ -1053,6 +1053,51 @@
   font-size: var(--theia-ui-font-size0);
 }
 
+/* Origin badge: where an entry came from (an AI registry entry, an Agent Plugin). Shaped like the
+   outline kind badge so provenance reads as one kind of annotation wherever it appears - in an overview
+   list, on a detail header, on a collapsible row - and differentiated from a plain tag by its leading
+   icon. `button` resets are explicit: the activatable variant is a real button. */
+.ai-configuration-origin-badges {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding) / 2);
+}
+
+.ai-configuration-origin-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: calc(var(--theia-ui-padding) / 2);
+  margin: 0;
+  padding: 1px 8px;
+  border: var(--theia-border-width) solid var(--theia-widget-border);
+  border-radius: 10px;
+  background-color: transparent;
+  color: var(--theia-descriptionForeground);
+  font-family: inherit;
+  font-size: var(--theia-ui-font-size0);
+  white-space: nowrap;
+}
+
+/* Link-coloured only when it leads somewhere, so the colour is the affordance rather than decoration. */
+.ai-configuration-origin-badge.activatable {
+  color: var(--theia-textLink-foreground);
+  cursor: pointer;
+}
+
+.ai-configuration-origin-badge.activatable:hover {
+  color: var(--theia-textLink-activeForeground);
+  border-color: var(--theia-focusBorder);
+}
+
+.ai-configuration-origin-badge.activatable:focus-visible {
+  outline: 1px solid var(--theia-focusBorder);
+  outline-offset: 1px;
+}
+
+.ai-configuration-origin-badge-icon {
+  font-size: var(--theia-ui-font-size0);
+}
+
 /* Horizontal, wrapping row of chips/badges */
 .ai-configuration-chip-row {
   display: flex;

--- a/packages/ai-core/src/browser/agent-plugin-ui-bridge.ts
+++ b/packages/ai-core/src/browser/agent-plugin-ui-bridge.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-core/src/browser/agent-plugin-ui-bridge.ts
+++ b/packages/ai-core/src/browser/agent-plugin-ui-bridge.ts
@@ -1,0 +1,43 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core';
+
+export interface InstalledAgentPluginInfo {
+    /** Registry identifier, e.g. `io.github.acme/bigquery-data-analytics`. */
+    pluginId: string;
+    /** From the plugin manifest, falling back to the identifier. */
+    name: string;
+}
+
+export const AgentPluginUiBridge = Symbol('AgentPluginUiBridge');
+/**
+ * Optional integration point implemented by `@theia/ai-registry`, so that packages which must not
+ * depend on it can still label and reveal the Agent Plugin behind a skill or an MCP server: both
+ * carry only its identifier.
+ *
+ * Nothing is bound by default. Consumers inject it `@optional()` and, when it is absent, hide every
+ * Agent Plugin affordance - a product without `@theia/ai-registry` cannot install one anyway.
+ */
+export interface AgentPluginUiBridge {
+    /** `undefined` means callers should render no provenance affordance, not a bare identifier. */
+    getPlugin(pluginId: string): InstalledAgentPluginInfo | undefined;
+    /** Resolves the qualifier a contributed skill root carries, which is not the plugin identifier. */
+    getPluginByQualifier(qualifier: string): InstalledAgentPluginInfo | undefined;
+    /** A no-op for an unknown identifier. */
+    revealPlugin(pluginId: string): void;
+    readonly onDidChange: Event<void>;
+}

--- a/packages/ai-core/src/browser/ai-core-frontend-module.ts
+++ b/packages/ai-core/src/browser/ai-core-frontend-module.ts
@@ -74,7 +74,7 @@ import { AIActivationService, AIActivationServiceImpl } from './ai-activation-se
 import { AgentService, AgentServiceImpl } from '../common/agent-service';
 import { AICommandHandlerFactory } from './ai-command-handler-factory';
 import { AISettingsService } from '../common/settings-service';
-import { DefaultSkillService, SkillService } from './skill-service';
+import { DefaultSkillService, SkillDirectoryContribution, SkillService } from './skill-service';
 import { SkillPromptCoordinator } from './skill-prompt-coordinator';
 import { AiCoreCommandContribution } from './ai-core-command-contribution';
 import { PromptVariableContribution } from './prompt-variable-contribution';
@@ -139,6 +139,9 @@ export default new ContainerModule(bind => {
 
     bind(SkillPromptCoordinator).toSelf().inSingletonScope();
     bind(FrontendApplicationContribution).toService(SkillPromptCoordinator);
+
+    bindRootContributionProvider(bind, SkillDirectoryContribution);
+
     bindRootContributionProvider(bind, AIVariableContribution);
     bind(DefaultFrontendVariableService).toSelf().inSingletonScope();
     bind(FrontendVariableService).toService(DefaultFrontendVariableService);

--- a/packages/ai-core/src/browser/generic-capabilities-variable-contribution.ts
+++ b/packages/ai-core/src/browser/generic-capabilities-variable-contribution.ts
@@ -162,9 +162,12 @@ export class GenericCapabilitiesVariableContribution implements AIVariableContri
             return { variable, value: '' };
         }
 
+        // Ids come from the capabilities panel, which lists qualified names; `getSkill` also accepts
+        // a plain one, so a selection stored before a skill gained a qualifier still resolves.
         const skills = skillIds
             .map(skillId => this.skillService!.getSkill(skillId))
-            .filter((skill): skill is NonNullable<typeof skill> => skill !== undefined);
+            .filter((skill): skill is NonNullable<typeof skill> => skill !== undefined)
+            .map(skill => this.skillsContribution!.toSkillSummary(skill));
 
         return this.skillsContribution.resolveSkillsVariable(skills, variable);
     }

--- a/packages/ai-core/src/browser/index.ts
+++ b/packages/ai-core/src/browser/index.ts
@@ -36,6 +36,7 @@ export * from './skills-variable-contribution';
 export * from './skill-service';
 export * from './skill-prompt-coordinator';
 export * from './agent-plugin-ui-bridge';
+export * from './skill-registry-ui-bridge';
 export * from './frontend-variable-service';
 export * from './ai-core-command-contribution';
 export * from '../common/language-model-service';

--- a/packages/ai-core/src/browser/index.ts
+++ b/packages/ai-core/src/browser/index.ts
@@ -35,6 +35,7 @@ export * from './open-editors-variable-contribution';
 export * from './skills-variable-contribution';
 export * from './skill-service';
 export * from './skill-prompt-coordinator';
+export * from './agent-plugin-ui-bridge';
 export * from './frontend-variable-service';
 export * from './ai-core-command-contribution';
 export * from '../common/language-model-service';

--- a/packages/ai-core/src/browser/skill-prompt-coordinator.spec.ts
+++ b/packages/ai-core/src/browser/skill-prompt-coordinator.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-core/src/browser/skill-prompt-coordinator.spec.ts
+++ b/packages/ai-core/src/browser/skill-prompt-coordinator.spec.ts
@@ -1,0 +1,114 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// The skill service reaches browser-side modules at import time.
+const disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { Emitter } from '@theia/core';
+import { CustomizedPromptFragment, PromptService } from '../common/prompt-service';
+import { Skill } from '../common/skill';
+import { SkillPromptCoordinator } from './skill-prompt-coordinator';
+import { SkillService } from './skill-service';
+
+after(() => disableJSDOM());
+
+/** Records what the coordinator registers, which is all these tests are about. */
+class FakePromptService {
+    readonly added: CustomizedPromptFragment[] = [];
+    readonly removed: string[] = [];
+    addBuiltInPromptFragment(fragment: CustomizedPromptFragment): void {
+        this.added.push(fragment);
+    }
+    removePromptFragment(id: string): void {
+        this.removed.push(id);
+    }
+}
+
+function skill(qualifiedName: string): Skill {
+    return {
+        name: qualifiedName.substring(qualifiedName.indexOf(':') + 1),
+        qualifiedName,
+        description: 'Does a thing.',
+        location: `/plugins/x/skills/${qualifiedName}`
+    };
+}
+
+function coordinator(skills: Skill[]): { instance: SkillPromptCoordinator; prompts: FakePromptService; changed: Emitter<void> } {
+    const prompts = new FakePromptService();
+    const changed = new Emitter<void>();
+    const instance = new SkillPromptCoordinator();
+    Object.assign(instance, {
+        promptService: prompts as unknown as PromptService,
+        skillService: {
+            ready: Promise.resolve(),
+            getSkills: () => skills,
+            onSkillsChanged: changed.event
+        } as unknown as SkillService
+    });
+    return { instance, prompts, changed };
+}
+
+describe('SkillPromptCoordinator', () => {
+
+    it('keeps the colon out of the fragment id, because the id becomes a customization file name', async () => {
+        // A colon is a reserved character in a Windows file name: `getTemplateURI` turns the fragment id
+        // straight into one, so a customization of this fragment would either fail to write or land in
+        // an alternate data stream that the directory scan never reads back.
+        const { instance, prompts } = coordinator([skill('io.github.acme_tools:query-builder')]);
+
+        await instance.onStart();
+
+        expect(prompts.added).to.have.lengthOf(1);
+        expect(prompts.added[0].id).to.equal('skill-command-io.github.acme_tools__query-builder');
+        expect(prompts.added[0].id).to.not.contain(':');
+    });
+
+    it('keeps the command name qualified, so the skill is still addressed as <qualifier>:<skill>', async () => {
+        const { instance, prompts } = coordinator([skill('io.github.acme_tools:query-builder')]);
+
+        await instance.onStart();
+
+        expect(prompts.added[0].commandName).to.equal('io.github.acme_tools:query-builder');
+        expect(prompts.added[0].isCommand).to.be.true;
+    });
+
+    it('removes a skill under the same id it registered it with', async () => {
+        const skills = [skill('io.github.acme_tools:query-builder')];
+        const { instance, prompts, changed } = coordinator(skills);
+        await instance.onStart();
+
+        skills.length = 0;
+        changed.fire();
+
+        expect(prompts.removed).to.deep.equal(['skill-command-io.github.acme_tools__query-builder']);
+    });
+
+    it('leaves the id of an unqualified skill unchanged', async () => {
+        const { instance, prompts } = coordinator([skill('deploy')]);
+
+        await instance.onStart();
+
+        expect(prompts.added[0].id).to.equal('skill-command-deploy');
+    });
+});

--- a/packages/ai-core/src/browser/skill-prompt-coordinator.ts
+++ b/packages/ai-core/src/browser/skill-prompt-coordinator.ts
@@ -47,28 +47,38 @@ export class SkillPromptCoordinator implements FrontendApplicationContribution {
 
     protected updateSkillCommands(): void {
         const currentSkills = this.skillService.getSkills();
-        const currentSkillNames = new Set(currentSkills.map(s => s.name));
+        // Keyed by qualified name: two skills owned by different plugins can share a plain name.
+        const currentSkillNames = new Set(currentSkills.map(s => s.qualifiedName));
 
         // Unregister removed skills
         for (const name of this.registeredSkillCommands) {
             if (!currentSkillNames.has(name)) {
-                this.promptService.removePromptFragment(`skill-command-${name}`);
+                this.promptService.removePromptFragment(this.fragmentId(name));
                 this.registeredSkillCommands.delete(name);
             }
         }
 
         // Register new skills
         for (const skill of currentSkills) {
-            if (!this.registeredSkillCommands.has(skill.name)) {
+            if (!this.registeredSkillCommands.has(skill.qualifiedName)) {
                 this.promptService.addBuiltInPromptFragment({
-                    id: `skill-command-${skill.name}`,
-                    template: `Load the skill ${skill.name} using ~{getSkillFileContent}.`,
+                    id: this.fragmentId(skill.qualifiedName),
+                    template: `Load the skill ${skill.qualifiedName} using ~{getSkillFileContent}.`,
                     isCommand: true,
-                    commandName: skill.name,
+                    commandName: skill.qualifiedName,
                     commandDescription: skill.description
                 });
-                this.registeredSkillCommands.add(skill.name);
+                this.registeredSkillCommands.add(skill.qualifiedName);
             }
         }
+    }
+
+    /**
+     * A fragment id becomes a file name when the user customizes the fragment, so the qualifier's `:`
+     * cannot survive into it - it is reserved on Windows. Only the id is sanitized; the command keeps
+     * the qualified name.
+     */
+    protected fragmentId(qualifiedName: string): string {
+        return `skill-command-${qualifiedName.replace(/:/g, '__')}`;
     }
 }

--- a/packages/ai-core/src/browser/skill-registry-ui-bridge.ts
+++ b/packages/ai-core/src/browser/skill-registry-ui-bridge.ts
@@ -1,0 +1,41 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Event } from '@theia/core';
+import { Skill } from '../common/skill';
+
+export const SkillRegistryUiBridge = Symbol('SkillRegistryUiBridge');
+/**
+ * Optional integration point implemented by `@theia/ai-registry`, so that packages which must not
+ * depend on it can tell which skills it manages and reveal them in the registry. The counterpart of
+ * {@link AgentPluginUiBridge} for skills installed or linked directly, rather than contributed by a
+ * plugin.
+ *
+ * Nothing is bound by default. Consumers inject it `@optional()` and, when it is absent, hide every
+ * registry affordance - a product without `@theia/ai-registry` has no registry to install from.
+ */
+export interface SkillRegistryUiBridge {
+    /**
+     * The registry entry `skill` was installed from or linked to, or `undefined` for a skill the
+     * registry does not manage - a workspace skill, a configured directory, or one contributed by an
+     * Agent Plugin. Takes the whole skill rather than its name: a name alone cannot tell a managed
+     * skill from one of the same name in a directory the user controls.
+     */
+    getRegistryEntryId(skill: Skill): string | undefined;
+    /** Reveals the entry in the registry UI. A no-op for a skill the registry does not manage. */
+    revealSkill(skillId: string): void;
+    readonly onDidChange: Event<void>;
+}

--- a/packages/ai-core/src/browser/skill-service.spec.ts
+++ b/packages/ai-core/src/browser/skill-service.spec.ts
@@ -18,15 +18,21 @@ import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
 const disableJSDOM = enableJSDOM();
 
 import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
-FrontendApplicationConfigProvider.set({});
+// Guarded: another spec in the same mocha process may already have set it, and `set` throws on a
+// second call.
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
 
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { parseSkillFile, combineSkillDirectories } from '../common/skill';
+import { parseSkillFile, combineSkillDirectories, Skill, SkillDirectoryEntry } from '../common/skill';
 import { Path } from '@theia/core/lib/common/path';
 import { Disposable, Emitter, ILogger, Logger, URI } from '@theia/core';
 import { FileChangesEvent } from '@theia/filesystem/lib/common/files';
-import { DefaultSkillService } from './skill-service';
+import { DefaultSkillService, SkillDirectoryContribution } from './skill-service';
 
 disableJSDOM();
 
@@ -322,8 +328,11 @@ description: Skill with no content
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         let preferenceChangedEmitter: Emitter<any>;
 
-        function createService(): DefaultSkillService {
+        function createService(contributions: SkillDirectoryContribution[] = []): DefaultSkillService {
             const service = new DefaultSkillService();
+            (service as unknown as { skillDirectoryContributions: unknown }).skillDirectoryContributions = {
+                getContributions: () => contributions
+            };
             (service as unknown as { preferences: unknown }).preferences = preferencesMock;
             (service as unknown as { fileService: unknown }).fileService = fileServiceMock;
             const loggerMock: ILogger = sinon.createStubInstance(Logger);
@@ -629,6 +638,185 @@ Test skill content`
             expect(loggerWarnSpy.calledWith(
                 sinon.match(/Duplicate skill found.*dup-skill/)
             )).to.be.true;
+        });
+
+        describe('contributed skill directories', () => {
+
+            const bigQueryQualifier = 'bigquery-data-analytics';
+            const athenaQualifier = 'athena-analytics';
+
+            /** A contribution returning a fixed set of roots. */
+            function contributing(...entries: SkillDirectoryEntry[]): SkillDirectoryContribution {
+                return { getSkillDirectories: () => entries };
+            }
+
+            /**
+             * Stubs `directory` as an existing skills root holding one skill directory per given name,
+             * each with a valid `SKILL.md` whose description names the root it came from.
+             */
+            function stubSkillsRoot(directory: string, ...skillNames: string[]): void {
+                fileServiceMock.exists
+                    .withArgs(sinon.match((uri: URI) => uri.path.toString() === directory))
+                    .resolves(true);
+                fileServiceMock.resolve
+                    .withArgs(sinon.match((uri: URI) => uri.path.toString() === directory))
+                    .resolves({
+                        children: skillNames.map(name => ({
+                            isDirectory: true,
+                            name,
+                            resource: URI.fromFilePath(`${directory}/${name}`)
+                        }))
+                    });
+                for (const name of skillNames) {
+                    const skillFile = `${directory}/${name}/SKILL.md`;
+                    fileServiceMock.exists
+                        .withArgs(sinon.match((uri: URI) => uri.path.toString() === skillFile))
+                        .resolves(true);
+                    fileServiceMock.read
+                        .withArgs(sinon.match((uri: URI) => uri.path.toString() === skillFile))
+                        .resolves({ value: `---\nname: ${name}\ndescription: from ${directory}\n---\nBody of ${name}` });
+                }
+            }
+
+            async function initialize(service: DefaultSkillService): Promise<void> {
+                (service as unknown as { init: () => void }).init();
+                await workspaceServiceMock.ready;
+                await new Promise(resolve => setTimeout(resolve, 10));
+            }
+
+            it('qualifies the names of skills found under an owned contributed root', async () => {
+                const pluginSkills = '/home/testuser/.agents/plugins/bigquery/skills';
+                stubSkillsRoot(pluginSkills, 'query-builder');
+
+                const service = createService([contributing({ path: pluginSkills, tier: 'plugin', qualifier: bigQueryQualifier })]);
+                await initialize(service);
+
+                const skills = service.getSkills();
+                expect(skills).to.have.length(1);
+                expect(skills[0].name).to.equal('query-builder');
+                expect(skills[0].qualifiedName).to.equal('bigquery-data-analytics:query-builder');
+                expect(Skill.qualifierOf(skills[0])).to.equal('bigquery-data-analytics');
+            });
+
+            it('leaves the qualified name of a skill from a built-in root equal to its plain name', async () => {
+                stubSkillsRoot('/home/testuser/.theia-ide/skills', 'code-review');
+
+                const service = createService();
+                await initialize(service);
+
+                const skills = service.getSkills();
+                expect(skills).to.have.length(1);
+                expect(skills[0].qualifiedName).to.equal('code-review');
+                expect(Skill.qualifierOf(skills[0])).to.be.undefined;
+            });
+
+            it('resolves an owned skill by its qualified name and by its plain name', async () => {
+                const pluginSkills = '/home/testuser/.agents/plugins/bigquery/skills';
+                stubSkillsRoot(pluginSkills, 'query-builder');
+
+                const service = createService([contributing({ path: pluginSkills, tier: 'plugin', qualifier: bigQueryQualifier })]);
+                await initialize(service);
+
+                expect(service.getSkill('bigquery-data-analytics:query-builder')?.name).to.equal('query-builder');
+                // The plain name keeps working, so every reference written before the skill was owned
+                // still resolves.
+                expect(service.getSkill('query-builder')?.qualifiedName).to.equal('bigquery-data-analytics:query-builder');
+            });
+
+            it('loads a skill of the same name from two different plugins and keeps both addressable', async () => {
+                const bigQuerySkills = '/home/testuser/.agents/plugins/bigquery/skills';
+                const athenaSkills = '/home/testuser/.agents/plugins/athena/skills';
+                stubSkillsRoot(bigQuerySkills, 'query-builder');
+                stubSkillsRoot(athenaSkills, 'query-builder');
+
+                const service = createService([contributing(
+                    { path: bigQuerySkills, tier: 'plugin', qualifier: bigQueryQualifier },
+                    { path: athenaSkills, tier: 'plugin', qualifier: athenaQualifier }
+                )]);
+                await initialize(service);
+
+                expect(service.getSkills()).to.have.length(2);
+                expect(service.getSkill('bigquery-data-analytics:query-builder')?.description).to.equal(`from ${bigQuerySkills}`);
+                expect(service.getSkill('athena-analytics:query-builder')?.description).to.equal(`from ${athenaSkills}`);
+                // Neither is dropped as a duplicate, because they no longer share a name.
+                expect(loggerWarnSpy.calledWith(sinon.match(/Duplicate skill found/))).to.be.false;
+            });
+
+            it('resolves an ambiguous plain name to undefined rather than guessing one of the candidates', async () => {
+                const bigQuerySkills = '/home/testuser/.agents/plugins/bigquery/skills';
+                const athenaSkills = '/home/testuser/.agents/plugins/athena/skills';
+                stubSkillsRoot(bigQuerySkills, 'query-builder');
+                stubSkillsRoot(athenaSkills, 'query-builder');
+
+                const service = createService([contributing(
+                    { path: bigQuerySkills, tier: 'plugin', qualifier: bigQueryQualifier },
+                    { path: athenaSkills, tier: 'plugin', qualifier: athenaQualifier }
+                )]);
+                await initialize(service);
+
+                expect(service.getSkill('query-builder')).to.be.undefined;
+            });
+
+            it('keeps loading the remaining roots when one contribution fails', async () => {
+                const pluginSkills = '/home/testuser/.agents/plugins/bigquery/skills';
+                stubSkillsRoot(pluginSkills, 'query-builder');
+                stubSkillsRoot('/home/testuser/.theia-ide/skills', 'code-review');
+
+                const failing: SkillDirectoryContribution = {
+                    getSkillDirectories: () => { throw new Error('cannot enumerate plugins'); }
+                };
+                const service = createService([
+                    failing,
+                    contributing({ path: pluginSkills, tier: 'plugin', qualifier: bigQueryQualifier })
+                ]);
+                await initialize(service);
+
+                expect(service.getSkills().map(skill => skill.qualifiedName).sort())
+                    .to.deep.equal(['bigquery-data-analytics:query-builder', 'code-review']);
+            });
+
+            it('watches the parent of a contributed root that does not exist yet instead of warning about it', async () => {
+                const pluginRoot = '/home/testuser/.agents/plugins/bigquery';
+                fileServiceMock.exists
+                    .withArgs(sinon.match((uri: URI) => uri.path.toString() === `${pluginRoot}/skills`))
+                    .resolves(false);
+                fileServiceMock.exists
+                    .withArgs(sinon.match((uri: URI) => uri.path.toString() === pluginRoot))
+                    .resolves(true);
+
+                const service = createService([contributing({ path: `${pluginRoot}/skills`, tier: 'plugin', qualifier: bigQueryQualifier })]);
+                await initialize(service);
+
+                expect(fileServiceMock.watch.calledWith(
+                    sinon.match((uri: URI) => uri.path.toString() === pluginRoot),
+                    sinon.match({ recursive: false, excludes: [] })
+                )).to.be.true;
+                // A plugin without skills is not a misconfiguration, so it must not warn like a
+                // non-existent configured directory does.
+                expect(loggerWarnSpy.calledWith(sinon.match(/does not exist/))).to.be.false;
+            });
+
+            it('rescans when a contribution reports that its set of roots changed', async () => {
+                const pluginSkills = '/home/testuser/.agents/plugins/bigquery/skills';
+                const onDidChangeEmitter = new Emitter<void>();
+                let entries: SkillDirectoryEntry[] = [];
+                const contribution: SkillDirectoryContribution = {
+                    getSkillDirectories: () => entries,
+                    onDidChange: onDidChangeEmitter.event
+                };
+
+                const service = createService([contribution]);
+                await initialize(service);
+                expect(service.getSkills()).to.have.length(0);
+
+                stubSkillsRoot(pluginSkills, 'query-builder');
+                entries = [{ path: pluginSkills, tier: 'plugin', qualifier: bigQueryQualifier }];
+                onDidChangeEmitter.fire();
+                await new Promise(resolve => setTimeout(resolve, 100));
+
+                expect(service.getSkills().map(skill => skill.qualifiedName)).to.deep.equal(['bigquery-data-analytics:query-builder']);
+                onDidChangeEmitter.dispose();
+            });
         });
     });
 });

--- a/packages/ai-core/src/browser/skill-service.ts
+++ b/packages/ai-core/src/browser/skill-service.ts
@@ -16,7 +16,7 @@
 
 import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
 import { Deferred } from '@theia/core/lib/common/promise-util';
-import { DisposableCollection, Emitter, Event, ILogger, URI } from '@theia/core';
+import { ContributionProvider, Disposable, DisposableCollection, Emitter, Event, ILogger, MaybePromise, URI } from '@theia/core';
 import { Path } from '@theia/core/lib/common/path';
 import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
@@ -26,6 +26,7 @@ import { AICorePreferences, PREFERENCE_NAME_SKILL_DIRECTORIES } from '../common/
 import {
     Skill,
     SkillDescription,
+    SkillDirectoryEntry,
     SKILL_FILE_NAME,
     validateSkillDescription,
     parseSkillFile,
@@ -35,12 +36,28 @@ import {
 /** Debounce delay for coalescing rapid file system events */
 const UPDATE_DEBOUNCE_MS = 50;
 
+export const SkillDirectoryContribution = Symbol('SkillDirectoryContribution');
+/**
+ * Contributes further roots to scan for skills. Point this at the *parent* of the skill folders,
+ * never at a skill folder itself. Contributed roots form the lowest-precedence `plugin` tier, so a
+ * directory the user controls always wins a path collision.
+ */
+export interface SkillDirectoryContribution {
+    /** Entries carrying a {@link SkillDirectoryEntry.qualifier} have their skills prefixed with it. */
+    getSkillDirectories(): MaybePromise<SkillDirectoryEntry[]>;
+    readonly onDidChange?: Event<void>;
+}
+
 export const SkillService = Symbol('SkillService');
 export interface SkillService {
     /** Get all discovered skills */
     getSkills(): Skill[];
 
-    /** Get a skill by name */
+    /**
+     * Matched against {@link Skill.qualifiedName} first, then the plain
+     * {@link SkillDescription.name} so unqualified references keep resolving. A plain name shared by
+     * several skills is ambiguous and resolves to `undefined`.
+     */
     getSkill(name: string): Skill | undefined;
 
     /** Event fired when skills change */
@@ -51,7 +68,7 @@ export interface SkillService {
 }
 
 @injectable()
-export class DefaultSkillService implements SkillService {
+export class DefaultSkillService implements SkillService, Disposable {
     @inject(AICorePreferences)
     protected readonly preferences: AICorePreferences;
 
@@ -67,8 +84,16 @@ export class DefaultSkillService implements SkillService {
     @inject(WorkspaceService)
     protected readonly workspaceService: WorkspaceService;
 
+    @inject(ContributionProvider)
+    @named(SkillDirectoryContribution)
+    protected readonly skillDirectoryContributions: ContributionProvider<SkillDirectoryContribution>;
+
+    /** Keyed by {@link Skill.qualifiedName}. */
     protected skills = new Map<string, Skill>();
+    /** Watchers of the current scan; disposed and rebuilt on every rescan. */
     protected toDispose = new DisposableCollection();
+    /** Kept apart from {@link toDispose}, which does not survive a rescan. */
+    protected readonly toDisposeOnServiceDispose = new DisposableCollection();
     protected watchedDirectories = new Set<string>();
     protected parentWatchers = new Map<string, string>();
 
@@ -90,6 +115,12 @@ export class DefaultSkillService implements SkillService {
 
     @postConstruct()
     protected init(): void {
+        for (const contribution of this.skillDirectoryContributions.getContributions()) {
+            if (contribution.onDidChange) {
+                this.toDisposeOnServiceDispose.push(contribution.onDidChange(() => this.scheduleUpdate()));
+            }
+        }
+
         this.fileService.onDidFilesChange(async (event: FileChangesEvent) => {
             for (const change of event.changes) {
                 if (change.type === FileChangeType.ADDED) {
@@ -160,7 +191,19 @@ export class DefaultSkillService implements SkillService {
     }
 
     getSkill(name: string): Skill | undefined {
-        return this.skills.get(name);
+        const qualifiedMatch = this.skills.get(name);
+        if (qualifiedMatch) {
+            return qualifiedMatch;
+        }
+        // Ambiguous plain names resolve to nothing: guessing would silently load a skill the caller
+        // did not ask for.
+        const plainMatches = this.getSkills().filter(skill => skill.name === name);
+        return plainMatches.length === 1 ? plainMatches[0] : undefined;
+    }
+
+    dispose(): void {
+        this.toDisposeOnServiceDispose.dispose();
+        this.toDispose.dispose();
     }
 
     protected scheduleUpdate(): void {
@@ -212,21 +255,25 @@ export class DefaultSkillService implements SkillService {
         const configuredDirectories = (this.preferences[PREFERENCE_NAME_SKILL_DIRECTORIES] ?? [])
             .map(dir => Path.untildify(dir, homePath));
         const defaultSkillsDirs = await this.getDefaultSkillsDirectoryPaths();
+        const pluginSkillsDirs = await this.getContributedSkillDirectories();
 
         const newWatchedDirectories = new Set<string>();
         const newParentWatchers = new Map<string, string>();
 
-        const allDirectories = combineSkillDirectories(workspaceSkillsDirs, configuredDirectories, defaultSkillsDirs);
-        for (const { path: directoryPath, tier } of allDirectories) {
+        const allDirectories = combineSkillDirectories(workspaceSkillsDirs, configuredDirectories, defaultSkillsDirs, pluginSkillsDirs);
+        for (const { path: directoryPath, tier, qualifier } of allDirectories) {
             if (tier === 'configured') {
-                await this.processConfiguredSkillDirectory(directoryPath, newSkills, newDisposables, newWatchedDirectories);
+                await this.processConfiguredSkillDirectory(directoryPath, newSkills, newDisposables, newWatchedDirectories, qualifier);
             } else {
+                // `plugin` roots take this path too: a plugin with no `skills` directory is a
+                // plugin without skills, worth watching for rather than warning about.
                 await this.processSkillDirectoryWithParentWatching(
                     directoryPath,
                     newSkills,
                     newDisposables,
                     newWatchedDirectories,
-                    newParentWatchers
+                    newParentWatchers,
+                    qualifier
                 );
             }
         }
@@ -241,6 +288,19 @@ export class DefaultSkillService implements SkillService {
         this.parentWatchers = newParentWatchers;
 
         this.onSkillsChangedEmitter.fire();
+    }
+
+    /** A failing contribution is skipped: one broken root must not cost every other skill. */
+    protected async getContributedSkillDirectories(): Promise<SkillDirectoryEntry[]> {
+        const entries: SkillDirectoryEntry[] = [];
+        for (const contribution of this.skillDirectoryContributions.getContributions()) {
+            try {
+                entries.push(...await contribution.getSkillDirectories());
+            } catch (error) {
+                this.logger.error(`Failed to collect contributed skill directories: ${error}`);
+            }
+        }
+        return entries;
     }
 
     protected getWorkspaceSkillsDirectoryPaths(): string[] {
@@ -266,7 +326,8 @@ export class DefaultSkillService implements SkillService {
         skills: Map<string, Skill>,
         disposables: DisposableCollection,
         watchedDirectories: Set<string>,
-        parentWatchers: Map<string, string>
+        parentWatchers: Map<string, string>,
+        qualifier?: string
     ): Promise<void> {
         const dirURI = URI.fromFilePath(directoryPath);
 
@@ -274,7 +335,7 @@ export class DefaultSkillService implements SkillService {
             const dirExists = await this.fileService.exists(dirURI);
 
             if (dirExists) {
-                await this.processExistingSkillDirectory(dirURI, skills, disposables, watchedDirectories);
+                await this.processExistingSkillDirectory(dirURI, skills, disposables, watchedDirectories, qualifier);
             } else {
                 const parentPath = dirURI.parent.path.fsPath();
                 const parentURI = URI.fromFilePath(parentPath);
@@ -298,7 +359,8 @@ export class DefaultSkillService implements SkillService {
         directoryPath: string,
         skills: Map<string, Skill>,
         disposables: DisposableCollection,
-        watchedDirectories: Set<string>
+        watchedDirectories: Set<string>,
+        qualifier?: string
     ): Promise<void> {
         const dirURI = URI.fromFilePath(directoryPath);
 
@@ -310,7 +372,7 @@ export class DefaultSkillService implements SkillService {
                 return;
             }
 
-            await this.processExistingSkillDirectory(dirURI, skills, disposables, watchedDirectories);
+            await this.processExistingSkillDirectory(dirURI, skills, disposables, watchedDirectories, qualifier);
         } catch (error) {
             this.logger.error(`Error processing configured directory '${directoryPath}': ${error}`);
         }
@@ -320,7 +382,8 @@ export class DefaultSkillService implements SkillService {
         dirURI: URI,
         skills: Map<string, Skill>,
         disposables: DisposableCollection,
-        watchedDirectories: Set<string>
+        watchedDirectories: Set<string>,
+        qualifier?: string
     ): Promise<void> {
         const stat = await this.fileService.resolve(dirURI);
         if (!stat.children) {
@@ -330,14 +393,14 @@ export class DefaultSkillService implements SkillService {
         for (const child of stat.children) {
             if (child.isDirectory) {
                 const directoryName = child.name;
-                await this.loadSkillFromDirectory(child.resource, directoryName, skills);
+                await this.loadSkillFromDirectory(child.resource, directoryName, skills, qualifier);
             }
         }
 
         this.setupDirectoryWatcher(dirURI, disposables, watchedDirectories);
     }
 
-    protected async loadSkillFromDirectory(directoryUri: URI, directoryName: string, skills: Map<string, Skill>): Promise<void> {
+    protected async loadSkillFromDirectory(directoryUri: URI, directoryName: string, skills: Map<string, Skill>, qualifier?: string): Promise<void> {
         const skillFileUri = directoryUri.resolve(SKILL_FILE_NAME);
 
         const fileExists = await this.fileService.exists(skillFileUri);
@@ -365,19 +428,20 @@ export class DefaultSkillService implements SkillService {
                 return;
             }
 
-            const skillName = parsed.metadata.name;
+            const qualifiedName = Skill.qualifyName(parsed.metadata.name, qualifier);
 
-            if (skills.has(skillName)) {
-                this.logger.warn(`Skill '${skillName}': Duplicate skill found in '${directoryName}', using first discovered instance`);
+            if (skills.has(qualifiedName)) {
+                this.logger.warn(`Skill '${qualifiedName}': Duplicate skill found in '${directoryName}', using first discovered instance`);
                 return;
             }
 
             const skill: Skill = {
                 ...parsed.metadata,
-                location: skillFileUri.path.fsPath()
+                location: skillFileUri.path.fsPath(),
+                qualifiedName
             };
 
-            skills.set(skillName, skill);
+            skills.set(qualifiedName, skill);
         } catch (error) {
             this.logger.error(`Failed to load skill from '${directoryName}': ${error}`);
         }

--- a/packages/ai-core/src/browser/skills-variable-contribution.spec.ts
+++ b/packages/ai-core/src/browser/skills-variable-contribution.spec.ts
@@ -163,11 +163,13 @@ describe('SkillsVariableContribution', () => {
             const skills: Skill[] = [
                 {
                     name: 'pdf-processing',
+                    qualifiedName: 'pdf-processing',
                     description: 'Processes PDF documents and extracts text content',
                     location: '/path/to/skills/pdf-processing/SKILL.md'
                 },
                 {
                     name: 'data-analysis',
+                    qualifiedName: 'data-analysis',
                     description: 'Analyzes data sets and generates reports',
                     location: '/path/to/skills/data-analysis/SKILL.md'
                 }
@@ -207,6 +209,7 @@ describe('SkillsVariableContribution', () => {
             const skills: Skill[] = [
                 {
                     name: 'test-skill',
+                    qualifiedName: 'test-skill',
                     description: 'Handles <tags> & "quotes" with \'apostrophes\'',
                     location: '/path/to/skill/SKILL.md'
                 }
@@ -228,6 +231,7 @@ describe('SkillsVariableContribution', () => {
             const skills: Skill[] = [
                 {
                     name: 'skill<test>',
+                    qualifiedName: 'skill<test>',
                     description: 'Test skill',
                     location: '/path/with/&special/chars'
                 }
@@ -266,6 +270,7 @@ describe('SkillsVariableContribution', () => {
         it('should return skill content when skill found', async () => {
             const skill: Skill = {
                 name: 'my-skill',
+                qualifiedName: 'my-skill',
                 description: 'A test skill',
                 location: '/path/to/skills/my-skill/SKILL.md'
             };
@@ -293,6 +298,7 @@ This is the skill content.`
         it('should return undefined when file read fails', async () => {
             const skill: Skill = {
                 name: 'my-skill',
+                qualifiedName: 'my-skill',
                 description: 'A test skill',
                 location: '/path/to/skills/my-skill/SKILL.md'
             };

--- a/packages/ai-core/src/browser/skills-variable-contribution.ts
+++ b/packages/ai-core/src/browser/skills-variable-contribution.ts
@@ -22,7 +22,7 @@ import {
 } from '../common/variable-service';
 import { FileService } from '@theia/filesystem/lib/browser/file-service';
 import { SkillService } from './skill-service';
-import { parseSkillFile } from '../common/skill';
+import { parseSkillFile, Skill } from '../common/skill';
 
 export const SKILLS_VARIABLE: AIVariable = {
     id: 'skills',
@@ -39,6 +39,7 @@ export const SKILL_VARIABLE: AIVariable = {
 };
 
 export interface SkillSummary {
+    /** The name the model has to write to address the skill, i.e. {@link Skill.qualifiedName}. */
     name: string;
     description: string;
     location: string;
@@ -80,9 +81,18 @@ export class SkillsVariableContribution implements AIVariableContribution, AIVar
 
         // Handle plural skills variable
         if (request.variable.name === SKILLS_VARIABLE.name) {
-            return this.resolveSkillsVariable(this.skillService.getSkills(), SKILLS_VARIABLE);
+            return this.resolveSkillsVariable(this.skillService.getSkills().map(skill => this.toSkillSummary(skill)), SKILLS_VARIABLE);
         }
         return undefined;
+    }
+
+    /** Named by {@link Skill.qualifiedName}: that is what the model has to write to load it again. */
+    toSkillSummary(skill: Skill): SkillSummary {
+        return {
+            name: skill.qualifiedName,
+            description: skill.description,
+            location: skill.location
+        };
     }
 
     /**

--- a/packages/ai-core/src/common/prompt-service.spec.ts
+++ b/packages/ai-core/src/common/prompt-service.spec.ts
@@ -669,3 +669,46 @@ describe('CustomAgentDescription', () => {
         });
     });
 });
+
+describe('PromptService variable arguments', () => {
+    let promptService: PromptService;
+
+    beforeEach(() => {
+        const container = new Container();
+        container.bind<PromptService>(PromptService).to(PromptServiceImpl).inSingletonScope();
+
+        const variableService = new DefaultAIVariableService({ getContributions: () => [] });
+        (variableService as unknown as Record<string, unknown>)['logger'] = sinon.createStubInstance(Logger);
+        // A resolver that echoes what it was given, so that the test asserts on the split of the
+        // reference into variable name and argument rather than on any resolver behaviour.
+        const fileVariable = { id: 'file', name: 'file', description: 'Echoes its argument' };
+        variableService.registerResolver(fileVariable, {
+            canResolve: () => 100,
+            resolve: async request => ({ variable: fileVariable, value: `arg=${request.arg}` })
+        });
+        container.bind<AIVariableService>(AIVariableService).toConstantValue(variableService);
+        container.bind<ILogger>(ILogger).toConstantValue(new MockLogger);
+
+        promptService = container.get<PromptService>(PromptService);
+    });
+
+    it('keeps the whole argument of a variable reference whose argument contains further colons', async () => {
+        // Regression test: the reference used to be split with `split(':', 2)`, which truncates, so a
+        // Windows path lost everything from its drive-letter colon onwards.
+        promptService.addBuiltInPromptFragment({ id: 'windows-path', template: 'Read {{file:C:\\some\\path}}' });
+        const prompt = await promptService.getResolvedPromptFragment('windows-path');
+        expect(prompt?.text).to.equal('Read arg=C:\\some\\path');
+    });
+
+    it('keeps a single-colon argument intact', async () => {
+        promptService.addBuiltInPromptFragment({ id: 'simple-arg', template: 'Read {{file:workspace/path/name.ext}}' });
+        const prompt = await promptService.getResolvedPromptFragment('simple-arg');
+        expect(prompt?.text).to.equal('Read arg=workspace/path/name.ext');
+    });
+
+    it('resolves a reference without an argument with an undefined argument', async () => {
+        promptService.addBuiltInPromptFragment({ id: 'no-arg', template: 'Read {{file}}' });
+        const prompt = await promptService.getResolvedPromptFragment('no-arg');
+        expect(prompt?.text).to.equal('Read arg=undefined');
+    });
+});

--- a/packages/ai-core/src/common/prompt-service.ts
+++ b/packages/ai-core/src/common/prompt-service.ts
@@ -983,10 +983,12 @@ export class PromptServiceImpl implements PromptService {
             let variableName = variableAndArg;
             let argument: string | undefined;
 
-            const parts = variableAndArg.split(':', 2);
-            if (parts.length > 1) {
-                variableName = parts[0];
-                argument = parts[1];
+            // First colon only, keeping the whole remainder: `split(':', 2)` truncates instead, which
+            // mangles every argument containing a colon, e.g. `{{file:C:\some\path}}`.
+            const separatorIndex = variableAndArg.indexOf(':');
+            if (separatorIndex >= 0) {
+                variableName = variableAndArg.substring(0, separatorIndex);
+                argument = variableAndArg.substring(separatorIndex + 1);
             }
 
             let replacementValue: string;

--- a/packages/ai-core/src/common/skill.spec.ts
+++ b/packages/ai-core/src/common/skill.spec.ts
@@ -17,7 +17,10 @@
 import { expect } from 'chai';
 import {
     SKILL_FILE_NAME,
+    Skill,
     SkillDescription,
+    SkillDirectoryEntry,
+    combineSkillDirectories,
     isValidSkillName,
     validateSkillDescription
 } from './skill';
@@ -217,6 +220,102 @@ describe('Skill Types', () => {
             };
             const errors = validateSkillDescription(description, 'my-skill');
             expect(errors).to.be.empty;
+        });
+
+        it('does not require the frontmatter name of an owned skill to carry its qualifier', () => {
+            // Qualification is layered on top of the name; it never changes what an artifact has to
+            // write into its SKILL.md, which would change the artifact's content hash.
+            const description: SkillDescription = {
+                name: 'query-builder',
+                description: 'Build SQL'
+            };
+            expect(validateSkillDescription(description, 'query-builder')).to.be.empty;
+            expect(Skill.qualifyName(description.name, 'bq')).to.equal('bq:query-builder');
+        });
+    });
+
+    describe('Skill.qualifyName', () => {
+        it('returns the plain name when there is no qualifier', () => {
+            expect(Skill.qualifyName('code-review')).to.equal('code-review');
+        });
+
+        it('prefixes the name with the qualifier', () => {
+            expect(Skill.qualifyName('query-builder', 'bigquery-data-analytics')).to.equal('bigquery-data-analytics:query-builder');
+        });
+    });
+
+    describe('Skill.qualifierOf', () => {
+        const skill = (name: string, qualifiedName: string): Skill =>
+            ({ name, description: 'd', location: '/skills/' + name + '/SKILL.md', qualifiedName });
+
+        it('returns undefined for a skill from a built-in root', () => {
+            expect(Skill.qualifierOf(skill('code-review', 'code-review'))).to.be.undefined;
+        });
+
+        it('returns the qualifier of a contributed skill', () => {
+            expect(Skill.qualifierOf(skill('query-builder', 'bq:query-builder'))).to.equal('bq');
+        });
+
+        it('round-trips with qualifyName', () => {
+            const qualifiedName = Skill.qualifyName('query-builder', 'io.github.acme_tools');
+            expect(Skill.qualifierOf(skill('query-builder', qualifiedName))).to.equal('io.github.acme_tools');
+        });
+    });
+
+    describe('combineSkillDirectories with plugin directories', () => {
+        const pluginEntry: SkillDirectoryEntry = {
+            path: '/home/user/.agents/plugins/io.example.bq/skills',
+            tier: 'plugin',
+            qualifier: 'bq'
+        };
+
+        it('appends plugin directories after every user-controlled tier', () => {
+            const result = combineSkillDirectories(
+                ['/workspace/.prompts/skills'],
+                ['/custom/skills'],
+                ['/home/user/.agents/skills'],
+                [pluginEntry]
+            );
+
+            expect(result).to.deep.equal([
+                { path: '/workspace/.prompts/skills', tier: 'workspace' },
+                { path: '/custom/skills', tier: 'configured' },
+                { path: '/home/user/.agents/skills', tier: 'default' },
+                pluginEntry
+            ]);
+        });
+
+        it('keeps the qualifier of a plugin directory', () => {
+            const result = combineSkillDirectories([], [], [], [pluginEntry]);
+            expect(result[0].qualifier).to.equal('bq');
+        });
+
+        it('drops a plugin directory whose path a user-controlled tier already claimed, so the user wins the collision', () => {
+            const result = combineSkillDirectories(
+                [],
+                [pluginEntry.path],
+                [],
+                [pluginEntry]
+            );
+
+            expect(result).to.deep.equal([
+                { path: pluginEntry.path, tier: 'configured' }
+            ]);
+        });
+
+        it('deduplicates two plugin directories with the same path, keeping the first', () => {
+            const second: SkillDirectoryEntry = {
+                ...pluginEntry,
+                qualifier: 'other'
+            };
+            const result = combineSkillDirectories([], [], [], [pluginEntry, second]);
+            expect(result).to.deep.equal([pluginEntry]);
+        });
+
+        it('behaves exactly as before when no plugin directories are passed', () => {
+            expect(combineSkillDirectories(['/workspace/skills'], [], [])).to.deep.equal([
+                { path: '/workspace/skills', tier: 'workspace' }
+            ]);
         });
     });
 });

--- a/packages/ai-core/src/common/skill.ts
+++ b/packages/ai-core/src/common/skill.ts
@@ -87,6 +87,32 @@ export namespace SkillDescription {
 export interface Skill extends SkillDescription {
     /** Absolute file path to the SKILL.md file */
     location: string;
+    /**
+     * What the runtime and the model address this skill by: `name` for a built-in root,
+     * `<qualifier>:<name>` for a contributed one. Unlike `name` this is unique across all discovered
+     * skills, which is why it keys the registry.
+     */
+    qualifiedName: string;
+}
+
+export namespace Skill {
+    /**
+     * Never changes what is written in `SKILL.md` - the frontmatter `name` must still equal the
+     * skill's directory name; qualification is layered on top.
+     */
+    export function qualifyName(name: string, qualifier?: string): string {
+        return qualifier ? `${qualifier}:${name}` : name;
+    }
+
+    /**
+     * The qualifier of {@link Skill.qualifiedName}, or `undefined` for a skill from a built-in root.
+     * Unambiguous because neither part can contain a colon: a skill name is validated as lowercase
+     * kebab-case, and a qualifier has to be a single path segment.
+     */
+    export function qualifierOf(skill: Skill): string | undefined {
+        const separatorIndex = skill.qualifiedName.indexOf(':');
+        return separatorIndex < 0 ? undefined : skill.qualifiedName.substring(0, separatorIndex);
+    }
 }
 
 /**
@@ -144,10 +170,8 @@ export function parseSkillFile(content: string): { metadata: SkillDescription | 
     return { metadata, content: body };
 }
 
-/**
- * Provenance tier of a skill directory, used to dispatch tier-specific processing.
- */
-export type SkillDirectoryTier = 'workspace' | 'configured' | 'default';
+/** Provenance tier of a skill directory, used to dispatch tier-specific processing. */
+export type SkillDirectoryTier = 'workspace' | 'configured' | 'default' | 'plugin';
 
 /**
  * A skill directory paired with the tier it originates from.
@@ -157,32 +181,43 @@ export interface SkillDirectoryEntry {
     path: string;
     /** Tier the directory belongs to */
     tier: SkillDirectoryTier;
+    /**
+     * Prefixes the names of skills beneath this root, as `<qualifier>:<name>`. Skills are addressed
+     * by one global name, so two artifacts shipping the same skill name could not otherwise coexist -
+     * and renaming the directory instead would change the artifact's content hash. Must be a single
+     * path segment, so that it can be told from the skill name it is joined to.
+     */
+    qualifier?: string;
 }
 
 /**
- * Combines skill directories with proper priority ordering and provenance.
- * Workspace directories have highest priority, followed by configured directories, then defaults.
+ * Combines skill directories with proper priority ordering and provenance: workspace, then
+ * configured, then defaults, then installed artifacts - so a directory the user controls always wins.
  * First occurrence of a path wins on duplicates; later occurrences (regardless of tier) are dropped.
  */
 export function combineSkillDirectories(
     workspaceSkillsDirs: string[],
     configuredDirectories: string[],
-    defaultSkillsDirs: string[]
+    defaultSkillsDirs: string[],
+    pluginSkillsDirs: SkillDirectoryEntry[] = []
 ): SkillDirectoryEntry[] {
     const seen = new Set<string>();
     const result: SkillDirectoryEntry[] = [];
-    const tiers: Array<{ dirs: string[]; tier: SkillDirectoryTier }> = [
-        { dirs: workspaceSkillsDirs, tier: 'workspace' },
-        { dirs: configuredDirectories, tier: 'configured' },
-        { dirs: defaultSkillsDirs, tier: 'default' }
+    const candidates: SkillDirectoryEntry[] = [
+        ...toSkillDirectoryEntries(workspaceSkillsDirs, 'workspace'),
+        ...toSkillDirectoryEntries(configuredDirectories, 'configured'),
+        ...toSkillDirectoryEntries(defaultSkillsDirs, 'default'),
+        ...pluginSkillsDirs
     ];
-    for (const { dirs, tier } of tiers) {
-        for (const dir of dirs) {
-            if (!seen.has(dir)) {
-                seen.add(dir);
-                result.push({ path: dir, tier });
-            }
+    for (const candidate of candidates) {
+        if (!seen.has(candidate.path)) {
+            seen.add(candidate.path);
+            result.push(candidate);
         }
     }
     return result;
+}
+
+function toSkillDirectoryEntries(dirs: string[], tier: SkillDirectoryTier): SkillDirectoryEntry[] {
+    return dirs.map(dir => ({ path: dir, tier }));
 }

--- a/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.spec.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.spec.ts
@@ -22,9 +22,6 @@ FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
 import { Event } from '@theia/core';
-import * as React from '@theia/core/shared/react';
-import { createRoot } from '@theia/core/shared/react-dom/client';
-import { flushSync } from '@theia/core/shared/react-dom';
 import { PromptFragment } from '@theia/ai-core/lib/common/prompt-service';
 import { Skill } from '@theia/ai-core/lib/common/skill';
 import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
@@ -70,22 +67,6 @@ describe('PromptsAndSkillsConfigurationCategory', () => {
     function skillRow(category: PromptsAndSkillsConfigurationCategory, forSkill: Skill): CollapsibleRow {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         return (category as any).buildSkillRow(forSkill) as CollapsibleRow;
-    }
-
-    /** Renders a row's action slot and clicks the action whose accessible name starts with `titlePrefix`. */
-    function clickRowAction(actions: React.ReactNode, titlePrefix: string): void {
-        const container = document.createElement('div');
-        document.body.appendChild(container);
-        const root = createRoot(container);
-        try {
-            flushSync(() => root.render(actions));
-            const button = container.querySelector(`button[aria-label^="${titlePrefix}"]`) as HTMLButtonElement | null;
-            expect(button, `no action labelled "${titlePrefix}…"`).to.not.be.null;
-            flushSync(() => button!.click());
-        } finally {
-            flushSync(() => root.unmount());
-            container.remove();
-        }
     }
 
     function skill(overrides: Partial<Skill>): Skill {
@@ -140,35 +121,41 @@ describe('PromptsAndSkillsConfigurationCategory', () => {
             expect(row.title).to.equal('bigquery:query-builder');
         });
 
-        it('labels a contributed skill with the name of the plugin that supplied it', () => {
+        it('labels a contributed skill with the shared origin badge naming the plugin that supplied it', () => {
             const row = skillRow(categoryWithPlugins([contributed], [bigquery]), contributed);
-            expect(row.pills).to.include('via BigQuery Data Analytics');
+            // The same descriptor the MCP page builds, so both pages render one badge rather than two designs.
+            expect(row.origins?.map(origin => origin.label)).to.deep.equal(['via BigQuery Data Analytics']);
             // Filterable by the plugin name too, so a plugin's skills can be listed together.
             expect(row.filterText).to.contain('bigquery data analytics');
         });
 
-        it('reveals the owning plugin when the provenance action is activated', () => {
+        it('reveals the owning plugin when the origin badge is activated', () => {
             const revealed: string[] = [];
             const row = skillRow(categoryWithPlugins([contributed], [bigquery], revealed), contributed);
-            clickRowAction(row.actions, 'Show the Agent Plugin');
+            // Activated directly: rendering the badge as a button is `AiConfigurationOriginBadge`'s
+            // contract, tested where it lives; what belongs here is where this page's badge leads.
+            row.origins![0].activate!();
             expect(revealed).to.deep.equal([bigquery.pluginId]);
+        });
+
+        it('keeps the provenance out of the pills, which state what the skill is rather than where it came from', () => {
+            const row = skillRow(categoryWithPlugins([contributed], [bigquery]), contributed);
+            expect(row.pills?.some(pill => pill.startsWith('via '))).to.not.equal(true);
         });
 
         it('labels nothing for a skill from a built-in root, which is the common case', () => {
             const own = skill({});
-            const row = skillRow(categoryWithPlugins([own], [bigquery]), own);
-            expect(row.pills?.some(pill => pill.startsWith('via '))).to.not.equal(true);
+            expect(skillRow(categoryWithPlugins([own], [bigquery]), own).origins).to.equal(undefined);
         });
 
         it('labels nothing rather than a bare qualifier when the qualifier belongs to no installed plugin', () => {
             const row = skillRow(categoryWithPlugins([contributed], []), contributed);
-            expect(row.pills?.some(pill => pill.startsWith('via '))).to.not.equal(true);
+            expect(row.origins).to.equal(undefined);
             expect(row.title).to.equal('bigquery:query-builder');
         });
 
         it('labels nothing when no bridge is bound, i.e. without `@theia/ai-registry`', () => {
-            const row = skillRow(categoryWithPlugins([contributed], undefined), contributed);
-            expect(row.pills?.some(pill => pill.startsWith('via '))).to.not.equal(true);
+            expect(skillRow(categoryWithPlugins([contributed], undefined), contributed).origins).to.equal(undefined);
         });
     });
 });

--- a/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.spec.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.spec.ts
@@ -21,12 +21,21 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
+import { Event } from '@theia/core';
+import * as React from '@theia/core/shared/react';
+import { createRoot } from '@theia/core/shared/react-dom/client';
+import { flushSync } from '@theia/core/shared/react-dom';
 import { PromptFragment } from '@theia/ai-core/lib/common/prompt-service';
 import { Skill } from '@theia/ai-core/lib/common/skill';
+import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
 import { AiConfigurationCategoryId } from '@theia/ai-core-ui/lib/browser/ai-configuration/ai-configuration-category';
+import { CollapsibleRow } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/collapsible-list';
 import { PromptsAndSkillsConfigurationCategory } from './prompts-and-skills-configuration-category';
 
 disableJSDOM();
+
+/** A plugin as the bridge knows it, plus the qualifier its contributed skill root carries. */
+type InstalledPlugin = InstalledAgentPluginInfo & { qualifier: string };
 
 describe('PromptsAndSkillsConfigurationCategory', () => {
 
@@ -42,6 +51,47 @@ describe('PromptsAndSkillsConfigurationCategory', () => {
         return category;
     }
 
+    /** Leaves the bridge unbound when `installedPlugins` is omitted, i.e. a product without `@theia/ai-registry`. */
+    function categoryWithPlugins(skills: Skill[], installedPlugins: InstalledPlugin[] | undefined, revealed: string[] = []): PromptsAndSkillsConfigurationCategory {
+        const category = categoryWith(skills, []);
+        if (installedPlugins) {
+            const bridge: AgentPluginUiBridge = {
+                getPlugin: pluginId => installedPlugins.find(plugin => plugin.pluginId === pluginId),
+                getPluginByQualifier: qualifier => installedPlugins.find(plugin => plugin.qualifier === qualifier),
+                revealPlugin: pluginId => { revealed.push(pluginId); },
+                onDidChange: Event.None
+            };
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (category as any).agentPluginUiBridge = bridge;
+        }
+        return category;
+    }
+
+    function skillRow(category: PromptsAndSkillsConfigurationCategory, forSkill: Skill): CollapsibleRow {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        return (category as any).buildSkillRow(forSkill) as CollapsibleRow;
+    }
+
+    /** Renders a row's action slot and clicks the action whose accessible name starts with `titlePrefix`. */
+    function clickRowAction(actions: React.ReactNode, titlePrefix: string): void {
+        const container = document.createElement('div');
+        document.body.appendChild(container);
+        const root = createRoot(container);
+        try {
+            flushSync(() => root.render(actions));
+            const button = container.querySelector(`button[aria-label^="${titlePrefix}"]`) as HTMLButtonElement | null;
+            expect(button, `no action labelled "${titlePrefix}…"`).to.not.be.null;
+            flushSync(() => button!.click());
+        } finally {
+            flushSync(() => root.unmount());
+            container.remove();
+        }
+    }
+
+    function skill(overrides: Partial<Skill>): Skill {
+        return { name: 'query-builder', qualifiedName: 'query-builder', description: 'Build SQL', location: '/skills/query-builder/SKILL.md', ...overrides } as Skill;
+    }
+
     it('declares the skills and slash commands single-page metadata', () => {
         const category = new PromptsAndSkillsConfigurationCategory();
         expect(category.id).to.equal(AiConfigurationCategoryId.PROMPTS_AND_SKILLS);
@@ -50,7 +100,7 @@ describe('PromptsAndSkillsConfigurationCategory', () => {
 
     it('indexes skills and slash commands for search, highlighting their rows', () => {
         const category = categoryWith(
-            [{ name: 'refactor', description: 'do it', location: '/s' } as unknown as Skill],
+            [{ name: 'refactor', qualifiedName: 'refactor', description: 'do it', location: '/s' } as unknown as Skill],
             [{ id: 'cmd', commandName: 'go', commandDescription: 'run' } as unknown as PromptFragment]
         );
         const items = category.getSearchItems();
@@ -77,5 +127,48 @@ describe('PromptsAndSkillsConfigurationCategory', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const commands = (category as any).slashCommands as PromptFragment[];
         expect(commands.map(command => command.id)).to.deep.equal(['remember']);
+    });
+
+    describe('Agent Plugin provenance', () => {
+
+        const bigquery: InstalledPlugin = { pluginId: 'io.example/bq', name: 'BigQuery Data Analytics', qualifier: 'bigquery' };
+        const contributed = skill({ qualifiedName: 'bigquery:query-builder', location: '/plugins/bigquery/skills/query-builder/SKILL.md' });
+
+        it('keys and titles a skill row by its qualified name, which is what the model addresses', () => {
+            const row = skillRow(categoryWithPlugins([contributed], [bigquery]), contributed);
+            expect(row.id).to.equal('skill:bigquery:query-builder');
+            expect(row.title).to.equal('bigquery:query-builder');
+        });
+
+        it('labels a contributed skill with the name of the plugin that supplied it', () => {
+            const row = skillRow(categoryWithPlugins([contributed], [bigquery]), contributed);
+            expect(row.pills).to.include('via BigQuery Data Analytics');
+            // Filterable by the plugin name too, so a plugin's skills can be listed together.
+            expect(row.filterText).to.contain('bigquery data analytics');
+        });
+
+        it('reveals the owning plugin when the provenance action is activated', () => {
+            const revealed: string[] = [];
+            const row = skillRow(categoryWithPlugins([contributed], [bigquery], revealed), contributed);
+            clickRowAction(row.actions, 'Show the Agent Plugin');
+            expect(revealed).to.deep.equal([bigquery.pluginId]);
+        });
+
+        it('labels nothing for a skill from a built-in root, which is the common case', () => {
+            const own = skill({});
+            const row = skillRow(categoryWithPlugins([own], [bigquery]), own);
+            expect(row.pills?.some(pill => pill.startsWith('via '))).to.not.equal(true);
+        });
+
+        it('labels nothing rather than a bare qualifier when the qualifier belongs to no installed plugin', () => {
+            const row = skillRow(categoryWithPlugins([contributed], []), contributed);
+            expect(row.pills?.some(pill => pill.startsWith('via '))).to.not.equal(true);
+            expect(row.title).to.equal('bigquery:query-builder');
+        });
+
+        it('labels nothing when no bridge is bound, i.e. without `@theia/ai-registry`', () => {
+            const row = skillRow(categoryWithPlugins([contributed], undefined), contributed);
+            expect(row.pills?.some(pill => pill.startsWith('via '))).to.not.equal(true);
+        });
     });
 });

--- a/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.spec.ts
+++ b/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.spec.ts
@@ -25,6 +25,7 @@ import { Event } from '@theia/core';
 import { PromptFragment } from '@theia/ai-core/lib/common/prompt-service';
 import { Skill } from '@theia/ai-core/lib/common/skill';
 import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
+import { SkillRegistryUiBridge } from '@theia/ai-core/lib/browser/skill-registry-ui-bridge';
 import { AiConfigurationCategoryId } from '@theia/ai-core-ui/lib/browser/ai-configuration/ai-configuration-category';
 import { CollapsibleRow } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/collapsible-list';
 import { PromptsAndSkillsConfigurationCategory } from './prompts-and-skills-configuration-category';
@@ -60,6 +61,26 @@ describe('PromptsAndSkillsConfigurationCategory', () => {
             };
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             (category as any).agentPluginUiBridge = bridge;
+        }
+        return category;
+    }
+
+    /**
+     * Leaves the bridge unbound when `managed` is omitted. `managed` maps a skill location to the
+     * registry entry it was installed from, which is how the real bridge keys them.
+     */
+    function categoryWithRegistrySkills(
+        skills: Skill[], managed: Record<string, string> | undefined, revealed: string[] = []
+    ): PromptsAndSkillsConfigurationCategory {
+        const category = categoryWith(skills, []);
+        if (managed) {
+            const bridge: SkillRegistryUiBridge = {
+                getRegistryEntryId: forSkill => managed[forSkill.location],
+                revealSkill: skillId => { revealed.push(skillId); },
+                onDidChange: Event.None
+            };
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (category as any).skillRegistryUiBridge = bridge;
         }
         return category;
     }
@@ -156,6 +177,50 @@ describe('PromptsAndSkillsConfigurationCategory', () => {
 
         it('labels nothing when no bridge is bound, i.e. without `@theia/ai-registry`', () => {
             expect(skillRow(categoryWithPlugins([contributed], undefined), contributed).origins).to.equal(undefined);
+        });
+    });
+
+    describe('AI registry provenance', () => {
+
+        const installed = skill({ location: '/home/alex/.agents/skills/query-builder/SKILL.md' });
+        const entryId = 'io.github.acme/query-builder';
+
+        it('labels a registry-installed skill with the shared "From registry" badge', () => {
+            const row = skillRow(categoryWithRegistrySkills([installed], { [installed.location]: entryId }), installed);
+            expect(row.origins?.map(origin => origin.label)).to.deep.equal(['From registry']);
+            expect(row.origins![0].tooltip).to.contain(entryId);
+        });
+
+        it('reveals the registry entry when the badge is activated', () => {
+            const revealed: string[] = [];
+            const row = skillRow(categoryWithRegistrySkills([installed], { [installed.location]: entryId }, revealed), installed);
+            row.origins![0].activate!();
+            expect(revealed).to.deep.equal([entryId]);
+        });
+
+        it('labels nothing for a skill in a directory the user controls', () => {
+            const own = skill({ location: '/workspace/.agents/skills/query-builder/SKILL.md' });
+            expect(skillRow(categoryWithRegistrySkills([own], { [installed.location]: entryId }), own).origins).to.equal(undefined);
+        });
+
+        it('labels nothing when no bridge is bound, i.e. without `@theia/ai-registry`', () => {
+            expect(skillRow(categoryWithRegistrySkills([installed], undefined), installed).origins).to.equal(undefined);
+        });
+
+        it('credits the plugin, not the registry, for a skill a plugin contributed', () => {
+            // A plugin ships its skills inside the plugin, so the two origins cannot both apply; were the
+            // registry consulted anyway, a stale name collision would show a skill as coming from both.
+            const bigquery: InstalledPlugin = { pluginId: 'io.example/bq', name: 'BigQuery', qualifier: 'bigquery' };
+            const contributed = skill({ qualifiedName: 'bigquery:query-builder', location: '/plugins/bigquery/skills/query-builder/SKILL.md' });
+            const category = categoryWithPlugins([contributed], [bigquery]);
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (category as any).skillRegistryUiBridge = {
+                getRegistryEntryId: () => entryId,
+                revealSkill: () => { },
+                onDidChange: Event.None
+            } satisfies SkillRegistryUiBridge;
+
+            expect(skillRow(category, contributed).origins?.map(origin => origin.label)).to.deep.equal(['via BigQuery']);
         });
     });
 });

--- a/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.tsx
@@ -18,13 +18,14 @@ import { Agent, AgentService } from '@theia/ai-core';
 import { GENERIC_CAPABILITIES_SKILLS_PROMPT_ID, matchVariablesRegEx, parseCapabilitiesFromTemplate } from '@theia/ai-core/lib/common';
 import { PREFERENCE_NAME_SKILL_DIRECTORIES } from '@theia/ai-core/lib/common/ai-core-preferences';
 import { SkillService } from '@theia/ai-core/lib/browser/skill-service';
+import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
 import { Skill } from '@theia/ai-core/lib/common/skill';
 import { isCustomizedPromptFragment, PromptFragment, PromptService } from '@theia/ai-core/lib/common/prompt-service';
 import { Emitter, Event, ILogger, nls, URI } from '@theia/core';
 import { codicon, open, OpenerService } from '@theia/core/lib/browser';
 import { ClipboardService } from '@theia/core/lib/browser/clipboard-service';
 import { DisposableCollection } from '@theia/core/lib/common';
-import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { inject, injectable, named, optional, postConstruct } from '@theia/core/shared/inversify';
 import * as React from '@theia/core/shared/react';
 import {
     AiConfigurationCategory,
@@ -91,6 +92,9 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
     @inject(ILogger) @named('ai-ide:PromptsAndSkillsConfigurationCategory')
     protected readonly logger: ILogger;
 
+    @inject(AgentPluginUiBridge) @optional()
+    protected readonly agentPluginUiBridge?: AgentPluginUiBridge;
+
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
     protected readonly toDispose = new DisposableCollection(this.onDidChangeEmitter);
@@ -131,6 +135,10 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
             }),
             this.settingsRowService.onPreferenceChanged(() => this.onDidChangeEmitter.fire())
         ]);
+        if (this.agentPluginUiBridge) {
+            // The plugin names come from the bridge, so installing one changes this page even when the skills do not.
+            this.toDispose.push(this.agentPluginUiBridge.onDidChange(() => this.onDidChangeEmitter.fire()));
+        }
     }
 
     dispose(): void {
@@ -142,7 +150,8 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
     }
 
     protected loadSkills(): void {
-        this.skills = this.skillService.getSkills().sort((a, b) => a.name.localeCompare(b.name));
+        // Sorted and keyed by the qualified name: it is what the model addresses and the only name unique across roots.
+        this.skills = this.skillService.getSkills().sort((a, b) => a.qualifiedName.localeCompare(b.qualifiedName));
     }
 
     protected loadSlashCommands(): void {
@@ -211,21 +220,32 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
     protected buildSkillRow(skill: Skill): CollapsibleRow {
         const tools = skill.allowedTools ?? [];
         const metadata = skill.metadata ? Object.entries(skill.metadata) : [];
+        const plugin = this.getOwningPlugin(skill);
         const pills: string[] = [];
         if (tools.length > 0) {
             pills.push(nls.localizeByDefault('{0} tools', tools.length));
         }
+        if (plugin) {
+            pills.push(nls.localize('theia/ai/ide/skillsConfiguration/skill/viaPlugin', 'via {0}', plugin.name));
+        }
         return {
-            id: SKILL_ROW_PREFIX + skill.name,
-            title: skill.name,
+            id: SKILL_ROW_PREFIX + skill.qualifiedName,
+            title: skill.qualifiedName,
             description: skill.description,
             pills,
-            filterText: `${skill.name} ${skill.description ?? ''}`.toLocaleLowerCase(),
-            actions: <CollapsibleRowAction
-                iconClass={codicon('edit')}
-                label={nls.localize('theia/ai/ide/skillsConfiguration/openSkillFile', 'Open SKILL.md')}
-                onActivate={() => this.openSkill(skill)}
-            />,
+            filterText: `${skill.qualifiedName} ${skill.description ?? ''} ${plugin?.name ?? ''}`.toLocaleLowerCase(),
+            actions: <>
+                {plugin && <CollapsibleRowAction
+                    iconClass={codicon('extensions')}
+                    label={nls.localize('theia/ai/ide/skillsConfiguration/skill/revealPlugin', 'Show the Agent Plugin \'{0}\' that provides this skill', plugin.name)}
+                    onActivate={() => this.agentPluginUiBridge?.revealPlugin(plugin.pluginId)}
+                />}
+                <CollapsibleRowAction
+                    iconClass={codicon('edit')}
+                    label={nls.localize('theia/ai/ide/skillsConfiguration/openSkillFile', 'Open SKILL.md')}
+                    onActivate={() => this.openSkill(skill)}
+                />
+            </>,
             body: <>
                 <AiConfigurationValueRow label={nls.localizeByDefault('Location')} value={skill.location} onCopy={this.copyValue} />
                 {(skill.license || skill.compatibility || metadata.length > 0) && <div className='ai-variable-section'>
@@ -341,17 +361,28 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
         open(this.openerService, URI.fromFilePath(skill.location));
     }
 
+    /**
+     * The Agent Plugin a skill was contributed by, or `undefined` for a skill from a built-in root - the
+     * common case - and for a qualifier belonging to no installed plugin: a bare qualifier is worth neither
+     * a label nor a reveal action. Always `undefined` without `@theia/ai-registry`, which binds the bridge.
+     */
+    protected getOwningPlugin(skill: Skill): InstalledAgentPluginInfo | undefined {
+        const qualifier = Skill.qualifierOf(skill);
+        return qualifier ? this.agentPluginUiBridge?.getPluginByQualifier(qualifier) : undefined;
+    }
+
     getSearchItems(): AiConfigurationSearchItem[] {
         const items: AiConfigurationSearchItem[] = [];
         const skillLabel = nls.localizeByDefault('Skill');
         const slashCommandLabel = nls.localize('theia/ai/ide/skillsConfiguration/slashCommandsSectionHeader', 'Slash Commands');
         for (const skill of this.skills) {
             items.push({
-                label: skill.name,
+                label: skill.qualifiedName,
                 typeLabel: skillLabel,
                 categoryId: this.id,
-                target: { categoryId: this.id, highlight: { rowId: SKILL_ROW_PREFIX + skill.name } },
-                keywords: skill.description ?? ''
+                target: { categoryId: this.id, highlight: { rowId: SKILL_ROW_PREFIX + skill.qualifiedName } },
+                // The unqualified name too: a skill contributed by a plugin is still looked up by the name in its SKILL.md.
+                keywords: `${skill.name} ${skill.description ?? ''}`
             });
         }
         for (const command of this.slashCommands) {

--- a/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.tsx
@@ -49,6 +49,7 @@ import {
     CollapsibleRow,
     CollapsibleRowAction
 } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/collapsible-list';
+import { AiConfigurationOrigin } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/ai-configuration-origin-badge';
 import { AgentChips } from './agent-chips';
 
 const SKILL_ROW_PREFIX = 'skill:';
@@ -225,27 +226,18 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
         if (tools.length > 0) {
             pills.push(nls.localizeByDefault('{0} tools', tools.length));
         }
-        if (plugin) {
-            pills.push(nls.localize('theia/ai/ide/skillsConfiguration/skill/viaPlugin', 'via {0}', plugin.name));
-        }
         return {
             id: SKILL_ROW_PREFIX + skill.qualifiedName,
             title: skill.qualifiedName,
             description: skill.description,
             pills,
+            origins: plugin ? [AiConfigurationOrigin.agentPlugin(plugin, () => this.agentPluginUiBridge?.revealPlugin(plugin.pluginId))] : undefined,
             filterText: `${skill.qualifiedName} ${skill.description ?? ''} ${plugin?.name ?? ''}`.toLocaleLowerCase(),
-            actions: <>
-                {plugin && <CollapsibleRowAction
-                    iconClass={codicon('extensions')}
-                    label={nls.localize('theia/ai/ide/skillsConfiguration/skill/revealPlugin', 'Show the Agent Plugin \'{0}\' that provides this skill', plugin.name)}
-                    onActivate={() => this.agentPluginUiBridge?.revealPlugin(plugin.pluginId)}
-                />}
-                <CollapsibleRowAction
-                    iconClass={codicon('edit')}
-                    label={nls.localize('theia/ai/ide/skillsConfiguration/openSkillFile', 'Open SKILL.md')}
-                    onActivate={() => this.openSkill(skill)}
-                />
-            </>,
+            actions: <CollapsibleRowAction
+                iconClass={codicon('edit')}
+                label={nls.localize('theia/ai/ide/skillsConfiguration/openSkillFile', 'Open SKILL.md')}
+                onActivate={() => this.openSkill(skill)}
+            />,
             body: <>
                 <AiConfigurationValueRow label={nls.localizeByDefault('Location')} value={skill.location} onCopy={this.copyValue} />
                 {(skill.license || skill.compatibility || metadata.length > 0) && <div className='ai-variable-section'>

--- a/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/categories/prompts-and-skills-configuration-category.tsx
@@ -19,6 +19,7 @@ import { GENERIC_CAPABILITIES_SKILLS_PROMPT_ID, matchVariablesRegEx, parseCapabi
 import { PREFERENCE_NAME_SKILL_DIRECTORIES } from '@theia/ai-core/lib/common/ai-core-preferences';
 import { SkillService } from '@theia/ai-core/lib/browser/skill-service';
 import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
+import { SkillRegistryUiBridge } from '@theia/ai-core/lib/browser/skill-registry-ui-bridge';
 import { Skill } from '@theia/ai-core/lib/common/skill';
 import { isCustomizedPromptFragment, PromptFragment, PromptService } from '@theia/ai-core/lib/common/prompt-service';
 import { Emitter, Event, ILogger, nls, URI } from '@theia/core';
@@ -96,6 +97,9 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
     @inject(AgentPluginUiBridge) @optional()
     protected readonly agentPluginUiBridge?: AgentPluginUiBridge;
 
+    @inject(SkillRegistryUiBridge) @optional()
+    protected readonly skillRegistryUiBridge?: SkillRegistryUiBridge;
+
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
     protected readonly toDispose = new DisposableCollection(this.onDidChangeEmitter);
@@ -139,6 +143,10 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
         if (this.agentPluginUiBridge) {
             // The plugin names come from the bridge, so installing one changes this page even when the skills do not.
             this.toDispose.push(this.agentPluginUiBridge.onDidChange(() => this.onDidChangeEmitter.fire()));
+        }
+        if (this.skillRegistryUiBridge) {
+            // Likewise: linking or unlinking a skill folder changes its provenance, not the skill itself.
+            this.toDispose.push(this.skillRegistryUiBridge.onDidChange(() => this.onDidChangeEmitter.fire()));
         }
     }
 
@@ -222,6 +230,7 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
         const tools = skill.allowedTools ?? [];
         const metadata = skill.metadata ? Object.entries(skill.metadata) : [];
         const plugin = this.getOwningPlugin(skill);
+        const origins = this.getSkillOrigins(skill);
         const pills: string[] = [];
         if (tools.length > 0) {
             pills.push(nls.localizeByDefault('{0} tools', tools.length));
@@ -231,7 +240,7 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
             title: skill.qualifiedName,
             description: skill.description,
             pills,
-            origins: plugin ? [AiConfigurationOrigin.agentPlugin(plugin, () => this.agentPluginUiBridge?.revealPlugin(plugin.pluginId))] : undefined,
+            origins,
             filterText: `${skill.qualifiedName} ${skill.description ?? ''} ${plugin?.name ?? ''}`.toLocaleLowerCase(),
             actions: <CollapsibleRowAction
                 iconClass={codicon('edit')}
@@ -351,6 +360,24 @@ export class PromptsAndSkillsConfigurationCategory extends SinglePageCategoryRen
 
     protected openSkill(skill: Skill): void {
         open(this.openerService, URI.fromFilePath(skill.location));
+    }
+
+    /**
+     * The registry entry a skill was installed from, or the Agent Plugin that contributed it - never
+     * both: the registry installs a skill into a root of its own, a plugin ships it inside the plugin.
+     * Empty for a workspace or configured skill, which is the common case, and always empty without
+     * `@theia/ai-registry`, which binds both bridges.
+     */
+    protected getSkillOrigins(skill: Skill): AiConfigurationOrigin[] | undefined {
+        const plugin = this.getOwningPlugin(skill);
+        if (plugin) {
+            return [AiConfigurationOrigin.agentPlugin(plugin, () => this.agentPluginUiBridge?.revealPlugin(plugin.pluginId))];
+        }
+        const entryId = this.skillRegistryUiBridge?.getRegistryEntryId(skill);
+        if (entryId) {
+            return [AiConfigurationOrigin.registry(entryId, () => this.skillRegistryUiBridge?.revealSkill(entryId))];
+        }
+        return undefined;
     }
 
     /**

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.spec.ts
@@ -644,6 +644,55 @@ describe('McpFrontendApplicationContribution workspace-trust handlers', () => {
     });
 });
 
+describe('McpFrontendApplicationContribution convertToMap', () => {
+
+    // `convertToMap` is a pure projection of the preference value, so no injected collaborators are needed.
+    let contribution: TestMcpFrontendApplicationContribution;
+
+    beforeEach(() => {
+        contribution = new TestMcpFrontendApplicationContribution();
+    });
+
+    it('carries cwd, pluginRoot and pluginData through to the local server description', () => {
+        const result = contribution.testConvertToMap({
+            validator: {
+                command: './bin/validator',
+                args: ['--data', '/home/alex/.agents/plugins/data/devtools/validator'],
+                cwd: '/home/alex/.agents/plugins/devtools',
+                pluginRoot: '/home/alex/.agents/plugins/devtools',
+                pluginData: '/home/alex/.agents/plugins/data/devtools'
+            }
+        });
+
+        expect(result.get('validator')).to.deep.equal({
+            name: 'validator',
+            command: './bin/validator',
+            args: ['--data', '/home/alex/.agents/plugins/data/devtools/validator'],
+            cwd: '/home/alex/.agents/plugins/devtools',
+            pluginRoot: '/home/alex/.agents/plugins/devtools',
+            pluginData: '/home/alex/.agents/plugins/data/devtools',
+            autostart: true
+        });
+    });
+
+    it('omits cwd, pluginRoot and pluginData when the preference entry does not set them', () => {
+        const result = contribution.testConvertToMap({ plain: { command: 'npx' } });
+
+        expect(result.get('plain')).to.deep.equal({ name: 'plain', command: 'npx', autostart: true });
+    });
+
+    it('carries a registryMetadata block that identifies an Agent Plugin instead of a registry server', () => {
+        const result = contribution.testConvertToMap({
+            'plugin-server': {
+                command: 'npx',
+                registryMetadata: { pluginId: 'io.github.acme/devtools', version: '1.0.0' }
+            }
+        });
+
+        expect(result.get('plugin-server')?.registryMetadata).to.deep.equal({ pluginId: 'io.github.acme/devtools', version: '1.0.0' });
+    });
+});
+
 class TestMcpFrontendApplicationContribution extends McpFrontendApplicationContribution {
     refreshCalls = 0;
 
@@ -674,6 +723,10 @@ class TestMcpFrontendApplicationContribution extends McpFrontendApplicationContr
     testEnqueueServerChanges(newServers: MCPServersPreference): Promise<void> {
         this.enqueueServerChanges(newServers);
         return this.serverChangeQueue;
+    }
+
+    testConvertToMap(servers: MCPServersPreference): Map<string, MCPServerDescription> {
+        return this.convertToMap(servers);
     }
 
     protected override updateBlockedServersStatusBar(): void {

--- a/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
+++ b/packages/ai-mcp/src/browser/mcp-frontend-application-contribution.ts
@@ -358,12 +358,15 @@ export class McpFrontendApplicationContribution implements FrontendApplicationCo
                 };
             } else {
                 // Create LocalMCPServerDescription by picking only local-specific properties
-                const { command, args, env, autostart, deferLoading } = description;
+                const { command, args, env, cwd, pluginRoot, pluginData, autostart, deferLoading } = description;
                 filteredDescription = {
                     name,
                     command,
                     ...(args && { args }),
                     ...(env && { env }),
+                    ...(cwd && { cwd }),
+                    ...(pluginRoot && { pluginRoot }),
+                    ...(pluginData && { pluginData }),
                     autostart: autostart ?? true,
                     ...(registryMetadata && { registryMetadata }),
                     ...(deferLoading !== undefined && { deferLoading }),

--- a/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
@@ -370,6 +370,54 @@ describe('MCPServerEditor OAuth form handling', () => {
         });
     });
 
+    it('preserves the Agent Plugin fields of a local server, which the dialog never edits', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            'oauth-server': {
+                command: 'node',
+                cwd: '/plugins/io.example_bq',
+                pluginRoot: '/plugins/io.example_bq',
+                pluginData: '/plugin-data/io.example_bq',
+                registryMetadata: { pluginId: 'io.example/bq' }
+            }
+        });
+
+        await editor.save(remoteFormData({ serverType: 'local', command: 'node', args: 'server.js', autostart: true }));
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            'oauth-server': {
+                command: 'node',
+                args: ['server.js'],
+                cwd: '/plugins/io.example_bq',
+                pluginRoot: '/plugins/io.example_bq',
+                pluginData: '/plugin-data/io.example_bq',
+                autostart: true,
+                deferLoading: false,
+                registryMetadata: { pluginId: 'io.example/bq' }
+            }
+        });
+    });
+
+    it('drops the Agent Plugin fields when a local plugin server is switched to remote', async () => {
+        await prefs.set(MCP_SERVERS_PREF, {
+            'oauth-server': {
+                command: 'node',
+                cwd: '/plugins/io.example_bq',
+                pluginRoot: '/plugins/io.example_bq',
+                pluginData: '/plugin-data/io.example_bq'
+            }
+        });
+
+        await editor.save(remoteFormData({ serverType: 'remote', autostart: true }));
+
+        expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
+            'oauth-server': {
+                serverUrl: 'https://mcp.example.com/mcp',
+                autostart: true,
+                deferLoading: false
+            }
+        });
+    });
+
     it('pre-populates OAuth fields when converting a remote server to form data', () => {
         const server: RemoteMCPServerDescription = {
             name: 'oauth-server',

--- a/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.spec.ts
@@ -381,7 +381,7 @@ describe('MCPServerEditor OAuth form handling', () => {
             }
         });
 
-        await editor.save(remoteFormData({ serverType: 'local', command: 'node', args: 'server.js', autostart: true }));
+        await editor.save(remoteFormData({ serverType: 'local', command: 'node', args: ['server.js'], autostart: true }));
 
         expect(prefs.snapshot(MCP_SERVERS_PREF)).to.deep.equal({
             'oauth-server': {

--- a/packages/ai-mcp/src/browser/mcp-server-editor.ts
+++ b/packages/ai-mcp/src/browser/mcp-server-editor.ts
@@ -329,8 +329,10 @@ export class MCPServerEditorImpl implements MCPServerEditor {
 
 const STALE_KEYS_BY_SERVER_TYPE: Record<MCPServerFormData['serverType'], readonly string[]> = {
     'local': ['serverUrl', 'serverAuthToken', 'serverAuthTokenHeader', 'headers', 'oauth'],
-    'remote': ['command', 'args', 'env', 'oauth'],
-    'remote-oauth': ['command', 'args', 'env', 'serverAuthToken', 'serverAuthTokenHeader']
+    // The plugin fields go with `command`: they only mean anything for a local server, and leaving
+    // them on an entry the user just turned into a remote one would keep a dead plugin root on it.
+    'remote': ['command', 'args', 'env', 'cwd', 'pluginRoot', 'pluginData', 'oauth'],
+    'remote-oauth': ['command', 'args', 'env', 'cwd', 'pluginRoot', 'pluginData', 'serverAuthToken', 'serverAuthTokenHeader']
 };
 
 function parseKeyValuePairs(input: string): Record<string, string> | undefined {

--- a/packages/ai-mcp/src/browser/mcp-servers-configuration-category.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-servers-configuration-category.spec.ts
@@ -21,9 +21,14 @@ import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/front
 FrontendApplicationConfigProvider.set({});
 
 import { expect } from 'chai';
+import { Event } from '@theia/core';
+import { createRoot } from '@theia/core/shared/react-dom/client';
+import { flushSync } from '@theia/core/shared/react-dom';
+import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
 import { MCPServerDescription, MCPServerStatus } from '../common/mcp-server-manager';
-import { AiConfigurationCategoryId } from '@theia/ai-core-ui/lib/browser/ai-configuration/ai-configuration-category';
+import { AiConfigurationCategoryId, AiConfigurationRenderContext } from '@theia/ai-core-ui/lib/browser/ai-configuration/ai-configuration-category';
 import { McpServersConfigurationCategory } from './mcp-servers-configuration-category';
+import { MCPRegistryUiBridge } from './mcp-registry-ui-bridge';
 
 disableJSDOM();
 
@@ -36,6 +41,21 @@ function createCategory(servers: MCPServerDescription[]): McpServersConfiguratio
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (category as any).servers = servers;
     return category;
+}
+
+/** Renders a server's detail page into a detached host, so the read-only rows and provenance links can be inspected. */
+function withServerDetail(category: McpServersConfigurationCategory, serverName: string, assertions: (host: HTMLElement) => void): void {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const ctx: AiConfigurationRenderContext = { scope: 'user', navigate: () => { }, update: () => { } };
+    try {
+        flushSync(() => root.render(category.renderItemDetail(serverName, ctx)));
+        assertions(container);
+    } finally {
+        flushSync(() => root.unmount());
+        container.remove();
+    }
 }
 
 describe('McpServersConfigurationCategory', () => {
@@ -108,5 +128,128 @@ describe('McpServersConfigurationCategory', () => {
         (category as any).updateServer(server('git'), { command: 'npx server' });
         expect(saved).to.have.lengthOf(1);
         expect(saved[0]).to.include({ name: 'git', command: 'npx server', serverType: 'local' });
+    });
+
+    describe('Agent Plugin paths', () => {
+
+        const pluginRoot = '/home/user/.agents/plugins/io.github.acme_devtools';
+        const pluginData = '/home/user/.agents/plugin-data/io.github.acme_devtools';
+        const pluginServer = {
+            name: 'validator',
+            command: './bin/validator',
+            status: MCPServerStatus.NotRunning,
+            cwd: pluginRoot,
+            pluginRoot,
+            pluginData
+        } as unknown as MCPServerDescription;
+
+        it('shows the working directory and the plugin roots, which the user cannot author', () => {
+            withServerDetail(createCategory([pluginServer]), 'validator', host => {
+                const readOnly = Array.from(host.querySelectorAll('.mcp-property-readonly')).map(node => node.textContent);
+                expect(readOnly).to.have.lengthOf(3);
+                expect(readOnly[0]).to.contain(pluginRoot);
+                expect(readOnly[1]).to.contain('PLUGIN_ROOT');
+                expect(readOnly[2]).to.contain(pluginData);
+                expect(readOnly[2]).to.contain('PLUGIN_DATA');
+            });
+        });
+
+        it('shows no plugin path rows for a server the user configured by hand', () => {
+            withServerDetail(createCategory([server('own', MCPServerStatus.NotRunning)]), 'own', host => {
+                expect(host.querySelectorAll('.mcp-property-readonly')).to.have.lengthOf(0);
+            });
+        });
+    });
+
+    describe('Agent Plugin provenance', () => {
+
+        const devtools: InstalledAgentPluginInfo = { pluginId: 'io.github.acme/devtools', name: 'Acme Devtools' };
+        const pluginServer = {
+            name: 'validator',
+            command: './bin/validator',
+            status: MCPServerStatus.NotRunning,
+            registryMetadata: { pluginId: devtools.pluginId }
+        } as unknown as MCPServerDescription;
+
+        /** Leaves the bridge unbound when `installedPlugins` is omitted, i.e. a product without `@theia/ai-registry`. */
+        function categoryWithPlugins(
+            servers: MCPServerDescription[],
+            installedPlugins: InstalledAgentPluginInfo[] | undefined,
+            hooks: { revealed?: string[], openedRegistryEntries?: (string | undefined)[] } = {}
+        ): McpServersConfigurationCategory {
+            const category = createCategory(servers);
+            if (installedPlugins) {
+                const bridge: AgentPluginUiBridge = {
+                    getPlugin: pluginId => installedPlugins.find(plugin => plugin.pluginId === pluginId),
+                    // Only the skills page looks a plugin up by qualifier; a server carries the identifier.
+                    getPluginByQualifier: () => undefined,
+                    revealPlugin: pluginId => { hooks.revealed?.push(pluginId); },
+                    onDidChange: Event.None
+                };
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (category as any).agentPluginBridge = bridge;
+            }
+            if (hooks.openedRegistryEntries) {
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                (category as any).registryBridge = {
+                    openRegistry: async (serverId?: string) => { hooks.openedRegistryEntries?.push(serverId); }
+                } as Partial<MCPRegistryUiBridge>;
+            }
+            return category;
+        }
+
+        function pluginLink(host: HTMLElement): HTMLButtonElement | null {
+            return host.querySelector('button[title^="Open the Agent Plugin"]') as HTMLButtonElement | null;
+        }
+
+        it('tags a plugin-provided server in the list, so it is told apart without being opened', () => {
+            const children = categoryWithPlugins([pluginServer], [devtools]).getTreeChildren();
+            expect(children[0].tags).to.deep.equal(['via Acme Devtools']);
+        });
+
+        it('tags a server that carries both a registry entry and a plugin with both origins', () => {
+            const both = { ...pluginServer, registryMetadata: { serverId: 'io.github.acme/validator', pluginId: devtools.pluginId } } as MCPServerDescription;
+            const children = categoryWithPlugins([both], [devtools]).getTreeChildren();
+            expect(children[0].tags).to.deep.equal(['From registry', 'via Acme Devtools']);
+        });
+
+        it('tags nothing rather than a bare identifier when the owning plugin is not installed', () => {
+            expect(categoryWithPlugins([pluginServer], []).getTreeChildren()[0].tags).to.equal(undefined);
+        });
+
+        it('tags nothing when no bridge is bound, i.e. without `@theia/ai-registry`', () => {
+            expect(categoryWithPlugins([pluginServer], undefined).getTreeChildren()[0].tags).to.equal(undefined);
+        });
+
+        it('labels the detail header with the name of the plugin that supplied the server', () => {
+            withServerDetail(categoryWithPlugins([pluginServer], [devtools]), 'validator', host => {
+                expect(pluginLink(host)?.textContent).to.contain('via Acme Devtools');
+            });
+        });
+
+        it('reveals the owning plugin rather than a registry server when the provenance link is clicked', () => {
+            const revealed: string[] = [];
+            const openedRegistryEntries: (string | undefined)[] = [];
+            const category = categoryWithPlugins([pluginServer], [devtools], { revealed, openedRegistryEntries });
+            withServerDetail(category, 'validator', host => {
+                flushSync(() => pluginLink(host)!.click());
+            });
+            expect(revealed).to.deep.equal([devtools.pluginId]);
+            expect(openedRegistryEntries).to.be.empty;
+        });
+
+        it('shows the plugin link alongside the registry link when the server carries both', () => {
+            const both = { ...pluginServer, registryMetadata: { serverId: 'io.github.acme/validator', pluginId: devtools.pluginId } } as MCPServerDescription;
+            withServerDetail(categoryWithPlugins([both], [devtools], { openedRegistryEntries: [] }), 'validator', host => {
+                expect(host.textContent).to.contain('From registry');
+                expect(host.textContent).to.contain('via Acme Devtools');
+            });
+        });
+
+        it('shows no provenance link for a server that was not contributed by a plugin', () => {
+            withServerDetail(categoryWithPlugins([server('plain-local', MCPServerStatus.NotRunning)], [devtools]), 'plain-local', host => {
+                expect(pluginLink(host)).to.be.null;
+            });
+        });
     });
 });

--- a/packages/ai-mcp/src/browser/mcp-servers-configuration-category.spec.ts
+++ b/packages/ai-mcp/src/browser/mcp-servers-configuration-category.spec.ts
@@ -198,57 +198,64 @@ describe('McpServersConfigurationCategory', () => {
             return category;
         }
 
-        function pluginLink(host: HTMLElement): HTMLButtonElement | null {
-            return host.querySelector('button[title^="Open the Agent Plugin"]') as HTMLButtonElement | null;
+        const bothOrigins = { ...pluginServer, registryMetadata: { serverId: 'io.github.acme/validator', pluginId: devtools.pluginId } } as MCPServerDescription;
+
+        function pluginBadge(host: HTMLElement): HTMLButtonElement | null {
+            return host.querySelector('.ai-configuration-origin-badge[title^="Open the Agent Plugin"]') as HTMLButtonElement | null;
         }
 
-        it('tags a plugin-provided server in the list, so it is told apart without being opened', () => {
-            const children = categoryWithPlugins([pluginServer], [devtools]).getTreeChildren();
-            expect(children[0].tags).to.deep.equal(['via Acme Devtools']);
+        function originLabels(category: McpServersConfigurationCategory): string[] | undefined {
+            return category.getTreeChildren()[0].origins?.map(origin => origin.label);
+        }
+
+        it('labels a plugin-provided server in the list, so it is told apart without being opened', () => {
+            expect(originLabels(categoryWithPlugins([pluginServer], [devtools]))).to.deep.equal(['via Acme Devtools']);
         });
 
-        it('tags a server that carries both a registry entry and a plugin with both origins', () => {
-            const both = { ...pluginServer, registryMetadata: { serverId: 'io.github.acme/validator', pluginId: devtools.pluginId } } as MCPServerDescription;
-            const children = categoryWithPlugins([both], [devtools]).getTreeChildren();
-            expect(children[0].tags).to.deep.equal(['From registry', 'via Acme Devtools']);
+        it('labels a server that carries both a registry entry and a plugin with both origins, which lead to different places', () => {
+            expect(originLabels(categoryWithPlugins([bothOrigins], [devtools], { openedRegistryEntries: [] })))
+                .to.deep.equal(['From registry', 'via Acme Devtools']);
         });
 
-        it('tags nothing rather than a bare identifier when the owning plugin is not installed', () => {
-            expect(categoryWithPlugins([pluginServer], []).getTreeChildren()[0].tags).to.equal(undefined);
+        it('labels nothing rather than a bare identifier when the owning plugin is not installed', () => {
+            expect(originLabels(categoryWithPlugins([pluginServer], []))).to.equal(undefined);
         });
 
-        it('tags nothing when no bridge is bound, i.e. without `@theia/ai-registry`', () => {
-            expect(categoryWithPlugins([pluginServer], undefined).getTreeChildren()[0].tags).to.equal(undefined);
+        it('labels nothing when no bridge is bound, i.e. without `@theia/ai-registry`', () => {
+            expect(originLabels(categoryWithPlugins([pluginServer], undefined))).to.equal(undefined);
         });
 
-        it('labels the detail header with the name of the plugin that supplied the server', () => {
-            withServerDetail(categoryWithPlugins([pluginServer], [devtools]), 'validator', host => {
-                expect(pluginLink(host)?.textContent).to.contain('via Acme Devtools');
+        it('still states a registry origin without a registry UI to open, but not as a link', () => {
+            // Unlike a plugin, whose display name only the bridge knows, a registry entry names itself in
+            // the server's own preference entry - so the fact survives even when nothing can act on it.
+            const linked = { ...pluginServer, registryMetadata: { serverId: 'io.github.acme/validator' } } as MCPServerDescription;
+            const origins = categoryWithPlugins([linked], undefined).getTreeChildren()[0].origins;
+            expect(origins?.map(origin => origin.label)).to.deep.equal(['From registry']);
+            expect(origins![0].activate).to.equal(undefined);
+        });
+
+        it('shows the same origin badges on the detail header as in the list, rather than a second design', () => {
+            const category = categoryWithPlugins([bothOrigins], [devtools], { openedRegistryEntries: [] });
+            withServerDetail(category, 'validator', host => {
+                const badges = Array.from(host.querySelectorAll('.ai-configuration-origin-badge')).map(badge => badge.textContent);
+                expect(badges).to.deep.equal(originLabels(category));
             });
         });
 
-        it('reveals the owning plugin rather than a registry server when the provenance link is clicked', () => {
+        it('reveals the owning plugin rather than a registry server when the plugin badge is clicked', () => {
             const revealed: string[] = [];
             const openedRegistryEntries: (string | undefined)[] = [];
-            const category = categoryWithPlugins([pluginServer], [devtools], { revealed, openedRegistryEntries });
+            const category = categoryWithPlugins([bothOrigins], [devtools], { revealed, openedRegistryEntries });
             withServerDetail(category, 'validator', host => {
-                flushSync(() => pluginLink(host)!.click());
+                flushSync(() => pluginBadge(host)!.click());
             });
             expect(revealed).to.deep.equal([devtools.pluginId]);
             expect(openedRegistryEntries).to.be.empty;
         });
 
-        it('shows the plugin link alongside the registry link when the server carries both', () => {
-            const both = { ...pluginServer, registryMetadata: { serverId: 'io.github.acme/validator', pluginId: devtools.pluginId } } as MCPServerDescription;
-            withServerDetail(categoryWithPlugins([both], [devtools], { openedRegistryEntries: [] }), 'validator', host => {
-                expect(host.textContent).to.contain('From registry');
-                expect(host.textContent).to.contain('via Acme Devtools');
-            });
-        });
-
-        it('shows no provenance link for a server that was not contributed by a plugin', () => {
+        it('shows no origin badge for a server that was not contributed by a plugin', () => {
             withServerDetail(categoryWithPlugins([server('plain-local', MCPServerStatus.NotRunning)], [devtools]), 'plain-local', host => {
-                expect(pluginLink(host)).to.be.null;
+                expect(host.querySelector('.ai-configuration-origin-badge')).to.be.null;
             });
         });
     });

--- a/packages/ai-mcp/src/browser/mcp-servers-configuration-category.tsx
+++ b/packages/ai-mcp/src/browser/mcp-servers-configuration-category.tsx
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { AiConfigurationService } from '@theia/ai-core';
+import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
 import { PROMPT_VARIABLE } from '@theia/ai-core/lib/browser/prompt-variable-contribution';
 import { Emitter, Event, ILogger, MessageService, nls, PreferenceScope } from '@theia/core';
 import { codicon, ConfirmDialog } from '@theia/core/lib/browser';
@@ -91,6 +92,9 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
     @inject(MCPRegistryUiBridge) @optional()
     protected readonly registryBridge?: MCPRegistryUiBridge;
 
+    @inject(AgentPluginUiBridge) @optional()
+    protected readonly agentPluginBridge?: AgentPluginUiBridge;
+
     protected readonly onDidChangeEmitter = new Emitter<void>();
     readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
     protected readonly toDispose = new DisposableCollection(this.onDidChangeEmitter);
@@ -113,6 +117,10 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
     @postConstruct()
     protected init(): void {
         this.toDispose.push(this.mcpFrontendNotificationService.onDidUpdateMCPServers(() => this.loadServers()));
+        if (this.agentPluginBridge) {
+            // An install changes which plugin names resolve, so the provenance labels must re-render.
+            this.toDispose.push(this.agentPluginBridge.onDidChange(() => this.onDidChangeEmitter.fire()));
+        }
         this.loadServers();
     }
 
@@ -150,9 +158,27 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
         } satisfies AiConfigurationTreeItem));
     }
 
-    /** "From registry" for a server linked to a registry entry, mirroring the detail header's link. */
+    /** "From registry" and/or `via <plugin>` for a server that came from elsewhere, mirroring the detail header's links. */
     protected getServerTags(server: MCPServerDescription): string[] | undefined {
-        return server.registryMetadata?.serverId ? [nls.localize('theia/ai/mcpConfiguration/fromRegistry', 'From registry')] : undefined;
+        const tags: string[] = [];
+        if (server.registryMetadata?.serverId) {
+            tags.push(nls.localize('theia/ai/mcpConfiguration/fromRegistry', 'From registry'));
+        }
+        const plugin = this.getOwningPlugin(server);
+        if (plugin) {
+            tags.push(nls.localize('theia/ai/mcpConfiguration/viaAgentPlugin', 'via {0}', plugin.name));
+        }
+        return tags.length > 0 ? tags : undefined;
+    }
+
+    /**
+     * The Agent Plugin that contributed a server, or `undefined` when the server is the user's own, when the
+     * owning plugin is not installed - a bare identifier is not worth an affordance - or when no bridge is
+     * bound, i.e. in a product without `@theia/ai-registry`.
+     */
+    protected getOwningPlugin(server: MCPServerDescription): InstalledAgentPluginInfo | undefined {
+        const pluginId = server.registryMetadata?.pluginId;
+        return pluginId ? this.agentPluginBridge?.getPlugin(pluginId) : undefined;
     }
 
     /** Overview subtitle: the server type (Local/Remote) and, once known, its tool count — not the raw command/URL. */
@@ -235,7 +261,10 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
             title={server.name}
             iconClass={this.iconClass}
             subtitle={this.getServerSummary(server)}
-            titleSuffix={this.renderRegistryAffordance(server)}
+            titleSuffix={<>
+                {this.renderRegistryAffordance(server)}
+                {this.renderAgentPluginAffordance(server)}
+            </>}
             status={this.getServerStatus(server)}
             actions={this.renderServerActions(server)}
         />;
@@ -308,6 +337,26 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
     }
 
     /**
+     * In addition to the registry affordance, not replacing it: this reveals the owning plugin, and a
+     * plugin-contributed server has no `serverId` of its own to open in the registry.
+     */
+    protected renderAgentPluginAffordance(server: MCPServerDescription): React.ReactNode {
+        const plugin = this.getOwningPlugin(server);
+        if (!plugin) {
+            return undefined;
+        }
+        return <button
+            type='button'
+            className='mcp-server-registry-link'
+            onClick={() => this.agentPluginBridge?.revealPlugin(plugin.pluginId)}
+            title={nls.localize('theia/ai/mcpConfiguration/openAgentPlugin', 'Open the Agent Plugin that provides this server: {0}', plugin.name)}
+        >
+            <i className={`${codicon('extensions')} mcp-server-registry-link-icon`} />
+            {nls.localize('theia/ai/mcpConfiguration/viaAgentPlugin', 'via {0}', plugin.name)}
+        </button>;
+    }
+
+    /**
      * The per-server configuration, edited in place. Each field patches the server's form representation and
      * re-persists it via {@link MCPServerEditor.save} — the same write path (and stale-key cleanup) the Add
      * dialog uses — so there is no separate Edit dialog. The server type is shown read-only: changing it means
@@ -328,6 +377,7 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
                 values => this.updateServer(server, { args: values }))}
             {local && this.renderKeyValueField(nls.localize('theia/ai/mcpConfiguration/environmentVariables', 'Environment Variables'), server.env ?? {},
                 lines => this.updateServer(server, { env: lines }))}
+            {local && this.renderPluginPathsSection(server)}
             {remote && this.renderTextField(nls.localize('theia/ai/mcpConfiguration/serverUrl', 'Server URL'), server.serverUrl, false, false,
                 value => this.updateServer(server, { serverUrl: value }),
                 server.serverUrl.trim() ? undefined : nls.localize('theia/ai/mcpConfiguration/form/serverUrlRequired', 'Server URL is required for remote servers'))}
@@ -386,6 +436,33 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
             return server.oauth ? nls.localize('theia/ai/mcpConfiguration/typeRemoteOAuth', 'Remote (OAuth)') : nls.localizeByDefault('Remote');
         }
         return nls.localizeByDefault('Unknown');
+    }
+
+    /**
+     * Read-only on purpose: all three are derived from where `@theia/ai-registry` installed the Agent
+     * Plugin, so there is nothing for the user to author. Shown rather than hidden because they decide
+     * where the process runs and what `PLUGIN_ROOT` and `PLUGIN_DATA` point at.
+     */
+    protected renderPluginPathsSection(server: MCPServerDescription): React.ReactNode {
+        if (!isLocalMCPServerDescription(server)) {
+            return undefined;
+        }
+        return <>
+            {this.renderReadOnlyPath(nls.localizeByDefault('Working Directory'), server.cwd)}
+            {this.renderReadOnlyPath(nls.localize('theia/ai/mcpConfiguration/pluginRoot', 'Plugin Root'), server.pluginRoot, 'PLUGIN_ROOT')}
+            {this.renderReadOnlyPath(nls.localize('theia/ai/mcpConfiguration/pluginData', 'Plugin Data'), server.pluginData, 'PLUGIN_DATA')}
+        </>;
+    }
+
+    /** @param variable the environment variable the value is exported as, when it is one. */
+    protected renderReadOnlyPath(label: string, value: string | undefined, variable?: string): React.ReactNode {
+        if (!value) {
+            return undefined;
+        }
+        return this.renderFieldRow(label, <code className='mcp-property-readonly' title={value}>
+            {value}
+            {variable && <span className='mcp-property-variable'>{variable}</span>}
+        </code>);
     }
 
     protected renderFieldRow(label: string, control: React.ReactNode): React.ReactNode {

--- a/packages/ai-mcp/src/browser/mcp-servers-configuration-category.tsx
+++ b/packages/ai-mcp/src/browser/mcp-servers-configuration-category.tsx
@@ -35,6 +35,7 @@ import {
 } from '@theia/ai-core-ui/lib/browser/ai-configuration/ai-configuration-category';
 import { CollectionCategoryRenderer, AiConfigurationAddDescriptor } from '@theia/ai-core-ui/lib/browser/ai-configuration/renderers/collection-category-renderer';
 import { AiConfigurationItemDetailHeader, AiConfigurationSection } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/ai-configuration-primitives';
+import { AiConfigurationOrigin } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/ai-configuration-origin-badge';
 import { AiConfigurationItemRow } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/ai-configuration-item-row';
 import { AiSettingsRow } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/ai-settings-row';
 import { AiSettingsRowService } from '@theia/ai-core-ui/lib/browser/ai-configuration/components/ai-settings-row-service';
@@ -153,22 +154,30 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
             description: this.getServerSummary(server),
             // Provenance belongs in the list too, not just on the detail page: it is how you tell a server you
             // configured by hand from one installed from the registry without opening each of them.
-            tags: this.getServerTags(server),
+            origins: this.getServerOrigins(server),
             status: this.getServerStatus(server)
         } satisfies AiConfigurationTreeItem));
     }
 
-    /** "From registry" and/or `via <plugin>` for a server that came from elsewhere, mirroring the detail header's links. */
-    protected getServerTags(server: MCPServerDescription): string[] | undefined {
-        const tags: string[] = [];
-        if (server.registryMetadata?.serverId) {
-            tags.push(nls.localize('theia/ai/mcpConfiguration/fromRegistry', 'From registry'));
+    /**
+     * The registry entry and/or the Agent Plugin a server came from. Both, when it carries both: a
+     * plugin-contributed server can also be linked to a registry approval of its own, and the two lead to
+     * different places. Empty for a server the user configured by hand, which is the common case.
+     */
+    protected getServerOrigins(server: MCPServerDescription): AiConfigurationOrigin[] | undefined {
+        const origins: AiConfigurationOrigin[] = [];
+        const registryId = server.registryMetadata?.serverId;
+        const bridge = this.registryBridge;
+        if (registryId) {
+            // Stated even without `@theia/ai-registry`, which is what would open it: the server did come
+            // from the registry, and the preference it was written into says so whether or not we can link.
+            origins.push(AiConfigurationOrigin.registry(registryId, bridge && (() => bridge.openRegistry(registryId))));
         }
         const plugin = this.getOwningPlugin(server);
         if (plugin) {
-            tags.push(nls.localize('theia/ai/mcpConfiguration/viaAgentPlugin', 'via {0}', plugin.name));
+            origins.push(AiConfigurationOrigin.agentPlugin(plugin, () => this.agentPluginBridge?.revealPlugin(plugin.pluginId)));
         }
-        return tags.length > 0 ? tags : undefined;
+        return origins.length > 0 ? origins : undefined;
     }
 
     /**
@@ -255,16 +264,13 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
         if (!server) {
             return undefined;
         }
-        // Use the shared detail header (icon + title), matching the other detail pages. The "From registry"
-        // link sits next to the title; the status badge is grouped with the lifecycle/delete controls on the right.
+        // Use the shared detail header (icon + title), matching the other detail pages. The origin badges sit
+        // next to the title; the status badge is grouped with the lifecycle/delete controls on the right.
         return <AiConfigurationItemDetailHeader
             title={server.name}
             iconClass={this.iconClass}
             subtitle={this.getServerSummary(server)}
-            titleSuffix={<>
-                {this.renderRegistryAffordance(server)}
-                {this.renderAgentPluginAffordance(server)}
-            </>}
+            origins={this.getServerOrigins(server)}
             status={this.getServerStatus(server)}
             actions={this.renderServerActions(server)}
         />;
@@ -317,43 +323,6 @@ export class McpServersConfigurationCategory extends CollectionCategoryRenderer 
                 title={nls.localize('theia/ai/mcpConfiguration/deleteServer', 'Delete Server')}
             />
         </>;
-    }
-
-    protected renderRegistryAffordance(server: MCPServerDescription): React.ReactNode {
-        const registryId = server.registryMetadata?.serverId;
-        const bridge = this.registryBridge;
-        if (!registryId || !bridge) {
-            return undefined;
-        }
-        return <button
-            type='button'
-            className='mcp-server-registry-link'
-            onClick={() => bridge.openRegistry(registryId)}
-            title={nls.localize('theia/ai/mcpConfiguration/openInRegistry', 'Open in AI registry: {0}', registryId)}
-        >
-            <i className={`${codicon('link-external')} mcp-server-registry-link-icon`} />
-            {nls.localize('theia/ai/mcpConfiguration/fromRegistry', 'From registry')}
-        </button>;
-    }
-
-    /**
-     * In addition to the registry affordance, not replacing it: this reveals the owning plugin, and a
-     * plugin-contributed server has no `serverId` of its own to open in the registry.
-     */
-    protected renderAgentPluginAffordance(server: MCPServerDescription): React.ReactNode {
-        const plugin = this.getOwningPlugin(server);
-        if (!plugin) {
-            return undefined;
-        }
-        return <button
-            type='button'
-            className='mcp-server-registry-link'
-            onClick={() => this.agentPluginBridge?.revealPlugin(plugin.pluginId)}
-            title={nls.localize('theia/ai/mcpConfiguration/openAgentPlugin', 'Open the Agent Plugin that provides this server: {0}', plugin.name)}
-        >
-            <i className={`${codicon('extensions')} mcp-server-registry-link-icon`} />
-            {nls.localize('theia/ai/mcpConfiguration/viaAgentPlugin', 'via {0}', plugin.name)}
-        </button>;
     }
 
     /**

--- a/packages/ai-mcp/src/browser/style/mcp-configuration-widget.css
+++ b/packages/ai-mcp/src/browser/style/mcp-configuration-widget.css
@@ -175,3 +175,19 @@
   outline: 1px dotted var(--theia-contrastActiveBorder, transparent);
   outline-offset: -1px;
 }
+
+/* Agent Plugin paths: displayed, never editable - `@theia/ai-registry` derives them from where the
+   plugin was installed, so the server form shows them without an input. */
+.mcp-property-readonly {
+  color: var(--theia-descriptionForeground);
+  word-break: break-all;
+}
+
+.mcp-property-variable {
+  margin-left: calc(var(--theia-ui-padding) / 2);
+  padding: 0 4px;
+  border: 1px solid var(--theia-panel-border);
+  border-radius: 3px;
+  font-size: calc(var(--theia-ui-font-size0) * 0.9);
+  color: var(--theia-descriptionForeground);
+}

--- a/packages/ai-mcp/src/browser/style/mcp-configuration-widget.css
+++ b/packages/ai-mcp/src/browser/style/mcp-configuration-widget.css
@@ -28,33 +28,6 @@
   color: var(--theia-descriptionForeground);
 }
 
-.mcp-server-registry-link {
-  display: inline-flex;
-  align-items: center;
-  gap: calc(var(--theia-ui-padding) / 2);
-  background: none;
-  border: none;
-  padding: 0 calc(var(--theia-ui-padding) / 2);
-  font-size: var(--theia-ui-font-size0);
-  font-weight: 400;
-  color: var(--theia-textLink-foreground);
-  cursor: pointer;
-}
-
-.mcp-server-registry-link:hover:not(:disabled) {
-  color: var(--theia-textLink-activeForeground);
-  text-decoration: underline;
-}
-
-.mcp-server-registry-link:disabled {
-  cursor: default;
-  opacity: 0.6;
-}
-
-.mcp-server-registry-link-icon {
-  font-size: var(--theia-ui-font-size1);
-}
-
 /* Inline-editable server configuration form: give the label column more room than the read-only view and
    let the control column fill the width, and align each label with the top of its (possibly multi-line) control. */
 .mcp-config-form .mcp-property-row {

--- a/packages/ai-mcp/src/common/mcp-preferences.ts
+++ b/packages/ai-mcp/src/common/mcp-preferences.ts
@@ -88,6 +88,12 @@ Example configuration:\n\
                             type: 'string'
                         }
                     },
+                    // `cwd`, `pluginRoot` and `pluginData` are deliberately absent: they are written by
+                    // `@theia/ai-registry` for a server contributed by an Agent Plugin and derived from
+                    // where that plugin was installed, so there is nothing for a user to author here.
+                    // Undeclared rather than documented as read-only, because a declared property is an
+                    // invitation to edit and the preference schema has no read-only affordance. Extra
+                    // properties stay legal, so the values still round-trip through the editor.
                     autostart: {
                         type: 'boolean',
                         title: nls.localize('theia/ai/mcp/servers/autostart/title', 'Autostart'),
@@ -191,7 +197,14 @@ Example configuration:\n\
                                 type: 'string',
                                 title: nls.localize('theia/ai/mcp/servers/registryMetadata/serverId/title', 'Registry Server Id'),
                                 markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/serverId/mdDescription',
-                                    'Identifies the AI registry entry this server was installed from.'),
+                                    'Identifies the AI registry entry this server was installed from. Absent for a server contributed by an Agent Plugin, ' +
+                                    'which carries `pluginId` instead.'),
+                            },
+                            pluginId: {
+                                type: 'string',
+                                title: nls.localize('theia/ai/mcp/servers/registryMetadata/pluginId/title', 'Agent Plugin Id'),
+                                markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/pluginId/mdDescription',
+                                    'Identifies the installed Agent Plugin that contributed this server. Written by `@theia/ai-registry`; not user-editable.'),
                             },
                             version: {
                                 type: 'string',
@@ -203,10 +216,22 @@ Example configuration:\n\
                                 type: 'string',
                                 title: nls.localize('theia/ai/mcp/servers/registryMetadata/configHash/title', 'Registry Config Hash'),
                                 markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/configHash/mdDescription',
-                                    'Content hash of the registry approval used to install this server.'),
+                                    'Content hash of the registry approval used to install this server, or of the Agent Plugin that contributed it.'),
+                            },
+                            installedAt: {
+                                type: 'string',
+                                title: nls.localize('theia/ai/mcp/servers/registryMetadata/installedAt/title', 'Agent Plugin Installed At'),
+                                markdownDescription: nls.localize('theia/ai/mcp/servers/registryMetadata/installedAt/mdDescription',
+                                    'When the Agent Plugin that contributed this server was last written to disk. Changing it restarts the server, '
+                                    + 'which is what makes an update take effect. Written by `@theia/ai-registry`; not user-editable.'),
                             }
                         },
-                        required: ['serverId']
+                        // The validator drops a block identifying nothing; requiring one here keeps
+                        // the settings editor from silently accepting what it will throw away.
+                        anyOf: [
+                            { required: ['serverId'] },
+                            { required: ['pluginId'] }
+                        ]
                     }
                 },
                 required: []

--- a/packages/ai-mcp/src/common/mcp-server-manager.ts
+++ b/packages/ai-mcp/src/common/mcp-server-manager.ts
@@ -174,8 +174,8 @@ export interface BaseMCPServerDescription {
  * separated from the server configuration the user edits.
  */
 export interface MCPRegistryMetadata {
-    /** Identifies the AI registry entry this server was installed from. */
-    serverId: string;
+    /** Absent for a plugin-contributed server, which carries {@link pluginId} instead. */
+    serverId?: string;
 
     /**
      * Registry-published version recorded at install / link / fix / update time.
@@ -189,8 +189,20 @@ export interface MCPRegistryMetadata {
      * Content hash of the registry approval that produced this entry. Used to detect
      * when the registry has published a new approval for this server. Do not use
      * {@link version} for update checks - it is display-only.
+     *
+     * For an entry written by an Agent Plugin this is the plugin's content hash.
      */
     configHash?: string;
+
+    /** Set when this entry was written by an installed Agent Plugin. */
+    pluginId?: string;
+
+    /**
+     * When the supplying Agent Plugin was last written. Not informational:
+     * `connectionDescription` includes it, so replacing a plugin's root restarts the servers running
+     * out of it even when their own configuration is byte-identical.
+     */
+    installedAt?: string;
 }
 
 /**
@@ -203,6 +215,16 @@ export interface MCPInstallEntryConfig {
     command?: string;
     args?: string[];
     env?: Record<string, string>;
+    /** Working directory for the process. Defaults to `pluginRoot` when that is set. */
+    cwd?: string;
+    /**
+     * Exported as PLUGIN_ROOT. Its own field rather than an `env` entry because the MCP edit dialog
+     * renders `env` as a user-editable KEY=VALUE box, and because the reserved variables have to be
+     * set *after* the plugin's `env` - not expressible once they share one map.
+     */
+    pluginRoot?: string;
+    /** Exported as PLUGIN_DATA. See {@link pluginRoot}. */
+    pluginData?: string;
     serverUrl?: string;
     serverAuthToken?: string;
     serverAuthTokenHeader?: string;
@@ -228,6 +250,12 @@ export interface LocalMCPServerDescription extends BaseMCPServerDescription {
      * Environment variables for the MCP server process.
      */
     env?: { [key: string]: string };
+    /** Defaults to {@link pluginRoot} when that is set. */
+    cwd?: string;
+    /** See {@link MCPInstallEntryConfig.pluginRoot} for why this is not folded into {@link env}. */
+    pluginRoot?: string;
+    /** Exported as PLUGIN_DATA. */
+    pluginData?: string;
 }
 
 export interface RemoteMCPServerDescription extends BaseMCPServerDescription {

--- a/packages/ai-mcp/src/common/mcp-server-preference-validator.spec.ts
+++ b/packages/ai-mcp/src/common/mcp-server-preference-validator.spec.ts
@@ -161,6 +161,22 @@ describe('MCPServersPreference validator', () => {
             // eslint-disable-next-line no-null/no-null
             expect(reasonFor({ command: 'node', oauth: null })).to.be.undefined;
         });
+
+        it('flags a non-string cwd', () => {
+            expect(reasonFor({ command: 'node', cwd: 42 })).to.contain('"cwd" must be a string');
+        });
+
+        it('flags a non-string pluginRoot', () => {
+            expect(reasonFor({ command: 'node', pluginRoot: 42 })).to.contain('"pluginRoot" must be a string');
+        });
+
+        it('flags a non-string pluginData', () => {
+            expect(reasonFor({ command: 'node', pluginData: 42 })).to.contain('"pluginData" must be a string');
+        });
+
+        it('flags a registryMetadata block that identifies neither a registry server nor an Agent Plugin', () => {
+            expect(reasonFor({ command: 'node', registryMetadata: { version: '1.0.0' } })).to.contain('registryMetadata');
+        });
     });
 
     describe('filterValidValues', () => {
@@ -214,6 +230,57 @@ describe('MCPServersPreference validator', () => {
 
         it('rejects a non-object value', () => {
             expect(MCPServersPreference.isValue('not-an-object')).to.be.false;
+        });
+
+        it('accepts a local entry carrying cwd, pluginRoot and pluginData', () => {
+            expect(MCPServersPreference.isValue({
+                command: './bin/validator',
+                cwd: '/home/alex/.agents/plugins/devtools',
+                pluginRoot: '/home/alex/.agents/plugins/devtools',
+                pluginData: '/home/alex/.agents/plugins/data/devtools'
+            })).to.be.true;
+        });
+
+        it('accepts an entry whose registryMetadata carries a pluginId and no serverId', () => {
+            expect(MCPServersPreference.isValue({
+                command: 'npx',
+                registryMetadata: { pluginId: 'io.github.acme/devtools', version: '1.0.0' }
+            })).to.be.true;
+        });
+
+        it('still accepts an entry whose registryMetadata carries only a serverId', () => {
+            expect(MCPServersPreference.isValue({
+                command: 'npx',
+                registryMetadata: { serverId: 'io.github.acme/brave-search', configHash: 'abc' }
+            })).to.be.true;
+        });
+
+        it('rejects a registryMetadata block with neither serverId nor pluginId', () => {
+            expect(MCPServersPreference.isValue({ command: 'npx', registryMetadata: { version: '1.0.0' } })).to.be.false;
+        });
+
+        it('rejects a registryMetadata block whose pluginId is not a string', () => {
+            expect(MCPServersPreference.isValue({ command: 'npx', registryMetadata: { pluginId: 42 } })).to.be.false;
+        });
+
+        it('rejects a plugin-provided entry that also declares a serverUrl, keeping the local/remote discriminator intact', () => {
+            expect(MCPServersPreference.isValue({
+                command: 'npx',
+                serverUrl: 'https://mcp.example.com/mcp',
+                registryMetadata: { pluginId: 'io.github.acme/devtools' }
+            })).to.be.false;
+        });
+
+        it('rejects a plugin-provided local entry that declares oauth', () => {
+            expect(MCPServersPreference.isValue({
+                command: 'npx',
+                oauth: {},
+                registryMetadata: { pluginId: 'io.github.acme/devtools' }
+            })).to.be.false;
+        });
+
+        it('rejects a local entry whose pluginRoot is not a string', () => {
+            expect(MCPServersPreference.isValue({ command: 'npx', pluginRoot: 42 })).to.be.false;
         });
     });
 });

--- a/packages/ai-mcp/src/common/mcp-server-preference-validator.ts
+++ b/packages/ai-mcp/src/common/mcp-server-preference-validator.ts
@@ -28,6 +28,12 @@ interface LocalMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
     command: string;
     args?: string[];
     env?: { [key: string]: string };
+    /** Working directory for the process; defaults to `pluginRoot`. Written by `@theia/ai-registry`. */
+    cwd?: string;
+    /** Absolute plugin root; exported as PLUGIN_ROOT. Written by `@theia/ai-registry`. */
+    pluginRoot?: string;
+    /** Absolute plugin data directory; exported as PLUGIN_DATA. Written by `@theia/ai-registry`. */
+    pluginData?: string;
 }
 
 interface RemoteMCPServerPreferenceValue extends BaseMCPServerPreferenceValue {
@@ -71,6 +77,9 @@ function isPreferenceValue(obj: unknown): obj is MCPServersPreferenceValue {
         (!('args' in candidate) || Array.isArray(candidate.args) && candidate.args.every(arg => typeof arg === 'string')) &&
         (!('env' in candidate) || !!candidate.env && typeof candidate.env === 'object'
             && Object.values(candidate.env).every(value => typeof value === 'string')) &&
+        (!('cwd' in candidate) || typeof candidate.cwd === 'string') &&
+        (!('pluginRoot' in candidate) || typeof candidate.pluginRoot === 'string') &&
+        (!('pluginData' in candidate) || typeof candidate.pluginData === 'string') &&
         (!('autostart' in candidate) || typeof candidate.autostart === 'boolean') &&
         (!('deferLoading' in candidate) || typeof candidate.deferLoading === 'boolean') &&
         (!('serverUrl' in candidate) || typeof candidate.serverUrl === 'string') &&
@@ -96,11 +105,19 @@ function isOAuthConfig(obj: unknown): obj is MCPOAuthConfig {
         (!('resource' in obj) || typeof obj.resource === 'string' && isHttpOrHttpsUrl(obj.resource));
 }
 
+/**
+ * A registry-installed server is identified by `serverId`, a server contributed by an installed
+ * Agent Plugin by `pluginId`. Exactly one of the two is written per entry, but at least one must be
+ * present - a `registryMetadata` block that identifies nothing is meaningless provenance.
+ */
 function isRegistryMetadata(obj: unknown): obj is MCPRegistryMetadata {
     return !!obj && typeof obj === 'object'
-        && 'serverId' in obj && typeof obj.serverId === 'string'
+        && ('serverId' in obj && typeof obj.serverId === 'string' || 'pluginId' in obj && typeof obj.pluginId === 'string')
+        && (!('serverId' in obj) || typeof obj.serverId === 'string')
+        && (!('pluginId' in obj) || typeof obj.pluginId === 'string')
         && (!('version' in obj) || typeof obj.version === 'string')
-        && (!('configHash' in obj) || typeof obj.configHash === 'string');
+        && (!('configHash' in obj) || typeof obj.configHash === 'string')
+        && (!('installedAt' in obj) || typeof obj.installedAt === 'string');
 }
 
 /**
@@ -157,6 +174,15 @@ function describeFieldMismatch(candidate: Record<string, unknown>): string | und
         && Object.values(candidate.env).every(envValue => typeof envValue === 'string'))) {
         return 'Field "env" must be an object mapping strings to strings.';
     }
+    if ('cwd' in candidate && typeof candidate.cwd !== 'string') {
+        return 'Field "cwd" must be a string.';
+    }
+    if ('pluginRoot' in candidate && typeof candidate.pluginRoot !== 'string') {
+        return 'Field "pluginRoot" must be a string.';
+    }
+    if ('pluginData' in candidate && typeof candidate.pluginData !== 'string') {
+        return 'Field "pluginData" must be a string.';
+    }
     if ('autostart' in candidate && typeof candidate.autostart !== 'boolean') {
         return 'Field "autostart" must be a boolean.';
     }
@@ -181,7 +207,7 @@ function describeFieldMismatch(candidate: Record<string, unknown>): string | und
         return oauthDetail ?? 'Field "oauth" must be an OAuth configuration object.';
     }
     if ('registryMetadata' in candidate && !isRegistryMetadata(candidate.registryMetadata)) {
-        return 'Field "registryMetadata" must be an object with a string "serverId".';
+        return 'Field "registryMetadata" must be an object with a string "serverId" or a string "pluginId".';
     }
     return undefined;
 }

--- a/packages/ai-mcp/src/node/mcp-server-manager-impl.spec.ts
+++ b/packages/ai-mcp/src/node/mcp-server-manager-impl.spec.ts
@@ -175,6 +175,62 @@ describe('MCPServerManagerImpl OAuth cleanup', () => {
         expect(calls).to.deep.equal(['update']);
     });
 
+    describe('an Agent Plugin server', () => {
+
+        const pluginServer = (overrides: Record<string, unknown> = {}) => ({
+            name: 'bigquery',
+            command: 'node',
+            args: ['server.js'],
+            cwd: '/home/u/.agents/plugins/acme_bq',
+            pluginRoot: '/home/u/.agents/plugins/acme_bq',
+            pluginData: '/home/u/.agents/plugin-data/acme_bq',
+            autostart: true,
+            registryMetadata: { pluginId: 'io.github.acme/bq', configHash: 'h1', installedAt: '2026-08-17T10:00:00.000Z' },
+            ...overrides
+        });
+
+        async function apply(next: Record<string, unknown>): Promise<string[]> {
+            const calls: string[] = [];
+            const manager = new MCPServerManagerImpl();
+            const server = {
+                isRunning: () => true,
+                isStopped: () => false,
+                isInFlight: () => false,
+                stop: async () => { calls.push('stop'); },
+                getCachedDescription: () => pluginServer(),
+                update: () => { calls.push('update'); },
+                setWorkspaceRoots: () => { },
+                onDidUpdateStatus: () => ({ dispose: () => { } })
+            };
+            (manager as unknown as { servers: Map<string, MCPServer> }).servers = new Map([
+                ['bigquery', server as unknown as MCPServer]
+            ]);
+            (manager as unknown as { credentialStore: Partial<MCPOAuthCredentialStore> }).credentialStore = { clear: async () => { } };
+            await manager.addOrUpdateServer(next as unknown as Parameters<typeof manager.addOrUpdateServer>[0]);
+            return calls;
+        }
+
+        it('restarts when the plugin was re-installed, even though its own configuration is identical', async () => {
+            // An update or a Fix deletes and re-creates the very directory the child is working in while
+            // changing nothing the server declared. Without a restart the process keeps running against
+            // a root that no longer exists.
+            const reinstalled = { ...pluginServer().registryMetadata, installedAt: '2026-08-17T12:00:00.000Z' };
+
+            expect(await apply(pluginServer({ registryMetadata: reinstalled }))).to.deep.equal(['stop', 'update']);
+        });
+
+        it('restarts when the working directory or either plugin path changes, because all three reach the process', async () => {
+            expect(await apply(pluginServer({ cwd: '/somewhere/else' }))).to.deep.equal(['stop', 'update']);
+            expect(await apply(pluginServer({ pluginRoot: '/other/root' }))).to.deep.equal(['stop', 'update']);
+            expect(await apply(pluginServer({ pluginData: '/other/data' }))).to.deep.equal(['stop', 'update']);
+        });
+
+        it('does not restart when nothing that reaches the process changed', async () => {
+            expect(await apply(pluginServer())).to.deep.equal(['update']);
+            expect(await apply(pluginServer({ autostart: false }))).to.deep.equal(['update']);
+        });
+    });
+
     it('restarts a running server for connection preference changes', async () => {
         const calls: string[] = [];
         const manager = new MCPServerManagerImpl();

--- a/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
+++ b/packages/ai-mcp/src/node/mcp-server-manager-impl.ts
@@ -216,13 +216,22 @@ export class MCPServerManagerImpl implements MCPServerManager {
         return restartedByCaller || (!server.isRunning() && !server.isInFlight());
     }
 
+    /**
+     * The part of a description that decides whether a running server has to be restarted rather than
+     * merely updated in place. Anything that shapes the connection - or, for a local server, the
+     * process - belongs here; anything purely presentational does not.
+     */
     protected connectionDescription(description: MCPServerDescription): object {
         if (isRemoteMCPServerDescription(description)) {
             const { serverUrl, serverAuthToken, serverAuthTokenHeader, headers, oauth } = description;
             return { type: 'remote', serverUrl, serverAuthToken, serverAuthTokenHeader, headers, oauth };
         }
-        const { command, args, env } = description;
-        return { type: 'local', command, args, env };
+        const { command, args, env, cwd, pluginRoot, pluginData } = description;
+        // `cwd`, `pluginRoot` and `pluginData` all reach the spawned process, so changing any of them
+        // needs a new one. `installedAt` is not configuration at all: it is here because replacing a
+        // plugin's root deletes the directory a running child works out of while leaving that child's
+        // own configuration identical.
+        return { type: 'local', command, args, env, cwd, pluginRoot, pluginData, installedAt: description.registryMetadata?.installedAt };
     }
 
     protected async clearOAuthCredentialsIfConnectionScopeChanged(oldDescription: MCPServerDescription, newDescription: MCPServerDescription): Promise<void> {

--- a/packages/ai-mcp/src/node/mcp-server.spec.ts
+++ b/packages/ai-mcp/src/node/mcp-server.spec.ts
@@ -26,7 +26,8 @@ import { MCPOAuthClientProvider } from './mcp-oauth-client-provider';
 import { MCPOAuthClientProviderFactory } from './mcp-oauth-client-provider-factory';
 import { MCPOAuthAuthorizationRequiredError, MCPOAuthAuthorizationServerError } from './mcp-oauth-errors';
 import { MCPOAuthCancelledError } from './mcp-oauth-callback-service';
-import { MCPServerDescription, MCPServerStatus } from '../common';
+import { StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { LocalMCPServerDescription, MCPServerDescription, MCPServerStatus } from '../common';
 
 class TestClient {
     connectCalls = 0;
@@ -150,6 +151,10 @@ class TestMCPServer extends MCPServer {
 
     testSetStatus(status: MCPServerStatus): void {
         this.setStatus(status);
+    }
+
+    testCreateStdioParameters(description: LocalMCPServerDescription): StdioServerParameters {
+        return this.createStdioParameters(description);
     }
 
     protected override createClient(): Client {
@@ -814,5 +819,95 @@ describe('MCPServer OAuth reconnect', () => {
         // getCachedDescription must not surface the stripped runtime fields either.
         const cached = server.getCachedDescription();
         expect(cached.tools).to.be.undefined;
+    });
+});
+
+describe('MCPServer stdio spawn parameters', () => {
+
+    /**
+     * The Agent Plugins specification fixes the order: the client-chosen base environment first, then the
+     * configured `env` overlay, then PLUGIN_ROOT / PLUGIN_DATA over the top of both.
+     */
+    function parametersFor(description: Partial<LocalMCPServerDescription>): StdioServerParameters {
+        return new TestMCPServer().testCreateStdioParameters({ name: 'test', command: 'npx', ...description });
+    }
+
+    it('inherits the ambient environment of the Theia process', () => {
+        const previous = process.env.THEIA_MCP_SPEC_AMBIENT;
+        process.env.THEIA_MCP_SPEC_AMBIENT = 'ambient-value';
+        try {
+            expect(parametersFor({}).env?.THEIA_MCP_SPEC_AMBIENT).to.equal('ambient-value');
+        } finally {
+            if (previous === undefined) {
+                delete process.env.THEIA_MCP_SPEC_AMBIENT;
+            } else {
+                process.env.THEIA_MCP_SPEC_AMBIENT = previous;
+            }
+        }
+    });
+
+    it('overlays a configured env entry on top of a same-named ambient variable', () => {
+        const previous = process.env.THEIA_MCP_SPEC_OVERLAY;
+        process.env.THEIA_MCP_SPEC_OVERLAY = 'ambient-value';
+        try {
+            const parameters = parametersFor({ env: { THEIA_MCP_SPEC_OVERLAY: 'configured-value' } });
+            expect(parameters.env?.THEIA_MCP_SPEC_OVERLAY).to.equal('configured-value');
+        } finally {
+            if (previous === undefined) {
+                delete process.env.THEIA_MCP_SPEC_OVERLAY;
+            } else {
+                process.env.THEIA_MCP_SPEC_OVERLAY = previous;
+            }
+        }
+    });
+
+    it('exports PLUGIN_ROOT and PLUGIN_DATA when the description carries them', () => {
+        const parameters = parametersFor({
+            pluginRoot: '/home/alex/.agents/plugins/devtools',
+            pluginData: '/home/alex/.agents/plugins/data/devtools'
+        });
+
+        expect(parameters.env?.PLUGIN_ROOT).to.equal('/home/alex/.agents/plugins/devtools');
+        expect(parameters.env?.PLUGIN_DATA).to.equal('/home/alex/.agents/plugins/data/devtools');
+    });
+
+    it('lets PLUGIN_ROOT and PLUGIN_DATA win over same-named configured env entries', () => {
+        const parameters = parametersFor({
+            env: { PLUGIN_ROOT: 'hijacked-root', PLUGIN_DATA: 'hijacked-data' },
+            pluginRoot: '/home/alex/.agents/plugins/devtools',
+            pluginData: '/home/alex/.agents/plugins/data/devtools'
+        });
+
+        expect(parameters.env?.PLUGIN_ROOT).to.equal('/home/alex/.agents/plugins/devtools');
+        expect(parameters.env?.PLUGIN_DATA).to.equal('/home/alex/.agents/plugins/data/devtools');
+    });
+
+    it('leaves a configured PLUGIN_ROOT alone when the description declares no plugin root', () => {
+        // Without a plugin root there is no reserved value to impose, so the configured entry stands.
+        expect(parametersFor({ env: { PLUGIN_ROOT: 'configured-root' } }).env?.PLUGIN_ROOT).to.equal('configured-root');
+    });
+
+    it('uses the plugin root as the working directory when no explicit cwd is configured', () => {
+        expect(parametersFor({ pluginRoot: '/home/alex/.agents/plugins/devtools' }).cwd).to.equal('/home/alex/.agents/plugins/devtools');
+    });
+
+    it('prefers an explicit cwd over the plugin root', () => {
+        const parameters = parametersFor({
+            cwd: '/home/alex/.agents/plugins/data/devtools/workdir',
+            pluginRoot: '/home/alex/.agents/plugins/devtools'
+        });
+
+        expect(parameters.cwd).to.equal('/home/alex/.agents/plugins/data/devtools/workdir');
+    });
+
+    it('leaves the working directory undefined when neither cwd nor pluginRoot is set', () => {
+        expect(parametersFor({}).cwd).to.be.undefined;
+    });
+
+    it('passes the command and args through unchanged', () => {
+        const parameters = parametersFor({ command: './bin/validator', args: ['--data', '/tmp/validator'] });
+
+        expect(parameters.command).to.equal('./bin/validator');
+        expect(parameters.args).to.deep.equal(['--data', '/tmp/validator']);
     });
 });

--- a/packages/ai-mcp/src/node/mcp-server.ts
+++ b/packages/ai-mcp/src/node/mcp-server.ts
@@ -15,11 +15,13 @@
 // *****************************************************************************
 import { UnauthorizedError } from '@modelcontextprotocol/sdk/client/auth.js';
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StdioClientTransport, StdioServerParameters } from '@modelcontextprotocol/sdk/client/stdio.js';
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js';
 import { StreamableHTTPClientTransport, StreamableHTTPClientTransportOptions, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { isLocalMCPServerDescription, isRemoteMCPServerDescription, MCPServerDescription, MCPServerStatus, ToolInformation } from '../common';
+import {
+    isLocalMCPServerDescription, isRemoteMCPServerDescription, LocalMCPServerDescription, MCPServerDescription, MCPServerStatus, ToolInformation
+} from '../common';
 import { Emitter } from '@theia/core/lib/common/event.js';
 import { nls } from '@theia/core/lib/common/nls';
 import { CallToolResult, CallToolResultSchema, ListResourcesResult, ListRootsRequestSchema, ListRootsResult, ReadResourceResult } from '@modelcontextprotocol/sdk/types.js';
@@ -169,22 +171,11 @@ export class MCPServer {
                 this.setStatus(MCPServerStatus.Starting);
                 console.log(
                     `Starting server "${this.description.name}" with command: ${this.description.command} ` +
-                    `and args: ${this.description.args?.join(' ')} and env: ${JSON.stringify(this.description.env)}`
+                    `and args: ${this.description.args?.join(' ')} and env: ${JSON.stringify(this.description.env)} ` +
+                    `and cwd: ${this.description.cwd ?? this.description.pluginRoot}`
                 );
 
-                const sanitizedEnv: Record<string, string> = Object.fromEntries(
-                    Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
-                );
-
-                const mergedEnv: Record<string, string> = {
-                    ...sanitizedEnv,
-                    ...(this.description.env || {})
-                };
-                this.transport = new StdioClientTransport({
-                    command: this.description.command,
-                    args: this.description.args,
-                    env: mergedEnv,
-                });
+                this.transport = new StdioClientTransport(this.createStdioParameters(this.description));
             } else if (isRemoteMCPServerDescription(this.description)) {
                 this.setStatus(MCPServerStatus.Connecting);
                 console.log(`Connecting to server "${this.description.name}" via MCP Server Communication with URL: ${this.description.serverUrl}`);
@@ -264,6 +255,40 @@ export class MCPServer {
             // Reset again so the flag never spans attempts.
             this.oauthHandshakeCompletedDuringStart = false;
         }
+    }
+
+    /**
+     * The configured `env` overlays the base environment, then PLUGIN_ROOT and PLUGIN_DATA are set
+     * last, replacing any same-named entries. That order is what the Agent Plugins specification
+     * prescribes, and it is why the two reserved variables cannot just live in `env`.
+     */
+    protected createStdioParameters(description: LocalMCPServerDescription): StdioServerParameters {
+        // The backend's own environment, inherited whole: every hand-configured server already
+        // depends on PATH, HOME and the proxy variables, and the SDK's allow-list default breaks them.
+        // For a downloaded plugin that means LLM provider keys too. The specification lets a client
+        // sanitize the base environment, so this is the place to narrow it, and `protected` so a
+        // product can.
+        const sanitizedEnv: Record<string, string> = Object.fromEntries(
+            Object.entries(process.env).filter((entry): entry is [string, string] => entry[1] !== undefined)
+        );
+
+        const mergedEnv: Record<string, string> = {
+            ...sanitizedEnv,
+            ...(description.env || {})
+        };
+        if (description.pluginRoot) {
+            mergedEnv.PLUGIN_ROOT = description.pluginRoot;
+        }
+        if (description.pluginData) {
+            mergedEnv.PLUGIN_DATA = description.pluginData;
+        }
+
+        return {
+            command: description.command,
+            args: description.args,
+            env: mergedEnv,
+            cwd: description.cwd ?? description.pluginRoot
+        };
     }
 
     protected async handleStartupError(error: unknown): Promise<void> {

--- a/packages/ai-registry/package.json
+++ b/packages/ai-registry/package.json
@@ -6,7 +6,9 @@
     "@theia/ai-core": "1.74.0",
     "@theia/ai-mcp": "1.74.0",
     "@theia/core": "1.74.0",
-    "@theia/vsx-registry": "1.74.0"
+    "@theia/vsx-registry": "1.74.0",
+    "filenamify": "^4.3.0",
+    "tar-fs": "^3.1.3"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -66,6 +66,8 @@ import { PluginMcpRegistrar, PluginMcpRegistrarImpl } from './plugin/plugin-mcp-
 import { PluginMcpReconciler } from './plugin/plugin-mcp-reconciler';
 import { PluginSkillDirectoryContribution } from './plugin/plugin-skill-directory-contribution';
 import { AgentPluginUiBridgeImpl } from './plugin/agent-plugin-ui-bridge-impl';
+import { InstallPluginUriConfiguration } from './plugin/install-plugin-uri-configuration';
+import { InstallPluginUriHandler } from './plugin/install-plugin-uri-handler';
 import { AIRegistryToolbarContribution } from './ai-registry-toolbar-contribution';
 import { AIRegistryMenuContribution } from './ai-registry-menu-contribution';
 import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from './auto-update/registry-auto-update-policy';
@@ -143,6 +145,10 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     // Nothing binds the bridge without this package, which is what makes every Agent Plugin
     // affordance disappear from the AI configuration widgets there.
     bind(AgentPluginUiBridge).toService(AgentPluginUiBridgeImpl);
+
+    bind(InstallPluginUriConfiguration).toSelf().inSingletonScope();
+    bind(InstallPluginUriHandler).toSelf().inSingletonScope();
+    bind(OpenHandler).toService(InstallPluginUriHandler);
 
     bind(AIRegistryToolbarContribution).toSelf().inSingletonScope();
     bind(TabBarToolbarContribution).toService(AIRegistryToolbarContribution);

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -16,6 +16,7 @@
 
 import '../../src/browser/style/mcp-entries.css';
 import '../../src/browser/style/skill-entries.css';
+import '../../src/browser/style/plugin-entries.css';
 
 import { ContainerModule } from '@theia/core/shared/inversify';
 import { CommandContribution, MenuContribution, PreferenceContribution } from '@theia/core';
@@ -24,12 +25,15 @@ import { OpenHandler } from '@theia/core/lib/browser/opener-service';
 import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar-toolbar';
 import { ExtensionsSourceContribution } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
+import { AgentPluginUiBridge } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
+import { SkillDirectoryContribution } from '@theia/ai-core/lib/browser/skill-service';
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
 import { AIRegistryPreferencesSchema } from '../common/ai-registry-preferences';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from '../common/mcp/mcp-registry-entry-resolver';
 import { RegistryFetchService, RegistryFetchServiceImpl } from '../common/registry-fetch-service';
 import { RegistrySearchFilter } from '../common/registry-search-filter';
 import { SkillRegistryEntryResolver, SkillRegistryEntryResolverImpl } from '../common/skill/skill-registry-entry-resolver';
+import { PluginRegistryEntryResolver, PluginRegistryEntryResolverImpl } from '../common/plugin/plugin-registry-entry-resolver';
 import { SkillInstallBackendService, SkillInstallBackendServicePath, SkillInstallClient } from '../common/skill/skill-install-protocol';
 import { SkillRegistryPreferencesSchema } from '../common/skill/skill-registry-preferences';
 import { MCPInstallService, MCPInstallServiceImpl } from './mcp/mcp-install-service';
@@ -40,18 +44,42 @@ import { SkillInstallClientImpl } from './skill/skill-install-client';
 import { SkillExtensionsContribution } from './skill/skill-extensions-contribution';
 import { InstallSkillUriConfiguration } from './skill/install-skill-uri-configuration';
 import { InstallSkillUriHandler } from './skill/install-skill-uri-handler';
+import {
+    PluginInstallBackendService,
+    PluginInstallBackendServicePath,
+    PluginInstallClient
+} from '../common/plugin/plugin-install-protocol';
+import { PluginDirectoryNaming, PluginDirectoryNamingImpl } from '../common/plugin/plugin-directory-naming';
+import { PluginInstallService, PluginInstallServiceImpl } from './plugin/plugin-install-service';
+import { PluginInstallClientImpl } from './plugin/plugin-install-client';
+import { PluginExtensionsContribution } from './plugin/plugin-extensions-contribution';
+import {
+    PluginHashMismatchDialog,
+    PluginHashMismatchDialogFactory,
+    PluginHashMismatchDialogOptions,
+    PluginInstallDialog,
+    PluginInstallDialogFactory,
+    PluginInstallDialogOptions
+} from './plugin/plugin-install-dialog';
+import { PluginInstaller, PluginInstallerImpl } from './plugin/plugin-installer';
+import { PluginMcpRegistrar, PluginMcpRegistrarImpl } from './plugin/plugin-mcp-registrar';
+import { PluginMcpReconciler } from './plugin/plugin-mcp-reconciler';
+import { PluginSkillDirectoryContribution } from './plugin/plugin-skill-directory-contribution';
+import { AgentPluginUiBridgeImpl } from './plugin/agent-plugin-ui-bridge-impl';
 import { AIRegistryToolbarContribution } from './ai-registry-toolbar-contribution';
 import { AIRegistryMenuContribution } from './ai-registry-menu-contribution';
 import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from './auto-update/registry-auto-update-policy';
 import { RegistryAutoUpdateService } from './auto-update/registry-auto-update-service';
 import { RegistryAutoUpdateContribution } from './auto-update/registry-auto-update-contribution';
 
-export default new ContainerModule(bind => {
+export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     bind(AIRegistryConfiguration).toSelf().inSingletonScope();
     bind(MCPRegistryEntryResolverImpl).toSelf().inSingletonScope();
     bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
     bind(SkillRegistryEntryResolverImpl).toSelf().inSingletonScope();
     bind(SkillRegistryEntryResolver).toService(SkillRegistryEntryResolverImpl);
+    bind(PluginRegistryEntryResolverImpl).toSelf().inSingletonScope();
+    bind(PluginRegistryEntryResolver).toService(PluginRegistryEntryResolverImpl);
     bind(RegistryFetchServiceImpl).toSelf().inSingletonScope();
     bind(RegistryFetchService).toService(RegistryFetchServiceImpl);
     bind(RegistrySearchFilter).toSelf().inSingletonScope();
@@ -80,6 +108,41 @@ export default new ContainerModule(bind => {
     bind(InstallSkillUriConfiguration).toSelf().inSingletonScope();
     bind(InstallSkillUriHandler).toSelf().inSingletonScope();
     bind(OpenHandler).toService(InstallSkillUriHandler);
+
+    bind(PluginInstallClientImpl).toSelf().inSingletonScope();
+    bind(PluginInstallClient).toService(PluginInstallClientImpl);
+    bind(PluginInstallBackendService).toDynamicValue(ctx => {
+        const connection = ctx.container.get<ServiceConnectionProvider>(RemoteConnectionProvider);
+        return connection.createProxy<PluginInstallBackendService>(PluginInstallBackendServicePath, ctx.container.get(PluginInstallClientImpl));
+    }).inSingletonScope();
+    // Shared with the backend, so that the directory a plugin may be adopted under is the same one an
+    // install would have created.
+    bind(PluginDirectoryNamingImpl).toSelf().inSingletonScope();
+    bind(PluginDirectoryNaming).toService(PluginDirectoryNamingImpl);
+    bind(PluginInstallServiceImpl).toSelf().inSingletonScope();
+    bind(PluginInstallService).toService(PluginInstallServiceImpl);
+    bind(PluginInstallDialogFactory).toFactory(() => (options: PluginInstallDialogOptions) => new PluginInstallDialog(options));
+    bind(PluginHashMismatchDialogFactory).toFactory(() => (options: PluginHashMismatchDialogOptions) => new PluginHashMismatchDialog(options));
+
+    bind(PluginSkillDirectoryContribution).toSelf().inSingletonScope();
+    bind(SkillDirectoryContribution).toService(PluginSkillDirectoryContribution);
+    bind(PluginMcpRegistrarImpl).toSelf().inSingletonScope();
+    bind(PluginMcpRegistrar).toService(PluginMcpRegistrarImpl);
+    bind(PluginMcpReconciler).toSelf().inSingletonScope();
+    bind(FrontendApplicationContribution).toService(PluginMcpReconciler);
+    // Sits above the install service rather than inside it: the install flow registers the plugin's
+    // components once the download is committed, and the registrar has to be able to list the
+    // installed plugins to do that, so folding the flow into the install service would close a cycle.
+    bind(PluginInstallerImpl).toSelf().inSingletonScope();
+    bind(PluginInstaller).toService(PluginInstallerImpl);
+
+    bind(PluginExtensionsContribution).toSelf().inSingletonScope();
+    bind(ExtensionsSourceContribution).toService(PluginExtensionsContribution);
+
+    bind(AgentPluginUiBridgeImpl).toSelf().inSingletonScope();
+    // Nothing binds the bridge without this package, which is what makes every Agent Plugin
+    // affordance disappear from the AI configuration widgets there.
+    bind(AgentPluginUiBridge).toService(AgentPluginUiBridgeImpl);
 
     bind(AIRegistryToolbarContribution).toSelf().inSingletonScope();
     bind(TabBarToolbarContribution).toService(AIRegistryToolbarContribution);

--- a/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
+++ b/packages/ai-registry/src/browser/ai-registry-frontend-module.ts
@@ -26,6 +26,7 @@ import { TabBarToolbarContribution } from '@theia/core/lib/browser/shell/tab-bar
 import { ExtensionsSourceContribution } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCPRegistryUiBridge } from '@theia/ai-mcp/lib/browser/mcp-registry-ui-bridge';
 import { AgentPluginUiBridge } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
+import { SkillRegistryUiBridge } from '@theia/ai-core/lib/browser/skill-registry-ui-bridge';
 import { SkillDirectoryContribution } from '@theia/ai-core/lib/browser/skill-service';
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
 import { AIRegistryPreferencesSchema } from '../common/ai-registry-preferences';
@@ -66,6 +67,7 @@ import { PluginMcpRegistrar, PluginMcpRegistrarImpl } from './plugin/plugin-mcp-
 import { PluginMcpReconciler } from './plugin/plugin-mcp-reconciler';
 import { PluginSkillDirectoryContribution } from './plugin/plugin-skill-directory-contribution';
 import { AgentPluginUiBridgeImpl } from './plugin/agent-plugin-ui-bridge-impl';
+import { SkillRegistryUiBridgeImpl } from './skill/skill-registry-ui-bridge-impl';
 import { InstallPluginUriConfiguration } from './plugin/install-plugin-uri-configuration';
 import { InstallPluginUriHandler } from './plugin/install-plugin-uri-handler';
 import { AIRegistryToolbarContribution } from './ai-registry-toolbar-contribution';
@@ -145,6 +147,10 @@ export default new ContainerModule((bind, _unbind, _isBound, rebind) => {
     // Nothing binds the bridge without this package, which is what makes every Agent Plugin
     // affordance disappear from the AI configuration widgets there.
     bind(AgentPluginUiBridge).toService(AgentPluginUiBridgeImpl);
+
+    bind(SkillRegistryUiBridgeImpl).toSelf().inSingletonScope();
+    // As above, for skills this package installs or links directly rather than through a plugin.
+    bind(SkillRegistryUiBridge).toService(SkillRegistryUiBridgeImpl);
 
     bind(InstallPluginUriConfiguration).toSelf().inSingletonScope();
     bind(InstallPluginUriHandler).toSelf().inSingletonScope();

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.spec.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.spec.ts
@@ -35,6 +35,10 @@ import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { MCPInstallService, MCPInstallServiceImpl } from '../mcp/mcp-install-service';
 import { SkillInstallService, SkillInstallServiceImpl } from '../skill/skill-install-service';
 import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from './registry-auto-update-policy';
+import { PluginDirectoryNamingImpl } from '../../common/plugin/plugin-directory-naming';
+import { InstalledPluginInfo, ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+import { PluginInstallService, PluginInstallServiceImpl } from '../plugin/plugin-install-service';
+import { PluginInstaller } from '../plugin/plugin-installer';
 import { RegistryAutoUpdateService } from './registry-auto-update-service';
 
 after(() => disableJSDOM());
@@ -65,6 +69,17 @@ const mcpEntry: ResolvedRegistryEntry = {
     mcpRegistryVerified: true
 };
 
+const pluginEntry: ResolvedPluginEntry = {
+    pluginId: 'io.github.example/plugin-a',
+    name: 'Plugin A',
+    description: 'A plugin',
+    sourceUrl: 'https://github.com/example/plugin-a',
+    contentHash: 'hash-v2',
+    endorsements: [{ organizationId: 'example', date: '2026-08-07' }],
+    containedSkills: [],
+    containedMcpServers: []
+};
+
 /** Installed skill whose recorded hash is behind the registry, i.e. an update is available. */
 function outdatedSkill(entry: ResolvedSkillEntry, drifted = false): InstalledSkillInfo {
     return { name: entry.name, skillId: entry.skillId, contentHash: 'hash-v1', drifted };
@@ -80,6 +95,23 @@ function outdatedServer(entry: ResolvedRegistryEntry, drifted = false): MCPServe
     } as MCPServerDescription;
 }
 
+/** Installed plugin whose recorded hash is behind the registry, i.e. an update is available. */
+function outdatedPlugin(entry: ResolvedPluginEntry, drifted = false): InstalledPluginInfo {
+    const directoryName = 'io.github.example_plugin-a';
+    return {
+        directoryName,
+        root: `/home/u/.agents/plugins/${directoryName}`,
+        dataRoot: `/home/u/.agents/plugin-data/${directoryName}`,
+        pluginId: entry.pluginId,
+        contentHash: 'hash-v1',
+        qualifier: 'plugin-a',
+        drifted,
+        skills: [],
+        servers: [],
+        skipped: []
+    };
+}
+
 interface RecordedMessage {
     kind: 'info' | 'warn';
     text: string;
@@ -93,6 +125,8 @@ interface TestOptions {
     mcpEntries?: ResolvedRegistryEntry[];
     installedSkills?: InstalledSkillInfo[];
     installedServers?: MCPServerDescription[];
+    pluginEntries?: ResolvedPluginEntry[];
+    installedPlugins?: InstalledPluginInfo[];
     /** Registry ids whose update should throw. */
     failing?: string[];
     /** Action label the user "clicks" on any notification offering it. */
@@ -155,6 +189,8 @@ function createService(options: TestOptions = {}): { service: TestAutoUpdateServ
     const mcpEntries = options.mcpEntries ?? [mcpEntry];
     const installedSkills = options.installedSkills ?? [];
     const installedServers = options.installedServers ?? [];
+    const pluginEntries = options.pluginEntries ?? [pluginEntry];
+    const installedPlugins = options.installedPlugins ?? [];
     const failing = new Set(options.failing ?? []);
     const policy = createPolicy(options.defaultMode ?? 'ask', options.overrides ?? {}, options.explicitDefault ?? true);
     const service = new TestAutoUpdateService();
@@ -163,6 +199,8 @@ function createService(options: TestOptions = {}): { service: TestAutoUpdateServ
     // pinned end to end; only the I/O around them is faked.
     const realSkillService = new SkillInstallServiceImpl();
     const realMcpService = new MCPInstallServiceImpl();
+    const realPluginService = new PluginInstallServiceImpl();
+    Object.assign(realPluginService, { directoryNaming: new PluginDirectoryNamingImpl() });
 
     const record = async (id: string): Promise<void> => {
         service.attempted.push(id);
@@ -184,7 +222,8 @@ function createService(options: TestOptions = {}): { service: TestAutoUpdateServ
                 }
                 return mcpEntries;
             },
-            getSkillEntries: async () => skillEntries
+            getSkillEntries: async () => skillEntries,
+            getPluginEntries: async () => pluginEntries
         } as unknown as RegistryFetchService,
         skillInstallService: {
             listInstalledSkills: async () => installedSkills,
@@ -196,6 +235,13 @@ function createService(options: TestOptions = {}): { service: TestAutoUpdateServ
             classifyLocalServer: (local: MCPServerDescription, entries: ResolvedRegistryEntry[]) => realMcpService.classifyLocalServer(local, entries),
             update: (entry: ResolvedRegistryEntry) => record(entry.serverId)
         } as unknown as MCPInstallService,
+        pluginInstallService: {
+            listInstalledPlugins: async () => installedPlugins,
+            classifyInstalledPlugin: (info: InstalledPluginInfo, entries: ResolvedPluginEntry[]) => realPluginService.classifyInstalledPlugin(info, entries)
+        } as unknown as PluginInstallService,
+        pluginInstaller: {
+            install: (entry: ResolvedPluginEntry) => record(entry.pluginId).then(() => true)
+        } as unknown as PluginInstaller,
         messageService: {
             info: (text: string, ...actions: string[]) => respond('info', text, actions),
             warn: (text: string, ...actions: string[]) => respond('warn', text, actions)
@@ -279,6 +325,74 @@ describe('RegistryAutoUpdateService', () => {
             const { service } = createService({ defaultMode: 'on', installedServers: [outdatedServer(mcpEntry, true)] });
             await service.check();
             expect(service.attempted).to.be.empty;
+        });
+
+        it('skips a drifted Agent Plugin in on mode', async () => {
+            const { service } = createService({ defaultMode: 'on', installedPlugins: [outdatedPlugin(pluginEntry, true)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+        });
+    });
+
+    describe('Agent Plugins', () => {
+
+        it('updates an outdated plugin without asking when the mode is on', async () => {
+            const { service } = createService({ defaultMode: 'on', installedPlugins: [outdatedPlugin(pluginEntry)] });
+            await service.check();
+            expect(service.attempted).to.deep.equal([pluginEntry.pluginId]);
+        });
+
+        it('leaves a plugin alone when the mode is off', async () => {
+            const { service } = createService({ defaultMode: 'off', installedPlugins: [outdatedPlugin(pluginEntry)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+            expect(service.messages).to.be.empty;
+        });
+
+        it('applies a per-plugin override over the default', async () => {
+            const { service } = createService({
+                defaultMode: 'off',
+                overrides: { [`plugin:${pluginEntry.pluginId}`]: 'on' },
+                installedPlugins: [outdatedPlugin(pluginEntry)]
+            });
+            await service.check();
+            expect(service.attempted).to.deep.equal([pluginEntry.pluginId]);
+        });
+
+        it('leaves a plugin the registry no longer lists alone', async () => {
+            const { service } = createService({ defaultMode: 'on', pluginEntries: [], installedPlugins: [outdatedPlugin(pluginEntry)] });
+            await service.check();
+            expect(service.attempted).to.be.empty;
+        });
+
+        it('names the plugin in the prompt, so the notification says what is about to change', async () => {
+            const { service } = createService({ defaultMode: 'ask', installedPlugins: [outdatedPlugin(pluginEntry)] });
+            await service.check();
+            expect(service.messages[0].text).to.contain('Agent Plugin "Plugin A" has an update available.');
+        });
+
+        it('batches a plugin together with the other artifact kinds', async () => {
+            const { service } = createService({
+                defaultMode: 'on',
+                installedSkills: [outdatedSkill(skillEntry)],
+                installedServers: [outdatedServer(mcpEntry)],
+                installedPlugins: [outdatedPlugin(pluginEntry)]
+            });
+            await service.check();
+            expect(service.attempted).to.deep.equal([skillEntry.skillId, mcpEntry.serverId, pluginEntry.pluginId]);
+            expect(service.messages.map(message => message.text)).to.deep.equal(['Updated 3 AI registry items.']);
+        });
+
+        it('reports the failure without aborting the rest of the batch', async () => {
+            const { service } = createService({
+                defaultMode: 'on',
+                installedSkills: [outdatedSkill(skillEntry)],
+                installedPlugins: [outdatedPlugin(pluginEntry)],
+                failing: [pluginEntry.pluginId]
+            });
+            await service.check();
+            expect(service.attempted).to.deep.equal([skillEntry.skillId, pluginEntry.pluginId]);
+            expect(service.messages.map(message => message.kind)).to.deep.equal(['info', 'warn']);
         });
     });
 

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
@@ -21,6 +21,8 @@ import { VSXExtensionsCommands } from '@theia/vsx-registry/lib/browser/vsx-exten
 import { AUTO_UPDATE_PREF, AutoUpdateMode, RegistryArtifactKind } from '../../common/ai-registry-preferences';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { MCPInstallService } from '../mcp/mcp-install-service';
+import { PluginInstallService } from '../plugin/plugin-install-service';
+import { PluginInstaller } from '../plugin/plugin-installer';
 import { SkillInstallService } from '../skill/skill-install-service';
 import { RegistryAutoUpdatePolicy } from './registry-auto-update-policy';
 
@@ -37,11 +39,11 @@ export interface PendingUpdate {
 }
 
 /**
- * Checks the registry for updates to installed skills and MCP servers and applies or
- * offers them according to the effective {@link RegistryAutoUpdatePolicy}.
+ * Checks the registry for updates to installed skills, MCP servers and Agent Plugins and applies
+ * or offers them according to the effective {@link RegistryAutoUpdatePolicy}.
  *
  * Drifted artifacts are deliberately excluded in every mode: they classify as `fix-skill` /
- * `fix-config` rather than `installed-from-registry`, so they never reach
+ * `fix-config` / `fix-plugin` rather than `installed-from-registry`, so they never reach
  * {@link collectPending} and the user resolves them with Fix in the Extensions view.
  *
  * Updates go through the install services directly rather than the contributions' action
@@ -58,6 +60,12 @@ export class RegistryAutoUpdateService {
 
     @inject(MCPInstallService)
     protected readonly mcpInstallService: MCPInstallService;
+
+    @inject(PluginInstallService)
+    protected readonly pluginInstallService: PluginInstallService;
+
+    @inject(PluginInstaller)
+    protected readonly pluginInstaller: PluginInstaller;
 
     @inject(RegistryAutoUpdatePolicy)
     protected readonly policy: RegistryAutoUpdatePolicy;
@@ -102,10 +110,11 @@ export class RegistryAutoUpdateService {
      * Forces a registry refresh first - the cached response would not surface anything new.
      */
     protected async collectPending(): Promise<PendingUpdate[]> {
-        // One refresh serves both slices: `getEntries(true)` refetches the shared response
-        // and invalidates both caches, so the skill call below resolves against it.
+        // One refresh serves every slice: `getEntries(true)` refetches the shared response and
+        // invalidates all the caches, so the calls below resolve against it.
         const mcpEntries = await this.fetchService.getEntries(true);
         const skillEntries = await this.fetchService.getSkillEntries();
+        const pluginEntries = await this.fetchService.getPluginEntries();
         const pending: PendingUpdate[] = [];
 
         for (const info of await this.skillInstallService.listInstalledSkills()) {
@@ -151,6 +160,33 @@ export class RegistryAutoUpdateService {
                 promptMessage: nls.localize('theia/ai-registry/autoUpdate/mcpAvailable', 'MCP server "{0}" has an update available.', entry.name),
                 successMessage: nls.localize('theia/ai-registry/mcp/updated', 'Updated MCP server "{0}".', entry.name),
                 apply: () => this.mcpInstallService.update(entry)
+            });
+        }
+
+        for (const info of await this.pluginInstallService.listInstalledPlugins()) {
+            const state = this.pluginInstallService.classifyInstalledPlugin(info, pluginEntries);
+            if (state.kind !== 'installed-from-registry' || !state.updateAvailable) {
+                continue;
+            }
+            const entry = pluginEntries.find(candidate => candidate.pluginId === info.pluginId);
+            if (!entry) {
+                continue;
+            }
+            const mode = this.policy.getMode('plugin', entry.pluginId);
+            if (mode === 'off') {
+                continue;
+            }
+            pending.push({
+                kind: 'plugin',
+                label: entry.name,
+                mode,
+                promptMessage: nls.localize('theia/ai-registry/autoUpdate/pluginAvailable', 'Agent Plugin "{0}" has an update available.', entry.name),
+                successMessage: nls.localize('theia/ai-registry/plugin/updated', 'Updated Agent Plugin "{0}".', entry.name),
+                // The same call the Update button makes, so the download is verified against the
+                // endorsed hash and the plugin's MCP servers are re-registered afterwards. A hash
+                // mismatch still opens its dialog: replacing content the registry cannot vouch for
+                // is the user's decision whether or not the update was automatic.
+                apply: () => this.pluginInstaller.install(entry, { replaceExisting: true, confirm: false }).then(() => undefined)
             });
         }
         return pending;

--- a/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
+++ b/packages/ai-registry/src/browser/auto-update/registry-auto-update-service.ts
@@ -272,7 +272,7 @@ export class RegistryAutoUpdateService {
         const answer = await this.messageService.info(
             `${nls.localize(
                 'theia/ai-registry/autoUpdate/defaultPrompt',
-                'Update skills and MCP servers from the AI registry automatically from now on?'
+                'Update skills, MCP servers and Agent Plugins from the AI registry automatically from now on?'
             )} ${this.settingsChangeHint()}`,
             enable, keepAsking, never
         );

--- a/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
+++ b/packages/ai-registry/src/browser/mcp/mcp-entries.tsx
@@ -63,7 +63,7 @@ export class MCPInstalledEntry implements TreeElement, RegistryEntryContext {
     }
 
     get autoUpdateId(): string | undefined {
-        return autoUpdateId(this.state, this.matchedEntry?.serverId);
+        return RegistryEntryContext.autoUpdateId(this.state, this.matchedEntry?.serverId ?? this.local.registryMetadata?.serverId);
     }
 
     render(): React.ReactNode {
@@ -108,7 +108,7 @@ export class MCPSearchResultEntry implements TreeElement, RegistryEntryContext {
     }
 
     get autoUpdateId(): string | undefined {
-        return autoUpdateId(this.state, this.entry.serverId);
+        return RegistryEntryContext.autoUpdateId(this.state, this.entry.serverId);
     }
 
     render(): React.ReactNode {
@@ -125,14 +125,6 @@ export class MCPSearchResultEntry implements TreeElement, RegistryEntryContext {
             />
         );
     }
-}
-
-/**
- * An auto-update policy is only meaningful for a server that is installed and linked to a live
- * registry entry - which excludes drifted servers, as the auto-updater does.
- */
-function autoUpdateId(state: ClassificationResult, serverId: string | undefined): string | undefined {
-    return state.kind === 'installed-from-registry' ? serverId : undefined;
 }
 
 interface MCPCardProps {

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.spec.ts
@@ -192,6 +192,32 @@ describe('MCPExtensionsContribution.resolveInstalled', () => {
         expect(entries[0].state).to.deep.equal({ kind: 'installed-link-stale' });
     });
 
+    it('never surfaces a server owned by an installed Agent Plugin: the plugin is the installed artifact, not its components', async () => {
+        const prefs = new FakePreferenceService();
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryMetadata: {
+                    serverId: exampleRegistryEntry.serverId,
+                    version: exampleRegistryEntry.version,
+                    configHash: exampleRegistryEntry.configHash
+                }
+            },
+            bigquery: {
+                command: 'node',
+                args: ['server.js'],
+                registryMetadata: { pluginId: 'io.github.acme/bigquery-data-analytics' }
+            }
+        });
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const entries = [...await contribution.resolveInstalled()] as MCPInstalledEntry[];
+
+        expect(entries.map(e => e.local.name)).to.deep.equal(['example']);
+    });
+
     it('skips malformed stored entries whose `command` is not a string — mere key presence is not enough', async () => {
         const prefs = new FakePreferenceService();
         await prefs.set(MCP_SERVERS_PREF, {
@@ -286,6 +312,28 @@ describe('MCPExtensionsContribution.resolveSearchResults', () => {
 
         expect(exampleResult, 'registry entry must surface in search results').to.not.be.undefined;
         expect((exampleResult!.element as MCPSearchResultEntry).state).to.deep.equal({ kind: 'installed-link-stale' });
+    });
+
+    it('does not let a plugin-owned server mark a standalone registry entry as installed', async () => {
+        // The plugin's server happens to be stored under the registry entry's local name and with a
+        // matching config. It must not be considered when classifying that entry: it belongs to the
+        // plugin, is a different artifact, and the standalone entry is still installable on its own.
+        const prefs = new FakePreferenceService();
+        await prefs.set(MCP_SERVERS_PREF, {
+            example: {
+                command: 'npx',
+                args: ['-y', 'example-mcp'],
+                registryMetadata: { pluginId: 'io.github.acme/bigquery-data-analytics' }
+            }
+        });
+        const fetch = new StubRegistryFetchService([exampleRegistryEntry]);
+        const contribution = buildContainer(prefs, fetch).get(MCPExtensionsContribution);
+
+        const results = [...await contribution.resolveSearchResults('example', { verifiedOnly: false })];
+        const exampleResult = results.find(r => (r.element as MCPSearchResultEntry).entry.serverId === exampleRegistryEntry.serverId);
+
+        expect(exampleResult, 'registry entry must surface in search results').to.not.be.undefined;
+        expect((exampleResult!.element as MCPSearchResultEntry).state).to.deep.equal({ kind: 'not-installed' });
     });
 
     it('omits unverified entries when verifiedOnly is true and keeps verified ones', async () => {

--- a/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/mcp/mcp-extensions-contribution.ts
@@ -20,6 +20,7 @@ import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
 import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { MCPServerDescription } from '@theia/ai-mcp/lib/common/mcp-server-manager';
 import { MCPServerInstallDialogFactory } from '@theia/ai-mcp/lib/browser/mcp-server-install-dialog';
 import { RegistryFetchService } from '../../common/registry-fetch-service';
 import { RegistrySearchFilter } from '../../common/registry-search-filter';
@@ -94,6 +95,9 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
         const byName = new Map(registryEntries.map(e => [e.localName, e]));
         const result: TreeElement[] = [];
         for (const local of this.installService.listInstalledServers()) {
+            if (this.isPluginOwned(local)) {
+                continue;
+            }
             const state = this.installService.classifyLocalServer(local, registryEntries);
             // Hand-added local servers belong to the MCP configuration widget, not this view.
             // Stale-linked entries (registryMetadata.serverId set but registry no longer lists
@@ -113,7 +117,10 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             return [];
         }
         const registryEntries = await this.safeGetRegistryEntries();
-        const localDescriptions = this.installService.listInstalledServers();
+        // Plugin-owned servers are withheld here too: `classifyRegistryEntry` compares stored
+        // configs against registry entries, so a plugin's server could otherwise match a standalone
+        // registry entry and make that entry claim to be installed.
+        const localDescriptions = this.installService.listInstalledServers().filter(local => !this.isPluginOwned(local));
         const result: SearchResult[] = [];
         for (const entry of registryEntries) {
             // `verifiedOnly` comes from the OVSX-named `extensions.onlyShowVerifiedExtensions`
@@ -153,6 +160,16 @@ export class MCPExtensionsContribution implements ExtensionsSourceContribution, 
             this.logger.warn('AI registry fetch failed; MCP entries unavailable.', error);
             return [];
         }
+    }
+
+    /**
+     * Whether the installed server belongs to an installed Agent Plugin.
+     *
+     * Such a server is a component of its plugin, installed and removed with it, so it must never
+     * appear as a row of its own: the plugin is the single installed artifact the user manages.
+     */
+    protected isPluginOwned(local: MCPServerDescription): boolean {
+        return local.registryMetadata?.pluginId !== undefined;
     }
 
     /**

--- a/packages/ai-registry/src/browser/plugin/agent-plugin-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/plugin/agent-plugin-ui-bridge-impl.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/agent-plugin-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/plugin/agent-plugin-ui-bridge-impl.ts
@@ -1,0 +1,100 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, Event, ILogger } from '@theia/core';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { AgentPluginUiBridge, InstalledAgentPluginInfo } from '@theia/ai-core/lib/browser/agent-plugin-ui-bridge';
+import { VSXExtensionsContribution } from '@theia/vsx-registry/lib/browser/vsx-extensions-contribution';
+import { VSXExtensionsSearchModel } from '@theia/vsx-registry/lib/browser/vsx-extensions-search-model';
+import { PluginInstallClientImpl } from './plugin-install-client';
+import { PluginInstallService } from './plugin-install-service';
+
+/**
+ * Lets the AI configuration widgets label and reveal the plugin that supplied a skill or server,
+ * without `@theia/ai-core` or `@theia/ai-mcp` depending on this package. Cached because
+ * {@link getPlugin} is called from React renders and must answer synchronously.
+ */
+@injectable()
+export class AgentPluginUiBridgeImpl implements AgentPluginUiBridge {
+
+    @inject(PluginInstallService)
+    protected readonly installService: PluginInstallService;
+
+    @inject(PluginInstallClientImpl)
+    protected readonly installClient: PluginInstallClientImpl;
+
+    @inject(VSXExtensionsContribution)
+    protected readonly viewContribution: VSXExtensionsContribution;
+
+    @inject(VSXExtensionsSearchModel)
+    protected readonly searchModel: VSXExtensionsSearchModel;
+
+    @inject(ILogger) @named('ai-registry:AgentPluginUiBridgeImpl')
+    protected readonly logger: ILogger;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    protected plugins = new Map<string, InstalledAgentPluginInfo>();
+    /** Keyed by the qualifier a contributed skill root carries, which is not the plugin identifier. */
+    protected pluginsByQualifier = new Map<string, InstalledAgentPluginInfo>();
+
+    @postConstruct()
+    protected init(): void {
+        this.installClient.onDidChangeInstalledPlugins(() => this.refreshCache());
+        // Primed eagerly, or the first render shows no provenance until something changes.
+        this.refreshCache();
+    }
+
+    getPlugin(pluginId: string): InstalledAgentPluginInfo | undefined {
+        return this.plugins.get(pluginId);
+    }
+
+    getPluginByQualifier(qualifier: string): InstalledAgentPluginInfo | undefined {
+        return this.pluginsByQualifier.get(qualifier);
+    }
+
+    revealPlugin(pluginId: string): void {
+        if (!this.plugins.has(pluginId)) {
+            // Nothing to reveal; an empty search would just hide what the user was looking at.
+            return;
+        }
+        this.searchModel.query = pluginId;
+        this.viewContribution.openView({ activate: true }).catch(error =>
+            this.logger.warn(`Could not open the Extensions view to reveal the Agent Plugin "${pluginId}".`, error));
+    }
+
+    protected async refreshCache(): Promise<void> {
+        try {
+            const installed = await this.installService.listInstalledPlugins();
+            const next = new Map<string, InstalledAgentPluginInfo>();
+            const byQualifier = new Map<string, InstalledAgentPluginInfo>();
+            for (const info of installed) {
+                if (info.pluginId !== undefined) {
+                    const plugin = { pluginId: info.pluginId, name: info.name ?? info.pluginId };
+                    next.set(info.pluginId, plugin);
+                    byQualifier.set(info.qualifier ?? info.directoryName, plugin);
+                }
+            }
+            this.plugins = next;
+            this.pluginsByQualifier = byQualifier;
+            this.onDidChangeEmitter.fire();
+        } catch (error) {
+            // Left as-is: a stale label beats dropping every affordance over one failed call.
+            this.logger.warn('Could not list installed Agent Plugins; plugin provenance may be out of date.', error);
+        }
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/install-plugin-uri-configuration.ts
+++ b/packages/ai-registry/src/browser/plugin/install-plugin-uri-configuration.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/install-plugin-uri-configuration.ts
+++ b/packages/ai-registry/src/browser/plugin/install-plugin-uri-configuration.ts
@@ -1,0 +1,35 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+
+/**
+ * Defaults to `<electron-uri-scheme>://install-plugin`; products override by rebinding this class.
+ * The registry generates per-entry install URLs with the same scheme and authority.
+ */
+@injectable()
+export class InstallPluginUriConfiguration {
+
+    /** Must match `theia.frontend.config.electron.uriScheme` in the product's `package.json`. */
+    getScheme(): string {
+        return FrontendApplicationConfigProvider.get().electron?.uriScheme ?? 'theia';
+    }
+
+    getAuthority(): string {
+        return 'install-plugin';
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.spec.ts
@@ -1,0 +1,136 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// The handler imports the install service, which pulls in the DOM-touching install dialogs, so a
+// DOM has to exist while those modules are evaluated.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { MessageService } from '@theia/core';
+import URI from '@theia/core/lib/common/uri';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+import { PluginInstaller, PluginInstallOptions } from './plugin-installer';
+import { InstallPluginUriConfiguration } from './install-plugin-uri-configuration';
+import { InstallPluginUriHandler } from './install-plugin-uri-handler';
+
+disableJSDOM();
+
+// Stubbed rather than instantiated: the real configuration reads the frontend application config off
+// the window, which no longer exists once the DOM used for the imports is torn down.
+const configuration: InstallPluginUriConfiguration = {
+    getScheme: () => 'theia',
+    getAuthority: () => 'install-plugin'
+} as InstallPluginUriConfiguration;
+
+const entry: ResolvedPluginEntry = {
+    pluginId: 'io.github.acme/bigquery-data-analytics',
+    name: 'BigQuery Data Analytics',
+    description: 'Query and explore BigQuery',
+    sourceUrl: 'https://github.com/acme/bigquery-plugin',
+    contentHash: 'hash-v1',
+    endorsements: [{ organizationId: 'acme', date: '2026-08-07' }],
+    containedSkills: [],
+    containedMcpServers: []
+};
+
+interface RecordedInstall {
+    readonly entry: ResolvedPluginEntry;
+    readonly options: PluginInstallOptions;
+}
+
+class TestInstallPluginUriHandler extends InstallPluginUriHandler {
+
+    readonly errors: string[] = [];
+    readonly infos: string[] = [];
+    readonly installs: RecordedInstall[] = [];
+
+    constructor(entries: ResolvedPluginEntry[] | Error) {
+        super();
+        Object.assign(this, {
+            configuration,
+            messageService: {
+                error: (message: string) => this.errors.push(message),
+                info: (message: string) => this.infos.push(message)
+            } as unknown as MessageService,
+            fetchService: {
+                getPluginEntries: async () => {
+                    if (entries instanceof Error) {
+                        throw entries;
+                    }
+                    return entries;
+                }
+            } as unknown as RegistryFetchService,
+            installer: {
+                install: async (installEntry: ResolvedPluginEntry, options: PluginInstallOptions) => {
+                    this.installs.push({ entry: installEntry, options });
+                    return true;
+                }
+            } as PluginInstaller
+        });
+    }
+}
+
+describe('InstallPluginUriHandler', () => {
+
+    it('handles theia://install-plugin links and nothing else', () => {
+        const handler = new TestInstallPluginUriHandler([entry]);
+
+        expect(handler.canHandle(new URI('theia://install-plugin?id=io.github.acme/bigquery-data-analytics'))).to.equal(500);
+        expect(handler.canHandle(new URI('theia://install-skill?id=io.github.acme/some-skill'))).to.equal(0);
+        expect(handler.canHandle(new URI('file:///tmp/plugin'))).to.equal(0);
+    });
+
+    it('refuses an id the registry does not list, naming it, and installs nothing', async () => {
+        const handler = new TestInstallPluginUriHandler([entry]);
+
+        await handler.open(new URI('theia://install-plugin?id=io.github.acme/absent'));
+
+        expect(handler.installs).to.be.empty;
+        expect(handler.errors).to.have.length(1);
+        expect(handler.errors[0]).to.contain('io.github.acme/absent');
+    });
+
+    it('reports a missing id parameter instead of guessing a plugin', async () => {
+        const handler = new TestInstallPluginUriHandler([entry]);
+
+        await handler.open(new URI('theia://install-plugin'));
+
+        expect(handler.installs).to.be.empty;
+        expect(handler.errors).to.have.length(1);
+    });
+
+    it('reports a failed registry fetch, naming the requested plugin, and installs nothing', async () => {
+        const handler = new TestInstallPluginUriHandler(new Error('offline'));
+
+        await handler.open(new URI('theia://install-plugin?id=io.github.acme/bigquery-data-analytics'));
+
+        expect(handler.installs).to.be.empty;
+        expect(handler.errors[0]).to.contain('io.github.acme/bigquery-data-analytics');
+    });
+
+    it('installs the registry entry the id resolves to, always with the pre-install confirmation', async () => {
+        const handler = new TestInstallPluginUriHandler([entry]);
+
+        await handler.open(new URI('theia://install-plugin?id=io.github.acme/bigquery-data-analytics'));
+
+        expect(handler.installs).to.have.length(1);
+        expect(handler.installs[0].entry).to.equal(entry);
+        expect(handler.installs[0].options).to.deep.equal({ replaceExisting: false, confirm: true });
+        expect(handler.infos).to.have.length(1);
+    });
+});

--- a/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.ts
+++ b/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.ts
+++ b/packages/ai-registry/src/browser/plugin/install-plugin-uri-handler.ts
@@ -1,0 +1,103 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MessageService, nls } from '@theia/core';
+import { OpenHandler } from '@theia/core/lib/browser/opener-service';
+import URI from '@theia/core/lib/common/uri';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+import { InstallPluginUriConfiguration } from './install-plugin-uri-configuration';
+import { PluginInstaller } from './plugin-installer';
+
+const ID_PARAM = 'id';
+
+/**
+ * Handles `theia://install-plugin?id=<pluginId>`. Minimal on purpose: everything else is read from the
+ * registry by id, so a link can name a plugin but never describe one. An id the registry does not
+ * list is refused rather than installed from the link's own data.
+ */
+@injectable()
+export class InstallPluginUriHandler implements OpenHandler {
+
+    readonly id = 'install-plugin-uri-handler';
+
+    @inject(InstallPluginUriConfiguration)
+    protected readonly configuration: InstallPluginUriConfiguration;
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    @inject(PluginInstaller)
+    protected readonly installer: PluginInstaller;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    canHandle(uri: URI): number {
+        return uri.scheme === this.configuration.getScheme()
+            && uri.authority === this.configuration.getAuthority()
+            ? 500
+            : 0;
+    }
+
+    async open(uri: URI): Promise<object | undefined> {
+        const pluginId = this.extractPluginId(uri);
+        if (!pluginId) {
+            this.messageService.error(nls.localize(
+                'theia/ai-registry/plugin/installUri/missingId',
+                'Install link is missing the required "id" parameter.'
+            ));
+            return undefined;
+        }
+        let entries: ResolvedPluginEntry[];
+        try {
+            entries = await this.fetchService.getPluginEntries();
+        } catch {
+            this.messageService.error(nls.localize(
+                'theia/ai-registry/plugin/installUri/fetchFailed',
+                'Could not load the AI registry to install Agent Plugin "{0}".',
+                pluginId
+            ));
+            return undefined;
+        }
+        const entry = entries.find(candidate => candidate.pluginId === pluginId);
+        if (!entry) {
+            this.messageService.error(nls.localize(
+                'theia/ai-registry/plugin/installUri/unknownId',
+                'Agent Plugin "{0}" is not listed in your AI registry.',
+                pluginId
+            ));
+            return undefined;
+        }
+        try {
+            if (await this.installer.install(entry, { replaceExisting: false, confirm: true })) {
+                this.messageService.info(nls.localize(
+                    'theia/ai-registry/plugin/installUri/success',
+                    'Installed Agent Plugin "{0}" from the AI registry.',
+                    entry.name
+                ));
+            }
+        } catch (error) {
+            this.messageService.error(error instanceof Error ? error.message : String(error));
+        }
+        return undefined;
+    }
+
+    protected extractPluginId(uri: URI): string | undefined {
+        return new URLSearchParams(uri.query).get(ID_PARAM)?.trim() || undefined;
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
@@ -1,0 +1,142 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// Needed for the imports below; torn down again straight away, because another spec in this package
+// disables JSDOM at import time and these tests re-acquire it in `before` instead.
+let disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { HoverRequest, HoverService } from '@theia/core/lib/browser';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import * as React from '@theia/core/shared/react';
+import { createRoot, Root } from '@theia/core/shared/react-dom/client';
+import { flushSync } from '@theia/core/shared/react-dom';
+import { InstalledPluginInfo } from '../../common/plugin/plugin-registry-types';
+import { PluginEntryHandlers, PluginInstalledEntry } from './plugin-entries';
+
+disableJSDOM();
+
+const DIRECTORY_NAME = 'io.github.acme_tools';
+
+const handlers: PluginEntryHandlers = {
+    install: async () => undefined,
+    update: async () => undefined,
+    fixPlugin: async () => undefined,
+    link: async () => undefined,
+    unlink: async () => undefined,
+    uninstall: async () => undefined
+};
+
+/** Stands in for the core renderer; the markdown body is not what these tests are about. */
+const markdownRenderer: MarkdownRenderer = {
+    render: (markdown: MarkdownString | undefined) => {
+        const element = document.createElement('div');
+        element.textContent = markdown?.value ?? '';
+        return { element, dispose: () => { } };
+    }
+};
+
+function installed(overrides: Partial<InstalledPluginInfo> = {}): InstalledPluginInfo {
+    return {
+        directoryName: DIRECTORY_NAME,
+        root: `/home/u/.agents/plugins/${DIRECTORY_NAME}`,
+        dataRoot: `/home/u/.agents/plugin-data/${DIRECTORY_NAME}`,
+        pluginId: 'io.github.acme/tools',
+        contentHash: 'hash-v1',
+        qualifier: 'tools',
+        drifted: false,
+        name: 'Acme Tools',
+        skills: ['deploy'],
+        servers: [],
+        skipped: [],
+        ...overrides
+    };
+}
+
+describe('PluginInstalledEntry hover', () => {
+
+    before(() => {
+        disableJSDOM = enableJSDOM();
+    });
+
+    after(() => {
+        disableJSDOM();
+    });
+
+    let host: HTMLElement;
+    let root: Root | undefined;
+    let requested: HoverRequest | undefined;
+
+    const hoverService = {
+        requestHover: (request: HoverRequest) => { requested = request; },
+        cancelHover: () => { }
+    } as unknown as HoverService;
+
+    beforeEach(() => {
+        host = document.createElement('div');
+        document.body.appendChild(host);
+        requested = undefined;
+    });
+
+    afterEach(() => {
+        root?.unmount();
+        root = undefined;
+        host.remove();
+    });
+
+    /** Renders the entry and hovers the card, which is when the tooltip content is handed over. */
+    function hover(info: InstalledPluginInfo): HoverRequest['content'] {
+        const entry = new PluginInstalledEntry(info, undefined, { kind: 'installed-from-registry', updateAvailable: false },
+            handlers, hoverService, markdownRenderer);
+        root ??= createRoot(host);
+        flushSync(() => root!.render(<div>{entry.render()}</div>));
+        const card = host.querySelector('.theia-vsx-extension') as HTMLElement;
+        card.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+        return requested!.content;
+    }
+
+    it('hands over markdown for a plugin that loaded cleanly', () => {
+        const content = hover(installed());
+
+        expect(content).to.not.be.instanceOf(HTMLElement);
+        expect((content as MarkdownString).value).to.contain('Acme Tools');
+        // Names, so the hover says what the plugin actually brings rather than how many of each.
+        expect((content as MarkdownString).value).to.contain('deploy');
+    });
+
+    it('renders the reasons a component was skipped in the warning colour, not as more description', () => {
+        const content = hover(installed({ skipped: [{ name: 'broken', reason: 'The server configuration is not a JSON object.' }] }));
+
+        expect(content).to.be.instanceOf(HTMLElement);
+        const warning = (content as HTMLElement).querySelector('.theia-agent-plugin-hover-warning');
+        expect(warning?.textContent).to.contain('The server configuration is not a JSON object.');
+    });
+
+    it('reports a rejected mcp.json in the same warning run', () => {
+        const content = hover(installed({ mcpDisabledReason: '"mcp.json" is not valid JSON.' }));
+
+        const warning = (content as HTMLElement).querySelector('.theia-agent-plugin-hover-warning');
+        expect(warning?.textContent).to.contain('"mcp.json" is not valid JSON.');
+    });
+});

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
@@ -26,7 +26,7 @@ try {
 }
 
 import { expect } from 'chai';
-import { HoverRequest, HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverRequest, HoverService } from '@theia/core/lib/browser';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdown-string';
 import * as React from '@theia/core/shared/react';
@@ -93,6 +93,8 @@ describe('PluginInstalledEntry hover', () => {
         cancelHover: () => { }
     } as unknown as HoverService;
 
+    const contextMenuRenderer = { render: () => { } } as unknown as ContextMenuRenderer;
+
     beforeEach(() => {
         host = document.createElement('div');
         document.body.appendChild(host);
@@ -108,7 +110,7 @@ describe('PluginInstalledEntry hover', () => {
     /** Renders the entry and hovers the card, which is when the tooltip content is handed over. */
     function hover(info: InstalledPluginInfo): HoverRequest['content'] {
         const entry = new PluginInstalledEntry(info, undefined, { kind: 'installed-from-registry', updateAvailable: false },
-            handlers, hoverService, markdownRenderer);
+            handlers, hoverService, markdownRenderer, contextMenuRenderer);
         root ??= createRoot(host);
         flushSync(() => root!.render(<div>{entry.render()}</div>));
         const card = host.querySelector('.theia-vsx-extension') as HTMLElement;

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
@@ -32,7 +32,7 @@ import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdo
 import * as React from '@theia/core/shared/react';
 import { createRoot, Root } from '@theia/core/shared/react-dom/client';
 import { flushSync } from '@theia/core/shared/react-dom';
-import { InstalledPluginInfo } from '../../common/plugin/plugin-registry-types';
+import { InstalledPluginInfo, PluginClassificationResult } from '../../common/plugin/plugin-registry-types';
 import { PluginEntryHandlers, PluginInstalledEntry } from './plugin-entries';
 
 disableJSDOM();
@@ -73,6 +73,29 @@ function installed(overrides: Partial<InstalledPluginInfo> = {}): InstalledPlugi
         ...overrides
     };
 }
+
+describe('PluginInstalledEntry auto-update context', () => {
+
+    function entryFor(state: PluginClassificationResult, info = installed()): PluginInstalledEntry {
+        return new PluginInstalledEntry(info, undefined, state, handlers, hoverService, markdownRenderer, contextMenuRenderer);
+    }
+
+    const hoverService = {} as unknown as HoverService;
+    const contextMenuRenderer = {} as unknown as ContextMenuRenderer;
+
+    it('offers a policy for a drifted plugin, which shows a warning and has to be fixed first', () => {
+        expect(entryFor({ kind: 'fix-plugin' }, installed({ drifted: true })).autoUpdateId).to.equal('io.github.acme/tools');
+    });
+
+    it('keeps the policy of a plugin whose registry entry has gone missing, using the recorded identifier', () => {
+        // `matchedEntry` is undefined by definition here, so this only works via the local marker.
+        expect(entryFor({ kind: 'installed-link-stale' }).autoUpdateId).to.equal('io.github.acme/tools');
+    });
+
+    it('offers no policy for a directory the registry has never known', () => {
+        expect(entryFor({ kind: 'installed-user-added' }, installed({ pluginId: undefined })).autoUpdateId).to.be.undefined;
+    });
+});
 
 describe('PluginInstalledEntry hover', () => {
 

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.spec.tsx
@@ -29,7 +29,6 @@ import { expect } from 'chai';
 import { ContextMenuRenderer, HoverRequest, HoverService } from '@theia/core/lib/browser';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdown-string';
-import * as React from '@theia/core/shared/react';
 import { createRoot, Root } from '@theia/core/shared/react-dom/client';
 import { flushSync } from '@theia/core/shared/react-dom';
 import { InstalledPluginInfo, PluginClassificationResult } from '../../common/plugin/plugin-registry-types';

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
@@ -69,7 +69,7 @@ export class PluginInstalledEntry implements TreeElement, RegistryEntryContext {
     }
 
     get autoUpdateId(): string | undefined {
-        return autoUpdateId(this.state, this.local.pluginId ?? this.matchedEntry?.pluginId);
+        return RegistryEntryContext.autoUpdateId(this.state, this.local.pluginId ?? this.matchedEntry?.pluginId);
     }
 
     render(): React.ReactNode {
@@ -121,7 +121,7 @@ export class PluginSearchResultEntry implements TreeElement, RegistryEntryContex
     }
 
     get autoUpdateId(): string | undefined {
-        return autoUpdateId(this.state, this.entry.pluginId);
+        return RegistryEntryContext.autoUpdateId(this.state, this.entry.pluginId);
     }
 
     render(): React.ReactNode {
@@ -144,14 +144,6 @@ export class PluginSearchResultEntry implements TreeElement, RegistryEntryContex
             />
         );
     }
-}
-
-/**
- * An auto-update policy is only meaningful for a plugin that is installed and linked to a live
- * registry entry - which excludes drifted plugins, as the auto-updater does.
- */
-function autoUpdateId(state: PluginClassificationResult, pluginId: string | undefined): string | undefined {
-    return state.kind === 'installed-from-registry' ? pluginId : undefined;
 }
 
 interface PluginDiagnostics {

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
@@ -16,13 +16,16 @@
 
 import * as React from '@theia/core/shared/react';
 import { nls } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { TypeBadge } from '@theia/vsx-registry/lib/browser/type-badge';
 import { ExtensionCard } from '@theia/vsx-registry/lib/browser/extension-card';
+import { RegistryArtifactKind } from '../../common/ai-registry-preferences';
 import { InstalledPluginInfo, PluginClassificationResult, ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+import { RegistryEntryContext } from '../registry-entry-context';
+import { RegistryEntryGear, RegistryEntryMenuEvent, showEntryMenu } from '../registry-entry-menu';
 
 export const AGENT_PLUGINS_LABEL = nls.localizeByDefault('Agent Plugins');
 
@@ -41,9 +44,10 @@ export interface PluginEntryHandlers {
     uninstall(pluginId: string): Promise<void>;
 }
 
-export class PluginInstalledEntry implements TreeElement {
+export class PluginInstalledEntry implements TreeElement, RegistryEntryContext {
 
     readonly id: string;
+    readonly artifactKind: RegistryArtifactKind = 'plugin';
     /** Precomputed so the Link action's argument stays stable across renders. */
     protected readonly linkTarget: PluginLinkTarget | undefined;
 
@@ -53,10 +57,19 @@ export class PluginInstalledEntry implements TreeElement {
         readonly state: PluginClassificationResult,
         readonly handlers: PluginEntryHandlers,
         readonly hoverService: HoverService,
-        readonly markdownRenderer: MarkdownRenderer
+        readonly markdownRenderer: MarkdownRenderer,
+        readonly contextMenuRenderer: ContextMenuRenderer
     ) {
         this.id = `agent-plugin-installed-${local.directoryName}`;
         this.linkTarget = matchedEntry && { entry: matchedEntry, directoryName: local.directoryName };
+    }
+
+    get copyableId(): string | undefined {
+        return this.local.pluginId ?? this.matchedEntry?.pluginId ?? this.local.directoryName;
+    }
+
+    get autoUpdateId(): string | undefined {
+        return autoUpdateId(this.state, this.local.pluginId ?? this.matchedEntry?.pluginId);
     }
 
     render(): React.ReactNode {
@@ -76,15 +89,17 @@ export class PluginInstalledEntry implements TreeElement {
                 diagnostics={diagnostics}
                 hoverService={this.hoverService}
                 markdownRenderer={this.markdownRenderer}
+                onManage={event => showEntryMenu(event, this, this.contextMenuRenderer)}
                 actions={renderActions(this.state, this.matchedEntry, identifier, this.linkTarget, this.handlers)}
             />
         );
     }
 }
 
-export class PluginSearchResultEntry implements TreeElement {
+export class PluginSearchResultEntry implements TreeElement, RegistryEntryContext {
 
     readonly id: string;
+    readonly artifactKind: RegistryArtifactKind = 'plugin';
     protected readonly linkTarget: PluginLinkTarget | undefined;
 
     constructor(
@@ -93,11 +108,20 @@ export class PluginSearchResultEntry implements TreeElement {
         readonly handlers: PluginEntryHandlers,
         readonly hoverService: HoverService,
         readonly markdownRenderer: MarkdownRenderer,
+        readonly contextMenuRenderer: ContextMenuRenderer,
         /** Directory of an unlinked local copy of this plugin, when there is one to adopt. */
         readonly linkDirectoryName?: string
     ) {
         this.id = `agent-plugin-search-${entry.pluginId}`;
         this.linkTarget = linkDirectoryName !== undefined ? { entry, directoryName: linkDirectoryName } : undefined;
+    }
+
+    get copyableId(): string | undefined {
+        return this.entry.pluginId;
+    }
+
+    get autoUpdateId(): string | undefined {
+        return autoUpdateId(this.state, this.entry.pluginId);
     }
 
     render(): React.ReactNode {
@@ -115,10 +139,19 @@ export class PluginSearchResultEntry implements TreeElement {
                 servers={servers}
                 hoverService={this.hoverService}
                 markdownRenderer={this.markdownRenderer}
+                onManage={event => showEntryMenu(event, this, this.contextMenuRenderer)}
                 actions={renderActions(this.state, this.entry, this.entry.pluginId, this.linkTarget, this.handlers)}
             />
         );
     }
+}
+
+/**
+ * An auto-update policy is only meaningful for a plugin that is installed and linked to a live
+ * registry entry - which excludes drifted plugins, as the auto-updater does.
+ */
+function autoUpdateId(state: PluginClassificationResult, pluginId: string | undefined): string | undefined {
+    return state.kind === 'installed-from-registry' ? pluginId : undefined;
 }
 
 interface PluginDiagnostics {
@@ -139,6 +172,7 @@ interface PluginCardProps {
     diagnostics?: PluginDiagnostics;
     hoverService: HoverService;
     markdownRenderer: MarkdownRenderer;
+    onManage: (event: RegistryEntryMenuEvent) => void;
     actions?: React.ReactNode;
 }
 
@@ -247,6 +281,7 @@ const PluginCard: React.FC<PluginCardProps> = props => (
         // Only endorsed plugins are published and the feed has no per-plugin verified flag.
         trust="verified"
         hover={{ content: buildHoverContent(props), hoverService: props.hoverService }}
+        onContextMenu={props.onManage}
         actions={
             <div className="theia-agent-plugin-extension-actions">
                 {props.diagnostics && (
@@ -256,12 +291,7 @@ const PluginCard: React.FC<PluginCardProps> = props => (
                     </span>
                 )}
                 {props.actions}
-                {/* Reserves the width VSX cards use for their context-menu gear, so every card type's
-                    action bar ends at the same place. Same placeholder the MCP and skill cards use. */}
-                <div
-                    className="codicon codicon-settings-gear action theia-agent-plugin-extension-gear-placeholder"
-                    aria-hidden="true"
-                />
+                <RegistryEntryGear className="theia-agent-plugin-extension-gear" onManage={props.onManage} />
             </div>
         }
     />

--- a/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-entries.tsx
@@ -1,0 +1,374 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+import { MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { TypeBadge } from '@theia/vsx-registry/lib/browser/type-badge';
+import { ExtensionCard } from '@theia/vsx-registry/lib/browser/extension-card';
+import { InstalledPluginInfo, PluginClassificationResult, ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+
+export const AGENT_PLUGINS_LABEL = nls.localizeByDefault('Agent Plugins');
+
+export interface PluginLinkTarget {
+    readonly entry: ResolvedPluginEntry;
+    readonly directoryName: string;
+}
+
+/** Entries close over these, so no React-level component injects the install service. */
+export interface PluginEntryHandlers {
+    install(entry: ResolvedPluginEntry): Promise<void>;
+    update(entry: ResolvedPluginEntry): Promise<void>;
+    fixPlugin(entry: ResolvedPluginEntry): Promise<void>;
+    link(target: PluginLinkTarget): Promise<void>;
+    unlink(pluginId: string): Promise<void>;
+    uninstall(pluginId: string): Promise<void>;
+}
+
+export class PluginInstalledEntry implements TreeElement {
+
+    readonly id: string;
+    /** Precomputed so the Link action's argument stays stable across renders. */
+    protected readonly linkTarget: PluginLinkTarget | undefined;
+
+    constructor(
+        readonly local: InstalledPluginInfo,
+        readonly matchedEntry: ResolvedPluginEntry | undefined,
+        readonly state: PluginClassificationResult,
+        readonly handlers: PluginEntryHandlers,
+        readonly hoverService: HoverService,
+        readonly markdownRenderer: MarkdownRenderer
+    ) {
+        this.id = `agent-plugin-installed-${local.directoryName}`;
+        this.linkTarget = matchedEntry && { entry: matchedEntry, directoryName: local.directoryName };
+    }
+
+    render(): React.ReactNode {
+        const identifier = this.local.pluginId ?? this.matchedEntry?.pluginId ?? this.local.directoryName;
+        const diagnostics = buildDiagnostics(this.local);
+        const serverNames = this.local.servers.map(server => server.name);
+        return (
+            <PluginCard
+                title={this.local.name ?? this.matchedEntry?.name ?? this.local.directoryName}
+                description={this.matchedEntry?.description}
+                identifier={identifier}
+                // From the root, which is authoritative once on disk and wins over the feed.
+                stat={buildStat(this.local.skills, serverNames)}
+                version={this.local.version ?? this.matchedEntry?.version}
+                skills={this.local.skills}
+                servers={serverNames}
+                diagnostics={diagnostics}
+                hoverService={this.hoverService}
+                markdownRenderer={this.markdownRenderer}
+                actions={renderActions(this.state, this.matchedEntry, identifier, this.linkTarget, this.handlers)}
+            />
+        );
+    }
+}
+
+export class PluginSearchResultEntry implements TreeElement {
+
+    readonly id: string;
+    protected readonly linkTarget: PluginLinkTarget | undefined;
+
+    constructor(
+        readonly entry: ResolvedPluginEntry,
+        readonly state: PluginClassificationResult,
+        readonly handlers: PluginEntryHandlers,
+        readonly hoverService: HoverService,
+        readonly markdownRenderer: MarkdownRenderer,
+        /** Directory of an unlinked local copy of this plugin, when there is one to adopt. */
+        readonly linkDirectoryName?: string
+    ) {
+        this.id = `agent-plugin-search-${entry.pluginId}`;
+        this.linkTarget = linkDirectoryName !== undefined ? { entry, directoryName: linkDirectoryName } : undefined;
+    }
+
+    render(): React.ReactNode {
+        const skills = this.entry.containedSkills.map(skill => skill.name);
+        const servers = this.entry.containedMcpServers.map(server => server.name);
+        return (
+            <PluginCard
+                title={this.entry.name}
+                description={this.entry.description}
+                identifier={this.entry.pluginId}
+                // Nothing on disk yet, so these are what the registry last found.
+                stat={buildStat(skills, servers)}
+                version={this.entry.version}
+                skills={skills}
+                servers={servers}
+                hoverService={this.hoverService}
+                markdownRenderer={this.markdownRenderer}
+                actions={renderActions(this.state, this.entry, this.entry.pluginId, this.linkTarget, this.handlers)}
+            />
+        );
+    }
+}
+
+interface PluginDiagnostics {
+    readonly summary: string;
+    readonly detail: string;
+}
+
+interface PluginCardProps {
+    title: string;
+    description?: string;
+    /** Shown in the publisher-row slot. */
+    identifier: string;
+    version?: string;
+    stat?: string;
+    /** Names, not a count: the hover is where the user finds out what a plugin actually brings. */
+    skills: string[];
+    servers: string[];
+    diagnostics?: PluginDiagnostics;
+    hoverService: HoverService;
+    markdownRenderer: MarkdownRenderer;
+    actions?: React.ReactNode;
+}
+
+/**
+ * Markdown while the plugin loaded cleanly, which is the common case. A plugin with diagnostics gets
+ * an element instead, because the markdown renderer escapes HTML and the reasons have to read as
+ * warnings rather than as more description.
+ */
+function buildHoverContent(props: PluginCardProps): MarkdownStringImpl | HTMLElement {
+    const lines = [`**${props.title}**`];
+    if (props.description) {
+        lines.push('', props.description);
+    }
+    appendNamedList(lines, nls.localizeByDefault('Skills'), props.skills);
+    appendNamedList(lines, nls.localizeByDefault('MCP Servers'), props.servers);
+    lines.push('', `_${props.identifier}_`);
+    const markdown = new MarkdownStringImpl(lines.join('\n'));
+    if (!props.diagnostics) {
+        return markdown;
+    }
+    const host = document.createElement('div');
+    host.appendChild(props.markdownRenderer.render(markdown).element);
+    const warning = document.createElement('div');
+    warning.className = 'theia-agent-plugin-hover-warning';
+    // One reason per line; `textContent` keeps the reasons out of the markup, and the class carries
+    // the colour so a skipped component does not read like part of the description.
+    warning.textContent = props.diagnostics.detail;
+    host.appendChild(warning);
+    return host;
+}
+
+/** A heading and one bullet per name, so the hover answers "what is in this plugin". */
+function appendNamedList(lines: string[], heading: string, names: string[]): void {
+    if (names.length === 0) {
+        return;
+    }
+    lines.push('', `**${heading}**`, ...names.map(name => `- ${name}`));
+}
+
+/** `3 skills · 1 MCP server`, omitting whichever part is empty. The card renders the version itself. */
+function buildStat(skills: string[], servers: string[]): string | undefined {
+    const parts: string[] = [];
+    if (skills.length > 0) {
+        parts.push(skills.length === 1
+            ? nls.localizeByDefault('1 skill')
+            : nls.localizeByDefault('{0} skills', skills.length));
+    }
+    if (servers.length > 0) {
+        parts.push(servers.length === 1
+            ? nls.localize('theia/ai-registry/plugin/stat/oneServer', '1 MCP server')
+            : nls.localize('theia/ai-registry/plugin/stat/servers', '{0} MCP servers', servers.length));
+    }
+    return parts.length > 0 ? parts.join(' · ') : undefined;
+}
+
+/** Failures are isolated per component, so without this a half-loaded plugin looks like a loaded one. */
+function buildDiagnostics(info: InstalledPluginInfo): PluginDiagnostics | undefined {
+    const problems = info.skipped.map(component => nls.localizeByDefault('{0}: {1}', component.name, component.reason));
+    if (info.mcpDisabledReason !== undefined) {
+        problems.unshift(info.mcpDisabledReason);
+    }
+    if (problems.length === 0) {
+        return undefined;
+    }
+    const detail = problems.join('\n');
+    if (info.skipped.length === 0) {
+        return { summary: nls.localize('theia/ai-registry/plugin/diagnostics/mcpDisabled', 'MCP configuration ignored'), detail };
+    }
+    if (info.skipped.length === 1 && info.mcpDisabledReason === undefined) {
+        return {
+            summary: nls.localize(
+                'theia/ai-registry/plugin/diagnostics/oneSkipped', 'Component "{0}" skipped: {1}', info.skipped[0].name, info.skipped[0].reason
+            ),
+            detail
+        };
+    }
+    // Skipped components only: a rejected `mcp.json` is the whole type being unusable, so it gets
+    // its own clause rather than being added to the tally.
+    const skipped = nls.localize('theia/ai-registry/plugin/diagnostics/manySkipped', '{0} components skipped', info.skipped.length);
+    return {
+        summary: info.mcpDisabledReason === undefined
+            ? skipped
+            : nls.localize('theia/ai-registry/plugin/diagnostics/mcpDisabledAndSkipped', 'MCP configuration ignored, {0}', skipped),
+        detail
+    };
+}
+
+/** `codicon-package` rather than `codicon-extensions`, which the VS Code extension section owns. */
+const PluginCard: React.FC<PluginCardProps> = props => (
+    <ExtensionCard
+        title={props.title}
+        version={props.version}
+        description={props.description}
+        icon={<i className="codicon codicon-package" />}
+        iconClassName="theia-agent-plugin-extension-icon"
+        typeBadge={
+            <TypeBadge
+                icon={<i className="codicon codicon-package" />}
+                label={AGENT_PLUGINS_LABEL}
+                variant="agent-plugin"
+            />
+        }
+        stat={props.stat}
+        publisher={props.identifier}
+        publisherTitle={props.identifier}
+        // Only endorsed plugins are published and the feed has no per-plugin verified flag.
+        trust="verified"
+        hover={{ content: buildHoverContent(props), hoverService: props.hoverService }}
+        actions={
+            <div className="theia-agent-plugin-extension-actions">
+                {props.diagnostics && (
+                    <span className="theia-agent-plugin-extension-diagnostics" title={props.diagnostics.detail}>
+                        <i className="codicon codicon-warning theia-agent-plugin-extension-warning" />
+                        {props.diagnostics.summary}
+                    </span>
+                )}
+                {props.actions}
+                {/* Reserves the width VSX cards use for their context-menu gear, so every card type's
+                    action bar ends at the same place. Same placeholder the MCP and skill cards use. */}
+                <div
+                    className="codicon codicon-settings-gear action theia-agent-plugin-extension-gear-placeholder"
+                    aria-hidden="true"
+                />
+            </div>
+        }
+    />
+);
+
+interface ActionButtonProps<T> {
+    readonly label: string;
+    /** Kept stable by the owning entry so the click handler can be cached. */
+    readonly argument: T;
+    readonly run: (argument: T) => void;
+    readonly prominent?: boolean;
+    readonly title?: string;
+}
+
+/** The handler comes from a stable `(run, argument)` pair, not an inline arrow, so React can cache it. */
+function ActionButton<T>(props: ActionButtonProps<T>): React.ReactElement {
+    const { run, argument } = props;
+    const onClick = React.useCallback(() => run(argument), [run, argument]);
+    return (
+        <button
+            className={props.prominent ? 'theia-button prominent action' : 'theia-button action'}
+            title={props.title}
+            onClick={onClick}
+        >
+            {props.label}
+        </button>
+    );
+}
+
+/** State-driven, and identical in the Installed and Search sections. */
+function renderActions(
+    state: PluginClassificationResult,
+    registryEntry: ResolvedPluginEntry | undefined,
+    pluginId: string,
+    linkTarget: PluginLinkTarget | undefined,
+    handlers: PluginEntryHandlers
+): React.ReactNode {
+    switch (state.kind) {
+        case 'not-installed':
+            return registryEntry && (
+                <ActionButton argument={registryEntry} run={handlers.install} label={nls.localizeByDefault('Install')} prominent={true} />
+            );
+        case 'installed-from-registry':
+            return (
+                <>
+                    {state.updateAvailable && registryEntry && (
+                        <ActionButton argument={registryEntry} run={handlers.update} label={nls.localizeByDefault('Update')} prominent={true} />
+                    )}
+                    <ActionButton argument={pluginId} run={handlers.uninstall} label={nls.localizeByDefault('Uninstall')} />
+                </>
+            );
+        case 'installed-manually':
+            return linkTarget && (
+                <ActionButton
+                    argument={linkTarget}
+                    run={handlers.link}
+                    label={nls.localize('theia/ai-registry/plugin/action/link', 'Link to registry')}
+                    title={nls.localize(
+                        'theia/ai-registry/plugin/warning/manual',
+                        'This directory was not installed from the registry. Linking records where it came from without changing its files.'
+                    )}
+                />
+            );
+        case 'fix-plugin': {
+            const tooltip = nls.localize(
+                'theia/ai-registry/plugin/warning/fix',
+                "This plugin's files differ from what was installed. Click 'Fix Plugin' to download the endorsed content again."
+            );
+            return (
+                <>
+                    <i className="codicon codicon-warning theia-agent-plugin-extension-warning" title={tooltip} />
+                    {registryEntry && (
+                        <ActionButton
+                            argument={registryEntry}
+                            run={handlers.fixPlugin}
+                            label={nls.localize('theia/ai-registry/plugin/action/fix', 'Fix Plugin')}
+                            prominent={true}
+                        />
+                    )}
+                    <ActionButton argument={pluginId} run={handlers.uninstall} label={nls.localizeByDefault('Uninstall')} />
+                </>
+            );
+        }
+        case 'installed-link-stale': {
+            const tooltip = nls.localize(
+                'theia/ai-registry/plugin/warning/linkStale',
+                'This plugin was installed from the registry, but the registry no longer lists it. Click Unlink to drop the registry link and '
+                + 'keep the files, or Uninstall to remove the plugin.'
+            );
+            return (
+                <>
+                    <span className="theia-agent-plugin-extension-link-stale-message" title={tooltip}>
+                        <i className="codicon codicon-warning theia-agent-plugin-extension-warning" />
+                        {nls.localize('theia/ai-registry/plugin/warning/notInRegistry', 'Not in registry')}
+                    </span>
+                    <ActionButton
+                        argument={pluginId}
+                        run={handlers.unlink}
+                        label={nls.localize('theia/ai-registry/plugin/action/unlink', 'Unlink')}
+                        title={tooltip}
+                    />
+                    <ActionButton argument={pluginId} run={handlers.uninstall} label={nls.localizeByDefault('Uninstall')} />
+                </>
+            );
+        }
+        case 'installed-user-added':
+            // Filtered out by `resolveInstalled`; kept as an exhaustiveness guard.
+            return undefined;
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.spec.ts
@@ -1,0 +1,213 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// The contribution reaches the Extensions view and the hover service at import time.
+const disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { Emitter, ILogger, MessageService } from '@theia/core';
+import { InstalledPluginInfo, ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+import { PluginInstallService } from './plugin-install-service';
+import { PluginInstaller } from './plugin-installer';
+import { PluginMcpRegistrar } from './plugin-mcp-registrar';
+import { PluginExtensionsContribution } from './plugin-extensions-contribution';
+
+after(() => disableJSDOM());
+
+const DIRECTORY_NAME = 'io.github.acme_tools';
+
+const entry: ResolvedPluginEntry = {
+    pluginId: 'io.github.acme/tools',
+    name: 'Acme Tools',
+    description: 'Tools',
+    sourceUrl: 'https://github.com/acme/tools',
+    contentHash: 'hash-v1',
+    endorsements: [{ organizationId: 'acme', date: '2026-08-07' }],
+    containedSkills: [],
+    containedMcpServers: []
+};
+
+function installed(): InstalledPluginInfo {
+    return {
+        directoryName: DIRECTORY_NAME,
+        root: `/home/u/.agents/plugins/${DIRECTORY_NAME}`,
+        dataRoot: `/home/u/.agents/plugin-data/${DIRECTORY_NAME}`,
+        pluginId: entry.pluginId,
+        contentHash: 'hash-v1',
+        drifted: false,
+        skills: [],
+        servers: [],
+        skipped: []
+    };
+}
+
+/** Records what the contribution did, which is all these tests are about. */
+interface Recorder {
+    calls: string[];
+    infos: string[];
+    registered: InstalledPluginInfo[];
+    changes: number;
+}
+
+function contribution(overrides: {
+    install?: () => Promise<boolean>;
+    link?: () => Promise<InstalledPluginInfo>;
+} = {}): { instance: PluginExtensionsContribution; recorder: Recorder } {
+    const recorder: Recorder = { calls: [], infos: [], registered: [], changes: 0 };
+    const instance = new PluginExtensionsContribution();
+    Object.assign(instance, {
+        installService: {
+            link: async () => {
+                recorder.calls.push('link');
+                return overrides.link ? overrides.link() : installed();
+            },
+            unlink: async () => { recorder.calls.push('unlink'); },
+            uninstall: async () => { recorder.calls.push('uninstall'); }
+        } as unknown as PluginInstallService,
+        installer: {
+            install: async () => {
+                recorder.calls.push('install');
+                return overrides.install ? overrides.install() : true;
+            }
+        } as unknown as PluginInstaller,
+        mcpRegistrar: {
+            register: async (info: InstalledPluginInfo) => {
+                recorder.calls.push('register');
+                recorder.registered.push(info);
+            },
+            unregister: async () => { recorder.calls.push('unregister'); }
+        } as unknown as PluginMcpRegistrar,
+        messageService: {
+            info: (message: string) => { recorder.infos.push(message); },
+            error: (message: string) => { recorder.calls.push(`error:${message}`); }
+        } as unknown as MessageService,
+        fetchService: { onDidChange: new Emitter<void>().event },
+        installClient: {
+            onDidChangeInstalledPlugins: new Emitter<void>().event,
+            onDidStopWatching: new Emitter<void>().event
+        },
+        logger: { warn: () => undefined, error: () => undefined } as unknown as ILogger
+    });
+    // `init` is the @postConstruct hook that builds the handler bag.
+    (instance as unknown as { init(): void }).init();
+    instance.onDidChange(() => recorder.changes++);
+    return { instance, recorder };
+}
+
+/** The handler bag the entries dispatch through; `protected` on the contribution. */
+function handlers(instance: PluginExtensionsContribution): {
+    install(entry: ResolvedPluginEntry): Promise<void>;
+    link(target: { entry: ResolvedPluginEntry; directoryName: string }): Promise<void>;
+    unlink(pluginId: string): Promise<void>;
+    uninstall(pluginId: string): Promise<void>;
+} {
+    return (instance as unknown as { handlers: ReturnType<typeof handlers> }).handlers;
+}
+
+describe('PluginExtensionsContribution link', () => {
+
+    it("registers the adopted plugin's MCP servers, so a linked plugin's servers actually run", async () => {
+        const { instance, recorder } = contribution();
+
+        await handlers(instance).link({ entry, directoryName: DIRECTORY_NAME });
+
+        expect(recorder.calls).to.deep.equal(['link', 'register']);
+        expect(recorder.registered[0].pluginId).to.equal(entry.pluginId);
+    });
+
+    it('registers the record link returned rather than listing the plugins root again', async () => {
+        const adopted = { ...installed(), name: 'Adopted From Link' };
+        const { instance, recorder } = contribution({ link: async () => adopted });
+
+        await handlers(instance).link({ entry, directoryName: DIRECTORY_NAME });
+
+        expect(recorder.registered[0]).to.equal(adopted);
+    });
+
+    it('reports the failure and registers nothing when the adoption itself fails', async () => {
+        const { instance, recorder } = contribution({
+            link: async () => { throw new Error('no such directory'); }
+        });
+
+        await handlers(instance).link({ entry, directoryName: DIRECTORY_NAME });
+
+        expect(recorder.calls).to.deep.equal(['link', 'error:no such directory']);
+        expect(recorder.infos).to.be.empty;
+    });
+
+    it('unregisters before dropping the marker on unlink, the mirror of link', async () => {
+        const { instance, recorder } = contribution();
+
+        await handlers(instance).unlink(entry.pluginId);
+
+        expect(recorder.calls).to.deep.equal(['unregister', 'unlink']);
+    });
+
+    it('unregisters before removing the root on uninstall', async () => {
+        const { instance, recorder } = contribution();
+
+        await handlers(instance).uninstall(entry.pluginId);
+
+        expect(recorder.calls).to.deep.equal(['unregister', 'uninstall']);
+    });
+});
+
+describe('PluginExtensionsContribution runAction', () => {
+
+    it('reports success and refreshes the view when the action did something', async () => {
+        const { instance, recorder } = contribution();
+
+        await handlers(instance).install(entry);
+
+        expect(recorder.infos).to.have.lengthOf(1);
+        expect(recorder.infos[0]).to.contain('Acme Tools');
+        expect(recorder.changes).to.equal(1);
+    });
+
+    it('stays silent when the user cancelled a dialog, but still refreshes the view', async () => {
+        const { instance, recorder } = contribution({ install: async () => false });
+
+        await handlers(instance).install(entry);
+
+        expect(recorder.infos).to.be.empty;
+        expect(recorder.changes).to.equal(1);
+    });
+
+    it('reports success for an action that returns nothing, which is not a cancellation', async () => {
+        const { instance, recorder } = contribution();
+
+        await handlers(instance).uninstall(entry.pluginId);
+
+        expect(recorder.infos).to.have.lengthOf(1);
+    });
+
+    it('refreshes the view even when the action threw, so the UI matches what is on disk', async () => {
+        const { instance, recorder } = contribution({ install: async () => { throw new Error('download failed'); } });
+
+        await handlers(instance).install(entry);
+
+        expect(recorder.infos).to.be.empty;
+        expect(recorder.calls).to.contain('error:download failed');
+        expect(recorder.changes).to.equal(1);
+    });
+});

--- a/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.ts
@@ -1,0 +1,219 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Disposable, DisposableCollection, Emitter, Event, ILogger, MessageService, nls } from '@theia/core';
+import { HoverService } from '@theia/core/lib/browser';
+import { CoreMarkdownRenderer, MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
+import { TreeElement } from '@theia/core/lib/browser/source-tree';
+import { WindowService } from '@theia/core/lib/browser/window/window-service';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { ExtensionsSourceContribution, SearchContext, SearchResult } from '@theia/vsx-registry/lib/browser/extensions-source-contribution';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { RegistrySearchFilter } from '../../common/registry-search-filter';
+import { ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+import { PluginInstallClientImpl } from './plugin-install-client';
+import { PluginInstallService } from './plugin-install-service';
+import { PluginInstaller } from './plugin-installer';
+import { PluginMcpRegistrar } from './plugin-mcp-registrar';
+import { AGENT_PLUGINS_LABEL, PluginEntryHandlers, PluginInstalledEntry, PluginSearchResultEntry } from './plugin-entries';
+
+/**
+ * Agent Plugins section of the Extensions view. A plugin is exactly one row: its skills and servers
+ * never appear as rows of their own, which would suggest they can be installed or removed alone.
+ */
+@injectable()
+export class PluginExtensionsContribution implements ExtensionsSourceContribution, Disposable {
+
+    readonly type = 'agent-plugin';
+    readonly displayName = AGENT_PLUGINS_LABEL;
+    readonly searchToken = '@agent-plugins';
+    // Agent Plugins sort below skills (200), which sort below MCP servers and extensions.
+    readonly priority = 300;
+
+    @inject(PluginInstallService)
+    protected readonly installService: PluginInstallService;
+
+    @inject(PluginInstaller)
+    protected readonly installer: PluginInstaller;
+
+    @inject(PluginMcpRegistrar)
+    protected readonly mcpRegistrar: PluginMcpRegistrar;
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    @inject(HoverService)
+    protected readonly hoverService: HoverService;
+
+    @inject(CoreMarkdownRenderer)
+    protected readonly markdownRenderer: MarkdownRenderer;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    @inject(WindowService)
+    protected readonly windowService: WindowService;
+
+    @inject(PluginInstallClientImpl)
+    protected readonly installClient: PluginInstallClientImpl;
+
+    @inject(RegistrySearchFilter)
+    protected readonly searchFilter: RegistrySearchFilter;
+
+    @inject(ILogger) @named('ai-registry:PluginExtensionsContribution')
+    protected readonly logger: ILogger;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection(this.onDidChangeEmitter);
+
+    protected handlers: PluginEntryHandlers;
+
+    @postConstruct()
+    protected init(): void {
+        this.handlers = {
+            install: entry => this.runAction(
+                () => this.installer.install(entry, { replaceExisting: false, confirm: true }),
+                nls.localize('theia/ai-registry/plugin/installed', 'Installed Agent Plugin "{0}".', entry.name)),
+            update: entry => this.runAction(
+                () => this.installer.install(entry, { replaceExisting: true, confirm: false }),
+                nls.localize('theia/ai-registry/plugin/updated', 'Updated Agent Plugin "{0}".', entry.name)),
+            fixPlugin: entry => this.runAction(
+                () => this.installer.install(entry, { replaceExisting: true, confirm: false }),
+                nls.localize('theia/ai-registry/plugin/fixed', 'Restored Agent Plugin "{0}".', entry.name)),
+            link: target => this.runAction(
+                () => this.link(target.entry, target.directoryName),
+                nls.localize('theia/ai-registry/plugin/linked', 'Linked Agent Plugin "{0}".', target.entry.name)
+            ),
+            unlink: pluginId => this.runAction(
+                () => this.unlink(pluginId),
+                nls.localize('theia/ai-registry/plugin/unlinked', 'Unlinked Agent Plugin "{0}".', pluginId)
+            ),
+            uninstall: pluginId => this.runAction(
+                () => this.uninstall(pluginId),
+                nls.localize('theia/ai-registry/plugin/uninstalled', 'Uninstalled Agent Plugin "{0}".', pluginId)
+            )
+        };
+        this.toDispose.push(this.fetchService.onDidChange(() => this.onDidChangeEmitter.fire()));
+        this.toDispose.push(this.installClient.onDidChangeInstalledPlugins(() => this.onDidChangeEmitter.fire()));
+        this.toDispose.push(this.installClient.onDidStopWatching(() => this.promptWatcherReload()));
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    async resolveInstalled(): Promise<Iterable<TreeElement>> {
+        const installed = await this.installService.listInstalledPlugins();
+        const registryEntries = await this.safeGetPluginEntries();
+        const byPluginId = new Map(registryEntries.map(entry => [entry.pluginId, entry]));
+        const result: TreeElement[] = [];
+        for (const info of installed) {
+            const state = this.installService.classifyInstalledPlugin(info, registryEntries);
+            // Hand-placed directories belong to the user's own management, not this view.
+            if (state.kind === 'installed-user-added') {
+                continue;
+            }
+            const matchedEntry = (info.pluginId && byPluginId.get(info.pluginId))
+                || registryEntries.find(entry => this.installService.findLinkDirectory(entry, [info]) !== undefined);
+            result.push(new PluginInstalledEntry(info, matchedEntry, state, this.handlers, this.hoverService, this.markdownRenderer));
+        }
+        return result;
+    }
+
+    async resolveSearchResults(query: string, context: SearchContext): Promise<Iterable<SearchResult>> {
+        if (!query.trim()) {
+            return [];
+        }
+        const registryEntries = await this.safeGetPluginEntries();
+        const installed = await this.installService.listInstalledPlugins();
+        const result: SearchResult[] = [];
+        for (const entry of registryEntries) {
+            // The shared Extensions ranker fuzzy-matches scattered characters across the whole
+            // searchable text, which given long descriptions makes almost every plugin a hit.
+            // `context.verifiedOnly` is ignored as it is for skills: the feed has no such flag.
+            if (!this.searchFilter.matches({ name: entry.name, identifier: entry.pluginId, description: entry.description }, query)) {
+                continue;
+            }
+            const state = this.installService.classifyRegistryEntry(entry, installed);
+            result.push({
+                element: new PluginSearchResultEntry(entry, state, this.handlers, this.hoverService, this.markdownRenderer,
+                    this.installService.findLinkDirectory(entry, installed)),
+                searchableText: `${entry.name} ${entry.pluginId} ${entry.description}`
+            });
+        }
+        return result;
+    }
+
+    async refresh(): Promise<void> {
+        await this.fetchService.getPluginEntries(true);
+    }
+
+    /** Register after adopting, or a linked plugin's skills load while none of its servers start. */
+    protected async link(entry: ResolvedPluginEntry, directoryName: string): Promise<void> {
+        await this.mcpRegistrar.register(await this.installService.link(entry, directoryName));
+    }
+
+    // Both unregister first: once the root is gone, or no longer ours, entries naming it would linger.
+
+    protected async uninstall(pluginId: string): Promise<void> {
+        await this.mcpRegistrar.unregister(pluginId);
+        await this.installService.uninstall(pluginId);
+    }
+
+    protected async unlink(pluginId: string): Promise<void> {
+        await this.mcpRegistrar.unregister(pluginId);
+        await this.installService.unlink(pluginId);
+    }
+
+    protected async promptWatcherReload(): Promise<void> {
+        const reload = nls.localizeByDefault('Reload Window');
+        const answer = await this.messageService.warn(
+            nls.localize(
+                'theia/ai-registry/plugin/watcherStopped',
+                'Stopped watching the Agent Plugins folder for changes. Installed plugins may no longer refresh automatically. '
+                + 'Reload the window to resume.'
+            ),
+            reload
+        );
+        if (answer === reload) {
+            this.windowService.reload();
+        }
+    }
+
+    protected async safeGetPluginEntries(): Promise<ResolvedPluginEntry[]> {
+        try {
+            return await this.fetchService.getPluginEntries();
+        } catch (error) {
+            this.logger.warn('AI registry fetch failed; Agent Plugin entries unavailable.', error);
+            return [];
+        }
+    }
+
+    /** `false` means the user cancelled a dialog, so nothing is reported. The view refreshes either way. */
+    protected async runAction(action: () => Promise<boolean | void>, successMessage: string): Promise<void> {
+        try {
+            if (await action() !== false) {
+                this.messageService.info(successMessage);
+            }
+        } catch (error) {
+            this.messageService.error(error instanceof Error ? error.message : String(error));
+        } finally {
+            this.onDidChangeEmitter.fire();
+        }
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-extensions-contribution.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { Disposable, DisposableCollection, Emitter, Event, ILogger, MessageService, nls } from '@theia/core';
-import { HoverService } from '@theia/core/lib/browser';
+import { ContextMenuRenderer, HoverService } from '@theia/core/lib/browser';
 import { CoreMarkdownRenderer, MarkdownRenderer } from '@theia/core/lib/browser/markdown-rendering/markdown-renderer';
 import { TreeElement } from '@theia/core/lib/browser/source-tree';
 import { WindowService } from '@theia/core/lib/browser/window/window-service';
@@ -57,6 +57,9 @@ export class PluginExtensionsContribution implements ExtensionsSourceContributio
 
     @inject(HoverService)
     protected readonly hoverService: HoverService;
+
+    @inject(ContextMenuRenderer)
+    protected readonly contextMenuRenderer: ContextMenuRenderer;
 
     @inject(CoreMarkdownRenderer)
     protected readonly markdownRenderer: MarkdownRenderer;
@@ -130,7 +133,7 @@ export class PluginExtensionsContribution implements ExtensionsSourceContributio
             }
             const matchedEntry = (info.pluginId && byPluginId.get(info.pluginId))
                 || registryEntries.find(entry => this.installService.findLinkDirectory(entry, [info]) !== undefined);
-            result.push(new PluginInstalledEntry(info, matchedEntry, state, this.handlers, this.hoverService, this.markdownRenderer));
+            result.push(new PluginInstalledEntry(info, matchedEntry, state, this.handlers, this.hoverService, this.markdownRenderer, this.contextMenuRenderer));
         }
         return result;
     }
@@ -152,7 +155,7 @@ export class PluginExtensionsContribution implements ExtensionsSourceContributio
             const state = this.installService.classifyRegistryEntry(entry, installed);
             result.push({
                 element: new PluginSearchResultEntry(entry, state, this.handlers, this.hoverService, this.markdownRenderer,
-                    this.installService.findLinkDirectory(entry, installed)),
+                    this.contextMenuRenderer, this.installService.findLinkDirectory(entry, installed)),
                 searchableText: `${entry.name} ${entry.pluginId} ${entry.description}`
             });
         }

--- a/packages/ai-registry/src/browser/plugin/plugin-install-client.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-client.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-install-client.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-client.ts
@@ -1,0 +1,38 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, Event } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
+import { PluginInstallClient } from '../../common/plugin/plugin-install-protocol';
+
+/** Frontend endpoint for the backend's plugins-folder watcher. */
+@injectable()
+export class PluginInstallClientImpl implements PluginInstallClient {
+
+    protected readonly onDidChangeInstalledPluginsEmitter = new Emitter<void>();
+    readonly onDidChangeInstalledPlugins: Event<void> = this.onDidChangeInstalledPluginsEmitter.event;
+
+    protected readonly onDidStopWatchingEmitter = new Emitter<void>();
+    readonly onDidStopWatching: Event<void> = this.onDidStopWatchingEmitter.event;
+
+    notifyDidChangeInstalledPlugins(): void {
+        this.onDidChangeInstalledPluginsEmitter.fire();
+    }
+
+    notifyWatcherStopped(): void {
+        this.onDidStopWatchingEmitter.fire();
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-install-dialog.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-dialog.tsx
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -36,7 +36,7 @@ export const PluginHashMismatchDialogFactory = Symbol('PluginHashMismatchDialogF
 export type PluginHashMismatchDialogFactory = (options: PluginHashMismatchDialogOptions) => PluginHashMismatchDialog;
 
 function renderEndorsement(endorsement: PluginEndorsement): string {
-    const base = nls.localize('theia/ai-registry/plugin/dialog/endorsement', '{0} · {1}', endorsement.organizationId, endorsement.date);
+    const base = nls.localizeByDefault('{0} · {1}', endorsement.organizationId, endorsement.date);
     return endorsement.viaTrust
         ? nls.localizeByDefault('{0} ({1})', base, nls.localize('theia/ai-registry/plugin/dialog/viaTrust', 'via {0}', endorsement.viaTrust))
         : base;

--- a/packages/ai-registry/src/browser/plugin/plugin-install-dialog.tsx
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-dialog.tsx
@@ -1,0 +1,210 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as React from '@theia/core/shared/react';
+import { nls } from '@theia/core';
+import { ReactDialog } from '@theia/core/lib/browser/dialogs/react-dialog';
+import { PluginEndorsement, PluginHashMismatch, ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+
+export interface PluginInstallDialogOptions {
+    readonly entry: ResolvedPluginEntry;
+}
+
+export interface PluginHashMismatchDialogOptions {
+    readonly entry: ResolvedPluginEntry;
+    readonly mismatch: PluginHashMismatch;
+}
+
+/** Injected so no caller imports the DOM-touching `ReactDialog` chain directly. */
+export const PluginInstallDialogFactory = Symbol('PluginInstallDialogFactory');
+export type PluginInstallDialogFactory = (options: PluginInstallDialogOptions) => PluginInstallDialog;
+
+export const PluginHashMismatchDialogFactory = Symbol('PluginHashMismatchDialogFactory');
+export type PluginHashMismatchDialogFactory = (options: PluginHashMismatchDialogOptions) => PluginHashMismatchDialog;
+
+function renderEndorsement(endorsement: PluginEndorsement): string {
+    const base = nls.localize('theia/ai-registry/plugin/dialog/endorsement', '{0} · {1}', endorsement.organizationId, endorsement.date);
+    return endorsement.viaTrust
+        ? nls.localizeByDefault('{0} ({1})', base, nls.localize('theia/ai-registry/plugin/dialog/viaTrust', 'via {0}', endorsement.viaTrust))
+        : base;
+}
+
+/**
+ * A plugin is installed whole and its servers start automatically, which is a materially larger
+ * decision than installing one skill - so the source, the endorsements and the contained components
+ * are all shown before anything is fetched. The counts come from the feed; once on disk, the root
+ * wins, which is why the installed card recounts them.
+ */
+export class PluginInstallDialog extends ReactDialog<boolean> {
+
+    constructor(protected readonly options: PluginInstallDialogOptions) {
+        super({
+            title: nls.localize('theia/ai-registry/plugin/dialog/install/title', 'Install Agent Plugin "{0}"', options.entry.name),
+            maxWidth: 520
+        });
+        this.appendCloseButton(nls.localizeByDefault('Cancel'));
+        this.appendAcceptButton(nls.localizeByDefault('Install'));
+    }
+
+    get value(): boolean {
+        return true;
+    }
+
+    protected render(): React.ReactNode {
+        const entry = this.options.entry;
+        return (
+            <div className="theia-plugin-dialog">
+                <div className="theia-plugin-dialog-field">
+                    <label>{nls.localize('theia/ai-registry/plugin/dialog/from', 'From')}:</label>
+                    <span className="theia-plugin-dialog-value">{this.renderSource(entry)}</span>
+                </div>
+                <div className="theia-plugin-dialog-field">
+                    <label>{nls.localize('theia/ai-registry/plugin/dialog/endorsedBy', 'Endorsed by')}:</label>
+                    <span className="theia-plugin-dialog-value">
+                        {entry.endorsements.length > 0
+                            ? entry.endorsements.map(renderEndorsement).join(', ')
+                            : nls.localize('theia/ai-registry/plugin/dialog/noEndorsements', 'No endorsing organization')}
+                    </span>
+                </div>
+                {entry.version !== undefined && (
+                    <div className="theia-plugin-dialog-field">
+                        <label>{nls.localizeByDefault('Version')}:</label>
+                        <span className="theia-plugin-dialog-value">{entry.version}</span>
+                    </div>
+                )}
+                {this.renderContents()}
+                {entry.containedMcpServers.length > 0 && this.renderMcpWarning()}
+            </div>
+        );
+    }
+
+    protected renderSource(entry: ResolvedPluginEntry): string {
+        return entry.sourcePath
+            ? nls.localizeByDefault('{0} ({1})', entry.sourceUrl, entry.sourcePath)
+            : entry.sourceUrl;
+    }
+
+    protected renderContents(): React.ReactNode {
+        const { containedSkills, containedMcpServers } = this.options.entry;
+        if (containedSkills.length === 0 && containedMcpServers.length === 0) {
+            return undefined;
+        }
+        return (
+            <div className="theia-plugin-dialog-section">
+                <div className="theia-plugin-dialog-section-title">
+                    {nls.localize('theia/ai-registry/plugin/dialog/contains', 'Contains')}
+                </div>
+                {containedSkills.length > 0 && (
+                    <div className="theia-plugin-dialog-field">
+                        <label>{nls.localizeByDefault('Skills')}:</label>
+                        <span className="theia-plugin-dialog-value">{containedSkills.map(skill => skill.name).join(', ')}</span>
+                    </div>
+                )}
+                {containedMcpServers.length > 0 && (
+                    <div className="theia-plugin-dialog-field">
+                        <label>{nls.localizeByDefault('MCP Servers')}:</label>
+                        <span className="theia-plugin-dialog-value">
+                            {containedMcpServers.map(server => server.transport
+                                ? nls.localizeByDefault('{0} ({1})', server.name, server.transport)
+                                : server.name).join(', ')}
+                        </span>
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    protected renderMcpWarning(): React.ReactNode {
+        return (
+            <div className="theia-plugin-dialog-warning">
+                <i className="codicon codicon-warning" />
+                <span>
+                    {nls.localize(
+                        'theia/ai-registry/plugin/dialog/mcpWarning',
+                        "This plugin's MCP servers can run arbitrary commands on your machine. The endorsement covers the plugin as a whole - "
+                        + 'no contained server is endorsed on its own. The servers start automatically after the install.'
+                    )}
+                </span>
+            </div>
+        );
+    }
+}
+
+/**
+ * Shown only when staging a download reported a content-hash mismatch, i.e. the files received do
+ * not match what the endorsing organization approved.
+ *
+ * The wording is deliberately even-handed. A mismatch is expected for up to a day after the plugin's
+ * authors commit, because the registry re-reads sources daily and pins no commit, and a repository
+ * using `.gitattributes` `export-ignore` produces one permanently. It is also what a compromised
+ * source looks like. Nothing in the data separates the cases, so both are stated and the decision
+ * stays with the user.
+ */
+export class PluginHashMismatchDialog extends ReactDialog<boolean> {
+
+    constructor(protected readonly options: PluginHashMismatchDialogOptions) {
+        super({
+            title: nls.localize('theia/ai-registry/plugin/dialog/mismatch/title', 'Source has changed'),
+            maxWidth: 520
+        });
+        this.appendCloseButton(nls.localizeByDefault('Cancel'));
+        this.appendAcceptButton(nls.localize('theia/ai-registry/plugin/dialog/mismatch/installAnyway', 'Install anyway'));
+    }
+
+    get value(): boolean {
+        return true;
+    }
+
+    protected render(): React.ReactNode {
+        const { entry, mismatch } = this.options;
+        const endorsement = entry.endorsements[0];
+        return (
+            <div className="theia-plugin-dialog">
+                <div className="theia-plugin-dialog-paragraph">
+                    {endorsement
+                        ? nls.localize(
+                            'theia/ai-registry/plugin/dialog/mismatch/endorsed',
+                            'The files downloaded for "{0}" do not match what {1} endorsed on {2}.',
+                            entry.name,
+                            endorsement.organizationId,
+                            endorsement.date
+                        )
+                        : nls.localize(
+                            'theia/ai-registry/plugin/dialog/mismatch/unendorsed',
+                            'The files downloaded for "{0}" do not match the content hash the registry publishes.',
+                            entry.name
+                        )}
+                </div>
+                <div className="theia-plugin-dialog-paragraph">
+                    {nls.localize(
+                        'theia/ai-registry/plugin/dialog/mismatch/explanation',
+                        "This is expected for up to a day after the plugin's authors commit, because the registry re-reads sources daily and "
+                        + 'pins no commit, and a repository that excludes files from its archives produces it permanently. It is also what a '
+                        + 'compromised source looks like.'
+                    )}
+                </div>
+                <div className="theia-plugin-dialog-field">
+                    <label>{nls.localize('theia/ai-registry/plugin/dialog/mismatch/expected', 'endorsed')}:</label>
+                    <span className="theia-plugin-dialog-hash">{mismatch.expected}</span>
+                </div>
+                <div className="theia-plugin-dialog-field">
+                    <label>{nls.localize('theia/ai-registry/plugin/dialog/mismatch/actual', 'received')}:</label>
+                    <span className="theia-plugin-dialog-hash">{mismatch.actual}</span>
+                </div>
+            </div>
+        );
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-service.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-service.spec.ts
@@ -1,0 +1,167 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { PluginDirectoryNamingImpl } from '../../common/plugin/plugin-directory-naming';
+import { InstalledPluginInfo, ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
+import { PluginInstallService, PluginInstallServiceImpl } from './plugin-install-service';
+
+/** The directory name an install of {@link entry} would create, and so the only one Link may adopt. */
+const CANONICAL_DIRECTORY = 'io.github.acme_bigquery-data-analytics';
+
+/** The real naming service: this is the agreement between the two sides that the tests are about. */
+function createService(): PluginInstallService {
+    const service = new PluginInstallServiceImpl();
+    Object.assign(service, { directoryNaming: new PluginDirectoryNamingImpl() });
+    return service;
+}
+
+const entry: ResolvedPluginEntry = {
+    pluginId: 'io.github.acme/bigquery-data-analytics',
+    name: 'BigQuery Data Analytics',
+    description: 'Query and explore BigQuery',
+    version: '1.2.0',
+    sourceUrl: 'https://github.com/acme/bigquery-plugin',
+    contentHash: 'hash-v1',
+    endorsements: [{ organizationId: 'acme', date: '2026-08-07' }],
+    containedSkills: [{ name: 'query-builder', description: 'Build SQL', path: 'skills/query-builder' }],
+    containedMcpServers: [{ name: 'bigquery', transport: 'stdio' }]
+};
+
+function installed(overrides: Partial<InstalledPluginInfo> = {}): InstalledPluginInfo {
+    return {
+        directoryName: CANONICAL_DIRECTORY,
+        root: '/home/user/.agents/plugins/io.github.acme_bigquery-data-analytics',
+        dataRoot: '/home/user/.agents/plugin-data/io.github.acme_bigquery-data-analytics',
+        drifted: false,
+        skills: [],
+        servers: [],
+        skipped: [],
+        ...overrides
+    };
+}
+
+describe('PluginInstallService.classifyInstalledPlugin', () => {
+
+    let service: PluginInstallService;
+
+    beforeEach(() => {
+        service = createService();
+    });
+
+    it('returns installed-user-added when the directory carries no provenance marker and the registry does not know it', () => {
+        const info = installed({ directoryName: 'my-own-plugin', name: 'my-own-plugin' });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'installed-user-added' });
+    });
+
+    it('returns installed-manually when the directory carries no marker but is the one the plugin would occupy', () => {
+        const info = installed({ name: 'bigquery-data-analytics' });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it("offers no adoption for a directory named after something other than the plugin's canonical directory", () => {
+        // Adopting it would leave Update and Fix - which derive their target from the identifier -
+        // creating a second directory beside this one, both marked as the same plugin.
+        for (const directoryName of ['bigquery-data-analytics', 'BigQuery Data Analytics', 'bigquery']) {
+            const info = installed({ directoryName, name: entry.name });
+            expect(service.classifyInstalledPlugin(info, [entry]), directoryName).to.deep.equal({ kind: 'installed-user-added' });
+        }
+    });
+
+    it('returns installed-link-stale when the provenance marker names a pluginId the registry no longer lists', () => {
+        const info = installed({ pluginId: 'io.github.acme/withdrawn', contentHash: 'hash-v1' });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'installed-link-stale' });
+    });
+
+    it('returns fix-plugin when the registry hash still matches but the local files have drifted', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v1', drifted: true });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'fix-plugin' });
+    });
+
+    it('prefers Update over Fix when the registry hash differs even if the local files have also drifted', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v0', drifted: true });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('offers an Update once the registry publishes a hash other than the recorded one', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v0' });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('offers Fix rather than Update when the recorded hash still matches but the tree drifted', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v1', drifted: true });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'fix-plugin' });
+    });
+
+    it('returns installed-from-registry without an update when the recorded hash equals the published one', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v1' });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+});
+
+describe('PluginInstallService.classifyRegistryEntry', () => {
+
+    let service: PluginInstallService;
+
+    beforeEach(() => {
+        service = createService();
+    });
+
+    it('returns not-installed when nothing under the plugins root corresponds to the entry', () => {
+        expect(service.classifyRegistryEntry(entry, [])).to.deep.equal({ kind: 'not-installed' });
+    });
+
+    it("returns installed-manually when the plugin's own directory exists without a marker, so Link is offered before any download", () => {
+        expect(service.classifyRegistryEntry(entry, [installed()])).to.deep.equal({ kind: 'installed-manually' });
+    });
+
+    it('returns installed-from-registry with an update when the published hash differs from the recorded one', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v0' });
+        expect(service.classifyRegistryEntry(entry, [info])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+    });
+
+    it('returns fix-plugin when the published hash matches the recorded one but the local files have drifted', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v1', drifted: true });
+        expect(service.classifyRegistryEntry(entry, [info])).to.deep.equal({ kind: 'fix-plugin' });
+    });
+
+    it('returns installed-from-registry without an update when the plugin is installed and unchanged', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v1' });
+        expect(service.classifyRegistryEntry(entry, [info])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: false });
+    });
+});
+
+describe('PluginInstallService.findLinkDirectory', () => {
+
+    let service: PluginInstallService;
+
+    beforeEach(() => {
+        service = createService();
+    });
+
+    it('names the marker-less directory a Link action would adopt, which is the canonical one', () => {
+        expect(service.findLinkDirectory(entry, [installed()])).to.equal(CANONICAL_DIRECTORY);
+    });
+
+    it('names no directory when the only marker-less one is not the canonical directory', () => {
+        expect(service.findLinkDirectory(entry, [installed({ directoryName: 'bigquery-data-analytics' })])).to.be.undefined;
+    });
+
+    it('returns undefined for a directory that already carries a provenance marker, which needs no adoption', () => {
+        const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v1' });
+        expect(service.findLinkDirectory(entry, [info])).to.be.undefined;
+    });
+});

--- a/packages/ai-registry/src/browser/plugin/plugin-install-service.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-service.spec.ts
@@ -15,7 +15,12 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { PluginDirectoryNamingImpl } from '../../common/plugin/plugin-directory-naming';
+import { PreferenceService } from '@theia/core';
+import { Container } from '@theia/core/shared/inversify';
+import { AUTO_UPDATE_OVERRIDES_PREF } from '../../common/ai-registry-preferences';
+import { PluginDirectoryNaming, PluginDirectoryNamingImpl } from '../../common/plugin/plugin-directory-naming';
+import { PluginInstallBackendService } from '../../common/plugin/plugin-install-protocol';
+import { RegistryAutoUpdatePolicy, RegistryAutoUpdatePolicyImpl } from '../auto-update/registry-auto-update-policy';
 import { InstalledPluginInfo, ResolvedPluginEntry } from '../../common/plugin/plugin-registry-types';
 import { PluginInstallService, PluginInstallServiceImpl } from './plugin-install-service';
 
@@ -91,9 +96,11 @@ describe('PluginInstallService.classifyInstalledPlugin', () => {
         expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'fix-plugin' });
     });
 
-    it('prefers Update over Fix when the registry hash differs even if the local files have also drifted', () => {
+    it('prefers Fix over Update when the root drifted and the registry hash also moved on', () => {
+        // Mirrors the skill and MCP classifiers, and is what keeps the auto-updater from replacing
+        // edited content: nothing is lost, because Fix and Update are the same clean replace.
         const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v0', drifted: true });
-        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'installed-from-registry', updateAvailable: true });
+        expect(service.classifyInstalledPlugin(info, [entry])).to.deep.equal({ kind: 'fix-plugin' });
     });
 
     it('offers an Update once the registry publishes a hash other than the recorded one', () => {
@@ -163,5 +170,72 @@ describe('PluginInstallService.findLinkDirectory', () => {
     it('returns undefined for a directory that already carries a provenance marker, which needs no adoption', () => {
         const info = installed({ pluginId: entry.pluginId, contentHash: 'hash-v1' });
         expect(service.findLinkDirectory(entry, [info])).to.be.undefined;
+    });
+});
+
+describe('PluginInstallService override cleanup', () => {
+
+    class FakePreferenceService {
+        private readonly store = new Map<string, unknown>();
+        get<T>(key: string, defaultValue?: T): T | undefined {
+            return (this.store.has(key) ? this.store.get(key) : defaultValue) as T | undefined;
+        }
+        async set(key: string, value: unknown): Promise<void> {
+            this.store.set(key, value);
+        }
+        snapshot<T>(key: string): T | undefined {
+            return this.store.get(key) as T | undefined;
+        }
+    }
+
+    let prefs: FakePreferenceService;
+    let uninstalled: string[];
+    let unlinked: string[];
+    let service: PluginInstallService;
+
+    beforeEach(() => {
+        const container = new Container();
+        prefs = new FakePreferenceService();
+        uninstalled = [];
+        unlinked = [];
+        container.bind(PreferenceService).toConstantValue(prefs);
+        container.bind(PluginInstallBackendService).toConstantValue({
+            uninstall: async (pluginId: string) => { uninstalled.push(pluginId); },
+            unlink: async (pluginId: string) => { unlinked.push(pluginId); }
+        } as unknown as PluginInstallBackendService);
+        container.bind(PluginDirectoryNaming).to(PluginDirectoryNamingImpl).inSingletonScope();
+        container.bind(RegistryAutoUpdatePolicyImpl).toSelf().inSingletonScope();
+        container.bind(RegistryAutoUpdatePolicy).toService(RegistryAutoUpdatePolicyImpl);
+        container.bind(PluginInstallServiceImpl).toSelf().inSingletonScope();
+        container.bind(PluginInstallService).toService(PluginInstallServiceImpl);
+        service = container.get(PluginInstallService);
+    });
+
+    it('drops the override on uninstall, since nothing is left to apply it to', async () => {
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, {
+            [`plugin:${entry.pluginId}`]: 'on',
+            'plugin:io.github.other/other-plugin': 'off'
+        });
+
+        await service.uninstall(entry.pluginId);
+
+        expect(uninstalled).to.deep.equal([entry.pluginId]);
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({ 'plugin:io.github.other/other-plugin': 'off' });
+    });
+
+    it('drops the override on unlink too, since the plugin stops being registry-managed', async () => {
+        await prefs.set(AUTO_UPDATE_OVERRIDES_PREF, { [`plugin:${entry.pluginId}`]: 'off' });
+
+        await service.unlink(entry.pluginId);
+
+        expect(unlinked).to.deep.equal([entry.pluginId]);
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.deep.equal({});
+    });
+
+    it('writes nothing when the plugin had no override', async () => {
+        await service.uninstall(entry.pluginId);
+
+        expect(uninstalled).to.deep.equal([entry.pluginId]);
+        expect(prefs.snapshot(AUTO_UPDATE_OVERRIDES_PREF)).to.be.undefined;
     });
 });

--- a/packages/ai-registry/src/browser/plugin/plugin-install-service.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-service.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-install-service.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-service.ts
@@ -16,6 +16,7 @@
 
 import { inject, injectable } from '@theia/core/shared/inversify';
 import { PluginDirectoryNaming } from '../../common/plugin/plugin-directory-naming';
+import { RegistryAutoUpdatePolicy } from '../auto-update/registry-auto-update-policy';
 import { PluginInstallBackendService } from '../../common/plugin/plugin-install-protocol';
 import {
     InstalledPluginInfo,
@@ -53,6 +54,9 @@ export class PluginInstallServiceImpl implements PluginInstallService {
     @inject(PluginDirectoryNaming)
     protected readonly directoryNaming: PluginDirectoryNaming;
 
+    @inject(RegistryAutoUpdatePolicy)
+    protected readonly autoUpdatePolicy: RegistryAutoUpdatePolicy;
+
     stage(entry: ResolvedPluginEntry): Promise<StagedPluginInstall> {
         return this.backend.stage(entry);
     }
@@ -65,16 +69,21 @@ export class PluginInstallServiceImpl implements PluginInstallService {
         return this.backend.discard(stagingId);
     }
 
-    uninstall(pluginId: string): Promise<void> {
-        return this.backend.uninstall(pluginId);
+    async uninstall(pluginId: string): Promise<void> {
+        await this.backend.uninstall(pluginId);
+        // The plugin is gone, so its override would linger with nothing left to apply it to.
+        await this.autoUpdatePolicy.clearMode('plugin', pluginId);
     }
 
     link(entry: ResolvedPluginEntry, directoryName: string): Promise<InstalledPluginInfo> {
         return this.backend.link(entry, directoryName);
     }
 
-    unlink(pluginId: string): Promise<void> {
-        return this.backend.unlink(pluginId);
+    async unlink(pluginId: string): Promise<void> {
+        // Unlinking is the other way a plugin stops being registry-managed, so it drops the
+        // override for the same reason uninstall does. Re-linking starts from the default again.
+        await this.backend.unlink(pluginId);
+        await this.autoUpdatePolicy.clearMode('plugin', pluginId);
     }
 
     listInstalledPlugins(): Promise<InstalledPluginInfo[]> {
@@ -112,17 +121,22 @@ export class PluginInstallServiceImpl implements PluginInstallService {
     }
 
     /**
-     * Update takes precedence over Fix: only when the registry offers nothing new do local edits
-     * surface. Both are decided against the one recorded hash, which is always the endorsed one -
-     * an update means the registry published a different hash, drift means the tree on disk no
-     * longer produces it.
+     * Drift takes precedence over Update, mirroring the skill and MCP classifiers: a plugin whose
+     * root no longer matches what was installed must be fixed before it counts as updatable, and
+     * that is also what keeps the auto-updater from silently replacing edited content. Nothing is
+     * lost by fixing first - Fix and Update are the same clean replace, so a single Fix already
+     * lands the current registry content.
+     *
+     * Both are decided against the one recorded hash, which is always the endorsed one: an update
+     * means the registry published a different hash, drift means the tree on disk no longer
+     * produces it.
      */
     protected classifyLinked(registryHash: string, info: InstalledPluginInfo): PluginClassificationResult {
-        if (registryHash !== info.contentHash) {
-            return { kind: 'installed-from-registry', updateAvailable: true };
-        }
         if (info.drifted) {
             return { kind: 'fix-plugin' };
+        }
+        if (registryHash !== info.contentHash) {
+            return { kind: 'installed-from-registry', updateAvailable: true };
         }
         return { kind: 'installed-from-registry', updateAvailable: false };
     }

--- a/packages/ai-registry/src/browser/plugin/plugin-install-service.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-install-service.ts
@@ -1,0 +1,141 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { PluginDirectoryNaming } from '../../common/plugin/plugin-directory-naming';
+import { PluginInstallBackendService } from '../../common/plugin/plugin-install-protocol';
+import {
+    InstalledPluginInfo,
+    PluginClassificationResult,
+    ResolvedPluginEntry,
+    StagedPluginInstall
+} from '../../common/plugin/plugin-registry-types';
+
+export const PluginInstallService = Symbol('PluginInstallService');
+/** Frontend view of {@link PluginInstallBackendService}, plus the classification the cards render from. */
+export interface PluginInstallService {
+    stage(entry: ResolvedPluginEntry): Promise<StagedPluginInstall>;
+    commit(stagingId: string, replaceExisting: boolean): Promise<InstalledPluginInfo>;
+    discard(stagingId: string): Promise<void>;
+    uninstall(pluginId: string): Promise<void>;
+    /** Adopts an existing local directory by writing the provenance marker. */
+    link(entry: ResolvedPluginEntry, directoryName: string): Promise<InstalledPluginInfo>;
+    unlink(pluginId: string): Promise<void>;
+    listInstalledPlugins(): Promise<InstalledPluginInfo[]>;
+    getPluginsRoot(): Promise<string>;
+    /** For the Installed view. */
+    classifyInstalledPlugin(info: InstalledPluginInfo, entries: ResolvedPluginEntry[]): PluginClassificationResult;
+    /** The marker-less directory Link should adopt for this entry, i.e. what `installed-manually` refers to. */
+    findLinkDirectory(entry: ResolvedPluginEntry, installed: InstalledPluginInfo[]): string | undefined;
+    /** For the Search view. */
+    classifyRegistryEntry(entry: ResolvedPluginEntry, installed: InstalledPluginInfo[]): PluginClassificationResult;
+}
+
+@injectable()
+export class PluginInstallServiceImpl implements PluginInstallService {
+
+    @inject(PluginInstallBackendService)
+    protected readonly backend: PluginInstallBackendService;
+
+    @inject(PluginDirectoryNaming)
+    protected readonly directoryNaming: PluginDirectoryNaming;
+
+    stage(entry: ResolvedPluginEntry): Promise<StagedPluginInstall> {
+        return this.backend.stage(entry);
+    }
+
+    commit(stagingId: string, replaceExisting: boolean): Promise<InstalledPluginInfo> {
+        return this.backend.commit(stagingId, replaceExisting);
+    }
+
+    discard(stagingId: string): Promise<void> {
+        return this.backend.discard(stagingId);
+    }
+
+    uninstall(pluginId: string): Promise<void> {
+        return this.backend.uninstall(pluginId);
+    }
+
+    link(entry: ResolvedPluginEntry, directoryName: string): Promise<InstalledPluginInfo> {
+        return this.backend.link(entry, directoryName);
+    }
+
+    unlink(pluginId: string): Promise<void> {
+        return this.backend.unlink(pluginId);
+    }
+
+    listInstalledPlugins(): Promise<InstalledPluginInfo[]> {
+        return this.backend.listInstalledPlugins();
+    }
+
+    getPluginsRoot(): Promise<string> {
+        return this.backend.getPluginsRoot();
+    }
+
+    classifyInstalledPlugin(info: InstalledPluginInfo, entries: ResolvedPluginEntry[]): PluginClassificationResult {
+        if (info.pluginId !== undefined) {
+            const matched = entries.find(entry => entry.pluginId === info.pluginId);
+            if (!matched) {
+                // The provenance marker names a pluginId the registry no longer lists.
+                return { kind: 'installed-link-stale' };
+            }
+            return this.classifyLinked(matched.contentHash, info);
+        }
+        // No provenance marker: a hand-placed directory. Offer Link only when the registry knows it.
+        return entries.some(entry => this.matchesUnlinked(entry, info))
+            ? { kind: 'installed-manually' }
+            : { kind: 'installed-user-added' };
+    }
+
+    classifyRegistryEntry(entry: ResolvedPluginEntry, installed: InstalledPluginInfo[]): PluginClassificationResult {
+        const linked = installed.find(info => info.pluginId === entry.pluginId);
+        if (linked) {
+            return this.classifyLinked(entry.contentHash, linked);
+        }
+        // Marker-less directory - offer Link, since Install would refuse to overwrite it.
+        return this.findLinkDirectory(entry, installed) !== undefined
+            ? { kind: 'installed-manually' }
+            : { kind: 'not-installed' };
+    }
+
+    /**
+     * Update takes precedence over Fix: only when the registry offers nothing new do local edits
+     * surface. Both are decided against the one recorded hash, which is always the endorsed one -
+     * an update means the registry published a different hash, drift means the tree on disk no
+     * longer produces it.
+     */
+    protected classifyLinked(registryHash: string, info: InstalledPluginInfo): PluginClassificationResult {
+        if (registryHash !== info.contentHash) {
+            return { kind: 'installed-from-registry', updateAvailable: true };
+        }
+        if (info.drifted) {
+            return { kind: 'fix-plugin' };
+        }
+        return { kind: 'installed-from-registry', updateAvailable: false };
+    }
+
+    findLinkDirectory(entry: ResolvedPluginEntry, installed: InstalledPluginInfo[]): string | undefined {
+        return installed.find(info => info.pluginId === undefined && this.matchesUnlinked(entry, info))?.directoryName;
+    }
+
+    /**
+     * A marker-less directory carries no identifier, so only the canonical name counts: adopting any
+     * other would make Update or Fix create a second directory beside the adopted one.
+     */
+    protected matchesUnlinked(entry: ResolvedPluginEntry, info: InstalledPluginInfo): boolean {
+        return info.directoryName === this.directoryNaming.directoryName(entry.pluginId);
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-installer.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-installer.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-installer.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-installer.spec.ts
@@ -1,0 +1,168 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// The installer imports the install dialogs, which extend the DOM-touching `ReactDialog`, so a DOM
+// has to exist while those modules are evaluated.
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+const disableJSDOM = enableJSDOM();
+
+import { expect } from 'chai';
+import { InstalledPluginInfo, ResolvedPluginEntry, StagedPluginInstall } from '../../common/plugin/plugin-registry-types';
+import { PluginInstallService } from './plugin-install-service';
+import { PluginMcpRegistrar } from './plugin-mcp-registrar';
+import { PluginInstallerImpl } from './plugin-installer';
+
+disableJSDOM();
+
+const entry: ResolvedPluginEntry = {
+    pluginId: 'io.github.acme/bigquery-data-analytics',
+    name: 'BigQuery Data Analytics',
+    description: 'Query and explore BigQuery',
+    sourceUrl: 'https://github.com/acme/bigquery-plugin',
+    contentHash: 'hash-v1',
+    endorsements: [{ organizationId: 'acme', date: '2026-08-07' }],
+    containedSkills: [],
+    containedMcpServers: []
+};
+
+const installedPlugin: InstalledPluginInfo = {
+    directoryName: 'io.github.acme_bigquery-data-analytics',
+    root: '/plugins/io.github.acme_bigquery-data-analytics',
+    dataRoot: '/plugin-data/io.github.acme_bigquery-data-analytics',
+    pluginId: entry.pluginId,
+    contentHash: 'hash-v1',
+    drifted: false,
+    skills: ['query-builder'],
+    servers: [],
+    skipped: []
+};
+
+/** Records which phases of the flow ran, so a test can assert what did *not* happen. */
+class RecordingInstallService {
+    readonly calls: string[] = [];
+    constructor(readonly staged: StagedPluginInstall) { }
+    async stage(): Promise<StagedPluginInstall> {
+        this.calls.push('stage');
+        return this.staged;
+    }
+    async commit(stagingId: string, replaceExisting: boolean): Promise<InstalledPluginInfo> {
+        this.calls.push(`commit(${stagingId}, ${replaceExisting})`);
+        return installedPlugin;
+    }
+    async discard(stagingId: string): Promise<void> {
+        this.calls.push(`discard(${stagingId})`);
+    }
+}
+
+class TestPluginInstaller extends PluginInstallerImpl {
+
+    readonly registered: InstalledPluginInfo[] = [];
+
+    constructor(
+        readonly service: RecordingInstallService,
+        protected readonly acceptInstall: boolean,
+        protected readonly acceptMismatch: boolean,
+        protected readonly registrationError?: Error
+    ) {
+        super();
+        Object.assign(this, {
+            installService: service as unknown as PluginInstallService,
+            mcpRegistrar: {
+                register: async (info: InstalledPluginInfo) => {
+                    if (this.registrationError) {
+                        throw this.registrationError;
+                    }
+                    this.registered.push(info);
+                },
+                unregister: async () => undefined,
+                reconcile: async () => undefined
+            } as PluginMcpRegistrar,
+            // Only that the flow is wrapped in one; the notification itself is Theia's.
+            messageService: { showProgress: async () => ({ cancel: () => { }, report: () => { } }) }
+        });
+    }
+
+    // The dialogs themselves are covered by their own rendering; what matters to the flow is the
+    // answer they return, so the two confirmations are stubbed rather than opened.
+    protected override async confirmInstall(): Promise<boolean> {
+        return this.acceptInstall;
+    }
+
+    protected override async confirmMismatch(): Promise<boolean> {
+        return this.acceptMismatch;
+    }
+}
+
+describe('PluginInstaller.install', () => {
+
+    it('downloads nothing when the user cancels the pre-install dialog', async () => {
+        const service = new RecordingInstallService({ stagingId: 'staging-1' });
+        const installer = new TestPluginInstaller(service, false, true);
+
+        expect(await installer.install(entry, { replaceExisting: false, confirm: true })).to.be.false;
+        expect(service.calls).to.be.empty;
+    });
+
+    it('commits and registers the resolved components when the download verifies', async () => {
+        const service = new RecordingInstallService({ stagingId: 'staging-1' });
+        const installer = new TestPluginInstaller(service, true, true);
+
+        expect(await installer.install(entry, { replaceExisting: false, confirm: true })).to.be.true;
+        expect(service.calls).to.deep.equal(['stage', 'commit(staging-1, false)']);
+        expect(installer.registered).to.deep.equal([installedPlugin]);
+    });
+
+    it('discards the staged download and installs nothing when the user declines a content-hash mismatch', async () => {
+        const service = new RecordingInstallService({ stagingId: 'staging-1', mismatch: { expected: 'a', actual: 'b' } });
+        const installer = new TestPluginInstaller(service, true, false);
+
+        expect(await installer.install(entry, { replaceExisting: false, confirm: true })).to.be.false;
+        expect(service.calls).to.deep.equal(['stage', 'discard(staging-1)']);
+        expect(installer.registered).to.be.empty;
+    });
+
+    it('installs a mismatched download only once the user has explicitly accepted it', async () => {
+        const service = new RecordingInstallService({ stagingId: 'staging-1', mismatch: { expected: 'a', actual: 'b' } });
+        const installer = new TestPluginInstaller(service, true, true);
+
+        expect(await installer.install(entry, { replaceExisting: false, confirm: true })).to.be.true;
+        expect(service.calls).to.deep.equal(['stage', 'commit(staging-1, false)']);
+    });
+
+    it('replaces the existing root and skips the pre-install dialog on an update', async () => {
+        const service = new RecordingInstallService({ stagingId: 'staging-2' });
+        // `acceptInstall` is false: an update must not ask again, so the flow has to reach `stage`.
+        const installer = new TestPluginInstaller(service, false, true);
+
+        expect(await installer.install(entry, { replaceExisting: true, confirm: false })).to.be.true;
+        expect(service.calls).to.deep.equal(['stage', 'commit(staging-2, true)']);
+    });
+
+    it('fails loudly, naming the plugin, when the committed plugin\'s MCP servers cannot be registered', async () => {
+        const service = new RecordingInstallService({ stagingId: 'staging-1' });
+        const installer = new TestPluginInstaller(service, true, true, new Error('preference write failed'));
+
+        let message = '';
+        try {
+            await installer.install(entry, { replaceExisting: false, confirm: true });
+        } catch (error) {
+            message = error instanceof Error ? error.message : String(error);
+        }
+
+        expect(message).to.contain(entry.name);
+        expect(message).to.contain('preference write failed');
+    });
+});

--- a/packages/ai-registry/src/browser/plugin/plugin-installer.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-installer.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-installer.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-installer.ts
@@ -1,0 +1,125 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { MessageService, nls, Progress } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { InstalledPluginInfo, ResolvedPluginEntry, StagedPluginInstall } from '../../common/plugin/plugin-registry-types';
+import { PluginHashMismatchDialogFactory, PluginInstallDialogFactory } from './plugin-install-dialog';
+import { PluginInstallService } from './plugin-install-service';
+import { PluginMcpRegistrar } from './plugin-mcp-registrar';
+
+export interface PluginInstallOptions {
+    /** True for update and fix, where the existing root is removed before the staged download lands. */
+    readonly replaceExisting: boolean;
+    /** True for a first install; cleared for update and fix, where the user already accepted once. */
+    readonly confirm: boolean;
+}
+
+export const PluginInstaller = Symbol('PluginInstaller');
+/**
+ * Drives the two-phase install to completion. Both the Extensions view and the `install-plugin` deep
+ * link go through here, so either path shows the same dialogs and registers the same way.
+ */
+export interface PluginInstaller {
+    /** @returns true when the plugin was installed, false when the user cancelled either dialog. */
+    install(entry: ResolvedPluginEntry, options: PluginInstallOptions): Promise<boolean>;
+}
+
+@injectable()
+export class PluginInstallerImpl implements PluginInstaller {
+
+    @inject(PluginInstallService)
+    protected readonly installService: PluginInstallService;
+
+    @inject(PluginMcpRegistrar)
+    protected readonly mcpRegistrar: PluginMcpRegistrar;
+
+    @inject(PluginInstallDialogFactory)
+    protected readonly installDialogFactory: PluginInstallDialogFactory;
+
+    @inject(PluginHashMismatchDialogFactory)
+    protected readonly mismatchDialogFactory: PluginHashMismatchDialogFactory;
+
+    @inject(MessageService)
+    protected readonly messageService: MessageService;
+
+    async install(entry: ResolvedPluginEntry, options: PluginInstallOptions): Promise<boolean> {
+        if (options.confirm && !await this.confirmInstall(entry)) {
+            return false;
+        }
+        // Downloading a repository tarball is slow enough that silence reads as a hang. The progress
+        // is closed around the mismatch dialog so it never sits behind a modal waiting on the user.
+        const staged = await this.withProgress(entry,
+            nls.localizeByDefault('Downloading...'),
+            () => this.installService.stage(entry));
+        // Nothing is in the plugins root yet, so the user can still decide.
+        if (staged.mismatch && !await this.confirmMismatch(entry, staged)) {
+            await this.installService.discard(staged.stagingId);
+            return false;
+        }
+        await this.withProgress(entry,
+            nls.localizeByDefault('Installing...'),
+            async () => {
+                const installed = await this.installService.commit(staged.stagingId, options.replaceExisting);
+                // Only the MCP servers; the skill root is picked up by `PluginSkillDirectoryContribution`.
+                await this.register(installed, entry);
+            });
+        return true;
+    }
+
+    protected async withProgress<T>(entry: ResolvedPluginEntry, message: string, run: () => Promise<T>): Promise<T> {
+        const progress = await this.startProgress(entry, message);
+        try {
+            return await run();
+        } finally {
+            progress.cancel();
+        }
+    }
+
+    protected startProgress(entry: ResolvedPluginEntry, message: string): Promise<Progress> {
+        return this.messageService.showProgress({
+            text: nls.localize('theia/ai-registry/plugin/progress/text', 'Agent Plugin "{0}": {1}', entry.name, message)
+        });
+    }
+
+    /**
+     * Fails loudly: the root is already in place, so a silent failure leaves a plugin that looks
+     * installed while the servers it declared never run.
+     */
+    protected async register(installed: InstalledPluginInfo, entry: ResolvedPluginEntry): Promise<void> {
+        try {
+            await this.mcpRegistrar.register(installed);
+        } catch (error) {
+            // Names Uninstall and Install, not Update: this state classifies as up to date, so the
+            // Extensions view renders no Update button to point the user at.
+            throw new Error(nls.localize(
+                'theia/ai-registry/plugin/registrationFailed',
+                'Agent Plugin "{0}" was installed, but its MCP servers could not be registered: {1}. '
+                + 'Uninstall and install it again to retry.',
+                entry.name,
+                error instanceof Error ? error.message : String(error)
+            ));
+        }
+    }
+
+    protected async confirmInstall(entry: ResolvedPluginEntry): Promise<boolean> {
+        return !!await this.installDialogFactory({ entry }).open();
+    }
+
+    protected async confirmMismatch(entry: ResolvedPluginEntry, staged: StagedPluginInstall): Promise<boolean> {
+        return !!await this.mismatchDialogFactory({ entry, mismatch: staged.mismatch! }).open();
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-mcp-reconciler.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-mcp-reconciler.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-mcp-reconciler.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-mcp-reconciler.ts
@@ -1,0 +1,76 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Disposable, DisposableCollection, ILogger } from '@theia/core';
+import { FrontendApplicationContribution } from '@theia/core/lib/browser';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { PluginInstallClientImpl } from './plugin-install-client';
+import { PluginInstallService } from './plugin-install-service';
+import { PluginMcpRegistrar } from './plugin-mcp-registrar';
+
+/**
+ * Keeps `ai-features.mcp.mcpServers` in step with what is actually in the plugins root, so that an
+ * `mcp.json` added, changed or removed after the install shows up the way a skill does.
+ *
+ * Installing registers a plugin's servers directly; this exists for every other way the root can
+ * change - an edit on disk, a plugin directory removed by hand, or an `mcp.json` added while the
+ * application was not running, which is why it also runs once at startup.
+ */
+@injectable()
+export class PluginMcpReconciler implements FrontendApplicationContribution, Disposable {
+
+    @inject(PluginInstallService)
+    protected readonly installService: PluginInstallService;
+
+    @inject(PluginInstallClientImpl)
+    protected readonly installClient: PluginInstallClientImpl;
+
+    @inject(PluginMcpRegistrar)
+    protected readonly registrar: PluginMcpRegistrar;
+
+    @inject(ILogger) @named('ai-registry:PluginMcpReconciler')
+    protected readonly logger: ILogger;
+
+    protected readonly toDispose = new DisposableCollection();
+
+    /** Serialises overlapping runs; two reconciles writing the same preference would race. */
+    protected pending: Promise<void> = Promise.resolve();
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.installClient.onDidChangeInstalledPlugins(() => this.reconcile()));
+    }
+
+    onStart(): void {
+        this.reconcile();
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    protected reconcile(): void {
+        this.pending = this.pending.then(async () => {
+            try {
+                await this.registrar.reconcile(await this.installService.listInstalledPlugins());
+            } catch (error) {
+                // Logged, not surfaced: this runs on every filesystem event, and a notification per
+                // event would be worse than a stale entry the next successful run repairs.
+                this.logger.warn('Could not reconcile the MCP servers of the installed Agent Plugins.', error);
+            }
+        });
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.spec.ts
@@ -1,0 +1,242 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { PreferenceService } from '@theia/core';
+import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { InstalledPluginInfo } from '../../common/plugin/plugin-registry-types';
+import { PluginMcpRegistrarImpl } from './plugin-mcp-registrar';
+
+/** Minimal preference double: the registrar only reads and writes the MCP servers preference. */
+class FakePreferenceService {
+    constructor(public value: Record<string, unknown> = {}) { }
+    get<T>(key: string, defaultValue?: T): T | undefined {
+        return (key === MCP_SERVERS_PREF ? this.value : defaultValue) as T | undefined;
+    }
+    async set(key: string, value: unknown): Promise<void> {
+        if (key === MCP_SERVERS_PREF) {
+            this.value = value as Record<string, unknown>;
+        }
+    }
+}
+
+class TestPluginMcpRegistrar extends PluginMcpRegistrarImpl {
+    constructor(readonly preferences: FakePreferenceService) {
+        super();
+        Object.assign(this, { preferenceService: preferences as unknown as PreferenceService });
+    }
+}
+
+const PLUGIN_ID = 'io.github.acme/bigquery-data-analytics';
+const PLUGIN_DIRECTORY = 'io.github.acme_bigquery-data-analytics';
+const PLUGIN_ROOT = '/home/user/.agents/plugins/io.github.acme_bigquery-data-analytics';
+const PLUGIN_DATA = '/home/user/.agents/plugin-data/io.github.acme_bigquery-data-analytics';
+
+function installedPlugin(overrides: Partial<InstalledPluginInfo> = {}): InstalledPluginInfo {
+    return {
+        directoryName: PLUGIN_DIRECTORY,
+        root: PLUGIN_ROOT,
+        dataRoot: PLUGIN_DATA,
+        skills: [],
+        pluginId: PLUGIN_ID,
+        contentHash: 'hash-v1',
+        drifted: false,
+        servers: [{ kind: 'stdio', name: 'bigquery', command: 'node', args: ['server.js'], cwd: PLUGIN_ROOT }],
+        skipped: [],
+        ...overrides
+    };
+}
+
+describe('PluginMcpRegistrar.register', () => {
+
+    it("writes the plugin's own mcp.json key when nothing else occupies it", async () => {
+        const preferences = new FakePreferenceService();
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.register(installedPlugin());
+
+        expect(Object.keys(preferences.value)).to.deep.equal(['bigquery']);
+        expect(preferences.value.bigquery).to.deep.equal({
+            command: 'node',
+            args: ['server.js'],
+            cwd: PLUGIN_ROOT,
+            pluginRoot: PLUGIN_ROOT,
+            pluginData: PLUGIN_DATA,
+            autostart: true,
+            registryMetadata: { pluginId: PLUGIN_ID, configHash: 'hash-v1' }
+        });
+    });
+
+    it('falls back to the qualified key when the plain one is already taken, leaving the existing entry untouched', async () => {
+        const preferences = new FakePreferenceService({ bigquery: { command: 'my-own-server' } });
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.register(installedPlugin());
+
+        expect(preferences.value.bigquery).to.deep.equal({ command: 'my-own-server' });
+        expect(preferences.value[`${PLUGIN_DIRECTORY}_bigquery`]).to.deep.include({
+            command: 'node',
+            registryMetadata: { pluginId: PLUGIN_ID, configHash: 'hash-v1' }
+        });
+    });
+
+    it('writes a streamable-http server as a remote entry with its headers', async () => {
+        const preferences = new FakePreferenceService();
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.register(installedPlugin({
+            servers: [{ kind: 'http', name: 'remote', serverUrl: 'https://example.org/mcp', headers: { 'X-Api-Key': 'k' } }]
+        }));
+
+        expect(preferences.value.remote).to.deep.equal({
+            serverUrl: 'https://example.org/mcp',
+            headers: { 'X-Api-Key': 'k' },
+            autostart: true,
+            registryMetadata: { pluginId: PLUGIN_ID, configHash: 'hash-v1' }
+        });
+    });
+
+    it('replaces the entries it previously owned rather than reconciling them, so a removed server disappears on update', async () => {
+        const preferences = new FakePreferenceService({
+            gone: { command: 'old', registryMetadata: { pluginId: PLUGIN_ID } },
+            unrelated: { command: 'other' }
+        });
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.register(installedPlugin());
+
+        expect(Object.keys(preferences.value).sort()).to.deep.equal(['bigquery', 'unrelated']);
+    });
+
+    it('writes a differing entry after an update whose mcp.json is unchanged, so the running server restarts', async () => {
+        const preferences = new FakePreferenceService();
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.register(installedPlugin());
+        const beforeUpdate = JSON.stringify(preferences.value);
+        // Same servers, same key, same everything the plugin declares - only the plugin's own content
+        // changed. The entry still has to differ, or nothing restarts the process whose `cwd` points
+        // into the plugin root that the update just deleted and re-created.
+        await registrar.register(installedPlugin({ contentHash: 'hash-v2' }));
+
+        expect(JSON.stringify(preferences.value)).to.not.equal(beforeUpdate);
+        expect(preferences.value.bigquery).to.deep.include({ registryMetadata: { pluginId: PLUGIN_ID, configHash: 'hash-v2' } });
+    });
+
+    it('writes nothing for a directory without a provenance marker, which is the user\'s own', async () => {
+        const preferences = new FakePreferenceService({ unrelated: { command: 'other' } });
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.register(installedPlugin({ pluginId: undefined }));
+
+        expect(preferences.value).to.deep.equal({ unrelated: { command: 'other' } });
+    });
+
+    it('registers no entry for a server the plugin root rejected', async () => {
+        const preferences = new FakePreferenceService();
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.register(installedPlugin({ servers: [], skipped: [{ name: 'legacy', reason: 'The MCP transport "sse" is not supported.' }] }));
+
+        expect(preferences.value).to.deep.equal({});
+    });
+});
+
+describe('PluginMcpRegistrar.unregister', () => {
+
+    it('removes exactly the entries owned by the plugin, whatever key they were stored under', async () => {
+        const preferences = new FakePreferenceService({
+            // A user renamed the key; ownership rides on `registryMetadata.pluginId`, not on the key.
+            renamed: { command: 'node', registryMetadata: { pluginId: PLUGIN_ID } },
+            other_plugin: { command: 'node', registryMetadata: { pluginId: 'io.github.other/plugin' } },
+            standalone: { command: 'npx', registryMetadata: { serverId: 'io.github.example/example-mcp' } },
+            handAdded: { command: 'my-own-server' }
+        });
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.unregister(PLUGIN_ID);
+
+        expect(Object.keys(preferences.value).sort()).to.deep.equal(['handAdded', 'other_plugin', 'standalone']);
+    });
+
+    it('leaves the preference untouched when the plugin owns no entry', async () => {
+        const stored = { handAdded: { command: 'my-own-server' } };
+        const preferences = new FakePreferenceService(stored);
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.unregister(PLUGIN_ID);
+
+        expect(preferences.value).to.equal(stored);
+    });
+});
+
+describe('PluginMcpRegistrar.reconcile', () => {
+
+    it('registers a server that appeared after the install, which is how a later mcp.json takes effect', async () => {
+        const preferences = new FakePreferenceService({ handAdded: { command: 'my-own-server' } });
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.reconcile([installedPlugin()]);
+
+        expect(Object.keys(preferences.value).sort()).to.deep.equal(['bigquery', 'handAdded']);
+        expect((preferences.value.bigquery as { registryMetadata: { pluginId: string } }).registryMetadata.pluginId).to.equal(PLUGIN_ID);
+    });
+
+    it('drops the entries of a plugin that is no longer installed', async () => {
+        const preferences = new FakePreferenceService({
+            bigquery: { command: 'node', registryMetadata: { pluginId: PLUGIN_ID } },
+            handAdded: { command: 'my-own-server' }
+        });
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.reconcile([]);
+
+        expect(Object.keys(preferences.value)).to.deep.equal(['handAdded']);
+    });
+
+    it('writes nothing when the plugins already match, so a filesystem event cannot restart a server', async () => {
+        const preferences = new FakePreferenceService();
+        const registrar = new TestPluginMcpRegistrar(preferences);
+        await registrar.reconcile([installedPlugin()]);
+        const afterFirst = preferences.value;
+
+        await registrar.reconcile([installedPlugin()]);
+
+        expect(preferences.value).to.equal(afterFirst);
+    });
+
+    it('removes an entry whose server disappeared from the plugin root', async () => {
+        const preferences = new FakePreferenceService();
+        const registrar = new TestPluginMcpRegistrar(preferences);
+        await registrar.reconcile([installedPlugin()]);
+
+        await registrar.reconcile([installedPlugin({ servers: [] })]);
+
+        expect(preferences.value).to.deep.equal({});
+    });
+
+    it('never touches an entry the user wrote themselves', async () => {
+        const own = { command: 'my-own-server' };
+        const standalone = { command: 'npx', registryMetadata: { serverId: 'io.github.example/example-mcp' } };
+        const preferences = new FakePreferenceService({ handAdded: own, standalone });
+        const registrar = new TestPluginMcpRegistrar(preferences);
+
+        await registrar.reconcile([installedPlugin()]);
+
+        expect(preferences.value.handAdded).to.equal(own);
+        expect(preferences.value.standalone).to.equal(standalone);
+    });
+});

--- a/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-mcp-registrar.ts
@@ -1,0 +1,163 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { PreferenceScope, PreferenceService } from '@theia/core';
+import { inject, injectable } from '@theia/core/shared/inversify';
+import { MCP_SERVERS_PREF } from '@theia/ai-mcp/lib/common/mcp-preferences';
+import { MCPInstallEntryConfig, MCPRegistryMetadata } from '@theia/ai-mcp/lib/common/mcp-server-manager';
+import { ResolvedPluginServer } from '../../common/plugin/agent-plugin-manifest';
+import { InstalledPluginInfo } from '../../common/plugin/plugin-registry-types';
+
+/** One entry of the `ai-features.mcp.mcpServers` preference, as this registrar writes it. */
+type StoredEntry = MCPInstallEntryConfig & {
+    autostart?: boolean;
+    registryMetadata?: MCPRegistryMetadata;
+};
+
+type StoredServers = Record<string, StoredEntry>;
+
+export const PluginMcpRegistrar = Symbol('PluginMcpRegistrar');
+/**
+ * The seam between installed Agent Plugins and Theia's MCP configuration. Ownership rides on
+ * `registryMetadata.pluginId` rather than a recorded list of keys, so renaming a key in the
+ * preference does not orphan the entry.
+ *
+ * No merge policy on purpose: an update deletes the plugin's entries and writes them again from the
+ * root. The MCP preference is about to become a file-based configuration and this is rewritten then.
+ */
+export interface PluginMcpRegistrar {
+    /** Servers the plugin root rejected are surfaced on the card instead of registered. */
+    register(info: InstalledPluginInfo): Promise<void>;
+    unregister(pluginId: string): Promise<void>;
+    /**
+     * Rewrites the entries of every managed plugin from `infos` and drops those of plugins that are
+     * no longer installed, leaving entries the user wrote alone. Writes nothing when the result is
+     * unchanged, so it is safe to call on every filesystem event.
+     */
+    reconcile(infos: InstalledPluginInfo[]): Promise<void>;
+}
+
+@injectable()
+export class PluginMcpRegistrarImpl implements PluginMcpRegistrar {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    async register(info: InstalledPluginInfo): Promise<void> {
+        const pluginId = info.pluginId;
+        if (pluginId === undefined) {
+            // A directory without our provenance marker is the user's own; we never write for it.
+            return;
+        }
+        // Delete-then-write, so an update never reconciles fields against the previous entries.
+        const next = this.withoutPlugin(this.readServers(), pluginId);
+        for (const server of info.servers) {
+            next[this.pickKey(next, server.name, info.directoryName)] = this.toEntry(server, info, pluginId);
+        }
+        await this.writeServers(next);
+    }
+
+    async reconcile(infos: InstalledPluginInfo[]): Promise<void> {
+        const current = this.readServers();
+        const next: StoredServers = {};
+        // Everything the user wrote themselves survives verbatim; every plugin-owned entry is
+        // rebuilt below, so one whose plugin has since gone simply does not come back.
+        for (const [key, entry] of Object.entries(current)) {
+            if (entry?.registryMetadata?.pluginId === undefined) {
+                next[key] = entry;
+            }
+        }
+        // Sorted, so which plugin wins a name collision does not depend on `readdir` order.
+        const managed = infos.filter(info => info.pluginId !== undefined)
+            .sort((left, right) => left.pluginId!.localeCompare(right.pluginId!));
+        for (const info of managed) {
+            for (const server of info.servers) {
+                next[this.pickKey(next, server.name, info.directoryName)] = this.toEntry(server, info, info.pluginId!);
+            }
+        }
+        if (!this.sameServers(current, next)) {
+            await this.writeServers(next);
+        }
+    }
+
+    /** Order-insensitive: rewriting the preference restarts servers, so an equal result must not. */
+    protected sameServers(left: StoredServers, right: StoredServers): boolean {
+        const keys = Object.keys(left).sort();
+        if (keys.length !== Object.keys(right).length) {
+            return false;
+        }
+        return keys.every(key => key in right && JSON.stringify(left[key]) === JSON.stringify(right[key]));
+    }
+
+    async unregister(pluginId: string): Promise<void> {
+        const current = this.readServers();
+        const next = this.withoutPlugin(current, pluginId);
+        if (Object.keys(next).length !== Object.keys(current).length) {
+            await this.writeServers(next);
+        }
+    }
+
+    /** The plugin's own key while it is free, so servers keep the name the plugin gave them. */
+    protected pickKey(servers: StoredServers, name: string, qualifier: string): string {
+        return name in servers ? `${qualifier}_${name}` : name;
+    }
+
+    protected toEntry(server: ResolvedPluginServer, info: InstalledPluginInfo, pluginId: string): StoredEntry {
+        // `installedAt` is what makes an update or a Fix restart the server: the entry then differs
+        // even when `mcp.json` did not change, and the manager reads it as part of the connection.
+        const registryMetadata: MCPRegistryMetadata = {
+            pluginId,
+            ...(info.contentHash !== undefined && { configHash: info.contentHash }),
+            ...(info.installedAt !== undefined && { installedAt: info.installedAt })
+        };
+        if (server.kind === 'stdio') {
+            return {
+                command: server.command,
+                ...(server.args !== undefined && { args: server.args }),
+                ...(server.env !== undefined && { env: server.env }),
+                cwd: server.cwd,
+                pluginRoot: info.root,
+                pluginData: info.dataRoot,
+                autostart: true,
+                registryMetadata
+            };
+        }
+        return {
+            serverUrl: server.serverUrl,
+            ...(server.headers !== undefined && { headers: server.headers }),
+            autostart: true,
+            registryMetadata
+        };
+    }
+
+    protected withoutPlugin(servers: StoredServers, pluginId: string): StoredServers {
+        const next: StoredServers = {};
+        for (const [key, entry] of Object.entries(servers)) {
+            if (entry?.registryMetadata?.pluginId !== pluginId) {
+                next[key] = entry;
+            }
+        }
+        return next;
+    }
+
+    protected readServers(): StoredServers {
+        return this.preferenceService.get<StoredServers>(MCP_SERVERS_PREF, {}) ?? {};
+    }
+
+    protected async writeServers(next: StoredServers): Promise<void> {
+        await this.preferenceService.set(MCP_SERVERS_PREF, next, PreferenceScope.User);
+    }
+}

--- a/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.spec.ts
@@ -1,0 +1,131 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// The contribution imports `@theia/ai-core`'s skill service and the install service, both of which
+// reach browser-side modules at import time.
+const disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { ILogger } from '@theia/core';
+import { InstalledPluginInfo } from '../../common/plugin/plugin-registry-types';
+import { PluginInstallService } from './plugin-install-service';
+import { PluginSkillDirectoryContribution } from './plugin-skill-directory-contribution';
+
+after(() => disableJSDOM());
+
+const silentLogger = { warn: () => undefined, error: () => undefined } as unknown as ILogger;
+
+class TestPluginSkillDirectoryContribution extends PluginSkillDirectoryContribution {
+    constructor(plugins: InstalledPluginInfo[]) {
+        super();
+        Object.assign(this, {
+            logger: silentLogger,
+            installService: { listInstalledPlugins: async () => plugins } as unknown as PluginInstallService
+        });
+    }
+}
+
+function plugin(pluginId: string | undefined, directoryName: string, name?: string): InstalledPluginInfo {
+    return {
+        directoryName,
+        root: `/home/user/.agents/plugins/${directoryName}`,
+        dataRoot: `/home/user/.agents/plugin-data/${directoryName}`,
+        drifted: false,
+        skills: [],
+        servers: [],
+        skipped: [],
+        ...(pluginId !== undefined && { pluginId }),
+        ...(name !== undefined && { name })
+    };
+}
+
+describe('PluginSkillDirectoryContribution.getSkillDirectories', () => {
+
+    it('contributes the skills directory of every installed plugin as a plugin-tier root, qualified by its directory name', async () => {
+        const contribution = new TestPluginSkillDirectoryContribution([
+            plugin('io.github.acme/bigquery-data-analytics', 'io.github.acme_bigquery-data-analytics', 'BigQuery Data Analytics')
+        ]);
+
+        expect(await contribution.getSkillDirectories()).to.deep.equal([{
+            path: '/home/user/.agents/plugins/io.github.acme_bigquery-data-analytics/skills',
+            tier: 'plugin',
+            qualifier: 'io.github.acme_bigquery-data-analytics'
+        }]);
+    });
+
+    it('contributes nothing for a directory without a provenance marker, which has no identifier to qualify its skills with', async () => {
+        const contribution = new TestPluginSkillDirectoryContribution([plugin(undefined, 'my-own-plugin', 'my-own-plugin')]);
+
+        expect(await contribution.getSkillDirectories()).to.be.empty;
+    });
+});
+
+describe('PluginSkillDirectoryContribution qualifier assignment', () => {
+
+    async function qualifiers(plugins: InstalledPluginInfo[]): Promise<(string | undefined)[]> {
+        return (await new TestPluginSkillDirectoryContribution(plugins).getSkillDirectories()).map(directory => directory.qualifier);
+    }
+
+    it('qualifies with the plugin directory name, which is unique by construction', async () => {
+        expect(await qualifiers([
+            plugin('io.github.acme/bigquery', 'io.github.acme_bigquery'),
+            plugin('io.github.other/athena', 'io.github.other_athena')
+        ])).to.deep.equal(['io.github.acme_bigquery', 'io.github.other_athena']);
+    });
+
+    it('keeps two plugins sharing a last identifier segment apart without any collision handling', async () => {
+        expect(await qualifiers([
+            plugin('io.github.acme/tools', 'io.github.acme_tools'),
+            plugin('io.github.other/tools', 'io.github.other_tools')
+        ])).to.deep.equal(['io.github.acme_tools', 'io.github.other_tools']);
+    });
+
+    it('does not rename an installed plugin\'s skills when another plugin is installed beside it', async () => {
+        const acme = plugin('io.github.acme/tools', 'io.github.acme_tools');
+
+        expect(await qualifiers([acme])).to.deep.equal(['io.github.acme_tools']);
+        expect(await qualifiers([acme, plugin('io.github.other/tools', 'io.github.other_tools')]))
+            .to.deep.equal(['io.github.acme_tools', 'io.github.other_tools']);
+    });
+
+    it('contributes the roots in identifier order whatever order they were discovered in', async () => {
+        // The sort is about the roots, not the qualifiers: `readdir` order is filesystem-dependent, and
+        // each qualifier is read off its own plugin so it could not depend on the order anyway.
+        const acmeTools = plugin('io.github.acme/tools', 'io.github.acme_tools');
+        const otherTools = plugin('io.github.other/tools', 'io.github.other_tools');
+        const acmeBigquery = plugin('io.github.acme/bigquery', 'io.github.acme_bigquery');
+        const expected = ['io.github.acme_bigquery', 'io.github.acme_tools', 'io.github.other_tools'];
+
+        expect(await qualifiers([acmeTools, otherTools, acmeBigquery])).to.deep.equal(expected);
+        expect(await qualifiers([acmeBigquery, otherTools, acmeTools])).to.deep.equal(expected);
+    });
+
+    it('yields no roots when the backend cannot be reached, so skills from every other tier keep loading', async () => {
+        const contribution = new TestPluginSkillDirectoryContribution([]);
+        Object.assign(contribution, {
+            installService: { listInstalledPlugins: async () => { throw new Error('backend unavailable'); } } as unknown as PluginInstallService
+        });
+
+        expect(await contribution.getSkillDirectories()).to.be.empty;
+    });
+});

--- a/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.spec.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -27,6 +27,7 @@ try {
 
 import { expect } from 'chai';
 import { ILogger } from '@theia/core';
+import { Path } from '@theia/core/lib/common/path';
 import { InstalledPluginInfo } from '../../common/plugin/plugin-registry-types';
 import { PluginInstallService } from './plugin-install-service';
 import { PluginSkillDirectoryContribution } from './plugin-skill-directory-contribution';
@@ -66,11 +67,15 @@ describe('PluginSkillDirectoryContribution.getSkillDirectories', () => {
             plugin('io.github.acme/bigquery-data-analytics', 'io.github.acme_bigquery-data-analytics', 'BigQuery Data Analytics')
         ]);
 
-        expect(await contribution.getSkillDirectories()).to.deep.equal([{
-            path: '/home/user/.agents/plugins/io.github.acme_bigquery-data-analytics/skills',
-            tier: 'plugin',
-            qualifier: 'io.github.acme_bigquery-data-analytics'
-        }]);
+        const directories = await contribution.getSkillDirectories();
+
+        expect(directories).to.have.lengthOf(1);
+        // The root is contributed in the backend's native form, so the separator is the host's; the
+        // separator-agnostic comparison keeps this about the joined `skills` segment. The native
+        // conversion itself is asserted, per format, in `agent-plugin-manifest.spec.ts`.
+        expect(Path.normalizePathSeparator(directories[0].path)).to.equal('/home/user/.agents/plugins/io.github.acme_bigquery-data-analytics/skills');
+        expect(directories[0].tier).to.equal('plugin');
+        expect(directories[0].qualifier).to.equal('io.github.acme_bigquery-data-analytics');
     });
 
     it('contributes nothing for a directory without a provenance marker, which has no identifier to qualify its skills with', async () => {

--- a/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.ts
+++ b/packages/ai-registry/src/browser/plugin/plugin-skill-directory-contribution.ts
@@ -1,0 +1,87 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Disposable, DisposableCollection, Emitter, Event, ILogger } from '@theia/core';
+import { Path } from '@theia/core/lib/common/path';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { SkillDirectoryContribution } from '@theia/ai-core/lib/browser/skill-service';
+import { SkillDirectoryEntry } from '@theia/ai-core/lib/common/skill';
+import { InstalledPluginInfo } from '../../common/plugin/plugin-registry-types';
+import { PluginInstallClientImpl } from './plugin-install-client';
+import { PluginInstallService } from './plugin-install-service';
+
+/** Fixed component location of the specification; not configurable. */
+const PLUGIN_SKILLS_DIRECTORY = 'skills';
+
+/**
+ * One skill root per installed Agent Plugin, carrying the qualifier that keeps two plugins' skills
+ * from colliding by name. Only plugins carrying our provenance marker are contributed: qualification
+ * needs an identifier, and a hand-placed directory has none until it is linked.
+ */
+@injectable()
+export class PluginSkillDirectoryContribution implements SkillDirectoryContribution, Disposable {
+
+    @inject(PluginInstallService)
+    protected readonly installService: PluginInstallService;
+
+    @inject(PluginInstallClientImpl)
+    protected readonly installClient: PluginInstallClientImpl;
+
+    @inject(ILogger) @named('ai-registry:PluginSkillDirectoryContribution')
+    protected readonly logger: ILogger;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    protected readonly toDispose = new DisposableCollection(this.onDidChangeEmitter);
+
+    @postConstruct()
+    protected init(): void {
+        this.toDispose.push(this.installClient.onDidChangeInstalledPlugins(() => this.onDidChangeEmitter.fire()));
+    }
+
+    dispose(): void {
+        this.toDispose.dispose();
+    }
+
+    /**
+     * The qualifier comes from the marker, chosen once when the plugin was installed or linked, so
+     * installing another plugin never renames these skills.
+     */
+    async getSkillDirectories(): Promise<SkillDirectoryEntry[]> {
+        return (await this.listManagedPlugins()).map(info => ({
+            path: new Path(info.root).join(PLUGIN_SKILLS_DIRECTORY).fsPath(),
+            tier: 'plugin' as const,
+            qualifier: info.qualifier ?? info.directoryName
+        }));
+    }
+
+    /**
+     * Ordered by identifier so the contributed roots do not depend on `readdir` order. A backend
+     * failure yields no roots rather than propagating, so every other skill tier keeps loading.
+     */
+    protected async listManagedPlugins(): Promise<InstalledPluginInfo[]> {
+        try {
+            const installed = await this.installService.listInstalledPlugins();
+            return installed
+                .filter(info => info.pluginId !== undefined)
+                .sort((left, right) => left.pluginId!.localeCompare(right.pluginId!));
+        } catch (error) {
+            this.logger.warn('Could not list installed Agent Plugins; no plugin skill roots are contributed.', error);
+            return [];
+        }
+    }
+}

--- a/packages/ai-registry/src/browser/registry-entry-context.ts
+++ b/packages/ai-registry/src/browser/registry-entry-context.ts
@@ -33,12 +33,33 @@ export interface RegistryEntryContext {
     readonly artifactKind: RegistryArtifactKind;
     /** The "Copy ID" payload: the registry identifier, or the local name for an unlinked artifact. */
     readonly copyableId: string | undefined;
-    /** The override key, set only while the artifact is installed and linked to a registry entry. */
+    /** The override key. See {@link RegistryEntryContext.autoUpdateId} for when there is one. */
     readonly autoUpdateId: string | undefined;
 }
 
 export namespace RegistryEntryContext {
     export function is(arg: unknown): arg is RegistryEntryContext {
         return !!arg && typeof arg === 'object' && 'artifactKind' in arg && 'autoUpdateId' in arg;
+    }
+
+    /**
+     * The override key for an entry in the given classification state, or `undefined` when a policy
+     * would have nothing to key on.
+     *
+     * Offered for every installed artifact with a registry identity, including the ones showing a
+     * warning: a drifted artifact, one that is still to be linked, and one whose registry entry has
+     * gone missing all keep their policy, so the choice the user makes now is already in place once
+     * the artifact becomes updatable again. The auto-updater still skips them until then - it only
+     * ever acts on `installed-from-registry`.
+     *
+     * Withheld for an artifact that is not installed, where there is nothing yet to keep updated,
+     * and for one the registry has never known, which has no id to key an override by.
+     *
+     * Typed against the bare `kind` because the three artifact families spell their fix state
+     * differently (`fix-skill`, `fix-config`, `fix-plugin`) while sharing every state that matters
+     * here - the same reason the gear menu itself is kind-agnostic.
+     */
+    export function autoUpdateId(state: { kind: string }, id: string | undefined): string | undefined {
+        return state.kind === 'not-installed' ? undefined : id;
     }
 }

--- a/packages/ai-registry/src/browser/registry-entry-menu.spec.ts
+++ b/packages/ai-registry/src/browser/registry-entry-menu.spec.ts
@@ -66,3 +66,36 @@ describe('showEntryMenu', () => {
         expect(rendered!.anchor).to.deep.equal({ x: 40, y: 90 });
     });
 });
+
+describe('RegistryEntryContext.autoUpdateId', () => {
+
+    const ID = 'io.github.example/example-skill';
+
+    it('offers a policy for an artifact installed from the registry', () => {
+        expect(RegistryEntryContext.autoUpdateId({ kind: 'installed-from-registry' }, ID)).to.equal(ID);
+    });
+
+    // The three warning states. A policy set here applies as soon as the artifact is updatable
+    // again; the auto-updater keeps skipping it until then.
+    for (const kind of ['fix-skill', 'fix-config', 'fix-plugin']) {
+        it(`offers a policy for a drifted artifact (${kind}), which the user has to fix first`, () => {
+            expect(RegistryEntryContext.autoUpdateId({ kind }, ID)).to.equal(ID);
+        });
+    }
+
+    it('offers a policy for an artifact whose registry entry has gone missing', () => {
+        expect(RegistryEntryContext.autoUpdateId({ kind: 'installed-link-stale' }, ID)).to.equal(ID);
+    });
+
+    it('offers a policy for a hand-placed artifact that is still to be linked', () => {
+        expect(RegistryEntryContext.autoUpdateId({ kind: 'installed-manually' }, ID)).to.equal(ID);
+    });
+
+    it('withholds a policy before the artifact is installed, where there is nothing to keep updated', () => {
+        expect(RegistryEntryContext.autoUpdateId({ kind: 'not-installed' }, ID)).to.be.undefined;
+    });
+
+    it('withholds a policy for an artifact the registry has never known, which has no id to key on', () => {
+        expect(RegistryEntryContext.autoUpdateId({ kind: 'installed-user-added' }, undefined)).to.be.undefined;
+    });
+});

--- a/packages/ai-registry/src/browser/skill/skill-entries.tsx
+++ b/packages/ai-registry/src/browser/skill/skill-entries.tsx
@@ -62,7 +62,7 @@ export class SkillInstalledEntry implements TreeElement, RegistryEntryContext {
     }
 
     get autoUpdateId(): string | undefined {
-        return autoUpdateId(this.state, this.matchedEntry?.skillId);
+        return RegistryEntryContext.autoUpdateId(this.state, this.matchedEntry?.skillId ?? this.local.skillId);
     }
 
     render(): React.ReactNode {
@@ -100,7 +100,7 @@ export class SkillSearchResultEntry implements TreeElement, RegistryEntryContext
     }
 
     get autoUpdateId(): string | undefined {
-        return autoUpdateId(this.state, this.entry.skillId);
+        return RegistryEntryContext.autoUpdateId(this.state, this.entry.skillId);
     }
 
     render(): React.ReactNode {
@@ -115,14 +115,6 @@ export class SkillSearchResultEntry implements TreeElement, RegistryEntryContext
             />
         );
     }
-}
-
-/**
- * An auto-update policy is only meaningful for a skill that is installed and linked to a live
- * registry entry - which excludes drifted skills, as the auto-updater does.
- */
-function autoUpdateId(state: SkillClassificationResult, skillId: string | undefined): string | undefined {
-    return state.kind === 'installed-from-registry' ? skillId : undefined;
 }
 
 interface SkillCardProps {

--- a/packages/ai-registry/src/browser/skill/skill-registry-ui-bridge-impl.spec.ts
+++ b/packages/ai-registry/src/browser/skill/skill-registry-ui-bridge-impl.spec.ts
@@ -1,0 +1,170 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { FrontendApplicationConfigProvider } from '@theia/core/lib/browser/frontend-application-config-provider';
+import { enableJSDOM } from '@theia/core/lib/browser/test/jsdom';
+// The view contribution import chain pulls in browser-side modules, so a DOM is required at import time.
+const disableJSDOM = enableJSDOM();
+try {
+    FrontendApplicationConfigProvider.get();
+} catch {
+    FrontendApplicationConfigProvider.set({});
+}
+
+import { expect } from 'chai';
+import { Event, ILogger } from '@theia/core';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { Skill } from '@theia/ai-core/lib/common/skill';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { InstalledSkillInfo, ResolvedSkillEntry } from '../../common/skill/skill-registry-types';
+import { SkillInstallService } from './skill-install-service';
+import { SkillInstallClientImpl } from './skill-install-client';
+import { SkillRegistryUiBridgeImpl } from './skill-registry-ui-bridge-impl';
+
+after(() => disableJSDOM());
+
+const HOME = '/home/alex';
+const SKILLS_ROOT = `${HOME}/.agents/skills`;
+
+const silentLogger = { warn: () => undefined, error: () => undefined } as unknown as ILogger;
+
+function skill(location: string, name = 'query-builder'): Skill {
+    return { name, qualifiedName: name, description: 'Build SQL', location } as Skill;
+}
+
+function installed(name: string, skillId?: string): InstalledSkillInfo {
+    return { name, drifted: false, ...(skillId !== undefined && { skillId }) };
+}
+
+/** Only `getSkillEntries` is reached; the ids are all the bridge reads off the entries. */
+function stubFetchService(skillIds: string[]): RegistryFetchService {
+    return {
+        onDidChange: Event.None,
+        getSkillEntries: async () => skillIds.map(skillId => ({ skillId } as ResolvedSkillEntry))
+    } as unknown as RegistryFetchService;
+}
+
+/**
+ * The bridge with its collaborators stubbed; `openedViews` records the reveal calls. The registry
+ * lists every installed id unless `listedSkillIds` says otherwise, which is the ordinary case.
+ */
+async function buildBridge(
+    skills: InstalledSkillInfo[],
+    hooks: { searchModel?: { query: string }, openedViews?: string[], listedSkillIds?: string[] } = {}
+): Promise<SkillRegistryUiBridgeImpl> {
+    const bridge = new SkillRegistryUiBridgeImpl();
+    const installClient = new SkillInstallClientImpl();
+    Object.assign(bridge, {
+        logger: silentLogger,
+        installClient,
+        installService: { listInstalledSkills: async () => skills } as unknown as SkillInstallService,
+        envVariablesServer: { getHomeDirUri: async () => `file://${HOME}` } as unknown as EnvVariablesServer,
+        fetchService: stubFetchService(hooks.listedSkillIds ?? skills.flatMap(info => info.skillId ?? [])),
+        searchModel: hooks.searchModel ?? { query: '' },
+        viewContribution: { openView: async () => { hooks.openedViews?.push('extensions'); } }
+    });
+    (bridge as unknown as { init: () => void }).init();
+    // `init` primes the cache asynchronously; the bridge answers synchronously once it has.
+    await (bridge as unknown as { refreshCache: () => Promise<void> }).refreshCache();
+    return bridge;
+}
+
+describe('SkillRegistryUiBridgeImpl', () => {
+
+    it('resolves the registry entry of a skill installed into the registry skills root', async () => {
+        const bridge = await buildBridge([installed('query-builder', 'io.github.acme/query-builder')]);
+        expect(bridge.getRegistryEntryId(skill(`${SKILLS_ROOT}/query-builder/SKILL.md`))).to.equal('io.github.acme/query-builder');
+    });
+
+    it('resolves nothing for a folder in the skills root that carries no registry metadata', async () => {
+        const bridge = await buildBridge([installed('hand-placed')]);
+        expect(bridge.getRegistryEntryId(skill(`${SKILLS_ROOT}/hand-placed/SKILL.md`, 'hand-placed'))).to.equal(undefined);
+    });
+
+    it('resolves nothing for a workspace skill of the same name, which the registry did not install', async () => {
+        // The name matches a managed skill, but the file is the user's own: a workspace root takes
+        // precedence over the registry root, so this is the skill the list actually shows.
+        const bridge = await buildBridge([installed('query-builder', 'io.github.acme/query-builder')]);
+        expect(bridge.getRegistryEntryId(skill('/workspace/.agents/skills/query-builder/SKILL.md'))).to.equal(undefined);
+    });
+
+    it('resolves nothing for a skill nested deeper than a folder below the skills root', async () => {
+        const bridge = await buildBridge([installed('query-builder', 'io.github.acme/query-builder')]);
+        expect(bridge.getRegistryEntryId(skill(`${SKILLS_ROOT}/query-builder/nested/SKILL.md`))).to.equal(undefined);
+    });
+
+    it('reveals a skill by searching the Extensions view for its registry id', async () => {
+        const searchModel = { query: '' };
+        const openedViews: string[] = [];
+        const bridge = await buildBridge([installed('query-builder', 'io.github.acme/query-builder')], { searchModel, openedViews });
+
+        bridge.revealSkill('io.github.acme/query-builder');
+
+        expect(searchModel.query).to.equal('io.github.acme/query-builder');
+        expect(openedViews).to.deep.equal(['extensions']);
+    });
+
+    it('opens the view without a search for a linked id the registry no longer lists, which a search would hide', async () => {
+        // A stale link shows up in the Installed section with a warning; a query switches the view to
+        // its search results, where a revoked id matches nothing.
+        const searchModel = { query: '' };
+        const openedViews: string[] = [];
+        const bridge = await buildBridge(
+            [installed('query-builder', 'io.github.acme/query-builder')],
+            { searchModel, openedViews, listedSkillIds: [] });
+
+        bridge.revealSkill('io.github.acme/query-builder');
+
+        expect(searchModel.query).to.equal('');
+        expect(openedViews).to.deep.equal(['extensions']);
+    });
+
+    it('refreshes when the installed skills change, so a link or unlink is reflected', async () => {
+        let skills = [installed('query-builder')];
+        const bridge = new SkillRegistryUiBridgeImpl();
+        const installClient = new SkillInstallClientImpl();
+        Object.assign(bridge, {
+            logger: silentLogger,
+            installClient,
+            installService: { listInstalledSkills: async () => skills } as unknown as SkillInstallService,
+            envVariablesServer: { getHomeDirUri: async () => `file://${HOME}` } as unknown as EnvVariablesServer,
+            fetchService: stubFetchService(['io.github.acme/query-builder']),
+            searchModel: { query: '' },
+            viewContribution: { openView: async () => { } }
+        });
+        (bridge as unknown as { init: () => void }).init();
+        const changes: number[] = [];
+        bridge.onDidChange(() => changes.push(1));
+
+        skills = [installed('query-builder', 'io.github.acme/query-builder')];
+        installClient.notifyDidChangeInstalledSkills();
+        await (bridge as unknown as { refreshCache: () => Promise<void> }).refreshCache();
+
+        expect(bridge.getRegistryEntryId(skill(`${SKILLS_ROOT}/query-builder/SKILL.md`))).to.equal('io.github.acme/query-builder');
+        expect(changes.length).to.be.greaterThan(0);
+    });
+
+    it('keeps the previous answers when the backend cannot be reached, rather than dropping every label', async () => {
+        const bridge = await buildBridge([installed('query-builder', 'io.github.acme/query-builder')]);
+        Object.assign(bridge, {
+            installService: { listInstalledSkills: (): Promise<never> => { throw new Error('backend unavailable'); } } as unknown as SkillInstallService
+        });
+
+        await (bridge as unknown as { refreshCache: () => Promise<void> }).refreshCache();
+
+        expect(bridge.getRegistryEntryId(skill(`${SKILLS_ROOT}/query-builder/SKILL.md`))).to.equal('io.github.acme/query-builder');
+    });
+});

--- a/packages/ai-registry/src/browser/skill/skill-registry-ui-bridge-impl.ts
+++ b/packages/ai-registry/src/browser/skill/skill-registry-ui-bridge-impl.ts
@@ -1,0 +1,121 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { Emitter, Event, ILogger, URI } from '@theia/core';
+import { EnvVariablesServer } from '@theia/core/lib/common/env-variables';
+import { Path } from '@theia/core/lib/common/path';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { SkillRegistryUiBridge } from '@theia/ai-core/lib/browser/skill-registry-ui-bridge';
+import { Skill, SKILL_FILE_NAME } from '@theia/ai-core/lib/common/skill';
+import { VSXExtensionsContribution } from '@theia/vsx-registry/lib/browser/vsx-extensions-contribution';
+import { VSXExtensionsSearchModel } from '@theia/vsx-registry/lib/browser/vsx-extensions-search-model';
+import { RegistryFetchService } from '../../common/registry-fetch-service';
+import { SkillInstallClientImpl } from './skill-install-client';
+import { SkillInstallService } from './skill-install-service';
+
+/**
+ * Lets the AI configuration view label and reveal the skills this package manages, without
+ * `@theia/ai-core` depending on it. Cached because {@link getRegistryEntryId} is called from React
+ * renders and must answer synchronously.
+ */
+@injectable()
+export class SkillRegistryUiBridgeImpl implements SkillRegistryUiBridge {
+
+    @inject(SkillInstallService)
+    protected readonly installService: SkillInstallService;
+
+    @inject(SkillInstallClientImpl)
+    protected readonly installClient: SkillInstallClientImpl;
+
+    @inject(RegistryFetchService)
+    protected readonly fetchService: RegistryFetchService;
+
+    @inject(EnvVariablesServer)
+    protected readonly envVariablesServer: EnvVariablesServer;
+
+    @inject(VSXExtensionsContribution)
+    protected readonly viewContribution: VSXExtensionsContribution;
+
+    @inject(VSXExtensionsSearchModel)
+    protected readonly searchModel: VSXExtensionsSearchModel;
+
+    @inject(ILogger) @named('ai-registry:SkillRegistryUiBridgeImpl')
+    protected readonly logger: ILogger;
+
+    protected readonly onDidChangeEmitter = new Emitter<void>();
+    readonly onDidChange: Event<void> = this.onDidChangeEmitter.event;
+
+    /**
+     * Registry entry ids of the managed skills, keyed by the `SKILL.md` path each one must sit at -
+     * `<skills root>/<name>/SKILL.md`, the only shape this package installs.
+     *
+     * Keyed by location rather than by name because a workspace skill takes precedence over a managed
+     * one of the same name, and labelling that as coming from the registry would credit the registry
+     * for a file the user wrote.
+     */
+    protected entryIdsByLocation = new Map<string, string>();
+
+    /** Ids the registry currently lists, so {@link revealSkill} can tell a live entry from a revoked one. */
+    protected listedSkillIds = new Set<string>();
+
+    @postConstruct()
+    protected init(): void {
+        this.installClient.onDidChangeInstalledSkills(() => this.refreshCache());
+        // A refreshed feed can revoke an entry, which changes where revealing it should land.
+        this.fetchService.onDidChange(() => this.refreshCache());
+        // Primed eagerly, or the first render shows no provenance until something changes.
+        this.refreshCache();
+    }
+
+    getRegistryEntryId(skill: Skill): string | undefined {
+        return this.entryIdsByLocation.get(Path.normalizePathSeparator(skill.location));
+    }
+
+    revealSkill(skillId: string): void {
+        // Search only for ids the registry still lists, as the MCP bridge does: a query switches the view
+        // to its search results, so for a revoked id an empty search would hide the very entry the user
+        // asked about - the Installed section shows it, with a warning, when no query is set.
+        if (this.listedSkillIds.has(skillId)) {
+            this.searchModel.query = skillId;
+        }
+        this.viewContribution.openView({ activate: true }).catch(error =>
+            this.logger.warn(`Could not open the Extensions view to reveal the skill "${skillId}".`, error));
+    }
+
+    protected async refreshCache(): Promise<void> {
+        try {
+            const root = await this.resolveSkillsRoot();
+            const installed = await this.installService.listInstalledSkills();
+            this.entryIdsByLocation = new Map(installed
+                .filter(info => info.skillId !== undefined)
+                .map(info => [`${root}/${info.name}/${SKILL_FILE_NAME}`, info.skillId!]));
+            this.listedSkillIds = new Set((await this.fetchService.getSkillEntries()).map(entry => entry.skillId));
+            this.onDidChangeEmitter.fire();
+        } catch (error) {
+            // Left as-is: a stale label beats dropping every affordance over one failed call.
+            this.logger.warn('Could not list installed registry skills; skill provenance may be out of date.', error);
+        }
+    }
+
+    /**
+     * The frontend view of the backend's install root, resolved the way `SkillService` resolves the
+     * same directory, with separators normalized so the keys compare on Windows too.
+     */
+    protected async resolveSkillsRoot(): Promise<string> {
+        const homeDir = new URI(await this.envVariablesServer.getHomeDirUri());
+        return Path.normalizePathSeparator(homeDir.resolve('.agents/skills').path.fsPath());
+    }
+}

--- a/packages/ai-registry/src/browser/style/plugin-entries.css
+++ b/packages/ai-registry/src/browser/style/plugin-entries.css
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (C) 2026 EclipseSource GmbH.
+ * Copyright (C) 2026 EclipseSource GmbH and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/browser/style/plugin-entries.css
+++ b/packages/ai-registry/src/browser/style/plugin-entries.css
@@ -36,11 +36,8 @@
     flex-shrink: 0;
 }
 
-/* Invisible spacer reserving the same width VSX cards use for their context-menu gear,
-   so Agent Plugin, MCP and VSX action bars line up across the unified Extensions view. */
-.theia-agent-plugin-extension-gear-placeholder {
-    visibility: hidden;
-    pointer-events: none;
+.theia-agent-plugin-extension-gear {
+    cursor: pointer;
 }
 
 .theia-agent-plugin-extension-warning {

--- a/packages/ai-registry/src/browser/style/plugin-entries.css
+++ b/packages/ai-registry/src/browser/style/plugin-entries.css
@@ -1,0 +1,138 @@
+/********************************************************************************
+ * Copyright (C) 2026 EclipseSource GmbH.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the Eclipse
+ * Public License v. 2.0 are satisfied: GNU General Public License, version 2
+ * with the GNU Classpath Exception which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+ ********************************************************************************/
+
+/** Agent-Plugin-specific tweaks layered on top of the shared `.theia-vsx-extension` card. */
+
+.theia-vsx-extension-icon.theia-agent-plugin-extension-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-image: none;
+}
+
+.theia-vsx-extension-icon.theia-agent-plugin-extension-icon .codicon {
+    /* Match the MCP and skill card icons so all three render at the same visual size. */
+    font-size: calc(var(--theia-vsx-extension-icon-size) * 0.65);
+    color: var(--theia-descriptionForeground);
+}
+
+.theia-agent-plugin-extension-actions {
+    display: flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) / 2);
+    flex-shrink: 0;
+}
+
+/* Invisible spacer reserving the same width VSX cards use for their context-menu gear,
+   so Agent Plugin, MCP and VSX action bars line up across the unified Extensions view. */
+.theia-agent-plugin-extension-gear-placeholder {
+    visibility: hidden;
+    pointer-events: none;
+}
+
+.theia-agent-plugin-extension-warning {
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+    font-size: var(--theia-ui-font-size1);
+}
+
+.theia-agent-plugin-extension-diagnostics,
+.theia-agent-plugin-extension-link-stale-message {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--theia-ui-padding) / 2);
+    font-size: var(--theia-ui-font-size0);
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+}
+
+.theia-agent-plugin-extension-diagnostics {
+    /* A long skip reason must not push the action buttons out of the card. */
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 16em;
+}
+
+.theia-extensions-type-badge--agent-plugin {
+    background-color: var(--theia-inputValidation-infoBackground, var(--theia-badge-background));
+    color: var(--theia-inputValidation-infoForeground, var(--theia-badge-foreground));
+}
+
+/** Install and hash-mismatch dialogs. */
+
+.theia-plugin-dialog {
+    display: flex;
+    flex-direction: column;
+    gap: var(--theia-ui-padding);
+    max-width: 480px;
+}
+
+.theia-plugin-dialog-paragraph {
+    color: var(--theia-foreground);
+}
+
+.theia-plugin-dialog-field {
+    display: flex;
+    gap: var(--theia-ui-padding);
+    align-items: baseline;
+}
+
+.theia-plugin-dialog-field > label {
+    flex: 0 0 8em;
+    color: var(--theia-descriptionForeground);
+}
+
+.theia-plugin-dialog-value {
+    flex: 1 1 auto;
+    word-break: break-word;
+}
+
+.theia-plugin-dialog-hash {
+    flex: 1 1 auto;
+    font-family: var(--theia-code-font-family);
+    word-break: break-all;
+}
+
+.theia-plugin-dialog-section {
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--theia-ui-padding) / 2);
+}
+
+.theia-plugin-dialog-section-title {
+    font-weight: bold;
+}
+
+.theia-plugin-dialog-warning {
+    display: flex;
+    gap: var(--theia-ui-padding);
+    padding: var(--theia-ui-padding);
+    align-items: flex-start;
+    border: 1px solid var(--theia-inputValidation-warningBorder, var(--theia-editorWarning-foreground));
+    background-color: var(--theia-inputValidation-warningBackground);
+    color: var(--theia-inputValidation-warningForeground, var(--theia-foreground));
+}
+
+.theia-plugin-dialog-warning .codicon {
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+}
+
+/* Diagnostics in the card's hover: reasons a component was skipped read as warnings, not as more
+   description. The hover is built as an element because the markdown renderer escapes HTML. */
+.theia-agent-plugin-hover-warning {
+    color: var(--theia-editorWarning-foreground, var(--theia-notificationsWarningIcon-foreground));
+    white-space: pre-line;
+    margin-top: var(--theia-ui-padding);
+}

--- a/packages/ai-registry/src/common/ai-registry-preferences.ts
+++ b/packages/ai-registry/src/common/ai-registry-preferences.ts
@@ -20,7 +20,7 @@ import { nls, PreferenceSchema, PreferenceScope } from '@theia/core';
 export const AUTO_UPDATE_PREF = 'ai-features.registry.autoUpdate';
 export const AUTO_UPDATE_OVERRIDES_PREF = 'ai-features.registry.autoUpdateOverrides';
 
-/** How registry-managed artifacts (skills, MCP servers) react to a newer registry entry. */
+/** How registry-managed artifacts (skills, MCP servers, Agent Plugins) react to a newer registry entry. */
 export type AutoUpdateMode = 'off' | 'ask' | 'on';
 
 export const AUTO_UPDATE_MODES: readonly AutoUpdateMode[] = ['off', 'ask', 'on'];
@@ -32,7 +32,7 @@ export namespace AutoUpdateMode {
 }
 
 /** Artifact families the registry can auto-update. Namespaces the override keys. */
-export type RegistryArtifactKind = 'skill' | 'mcp';
+export type RegistryArtifactKind = 'skill' | 'mcp' | 'plugin';
 
 /**
  * Both preferences are `User`-scoped on purpose: a workspace-settable policy would let a cloned
@@ -47,13 +47,14 @@ export const AIRegistryPreferencesSchema: PreferenceSchema = {
             default: 'ask',
             scope: PreferenceScope.User,
             enumDescriptions: [
-                nls.localize('theia/ai-registry/autoUpdate/off', 'Never update installed skills and MCP servers, and never notify about available updates.'),
-                nls.localize('theia/ai-registry/autoUpdate/ask', 'Notify when an update is available for an installed skill or MCP server.'),
-                nls.localize('theia/ai-registry/autoUpdate/on', 'Update installed skills and MCP servers automatically.')
+                nls.localize('theia/ai-registry/autoUpdate/off',
+                    'Never update installed skills, MCP servers and Agent Plugins, and never notify about available updates.'),
+                nls.localize('theia/ai-registry/autoUpdate/ask', 'Notify when an update is available for an installed skill, MCP server or Agent Plugin.'),
+                nls.localize('theia/ai-registry/autoUpdate/on', 'Update installed skills, MCP servers and Agent Plugins automatically.')
             ],
             description: nls.localize('theia/ai-registry/autoUpdate/description',
-                'Default update behavior for skills and MCP servers installed from the AI registry. Updates are checked once per window load. \
-Individual skills and MCP servers can override this from the gear menu in the Extensions view.'),
+                'Default update behavior for skills, MCP servers and Agent Plugins installed from the AI registry. Updates are checked once per \
+window load. Individual artifacts can override this from the gear menu in the Extensions view.'),
             title: AI_CORE_PREFERENCES_TITLE
         },
         [AUTO_UPDATE_OVERRIDES_PREF]: {
@@ -65,8 +66,9 @@ Individual skills and MCP servers can override this from the gear menu in the Ex
                 enum: [...AUTO_UPDATE_MODES]
             },
             markdownDescription: nls.localize('theia/ai-registry/autoUpdateOverrides/mdDescription',
-                'Per-artifact overrides of `#ai-features.registry.autoUpdate#`, keyed by `skill:<skillId>` or `mcp:<serverId>`. \
-Entries are normally maintained through the gear menu in the Extensions view; an artifact without an entry follows the default.'),
+                'Per-artifact overrides of `#ai-features.registry.autoUpdate#`, keyed by `skill:<skillId>`, `mcp:<serverId>` or \
+`plugin:<pluginId>`. Entries are normally maintained through the gear menu in the Extensions view; an artifact without an entry follows \
+the default.'),
             title: AI_CORE_PREFERENCES_TITLE
         }
     }

--- a/packages/ai-registry/src/common/content-hash.spec.ts
+++ b/packages/ai-registry/src/common/content-hash.spec.ts
@@ -15,33 +15,33 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { computeSkillContentHash, SkillFileContent } from './skill-content-hash';
+import { computeContentHash, FileContent } from './content-hash';
 
-function file(relativePath: string, content: string): SkillFileContent {
+function file(relativePath: string, content: string): FileContent {
     return { relativePath, content: new TextEncoder().encode(content) };
 }
 
-describe('computeSkillContentHash', () => {
+describe('computeContentHash', () => {
 
     it('hashes an empty file set to the sha256-of-nothing 12-char prefix', () => {
         // sha256('') = e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855
-        expect(computeSkillContentHash([])).to.equal('e3b0c44298fc');
+        expect(computeContentHash([])).to.equal('e3b0c44298fc');
     });
 
     it('produces a 12-character lowercase hex prefix', () => {
-        const hash = computeSkillContentHash([file('SKILL.md', '# Example')]);
+        const hash = computeContentHash([file('SKILL.md', '# Example')]);
         expect(hash).to.match(/^[0-9a-f]{12}$/);
     });
 
     it('is independent of the input order (paths are sorted lexicographically)', () => {
-        const a = computeSkillContentHash([file('a.txt', 'A'), file('b.txt', 'B'), file('c/d.txt', 'D')]);
-        const b = computeSkillContentHash([file('c/d.txt', 'D'), file('b.txt', 'B'), file('a.txt', 'A')]);
+        const a = computeContentHash([file('a.txt', 'A'), file('b.txt', 'B'), file('c/d.txt', 'D')]);
+        const b = computeContentHash([file('c/d.txt', 'D'), file('b.txt', 'B'), file('a.txt', 'A')]);
         expect(a).to.equal(b);
     });
 
     it('excludes dot-prefixed files at the root (e.g. the .registry.json registry metadata file)', () => {
-        const withoutMetadata = computeSkillContentHash([file('SKILL.md', '# Example')]);
-        const withMetadata = computeSkillContentHash([
+        const withoutMetadata = computeContentHash([file('SKILL.md', '# Example')]);
+        const withMetadata = computeContentHash([
             file('SKILL.md', '# Example'),
             file('.registry.json', '{"skillId":"x"}')
         ]);
@@ -49,8 +49,8 @@ describe('computeSkillContentHash', () => {
     });
 
     it('excludes files inside dot-prefixed directories at any level', () => {
-        const baseline = computeSkillContentHash([file('SKILL.md', '# Example')]);
-        const withHidden = computeSkillContentHash([
+        const baseline = computeContentHash([file('SKILL.md', '# Example')]);
+        const withHidden = computeContentHash([
             file('SKILL.md', '# Example'),
             file('.git/config', 'ignored'),
             file('docs/.hidden/note.txt', 'ignored')
@@ -59,24 +59,24 @@ describe('computeSkillContentHash', () => {
     });
 
     it('excludes the empty set and a dot-only set identically', () => {
-        expect(computeSkillContentHash([file('.registry.json', '{}')])).to.equal(computeSkillContentHash([]));
+        expect(computeContentHash([file('.registry.json', '{}')])).to.equal(computeContentHash([]));
     });
 
     it('normalises backslash separators to POSIX so Windows and Linux backends agree', () => {
-        const windows = computeSkillContentHash([file('docs\\guide.md', 'content')]);
-        const posix = computeSkillContentHash([file('docs/guide.md', 'content')]);
+        const windows = computeContentHash([file('docs\\guide.md', 'content')]);
+        const posix = computeContentHash([file('docs/guide.md', 'content')]);
         expect(windows).to.equal(posix);
     });
 
     it('changes when a file path changes', () => {
-        const first = computeSkillContentHash([file('SKILL.md', 'same')]);
-        const renamed = computeSkillContentHash([file('OTHER.md', 'same')]);
+        const first = computeContentHash([file('SKILL.md', 'same')]);
+        const renamed = computeContentHash([file('OTHER.md', 'same')]);
         expect(first).to.not.equal(renamed);
     });
 
     it('changes when file content changes', () => {
-        const first = computeSkillContentHash([file('SKILL.md', 'one')]);
-        const second = computeSkillContentHash([file('SKILL.md', 'two')]);
+        const first = computeContentHash([file('SKILL.md', 'one')]);
+        const second = computeContentHash([file('SKILL.md', 'two')]);
         expect(first).to.not.equal(second);
     });
 });

--- a/packages/ai-registry/src/common/content-hash.ts
+++ b/packages/ai-registry/src/common/content-hash.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { createHash } from 'crypto';
+
+/** A file participating in a content hash; `relativePath` may use any separator. */
+export interface FileContent {
+    relativePath: string;
+    content: Uint8Array;
+}
+
+/** Number of leading hex characters kept from the sha256 digest, matching the registry. */
+const HASH_PREFIX_LENGTH = 12;
+
+/** Normalises a relative path to POSIX separators so Windows backends match the Linux registry. */
+function toPosix(relativePath: string): string {
+    return relativePath.replace(/\\/g, '/');
+}
+
+/** True when any path segment is dot-prefixed; such files are excluded from the hash at every level. */
+function hasDotSegment(posixPath: string): boolean {
+    return posixPath.split('/').some(segment => segment.startsWith('.'));
+}
+
+/**
+ * Reproduces the registry's content hash byte-for-byte (registry `src/skill-source.ts`), which uses
+ * one algorithm for both skill folders and Agent Plugin directories.
+ */
+export function computeContentHash(files: FileContent[]): string {
+    const normalized = files
+        .map(file => ({ relativePath: toPosix(file.relativePath), content: file.content }))
+        .filter(file => !hasDotSegment(file.relativePath))
+        .sort((a, b) => (a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0));
+    const hash = createHash('sha256');
+    for (const file of normalized) {
+        hash.update(file.relativePath);
+        hash.update(Buffer.from(file.content));
+    }
+    return hash.digest('hex').slice(0, HASH_PREFIX_LENGTH);
+}

--- a/packages/ai-registry/src/common/plugin/agent-plugin-manifest.spec.ts
+++ b/packages/ai-registry/src/common/plugin/agent-plugin-manifest.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -29,22 +29,26 @@ const MCP_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json';
 const PLUGIN_ROOT = '/home/alex/.agents/plugins/devtools';
 const PLUGIN_DATA = '/home/alex/.agents/plugins/data/devtools';
 
-const reader = new AgentPluginManifestReader();
-
 /**
- * Pins the native path form to Windows, which is otherwise decided by the backend OS - and every test
- * here runs on Linux, where the `Path` form and the native form are identical and the conversion is
- * invisible.
+ * Pins the native path form, which production otherwise takes from the backend OS. Both forms are
+ * exercised below - the POSIX one against the POSIX-shaped fixtures, the Windows one against Windows
+ * paths - so neither is left to the host the suite happens to run on: on a Windows runner the default
+ * would turn every expected POSIX path into a backslashed one.
  *
  * Only the format is overridden, never `toNativePath` itself: overriding the conversion would mean the
  * production one is never executed by any test, and could be reverted to a no-op without a single test
  * going red.
  */
-class WindowsAgentPluginManifestReader extends AgentPluginManifestReader {
+class PinnedAgentPluginManifestReader extends AgentPluginManifestReader {
+    constructor(protected readonly format: Path.Format) {
+        super();
+    }
     protected override nativePathFormat(): Path.Format {
-        return Path.Format.Windows;
+        return this.format;
     }
 }
+
+const reader = new PinnedAgentPluginManifestReader(Path.Format.Posix);
 
 function manifest(fields: Record<string, unknown>): string {
     return JSON.stringify({ $schema: PLUGIN_SCHEMA, name: 'devtools', ...fields });
@@ -565,7 +569,7 @@ describe('AgentPluginManifestReader.resolveComponents', () => {
         // Theia's `Path` canonicalizes a Windows drive path to the `/c:/…` form, which is what
         // containment is decided in - and which no `spawn` accepts. Every value that leaves the reader
         // has to be converted back, `args` and `env` included: `cwd` alone is not enough.
-        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+        const components = new PinnedAgentPluginManifestReader(Path.Format.Windows).resolveComponents({
             mcpJsonText: mcp({
                 s: {
                     type: 'stdio',
@@ -589,7 +593,7 @@ describe('AgentPluginManifestReader.resolveComponents', () => {
     });
 
     it('defaults cwd to the plugin root in native form when the entry omits it', () => {
-        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+        const components = new PinnedAgentPluginManifestReader(Path.Format.Windows).resolveComponents({
             mcpJsonText: mcp({ s: { type: 'stdio', command: 'npx' } }),
             manifestSchema: PLUGIN_SCHEMA,
             pluginRoot: 'C:\\plugins\\devtools',
@@ -612,7 +616,7 @@ describe('AgentPluginManifestReader.resolveComponents', () => {
         // `Path.normalize` drops empty segments, which would fold `\\server\share` to `/server/share`.
         // The backend derives PLUGIN_ROOT with Node's `path.join`, which keeps the UNC prefix, so a
         // collapsed `cwd` would point somewhere else than the root the same entry advertises.
-        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+        const components = new PinnedAgentPluginManifestReader(Path.Format.Windows).resolveComponents({
             mcpJsonText: mcp({ s: { type: 'stdio', command: './bin/a', args: ['${PLUGIN_ROOT}'] } }),
             manifestSchema: PLUGIN_SCHEMA,
             pluginRoot: '\\\\server\\share\\plugins\\devtools',
@@ -625,7 +629,7 @@ describe('AgentPluginManifestReader.resolveComponents', () => {
     });
 
     it('still contains a UNC-rooted plugin, so a ../ escape is rejected there too', () => {
-        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+        const components = new PinnedAgentPluginManifestReader(Path.Format.Windows).resolveComponents({
             mcpJsonText: mcp({ s: { type: 'stdio', command: './../../elsewhere/evil.exe' } }),
             manifestSchema: PLUGIN_SCHEMA,
             pluginRoot: '\\\\server\\share\\plugins\\devtools',

--- a/packages/ai-registry/src/common/plugin/agent-plugin-manifest.spec.ts
+++ b/packages/ai-registry/src/common/plugin/agent-plugin-manifest.spec.ts
@@ -1,0 +1,648 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { Path } from '@theia/core/lib/common/path';
+import {
+    AgentPluginManifestReader,
+    AgentPluginRejectedError,
+    ResolvedHttpServer,
+    ResolvedPluginComponents,
+    ResolvedStdioServer
+} from './agent-plugin-manifest';
+
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+const MCP_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json';
+const PLUGIN_ROOT = '/home/alex/.agents/plugins/devtools';
+const PLUGIN_DATA = '/home/alex/.agents/plugins/data/devtools';
+
+const reader = new AgentPluginManifestReader();
+
+/**
+ * Pins the native path form to Windows, which is otherwise decided by the backend OS - and every test
+ * here runs on Linux, where the `Path` form and the native form are identical and the conversion is
+ * invisible.
+ *
+ * Only the format is overridden, never `toNativePath` itself: overriding the conversion would mean the
+ * production one is never executed by any test, and could be reverted to a no-op without a single test
+ * going red.
+ */
+class WindowsAgentPluginManifestReader extends AgentPluginManifestReader {
+    protected override nativePathFormat(): Path.Format {
+        return Path.Format.Windows;
+    }
+}
+
+function manifest(fields: Record<string, unknown>): string {
+    return JSON.stringify({ $schema: PLUGIN_SCHEMA, name: 'devtools', ...fields });
+}
+
+function mcp(mcpServers: Record<string, unknown>, schema: string = MCP_SCHEMA): string {
+    return JSON.stringify({ $schema: schema, mcpServers });
+}
+
+function resolve(mcpJsonText: string | undefined, pluginData: string = PLUGIN_DATA): ResolvedPluginComponents {
+    return reader.resolveComponents({ mcpJsonText, manifestSchema: PLUGIN_SCHEMA, pluginRoot: PLUGIN_ROOT, pluginData });
+}
+
+function stdio(components: ResolvedPluginComponents, name: string): ResolvedStdioServer {
+    const server = components.servers.find(candidate => candidate.name === name);
+    expect(server, `expected a resolved server named "${name}"`).to.not.be.undefined;
+    expect(server!.kind).to.equal('stdio');
+    return server as ResolvedStdioServer;
+}
+
+describe('AgentPluginManifestReader.parseManifest', () => {
+
+    it('parses the minimal manifest from the specification', () => {
+        // spec/1.0.0.md:157-162 - `$schema` and `name` are the only required fields.
+        const parsed = reader.parseManifest(JSON.stringify({ $schema: PLUGIN_SCHEMA, name: 'minimal-plugin' }));
+        expect(parsed.name).to.equal('minimal-plugin');
+        expect(parsed.schema).to.equal(PLUGIN_SCHEMA);
+        expect(parsed.warnings).to.deep.equal([]);
+    });
+
+    it('parses the full manifest from the specification, taking the author name from the author object', () => {
+        // spec/1.0.0.md:166-187
+        const parsed = reader.parseManifest(manifest({
+            version: '1.2.0',
+            description: 'Brief plugin description',
+            author: { name: 'Author Name', email: 'author@example.com', url: 'https://example.com' },
+            homepage: 'https://docs.example.com/plugin',
+            repository: 'https://github.com/example/plugin',
+            license: 'MIT',
+            keywords: ['keyword1', 'keyword2'],
+            extensions: { 'com.example.client': { setting: true } }
+        }));
+        expect(parsed).to.deep.equal({
+            name: 'devtools',
+            version: '1.2.0',
+            description: 'Brief plugin description',
+            authorName: 'Author Name',
+            homepage: 'https://docs.example.com/plugin',
+            keywords: ['keyword1', 'keyword2'],
+            schema: PLUGIN_SCHEMA,
+            warnings: []
+        });
+    });
+
+    it('reports and ignores an unknown top-level field and still loads the plugin', () => {
+        // spec/1.0.0.md:145 - unknown top-level fields are non-fatal: report, ignore, continue.
+        const parsed = reader.parseManifest(manifest({ hooks: { onSave: 'x' } }));
+        expect(parsed.name).to.equal('devtools');
+        expect(parsed.warnings).to.have.lengthOf(1);
+        expect(parsed.warnings[0]).to.contain('hooks');
+    });
+
+    it('reports and ignores a non-object extensions field and still loads the plugin', () => {
+        // spec/1.0.0.md:427 - a non-object `extensions` field is non-fatal.
+        const parsed = reader.parseManifest(manifest({ extensions: 'nope' }));
+        expect(parsed.name).to.equal('devtools');
+        expect(parsed.warnings).to.have.lengthOf(1);
+        expect(parsed.warnings[0]).to.contain('extensions');
+    });
+
+    it('does not validate the contents of extension namespaces it does not implement', () => {
+        // spec/1.0.0.md:427 - ignore unimplemented namespaces without validating their values.
+        const parsed = reader.parseManifest(manifest({ extensions: { 'com.example.client': { anything: [1, 2, 3] } } }));
+        expect(parsed.warnings).to.deep.equal([]);
+    });
+
+    it('rejects the plugin when name is missing', () => {
+        // spec/1.0.0.md:196 - a missing required field rejects the plugin.
+        expect(() => reader.parseManifest(JSON.stringify({ $schema: PLUGIN_SCHEMA }))).to.throw(AgentPluginRejectedError);
+    });
+
+    it('rejects the plugin when name is empty or violates the name constraints', () => {
+        // spec/1.0.0.md:216-229 - lowercase alphanumerics, hyphens and periods, alphanumeric edges, no `--` or `..`.
+        for (const name of ['', 'My-Plugin', '-start', 'has--double', 'too.many..dots', 'a'.repeat(65)]) {
+            expect(() => reader.parseManifest(JSON.stringify({ $schema: PLUGIN_SCHEMA, name })), name).to.throw(AgentPluginRejectedError);
+        }
+        for (const name of ['my-plugin', 'acme.tools', 'lint3r', 'a']) {
+            expect(reader.parseManifest(JSON.stringify({ $schema: PLUGIN_SCHEMA, name })).name, name).to.equal(name);
+        }
+    });
+
+    it('rejects the plugin when the manifest is not JSON or not a JSON object', () => {
+        // spec/1.0.0.md:143
+        expect(() => reader.parseManifest('{')).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest('[]')).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest('"a string"')).to.throw(AgentPluginRejectedError);
+    });
+
+    it('rejects the plugin when $schema is missing, empty, wrong-typed or an unrecognized version', () => {
+        // spec/1.0.0.md:153 - an unsupported declared version rejects the plugin.
+        expect(() => reader.parseManifest(JSON.stringify({ name: 'devtools' }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(JSON.stringify({ $schema: '', name: 'devtools' }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(JSON.stringify({ $schema: 7, name: 'devtools' }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(JSON.stringify({
+            $schema: 'https://agent-plugins.org/schemas/2.0.0/plugin.schema.json', name: 'devtools'
+        }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(JSON.stringify({ $schema: MCP_SCHEMA, name: 'devtools' }))).to.throw(AgentPluginRejectedError);
+    });
+
+    it('rejects the plugin when author is not an object or carries an unknown or non-string field', () => {
+        // spec/1.0.0.md:210 - "Any other field or value type makes the manifest invalid", and
+        // spec/1.0.0.md:147 makes every violation other than the two non-fatal ones fatal.
+        expect(() => reader.parseManifest(manifest({ author: 'Author Name' }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(manifest({ author: { name: 'A', twitter: '@a' } }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(manifest({ author: { name: 42 } }))).to.throw(AgentPluginRejectedError);
+    });
+
+    it('yields an undefined author name when the author object omits name', () => {
+        expect(reader.parseManifest(manifest({ author: { email: 'a@example.com' } })).authorName).to.be.undefined;
+    });
+
+    it('rejects the plugin when an optional metadata field has the wrong JSON type', () => {
+        // spec/1.0.0.md:147 - any other schema violation is fatal.
+        expect(() => reader.parseManifest(manifest({ version: 1.2 }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(manifest({ keywords: 'one' }))).to.throw(AgentPluginRejectedError);
+        expect(() => reader.parseManifest(manifest({ keywords: ['one', 2] }))).to.throw(AgentPluginRejectedError);
+    });
+
+    it('reports every unknown top-level field, in manifest order', () => {
+        // spec/1.0.0.md:145 - "Clients MUST report and ignore each unknown field".
+        const parsed = reader.parseManifest(manifest({ hooks: {}, commands: [], agents: 'x' }));
+        expect(parsed.warnings).to.have.lengthOf(3);
+        expect(parsed.warnings[0]).to.contain('hooks');
+        expect(parsed.warnings[1]).to.contain('commands');
+        expect(parsed.warnings[2]).to.contain('agents');
+    });
+
+    it('accepts an empty keywords array and keeps it', () => {
+        expect(reader.parseManifest(manifest({ keywords: [] })).keywords).to.deep.equal([]);
+    });
+
+    it('assigns no semantics to an unknown field, so an unknown "extensions"-like field cannot smuggle data in', () => {
+        // spec/1.0.0.md:145 - "Clients MUST NOT assign semantics to unknown fields."
+        const parsed = reader.parseManifest(manifest({ extension: { 'com.example.client': { setting: true } } })) as unknown as Record<string, unknown>;
+        expect(parsed.extension).to.be.undefined;
+    });
+
+    it('does not reject a manifest solely because version is not semver or homepage is not a URL', () => {
+        // spec/1.0.0.md:212 - metadata fields are validated only by their JSON types.
+        const parsed = reader.parseManifest(manifest({ version: 'nightly', homepage: 'not a url', license: 'whatever' }));
+        expect(parsed.version).to.equal('nightly');
+        expect(parsed.homepage).to.equal('not a url');
+    });
+});
+
+describe('AgentPluginManifestReader.resolveComponents', () => {
+
+    it('resolves nothing and reports nothing when the plugin has no mcp.json', () => {
+        // spec/1.0.0.md:263 - an absent fixed component location is not an error.
+        expect(resolve(undefined)).to.deep.equal({ servers: [], skipped: [] });
+    });
+
+    it('accepts an empty mcpServers object, yielding no servers and no skips', () => {
+        // spec/1.0.0.md:305 - "An empty `mcpServers` object is valid."
+        expect(resolve(mcp({}))).to.deep.equal({ servers: [], skipped: [] });
+    });
+
+    it('resolves the worked mcp.json example from the specification', () => {
+        // spec/1.0.0.md:365-391
+        const components = resolve(mcp({
+            'local-validator': {
+                type: 'stdio',
+                command: './bin/validator',
+                args: ['--data', '${PLUGIN_DATA}/validator'],
+                env: { CONFIG: '${PLUGIN_ROOT}/config.json' },
+                cwd: '${PLUGIN_ROOT}'
+            },
+            'deployment-api': {
+                type: 'streamable-http',
+                url: 'https://deploy.example.com/mcp',
+                headers: { 'X-Tenant': 'public-tenant' }
+            },
+            'legacy-events': {
+                type: 'sse',
+                url: 'https://legacy.example.com/sse'
+            }
+        }));
+        expect(components.mcpDisabledReason).to.be.undefined;
+        expect(stdio(components, 'local-validator')).to.deep.equal({
+            kind: 'stdio',
+            name: 'local-validator',
+            command: `${PLUGIN_ROOT}/bin/validator`,
+            args: ['--data', `${PLUGIN_DATA}/validator`],
+            env: { CONFIG: `${PLUGIN_ROOT}/config.json` },
+            cwd: PLUGIN_ROOT
+        });
+        expect(components.servers[1]).to.deep.equal({
+            kind: 'http',
+            name: 'deployment-api',
+            serverUrl: 'https://deploy.example.com/mcp',
+            headers: { 'X-Tenant': 'public-tenant' }
+        } as ResolvedHttpServer);
+        // spec/1.0.0.md:361 - `sse` support is OPTIONAL; spec/1.0.0.md:398 - skip and report it.
+        expect(components.skipped).to.have.lengthOf(1);
+        expect(components.skipped[0].name).to.equal('legacy-events');
+        expect(components.skipped[0].reason).to.contain('sse');
+    });
+
+    it('accepts the valid command and cwd pair from the containment example', () => {
+        // spec/1.0.0.md:66-94 - "both paths start with `./` and stay within the plugin root".
+        const server = stdio(resolve(mcp({ server: { type: 'stdio', command: './bin/server', cwd: './data' } })), 'server');
+        expect(server.command).to.equal(`${PLUGIN_ROOT}/bin/server`);
+        expect(server.cwd).to.equal(`${PLUGIN_ROOT}/data`);
+    });
+
+    it('rejects the invalid command and cwd pair from the containment example', () => {
+        // spec/1.0.0.md:66-94 - "`../bin/server` escapes the plugin root and `data` is not a plugin-relative path".
+        const components = resolve(mcp({ server: { type: 'stdio', command: '../bin/server', cwd: 'data' } }));
+        expect(components.servers).to.be.empty;
+        expect(components.skipped).to.have.lengthOf(1);
+        expect(components.skipped[0].name).to.equal('server');
+        // Each half fails on its own, too.
+        expect(resolve(mcp({ server: { type: 'stdio', command: '../bin/server' } })).servers).to.be.empty;
+        expect(resolve(mcp({ server: { type: 'stdio', command: './bin/server', cwd: 'data' } })).servers).to.be.empty;
+    });
+
+    it('defaults cwd to the plugin root when the entry omits it', () => {
+        // spec/1.0.0.md:331 - "When `cwd` is omitted, clients MUST use the plugin root".
+        expect(stdio(resolve(mcp({ s: { type: 'stdio', command: 'npx' } })), 's').cwd).to.equal(PLUGIN_ROOT);
+    });
+
+    it('keeps a bare command verbatim for the platform to resolve', () => {
+        // spec/1.0.0.md:325 - bare names are resolved using the platform's executable search rules.
+        expect(stdio(resolve(mcp({ s: { type: 'stdio', command: 'npx' } })), 's').command).to.equal('npx');
+    });
+
+    it('invalidates an entry whose command is neither a bare name nor a ./-prefixed path', () => {
+        // spec/1.0.0.md:325 - a `command` is a bare name or a plugin-relative path beginning with `./`.
+        for (const command of ['/usr/bin/node', 'bin/server', 'node --inspect', '']) {
+            expect(resolve(mcp({ s: { type: 'stdio', command } })).servers, command).to.be.empty;
+        }
+    });
+
+    it('expands placeholders in args, env values and cwd', () => {
+        // spec/1.0.0.md:475 - "Expansion applies to every string element of `args`, every string value
+        // in `env`, and the `cwd` string."
+        const server = stdio(resolve(mcp({
+            s: {
+                type: 'stdio',
+                command: 'npx',
+                args: ['--config', '${PLUGIN_ROOT}/config/db.json'],
+                env: { DATA_DIR: '${PLUGIN_DATA}/database' },
+                cwd: '${PLUGIN_DATA}/work'
+            }
+        })), 's');
+        expect(server.args).to.deep.equal(['--config', `${PLUGIN_ROOT}/config/db.json`]);
+        expect(server.env).to.deep.equal({ DATA_DIR: `${PLUGIN_DATA}/database` });
+        expect(server.cwd).to.equal(`${PLUGIN_DATA}/work`);
+    });
+
+    it('does not expand placeholders in command or in env keys', () => {
+        // spec/1.0.0.md:475 - "It does not apply to `env` keys, `command`, or fixed component locations."
+        const server = stdio(resolve(mcp({
+            s: { type: 'stdio', command: '${PLUGIN_ROOT}', env: { '${PLUGIN_ROOT}_TOOL': 'plain' } }
+        })), 's');
+        expect(server.command).to.equal('${PLUGIN_ROOT}');
+        expect(server.env).to.deep.equal({ '${PLUGIN_ROOT}_TOOL': 'plain' });
+    });
+
+    it('does not expand placeholders in url or header values', () => {
+        // spec/1.0.0.md:353 - no placeholder expansion in `url`, header names or header values.
+        const components = resolve(mcp({
+            s: {
+                type: 'streamable-http',
+                url: 'https://example.com/mcp?root=${PLUGIN_ROOT}',
+                headers: { 'X-Root': 'v-${PLUGIN_ROOT}', 'X-Data': '${PLUGIN_DATA}' }
+            }
+        }));
+        expect(components.servers[0]).to.deep.equal({
+            kind: 'http',
+            name: 's',
+            serverUrl: 'https://example.com/mcp?root=${PLUGIN_ROOT}',
+            headers: { 'X-Root': 'v-${PLUGIN_ROOT}', 'X-Data': '${PLUGIN_DATA}' }
+        } as ResolvedHttpServer);
+    });
+
+    it('rejects a placeholder-shaped header name because braces are not valid HTTP header field characters', () => {
+        // spec/1.0.0.md:353 - header names must be valid HTTP header fields, so a header name can never
+        // legally contain `${...}`; non-expansion in header names is therefore unobservable and the entry
+        // is invalid instead.
+        expect(resolve(mcp({ s: { type: 'streamable-http', url: 'https://example.com/mcp', headers: { 'X-${PLUGIN_DATA}': 'a' } } })).servers).to.be.empty;
+    });
+
+    it('replaces every occurrence of a placeholder, not just the first', () => {
+        // spec/1.0.0.md:473 - "every exact occurrence of either placeholder".
+        const server = stdio(resolve(mcp({
+            s: {
+                type: 'stdio',
+                command: 'npx',
+                args: ['${PLUGIN_ROOT}/a:${PLUGIN_ROOT}/b', '${PLUGIN_DATA}-${PLUGIN_DATA}'],
+                env: { BOTH: '${PLUGIN_ROOT};${PLUGIN_DATA};${PLUGIN_ROOT}' }
+            }
+        })), 's');
+        expect(server.args).to.deep.equal([`${PLUGIN_ROOT}/a:${PLUGIN_ROOT}/b`, `${PLUGIN_DATA}-${PLUGIN_DATA}`]);
+        expect(server.env).to.deep.equal({ BOTH: `${PLUGIN_ROOT};${PLUGIN_DATA};${PLUGIN_ROOT}` });
+    });
+
+    it('does not re-scan text introduced by a replacement', () => {
+        // spec/1.0.0.md:473 - "Text introduced by a replacement MUST NOT be scanned for further placeholders."
+        const trickyData = '/var/data/${PLUGIN_ROOT}/devtools';
+        const server = stdio(resolve(mcp({
+            s: { type: 'stdio', command: 'npx', args: ['${PLUGIN_DATA}/cache'], env: { D: '${PLUGIN_DATA}' } }
+        }), trickyData), 's');
+        expect(server.args).to.deep.equal([`${trickyData}/cache`]);
+        expect(server.env).to.deep.equal({ D: trickyData });
+    });
+
+    it('leaves unrecognized placeholder-like text literal and performs no other variable expansion', () => {
+        // spec/1.0.0.md:477
+        const server = stdio(resolve(mcp({
+            s: { type: 'stdio', command: 'npx', args: ['${PLUGIN_HOME}', '$PLUGIN_ROOT', '${env:FOO}', '$HOME'] }
+        })), 's');
+        expect(server.args).to.deep.equal(['${PLUGIN_HOME}', '$PLUGIN_ROOT', '${env:FOO}', '$HOME']);
+    });
+
+    it('never containment-checks args or env values, even when they look like escaping paths', () => {
+        // spec/1.0.0.md:64 - "Configuration values not defined as paths, including command arguments and
+        // environment variable values, are opaque strings."
+        const server = stdio(resolve(mcp({
+            s: { type: 'stdio', command: 'npx', args: ['../../etc/passwd', '${PLUGIN_ROOT}/../../elsewhere'], env: { P: '/etc/shadow' } }
+        })), 's');
+        expect(server.args).to.deep.equal(['../../etc/passwd', `${PLUGIN_ROOT}/../../elsewhere`]);
+        expect(server.env).to.deep.equal({ P: '/etc/shadow' });
+    });
+
+    it('invalidates only the entry whose env declares a reserved variable name', () => {
+        // spec/1.0.0.md:481 - an `env` entry named PLUGIN_ROOT or PLUGIN_DATA invalidates that server.
+        const components = resolve(mcp({
+            bad: { type: 'stdio', command: 'npx', env: { PLUGIN_ROOT: '/tmp' } },
+            alsoBad: { type: 'stdio', command: 'npx', env: { PLUGIN_DATA: '/tmp' } },
+            good: { type: 'stdio', command: 'npx' }
+        }));
+        expect(components.servers.map(server => server.name)).to.deep.equal(['good']);
+        expect(components.skipped.map(entry => entry.name)).to.deep.equal(['bad', 'alsoBad']);
+        expect(components.skipped[0].reason).to.contain('PLUGIN_ROOT');
+    });
+
+    it('invalidates an entry whose env declares a reserved variable name under any casing', () => {
+        // Windows environment names are case-insensitive, so `Plugin_Root` there is the same variable
+        // the client sets itself. Rejected everywhere, so a plugin cannot load on one platform and
+        // silently misbehave on another.
+        const components = resolve(mcp({
+            lower: { type: 'stdio', command: 'npx', env: { plugin_root: '/tmp' } },
+            mixed: { type: 'stdio', command: 'npx', env: { Plugin_Data: '/tmp' } },
+            good: { type: 'stdio', command: 'npx' }
+        }));
+        expect(components.servers.map(server => server.name)).to.deep.equal(['good']);
+        expect(components.skipped.map(entry => entry.name)).to.deep.equal(['lower', 'mixed']);
+    });
+
+    it('invalidates an entry that carries a field belonging to another variant', () => {
+        // spec/1.0.0.md:313 - "a field belonging to another variant makes that server entry invalid".
+        const components = resolve(mcp({
+            stdioWithUrl: { type: 'stdio', command: 'npx', url: 'https://example.com/mcp' },
+            httpWithCwd: { type: 'streamable-http', url: 'https://example.com/mcp', cwd: './data' },
+            httpWithEnv: { type: 'streamable-http', url: 'https://example.com/mcp', env: { A: 'b' } },
+            good: { type: 'stdio', command: 'npx' }
+        }));
+        expect(components.servers.map(server => server.name)).to.deep.equal(['good']);
+        expect(components.skipped.map(entry => entry.name)).to.deep.equal(['stdioWithUrl', 'httpWithCwd', 'httpWithEnv']);
+    });
+
+    it('invalidates an entry with an unknown field or an unknown transport type', () => {
+        // spec/1.0.0.md:313
+        expect(resolve(mcp({ s: { type: 'stdio', command: 'npx', timeout: 5 } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'websocket', url: 'https://example.com/mcp' } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { command: 'npx' } })).servers).to.be.empty;
+    });
+
+    it('invalidates an entry that is missing a required field or types one wrongly', () => {
+        // spec/1.0.0.md:317-323, spec/1.0.0.md:343-347
+        expect(resolve(mcp({ s: { type: 'stdio' } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'stdio', command: 12 } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'stdio', command: 'npx', args: 'one' } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'stdio', command: 'npx', args: ['one', 2] } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'stdio', command: 'npx', env: { A: 2 } } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'streamable-http' } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: 'not-an-object' })).servers).to.be.empty;
+    });
+
+    it('checks a ${PLUGIN_DATA}-rooted cwd against the plugin data directory rather than the plugin root', () => {
+        // spec/1.0.0.md:337 - "A `${PLUGIN_DATA}`-rooted value MUST remain within the filesystem-resolved
+        // plugin data directory."
+        const inside = stdio(resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd: '${PLUGIN_DATA}/venv' } })), 's');
+        expect(inside.cwd).to.equal(`${PLUGIN_DATA}/venv`);
+        expect(stdio(resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd: '${PLUGIN_DATA}' } })), 's').cwd).to.equal(PLUGIN_DATA);
+        // The data directory is a sibling tree of the plugin root (spec/1.0.0.md:464-469), so a
+        // PLUGIN_DATA-rooted cwd is legal even though it lies outside the plugin root.
+        expect(PLUGIN_DATA.startsWith(`${PLUGIN_ROOT}/`)).to.be.false;
+    });
+
+    it('invalidates an entry whose ${PLUGIN_DATA}-rooted cwd escapes the plugin data directory', () => {
+        // spec/1.0.0.md:337 - "any post-resolution escape makes that server entry invalid".
+        const components = resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd: '${PLUGIN_DATA}/../other' } }));
+        expect(components.servers).to.be.empty;
+        expect(components.skipped[0].name).to.equal('s');
+    });
+
+    it('invalidates an entry whose ${PLUGIN_ROOT}-rooted or plugin-relative cwd escapes the plugin root', () => {
+        // spec/1.0.0.md:337
+        expect(resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd: '${PLUGIN_ROOT}/../devtools-2' } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd: './../devtools-2' } })).servers).to.be.empty;
+    });
+
+    it('invalidates an entry whose cwd has none of the three permitted forms', () => {
+        // spec/1.0.0.md:331-337 - `./`, `${PLUGIN_ROOT}`-rooted or `${PLUGIN_DATA}`-rooted only.
+        for (const cwd of ['data', '/absolute/data', '~/data', '${PLUGIN_HOME}/data', '${PLUGIN_ROOTX}', 42]) {
+            expect(resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd } })).servers, String(cwd)).to.be.empty;
+        }
+    });
+
+    it('isolates failures per entry so that one invalid entry never affects the others', () => {
+        // spec/1.0.0.md:397 - skip that server and continue loading other servers.
+        const components = resolve(mcp({
+            first: { type: 'stdio', command: './bin/a' },
+            broken: { type: 'stdio', command: '../bin/b' },
+            second: { type: 'streamable-http', url: 'https://example.com/mcp' },
+            legacy: { type: 'sse', url: 'https://example.com/sse' },
+            third: { type: 'stdio', command: 'npx', cwd: './work' }
+        }));
+        expect(components.servers.map(server => server.name)).to.deep.equal(['first', 'second', 'third']);
+        expect(components.skipped.map(entry => entry.name)).to.deep.equal(['broken', 'legacy']);
+        expect(components.mcpDisabledReason).to.be.undefined;
+    });
+
+    it('accepts an http url only when it is absolute, fragment-free, user-info-free and https unless loopback', () => {
+        // spec/1.0.0.md:351
+        for (const url of ['https://example.com/mcp', 'http://localhost:3000/mcp', 'http://127.0.0.1:3000/mcp', 'http://[::1]:3000/mcp']) {
+            expect(resolve(mcp({ s: { type: 'streamable-http', url } })).servers, url).to.have.lengthOf(1);
+        }
+        for (const url of ['http://example.com/mcp', '/mcp', 'ftp://example.com/mcp', 'https://user:pw@example.com/mcp', 'https://example.com/mcp#frag']) {
+            expect(resolve(mcp({ s: { type: 'streamable-http', url } })).servers, url).to.be.empty;
+        }
+    });
+
+    it('invalidates an entry whose headers repeat a name under different casing or are not valid header fields', () => {
+        // spec/1.0.0.md:353
+        expect(resolve(mcp({ s: { type: 'streamable-http', url: 'https://example.com/mcp', headers: { 'X-Tenant': 'a', 'x-tenant': 'b' } } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'streamable-http', url: 'https://example.com/mcp', headers: { 'X Tenant': 'a' } } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'streamable-http', url: 'https://example.com/mcp', headers: { 'X-Tenant': 'a\r\nb' } } })).servers).to.be.empty;
+        expect(resolve(mcp({ s: { type: 'streamable-http', url: 'https://example.com/mcp', headers: { 'X-Tenant': 2 } } })).servers).to.be.empty;
+    });
+
+    it('disables MCP without throwing when mcp.json is not valid JSON', () => {
+        // spec/1.0.0.md:396
+        const components = resolve('{ oops');
+        expect(components.mcpDisabledReason).to.not.be.undefined;
+        expect(components.servers).to.be.empty;
+        expect(components.skipped).to.be.empty;
+    });
+
+    it('disables MCP when the top-level document has an extra field, a missing field or a wrong-typed field', () => {
+        // spec/1.0.0.md:305 - exactly `$schema` and `mcpServers`, both required.
+        expect(resolve(JSON.stringify({ $schema: MCP_SCHEMA, mcpServers: {}, timeout: 1 })).mcpDisabledReason).to.not.be.undefined;
+        expect(resolve(JSON.stringify({ $schema: MCP_SCHEMA })).mcpDisabledReason).to.not.be.undefined;
+        expect(resolve(JSON.stringify({ mcpServers: {} })).mcpDisabledReason).to.not.be.undefined;
+        expect(resolve(JSON.stringify({ $schema: MCP_SCHEMA, mcpServers: [] })).mcpDisabledReason).to.not.be.undefined;
+        expect(resolve('[]').mcpDisabledReason).to.not.be.undefined;
+    });
+
+    it('disables MCP when mcp.json targets an unsupported Agent Plugins version', () => {
+        // spec/1.0.0.md:396
+        const components = resolve(mcp({ s: { type: 'stdio', command: 'npx' } }, 'https://agent-plugins.org/schemas/2.0.0/mcp.schema.json'));
+        expect(components.mcpDisabledReason).to.not.be.undefined;
+        expect(components.servers).to.be.empty;
+    });
+
+    it('disables MCP without throwing when the mcp.json and plugin.json schema versions differ', () => {
+        // spec/1.0.0.md:508 - a mismatch invalidates the MCP configuration only, not other component types.
+        const components = reader.resolveComponents({
+            mcpJsonText: mcp({ s: { type: 'stdio', command: 'npx' } }),
+            manifestSchema: 'https://agent-plugins.org/schemas/0.9.0/plugin.schema.json',
+            pluginRoot: PLUGIN_ROOT,
+            pluginData: PLUGIN_DATA
+        });
+        expect(components.mcpDisabledReason).to.not.be.undefined;
+        expect(components.servers).to.be.empty;
+        expect(components.skipped).to.be.empty;
+    });
+
+    it('accepts a plugin-relative cwd or command that only traverses inside the plugin root', () => {
+        // spec/1.0.0.md:63 - resolution happens first, containment is checked on the resolved path.
+        const server = stdio(resolve(mcp({ s: { type: 'stdio', command: './bin/../bin/server', cwd: './work/../data/nested' } })), 's');
+        expect(server.command).to.equal(`${PLUGIN_ROOT}/bin/server`);
+        expect(server.cwd).to.equal(`${PLUGIN_ROOT}/data/nested`);
+    });
+
+    it('resolves a bare "./" cwd to the plugin root without a trailing separator', () => {
+        expect(stdio(resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd: './' } })), 's').cwd).to.equal(PLUGIN_ROOT);
+        expect(stdio(resolve(mcp({ s: { type: 'stdio', command: 'npx', cwd: '${PLUGIN_ROOT}/' } })), 's').cwd).to.equal(PLUGIN_ROOT);
+    });
+
+    it('keeps an empty env object and omits absent optional fields', () => {
+        const server = stdio(resolve(mcp({ s: { type: 'stdio', command: 'npx', env: {} } })), 's');
+        expect(server.env).to.deep.equal({});
+        expect(server.args).to.be.undefined;
+        const http = resolve(mcp({ s: { type: 'streamable-http', url: 'https://example.com/mcp' } })).servers[0] as ResolvedHttpServer;
+        expect(http.headers).to.be.undefined;
+    });
+
+    it('skips an entry whose type is not a string and reports the missing type', () => {
+        const components = resolve(mcp({ s: { type: 42, command: 'npx' } }));
+        expect(components.servers).to.be.empty;
+        expect(components.skipped[0].reason).to.contain('type');
+    });
+
+    it('returns every resolved path in the native form on Windows, so nothing reaches a spawn as /c:/…', () => {
+        // Theia's `Path` canonicalizes a Windows drive path to the `/c:/…` form, which is what
+        // containment is decided in - and which no `spawn` accepts. Every value that leaves the reader
+        // has to be converted back, `args` and `env` included: `cwd` alone is not enough.
+        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+            mcpJsonText: mcp({
+                s: {
+                    type: 'stdio',
+                    command: './bin/validator.cmd',
+                    args: ['--config', '${PLUGIN_ROOT}/config.json'],
+                    env: { DATA: '${PLUGIN_DATA}' },
+                    cwd: '${PLUGIN_ROOT}/data'
+                }
+            }),
+            manifestSchema: PLUGIN_SCHEMA,
+            pluginRoot: 'C:\\plugins\\devtools',
+            pluginData: 'C:\\plugins\\data\\devtools'
+        });
+        const server = stdio(components, 's');
+        expect(server.command).to.equal('C:\\plugins\\devtools\\bin\\validator.cmd');
+        expect(server.cwd).to.equal('C:\\plugins\\devtools\\data');
+        // Only what the placeholder stands for is native. The rest of the argument is the plugin's own
+        // text and stays verbatim - `args` are opaque strings, not necessarily paths (spec/1.0.0.md:64).
+        expect(server.args).to.deep.equal(['--config', 'C:\\plugins\\devtools/config.json']);
+        expect(server.env).to.deep.equal({ DATA: 'C:\\plugins\\data\\devtools' });
+    });
+
+    it('defaults cwd to the plugin root in native form when the entry omits it', () => {
+        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+            mcpJsonText: mcp({ s: { type: 'stdio', command: 'npx' } }),
+            manifestSchema: PLUGIN_SCHEMA,
+            pluginRoot: 'C:\\plugins\\devtools',
+            pluginData: 'C:\\plugins\\data\\devtools'
+        });
+        expect(stdio(components, 's').cwd).to.equal('C:\\plugins\\devtools');
+    });
+
+    it('rejects a Windows-style plugin-relative command that escapes the plugin root', () => {
+        const components = reader.resolveComponents({
+            mcpJsonText: mcp({ s: { type: 'stdio', command: './..\\..\\evil.exe' } }),
+            manifestSchema: PLUGIN_SCHEMA,
+            pluginRoot: 'C:\\plugins\\devtools',
+            pluginData: 'C:\\plugins\\data\\devtools'
+        });
+        expect(components.servers).to.be.empty;
+    });
+
+    it('keeps the double leading separator of a UNC plugin root, so it stays the same location', () => {
+        // `Path.normalize` drops empty segments, which would fold `\\server\share` to `/server/share`.
+        // The backend derives PLUGIN_ROOT with Node's `path.join`, which keeps the UNC prefix, so a
+        // collapsed `cwd` would point somewhere else than the root the same entry advertises.
+        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+            mcpJsonText: mcp({ s: { type: 'stdio', command: './bin/a', args: ['${PLUGIN_ROOT}'] } }),
+            manifestSchema: PLUGIN_SCHEMA,
+            pluginRoot: '\\\\server\\share\\plugins\\devtools',
+            pluginData: '\\\\server\\share\\plugin-data\\devtools'
+        });
+        const server = stdio(components, 's');
+        expect(server.command).to.equal('\\\\server\\share\\plugins\\devtools\\bin\\a');
+        expect(server.cwd).to.equal('\\\\server\\share\\plugins\\devtools');
+        expect(server.args).to.deep.equal(['\\\\server\\share\\plugins\\devtools']);
+    });
+
+    it('still contains a UNC-rooted plugin, so a ../ escape is rejected there too', () => {
+        const components = new WindowsAgentPluginManifestReader().resolveComponents({
+            mcpJsonText: mcp({ s: { type: 'stdio', command: './../../elsewhere/evil.exe' } }),
+            manifestSchema: PLUGIN_SCHEMA,
+            pluginRoot: '\\\\server\\share\\plugins\\devtools',
+            pluginData: '\\\\server\\share\\plugin-data\\devtools'
+        });
+        expect(components.servers).to.be.empty;
+    });
+
+    it('normalizes a plugin root and plugin data path that carry a trailing separator or dot segments', () => {
+        const components = reader.resolveComponents({
+            mcpJsonText: mcp({ s: { type: 'stdio', command: './bin/a', cwd: '${PLUGIN_DATA}' } }),
+            manifestSchema: PLUGIN_SCHEMA,
+            pluginRoot: '/plugins/./devtools/',
+            pluginData: '/plugins/data/x/../devtools'
+        });
+        const server = stdio(components, 's');
+        expect(server.command).to.equal('/plugins/devtools/bin/a');
+        expect(server.cwd).to.equal('/plugins/data/devtools');
+    });
+});

--- a/packages/ai-registry/src/common/plugin/agent-plugin-manifest.ts
+++ b/packages/ai-registry/src/common/plugin/agent-plugin-manifest.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/plugin/agent-plugin-manifest.ts
+++ b/packages/ai-registry/src/common/plugin/agent-plugin-manifest.ts
@@ -1,0 +1,557 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { nls } from '@theia/core';
+import { Path } from '@theia/core/lib/common/path';
+import { injectable } from '@theia/core/shared/inversify';
+
+/** Parsed `plugin.json`, restricted to the fields Theia uses. */
+export interface AgentPluginManifest {
+    name: string;
+    version?: string;
+    description?: string;
+    authorName?: string;
+    homepage?: string;
+    keywords?: string[];
+    /** The `$schema` value, so the caller can enforce the plugin.json/mcp.json version match. */
+    schema: string;
+    /**
+     * Non-fatal problems that the specification requires the client to report and ignore,
+     * i.e. unknown top-level fields and a non-object `extensions` field. Already localized.
+     */
+    warnings: string[];
+}
+
+/**
+ * Every resolved path here is in the filesystem's native form and can be handed to a spawn as is.
+ * Containment is checked in Theia's `Path` form internally, but that form never leaves this service:
+ * on Windows it renders a drive path as `/c:/…`, which no `spawn` accepts.
+ */
+export interface ResolvedStdioServer {
+    kind: 'stdio';
+    name: string;
+    /** Bare executable name kept verbatim, or a `./`-relative path resolved against the plugin root. */
+    command: string;
+    args?: string[];
+    env?: Record<string, string>;
+    /** Always set: `cwd` defaults to the plugin root when the entry omits it. */
+    cwd: string;
+}
+
+/** A resolved `streamable-http` MCP server entry of a plugin's `mcp.json`. */
+export interface ResolvedHttpServer {
+    kind: 'http';
+    name: string;
+    serverUrl: string;
+    headers?: Record<string, string>;
+}
+
+export type ResolvedPluginServer = ResolvedStdioServer | ResolvedHttpServer;
+
+/** One component the client refused to load, and why - surfaced on the plugin's card. */
+export interface SkippedPluginComponent {
+    /** Component name, e.g. the `mcpServers` key or the skill directory name. */
+    name: string;
+    /** Human-readable, already localized. */
+    reason: string;
+}
+
+/** The outcome of resolving a plugin's `mcp.json`. */
+export interface ResolvedPluginComponents {
+    servers: ResolvedPluginServer[];
+    skipped: SkippedPluginComponent[];
+    /** Set when `mcp.json` as a whole was rejected, disabling MCP for the plugin. Already localized. */
+    mcpDisabledReason?: string;
+}
+
+/** Input of {@link AgentPluginManifestReader.resolveComponents}. */
+export interface ResolveComponentsOptions {
+    /** Raw `mcp.json` text, or undefined when the plugin has no `mcp.json`. */
+    mcpJsonText?: string;
+    /** The `$schema` from `plugin.json`, for the version-match rule. */
+    manifestSchema: string;
+    /** Absolute, already filesystem-resolved plugin root. */
+    pluginRoot: string;
+    /** Absolute, already filesystem-resolved plugin data directory. */
+    pluginData: string;
+}
+
+/** Thrown only for conditions the spec says are fatal to the whole plugin. */
+export class AgentPluginRejectedError extends Error { }
+
+/** `$schema` selects the rules; the schema documents themselves are never fetched. */
+export const SUPPORTED_AGENT_PLUGINS_VERSIONS: readonly string[] = ['1.0.0'];
+
+/** One invalid `mcpServers` entry is skipped without affecting other entries or component types. */
+class ServerEntryInvalid extends Error { }
+
+const MANIFEST_FIELDS = ['$schema', 'name', 'version', 'description', 'author', 'homepage', 'repository', 'license', 'keywords', 'extensions'];
+const AUTHOR_FIELDS = ['name', 'email', 'url'];
+const STDIO_FIELDS = ['type', 'command', 'args', 'env', 'cwd'];
+const HTTP_FIELDS = ['type', 'url', 'headers'];
+/** Reserved variables the client supplies itself; a plugin must not declare them. */
+const RESERVED_ENV_NAMES = ['PLUGIN_ROOT', 'PLUGIN_DATA'];
+/** `${NAME}` only; braces are mandatory and there is no `$NAME` form. */
+const PLACEHOLDER_PATTERN = /\$\{(PLUGIN_ROOT|PLUGIN_DATA)\}/g;
+const MANIFEST_NAME_PATTERN = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+/** RFC 7230 token, i.e. a valid HTTP header field name. */
+const HEADER_NAME_PATTERN = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+/** Horizontal tab, space, visible ASCII and obs-text. */
+const HEADER_VALUE_PATTERN = /^[\t\x20-\x7e\x80-\xff]*$/;
+
+/**
+ * Validates, expands and resolves `plugin.json` and `mcp.json` per Agent Plugins v1.0.0.
+ *
+ * Performs no filesystem and no network access: the caller walks the plugin directory and hands in
+ * the file contents plus the already filesystem-resolved plugin root and data directory.
+ */
+@injectable()
+export class AgentPluginManifestReader {
+
+    /**
+     * Only two schema violations are non-fatal - an unknown top-level field and a non-object
+     * `extensions` - and both are reported via {@link AgentPluginManifest.warnings} and ignored.
+     *
+     * @throws AgentPluginRejectedError on any other violation.
+     */
+    parseManifest(pluginJsonText: string): AgentPluginManifest {
+        let parsed: unknown;
+        try {
+            parsed = this.parseJson(pluginJsonText);
+        } catch (error) {
+            throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestNotJson', '"plugin.json" is not valid JSON.'));
+        }
+        if (!this.isRecord(parsed)) {
+            throw new AgentPluginRejectedError(
+                nls.localize('theia/ai-registry/plugin/manifestNotObject', '"plugin.json" must contain a top-level JSON object.'));
+        }
+        const warnings: string[] = [];
+        for (const field of Object.keys(parsed)) {
+            if (!MANIFEST_FIELDS.includes(field)) {
+                warnings.push(nls.localize('theia/ai-registry/plugin/unknownManifestField',
+                    'Ignoring the unknown "plugin.json" field "{0}".', field));
+            }
+        }
+        const schema = this.requiredString(parsed, '$schema');
+        if (this.pluginSchemaVersion(schema) === undefined) {
+            throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestUnsupportedVersion',
+                '"plugin.json" targets the unsupported Agent Plugins schema "{0}".', schema));
+        }
+        const name = this.requiredString(parsed, 'name');
+        if (name.length > 64 || !MANIFEST_NAME_PATTERN.test(name)) {
+            throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestInvalidName',
+                'The plugin name "{0}" is invalid: it must be 1 to 64 lowercase alphanumeric characters, hyphens or periods, '
+                + 'must start and end with an alphanumeric character and must not contain "--" or "..".', name));
+        }
+        if ('extensions' in parsed && !this.isRecord(parsed.extensions)) {
+            warnings.push(nls.localize('theia/ai-registry/plugin/nonObjectExtensions',
+                'Ignoring the "extensions" field of "plugin.json" because it is not an object.'));
+        }
+        return {
+            name,
+            version: this.optionalString(parsed, 'version'),
+            description: this.optionalString(parsed, 'description'),
+            authorName: this.authorName(parsed),
+            homepage: this.optionalString(parsed, 'homepage'),
+            keywords: this.keywords(parsed),
+            schema,
+            warnings
+        };
+    }
+
+    /**
+     * A rejected document only disables MCP for the plugin
+     * ({@link ResolvedPluginComponents.mcpDisabledReason}); a rejected entry only skips that entry.
+     * Neither affects skills, and nothing here throws.
+     */
+    resolveComponents(options: ResolveComponentsOptions): ResolvedPluginComponents {
+        if (options.mcpJsonText === undefined) {
+            // An absent fixed component location is not an error.
+            return { servers: [], skipped: [] };
+        }
+        const pluginRoot = this.normalizePath(options.pluginRoot);
+        const pluginData = this.normalizePath(options.pluginData);
+        let parsed: unknown;
+        try {
+            parsed = this.parseJson(options.mcpJsonText);
+        } catch (error) {
+            return this.mcpDisabled(nls.localize('theia/ai-registry/plugin/mcpNotJson', '"mcp.json" is not valid JSON.'));
+        }
+        const invalidDocument = nls.localize('theia/ai-registry/plugin/mcpInvalidDocument',
+            '"mcp.json" must contain a top-level JSON object with exactly the required "$schema" and "mcpServers" fields.');
+        if (!this.isRecord(parsed) || !this.isRecord(parsed.mcpServers) || typeof parsed.$schema !== 'string'
+            || Object.keys(parsed).some(field => field !== '$schema' && field !== 'mcpServers')) {
+            return this.mcpDisabled(invalidDocument);
+        }
+        const mcpVersion = this.mcpSchemaVersion(parsed.$schema);
+        if (mcpVersion === undefined) {
+            return this.mcpDisabled(nls.localize('theia/ai-registry/plugin/mcpUnsupportedVersion',
+                '"mcp.json" targets the unsupported Agent Plugins schema "{0}".', parsed.$schema));
+        }
+        const manifestVersion = this.pluginSchemaVersion(options.manifestSchema);
+        if (manifestVersion === undefined || manifestVersion !== mcpVersion) {
+            return this.mcpDisabled(nls.localize('theia/ai-registry/plugin/mcpVersionMismatch',
+                '"mcp.json" targets Agent Plugins version "{0}" but "plugin.json" targets "{1}".', mcpVersion, manifestVersion ?? options.manifestSchema));
+        }
+        const servers: ResolvedPluginServer[] = [];
+        const skipped: SkippedPluginComponent[] = [];
+        for (const [name, entry] of Object.entries(parsed.mcpServers)) {
+            try {
+                servers.push(this.resolveServer(name, entry, pluginRoot, pluginData));
+            } catch (error) {
+                skipped.push({ name, reason: this.skipReason(error) });
+            }
+        }
+        return { servers, skipped };
+    }
+
+    protected resolveServer(name: string, entry: unknown, pluginRoot: string, pluginData: string): ResolvedPluginServer {
+        if (!this.isRecord(entry)) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverNotObject', 'The server configuration is not a JSON object.'));
+        }
+        const type = entry.type;
+        if (typeof type !== 'string') {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverMissingField',
+                'The server configuration is missing the required "{0}" field.', 'type'));
+        }
+        if (type === 'sse') {
+            // `sse` support is OPTIONAL; Theia supports `stdio` and `streamable-http`.
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverUnsupportedTransport',
+                'The MCP transport "{0}" is not supported.', type));
+        }
+        if (type === 'stdio') {
+            return this.resolveStdioServer(name, entry, pluginRoot, pluginData);
+        }
+        if (type === 'streamable-http') {
+            return this.resolveHttpServer(name, entry);
+        }
+        throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverUnknownType',
+            'The server configuration declares the unknown transport type "{0}".', type));
+    }
+
+    protected resolveStdioServer(name: string, entry: Record<string, unknown>, pluginRoot: string, pluginData: string): ResolvedStdioServer {
+        this.checkClosedFields(entry, STDIO_FIELDS);
+        // `args` and `env` values are opaque strings that are never containment-checked, so they are
+        // expanded with the native paths straight away. `command` and `cwd` are resolved in `Path` form,
+        // because containment is decided there, and converted once the check has passed.
+        const nativeRoot = this.toNativePath(pluginRoot);
+        const nativeData = this.toNativePath(pluginData);
+        const command = this.resolveCommand(this.requiredEntryString(entry, 'command'), pluginRoot);
+        const args = this.args(entry, nativeRoot, nativeData);
+        const env = this.env(entry, nativeRoot, nativeData);
+        const cwd = this.resolveCwd(entry, pluginRoot, pluginData);
+        return { kind: 'stdio', name, command, args, env, cwd };
+    }
+
+    protected resolveHttpServer(name: string, entry: Record<string, unknown>): ResolvedHttpServer {
+        this.checkClosedFields(entry, HTTP_FIELDS);
+        // No placeholder expansion in `url`, header names or header values.
+        const serverUrl = this.requiredEntryString(entry, 'url');
+        this.checkUrl(serverUrl);
+        return { kind: 'http', name, serverUrl, headers: this.headers(entry) };
+    }
+
+    /**
+     * `command` is a single executable token, never a shell command string, and placeholders are never
+     * expanded in it.
+     */
+    protected resolveCommand(command: string, pluginRoot: string): string {
+        if (command.startsWith('./')) {
+            return this.toNativePath(this.resolveContained(command, pluginRoot, pluginRoot, 'command'));
+        }
+        // A bare name is a single token, so it can neither be a path nor a shell command string.
+        if (command.includes('/') || command.includes('\\') || /\s/.test(command)) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidCommand',
+                'The "command" value "{0}" must be a bare executable name or a plugin-relative path beginning with "./".', command));
+        }
+        return command;
+    }
+
+    /**
+     * Omitted `cwd` means the plugin root. A `./`- or `${PLUGIN_ROOT}`-rooted value must stay inside
+     * the plugin root; a `${PLUGIN_DATA}`-rooted one must stay inside the data directory.
+     */
+    protected resolveCwd(entry: Record<string, unknown>, pluginRoot: string, pluginData: string): string {
+        if (entry.cwd === undefined) {
+            return this.toNativePath(pluginRoot);
+        }
+        const cwd = this.entryString(entry, 'cwd');
+        const relative = cwd.startsWith('./');
+        const rootRelative = cwd === '${PLUGIN_ROOT}' || cwd.startsWith('${PLUGIN_ROOT}/');
+        const dataRelative = cwd === '${PLUGIN_DATA}' || cwd.startsWith('${PLUGIN_DATA}/');
+        if (!relative && !rootRelative && !dataRelative) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidCwd',
+                'The "cwd" value "{0}" must begin with "./", "${PLUGIN_ROOT}" or "${PLUGIN_DATA}".', cwd));
+        }
+        const expanded = this.expand(cwd, pluginRoot, pluginData);
+        const containmentRoot = dataRelative ? pluginData : pluginRoot;
+        return this.toNativePath(this.resolveContained(expanded, containmentRoot, relative ? pluginRoot : undefined, 'cwd'));
+    }
+
+    /** @throws ServerEntryInvalid when `value` resolves outside `containmentRoot`. */
+    protected resolveContained(value: string, containmentRoot: string, base: string | undefined, field: string): string {
+        const resolved = base === undefined
+            ? this.normalizePath(value)
+            : this.normalizePath(new Path(base).join(value).toString());
+        if (!new Path(containmentRoot).isEqualOrParent(new Path(resolved))) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverPathEscapes',
+                'The "{0}" value "{1}" resolves outside "{2}".', field, value, containmentRoot));
+        }
+        return resolved;
+    }
+
+    /**
+     * Single non-recursive pass: replacement text is never re-scanned, and unrecognized
+     * placeholder-like text stays literal.
+     */
+    protected expand(value: string, pluginRoot: string, pluginData: string): string {
+        return value.replace(PLACEHOLDER_PATTERN, (_match, placeholder) => placeholder === 'PLUGIN_ROOT' ? pluginRoot : pluginData);
+    }
+
+    protected args(entry: Record<string, unknown>, nativeRoot: string, nativeData: string): string[] | undefined {
+        if (entry.args === undefined) {
+            return undefined;
+        }
+        if (!Array.isArray(entry.args) || entry.args.some(element => typeof element !== 'string')) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidArgs', 'The "args" field must be an array of strings.'));
+        }
+        // `args` are opaque strings and are never containment-checked.
+        return entry.args.map(element => this.expand(element as string, nativeRoot, nativeData));
+    }
+
+    protected env(entry: Record<string, unknown>, nativeRoot: string, nativeData: string): Record<string, string> | undefined {
+        if (entry.env === undefined) {
+            return undefined;
+        }
+        if (!this.isRecord(entry.env)) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidEnv', 'The "env" field must be an object of strings.'));
+        }
+        const env: Record<string, string> = {};
+        for (const [key, value] of Object.entries(entry.env)) {
+            // Compared case-insensitively: Windows environment names are, so `Plugin_Root` there is the
+            // same variable we set ourselves, and rejecting it everywhere keeps a plugin from loading on
+            // one platform and failing on another.
+            if (RESERVED_ENV_NAMES.includes(key.toUpperCase())) {
+                throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverReservedEnv',
+                    'The "env" entry "{0}" is reserved and must not be declared by a plugin.', key));
+            }
+            if (typeof value !== 'string') {
+                throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidEnv', 'The "env" field must be an object of strings.'));
+            }
+            env[key] = this.expand(value, nativeRoot, nativeData);
+        }
+        return env;
+    }
+
+    protected headers(entry: Record<string, unknown>): Record<string, string> | undefined {
+        if (entry.headers === undefined) {
+            return undefined;
+        }
+        if (!this.isRecord(entry.headers)) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidHeaders', 'The "headers" field must be an object of strings.'));
+        }
+        const headers: Record<string, string> = {};
+        const seen = new Set<string>();
+        for (const [key, value] of Object.entries(entry.headers)) {
+            if (typeof value !== 'string' || !HEADER_NAME_PATTERN.test(key) || !this.isValidHeaderValue(value)) {
+                throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidHeader',
+                    'The header "{0}" is not a valid HTTP header field.', key));
+            }
+            // Header names are case-insensitive, so a repeat under different casing is a duplicate.
+            if (seen.has(key.toLowerCase())) {
+                throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverDuplicateHeader',
+                    'The header name "{0}" is declared more than once.', key));
+            }
+            seen.add(key.toLowerCase());
+            headers[key] = value;
+        }
+        return headers;
+    }
+
+    protected isValidHeaderValue(value: string): boolean {
+        return HEADER_VALUE_PATTERN.test(value);
+    }
+
+    /**
+     * The `url` must be absolute http(s) without user information and without a fragment, and a
+     * non-loopback endpoint must use https.
+     */
+    protected checkUrl(serverUrl: string): void {
+        const invalid = (): ServerEntryInvalid => this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverInvalidUrl',
+            'The "url" value "{0}" must be an absolute http or https URL without user information and without a fragment, '
+            + 'and a non-loopback URL must use https.', serverUrl));
+        let url: URL;
+        try {
+            url = new URL(serverUrl);
+        } catch (error) {
+            throw invalid();
+        }
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            throw invalid();
+        }
+        if (url.username || url.password || serverUrl.includes('#')) {
+            throw invalid();
+        }
+        if (url.protocol === 'http:' && !this.isLoopbackHost(url.hostname)) {
+            throw invalid();
+        }
+    }
+
+    protected isLoopbackHost(hostname: string): boolean {
+        if (hostname === 'localhost' || hostname === '[::1]' || hostname === '::1') {
+            return true;
+        }
+        const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname);
+        return !!ipv4 && Number(ipv4[1]) === 127 && ipv4.slice(1).every(part => Number(part) <= 255);
+    }
+
+    protected pluginSchemaVersion(schema: string): string | undefined {
+        return this.schemaVersion(schema, 'plugin');
+    }
+
+    protected mcpSchemaVersion(schema: string): string | undefined {
+        return this.schemaVersion(schema, 'mcp');
+    }
+
+    protected schemaVersion(schema: string, document: 'plugin' | 'mcp'): string | undefined {
+        return SUPPORTED_AGENT_PLUGINS_VERSIONS.find(version => schema === `https://agent-plugins.org/schemas/${version}/${document}.schema.json`);
+    }
+
+    protected checkClosedFields(entry: Record<string, unknown>, allowed: string[]): void {
+        for (const field of Object.keys(entry)) {
+            if (!allowed.includes(field)) {
+                throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverUnknownField',
+                    'The server configuration declares the field "{0}", which is not permitted for its transport type.', field));
+            }
+        }
+    }
+
+    protected requiredEntryString(entry: Record<string, unknown>, field: string): string {
+        if (entry[field] === undefined) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverMissingField',
+                'The server configuration is missing the required "{0}" field.', field));
+        }
+        const value = this.entryString(entry, field);
+        if (!value) {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverEmptyField',
+                'The server configuration field "{0}" must not be empty.', field));
+        }
+        return value;
+    }
+
+    protected entryString(entry: Record<string, unknown>, field: string): string {
+        const value = entry[field];
+        if (typeof value !== 'string') {
+            throw this.entryInvalid(nls.localize('theia/ai-registry/plugin/serverFieldNotString',
+                'The server configuration field "{0}" must be a string.', field));
+        }
+        return value;
+    }
+
+    protected requiredString(manifest: Record<string, unknown>, field: string): string {
+        const value = manifest[field];
+        if (typeof value !== 'string' || value.length === 0) {
+            throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestRequiredField',
+                'The "plugin.json" field "{0}" is required and must be a non-empty string.', field));
+        }
+        return value;
+    }
+
+    protected optionalString(manifest: Record<string, unknown>, field: string): string | undefined {
+        const value = manifest[field];
+        if (value === undefined) {
+            return undefined;
+        }
+        if (typeof value !== 'string') {
+            throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestFieldNotString',
+                'The "plugin.json" field "{0}" must be a string.', field));
+        }
+        return value;
+    }
+
+    protected authorName(manifest: Record<string, unknown>): string | undefined {
+        const author = manifest.author;
+        if (author === undefined) {
+            return undefined;
+        }
+        if (!this.isRecord(author) || Object.keys(author).some(field => !AUTHOR_FIELDS.includes(field))
+            || Object.values(author).some(value => typeof value !== 'string')) {
+            throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestInvalidAuthor',
+                'The "plugin.json" field "author" must be an object with the optional string fields "name", "email" and "url".'));
+        }
+        return typeof author.name === 'string' ? author.name : undefined;
+    }
+
+    protected keywords(manifest: Record<string, unknown>): string[] | undefined {
+        const keywords = manifest.keywords;
+        if (keywords === undefined) {
+            return undefined;
+        }
+        if (!Array.isArray(keywords) || keywords.some(keyword => typeof keyword !== 'string')) {
+            throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestInvalidKeywords',
+                'The "plugin.json" field "keywords" must be an array of strings.'));
+        }
+        return keywords as string[];
+    }
+
+    protected parseJson(text: string): unknown {
+        return JSON.parse(text);
+    }
+
+    protected mcpDisabled(reason: string): ResolvedPluginComponents {
+        return { servers: [], skipped: [], mcpDisabledReason: reason };
+    }
+
+    protected entryInvalid(reason: string): ServerEntryInvalid {
+        return new ServerEntryInvalid(reason);
+    }
+
+    protected skipReason(error: unknown): string {
+        return error instanceof Error && error.message
+            ? error.message
+            : nls.localize('theia/ai-registry/plugin/serverInvalid', 'The server configuration is invalid.');
+    }
+
+    /**
+     * A UNC root keeps its leading `//`: `Path.normalize` drops empty segments, folding
+     * `\\server\share\x` to `/server/share/x` - a different location, and one that would then
+     * disagree with the `PLUGIN_ROOT` the backend derives with Node's `path.join`.
+     */
+    protected normalizePath(path: string): string {
+        const unc = /^[/\\]{2}[^/\\]/.test(path);
+        const normalized = new Path(path).normalize().toString();
+        const trimmed = normalized.length > 1 && normalized.endsWith(Path.separator) ? normalized.slice(0, -1) : normalized;
+        return unc && !trimmed.startsWith('//') ? `/${trimmed}` : trimmed;
+    }
+
+    /** A no-op on POSIX; on Windows it turns `/c:/plugins/acme` back into `c:\plugins\acme`. */
+    protected toNativePath(path: string): string {
+        return new Path(path).fsPath(this.nativePathFormat());
+    }
+
+    /**
+     * Its own seam so a test can pin the format without replacing the conversion it is exercising:
+     * tests run on POSIX, where an overridden {@link toNativePath} would prove nothing about the real
+     * one. `undefined` means "whatever the backend runs on".
+     */
+    protected nativePathFormat(): Path.Format | undefined {
+        return undefined;
+    }
+
+    protected isRecord(value: unknown): value is Record<string, unknown> {
+        return typeof value === 'object' && !!value && !Array.isArray(value);
+    }
+}

--- a/packages/ai-registry/src/common/plugin/plugin-directory-naming.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-directory-naming.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/plugin/plugin-directory-naming.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-directory-naming.ts
@@ -1,0 +1,53 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+// Do not "fix" this to `filenamify/browser`: TypeScript's `moduleResolution: node` cannot read the
+// package's `exports` map, and the sub-path that does type-resolve fails at runtime with
+// ERR_PACKAGE_PATH_NOT_EXPORTED. The entry point pulls Node's `path` into the browser graph, which
+// both bundlers already polyfill.
+import * as filenamify from 'filenamify';
+import { nls } from '@theia/core';
+import { injectable } from '@theia/core/shared/inversify';
+
+/** Rejects anything that is not a single path segment, including a Windows drive-absolute path. */
+const NOT_A_SINGLE_SEGMENT = /[/\\]|^[A-Za-z]:/;
+
+export const PluginDirectoryNaming = Symbol('PluginDirectoryNaming');
+/**
+ * Turns a plugin identifier into its directory name under the plugins root. Shared between backend
+ * and frontend on purpose: two independent encodings would disagree on some identifier and produce
+ * two directories for one plugin, which is what adoption exists to prevent.
+ */
+export interface PluginDirectoryNaming {
+    /**
+     * @throws Error when the identifier does not encode to a usable single path segment. The name
+     * comes from registry JSON, so this is what stops a `..` escaping the plugins root.
+     */
+    directoryName(pluginId: string): string;
+}
+
+@injectable()
+export class PluginDirectoryNamingImpl implements PluginDirectoryNaming {
+
+    directoryName(pluginId: string): string {
+        const encoded = filenamify(pluginId, { replacement: '_' });
+        if (!encoded || encoded === '.' || encoded === '..' || NOT_A_SINGLE_SEGMENT.test(encoded)) {
+            throw new Error(nls.localize('theia/ai-registry/plugin/invalidDirectoryName',
+                'Invalid plugin directory name "{0}": it must be a single path segment without separators.', encoded));
+        }
+        return encoded;
+    }
+}

--- a/packages/ai-registry/src/common/plugin/plugin-install-protocol.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-install-protocol.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/plugin/plugin-install-protocol.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-install-protocol.ts
@@ -1,0 +1,55 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { InstalledPluginInfo, ResolvedPluginEntry, StagedPluginInstall } from './plugin-registry-types';
+
+export const PluginInstallBackendServicePath = '/services/ai-registry/plugin-install';
+
+export const PluginInstallClient = Symbol('PluginInstallClient');
+export interface PluginInstallClient {
+    notifyDidChangeInstalledPlugins(): void;
+    /** The watcher stopped after an error; no further change notifications arrive until reload. */
+    notifyWatcherStopped(): void;
+}
+
+export const PluginInstallBackendService = Symbol('PluginInstallBackendService');
+
+/**
+ * Performs all Agent Plugin filesystem and network work: the plugins root lives outside the browser
+ * FileService sandbox.
+ *
+ * Installing is two-phase so that a content-hash mismatch is an explicit user decision rather than
+ * something discovered after the plugin is already in place: {@link stage} downloads and verifies
+ * without touching the final location, and the frontend then {@link commit}s or {@link discard}s.
+ * Registering the resolved components is the frontend's job, after {@link commit} returns.
+ */
+export interface PluginInstallBackendService {
+    /** @throws when the source cannot be downloaded, or `plugin.json` is missing or invalid. */
+    stage(entry: ResolvedPluginEntry): Promise<StagedPluginInstall>;
+    /**
+     * @param replaceExisting true for update and fix, where the existing root is removed first. The
+     * plugin's data directory is preserved either way, as the specification requires.
+     */
+    commit(stagingId: string, replaceExisting: boolean): Promise<InstalledPluginInfo>;
+    discard(stagingId: string): Promise<void>;
+    /** Only removes roots carrying our provenance marker. */
+    uninstall(pluginId: string): Promise<void>;
+    /** Adopts an existing directory by writing the provenance marker, leaving its content untouched. */
+    link(entry: ResolvedPluginEntry, directoryName: string): Promise<InstalledPluginInfo>;
+    unlink(pluginId: string): Promise<void>;
+    listInstalledPlugins(): Promise<InstalledPluginInfo[]>;
+    getPluginsRoot(): Promise<string>;
+}

--- a/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.spec.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.spec.ts
@@ -1,0 +1,148 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import { PluginRegistryEntryResolverImpl } from './plugin-registry-entry-resolver';
+import { RegistryPlugin, RegistryPluginApproval } from './plugin-registry-types';
+
+function approval(organizationId: string, date: string, installConfigs: RegistryPluginApproval['installConfigs'] = []): RegistryPluginApproval {
+    return { organizationId, date, configHash: `hash-${organizationId}`, installConfigs };
+}
+
+function plugin(overrides: Partial<RegistryPlugin> = {}): RegistryPlugin {
+    return {
+        pluginId: 'io.github.acme/bigquery-data-analytics',
+        name: 'BigQuery Data Analytics',
+        description: 'Analyse BigQuery data.',
+        version: '1.2.0',
+        source: { url: 'https://github.com/acme/bigquery-data-analytics.git' },
+        contentHash: '5b8ad3f0e174',
+        containedSkills: [{ name: 'query-builder', description: 'Build SQL.', path: 'skills/query-builder' }],
+        containedMcpServers: [{ name: 'bigquery', transport: 'stdio' }],
+        approvals: [approval('example-org', '2026-08-07')],
+        ...overrides
+    };
+}
+
+describe('PluginRegistryEntryResolver', () => {
+
+    let resolver: PluginRegistryEntryResolverImpl;
+
+    beforeEach(() => {
+        resolver = new PluginRegistryEntryResolverImpl();
+    });
+
+    it('resolves a plugin entry, carrying the source, hash and consolidated components through', () => {
+        const resolved = resolver.resolve(plugin());
+
+        expect(resolved?.pluginId).to.equal('io.github.acme/bigquery-data-analytics');
+        expect(resolved?.name).to.equal('BigQuery Data Analytics');
+        expect(resolved?.version).to.equal('1.2.0');
+        expect(resolved?.sourceUrl).to.equal('https://github.com/acme/bigquery-data-analytics.git');
+        expect(resolved?.sourcePath).to.equal(undefined);
+        expect(resolved?.contentHash).to.equal('5b8ad3f0e174');
+        expect(resolved?.containedSkills.map(skill => skill.name)).to.deep.equal(['query-builder']);
+        expect(resolved?.containedMcpServers.map(server => server.name)).to.deep.equal(['bigquery']);
+    });
+
+    it('keeps the in-repository plugin path when the source declares one', () => {
+        expect(resolver.resolve(plugin({ source: { url: 'https://github.com/acme/monorepo', path: 'plugins/bigquery' } }))?.sourcePath)
+            .to.equal('plugins/bigquery');
+    });
+
+    it('returns undefined for an entry without a source URL', () => {
+        expect(resolver.resolve(plugin({ source: { url: '' } }))).to.equal(undefined);
+    });
+
+    it('returns undefined for an entry no organization has endorsed', () => {
+        expect(resolver.resolve(plugin({ approvals: [] }))).to.equal(undefined);
+    });
+
+    it('orders endorsements by date descending', () => {
+        const resolved = resolver.resolve(plugin({
+            approvals: [approval('older-org', '2026-01-05'), approval('newest-org', '2026-08-07'), approval('middle-org', '2026-04-01')]
+        }));
+
+        expect(resolved?.endorsements.map(endorsement => endorsement.organizationId)).to.deep.equal(['newest-org', 'middle-org', 'older-org']);
+    });
+
+    it('breaks a date tie by organization id ascending, so two clients reading the same feed agree', () => {
+        const resolved = resolver.resolve(plugin({
+            approvals: [approval('zeta-org', '2026-08-07'), approval('alpha-org', '2026-08-07'), approval('mid-org', '2026-08-07')]
+        }));
+
+        expect(resolved?.endorsements.map(endorsement => endorsement.organizationId)).to.deep.equal(['alpha-org', 'mid-org', 'zeta-org']);
+    });
+
+    it('resolves an approval whose install configs were filtered out of the per-tool view, and still counts its endorsement', () => {
+        // In `tools/<id>.json` another organization's approval survives stripped of its install configs,
+        // so that every endorsing organization stays visible.
+        const resolved = resolver.resolve(plugin({
+            approvals: [approval('endorsing-org', '2026-08-07', []), approval('other-org', '2026-08-06', [{ tool: 'theia-ide' }])]
+        }));
+
+        expect(resolved).to.not.equal(undefined);
+        expect(resolved?.endorsements.map(endorsement => endorsement.organizationId)).to.deep.equal(['endorsing-org', 'other-org']);
+    });
+
+    it('reports the organization an endorsement was filed through when it came via trust', () => {
+        const resolved = resolver.resolve(plugin({
+            approvals: [{ ...approval('trusting-org', '2026-08-07'), viaTrust: 'filing-org' }]
+        }));
+
+        expect(resolved?.endorsements).to.deep.equal([{ organizationId: 'trusting-org', date: '2026-08-07', viaTrust: 'filing-org' }]);
+    });
+
+    it('does not mutate the approval order of the raw entry', () => {
+        const raw = plugin({ approvals: [approval('older-org', '2026-01-05'), approval('newest-org', '2026-08-07')] });
+
+        resolver.resolve(raw);
+
+        expect(raw.approvals.map(item => item.organizationId)).to.deep.equal(['older-org', 'newest-org']);
+    });
+});
+
+describe('PluginRegistryEntryResolver plugin id validation', () => {
+
+    const resolver = new PluginRegistryEntryResolverImpl();
+
+    it('accepts the identifier shapes the registry publishes', () => {
+        for (const pluginId of ['io.github.acme/bigquery-data-analytics', 'acme/tools', 'a', 'a.b_c-d/e.f_g-h']) {
+            expect(resolver.resolve(plugin({ pluginId })), pluginId).to.not.be.undefined;
+        }
+    });
+
+    it('drops an identifier carrying a character the directory encoding or the chat parser would mangle', () => {
+        // Each of these either folds to the same directory name as another identifier, or survives into
+        // a skill qualifier that `/`-command parsing stops at.
+        for (const pluginId of ['acme tools', 'acme|tools', 'acme:tools', 'acme#tools', 'acme(tools)', 'acme%tools', '', '/leading', 'trailing/']) {
+            expect(resolver.resolve(plugin({ pluginId })), JSON.stringify(pluginId)).to.be.undefined;
+        }
+    });
+
+    it('drops two identifiers that would encode to the same directory name', () => {
+        // `filenamify` folds the reserved set to one character and collapses runs of it, so `a:b`, `a|b`
+        // and `a//b` all become `a_b`. Only the plain form survives validation, so the collision - and
+        // with it two plugins claiming one directory - cannot arise.
+        expect(resolver.resolve(plugin({ pluginId: 'acme/tools' }))).to.not.be.undefined;
+        expect(resolver.resolve(plugin({ pluginId: 'acme:tools' }))).to.be.undefined;
+        expect(resolver.resolve(plugin({ pluginId: 'acme|tools' }))).to.be.undefined;
+    });
+
+    it('drops an identifier long enough for the encoding to truncate', () => {
+        expect(resolver.resolve(plugin({ pluginId: `acme/${'x'.repeat(120)}` }))).to.be.undefined;
+    });
+});

--- a/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-registry-entry-resolver.ts
@@ -1,0 +1,88 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { injectable } from '@theia/core/shared/inversify';
+import { PluginEndorsement, RegistryPlugin, RegistryPluginApproval, ResolvedPluginEntry } from './plugin-registry-types';
+
+// Narrower than what the feed might publish: the identifier is encoded into the directory name, and
+// that name becomes the qualifier inside a `/`-command. Restricting it once here is what stops two
+// identifiers encoding to one directory, and a qualifier containing a character the parser stops at.
+const PLUGIN_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*(?:\/[A-Za-z0-9][A-Za-z0-9._-]*)*$/;
+
+export const PluginRegistryEntryResolver = Symbol('PluginRegistryEntryResolver');
+export interface PluginRegistryEntryResolver {
+    /** Normalises a raw registry plugin entry into the shape the install path uses, or undefined when it is not approved/usable. */
+    resolve(raw: RegistryPlugin): ResolvedPluginEntry | undefined;
+}
+
+@injectable()
+export class PluginRegistryEntryResolverImpl implements PluginRegistryEntryResolver {
+
+    resolve(raw: RegistryPlugin): ResolvedPluginEntry | undefined {
+        if (!raw.source?.url) {
+            return undefined;
+        }
+        // A plugin is only installable once at least one organization has endorsed it.
+        if (!raw.approvals?.length) {
+            return undefined;
+        }
+        if (!this.isUsablePluginId(raw.pluginId)) {
+            return undefined;
+        }
+        const approvals = this.sortApprovals(raw.approvals);
+        return {
+            pluginId: raw.pluginId,
+            name: raw.name,
+            description: raw.description,
+            ...(raw.version !== undefined && { version: raw.version }),
+            sourceUrl: raw.source.url,
+            ...(raw.source.path !== undefined && { sourcePath: raw.source.path }),
+            contentHash: raw.contentHash,
+            // Every endorsing organization stays visible: the install dialog names all of them, and an
+            // approval whose install configs were filtered out of the per-tool view still endorses.
+            endorsements: approvals.map(approval => this.toEndorsement(approval)),
+            containedSkills: raw.containedSkills ?? [],
+            containedMcpServers: raw.containedMcpServers ?? []
+        };
+    }
+
+    /**
+     * Unusable identifiers are dropped from the feed rather than half-supported: the alternatives are
+     * two plugins silently sharing one directory, or a skill whose `/`-command cannot be typed. The
+     * length cap matters because the encoding truncates, so two identifiers differing only past the
+     * cap would encode to the same directory name.
+     */
+    protected isUsablePluginId(pluginId: string): boolean {
+        return typeof pluginId === 'string' && pluginId.length > 0 && pluginId.length <= 100 && PLUGIN_ID_PATTERN.test(pluginId);
+    }
+
+    /**
+     * Most recent first, `organizationId` ascending on ties. The specification prescribes a *total*
+     * order: two clients given the same feed must pick the same approval, which a date-only sort
+     * does not guarantee.
+     */
+    protected sortApprovals(approvals: RegistryPluginApproval[]): RegistryPluginApproval[] {
+        return [...approvals].sort((a, b) => b.date.localeCompare(a.date) || a.organizationId.localeCompare(b.organizationId));
+    }
+
+    protected toEndorsement(approval: RegistryPluginApproval): PluginEndorsement {
+        return {
+            organizationId: approval.organizationId,
+            date: approval.date,
+            ...(approval.viaTrust !== undefined && { viaTrust: approval.viaTrust })
+        };
+    }
+}

--- a/packages/ai-registry/src/common/plugin/plugin-registry-types.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-registry-types.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/common/plugin/plugin-registry-types.ts
+++ b/packages/ai-registry/src/common/plugin/plugin-registry-types.ts
@@ -1,0 +1,193 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { ResolvedPluginServer, SkippedPluginComponent } from './agent-plugin-manifest';
+
+/** The registry points at a plugin; it does not host it. `path` omitted means the repository root. */
+export interface RegistryPluginSource {
+    url: string;
+    path?: string;
+}
+
+export interface RegistryPluginInstallConfig {
+    tool?: string;
+    installUrl?: string;
+    config?: Record<string, unknown>;
+    instructions?: string;
+}
+
+export interface RegistryPluginApproval {
+    organizationId: string;
+    date: string;
+    configHash: string;
+    /**
+     * Never assume this is non-empty: in the per-tool view an approval filed for another tool
+     * survives with its configs filtered away, so that every endorsing organization stays visible.
+     */
+    installConfigs: RegistryPluginInstallConfig[];
+    /** The organization that actually filed the approval, when endorsed via trust. */
+    viaTrust?: string;
+}
+
+export interface RegistryContainedSkill {
+    name: string;
+    description: string;
+    /** Plugin-root-relative, e.g. `skills/query-builder`. */
+    path: string;
+}
+
+export interface RegistryContainedMcpServer {
+    name: string;
+    /** Empty when the entry declared no `type`, which v1 treats as invalid - the server is skipped. */
+    transport: string;
+}
+
+/**
+ * Top-level Agent Plugin entry as published by the registry. `containedSkills` and
+ * `containedMcpServers` are what consolidation saw when it last ran, for telling the user what they
+ * are about to install; the plugin root is authoritative once downloaded and wins on disagreement.
+ */
+export interface RegistryPlugin {
+    pluginId: string;
+    name: string;
+    description: string;
+    version?: string;
+    author?: string;
+    homepage?: string;
+    keywords?: string[];
+    source: RegistryPluginSource;
+    contentHash: string;
+    containedSkills: RegistryContainedSkill[];
+    containedMcpServers: RegistryContainedMcpServer[];
+    approvals: RegistryPluginApproval[];
+}
+
+export interface PluginEndorsement {
+    organizationId: string;
+    date: string;
+    /** The organization that actually filed the approval, when endorsed via trust. */
+    viaTrust?: string;
+}
+
+/** A registry entry with its approvals resolved down to the shape the install service operates on. */
+export interface ResolvedPluginEntry {
+    pluginId: string;
+    name: string;
+    description: string;
+    /** Display only - never an update signal, the content hash decides. */
+    version?: string;
+    sourceUrl: string;
+    sourcePath?: string;
+    contentHash: string;
+    /** Every endorsing organization, not only the one whose install config was selected. */
+    endorsements: PluginEndorsement[];
+    containedSkills: RegistryContainedSkill[];
+    containedMcpServers: RegistryContainedMcpServer[];
+}
+
+/**
+ * Provenance marker written to `<pluginRoot>/.registry.json`.
+ *
+ * Dot-prefixed so it is excluded from the content hash. Its presence is what distinguishes a plugin
+ * we installed from a directory the user placed there, which must never be modified or removed.
+ */
+export interface PluginRegistryMetadata {
+    pluginId: string;
+    /**
+     * The registry hash this install was accepted against, exactly as the skill marker records it:
+     * one baseline driving both update detection (the registry publishes a different hash) and
+     * drift detection (the hash computed from disk differs).
+     */
+    contentHash: string;
+    /**
+     * The prefix this plugin's skills are addressed by, chosen when the plugin was installed or
+     * linked. Recorded rather than derived so that it never changes underneath a plugin: it is the
+     * last segment of the identifier while that is free, and the full directory name otherwise.
+     */
+    qualifier: string;
+    /**
+     * When the root was last written. Load-bearing: it is carried into the plugin's MCP entries so
+     * that replacing the root restarts the servers running out of it, even when their own
+     * configuration is unchanged.
+     */
+    installedAt?: string;
+}
+
+/**
+ * A directory found under the plugins root. `pluginId` and `contentHash` are present only when it
+ * carries our `.registry.json`; `drifted` means the on-disk hash no longer matches the recorded one.
+ */
+export interface InstalledPluginInfo {
+    /**
+     * The one name a plugin may occupy: install creates it, adoption accepts no other, and every
+     * other operation derives its target from the identifier the same way. Unique across installed
+     * plugins, which is why it is also the fallback qualifier and the MCP server key disambiguator.
+     */
+    directoryName: string;
+    /** `PLUGIN_ROOT`. */
+    root: string;
+    /**
+     * `PLUGIN_DATA`. Outside the plugin root on purpose: the root is content hashed, so anything
+     * written inside it would report the plugin as drifted the moment its own server ran, and an
+     * update replaces the root wholesale.
+     */
+    dataRoot: string;
+    pluginId?: string;
+    contentHash?: string;
+    /** See {@link PluginRegistryMetadata.qualifier}. Absent for a directory without our marker. */
+    qualifier?: string;
+    installedAt?: string;
+    drifted: boolean;
+    name?: string;
+    version?: string;
+    /**
+     * Discovered under `<root>/skills` rather than taken from the feed, which only records what
+     * consolidation last saw. Names only: reading each `SKILL.md`'s frontmatter here would mean a
+     * second frontmatter parser in the backend when `@theia/ai-core` already owns one.
+     */
+    skills: string[];
+    servers: ResolvedPluginServer[];
+    skipped: SkippedPluginComponent[];
+    /** Set when `mcp.json` as a whole was rejected, disabling MCP for this plugin. */
+    mcpDisabledReason?: string;
+}
+
+/**
+ * Outcome of classifying a plugin against the opposite side. Mirrors the skill union.
+ *
+ * `installed-link-stale` means the marker names a `pluginId` the registry no longer lists - either a
+ * withdrawn endorsement or a source briefly unreachable during consolidation. Nothing in the data
+ * separates the two, so it is surfaced and acted on only by the user.
+ */
+export type PluginClassificationResult =
+    | { kind: 'installed-from-registry'; updateAvailable: boolean }
+    | { kind: 'installed-manually' }
+    | { kind: 'fix-plugin' }
+    | { kind: 'not-installed' }
+    | { kind: 'installed-link-stale' }
+    | { kind: 'installed-user-added' };
+
+export interface PluginHashMismatch {
+    expected: string;
+    actual: string;
+}
+
+/** Verified while still in staging, so nothing lands at its final path until the hash is settled. */
+export interface StagedPluginInstall {
+    stagingId: string;
+    /** Set when the computed hash differed from the endorsed one; the user must then choose. */
+    mismatch?: PluginHashMismatch;
+}

--- a/packages/ai-registry/src/common/registry-fetch-service.spec.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.spec.ts
@@ -19,6 +19,7 @@ import { Container } from '@theia/core/shared/inversify';
 import { BackendRequestService, RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
 import { AIRegistryConfiguration } from './ai-registry-configuration';
 import { MCPRegistryEntryResolver, MCPRegistryEntryResolverImpl } from './mcp/mcp-registry-entry-resolver';
+import { PluginRegistryEntryResolver, PluginRegistryEntryResolverImpl } from './plugin/plugin-registry-entry-resolver';
 import { SkillRegistryEntryResolver, SkillRegistryEntryResolverImpl } from './skill/skill-registry-entry-resolver';
 import { RegistryFetchService, RegistryFetchServiceImpl } from './registry-fetch-service';
 import { ILogger } from '@theia/core';
@@ -63,6 +64,20 @@ class TestRegistryFetchService extends RegistryFetchServiceImpl {
     protected override now(): number { return this.currentTime; }
 }
 
+/** Succeeds once and then fails, so that the "a failed refetch keeps the previous state" rule can be asserted. */
+class FailingOnSecondRequestService implements RequestService {
+    public callCount = 0;
+    constructor(private readonly responseBody: string) { }
+    async configure(): Promise<void> { /* no-op */ }
+    async resolveProxy(): Promise<string | undefined> { return undefined; }
+    async request(options: RequestOptions): Promise<RequestContext> {
+        this.callCount += 1;
+        return this.callCount === 1
+            ? { url: options.url, res: { headers: {}, statusCode: 200 }, buffer: new TextEncoder().encode(this.responseBody) }
+            : { url: options.url, res: { headers: {}, statusCode: 503 }, buffer: new Uint8Array() };
+    }
+}
+
 class FakeConfiguration extends AIRegistryConfiguration {
     constructor(private readonly toolName: string, private readonly baseUrl: string) { super(); }
     override getToolName(): string { return this.toolName; }
@@ -100,6 +115,22 @@ function payload(): string {
                 date: '2026-04-01',
                 installConfigs: [{ tool: 'theia-ide', installUrl: 'theia://install-skill?id=io.github.example/example-skill' }]
             }]
+        }],
+        plugins: [{
+            pluginId: 'io.github.example/example-plugin',
+            name: 'Example Plugin',
+            description: 'Example Agent Plugin',
+            version: '1.2.0',
+            source: { url: 'https://github.com/example/example-plugin.git' },
+            contentHash: 'def456def456',
+            containedSkills: [{ name: 'query-builder', description: 'Build SQL.', path: 'skills/query-builder' }],
+            containedMcpServers: [{ name: 'bigquery', transport: 'stdio' }],
+            approvals: [{
+                organizationId: 'theia',
+                date: '2026-04-01',
+                configHash: 'plugin-hash-v1',
+                installConfigs: [{ tool: 'theia-ide', installUrl: 'theia://install-plugin?id=io.github.example/example-plugin' }]
+            }]
         }]
     });
 }
@@ -115,6 +146,8 @@ describe('RegistryFetchService', () => {
         container.bind(MCPRegistryEntryResolver).toService(MCPRegistryEntryResolverImpl);
         container.bind(SkillRegistryEntryResolverImpl).toSelf().inSingletonScope();
         container.bind(SkillRegistryEntryResolver).toService(SkillRegistryEntryResolverImpl);
+        container.bind(PluginRegistryEntryResolverImpl).toSelf().inSingletonScope();
+        container.bind(PluginRegistryEntryResolver).toService(PluginRegistryEntryResolverImpl);
         container.bind(RegistryFetchServiceImpl).toSelf().inSingletonScope();
         container.bind(RegistryFetchService).toService(RegistryFetchServiceImpl);
         return container;
@@ -169,15 +202,72 @@ describe('RegistryFetchService', () => {
         });
     });
 
-    it('shares a single HTTP request between MCP and skill slices', async () => {
+    it('fetches and resolves Agent Plugin entries from the same per-tool JSON', async () => {
+        const request = new FakeRequestService(payload());
+        const config = new FakeConfiguration('theia-ide', 'https://example.test/api/v1/');
+        const service = buildContainer(request, config).get<RegistryFetchService>(RegistryFetchService);
+
+        const plugins = await service.getPluginEntries();
+
+        expect(plugins).to.have.length(1);
+        expect(plugins[0]).to.deep.equal({
+            pluginId: 'io.github.example/example-plugin',
+            name: 'Example Plugin',
+            description: 'Example Agent Plugin',
+            version: '1.2.0',
+            sourceUrl: 'https://github.com/example/example-plugin.git',
+            contentHash: 'def456def456',
+            endorsements: [{ organizationId: 'theia', date: '2026-04-01' }],
+            containedSkills: [{ name: 'query-builder', description: 'Build SQL.', path: 'skills/query-builder' }],
+            containedMcpServers: [{ name: 'bigquery', transport: 'stdio' }]
+        });
+    });
+
+    it('returns an empty plugin slice when the registry response has none', async () => {
+        const request = new FakeRequestService(JSON.stringify({ mcp: [], skills: [] }));
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get<RegistryFetchService>(RegistryFetchService);
+
+        expect(await service.getPluginEntries()).to.deep.equal([]);
+    });
+
+    it('shares a single HTTP request between the MCP, skill and plugin slices', async () => {
         const request = new FakeRequestService(payload());
         const config = new FakeConfiguration('theia-ide', 'https://example.test/api/v1/');
         const service = buildContainer(request, config).get<RegistryFetchService>(RegistryFetchService);
 
         await service.getEntries();
         await service.getSkillEntries();
+        await service.getPluginEntries();
 
         expect(request.callCount).to.equal(1);
+    });
+
+    it('re-resolves the plugin slice after a forced refetch', async () => {
+        const request = new FakeRequestService(payload());
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get<RegistryFetchService>(RegistryFetchService);
+
+        const first = await service.getPluginEntries();
+        const refreshed = await service.getPluginEntries(true);
+
+        expect(request.callCount).to.equal(2);
+        expect(refreshed).to.not.equal(first);
+        expect(refreshed).to.deep.equal(first);
+    });
+
+    it('leaves the previously cached plugin entries intact when a refetch fails', async () => {
+        const request = new FailingOnSecondRequestService(payload());
+        const service = buildContainer(request, new FakeConfiguration('theia-ide', 'https://example.test/api/v1/')).get<RegistryFetchService>(RegistryFetchService);
+        const plugins = await service.getPluginEntries();
+
+        let caught: Error | undefined;
+        try {
+            await service.getPluginEntries(true);
+        } catch (error) {
+            caught = error as Error;
+        }
+
+        expect(caught?.message).to.match(/HTTP 503/);
+        expect(await service.getPluginEntries()).to.deep.equal(plugins);
     });
 
     it('serves cached entries on a second call without issuing a new request', async () => {

--- a/packages/ai-registry/src/common/registry-fetch-service.ts
+++ b/packages/ai-registry/src/common/registry-fetch-service.ts
@@ -20,12 +20,15 @@ import { BackendRequestService, RequestContext, RequestService } from '@theia/co
 import { AIRegistryConfiguration } from './ai-registry-configuration';
 import { MCPRegistryEntryResolver } from './mcp/mcp-registry-entry-resolver';
 import { RegistryMCPServer, ResolvedRegistryEntry } from './mcp/mcp-registry-types';
+import { PluginRegistryEntryResolver } from './plugin/plugin-registry-entry-resolver';
+import { RegistryPlugin, ResolvedPluginEntry } from './plugin/plugin-registry-types';
 import { SkillRegistryEntryResolver } from './skill/skill-registry-entry-resolver';
 import { RegistrySkill, ResolvedSkillEntry } from './skill/skill-registry-types';
 
 interface RegistryResponse {
     mcp?: RegistryMCPServer[];
     skills?: RegistrySkill[];
+    plugins?: RegistryPlugin[];
 }
 
 /**
@@ -51,6 +54,8 @@ export interface RegistryFetchService {
     getEntries(forceRefresh?: boolean): Promise<ResolvedRegistryEntry[]>;
     /** Returns the resolved skill registry entries, fetching (and caching) them on first use or when `forceRefresh` is set. */
     getSkillEntries(forceRefresh?: boolean): Promise<ResolvedSkillEntry[]>;
+    /** Returns the resolved Agent Plugin registry entries, fetching (and caching) them on first use or when `forceRefresh` is set. */
+    getPluginEntries(forceRefresh?: boolean): Promise<ResolvedPluginEntry[]>;
 }
 
 @injectable()
@@ -72,9 +77,13 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
     @inject(SkillRegistryEntryResolver)
     protected readonly skillResolver: SkillRegistryEntryResolver;
 
+    @inject(PluginRegistryEntryResolver)
+    protected readonly pluginResolver: PluginRegistryEntryResolver;
+
     protected cachedResponse: RegistryResponse | undefined;
     protected cachedEntries: ResolvedRegistryEntry[] | undefined;
     protected cachedSkills: ResolvedSkillEntry[] | undefined;
+    protected cachedPlugins: ResolvedPluginEntry[] | undefined;
     /** Shared while a request is in flight so concurrent callers issue a single request. */
     protected pendingResponse: Promise<RegistryResponse> | undefined;
     /** The last failure and when it happened, used to back off from a registry that is unreachable. */
@@ -104,10 +113,20 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
         return this.cachedSkills;
     }
 
+    async getPluginEntries(forceRefresh: boolean = false): Promise<ResolvedPluginEntry[]> {
+        const data = await this.fetchResponse(forceRefresh);
+        if (!this.cachedPlugins) {
+            this.cachedPlugins = (data.plugins ?? [])
+                .map(plugin => this.pluginResolver.resolve(plugin))
+                .filter((entry): entry is ResolvedPluginEntry => entry !== undefined);
+        }
+        return this.cachedPlugins;
+    }
+
     /**
-     * Fetches and caches the raw registry response. One HTTP request backs both the MCP
-     * and skill slices; the resolved slices are memoized separately and invalidated
-     * whenever the raw response is (re-)fetched.
+     * Fetches and caches the raw registry response. One HTTP request backs the MCP, skill and
+     * plugin slices; the resolved slices are memoized separately and invalidated whenever the
+     * raw response is (re-)fetched.
      */
     protected async fetchResponse(forceRefresh: boolean): Promise<RegistryResponse> {
         if (this.cachedResponse && !forceRefresh) {
@@ -149,6 +168,7 @@ export class RegistryFetchServiceImpl implements RegistryFetchService {
             this.cachedResponse = data;
             this.cachedEntries = undefined;
             this.cachedSkills = undefined;
+            this.cachedPlugins = undefined;
             this.onDidChangeEmitter.fire();
             return data;
         } catch (error) {

--- a/packages/ai-registry/src/common/skill/skill-content-hash.ts
+++ b/packages/ai-registry/src/common/skill/skill-content-hash.ts
@@ -14,48 +14,11 @@
 // SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
 // *****************************************************************************
 
-import { createHash } from 'crypto';
+// The content hash is not skill-specific: the registry uses the same algorithm for skill folders and
+// for Agent Plugin directories, so it now lives in `../content-hash`. These aliases keep the original
+// skill-flavoured names working for existing importers.
 
-/**
- * A single file participating in the skill content hash, identified by its path relative
- * to the skill root (any path separator) and its raw bytes.
- */
-export interface SkillFileContent {
-    relativePath: string;
-    content: Uint8Array;
-}
-
-/** Number of leading hex characters kept from the sha256 digest, matching the registry. */
-const HASH_PREFIX_LENGTH = 12;
-
-/** Normalises a relative path to POSIX separators so Windows backends match the Linux registry. */
-function toPosix(relativePath: string): string {
-    return relativePath.replace(/\\/g, '/');
-}
-
-/** True when any path segment is dot-prefixed; such files are excluded from the hash at every level. */
-function hasDotSegment(posixPath: string): boolean {
-    return posixPath.split('/').some(segment => segment.startsWith('.'));
-}
-
-/**
- * Reproduces the registry's skill content hash byte-for-byte (registry `src/skill-source.ts`):
- *
- * - Recursively considers all files, skipping any entry whose name starts with `.` at any
- *   directory level (this excludes the `.registry.json` registry metadata file automatically).
- * - Normalises relative paths to POSIX separators and sorts them lexicographically.
- * - For each file in order: `sha256.update(relativePath)` then `sha256.update(rawBytes)`.
- * - Returns the first {@link HASH_PREFIX_LENGTH} hex characters of the digest.
- */
-export function computeSkillContentHash(files: SkillFileContent[]): string {
-    const normalized = files
-        .map(file => ({ relativePath: toPosix(file.relativePath), content: file.content }))
-        .filter(file => !hasDotSegment(file.relativePath))
-        .sort((a, b) => (a.relativePath < b.relativePath ? -1 : a.relativePath > b.relativePath ? 1 : 0));
-    const hash = createHash('sha256');
-    for (const file of normalized) {
-        hash.update(file.relativePath);
-        hash.update(Buffer.from(file.content));
-    }
-    return hash.digest('hex').slice(0, HASH_PREFIX_LENGTH);
-}
+/** @deprecated since 1.75.0 - use `computeContentHash` from `../content-hash` instead. */
+export { computeContentHash as computeSkillContentHash } from '../content-hash';
+/** @deprecated since 1.75.0 - use `FileContent` from `../content-hash` instead. */
+export type { FileContent as SkillFileContent } from '../content-hash';

--- a/packages/ai-registry/src/node/ai-registry-backend-module.ts
+++ b/packages/ai-registry/src/node/ai-registry-backend-module.ts
@@ -18,9 +18,14 @@ import { ContainerModule } from '@theia/core/shared/inversify';
 import { ConnectionHandler, PreferenceContribution, RpcConnectionHandler } from '@theia/core';
 import { BackendRequestAllowedContribution } from '@theia/core/lib/node';
 import { AIRegistryConfiguration } from '../common/ai-registry-configuration';
+import { AgentPluginManifestReader } from '../common/plugin/agent-plugin-manifest';
+import { PluginDirectoryNaming, PluginDirectoryNamingImpl } from '../common/plugin/plugin-directory-naming';
+import { PluginInstallBackendService, PluginInstallBackendServicePath, PluginInstallClient } from '../common/plugin/plugin-install-protocol';
 import { SkillInstallBackendService, SkillInstallBackendServicePath, SkillInstallClient } from '../common/skill/skill-install-protocol';
 import { SkillRegistryPreferencesSchema } from '../common/skill/skill-registry-preferences';
 import { AIRegistryRequestAllowedContribution } from './ai-registry-request-allowed-contribution';
+import { GitHubTarballSource, GitHubTarballSourceImpl } from './github-tarball-source';
+import { PluginInstallBackendServiceImpl } from './plugin-install-backend-service';
 import { SkillInstallBackendServiceImpl } from './skill-install-backend-service';
 
 export default new ContainerModule(bind => {
@@ -34,6 +39,24 @@ export default new ContainerModule(bind => {
     bind(ConnectionHandler).toDynamicValue(ctx =>
         new RpcConnectionHandler<SkillInstallClient>(SkillInstallBackendServicePath, client => {
             const server = ctx.container.get<SkillInstallBackendServiceImpl>(SkillInstallBackendService);
+            server.setClient(client);
+            client.onDidCloseConnection(() => server.disconnectClient(client));
+            return server;
+        })
+    ).inSingletonScope();
+
+    bind(AgentPluginManifestReader).toSelf().inSingletonScope();
+    // Shared with the frontend, so that the directory a plugin may be adopted under is the same one an
+    // install would have created.
+    bind(PluginDirectoryNamingImpl).toSelf().inSingletonScope();
+    bind(PluginDirectoryNaming).toService(PluginDirectoryNamingImpl);
+    bind(GitHubTarballSourceImpl).toSelf().inSingletonScope();
+    bind(GitHubTarballSource).toService(GitHubTarballSourceImpl);
+    bind(PluginInstallBackendServiceImpl).toSelf().inSingletonScope();
+    bind(PluginInstallBackendService).toService(PluginInstallBackendServiceImpl);
+    bind(ConnectionHandler).toDynamicValue(ctx =>
+        new RpcConnectionHandler<PluginInstallClient>(PluginInstallBackendServicePath, client => {
+            const server = ctx.container.get<PluginInstallBackendServiceImpl>(PluginInstallBackendService);
             server.setClient(client);
             client.onDidCloseConnection(() => server.disconnectClient(client));
             return server;

--- a/packages/ai-registry/src/node/github-tarball-source.spec.ts
+++ b/packages/ai-registry/src/node/github-tarball-source.spec.ts
@@ -1,0 +1,350 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { gzipSync } from 'zlib';
+import { ILogger, PreferenceService } from '@theia/core';
+import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
+import { GitHubTarballSourceImpl } from './github-tarball-source';
+
+const TARBALL_URL = 'https://api.github.com/repos/example/plugins/tarball';
+const ARCHIVE_ROOT = 'example-plugins-9f3c2a1b';
+
+/** One tar entry: a regular file, a directory, a symlink or a hard link. */
+interface TarEntry {
+    name: string;
+    content?: string;
+    type?: 'file' | 'directory' | 'symlink' | 'link';
+    linkname?: string;
+}
+
+const TYPE_FLAGS = { file: '0', link: '1', symlink: '2', directory: '5' };
+
+/**
+ * Writes a minimal but valid ustar archive.
+ *
+ * Hand-written on purpose: entry names that a real archiver refuses to produce - an absolute path, a
+ * `..` segment, a symlink pointing out of the tree - are exactly what the extraction guard must reject.
+ */
+function tar(entries: TarEntry[]): Buffer {
+    const blocks: Buffer[] = [];
+    for (const entry of entries) {
+        const type = entry.type ?? 'file';
+        const content = Buffer.from(entry.content ?? '');
+        const size = type === 'file' ? content.length : 0;
+        const header = Buffer.alloc(512, 0);
+        header.write(entry.name, 0, 100, 'utf8');
+        header.write('0000755\0', 100, 8, 'utf8');
+        header.write('0000000\0', 108, 8, 'utf8');
+        header.write('0000000\0', 116, 8, 'utf8');
+        header.write(`${size.toString(8).padStart(11, '0')}\0`, 124, 12, 'utf8');
+        header.write('00000000000\0', 136, 12, 'utf8');
+        header.write('        ', 148, 8, 'utf8');
+        header.write(TYPE_FLAGS[type], 156, 1, 'utf8');
+        header.write(entry.linkname ?? '', 157, 100, 'utf8');
+        header.write('ustar\0', 257, 6, 'utf8');
+        header.write('00', 263, 2, 'utf8');
+        let checksum = 0;
+        for (const byte of header) {
+            checksum += byte;
+        }
+        header.write(`${checksum.toString(8).padStart(6, '0')}\0 `, 148, 8, 'utf8');
+        blocks.push(header);
+        if (size > 0) {
+            const padded = Buffer.alloc(Math.ceil(size / 512) * 512, 0);
+            content.copy(padded);
+            blocks.push(padded);
+        }
+    }
+    // Two zero blocks terminate the archive.
+    blocks.push(Buffer.alloc(1024, 0));
+    return Buffer.concat(blocks);
+}
+
+class FakeRequestService implements RequestService {
+    public requestedUrls: string[] = [];
+    public lastHeaders: Record<string, string | string[]> | undefined;
+    constructor(private readonly body: Buffer | undefined, private readonly statusCode = 200) { }
+    async configure(): Promise<void> { /* no-op */ }
+    async resolveProxy(): Promise<string | undefined> { return undefined; }
+    async request(options: RequestOptions): Promise<RequestContext> {
+        this.requestedUrls.push(options.url);
+        this.lastHeaders = options.headers as Record<string, string | string[]> | undefined;
+        return {
+            url: options.url,
+            res: { headers: {}, statusCode: this.body ? this.statusCode : 404 },
+            buffer: this.body ? new Uint8Array(this.body) : new Uint8Array()
+        };
+    }
+}
+
+const fakePreferenceService = { get: () => undefined } as unknown as PreferenceService;
+const silentLogger = {
+    warn: () => Promise.resolve(),
+    error: () => Promise.resolve(),
+    info: () => Promise.resolve(),
+    debug: () => Promise.resolve(),
+    trace: () => Promise.resolve()
+} as unknown as ILogger;
+
+class TestGitHubTarballSource extends GitHubTarballSourceImpl {
+    constructor(request: RequestService, protected readonly caps: { archive?: number; extracted?: number } = {}) {
+        super();
+        Object.assign(this, { requestService: request, preferenceService: fakePreferenceService, logger: silentLogger });
+    }
+    protected override maxArchiveBytes(): number {
+        return this.caps.archive ?? super.maxArchiveBytes();
+    }
+    protected override maxExtractedBytes(): number {
+        return this.caps.extracted ?? super.maxExtractedBytes();
+    }
+}
+
+async function exists(target: string): Promise<boolean> {
+    try {
+        await fs.lstat(target);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function expectRejection(promise: Promise<unknown>): Promise<Error> {
+    try {
+        await promise;
+    } catch (error) {
+        return error as Error;
+    }
+    throw new Error('Expected the promise to be rejected.');
+}
+
+describe('GitHubTarballSource', () => {
+
+    let destination: string;
+
+    beforeEach(async () => {
+        destination = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-tarball-test-'));
+    });
+
+    afterEach(async () => {
+        await fs.rm(destination, { recursive: true, force: true });
+    });
+
+    function source(
+        body: Buffer | undefined,
+        statusCode = 200,
+        caps: { archive?: number; extracted?: number } = {}
+    ): { service: TestGitHubTarballSource; request: FakeRequestService } {
+        const request = new FakeRequestService(body, statusCode);
+        return { service: new TestGitHubTarballSource(request, caps), request };
+    }
+
+    function archive(entries: TarEntry[]): Buffer {
+        return gzipSync(tar(entries));
+    }
+
+    const pluginArchive = (): Buffer => archive([
+        { name: `${ARCHIVE_ROOT}/`, type: 'directory' },
+        { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
+        { name: `${ARCHIVE_ROOT}/skills/`, type: 'directory' },
+        { name: `${ARCHIVE_ROOT}/skills/deploy/SKILL.md`, content: '# Deploy' }
+    ]);
+
+    it('downloads the repository tarball in one request and strips the archive top-level directory', async () => {
+        const { service, request } = source(pluginArchive());
+
+        const tree = await service.fetch({ sourceUrl: 'https://github.com/example/plugins.git', destination });
+
+        expect(request.requestedUrls).to.deep.equal([TARBALL_URL]);
+        expect(request.lastHeaders?.['User-Agent']).to.equal('Theia-AI-Registry');
+        expect(await fs.readFile(path.join(destination, 'plugin.json'), 'utf8')).to.equal('{"name":"demo"}');
+        expect(await fs.readFile(path.join(destination, 'skills', 'deploy', 'SKILL.md'), 'utf8')).to.equal('# Deploy');
+        expect(tree.fileCount).to.equal(2);
+    });
+
+    it('keeps only the requested subtree and makes it the root', async () => {
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/README.md`, content: 'repository readme' },
+            { name: `${ARCHIVE_ROOT}/plugins/demo/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${ARCHIVE_ROOT}/plugins/demo/skills/deploy/SKILL.md`, content: '# Deploy' },
+            { name: `${ARCHIVE_ROOT}/plugins/other/plugin.json`, content: '{"name":"other"}' }
+        ]));
+
+        await service.fetch({ sourceUrl: 'https://github.com/example/plugins', sourcePath: 'plugins/demo', destination });
+
+        expect(await fs.readFile(path.join(destination, 'plugin.json'), 'utf8')).to.equal('{"name":"demo"}');
+        expect(await exists(path.join(destination, 'skills', 'deploy', 'SKILL.md'))).to.equal(true);
+        expect(await exists(path.join(destination, 'README.md'))).to.equal(false);
+        expect(await exists(path.join(destination, 'plugins'))).to.equal(false);
+    });
+
+    it('fails when the requested subtree is not in the repository', async () => {
+        const { service } = source(pluginArchive());
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', sourcePath: 'plugins/missing', destination }));
+
+        expect(error.message).to.match(/plugins\/missing/);
+    });
+
+    it('rejects an entry with an absolute path, writing nothing outside the destination', async () => {
+        const escaped = path.join(destination, '..', 'absolute-escape.txt');
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${escaped}`, content: 'pwned' }
+        ]));
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination }));
+
+        expect(error.message).to.match(/outside the plugin directory/i);
+        expect(await exists(escaped)).to.equal(false);
+    });
+
+    it('rejects an entry containing a .. segment, writing nothing outside the destination', async () => {
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${ARCHIVE_ROOT}/../relative-escape.txt`, content: 'pwned' }
+        ]));
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination }));
+
+        expect(error.message).to.match(/outside the plugin directory/i);
+        expect(await exists(path.join(destination, '..', 'relative-escape.txt'))).to.equal(false);
+    });
+
+    it('drops a symlink whose target resolves outside the plugin, and installs the rest', async () => {
+        // The link itself would be written *inside* the plugin; only its target is outside. A monorepo
+        // plugin with a `LICENSE -> ../../LICENSE` is the ordinary case, so losing the link is right and
+        // failing the whole install is not.
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${ARCHIVE_ROOT}/escape`, type: 'symlink', linkname: '../../..' }
+        ]));
+
+        const tree = await service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination });
+
+        expect(tree.droppedLinks).to.deep.equal(['escape']);
+        expect(await exists(path.join(destination, 'escape'))).to.equal(false);
+        expect(await fs.readFile(path.join(destination, 'plugin.json'), 'utf8')).to.equal('{"name":"demo"}');
+    });
+
+    it('drops a hard link whose target resolves outside the plugin, and installs the rest', async () => {
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${ARCHIVE_ROOT}/hard`, type: 'link', linkname: '/etc/passwd' }
+        ]));
+
+        const tree = await service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination });
+
+        expect(tree.droppedLinks).to.deep.equal(['hard']);
+        expect(await exists(path.join(destination, 'hard'))).to.equal(false);
+        expect(await fs.readFile(path.join(destination, 'plugin.json'), 'utf8')).to.equal('{"name":"demo"}');
+    });
+
+    it('drops a link pointing out of the requested subtree without failing the install', async () => {
+        // The shape that made an endorsed monorepo plugin uninstallable: out-of-subtree *content* was
+        // dropped silently while an out-of-subtree *link* failed everything.
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugins/demo/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${ARCHIVE_ROOT}/plugins/demo/vendor`, type: 'symlink', linkname: '../..' }
+        ]));
+
+        const tree = await service.fetch({ sourceUrl: 'https://github.com/example/plugins', sourcePath: 'plugins/demo', destination });
+
+        expect(tree.droppedLinks).to.deep.equal(['vendor']);
+        expect(await fs.readFile(path.join(destination, 'plugin.json'), 'utf8')).to.equal('{"name":"demo"}');
+    });
+
+    it('drops the second link of a chain that is only lexically contained, writing nothing outside', async () => {
+        // `sub/up -> ..` and `s -> sub/up/..` are each lexically inside the destination, but resolving
+        // the second one through the first lands on the destination's parent. A purely lexical check
+        // cannot see that; the kept-symlink walk can.
+        const outside = path.join(destination, '..', 'chain-escape.txt');
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${ARCHIVE_ROOT}/sub/`, type: 'directory' },
+            { name: `${ARCHIVE_ROOT}/sub/up`, type: 'symlink', linkname: '..' },
+            { name: `${ARCHIVE_ROOT}/s`, type: 'symlink', linkname: 'sub/up/..' }
+        ]));
+
+        const tree = await service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination });
+
+        expect(tree.droppedLinks).to.deep.equal(['s']);
+        expect(await exists(path.join(destination, 's'))).to.equal(false);
+        expect(await exists(outside)).to.equal(false);
+        expect(await fs.readFile(path.join(destination, 'plugin.json'), 'utf8')).to.equal('{"name":"demo"}');
+    });
+
+    it('keeps a symlink whose target stays inside the destination', async () => {
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
+            { name: `${ARCHIVE_ROOT}/alias.json`, type: 'symlink', linkname: 'plugin.json' }
+        ]));
+
+        await service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination });
+
+        expect(await fs.readFile(path.join(destination, 'alias.json'), 'utf8')).to.equal('{"name":"demo"}');
+    });
+
+    it('refuses an archive larger than the download cap before extracting anything', async () => {
+        const { service } = source(pluginArchive(), 200, { archive: 16 });
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination }));
+
+        expect(error.message).to.match(/too large/i);
+        expect(await exists(path.join(destination, 'plugin.json'))).to.equal(false);
+    });
+
+    it('refuses a tree larger than the extraction cap, and writes nothing past it', async () => {
+        // A gzip bomb compresses to almost nothing, so the download cap cannot catch it - the entry
+        // sizes have to be added up while mapping. Modelled by lowering the cap rather than by
+        // generating hundreds of megabytes.
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugin.json`, content: '0123456789' },
+            { name: `${ARCHIVE_ROOT}/huge.bin`, content: '0123456789' }
+        ]), 200, { extracted: 15 });
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination }));
+
+        expect(error.message).to.match(/too large/i);
+        expect(await exists(path.join(destination, 'huge.bin'))).to.equal(false);
+    });
+
+    it('refuses a source that is not a GitHub repository', async () => {
+        const { service, request } = source(pluginArchive());
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://gitlab.com/example/plugins.git', destination }));
+
+        expect(error.message).to.match(/not GitHub/i);
+        expect(request.requestedUrls).to.deep.equal([]);
+    });
+
+    it('refuses a source URL that names no repository', async () => {
+        const { service } = source(pluginArchive());
+
+        expect((await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example', destination }))).message)
+            .to.match(/owner\/repo/i);
+    });
+
+    it('reports the HTTP status when the download fails', async () => {
+        const { service } = source(undefined);
+
+        expect((await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination }))).message)
+            .to.match(/HTTP 404/);
+    });
+});

--- a/packages/ai-registry/src/node/github-tarball-source.spec.ts
+++ b/packages/ai-registry/src/node/github-tarball-source.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -200,6 +200,34 @@ describe('GitHubTarballSource', () => {
         const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', sourcePath: 'plugins/missing', destination }));
 
         expect(error.message).to.match(/plugins\/missing/);
+        expect(error.message).to.match(/does not exist/i);
+    });
+
+    it('reports a subtree that exists but holds no installable file as such, not as a wrong path', async () => {
+        // Only a directory and a link out of the subtree: the path is right, there is just nothing to
+        // install under it. Telling the user the path does not exist would send them looking for a typo.
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/plugins/demo/`, type: 'directory' },
+            { name: `${ARCHIVE_ROOT}/plugins/demo/nested/`, type: 'directory' },
+            { name: `${ARCHIVE_ROOT}/plugins/demo/vendor`, type: 'symlink', linkname: '../..' }
+        ]));
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', sourcePath: 'plugins/demo', destination }));
+
+        expect(error.message).to.match(/holds no file to install/i);
+        expect(error.message).to.not.match(/does not exist/i);
+        expect(error.message).to.match(/plugins\/demo/);
+    });
+
+    it('reports a repository that holds no installable file as such, not as empty', async () => {
+        const { service } = source(archive([
+            { name: `${ARCHIVE_ROOT}/`, type: 'directory' },
+            { name: `${ARCHIVE_ROOT}/docs/`, type: 'directory' }
+        ]));
+
+        const error = await expectRejection(service.fetch({ sourceUrl: 'https://github.com/example/plugins', destination }));
+
+        expect(error.message).to.match(/holds no file to install/i);
     });
 
     it('rejects an entry with an absolute path, writing nothing outside the destination', async () => {
@@ -290,7 +318,9 @@ describe('GitHubTarballSource', () => {
         expect(await fs.readFile(path.join(destination, 'plugin.json'), 'utf8')).to.equal('{"name":"demo"}');
     });
 
-    it('keeps a symlink whose target stays inside the destination', async () => {
+    // Skipped on Windows, where creating a symlink needs elevation or developer mode: `tar-fs` drops the
+    // entry there whatever the guard decides, so the assertion would be about the OS, not about us.
+    (process.platform === 'win32' ? it.skip : it)('keeps a symlink whose target stays inside the destination', async () => {
         const { service } = source(archive([
             { name: `${ARCHIVE_ROOT}/plugin.json`, content: '{"name":"demo"}' },
             { name: `${ARCHIVE_ROOT}/alias.json`, type: 'symlink', linkname: 'plugin.json' }

--- a/packages/ai-registry/src/node/github-tarball-source.ts
+++ b/packages/ai-registry/src/node/github-tarball-source.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at
@@ -53,6 +53,12 @@ interface TarExtractionState {
     /** Symlinks kept so far, so a later link cannot be resolved through one. */
     keptSymlinks: Set<string>;
     fileCount: number;
+    /**
+     * Entries found inside the requested subtree, of any type - directories and dropped links included.
+     * Distinguishes a subtree that is not in the archive at all from one that is there but holds no
+     * regular file, which are the same `fileCount` of 0 but not the same thing to tell the user.
+     */
+    subtreeEntryCount: number;
     byteCount: number;
     tooLarge?: boolean;
 }
@@ -151,7 +157,7 @@ export class GitHubTarballSourceImpl implements GitHubTarballSource {
     protected async extractTarball(archive: Uint8Array, request: PluginTarballRequest): Promise<ExtractedPluginTree> {
         const destination = path.resolve(request.destination);
         const prefix = this.normalizeSubPath(request.sourcePath);
-        const state: TarExtractionState = { unsafe: [], droppedLinks: [], keptSymlinks: new Set(), fileCount: 0, byteCount: 0 };
+        const state: TarExtractionState = { unsafe: [], droppedLinks: [], keptSymlinks: new Set(), fileCount: 0, subtreeEntryCount: 0, byteCount: 0 };
         const options: ExtractOptions = {
             map: header => this.mapEntry(header as TarEntryHeader, prefix, destination, state),
             ignore: (_name, header) => !header || header.name === DROPPED_ENTRY,
@@ -172,10 +178,7 @@ export class GitHubTarballSourceImpl implements GitHubTarballSource {
                 'The plugin archive contains the entry "{0}", which would be written outside the plugin directory.', state.unsafe[0]));
         }
         if (state.fileCount === 0) {
-            throw new Error(request.sourcePath
-                ? nls.localize('theia/ai-registry/plugin/tarballPathMissing',
-                    'The plugin path "{0}" does not exist in the repository "{1}".', request.sourcePath, request.sourceUrl)
-                : nls.localize('theia/ai-registry/plugin/tarballEmpty', 'The repository "{0}" contains no files.', request.sourceUrl));
+            throw new Error(this.nothingToInstall(request, state));
         }
         if (state.droppedLinks.length > 0) {
             this.logger.info(
@@ -185,6 +188,27 @@ export class GitHubTarballSourceImpl implements GitHubTarballSource {
             fileCount: state.fileCount,
             droppedLinks: state.droppedLinks
         };
+    }
+
+    /**
+     * No regular file was written, which has two causes worth telling apart: the requested subtree is not
+     * in the archive at all, or it is there and holds only directories and links whose targets were
+     * dropped. Reporting the second as a wrong path would send the user hunting for a typo that is not
+     * there.
+     */
+    protected nothingToInstall(request: PluginTarballRequest, state: TarExtractionState): string {
+        if (state.subtreeEntryCount > 0) {
+            return request.sourcePath
+                ? nls.localize('theia/ai-registry/plugin/tarballPathNoFiles',
+                    'The plugin path "{0}" in the repository "{1}" holds no file to install, only directories or links pointing outside it.',
+                    request.sourcePath, request.sourceUrl)
+                : nls.localize('theia/ai-registry/plugin/tarballNoFiles',
+                    'The repository "{0}" holds no file to install, only directories or links pointing outside it.', request.sourceUrl);
+        }
+        return request.sourcePath
+            ? nls.localize('theia/ai-registry/plugin/tarballPathMissing',
+                'The plugin path "{0}" does not exist in the repository "{1}".', request.sourcePath, request.sourceUrl)
+            : nls.localize('theia/ai-registry/plugin/tarballEmpty', 'The repository "{0}" contains no files.', request.sourceUrl);
     }
 
     /**
@@ -226,6 +250,7 @@ export class GitHubTarballSourceImpl implements GitHubTarballSource {
             return header;
         }
         header.name = withinSubtree;
+        state.subtreeEntryCount++;
         if (header.type === 'symlink' || header.type === 'link') {
             if (!this.isSafeLink(header, withinSubtree, prefix, destination, state)) {
                 state.droppedLinks.push(withinSubtree);

--- a/packages/ai-registry/src/node/github-tarball-source.ts
+++ b/packages/ai-registry/src/node/github-tarball-source.ts
@@ -1,0 +1,373 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as path from 'path';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
+import { createGunzip } from 'zlib';
+import { extract, ExtractOptions, Headers } from 'tar-fs';
+import { inject, injectable, named } from '@theia/core/shared/inversify';
+import { ILogger, nls, PreferenceService } from '@theia/core';
+import { Headers as RequestHeaders, RequestContext, RequestService } from '@theia/core/shared/@theia/request';
+import { GITHUB_TOKEN_PREF } from '../common/skill/skill-registry-preferences';
+
+const USER_AGENT = 'Theia-AI-Registry';
+/** Name given to a mapped entry that must not be written; {@link GitHubTarballSourceImpl} skips it. */
+const DROPPED_ENTRY = '';
+
+/**
+ * The download runs in the backend, which serves every connected frontend, so an enormous repository
+ * or a gzip bomb costs far more than the session that asked for it. The content hash cannot help: it
+ * is verified after extraction.
+ */
+const DEFAULT_MAX_ARCHIVE_BYTES = 64 * 1024 * 1024;
+const DEFAULT_MAX_EXTRACTED_BYTES = 256 * 1024 * 1024;
+
+/** A `tar-stream` header, with the link target the bundled `@types/tar-fs` (written for 1.x) omits. */
+interface TarEntryHeader extends Headers {
+    linkname?: string | null;
+}
+
+interface TarExtractionState {
+    /** Entry paths that would have escaped the root: a hostile shape, so one of them fails extraction. */
+    unsafe: string[];
+    /**
+     * Links refused because their target lies outside the plugin - a monorepo's
+     * `LICENSE -> ../../LICENSE` is the ordinary case. Nothing would be written outside the root, so
+     * these are dropped and reported rather than failing the install.
+     */
+    droppedLinks: string[];
+    /** Symlinks kept so far, so a later link cannot be resolved through one. */
+    keptSymlinks: Set<string>;
+    fileCount: number;
+    byteCount: number;
+    tooLarge?: boolean;
+}
+
+export interface PluginTarballRequest {
+    sourceUrl: string;
+    /** Path within the repository pointing at the plugin root. Omitted means the repository root. */
+    sourcePath?: string;
+    /** Directory the plugin tree is extracted into; it becomes the plugin root. */
+    destination: string;
+}
+
+export interface ExtractedPluginTree {
+    /** Read from the trailing SHA of `<owner>-<repo>-<sha>/`; a pin the registry feed cannot give us. */
+    /** So a caller can tell an empty `source.path` subtree from a populated one. */
+    fileCount: number;
+    /** Links not created because their target lies outside the plugin; empty is the normal case. */
+    droppedLinks: string[];
+}
+
+export const GitHubTarballSource = Symbol('GitHubTarballSource');
+/**
+ * A repository tarball is a single request that also carries the commit it was taken from, unlike the
+ * Contents API walk the skill installer uses, which needs one request per directory and per file.
+ */
+export interface GitHubTarballSource {
+    /**
+     * Strips the archive's top-level directory so the plugin root - `source.path`, or the repository
+     * root when omitted - becomes `destination` itself.
+     *
+     * @throws when the source is not a GitHub repository, the download fails, the archive contains an
+     * entry that would escape `destination`, or the requested `source.path` is not in the archive.
+     */
+    fetch(request: PluginTarballRequest): Promise<ExtractedPluginTree>;
+}
+
+@injectable()
+export class GitHubTarballSourceImpl implements GitHubTarballSource {
+
+    @inject(PreferenceService)
+    protected readonly preferenceService: PreferenceService;
+
+    // The raw RequestService, like the skill installer: this talks to GitHub rather than to the
+    // registry host, so the backend request allowlist (which covers the registry only) does not apply.
+    @inject(RequestService)
+    protected readonly requestService: RequestService;
+
+    @inject(ILogger) @named('ai-registry:GitHubTarballSourceImpl')
+    protected readonly logger: ILogger;
+
+    async fetch(request: PluginTarballRequest): Promise<ExtractedPluginTree> {
+        const { owner, repo } = this.parseGitHub(request.sourceUrl);
+        const archive = await this.downloadTarball(owner, repo);
+        return this.extractTarball(archive, request);
+    }
+
+    /** One request; the GitHub API redirects to `codeload`, which the request service follows. */
+    protected async downloadTarball(owner: string, repo: string): Promise<Uint8Array> {
+        const url = `https://api.github.com/repos/${owner}/${repo}/tarball`;
+        const context = await this.requestService.request({ url, headers: this.headers(this.resolveToken()) });
+        if (!RequestContext.isSuccess(context)) {
+            throw new Error(nls.localize('theia/ai-registry/plugin/tarballDownloadFailed',
+                'Could not download the plugin source from "{0}": HTTP {1}.', url, String(context.res.statusCode ?? 'unknown')));
+        }
+        const bytes = this.toBytes(context);
+        // After the fact - the request service buffers the whole body - but it still bounds what gets
+        // decompressed and written, which is where the amplification is.
+        if (bytes.byteLength > this.maxArchiveBytes()) {
+            throw new Error(this.tooLarge(url));
+        }
+        return bytes;
+    }
+
+    /** `protected` so a product can change the caps. */
+    protected maxArchiveBytes(): number {
+        return DEFAULT_MAX_ARCHIVE_BYTES;
+    }
+
+    protected maxExtractedBytes(): number {
+        return DEFAULT_MAX_EXTRACTED_BYTES;
+    }
+
+    /** The one message both caps report, so the user is not told two different things. */
+    protected tooLarge(sourceUrl: string): string {
+        return nls.localize('theia/ai-registry/plugin/tarballTooLarge',
+            'The plugin source at "{0}" is too large to install. An Agent Plugin is expected to be a small tree of '
+            + 'configuration, skills and code.', sourceUrl);
+    }
+
+    /**
+     * Every entry is mapped before anything is written, so a malicious archive cannot write outside the
+     * staging directory even partially. Containment here is *lexical* and deliberately so: it runs
+     * before extraction, when the tree to resolve against does not exist yet. `tar-fs` performs the
+     * real check as it writes, refusing to follow a symlinked parent directory.
+     */
+    protected async extractTarball(archive: Uint8Array, request: PluginTarballRequest): Promise<ExtractedPluginTree> {
+        const destination = path.resolve(request.destination);
+        const prefix = this.normalizeSubPath(request.sourcePath);
+        const state: TarExtractionState = { unsafe: [], droppedLinks: [], keptSymlinks: new Set(), fileCount: 0, byteCount: 0 };
+        const options: ExtractOptions = {
+            map: header => this.mapEntry(header as TarEntryHeader, prefix, destination, state),
+            ignore: (_name, header) => !header || header.name === DROPPED_ENTRY,
+            // No device nodes or fifos.
+            strict: true
+        };
+        try {
+            await pipeline(Readable.from(Buffer.from(archive)), createGunzip(), extract(destination, options));
+        } catch (error) {
+            throw this.extractionFailed(error, request, state);
+        }
+        if (state.tooLarge) {
+            throw new Error(this.tooLarge(request.sourceUrl));
+        }
+        if (state.unsafe.length > 0) {
+            this.logger.warn(`Refused ${state.unsafe.length} unsafe entries in the plugin archive of ${request.sourceUrl}: ${state.unsafe.join(', ')}`);
+            throw new Error(nls.localize('theia/ai-registry/plugin/tarballUnsafeEntry',
+                'The plugin archive contains the entry "{0}", which would be written outside the plugin directory.', state.unsafe[0]));
+        }
+        if (state.fileCount === 0) {
+            throw new Error(request.sourcePath
+                ? nls.localize('theia/ai-registry/plugin/tarballPathMissing',
+                    'The plugin path "{0}" does not exist in the repository "{1}".', request.sourcePath, request.sourceUrl)
+                : nls.localize('theia/ai-registry/plugin/tarballEmpty', 'The repository "{0}" contains no files.', request.sourceUrl));
+        }
+        if (state.droppedLinks.length > 0) {
+            this.logger.info(
+                `Did not create ${state.droppedLinks.length} link(s) pointing outside the plugin of ${request.sourceUrl}: ${state.droppedLinks.join(', ')}`);
+        }
+        return {
+            fileCount: state.fileCount,
+            droppedLinks: state.droppedLinks
+        };
+    }
+
+    /**
+     * `tar-fs` reports a refusal to write through a symlinked parent as `<absolute path> is not a valid
+     * path`, a raw message naming an internal staging directory. It is a containment refusal like any
+     * other, so it is reported like one.
+     */
+    protected extractionFailed(error: unknown, request: PluginTarballRequest, state: TarExtractionState): Error {
+        const message = error instanceof Error ? error.message : String(error);
+        if (/is not a valid path/.test(message)) {
+            this.logger.warn(`Extraction of the plugin archive of ${request.sourceUrl} was refused by the archive writer: ${message}`);
+            return new Error(nls.localize('theia/ai-registry/plugin/tarballRefused',
+                'The plugin archive of "{0}" could not be extracted safely: one of its entries tried to write outside the plugin directory.',
+                request.sourceUrl));
+        }
+        if (state.tooLarge) {
+            return new Error(this.tooLarge(request.sourceUrl));
+        }
+        return error instanceof Error ? error : new Error(message);
+    }
+
+    /**
+     * An entry whose own path escapes the root is unsafe and fails the extraction. A link whose
+     * *target* merely points out of the plugin is dropped instead: it would have been written inside
+     * the root, so refusing to create it loses that one link and nothing else.
+     */
+    protected mapEntry(header: TarEntryHeader, prefix: string, destination: string, state: TarExtractionState): TarEntryHeader {
+        const original = this.toPosix(header.name);
+        if (!this.isSafeArchivePath(original)) {
+            state.unsafe.push(header.name);
+            header.name = DROPPED_ENTRY;
+            return header;
+        }
+        const relative = this.stripTopLevel(original);
+        const withinSubtree = this.relativeToSubtree(relative, prefix);
+        if (withinSubtree === undefined || withinSubtree === '') {
+            // Outside the requested subtree, or the subtree/archive root directory itself.
+            header.name = DROPPED_ENTRY;
+            return header;
+        }
+        header.name = withinSubtree;
+        if (header.type === 'symlink' || header.type === 'link') {
+            if (!this.isSafeLink(header, withinSubtree, prefix, destination, state)) {
+                state.droppedLinks.push(withinSubtree);
+                header.name = DROPPED_ENTRY;
+                return header;
+            }
+            if (header.type === 'symlink') {
+                state.keptSymlinks.add(withinSubtree);
+            }
+        }
+        if (header.type === 'file') {
+            state.byteCount += header.size ?? 0;
+            if (state.byteCount > this.maxExtractedBytes()) {
+                // Dropped rather than thrown: `map` runs synchronously from a `tar-stream` event
+                // handler, so a throw escapes the pipeline's promise as an uncaught exception.
+                state.byteCount -= header.size ?? 0;
+                header.name = DROPPED_ENTRY;
+                state.tooLarge = true;
+                return header;
+            }
+            state.fileCount++;
+        }
+        return header;
+    }
+
+    /**
+     * A symlink target is relative to the link's own directory; a hard-link target is an archive path,
+     * so it gets the same strip and subtree mapping as the entry itself and is rewritten in place.
+     */
+    protected isSafeLink(header: TarEntryHeader, mappedName: string, prefix: string, destination: string, state: TarExtractionState): boolean {
+        const linkname = header.linkname ? this.toPosix(header.linkname) : undefined;
+        if (!linkname || path.posix.isAbsolute(linkname) || path.win32.isAbsolute(linkname)) {
+            return false;
+        }
+        if (header.type === 'symlink') {
+            const target = path.resolve(path.dirname(path.resolve(destination, mappedName)), linkname);
+            return this.isInside(target, destination) && !this.traversesKeptSymlink(mappedName, linkname, state);
+        }
+        const mappedLink = this.relativeToSubtree(this.stripTopLevel(linkname), prefix);
+        if (!mappedLink) {
+            return false;
+        }
+        header.linkname = mappedLink;
+        return this.isInside(path.resolve(destination, mappedLink), destination);
+    }
+
+    /**
+     * The shape a lexical check cannot see: `sub/up -> ..` then `s -> sub/up/..` are both lexically
+     * contained, while the second really resolves to the parent of the extraction root.
+     */
+    protected traversesKeptSymlink(mappedName: string, linkname: string, state: TarExtractionState): boolean {
+        if (state.keptSymlinks.size === 0) {
+            return false;
+        }
+        const base = path.posix.dirname(mappedName);
+        const segments = linkname.split('/').filter(segment => segment && segment !== '.');
+        let walked = base === '.' ? '' : base;
+        for (const segment of segments) {
+            walked = segment === '..'
+                ? path.posix.dirname(walked || '.').replace(/^\.$/, '')
+                : (walked ? `${walked}/${segment}` : segment);
+            if (walked && state.keptSymlinks.has(walked)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    protected isSafeArchivePath(posixPath: string): boolean {
+        if (posixPath.startsWith('/') || path.win32.isAbsolute(posixPath)) {
+            return false;
+        }
+        return !posixPath.split('/').includes('..');
+    }
+
+    protected isInside(target: string, root: string): boolean {
+        const relative = path.relative(root, target);
+        return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+    }
+
+    /** Drops GitHub's `<owner>-<repo>-<sha>/` wrapper. */
+    protected stripTopLevel(posixPath: string): string {
+        return posixPath.split('/').filter(Boolean).slice(1).join('/');
+    }
+
+    /** `''` for the subtree root itself, `undefined` when outside the subtree. */
+    protected relativeToSubtree(relative: string, prefix: string): string | undefined {
+        if (!prefix) {
+            return relative;
+        }
+        if (relative === prefix) {
+            return '';
+        }
+        return relative.startsWith(`${prefix}/`) ? relative.slice(prefix.length + 1) : undefined;
+    }
+
+    protected normalizeSubPath(sourcePath: string | undefined): string {
+        return this.toPosix(sourcePath ?? '').split('/').filter(segment => segment && segment !== '.').join('/');
+    }
+
+    protected toPosix(value: string): string {
+        return value.replace(/\\/g, '/');
+    }
+
+    /** Only GitHub sources are supported, matching what the skill installer accepts. */
+    protected parseGitHub(sourceUrl: string): { owner: string; repo: string } {
+        let url: URL;
+        try {
+            url = new URL(sourceUrl);
+        } catch {
+            throw new Error(nls.localize('theia/ai-registry/plugin/invalidSourceUrl', 'Invalid plugin source URL: {0}', sourceUrl));
+        }
+        if (url.hostname !== 'github.com' && url.hostname !== 'www.github.com') {
+            throw new Error(nls.localize('theia/ai-registry/plugin/nonGitHubSource',
+                'Only GitHub plugin sources are supported; "{0}" is not GitHub.', url.hostname));
+        }
+        const segments = url.pathname.split('/').filter(Boolean);
+        if (segments.length < 2) {
+            throw new Error(nls.localize('theia/ai-registry/plugin/noOwnerRepo',
+                'Cannot determine owner/repo from the plugin source URL: {0}', sourceUrl));
+        }
+        return { owner: segments[0], repo: segments[1].replace(/\.git$/, '') };
+    }
+
+    protected headers(token?: string): RequestHeaders {
+        const headers: RequestHeaders = { 'User-Agent': USER_AGENT };
+        if (token) {
+            headers['Authorization'] = `Bearer ${token}`;
+        }
+        return headers;
+    }
+
+    protected toBytes(context: RequestContext): Uint8Array {
+        // NodeRequestService returns raw bytes; the string branch is the base64 form used over RPC.
+        const buffer = context.buffer;
+        return typeof buffer === 'string' ? Buffer.from(buffer, 'base64') : buffer;
+    }
+
+    /** Preference value (trimmed) when set, otherwise `GITHUB_TOKEN` from the environment. */
+    protected resolveToken(): string | undefined {
+        const fromPreference = this.preferenceService.get<string>(GITHUB_TOKEN_PREF, undefined)?.trim();
+        const token = fromPreference || process.env.GITHUB_TOKEN?.trim();
+        return token || undefined;
+    }
+}

--- a/packages/ai-registry/src/node/plugin-install-backend-service.spec.ts
+++ b/packages/ai-registry/src/node/plugin-install-backend-service.spec.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/node/plugin-install-backend-service.spec.ts
+++ b/packages/ai-registry/src/node/plugin-install-backend-service.spec.ts
@@ -1,0 +1,659 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { expect } from 'chai';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { ILogger } from '@theia/core';
+import { computeContentHash } from '../common/content-hash';
+import { AgentPluginManifestReader } from '../common/plugin/agent-plugin-manifest';
+import { PluginDirectoryNamingImpl } from '../common/plugin/plugin-directory-naming';
+import { ResolvedPluginEntry } from '../common/plugin/plugin-registry-types';
+import { ExtractedPluginTree, GitHubTarballSource, PluginTarballRequest } from './github-tarball-source';
+import { PluginInstallBackendServiceImpl } from './plugin-install-backend-service';
+
+const REGISTRY_METADATA_FILE = '.registry.json';
+const DIRECTORY_NAME = 'io.github.example_demo-plugin';
+
+const PLUGIN_JSON = JSON.stringify({
+    $schema: 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json',
+    name: 'demo-plugin',
+    version: '1.2.0',
+    description: 'A demo plugin'
+});
+const MCP_JSON = JSON.stringify({
+    $schema: 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json',
+    mcpServers: { demo: { type: 'stdio', command: './bin/serve' } }
+});
+const SKILL_MD = '---\nname: deploy\n---\n# Deploy';
+
+/** The plugin tree the fake source extracts, i.e. what the registry consolidated the hash from. */
+const PLUGIN_FILES: Record<string, string> = {
+    'plugin.json': PLUGIN_JSON,
+    'mcp.json': MCP_JSON,
+    'bin/serve': '#!/bin/sh\n',
+    'skills/deploy/SKILL.md': SKILL_MD
+};
+
+function encode(text: string): Uint8Array {
+    return new TextEncoder().encode(text);
+}
+
+/**
+ * The registry hash equals the hash the backend computes for a faithfully-downloaded tree: reproducing
+ * the registry algorithm is what lets a single recorded hash drive both update and drift detection.
+ * Derived from the production function, never hardcoded.
+ */
+function hashOf(files: Record<string, string>): string {
+    return computeContentHash(Object.entries(files).map(([relativePath, content]) => ({ relativePath, content: encode(content) })));
+}
+
+const REGISTRY_HASH = hashOf(PLUGIN_FILES);
+
+const entry: ResolvedPluginEntry = {
+    pluginId: 'io.github.example/demo-plugin',
+    name: 'Demo Plugin',
+    description: 'A demo plugin',
+    version: '1.2.0',
+    sourceUrl: 'https://github.com/example/demo-plugin.git',
+    contentHash: REGISTRY_HASH,
+    endorsements: [{ organizationId: 'theia', date: '2026-08-07' }],
+    containedSkills: [{ name: 'deploy', description: 'Deploy things.', path: 'skills/deploy' }],
+    containedMcpServers: [{ name: 'demo', transport: 'stdio' }]
+};
+
+const silentLogger = {
+    warn: () => Promise.resolve(),
+    error: () => Promise.resolve(),
+    info: () => Promise.resolve(),
+    debug: () => Promise.resolve(),
+    trace: () => Promise.resolve()
+} as unknown as ILogger;
+
+/** Writes a canned plugin tree into the staging directory the service asks it to fill. */
+class FakeTarballSource implements GitHubTarballSource {
+    public requests: PluginTarballRequest[] = [];
+    constructor(private readonly files: Record<string, string>, private readonly failAfterWriting?: Error) { }
+    async fetch(request: PluginTarballRequest): Promise<ExtractedPluginTree> {
+        this.requests.push(request);
+        for (const [relativePath, content] of Object.entries(this.files)) {
+            const target = path.join(request.destination, ...relativePath.split('/'));
+            await fs.mkdir(path.dirname(target), { recursive: true });
+            await fs.writeFile(target, content);
+        }
+        if (this.failAfterWriting) {
+            throw this.failAfterWriting;
+        }
+        return { fileCount: Object.keys(this.files).length, droppedLinks: [] };
+    }
+}
+
+class TestPluginInstallBackendService extends PluginInstallBackendServiceImpl {
+    constructor(private readonly pluginsDirectory: string, private readonly dataDirectory: string, tarballSource: GitHubTarballSource) {
+        super();
+        Object.assign(this, {
+            tarballSource,
+            manifestReader: new AgentPluginManifestReader(),
+            directoryNaming: new PluginDirectoryNamingImpl(),
+            logger: silentLogger
+        });
+    }
+    protected override pluginsRoot(): string {
+        return this.pluginsDirectory;
+    }
+    protected override pluginDataRoot(): string {
+        return this.dataDirectory;
+    }
+    /** Exposes the in-memory drift-hash cache size so eviction can be asserted. */
+    cacheSize(): number {
+        return this.hashCache.size;
+    }
+    /** Exposes the startup staging sweep so it can be asserted without going through @postConstruct. */
+    sweepStaging(): Promise<void> {
+        return this.sweepStagingFolders();
+    }
+}
+
+async function exists(target: string): Promise<boolean> {
+    try {
+        await fs.lstat(target);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+async function expectRejection(promise: Promise<unknown>): Promise<Error> {
+    try {
+        await promise;
+    } catch (error) {
+        return error as Error;
+    }
+    throw new Error('Expected the promise to be rejected.');
+}
+
+describe('PluginInstallBackendService', () => {
+
+    let root: string;
+    let dataRoot: string;
+    const created: TestPluginInstallBackendService[] = [];
+
+    beforeEach(async () => {
+        const base = await fs.mkdtemp(path.join(os.tmpdir(), 'plugin-install-test-'));
+        root = path.join(base, 'plugins');
+        dataRoot = path.join(base, 'plugin-data');
+        created.length = 0;
+    });
+
+    afterEach(async () => {
+        created.forEach(instance => instance.dispose());
+        await fs.rm(path.dirname(root), { recursive: true, force: true });
+    });
+
+    function service(files: Record<string, string> = PLUGIN_FILES, failAfterWriting?: Error): TestPluginInstallBackendService {
+        const instance = new TestPluginInstallBackendService(root, dataRoot, new FakeTarballSource(files, failAfterWriting));
+        created.push(instance);
+        return instance;
+    }
+
+    async function stagingFolders(): Promise<string[]> {
+        return (await fs.readdir(root)).filter(name => name.startsWith('.installing-'));
+    }
+
+    async function install(instance: TestPluginInstallBackendService, replaceExisting = false): Promise<void> {
+        const staged = await instance.stage(entry);
+        await instance.commit(staged.stagingId, replaceExisting);
+    }
+
+    it('stages a download without writing anything to the plugin root', async () => {
+        const instance = service();
+
+        const staged = await instance.stage(entry);
+
+        expect(staged.mismatch).to.equal(undefined);
+        expect(await exists(path.join(root, DIRECTORY_NAME))).to.equal(false);
+        expect(await stagingFolders()).to.have.length(1);
+        expect(await instance.listInstalledPlugins()).to.deep.equal([]);
+    });
+
+    it('commits a staged download into <pluginsRoot>/<filenamified id> and records the endorsed hash', async () => {
+        const instance = service();
+
+        const staged = await instance.stage(entry);
+        const installed = await instance.commit(staged.stagingId, false);
+
+        const pluginRoot = path.join(root, DIRECTORY_NAME);
+        expect(await fs.readFile(path.join(pluginRoot, 'plugin.json'), 'utf8')).to.equal(PLUGIN_JSON);
+        expect(await fs.readFile(path.join(pluginRoot, 'skills', 'deploy', 'SKILL.md'), 'utf8')).to.equal(SKILL_MD);
+        const metadata = JSON.parse(await fs.readFile(path.join(pluginRoot, REGISTRY_METADATA_FILE), 'utf8'));
+        expect(metadata.pluginId).to.equal(entry.pluginId);
+        expect(metadata.contentHash).to.equal(REGISTRY_HASH);
+        expect(installed.directoryName).to.equal(DIRECTORY_NAME);
+        expect(installed.root).to.equal(pluginRoot);
+        expect(installed.drifted).to.equal(false);
+        expect(await stagingFolders()).to.deep.equal([]);
+    });
+
+    describe('qualifier', () => {
+
+        it('uses the last segment of the identifier, not the publisher-qualified directory name', async () => {
+            const instance = service();
+
+            const installed = await instance.commit((await instance.stage(entry)).stagingId, false);
+
+            expect(installed.directoryName).to.equal(DIRECTORY_NAME);
+            expect(installed.qualifier).to.equal('demo-plugin');
+        });
+
+        it('leaves the qualifier of the plugin that claimed it first alone, and falls back for the second', async () => {
+            const first = service();
+            await first.commit((await first.stage(entry)).stagingId, false);
+
+            const rival = { ...entry, pluginId: 'io.github.other/demo-plugin' };
+            const second = service();
+            const installed = await second.commit((await second.stage(rival)).stagingId, false);
+
+            expect(installed.qualifier).to.equal('io.github.other_demo-plugin');
+            expect((await second.listInstalledPlugins()).find(p => p.pluginId === entry.pluginId)?.qualifier).to.equal('demo-plugin');
+        });
+
+        it('keeps the recorded qualifier across an update, so a plugin never renames its own skills', async () => {
+            const instance = service();
+            await instance.commit((await instance.stage(entry)).stagingId, false);
+
+            const updated = await instance.commit((await instance.stage(entry)).stagingId, true);
+
+            expect(updated.qualifier).to.equal('demo-plugin');
+        });
+
+        it('records a qualifier on link, so an adopted directory qualifies like an installed one', async () => {
+            const instance = service();
+            await fs.mkdir(path.join(root, DIRECTORY_NAME), { recursive: true });
+            await fs.writeFile(path.join(root, DIRECTORY_NAME, 'plugin.json'), PLUGIN_JSON);
+
+            const linked = await instance.link(entry, DIRECTORY_NAME);
+
+            expect(linked.qualifier).to.equal('demo-plugin');
+        });
+    });
+
+    it('creates the plugin data directory on commit, because it must exist before any server is launched', async () => {
+        const instance = service();
+
+        const installed = await instance.commit((await instance.stage(entry)).stagingId, false);
+
+        expect(installed.dataRoot).to.equal(path.join(dataRoot, DIRECTORY_NAME));
+        expect(await exists(installed.dataRoot)).to.equal(true);
+    });
+
+    it('reports a content hash mismatch instead of throwing, and leaves the plugins root untouched', async () => {
+        const instance = service();
+
+        const staged = await instance.stage({ ...entry, contentHash: 'deadbeefdead' });
+
+        expect(staged.mismatch).to.deep.equal({ expected: 'deadbeefdead', actual: REGISTRY_HASH });
+        expect(await exists(path.join(root, DIRECTORY_NAME))).to.equal(false);
+    });
+
+    it('records the endorsed hash when the user overrides a mismatch, so the difference shows as drift', async () => {
+        const instance = service();
+
+        const staged = await instance.stage({ ...entry, contentHash: 'deadbeefdead' });
+        const installed = await instance.commit(staged.stagingId, false);
+
+        const metadata = JSON.parse(await fs.readFile(path.join(root, DIRECTORY_NAME, REGISTRY_METADATA_FILE), 'utf8'));
+        expect(metadata.contentHash).to.equal('deadbeefdead');
+        expect(installed.drifted).to.equal(true);
+    });
+
+    it('rejects a download without a plugin.json and cleans up its staging directory', async () => {
+        const instance = service({ 'mcp.json': MCP_JSON });
+
+        const error = await expectRejection(instance.stage(entry));
+
+        expect(error.message).to.match(/plugin\.json/);
+        expect(await stagingFolders()).to.deep.equal([]);
+        expect(await exists(path.join(root, DIRECTORY_NAME))).to.equal(false);
+    });
+
+    it('rejects a download whose plugin.json violates the manifest schema and cleans up its staging directory', async () => {
+        const instance = service({ ...PLUGIN_FILES, 'plugin.json': JSON.stringify({ name: 'demo-plugin' }) });
+
+        const error = await expectRejection(instance.stage(entry));
+
+        expect(error.message).to.match(/\$schema/);
+        expect(await stagingFolders()).to.deep.equal([]);
+    });
+
+    it('cleans up the staging directory when the download fails partway through', async () => {
+        const instance = service(PLUGIN_FILES, new Error('connection reset'));
+
+        const error = await expectRejection(instance.stage(entry));
+
+        expect(error.message).to.equal('connection reset');
+        expect(await stagingFolders()).to.deep.equal([]);
+        expect(await exists(path.join(root, DIRECTORY_NAME))).to.equal(false);
+    });
+
+    it('discards a staged download the user declined, and then refuses to commit it', async () => {
+        const instance = service();
+        const staged = await instance.stage(entry);
+
+        await instance.discard(staged.stagingId);
+
+        expect(await stagingFolders()).to.deep.equal([]);
+        expect((await expectRejection(instance.commit(staged.stagingId, false))).message).to.match(/no longer available/i);
+    });
+
+    it('refuses to commit over an existing plugin directory rather than failing on the rename', async () => {
+        const instance = service();
+        await install(instance);
+        const staged = await instance.stage(entry);
+
+        const error = await expectRejection(instance.commit(staged.stagingId, false));
+
+        // Without the check this is a raw ENOTEMPTY quoting the user's home directory.
+        expect(error.message).to.match(/already installed/i);
+        expect(error.message).to.not.match(/ENOTEMPTY/);
+        // The install that is already there is untouched, and nothing is left in staging.
+        expect(await exists(path.join(root, DIRECTORY_NAME, 'plugin.json'))).to.equal(true);
+        expect(await stagingFolders()).to.deep.equal([]);
+    });
+
+    it('refuses a plugin id that does not encode to a usable directory name', async () => {
+        const error = await expectRejection(service().stage({ ...entry, pluginId: '' }));
+
+        expect(error.message).to.match(/invalid plugin directory name/i);
+        expect(await exists(root)).to.equal(false);
+    });
+
+    it('replaces the plugin root on update while preserving the plugin data directory', async () => {
+        const instance = service();
+        await install(instance);
+        const pluginRoot = path.join(root, DIRECTORY_NAME);
+        const dataDirectory = path.join(dataRoot, DIRECTORY_NAME);
+        await fs.writeFile(path.join(dataDirectory, 'state.db'), 'plugin state');
+        // A file the new version no longer ships must be gone after the update.
+        await fs.writeFile(path.join(pluginRoot, 'stale.txt'), 'from the old version');
+
+        const updated = service({ ...PLUGIN_FILES, 'plugin.json': PLUGIN_JSON.replace('1.2.0', '1.3.0') });
+        await install(updated, true);
+
+        expect(await fs.readFile(path.join(dataDirectory, 'state.db'), 'utf8')).to.equal('plugin state');
+        expect(await exists(path.join(pluginRoot, 'stale.txt'))).to.equal(false);
+        expect((await updated.listInstalledPlugins())[0].version).to.equal('1.3.0');
+    });
+
+    it('uninstalls a plugin root that carries our provenance marker, including its data directory', async () => {
+        const instance = service();
+        await install(instance);
+
+        await instance.uninstall(entry.pluginId);
+
+        expect(await exists(path.join(root, DIRECTORY_NAME))).to.equal(false);
+        expect(await exists(path.join(dataRoot, DIRECTORY_NAME))).to.equal(false);
+    });
+
+    it('leaves a directory without our provenance marker untouched on uninstall', async () => {
+        const handPlaced = path.join(root, DIRECTORY_NAME);
+        await fs.mkdir(handPlaced, { recursive: true });
+        await fs.writeFile(path.join(handPlaced, 'plugin.json'), PLUGIN_JSON);
+
+        await service().uninstall(entry.pluginId);
+
+        expect(await exists(path.join(handPlaced, 'plugin.json'))).to.equal(true);
+    });
+
+    it('links a hand-placed directory by writing only the provenance marker', async () => {
+        const handPlaced = path.join(root, DIRECTORY_NAME);
+        await fs.mkdir(handPlaced, { recursive: true });
+        await fs.writeFile(path.join(handPlaced, 'plugin.json'), PLUGIN_JSON);
+
+        await service().link(entry, DIRECTORY_NAME);
+
+        expect(await fs.readFile(path.join(handPlaced, 'plugin.json'), 'utf8')).to.equal(PLUGIN_JSON);
+        expect(JSON.parse(await fs.readFile(path.join(handPlaced, REGISTRY_METADATA_FILE), 'utf8')).pluginId).to.equal(entry.pluginId);
+    });
+
+    it('refuses to link a directory that does not exist', async () => {
+        expect((await expectRejection(service().link(entry, DIRECTORY_NAME))).message).to.match(/no local plugin directory/i);
+    });
+
+    it('creates the plugin data directory on link, because adoption also ends in launching a subprocess', async () => {
+        const handPlaced = path.join(root, DIRECTORY_NAME);
+        await fs.mkdir(handPlaced, { recursive: true });
+        await fs.writeFile(path.join(handPlaced, 'plugin.json'), PLUGIN_JSON);
+
+        const linked = await service().link(entry, DIRECTORY_NAME);
+
+        expect(await exists(path.join(dataRoot, DIRECTORY_NAME))).to.equal(true);
+        expect(linked.dataRoot).to.equal(path.join(dataRoot, DIRECTORY_NAME));
+    });
+
+    it('returns the adopted plugin from link, so the caller needs no second listing to register it', async () => {
+        const handPlaced = path.join(root, DIRECTORY_NAME);
+        await fs.mkdir(path.join(handPlaced, 'skills', 'deploy'), { recursive: true });
+        await fs.writeFile(path.join(handPlaced, 'plugin.json'), PLUGIN_JSON);
+        await fs.writeFile(path.join(handPlaced, 'mcp.json'), MCP_JSON);
+        await fs.writeFile(path.join(handPlaced, 'skills', 'deploy', 'SKILL.md'), SKILL_MD);
+
+        const linked = await service().link(entry, DIRECTORY_NAME);
+
+        expect(linked.pluginId).to.equal(entry.pluginId);
+        expect(linked.name).to.equal('demo-plugin');
+        expect(linked.skills).to.deep.equal(['deploy']);
+        expect(linked.servers.map(server => server.name)).to.deep.equal(['demo']);
+        expect(linked.installedAt).to.be.a('string');
+    });
+
+    it("refuses to link a directory that is not the one the plugin's identifier names", async () => {
+        // Update, Fix and Uninstall all derive their target from the identifier, so adopting any other
+        // directory would leave them creating a second one beside it.
+        const handPlaced = path.join(root, 'hand-placed-plugin');
+        await fs.mkdir(handPlaced, { recursive: true });
+
+        const error = await expectRejection(service().link(entry, 'hand-placed-plugin'));
+
+        expect(error.message).to.match(/can only be linked to a directory named/i);
+        expect(await exists(path.join(handPlaced, REGISTRY_METADATA_FILE))).to.equal(false);
+    });
+
+    it('unlinks by removing the provenance marker while keeping every other file', async () => {
+        const instance = service();
+        await install(instance);
+
+        await instance.unlink(entry.pluginId);
+
+        expect(await exists(path.join(root, DIRECTORY_NAME, REGISTRY_METADATA_FILE))).to.equal(false);
+        expect(await exists(path.join(root, DIRECTORY_NAME, 'plugin.json'))).to.equal(true);
+    });
+
+    it('creates a server working directory declared under ${PLUGIN_DATA}, which nothing else would create', async () => {
+        // A subprocess cannot create its own cwd, and the manifest reader does no I/O - so without this
+        // the spawn fails with ENOENT on the working directory, reading like a missing executable.
+        const files = {
+            ...PLUGIN_FILES,
+            'mcp.json': JSON.stringify({
+                $schema: 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json',
+                mcpServers: { demo: { type: 'stdio', command: './bin/serve', cwd: '${PLUGIN_DATA}/work' } }
+            })
+        };
+        const instance = service(files);
+        const staged = await instance.stage({ ...entry, contentHash: hashOf(files) });
+
+        const installed = await instance.commit(staged.stagingId, false);
+
+        expect(await exists(path.join(dataRoot, DIRECTORY_NAME, 'work'))).to.equal(true);
+        expect(installed.servers[0]).to.have.property('cwd', path.join(dataRoot, DIRECTORY_NAME, 'work'));
+    });
+
+    it('does not invent a server working directory that should have shipped with the plugin', async () => {
+        // A cwd under the plugin root is the plugin's own content. Creating it would hide a broken
+        // plugin behind an empty directory.
+        const files = {
+            ...PLUGIN_FILES,
+            'mcp.json': JSON.stringify({
+                $schema: 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json',
+                mcpServers: { demo: { type: 'stdio', command: './bin/serve', cwd: './missing' } }
+            })
+        };
+        const instance = service(files);
+        const staged = await instance.stage({ ...entry, contentHash: hashOf(files) });
+
+        await instance.commit(staged.stagingId, false);
+
+        expect(await exists(path.join(root, DIRECTORY_NAME, 'missing'))).to.equal(false);
+    });
+
+    it('records the endorsed hash the install was accepted against, alongside the computed one', async () => {
+        const instance = service();
+        const staged = await instance.stage(entry);
+
+        const installed = await instance.commit(staged.stagingId, false);
+
+        expect(installed.contentHash).to.equal(REGISTRY_HASH);
+    });
+
+    it('records the endorsed hash, so content the user accepted despite a mismatch reads as drifted', async () => {
+        // One stored hash, as the skill marker does it: the registry's. Accepting a mismatch means the
+        // content really does differ from what was endorsed, and Fix is the honest offer.
+        const instance = service({ ...PLUGIN_FILES, 'extra.txt': 'not in the endorsed tree' });
+        const staged = await instance.stage(entry);
+        expect(staged.mismatch).to.not.equal(undefined);
+
+        const installed = await instance.commit(staged.stagingId, false);
+
+        expect(installed.contentHash).to.equal(REGISTRY_HASH);
+        expect(installed.drifted).to.equal(true);
+    });
+
+    it('resolves the manifest, the MCP servers and the skills from the installed plugin root', async () => {
+        const instance = service();
+        await install(instance);
+
+        const installed = await instance.listInstalledPlugins();
+
+        expect(installed).to.have.length(1);
+        const pluginRoot = path.join(root, DIRECTORY_NAME);
+        expect(installed[0].pluginId).to.equal(entry.pluginId);
+        expect(installed[0].name).to.equal('demo-plugin');
+        expect(installed[0].version).to.equal('1.2.0');
+        expect(installed[0].skills).to.deep.equal(['deploy']);
+        expect(installed[0].servers).to.have.length(1);
+        expect(installed[0].servers[0].name).to.equal('demo');
+        expect(installed[0].servers[0].kind).to.equal('stdio');
+        expect(installed[0].skipped).to.deep.equal([]);
+        expect(installed[0].mcpDisabledReason).to.equal(undefined);
+        expect(installed[0].root).to.equal(pluginRoot);
+    });
+
+    it('discovers only immediate children of skills/ and never recurses deeper', async () => {
+        const instance = service({
+            ...PLUGIN_FILES,
+            'skills/report/SKILL.md': '# Report',
+            'skills/report/nested/SKILL.md': '# Not a skill of its own',
+            'skills/no-manifest/notes.md': 'no SKILL.md here',
+            'skills/SKILL.md': '# Not a skill either - not inside a child directory'
+        });
+        await install(instance);
+
+        const installed = await instance.listInstalledPlugins();
+
+        // Sorted, not in readdir order, so a card rendered from this does not reshuffle between scans.
+        expect(installed[0].skills).to.deep.equal(['deploy', 'report']);
+    });
+
+    it('reports the skills component as invalid when skills is not a directory', async () => {
+        const instance = service({ 'plugin.json': PLUGIN_JSON, skills: 'not a directory' });
+        await install(instance);
+
+        const installed = await instance.listInstalledPlugins();
+
+        expect(installed[0].skills).to.deep.equal([]);
+        expect(installed[0].skipped).to.deep.equal([{ name: 'skills', reason: '"skills" is not a directory.' }]);
+    });
+
+    it('disables MCP for the plugin when mcp.json is not valid JSON, keeping the skills', async () => {
+        const instance = service({ ...PLUGIN_FILES, 'mcp.json': 'not json at all' });
+        await install(instance);
+
+        const installed = await instance.listInstalledPlugins();
+
+        expect(installed[0].mcpDisabledReason).to.match(/not valid JSON/i);
+        expect(installed[0].servers).to.deep.equal([]);
+        expect(installed[0].skills).to.deep.equal(['deploy']);
+    });
+
+    it('reports a plugin whose plugin.json cannot be parsed without components, rather than hiding it', async () => {
+        const instance = service();
+        await install(instance);
+        await fs.writeFile(path.join(root, DIRECTORY_NAME, 'plugin.json'), 'not json at all');
+
+        const installed = await instance.listInstalledPlugins();
+
+        expect(installed[0].name).to.equal(undefined);
+        expect(installed[0].servers).to.deep.equal([]);
+        expect(installed[0].skipped[0].name).to.equal('plugin.json');
+        expect(installed[0].drifted).to.equal(true);
+    });
+
+    it('lists a hand-placed directory without provenance, and skips dot-prefixed entries and plain files', async () => {
+        const instance = service();
+        await install(instance);
+        await fs.mkdir(path.join(root, 'hand-placed-plugin'), { recursive: true });
+        await fs.writeFile(path.join(root, 'hand-placed-plugin', 'plugin.json'), PLUGIN_JSON);
+        await fs.mkdir(path.join(root, '.hidden'), { recursive: true });
+        await fs.writeFile(path.join(root, 'loose-file.txt'), 'not a plugin');
+
+        const installed = await instance.listInstalledPlugins();
+
+        expect(installed.map(info => info.directoryName).sort()).to.deep.equal(['hand-placed-plugin', DIRECTORY_NAME]);
+        const handPlaced = installed.find(info => info.directoryName === 'hand-placed-plugin');
+        expect(handPlaced?.pluginId).to.equal(undefined);
+        expect(handPlaced?.drifted).to.equal(false);
+        expect(handPlaced?.name).to.equal('demo-plugin');
+    });
+
+    it('reports the plugin data directory even for a directory that has none yet, so PLUGIN_DATA is always known', async () => {
+        await fs.mkdir(path.join(root, 'hand-placed-plugin'), { recursive: true });
+        await fs.writeFile(path.join(root, 'hand-placed-plugin', 'plugin.json'), PLUGIN_JSON);
+
+        const installed = await service().listInstalledPlugins();
+
+        expect(installed[0].dataRoot).to.equal(path.join(dataRoot, 'hand-placed-plugin'));
+        expect(await exists(installed[0].dataRoot)).to.equal(false);
+    });
+
+    it('reports drift once the installed files diverge from the recorded hash', async () => {
+        const instance = service();
+        await install(instance);
+
+        expect((await instance.listInstalledPlugins())[0].drifted).to.equal(false);
+        await fs.writeFile(path.join(root, DIRECTORY_NAME, 'bin', 'serve'), '#!/bin/sh\necho edited locally\n');
+
+        expect((await instance.listInstalledPlugins())[0].drifted).to.equal(true);
+    });
+
+    it('evicts cached drift hashes for plugins that no longer exist', async () => {
+        const instance = service();
+        await install(instance);
+        await instance.listInstalledPlugins();
+        expect(instance.cacheSize()).to.equal(1);
+
+        await instance.uninstall(entry.pluginId);
+        await instance.listInstalledPlugins();
+
+        expect(instance.cacheSize()).to.equal(0);
+    });
+
+    it('sweeps staging directories left behind by a previous backend, keeping other dot-directories', async () => {
+        await fs.mkdir(path.join(root, `.installing-${DIRECTORY_NAME}-123`), { recursive: true });
+        await fs.mkdir(path.join(root, '.other'), { recursive: true });
+
+        await service().sweepStaging();
+
+        expect(await exists(path.join(root, `.installing-${DIRECTORY_NAME}-123`))).to.equal(false);
+        expect(await exists(path.join(root, '.other'))).to.equal(true);
+    });
+
+    it('keeps a staging directory of the running process when sweeping', async () => {
+        const instance = service();
+        const staged = await instance.stage(entry);
+
+        await instance.sweepStaging();
+
+        expect(await exists(path.join(root, staged.stagingId))).to.equal(true);
+    });
+
+    it('notifies a registered client when the plugins directory changes on disk', async function (): Promise<void> {
+        this.timeout(8000);
+        const instance = service();
+        let notifications = 0;
+        instance.setClient({ notifyDidChangeInstalledPlugins: () => { notifications += 1; }, notifyWatcherStopped: () => { } });
+        // Allow the (async) recursive watcher to start before triggering a change.
+        await new Promise(resolve => setTimeout(resolve, 700));
+        await fs.mkdir(path.join(root, 'externally-added'), { recursive: true });
+        // Wait past the debounce window for the notification to land.
+        await new Promise(resolve => setTimeout(resolve, 1000));
+
+        expect(notifications).to.be.greaterThan(0);
+    });
+
+    it('exposes the plugins root so the frontend can contribute skill roots beneath it', async () => {
+        expect(await service().getPluginsRoot()).to.equal(root);
+    });
+});

--- a/packages/ai-registry/src/node/plugin-install-backend-service.ts
+++ b/packages/ai-registry/src/node/plugin-install-backend-service.ts
@@ -1,5 +1,5 @@
 // *****************************************************************************
-// Copyright (C) 2026 EclipseSource GmbH.
+// Copyright (C) 2026 EclipseSource GmbH and others.
 //
 // This program and the accompanying materials are made available under the
 // terms of the Eclipse Public License v. 2.0 which is available at

--- a/packages/ai-registry/src/node/plugin-install-backend-service.ts
+++ b/packages/ai-registry/src/node/plugin-install-backend-service.ts
@@ -1,0 +1,720 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource GmbH.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import { AsyncSubscription, subscribe } from '@theia/core/shared/@parcel/watcher';
+import { inject, injectable, named, postConstruct } from '@theia/core/shared/inversify';
+import { Disposable, ILogger, nls } from '@theia/core';
+import { computeContentHash, FileContent } from '../common/content-hash';
+import { AgentPluginManifest, AgentPluginManifestReader, AgentPluginRejectedError, SkippedPluginComponent } from '../common/plugin/agent-plugin-manifest';
+import { PluginDirectoryNaming } from '../common/plugin/plugin-directory-naming';
+import { PluginInstallBackendService, PluginInstallClient } from '../common/plugin/plugin-install-protocol';
+import { InstalledPluginInfo, PluginRegistryMetadata, ResolvedPluginEntry, StagedPluginInstall } from '../common/plugin/plugin-registry-types';
+import { GitHubTarballSource } from './github-tarball-source';
+
+/** Dot-prefixed so it is excluded from the content hash. */
+const REGISTRY_METADATA_FILE = '.registry.json';
+const STAGING_PREFIX = '.installing-';
+/** Fixed component locations of the specification; none of them is configurable. */
+const PLUGIN_MANIFEST = 'plugin.json';
+const MCP_CONFIG = 'mcp.json';
+const SKILLS_DIRECTORY = 'skills';
+const SKILL_MANIFEST = 'SKILL.md';
+/** Quiet period (ms) collapsing a burst of filesystem events into one notification. */
+const WATCH_DEBOUNCE_MS = 300;
+
+/** A verified download waiting for the frontend to commit or discard it. */
+interface StagedDownload {
+    entry: ResolvedPluginEntry;
+    stagingDirectory: string;
+    directoryName: string;
+    /** The hash we computed over the extracted tree - the one that gets recorded. */
+    contentHash: string;
+}
+
+interface PluginStatEntry {
+    relativePath: string;
+    full: string;
+    size: number;
+    mtimeMs: number;
+}
+
+@injectable()
+export class PluginInstallBackendServiceImpl implements PluginInstallBackendService, Disposable {
+
+    @inject(GitHubTarballSource)
+    protected readonly tarballSource: GitHubTarballSource;
+
+    @inject(AgentPluginManifestReader)
+    protected readonly manifestReader: AgentPluginManifestReader;
+
+    @inject(PluginDirectoryNaming)
+    protected readonly directoryNaming: PluginDirectoryNaming;
+
+    @inject(ILogger) @named('ai-registry:PluginInstallBackendServiceImpl')
+    protected readonly logger: ILogger;
+
+    protected readonly clients = new Set<PluginInstallClient>();
+    protected subscription: AsyncSubscription | undefined;
+    protected watching = false;
+    protected notifyTimeout: ReturnType<typeof setTimeout> | undefined;
+
+    protected readonly staged = new Map<string, StagedDownload>();
+
+    /** Disambiguates two staging directories created within the same millisecond. */
+    protected stagingCounter = 0;
+
+    /** Content hash per root, keyed on a stat signature, so drift detection skips unchanged files. */
+    protected readonly hashCache = new Map<string, { signature: string; contentHash: string }>();
+
+    @postConstruct()
+    protected init(): void {
+        this.sweepStagingFolders().catch(error => this.logger.warn('Could not sweep stale plugin staging folders at startup.', error));
+    }
+
+    setClient(client: PluginInstallClient | undefined): void {
+        if (!client) {
+            return;
+        }
+        this.clients.add(client);
+        this.ensureWatching();
+    }
+
+    disconnectClient(client: PluginInstallClient): void {
+        this.clients.delete(client);
+        if (this.clients.size === 0) {
+            this.stopWatching();
+        }
+    }
+
+    dispose(): void {
+        this.clients.clear();
+        this.stopWatching();
+    }
+
+    async getPluginsRoot(): Promise<string> {
+        return this.pluginsRoot();
+    }
+
+    /**
+     * A hash mismatch is reported rather than thrown - the user decides - while a missing or invalid
+     * `plugin.json` throws. The staging directory is removed again if anything fails, so a partial
+     * download never survives.
+     */
+    async stage(entry: ResolvedPluginEntry): Promise<StagedPluginInstall> {
+        const directoryName = this.directoryNaming.directoryName(entry.pluginId);
+        const root = this.pluginsRoot();
+        await fs.mkdir(root, { recursive: true });
+        const stagingId = `${STAGING_PREFIX}${directoryName}-${Date.now()}-${this.stagingCounter++}`;
+        const stagingDirectory = path.join(root, stagingId);
+        try {
+            await fs.mkdir(stagingDirectory, { recursive: true });
+            await this.tarballSource.fetch({
+                sourceUrl: entry.sourceUrl,
+                ...(entry.sourcePath !== undefined && { sourcePath: entry.sourcePath }),
+                destination: stagingDirectory
+            });
+            const manifestText = await this.readTextFile(path.join(stagingDirectory, PLUGIN_MANIFEST));
+            if (manifestText === undefined) {
+                throw new AgentPluginRejectedError(nls.localize('theia/ai-registry/plugin/manifestMissing',
+                    'The plugin "{0}" has no "{1}" at {2}.', entry.name, PLUGIN_MANIFEST, entry.sourcePath ?? 'the repository root'));
+            }
+            this.manifestReader.parseManifest(manifestText);
+            const contentHash = await this.computeTreeHash(stagingDirectory);
+            this.staged.set(stagingId, {
+                entry,
+                stagingDirectory,
+                directoryName,
+                contentHash
+            });
+            return {
+                stagingId,
+                ...(contentHash !== entry.contentHash && {
+                    mismatch: { expected: entry.contentHash, actual: contentHash }
+                })
+            };
+        } catch (error) {
+            this.staged.delete(stagingId);
+            await fs.rm(stagingDirectory, { recursive: true, force: true });
+            throw error;
+        }
+    }
+
+    /**
+     * The data directory is created here and never removed on update: the specification makes creating
+     * it a MUST before any plugin subprocess launches, and requires its contents to survive an update.
+     */
+    async commit(stagingId: string, replaceExisting: boolean): Promise<InstalledPluginInfo> {
+        const staged = this.staged.get(stagingId);
+        if (!staged) {
+            throw new Error(nls.localize('theia/ai-registry/plugin/stagingGone',
+                'The staged plugin download is no longer available. Please install the plugin again.'));
+        }
+        const target = path.join(this.pluginsRoot(), staged.directoryName);
+        try {
+            await this.writeRegistryMetadataFile(path.join(staged.stagingDirectory, REGISTRY_METADATA_FILE), {
+                pluginId: staged.entry.pluginId,
+                contentHash: staged.entry.contentHash,
+                qualifier: await this.chooseQualifier(staged.entry.pluginId, staged.directoryName)
+            });
+            if (replaceExisting) {
+                // Only the plugin root is replaced. The data directory below is deliberately untouched.
+                await fs.rm(target, { recursive: true, force: true });
+            } else if (await this.exists(target)) {
+                // `rename` onto a non-empty directory fails with a raw ENOTEMPTY naming the user's home
+                // directory. Say what actually happened instead, and what to do about it.
+                throw new Error(nls.localize('theia/ai-registry/plugin/alreadyInstalled',
+                    'The Agent Plugin "{0}" is already installed at "{1}". Use Update on the installed plugin to replace it.',
+                    staged.entry.name, staged.directoryName));
+            }
+            await fs.rename(staged.stagingDirectory, target);
+        } finally {
+            this.staged.delete(stagingId);
+            await fs.rm(staged.stagingDirectory, { recursive: true, force: true });
+        }
+        await fs.mkdir(this.pluginDataDirectory(staged.directoryName), { recursive: true });
+        return this.prepareForLaunch(await this.describeInstalledPlugin(staged.directoryName));
+    }
+
+    async discard(stagingId: string): Promise<void> {
+        const staged = this.staged.get(stagingId);
+        if (!staged) {
+            return;
+        }
+        this.staged.delete(stagingId);
+        await fs.rm(staged.stagingDirectory, { recursive: true, force: true });
+    }
+
+    /**
+     * Only directories carrying our provenance marker are removed: one without it may be the user's.
+     * Deleting the data directory is permitted on uninstall, unlike on update.
+     */
+    async uninstall(pluginId: string): Promise<void> {
+        const directoryName = await this.findManagedDirectory(pluginId);
+        if (!directoryName) {
+            return;
+        }
+        await fs.rm(path.join(this.pluginsRoot(), directoryName), { recursive: true, force: true });
+        await fs.rm(this.pluginDataDirectory(directoryName), { recursive: true, force: true });
+    }
+
+    /**
+     * Writes only the provenance marker, touching no file the plugin owns. Only the canonical directory
+     * name may be adopted: every other operation derives its target from the plugin identifier, so
+     * adopting another name would let an update create a second directory beside the adopted one.
+     *
+     * Ends in launching a subprocess exactly like {@link commit}, so it carries the same obligations.
+     */
+    async link(entry: ResolvedPluginEntry, directoryName: string): Promise<InstalledPluginInfo> {
+        const expected = this.directoryNaming.directoryName(entry.pluginId);
+        if (directoryName !== expected) {
+            throw new Error(nls.localize('theia/ai-registry/plugin/linkNameMismatch',
+                'The Agent Plugin "{0}" can only be linked to a directory named "{1}", not to "{2}".', entry.name, expected, directoryName));
+        }
+        const target = path.join(this.pluginsRoot(), expected);
+        if (!await this.exists(target)) {
+            throw new Error(nls.localize('theia/ai-registry/plugin/linkTargetMissing',
+                'There is no local plugin directory named "{0}" to link.', directoryName));
+        }
+        await this.writeRegistryMetadataFile(path.join(target, REGISTRY_METADATA_FILE), {
+            pluginId: entry.pluginId,
+            contentHash: entry.contentHash,
+            qualifier: await this.chooseQualifier(entry.pluginId, expected)
+        });
+        await fs.mkdir(this.pluginDataDirectory(expected), { recursive: true });
+        return this.prepareForLaunch(await this.describeInstalledPlugin(expected));
+    }
+
+    async unlink(pluginId: string): Promise<void> {
+        const directoryName = await this.findManagedDirectory(pluginId);
+        if (!directoryName) {
+            return;
+        }
+        await fs.rm(path.join(this.pluginsRoot(), directoryName, REGISTRY_METADATA_FILE), { force: true });
+    }
+
+    async listInstalledPlugins(): Promise<InstalledPluginInfo[]> {
+        const root = this.pluginsRoot();
+        if (!await this.exists(root)) {
+            this.hashCache.clear();
+            return [];
+        }
+        const dirents = await fs.readdir(root, { withFileTypes: true });
+        const result: InstalledPluginInfo[] = [];
+        const presentDirs = new Set<string>();
+        for (const dirent of dirents) {
+            // Dot-prefixed entries are ours (staging directories) or the user's; neither is a plugin.
+            if (!dirent.isDirectory() || dirent.name.startsWith('.')) {
+                continue;
+            }
+            presentDirs.add(path.join(root, dirent.name));
+            result.push(await this.describeInstalledPlugin(dirent.name));
+        }
+        // Drop cached hashes for directories that are gone, so the cache cannot grow unbounded.
+        for (const cachedDir of this.hashCache.keys()) {
+            if (!presentDirs.has(cachedDir)) {
+                this.hashCache.delete(cachedDir);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Failures are isolated at the narrowest boundary the specification defines: an invalid
+     * `plugin.json` leaves the directory without components, an invalid `mcp.json` only disables MCP,
+     * and a single invalid server or skill is skipped.
+     */
+    protected async describeInstalledPlugin(directoryName: string): Promise<InstalledPluginInfo> {
+        const root = path.join(this.pluginsRoot(), directoryName);
+        const metadata = await this.readRegistryMetadata(root);
+        const skipped: SkippedPluginComponent[] = [];
+        const info: InstalledPluginInfo = {
+            directoryName,
+            root,
+            dataRoot: this.pluginDataDirectory(directoryName),
+            drifted: false,
+            skills: [],
+            servers: [],
+            skipped
+        };
+        if (metadata) {
+            info.pluginId = metadata.pluginId;
+            info.contentHash = metadata.contentHash;
+            info.qualifier = metadata.qualifier;
+            info.installedAt = metadata.installedAt;
+            // Drift is local divergence only; update detection is the frontend classifier's job.
+            info.drifted = await this.computeDriftHash(root) !== metadata.contentHash;
+        }
+        const manifest = await this.readManifest(root, skipped);
+        if (!manifest) {
+            return info;
+        }
+        info.name = manifest.name;
+        info.version = manifest.version;
+        const mcp = await this.readMcpConfig(root);
+        if (mcp.mcpDisabledReason !== undefined) {
+            info.mcpDisabledReason = mcp.mcpDisabledReason;
+        } else {
+            const components = this.manifestReader.resolveComponents({
+                ...mcp,
+                manifestSchema: manifest.schema,
+                pluginRoot: root,
+                pluginData: info.dataRoot
+            });
+            info.servers = components.servers;
+            info.mcpDisabledReason = components.mcpDisabledReason;
+            skipped.push(...components.skipped);
+        }
+        info.skills = await this.discoverSkills(root, skipped);
+        return info;
+    }
+
+    /** Reports rather than throws: a bad manifest on disk shows the plugin without components. */
+    protected async readManifest(root: string, skipped: SkippedPluginComponent[]): Promise<AgentPluginManifest | undefined> {
+        const manifestText = await this.readTextFile(path.join(root, PLUGIN_MANIFEST));
+        if (manifestText === undefined) {
+            skipped.push({
+                name: PLUGIN_MANIFEST,
+                reason: nls.localize('theia/ai-registry/plugin/manifestUnreadable', 'The plugin has no readable "{0}".', PLUGIN_MANIFEST)
+            });
+            return undefined;
+        }
+        try {
+            const manifest = this.manifestReader.parseManifest(manifestText);
+            // The only channel we have for the two non-fatal problems the spec makes us report.
+            skipped.push(...manifest.warnings.map(warning => ({ name: PLUGIN_MANIFEST, reason: warning })));
+            return manifest;
+        } catch (error) {
+            skipped.push({ name: PLUGIN_MANIFEST, reason: this.reason(error) });
+            return undefined;
+        }
+    }
+
+    /**
+     * An absent `mcp.json` is not an error. One that is not a regular file, or resolves outside the
+     * plugin root, invalidates the MCP component type without touching the others.
+     */
+    protected async readMcpConfig(root: string): Promise<{ mcpJsonText?: string; mcpDisabledReason?: string }> {
+        const mcpPath = path.join(root, MCP_CONFIG);
+        const stat = await this.statOrUndefined(mcpPath);
+        if (!stat) {
+            return {};
+        }
+        if (!stat.isFile()) {
+            return { mcpDisabledReason: nls.localize('theia/ai-registry/plugin/mcpNotAFile', '"{0}" is not a regular file.', MCP_CONFIG) };
+        }
+        if (!await this.resolvesInside(mcpPath, root)) {
+            return {
+                mcpDisabledReason: nls.localize('theia/ai-registry/plugin/mcpEscapesRoot',
+                    '"{0}" resolves outside the plugin directory.', MCP_CONFIG)
+            };
+        }
+        const mcpJsonText = await this.readTextFile(mcpPath);
+        return mcpJsonText === undefined
+            ? { mcpDisabledReason: nls.localize('theia/ai-registry/plugin/mcpUnreadable', '"{0}" could not be read.', MCP_CONFIG) }
+            : { mcpJsonText };
+    }
+
+    /**
+     * Immediate children of `skills/` only, never recursive. A directory without a `SKILL.md` is simply
+     * not a skill and is not reported.
+     *
+     * @returns the names sorted, so a card rendered from this does not reshuffle between scans.
+     */
+    protected async discoverSkills(root: string, skipped: SkippedPluginComponent[]): Promise<string[]> {
+        const skillsPath = path.join(root, SKILLS_DIRECTORY);
+        const stat = await this.statOrUndefined(skillsPath);
+        if (!stat) {
+            return [];
+        }
+        if (!stat.isDirectory()) {
+            skipped.push({
+                name: SKILLS_DIRECTORY,
+                reason: nls.localize('theia/ai-registry/plugin/skillsNotADirectory', '"{0}" is not a directory.', SKILLS_DIRECTORY)
+            });
+            return [];
+        }
+        if (!await this.resolvesInside(skillsPath, root)) {
+            skipped.push({
+                name: SKILLS_DIRECTORY,
+                reason: nls.localize('theia/ai-registry/plugin/skillsEscapeRoot', '"{0}" resolves outside the plugin directory.', SKILLS_DIRECTORY)
+            });
+            return [];
+        }
+        const skills: string[] = [];
+        for (const dirent of await fs.readdir(skillsPath, { withFileTypes: true })) {
+            const skillDirectory = path.join(skillsPath, dirent.name);
+            if (!(await this.statOrUndefined(skillDirectory))?.isDirectory()) {
+                continue;
+            }
+            const manifestPath = path.join(skillDirectory, SKILL_MANIFEST);
+            // stat, not lstat: a symlink resolving to a regular file inside the plugin root is a skill.
+            if (!(await this.statOrUndefined(manifestPath))?.isFile()) {
+                continue;
+            }
+            if (!await this.resolvesInside(manifestPath, root)) {
+                skipped.push({
+                    name: dirent.name,
+                    reason: nls.localize('theia/ai-registry/plugin/skillEscapesRoot',
+                        'The skill\'s "{0}" resolves outside the plugin directory.', SKILL_MANIFEST)
+                });
+                continue;
+            }
+            skills.push(dirent.name);
+        }
+        return skills.sort();
+    }
+
+    /** True when `target`'s fully resolved path stays inside the resolved `root`. */
+    protected async resolvesInside(target: string, root: string): Promise<boolean> {
+        try {
+            const resolvedRoot = await fs.realpath(root);
+            const resolvedTarget = await fs.realpath(target);
+            const relative = path.relative(resolvedRoot, resolvedTarget);
+            return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+        } catch {
+            return false;
+        }
+    }
+
+    /** Read straight from disk, without consulting the drift cache. */
+    protected async computeTreeHash(directory: string): Promise<string> {
+        const stats = await this.readPluginStats(directory);
+        return computeContentHash(await this.readFileContents(stats));
+    }
+
+    /**
+     * Reuses the cached hash while size and mtime of every hash-relevant file are unchanged, so an
+     * unchanged root is walked once and never re-read.
+     */
+    protected async computeDriftHash(directory: string): Promise<string> {
+        const stats = await this.readPluginStats(directory);
+        const signature = stats
+            .map(stat => `${stat.relativePath}:${stat.size}:${stat.mtimeMs}`)
+            .sort()
+            .join('|');
+        const cached = this.hashCache.get(directory);
+        if (cached && cached.signature === signature) {
+            return cached.contentHash;
+        }
+        const contentHash = computeContentHash(await this.readFileContents(stats));
+        this.hashCache.set(directory, { signature, contentHash });
+        return contentHash;
+    }
+
+    protected async readFileContents(stats: PluginStatEntry[]): Promise<FileContent[]> {
+        return Promise.all(stats.map(async stat => ({ relativePath: stat.relativePath, content: await fs.readFile(stat.full) })));
+    }
+
+    /**
+     * Dot-prefixed entries are skipped at every level, matching {@link computeContentHash} - which is
+     * what excludes our own `.registry.json`.
+     */
+    protected async readPluginStats(directory: string, relativeBase: string = ''): Promise<PluginStatEntry[]> {
+        const dirents = await fs.readdir(directory, { withFileTypes: true });
+        const entries: PluginStatEntry[] = [];
+        for (const dirent of dirents) {
+            if (dirent.name.startsWith('.')) {
+                continue;
+            }
+            const rel = relativeBase ? `${relativeBase}/${dirent.name}` : dirent.name;
+            const full = path.join(directory, dirent.name);
+            if (dirent.isDirectory()) {
+                entries.push(...await this.readPluginStats(full, rel));
+            } else if (dirent.isFile()) {
+                const stat = await fs.stat(full);
+                entries.push({ relativePath: rel, full, size: stat.size, mtimeMs: stat.mtimeMs });
+            }
+        }
+        return entries;
+    }
+
+    /**
+     * A subprocess cannot create its own `cwd`, and the manifest reader never touches the filesystem,
+     * so the `${PLUGIN_DATA}`-rooted ones are created here. A `cwd` under the plugin root ships with
+     * the plugin: inventing it would hide a broken plugin. Best-effort, so one bad server does not
+     * fail the install.
+     */
+    protected async prepareForLaunch(info: InstalledPluginInfo): Promise<InstalledPluginInfo> {
+        for (const server of info.servers) {
+            if (server.kind !== 'stdio' || !this.isInside(server.cwd, info.dataRoot)) {
+                continue;
+            }
+            try {
+                await fs.mkdir(server.cwd, { recursive: true });
+            } catch (error) {
+                this.logger.warn(`Could not create the working directory "${server.cwd}" of plugin server "${server.name}".`, error);
+            }
+        }
+        return info;
+    }
+
+    protected isInside(target: string, root: string): boolean {
+        const relative = path.relative(root, target);
+        return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative));
+    }
+
+    /** The marker is the only evidence of ownership there is, so this scans for it. */
+    protected async findManagedDirectory(pluginId: string): Promise<string | undefined> {
+        const root = this.pluginsRoot();
+        if (!await this.exists(root)) {
+            return undefined;
+        }
+        for (const dirent of await fs.readdir(root, { withFileTypes: true })) {
+            if (!dirent.isDirectory() || dirent.name.startsWith('.')) {
+                continue;
+            }
+            const metadata = await this.readRegistryMetadata(path.join(root, dirent.name));
+            if (metadata?.pluginId === pluginId) {
+                return dirent.name;
+            }
+        }
+        return undefined;
+    }
+
+    /**
+     * The last segment of the identifier while no other installed plugin has claimed it, and the
+     * directory name otherwise. First come, first served, and recorded rather than derived: a plugin
+     * installed later must never rename the skills of one that is already there, and an update of
+     * this plugin must not rename its own.
+     */
+    protected async chooseQualifier(pluginId: string, directoryName: string): Promise<string> {
+        const existing = (await this.readRegistryMetadata(path.join(this.pluginsRoot(), directoryName)))?.qualifier;
+        if (existing !== undefined) {
+            return existing;
+        }
+        const short = pluginId.substring(pluginId.lastIndexOf('/') + 1);
+        if (!short || short === directoryName) {
+            return directoryName;
+        }
+        return (await this.claimedQualifiers(directoryName)).has(short) ? directoryName : short;
+    }
+
+    /**
+     * Qualifiers of every managed plugin other than `exceptDirectory`, read from the markers alone -
+     * `listInstalledPlugins` would walk every tree and hash it just to answer this.
+     */
+    protected async claimedQualifiers(exceptDirectory: string): Promise<Set<string>> {
+        const root = this.pluginsRoot();
+        if (!await this.exists(root)) {
+            return new Set();
+        }
+        const claimed = new Set<string>();
+        for (const dirent of await fs.readdir(root, { withFileTypes: true })) {
+            if (!dirent.isDirectory() || dirent.name.startsWith('.') || dirent.name === exceptDirectory) {
+                continue;
+            }
+            const metadata = await this.readRegistryMetadata(path.join(root, dirent.name));
+            if (metadata) {
+                claimed.add(metadata.qualifier);
+            }
+        }
+        return claimed;
+    }
+
+    protected async readRegistryMetadata(directory: string): Promise<PluginRegistryMetadata | undefined> {
+        try {
+            const raw = await fs.readFile(path.join(directory, REGISTRY_METADATA_FILE), 'utf8');
+            const parsed = JSON.parse(raw) as Partial<PluginRegistryMetadata>;
+            if (typeof parsed.pluginId === 'string' && typeof parsed.contentHash === 'string') {
+                return {
+                    pluginId: parsed.pluginId,
+                    contentHash: parsed.contentHash,
+                    // A marker written before qualifiers were recorded falls back to the directory
+                    // name, which is what its skills were qualified with at the time.
+                    qualifier: parsed.qualifier ?? path.basename(directory),
+                    installedAt: parsed.installedAt
+                };
+            }
+        } catch {
+            // Missing or malformed - treat as not registry-managed.
+        }
+        return undefined;
+    }
+
+    protected async writeRegistryMetadataFile(metadataPath: string, metadata: Omit<PluginRegistryMetadata, 'installedAt'>): Promise<void> {
+        const written: PluginRegistryMetadata = {
+            pluginId: metadata.pluginId,
+            contentHash: metadata.contentHash,
+            qualifier: metadata.qualifier,
+            // Tells the MCP layer the code behind a running server was replaced, even when the
+            // server's own configuration did not change - see `connectionDescription`.
+            installedAt: new Date().toISOString()
+        };
+        await fs.writeFile(metadataPath, JSON.stringify(written, undefined, 2));
+    }
+
+    /** `@parcel/watcher` reports bare directory deletions reliably across platforms; `fs.watch` does not. */
+    protected ensureWatching(): void {
+        if (this.watching) {
+            return;
+        }
+        this.watching = true;
+        const root = this.pluginsRoot();
+        fs.mkdir(root, { recursive: true })
+            .then(() => subscribe(root, (error, events) => {
+                if (error) {
+                    this.logger.warn('Stopped watching the plugins directory after a watcher error.', error);
+                    this.stopWatching();
+                    this.notifyWatcherStopped();
+                    return;
+                }
+                if (events.length > 0) {
+                    this.scheduleNotify();
+                }
+            }))
+            .then(subscription => {
+                // Superseded while the subscription was pending - do not leak an orphaned watcher.
+                if (!this.watching || this.subscription) {
+                    subscription.unsubscribe();
+                    return;
+                }
+                this.subscription = subscription;
+            })
+            .catch(error => {
+                this.watching = false;
+                this.logger.warn('Could not watch the plugins directory for changes.', error);
+            });
+    }
+
+    protected stopWatching(): void {
+        this.watching = false;
+        if (this.notifyTimeout) {
+            clearTimeout(this.notifyTimeout);
+            this.notifyTimeout = undefined;
+        }
+        this.subscription?.unsubscribe();
+        this.subscription = undefined;
+    }
+
+    protected scheduleNotify(): void {
+        if (this.notifyTimeout) {
+            clearTimeout(this.notifyTimeout);
+        }
+        this.notifyTimeout = setTimeout(() => {
+            this.notifyTimeout = undefined;
+            for (const client of this.clients) {
+                client.notifyDidChangeInstalledPlugins();
+            }
+        }, WATCH_DEBOUNCE_MS);
+    }
+
+    protected notifyWatcherStopped(): void {
+        for (const client of this.clients) {
+            client.notifyWatcherStopped();
+        }
+    }
+
+    /** `protected` so a product can override it; deliberately not a preference. */
+    protected pluginsRoot(): string {
+        return path.join(os.homedir(), '.agents', 'plugins');
+    }
+
+    /**
+     * A sibling tree of the plugin roots, so plugin data is never part of a content hash and survives
+     * replacing the root.
+     */
+    protected pluginDataRoot(): string {
+        return path.join(os.homedir(), '.agents', 'plugin-data');
+    }
+
+    protected pluginDataDirectory(directoryName: string): string {
+        return path.join(this.pluginDataRoot(), directoryName);
+    }
+
+    protected async readTextFile(target: string): Promise<string | undefined> {
+        try {
+            return await fs.readFile(target, 'utf8');
+        } catch {
+            return undefined;
+        }
+    }
+
+    protected async statOrUndefined(target: string): Promise<{ isFile(): boolean; isDirectory(): boolean } | undefined> {
+        try {
+            return await fs.stat(target);
+        } catch {
+            return undefined;
+        }
+    }
+
+    protected async exists(target: string): Promise<boolean> {
+        return await this.statOrUndefined(target) !== undefined;
+    }
+
+    protected reason(error: unknown): string {
+        return error instanceof Error && error.message
+            ? error.message
+            : nls.localize('theia/ai-registry/plugin/manifestInvalid', 'The plugin manifest is invalid.');
+    }
+
+    /**
+     * Same-process failures always clean their own staging directory; this handles the crash case.
+     */
+    protected async sweepStagingFolders(): Promise<void> {
+        const root = this.pluginsRoot();
+        if (!await this.exists(root)) {
+            return;
+        }
+        const dirents = await fs.readdir(root, { withFileTypes: true });
+        await Promise.all(dirents
+            .filter(dirent => dirent.isDirectory() && dirent.name.startsWith(STAGING_PREFIX) && !this.staged.has(dirent.name))
+            .map(dirent => fs.rm(path.join(root, dirent.name), { recursive: true, force: true })
+                .catch(error => this.logger.warn(`Could not remove stale plugin staging folder "${dirent.name}".`, error))));
+    }
+}

--- a/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
@@ -253,6 +253,42 @@ describe('SkillInstallBackendService', () => {
         expect(leftovers).to.deep.equal([]);
     });
 
+    it('gives two installs of the same skill in the same millisecond separate staging folders', async () => {
+        // `Date.now()` alone is millisecond-resolution, so a shared staging path was possible and
+        // whichever install finished first deleted it from under the other's rename (ENOENT).
+        const svc = service(githubResponses(SKILL_MD)) as unknown as {
+            writeSkill(entry: ResolvedSkillEntry, files: { relativePath: string; content: Uint8Array }[], replace: boolean): Promise<void>;
+        };
+        const stagingPaths = new Set<string>();
+        const original = fs.rename;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (fs as any).rename = async (from: string, to: string) => {
+            stagingPaths.add(String(from));
+            return original(from, to);
+        };
+        try {
+            const files = [{ relativePath: 'SKILL.md', content: Buffer.from(SKILL_MD) }];
+            await svc.writeSkill(entry, files, false);
+            await fs.rm(path.join(root, 'example-skill'), { recursive: true, force: true });
+            await svc.writeSkill(entry, files, false);
+        } finally {
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (fs as any).rename = original;
+        }
+        expect(stagingPaths.size).to.equal(2);
+    });
+
+    it('leaves the installed skill in place when a later install stages under the same path', async () => {
+        // The `finally` used to remove the staging path unconditionally, which after a successful
+        // rename could delete whatever another install had since staged there.
+        const svc = service(githubResponses(SKILL_MD));
+        await svc.install(entry);
+
+        expect(await fs.readFile(path.join(root, 'example-skill', 'SKILL.md'), 'utf8')).to.contain('example-skill');
+        const leftovers = (await fs.readdir(root)).filter(name => name.startsWith('.installing-'));
+        expect(leftovers).to.deep.equal([]);
+    });
+
     it('sweepStagingFolders removes any leftover .installing-* folders from previous backend crashes', async () => {
         await fs.mkdir(path.join(root, '.installing-example-skill-123'), { recursive: true });
         await fs.writeFile(path.join(root, '.installing-example-skill-123', 'partial.txt'), 'leftover');

--- a/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.spec.ts
@@ -21,7 +21,7 @@ import * as path from 'path';
 import { PreferenceService } from '@theia/core';
 import { RequestContext, RequestOptions, RequestService } from '@theia/core/shared/@theia/request';
 import { ResolvedSkillEntry } from '../common/skill/skill-registry-types';
-import { computeSkillContentHash } from '../common/skill/skill-content-hash';
+import { computeContentHash } from '../common/content-hash';
 import { SkillInstallBackendServiceImpl } from './skill-install-backend-service';
 import { MockLogger } from '@theia/core/lib/common/test/mock-logger';
 
@@ -36,7 +36,7 @@ const HELPER_MD = 'helper content';
 function encode(text: string): Uint8Array {
     return new TextEncoder().encode(text);
 }
-const REGISTRY_HASH = computeSkillContentHash([
+const REGISTRY_HASH = computeContentHash([
     { relativePath: 'SKILL.md', content: encode(SKILL_MD) },
     { relativePath: 'helper.md', content: encode(HELPER_MD) }
 ]);

--- a/packages/ai-registry/src/node/skill-install-backend-service.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.ts
@@ -84,6 +84,11 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
     protected readonly hashCache = new Map<string, { signature: string; contentHash: string }>();
 
     /**
+     * Disambiguates staging folders created within the same millisecond. See {@link writeSkill}.
+     */
+    protected stagingCounter = 0;
+
+    /**
      * Runs once after construction to sweep any stale staging folders left behind by a
      * backend crash mid-install (see {@link writeSkill}). Best-effort: failures are logged
      * and swallowed so an unreachable skills root never blocks the service from starting.
@@ -232,8 +237,15 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         const root = this.skillsRoot();
         await fs.mkdir(root, { recursive: true });
         const target = this.skillDir(entry.name);
-        const staging = path.join(root, `${STAGING_PREFIX}${entry.name}-${Date.now()}`);
+        // A counter as well as the clock: `Date.now()` only has millisecond resolution, so two
+        // installs of the same skill in the same millisecond would otherwise pick the same staging
+        // folder, and whichever finished first would delete it from under the other's rename.
+        const staging = path.join(root, `${STAGING_PREFIX}${entry.name}-${Date.now()}-${this.stagingCounter++}`);
+        let renamed = false;
         try {
+            // Created up front rather than by the first file's `mkdir`, so that the metadata write
+            // below has somewhere to go even for a skill whose file list came back empty.
+            await fs.mkdir(staging, { recursive: true });
             for (const file of files) {
                 const segments = file.relativePath.split('/');
                 if (segments.some(segment => segment === '' || segment === '.' || segment === '..' || segment.includes('\\'))) {
@@ -248,11 +260,13 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
                 await fs.rm(target, { recursive: true, force: true });
             }
             await fs.rename(staging, target);
+            renamed = true;
         } finally {
-            // After a successful rename the staging path no longer exists; force makes the
-            // call a no-op in that case. Otherwise (thrown error, or rename failure because
-            // the target was raced into existence) this removes the partial staging folder.
-            await fs.rm(staging, { recursive: true, force: true });
+            // Only when the rename did not happen. Removing unconditionally would, after a
+            // successful rename, delete a path another install may already have staged there.
+            if (!renamed) {
+                await fs.rm(staging, { recursive: true, force: true });
+            }
         }
     }
 

--- a/packages/ai-registry/src/node/skill-install-backend-service.ts
+++ b/packages/ai-registry/src/node/skill-install-backend-service.ts
@@ -23,7 +23,7 @@ import { Disposable, ILogger, PreferenceService } from '@theia/core';
 import { Headers, RequestContext, RequestService } from '@theia/core/shared/@theia/request';
 import { SkillInstallBackendService, SkillInstallClient } from '../common/skill/skill-install-protocol';
 import { InstalledSkillInfo, ResolvedSkillEntry } from '../common/skill/skill-registry-types';
-import { computeSkillContentHash, SkillFileContent } from '../common/skill/skill-content-hash';
+import { computeContentHash, FileContent } from '../common/content-hash';
 import { GITHUB_TOKEN_PREF } from '../common/skill/skill-registry-preferences';
 
 /** File name of the per-skill registry metadata. Dot-prefixed so it is excluded from the content hash. */
@@ -41,7 +41,7 @@ interface SkillRegistryMetadata {
     /**
      * Registry content hash recorded at install/link time. It is the baseline for both
      * update detection (registry's current hash differs) and drift detection (the on-disk
-     * content hash differs), which works because {@link computeSkillContentHash} reproduces
+     * content hash differs), which works because {@link computeContentHash} reproduces
      * the registry's hash byte-for-byte.
      */
     contentHash: string;
@@ -233,7 +233,7 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
      * The staging folder is always cleaned up in `finally`, so a thrown error or an
      * already-existing target never leaves an orphan `.installing-*` folder behind.
      */
-    protected async writeSkill(entry: ResolvedSkillEntry, files: SkillFileContent[], replaceExisting: boolean): Promise<void> {
+    protected async writeSkill(entry: ResolvedSkillEntry, files: FileContent[], replaceExisting: boolean): Promise<void> {
         const root = this.skillsRoot();
         await fs.mkdir(root, { recursive: true });
         const target = this.skillDir(entry.name);
@@ -270,7 +270,7 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         }
     }
 
-    protected validateSkill(entry: ResolvedSkillEntry, files: SkillFileContent[]): void {
+    protected validateSkill(entry: ResolvedSkillEntry, files: FileContent[]): void {
         const manifest = files.find(file => file.relativePath === SKILL_MANIFEST);
         if (!manifest) {
             throw new Error(`Skill "${entry.name}" has no ${SKILL_MANIFEST} at ${entry.sourcePath ?? 'the repository root'}.`);
@@ -294,20 +294,20 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         return line.replace(/^\s*name\s*:/, '').trim().replace(/^['"]|['"]$/g, '');
     }
 
-    protected async download(entry: ResolvedSkillEntry): Promise<SkillFileContent[]> {
+    protected async download(entry: ResolvedSkillEntry): Promise<FileContent[]> {
         const { owner, repo } = this.parseGitHub(entry.sourceUrl);
         const token = this.resolveToken();
         return this.downloadDir(owner, repo, entry.sourcePath ?? '', '', token);
     }
 
-    protected async downloadDir(owner: string, repo: string, repoPath: string, relativeBase: string, token?: string): Promise<SkillFileContent[]> {
+    protected async downloadDir(owner: string, repo: string, repoPath: string, relativeBase: string, token?: string): Promise<FileContent[]> {
         const suffix = this.encodePath(repoPath);
         const apiUrl = `https://api.github.com/repos/${owner}/${repo}/contents${suffix ? '/' + suffix : ''}`;
         const items = await this.githubJson(apiUrl, token);
         if (!Array.isArray(items)) {
             throw new Error(`Expected a directory at ${repoPath || 'the repository root'} of ${owner}/${repo}.`);
         }
-        const files: SkillFileContent[] = [];
+        const files: FileContent[] = [];
         for (const item of items as GitHubContentItem[]) {
             const rel = relativeBase ? `${relativeBase}/${item.name}` : item.name;
             if (item.type === 'dir') {
@@ -403,9 +403,9 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
         if (cached && cached.signature === signature) {
             return cached.contentHash;
         }
-        const files: SkillFileContent[] = await Promise.all(stats.map(async stat =>
+        const files: FileContent[] = await Promise.all(stats.map(async stat =>
             ({ relativePath: stat.relativePath, content: await fs.readFile(stat.full) })));
-        const contentHash = computeSkillContentHash(files);
+        const contentHash = computeContentHash(files);
         this.hashCache.set(dir, { signature, contentHash });
         return contentHash;
     }
@@ -413,7 +413,7 @@ export class SkillInstallBackendServiceImpl implements SkillInstallBackendServic
     /**
      * Single recursive traversal of the hash-relevant files under `dir`, capturing each
      * file's POSIX relative path, absolute path, size and mtime. Dot-prefixed entries are
-     * skipped at every level, matching {@link computeSkillContentHash}.
+     * skipped at every level, matching {@link computeContentHash}.
      */
     protected async readSkillStats(dir: string, relativeBase: string = ''): Promise<SkillStatEntry[]> {
         const dirents = await fs.readdir(dir, { withFileTypes: true });

--- a/packages/vsx-registry/src/browser/extension-card.tsx
+++ b/packages/vsx-registry/src/browser/extension-card.tsx
@@ -28,9 +28,13 @@ import { MarkdownString } from '@theia/core/lib/common/markdown-rendering/markdo
  */
 export type ExtensionCardTrust = 'verified' | 'unverified' | 'unknown';
 
-/** Markdown (or plain text) tooltip shown when hovering the card. */
+/** Markdown, plain text or a prepared element as the tooltip shown when hovering the card. */
 export interface ExtensionCardHover {
-    readonly content: string | MarkdownString;
+    /**
+     * An element when the tooltip needs markup the markdown renderer cannot express - the renderer
+     * escapes HTML, so a coloured run of text has to be built as DOM.
+     */
+    readonly content: string | MarkdownString | HTMLElement;
     readonly hoverService: HoverService;
     /** Defaults to `'right'`. */
     readonly position?: HoverPosition;


### PR DESCRIPTION
#### What it does

An Agent Plugin is one artifact that bundles skills and MCP servers, endorsed as a unit by an organization in the AI registry. The registry points at the plugin's git source, it does not host it. This implements the Agent Plugins v1.0.0 loading contract as a client.

- Adds an `Agent Plugins` section to the Extensions view, searchable with `@agent-plugins`, with Install, Update, Fix, Link, Unlink and Uninstall per card.
- Downloads the source as a GitHub tarball into a staging directory, verifies it against the endorsed content hash, and only then renames it into `~/.agents/plugins/<directory>`. A mismatch is a dialog, not a silent install.
- Reads `plugin.json` and `mcp.json` per spec, including the placeholder expansion, the containment rules and the failure boundaries: a broken `mcp.json` disables MCP for that plugin only, one broken server entry skips that entry, neither touches the plugin's skills.
- Loads the plugin's skills from its own root under a qualified name (`bigquery-data-analytics:query-builder`) and writes its MCP servers to `ai-features.mcp.mcpServers` with a back-pointer to the plugin. Both are reconciled when the root changes on disk.
- Runs stdio servers with `cwd` at the plugin root and `PLUGIN_ROOT` / `PLUGIN_DATA` in the environment. A server is restarted when any of those change, or when the plugin was reinstalled underneath it.
- Shows the plugin behind a skill or an MCP server in the AI Configuration view, and joins the auto-update check on the same terms as skills and MCP servers.
- `theia://install-plugin?id=<pluginId>` installs from a link. The link carries only the id, everything else is read from the user's registry.

Two fixes came out of this that stand on their own, so they are separate commits at the base: variable arguments containing a colon were truncated in prompt templates (`{{file:C:\some\path}}` resolved with `C`), and two installs of the same skill in the same millisecond shared a staging folder, which failed with `ENOENT`.

#### How to test

Uses `io.github.gemini-cli-extensions/bigquery-data-analytics`, which brings 3 skills and no MCP servers. No approved plugin has MCP servers yet, so step 9 adds one by hand.

1. Extensions view, search `@agent-plugins`. The section lists the approved plugins.
2. Hover the `bigquery-data-analytics` card. The tooltip names the 3 skills.
3. Install. The dialog shows source, endorsing organization, the contained skills and the warning that a plugin's MCP servers can run arbitrary commands.
4. Confirm. A progress notification runs through Downloading and Installing.
5. `ls ~/.agents/plugins/io.github.gemini-cli-extensions_bigquery-data-analytics ~/.agents/plugin-data/io.github.gemini-cli-extensions_bigquery-data-analytics`. Both exist.
6. `cat ~/.agents/plugins/io.github.gemini-cli-extensions_bigquery-data-analytics/.registry.json`. `qualifier` is `bigquery-data-analytics`, not the publisher-prefixed directory name.
7. AI Configuration, Skills tab. The 3 skills appear as `bigquery-data-analytics:<name>` with a `via BigQuery Data Analytics` link. Click it, the Extensions view reveals the plugin.
8. In chat, type `/bigquery-data-analytics:` and pick one of the skills. It resolves and loads.
9. Write the `mcp.json` from below into the plugin root.
10. Shortly after saving, both servers are in `ai-features.mcp.mcpServers` in your `settings.json`, each with `registryMetadata.pluginId`.
11. AI Configuration, MCP Servers tab. Both show `via BigQuery Data Analytics`. `chrome-devtools-via-plugin` shows Working Directory, Plugin Root and Plugin Data as read-only rows, `context7-via-plugin` shows none of them.
12. Start `chrome-devtools-via-plugin`. It comes up and lists its tools.
13. Back in the Extensions view the plugin card now reads drifted and offers Fix. Expected, the root no longer hashes to what was endorsed. Do not press Fix yet, it would restore the root and remove the `mcp.json`.
14. Open the card's gear menu. Auto Update is offered on the drifted card, with the check mark on the item marked `(Default)`. Set it to `On` and check `ai-features.registry.autoUpdateOverrides` gets `plugin:io.github.gemini-cli-extensions/bigquery-data-analytics`.
15. Delete `mcp.json` again. The two servers disappear from the preference, the card stops reading drifted.
16. Uninstall. Plugin root, data directory, the skills in the Skills tab and the override are all gone.
17. Open `theia://install-plugin?id=io.github.gemini-cli-extensions/bigquery-data-analytics` in the running app. The install dialog opens. Try a bogus id, it is refused with a message naming it.
18. Install again, then Unlink. Only `.registry.json` is removed and the card offers Link. Link it, the marker comes back and nothing else in the root changes.
19. Write the `mcp.json` again, without the `$schema` field. The card reports MCP disabled for the plugin and the 3 skills still load.
20. Restore `$schema` and put a `url` field on the stdio entry. Only that server is skipped with a reason on the card, `context7-via-plugin` still registers.

`mcp.json` for step 9, at `~/.agents/plugins/io.github.gemini-cli-extensions_bigquery-data-analytics/mcp.json`:

```json
{
  "$schema": "https://agent-plugins.org/schemas/1.0.0/mcp.schema.json",
  "mcpServers": {
    "chrome-devtools-via-plugin": {
      "type": "stdio",
      "command": "npx",
      "args": [
        "-y",
        "chrome-devtools-mcp@latest",
        "--cdp-endpoint http://127.0.0.1:9222",
        "--no-usage-statistics"
      ]
    },
    "context7-via-plugin": {
      "type": "streamable-http",
      "url": "https://mcp.context7.com/mcp"
    }
  }
}
```

#### Follow-ups

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)