### PR TITLE
test(filesystem): tolerate FSEvents reporting the watched root

### DIFF
--- a/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-watcher.spec.ts
+++ b/packages/filesystem/src/node/parcel-watcher/parcel-filesystem-watcher.spec.ts
@@ -88,7 +88,10 @@ describe('parcel-filesystem-watcher', function (): void {
         expect(fs.readFileSync(FileUri.fsPath(root.resolve('foo').resolve('bar').resolve('baz.txt')), 'utf8')).to.be.equal('baz');
         await waitForChange(actualUris, changeListeners, expectedUris[2]);
 
-        assert.deepStrictEqual([...actualUris], expectedUris);
+        // Each expected URI already arrived above, so what is left is that nothing else did. macOS may also
+        // report the root, since creating a child modifies it.
+        const unexpectedUris = [...actualUris].filter(uri => !expectedUris.includes(uri) && uri !== root.toString());
+        assert.deepStrictEqual(unexpectedUris, []);
     });
 
     it('Should not receive file changes events from in the workspace by default if unwatched', async function (): Promise<void> {


### PR DESCRIPTION
#### What it does

Fixes a macOS flake in `parcel-filesystem-watcher.spec.ts`. On macOS, creating a child also modifies its parent, so FSEvents may or may not additionally report the watched root, and the exact-set assertion `assert.deepStrictEqual([...actualUris], expectedUris)` failed intermittently: on the same #17875 commit, `macos-15 node-24.x` passed while `macos-15 node-22.x` failed.

The test now asserts that no unexpected path arrived, excluding the root. The `waitForChange` calls above already establish that each expected URI arrived, so nothing is lost.

First of the stack: #17875 (non-recursive watching) is based on this branch, #17944 (refactor) on #17875. Bases stay `master` because the base branches live on a fork.

#### How to test

`npx lerna run test --scope @theia/filesystem`, most tellingly on macOS.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
