### PR TITLE
Cache getConfigDirUri() on frontend to avoid duplicate RPC round-trips

### DIFF
--- a/packages/core/src/browser/env-variables/caching-env-variables-server.ts
+++ b/packages/core/src/browser/env-variables/caching-env-variables-server.ts
@@ -1,0 +1,67 @@
+// *****************************************************************************
+// Copyright (C) 2026 EclipseSource and others.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: GNU General Public License, version 2
+// with the GNU Classpath Exception which is available at
+// https://www.gnu.org/software/classpath/license.html.
+//
+// SPDX-License-Identifier: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+// *****************************************************************************
+
+import { EnvVariable, EnvVariablesServer } from '../../common/env-variables';
+
+/**
+ * Wraps the raw `EnvVariablesServer` RPC proxy and caches the result of `getConfigDirUri()`
+ * on the frontend.
+ *
+ * The config directory URI is constant for the lifetime of a Theia session, but several
+ * `FrontendApplicationContribution`s resolve it independently during startup (for example
+ * `CommonFrontendContribution.configure()`). Without this cache, each caller pays a full
+ * RPC round-trip, even though the backend already memoizes the resolved value in a single
+ * `Promise` (see `EnvVariablesServerImpl`) - the backend-side memoization only avoids
+ * recomputation, not the round-trip itself.
+ *
+ * Caching the pending promise here - rather than only the resolved value - means concurrent
+ * callers that ask before the first round-trip has resolved still share that one in-flight
+ * request instead of each starting their own.
+ *
+ * This class is instantiated manually (see `frontend-application-module.ts`) around the
+ * connection proxy, so it is not itself bound in the DI container.
+ */
+export class CachingEnvVariablesServer implements EnvVariablesServer {
+
+    protected configDirUri: Promise<string> | undefined;
+
+    constructor(protected readonly delegate: EnvVariablesServer) { }
+
+    getExecPath(): Promise<string> {
+        return this.delegate.getExecPath();
+    }
+
+    getVariables(): Promise<EnvVariable[]> {
+        return this.delegate.getVariables();
+    }
+
+    getValue(key: string): Promise<EnvVariable | undefined> {
+        return this.delegate.getValue(key);
+    }
+
+    getConfigDirUri(): Promise<string> {
+        return this.configDirUri ??= this.delegate.getConfigDirUri();
+    }
+
+    getHomeDirUri(): Promise<string> {
+        return this.delegate.getHomeDirUri();
+    }
+
+    getDrives(): Promise<string[]> {
+        return this.delegate.getDrives();
+    }
+
+}

--- a/packages/core/src/browser/frontend-application-module.ts
+++ b/packages/core/src/browser/frontend-application-module.ts
@@ -65,6 +65,7 @@ import { ApplicationServer, applicationPath } from '../common/application-protoc
 import { WebSocketConnectionProvider } from './messaging';
 import { AboutDialog, AboutDialogProps } from './about-dialog';
 import { EnvVariablesServer, envVariablesPath, EnvVariable } from './../common/env-variables';
+import { CachingEnvVariablesServer } from './env-variables/caching-env-variables-server';
 import { FrontendApplicationStateService } from './frontend-application-state';
 import { JsonSchemaStore, JsonSchemaContribution, DefaultJsonSchemaContribution, JsonSchemaDataStore } from './json-schema-store';
 import { TabBarToolbarRegistry, TabBarToolbarContribution, TabBarToolbarFactory, TabBarToolbar } from './shell/tab-bar-toolbar';
@@ -381,7 +382,10 @@ export const frontendApplicationModule = new ContainerModule((bind, _unbind, _is
 
     bind(EnvVariablesServer).toDynamicValue(ctx => {
         const connection = ctx.container.get(WebSocketConnectionProvider);
-        return connection.createProxy<EnvVariablesServer>(envVariablesPath);
+        const rawEnvVariablesServer = connection.createProxy<EnvVariablesServer>(envVariablesPath);
+        // Cache `getConfigDirUri()` on the frontend so the many contributions that call it
+        // during startup share a single RPC round-trip instead of each paying for their own.
+        return new CachingEnvVariablesServer(rawEnvVariablesServer);
     }).inSingletonScope();
 
     bind(ThemeService).toSelf().inSingletonScope();


### PR DESCRIPTION
#### What it does
Several `FrontendApplicationContribution`s (e.g. `CommonFrontendContribution.configure`, SketchedToolServiceImpl.onStart`) independently call `EnvVariablesServer.getConfigDirUri()` during the serial frontend startup loop in `startContributions()`. Each call pays a full RPC round-trip even though the value is constant for the session and the backend already memoizes it in a single `Promise` (`EnvVariablesServerImpl`) - that memoization only avoids recomputation on the backend, not the round-trip itself.

This adds `CachingEnvVariablesServer`, a thin wrapper around the frontend RPC proxy that caches the *pending* `getConfigDirUri()` promise, so concurrent and serial callers share one round-trip instead of each starting their own. On rejection the cache is cleared so a later call can retry rather than being permanently stuck on one failure.

There's a pre-existing `// FIXME: This request blocks valuable startup time (~200ms).` comment at `common-frontend-contribution.ts:170` flagging exactly this cost.

#### How to test
1. Run `npm run start --workspace=examples/browser -- --port=3002` and load the app in a browser.
2. Watch the console for `core:FrontendStopwatch WARN` lines.
3. Compare `SketchedToolServiceImpl.onStart` and `CommonFrontendContribution.configure`    durations against `main` (unfixed).

Measured locally across multiple runs on the same machine:

| Hook | Before (unfixed) | After (fixed) |
|---|---|---|
| `SketchedToolServiceImpl.onStart` | ~555-714 ms | consistently <100ms (no warning) |
| `CommonFrontendContribution.configure` | ~389-645 ms | ~175-201 ms |

#### Follow-ups
This only addresses the `getConfigDirUri()` duplicate-RPC issue. It does **not** address the broader question of whether the ~81 `onStart()` / ~19 `initialize()` contribution hooks could run in parallel instead of strictly serially in `startContributions()` - that touches core DI bootstrap for the whole app, carries real risk of breaking implicit contribution ordering dependencies, and needs a separate design discussion before any code change. Happy to open a follow-up issue if there's interest.

#### Breaking changes
- [ ] This PR introduces breaking changes and requires careful review.

#### Review checklist
- [x] As an author, I have thoroughly tested my changes and carefully followed the review guidelines
- [x] User-facing text is internationalized using the `nls` service