### PR TITLE
fix(core,toolbar): disable dragging on toolbar areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [ai-ide] added an opt-in "Memory" prompt capability that lets agents maintain a wiki-style knowledge base per workspace, stored in the workspace metadata store and exposed to prompts via the new `{{memoryDirectory}}` variable [#17865](https://github.com/eclipse-theia/theia/pull/17865)
 - [core, monaco] fixed Monaco theme CSS, `SelectComponent` dropdown placement, and the OS font class in secondary windows [#17874](https://github.com/eclipse-theia/theia/pull/17874)
+- [core, toolbar] fixed toolbar areas being draggable/text-selectable, dragging through them into the underlying panel content or main toolbar sections [#17939](https://github.com/eclipse-theia/theia/pull/17939)
 - [plugin-ext] moved scanner, manifest, and localization helpers to `@theia/plugin-utils` [#17758](https://github.com/eclipse-theia/theia/pull/17758)
 - [plugin-utils] added `@theia/plugin-utils` for shared plugin manifest utilities; browser-only builds prepare plugins into `hostedPlugin/` with `list.json` [#17758](https://github.com/eclipse-theia/theia/pull/17758)
 - [scm] aligned the history graph with VS Code: ref-role lane and badge colors, a current-commit indicator, and a commit hover rendered from the content the history provider supplies [#17880](https://github.com/eclipse-theia/theia/pull/17880)

--- a/packages/core/src/browser/style/sidepanel.css
+++ b/packages/core/src/browser/style/sidepanel.css
@@ -342,6 +342,8 @@
   min-height: var(--theia-horizontal-toolbar-height);
   background-color: var(--theia-sideBar-background);
   overflow: hidden;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .theia-sidepanel-toolbar .theia-sidepanel-title {

--- a/packages/core/src/browser/style/tabs.css
+++ b/packages/core/src/browser/style/tabs.css
@@ -388,6 +388,8 @@
   justify-content: center;
   padding-inline: var(--theia-ui-padding);
   gap: 2px;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .lm-TabBar-content-container {

--- a/packages/core/src/browser/style/view-container.css
+++ b/packages/core/src/browser/style/view-container.css
@@ -157,6 +157,8 @@
 
 .theia-view-container-part-title {
   display: none;
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 .theia-view-container-part-title.menu-open,

--- a/packages/toolbar/src/browser/style/toolbar.css
+++ b/packages/toolbar/src/browser/style/toolbar.css
@@ -28,6 +28,8 @@
   justify-content: center;
   position: relative;
   border-bottom: 1px solid var(--theia-titleBar-border);
+  user-select: none;
+  -webkit-user-drag: none;
 }
 
 #main-toolbar .theia-progress-bar-container {
@@ -174,14 +176,21 @@
   align-items: center;
 }
 
-#toolbar-icon-selector-dialog .dialogContent .icon-selector-options .icon-set-selector-wrapper {
+#toolbar-icon-selector-dialog
+  .dialogContent
+  .icon-selector-options
+  .icon-set-selector-wrapper {
   display: flex;
   align-items: baseline;
   gap: var(--theia-ui-padding);
 }
 
-#toolbar-icon-selector-dialog .dialogContent .icon-selector-options .icon-set-selector-wrapper .theia-select-component {
-  width: 125px
+#toolbar-icon-selector-dialog
+  .dialogContent
+  .icon-selector-options
+  .icon-set-selector-wrapper
+  .theia-select-component {
+  width: 125px;
 }
 
 #toolbar-icon-selector-dialog .dialogControl {


### PR DESCRIPTION
#### What it does

Fixes #17840: toolbar areas were unintentionally draggable/text-selectable.

Adds `user-select: none` and `-webkit-user-drag: none` to the toolbar containers:
- `packages/core/src/browser/style/sidepanel.css` (`.theia-sidepanel-toolbar`)
- `packages/core/src/browser/style/tabs.css` (`.lm-TabBar-toolbar`)
- `packages/core/src/browser/style/view-container.css` (`.theia-view-container-part-title`, the per-section toolbar e.g. above "Open Editors")
- `packages/toolbar/src/browser/style/toolbar.css` (`#main-toolbar`)

`-webkit-user-drag` is not an inherited property, so setting it on these containers doesn't affect the `@theia/toolbar` item-reordering feature, which relies on `draggable={true}` on individual `.toolbar-item` elements.

#### How to test

1. `npm run build:browser && npm run start:browser`
2. Open the Explorer or Source Control view in the sidebar and try to click-drag on the icon row above the view content (or above a nested section header like "Open Editors") — nothing should happen; the underlying text should no longer get selected/dragged.
3. Enable the main toolbar (`@theia/toolbar`) and try to click-drag on the empty space of its left/center/right sections — nothing should happen.
4. Confirm the main toolbar's item-reordering drag-and-drop (dragging an actual toolbar icon to reposition it) still works.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines) — N/A, CSS-only change, no user-facing text

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
