### PR TITLE
feat(terminal-manager): support moving the view to a secondary window

### DIFF
--- a/packages/core/src/browser/dialogs.ts
+++ b/packages/core/src/browser/dialogs.ts
@@ -405,9 +405,10 @@ export class ConfirmDialog extends AbstractDialog<boolean> {
     protected confirmed = true;
 
     constructor(
-        @inject(ConfirmDialogProps) protected override readonly props: ConfirmDialogProps
+        @inject(ConfirmDialogProps) protected override readonly props: ConfirmDialogProps,
+        @unmanaged() options?: Widget.IOptions
     ) {
-        super(props);
+        super(props, options);
 
         this.contentNode.appendChild(this.createMessageNode(this.props.msg));
         this.appendCloseButton(props.cancel);

--- a/packages/terminal-manager/package.json
+++ b/packages/terminal-manager/package.json
@@ -30,7 +30,8 @@
   },
   "theiaExtensions": [
     {
-      "frontend": "lib/browser/terminal-manager-frontend-module"
+      "frontend": "lib/browser/terminal-manager-frontend-module",
+      "secondaryWindow": "lib/browser/terminal-manager-frontend-module"
     }
   ],
   "publishConfig": {

--- a/packages/terminal-manager/src/browser/terminal-manager-widget.ts
+++ b/packages/terminal-manager/src/browser/terminal-manager-widget.ts
@@ -20,6 +20,7 @@ import {
     BaseWidget,
     codicon,
     CompositeTreeNode,
+    ExtractableWidget,
     Message,
     Panel,
     PanelLayout,
@@ -78,9 +79,12 @@ export namespace TerminalManagerWidgetState {
 }
 
 @injectable()
-export class TerminalManagerWidget extends BaseWidget implements StatefulWidget, ApplicationShell.TrackableWidgetProvider {
+export class TerminalManagerWidget extends BaseWidget implements StatefulWidget, ApplicationShell.TrackableWidgetProvider, ExtractableWidget {
     static ID = 'terminal-manager-widget';
     static LABEL = nls.localize('theia/terminal-manager/label', 'Terminals');
+
+    isExtractable: boolean = true;
+    secondaryWindow: Window | undefined;
 
     protected panel: SplitPanel;
     protected pageAndTreeLayout: SplitLayout | undefined;
@@ -279,6 +283,8 @@ export class TerminalManagerWidget extends BaseWidget implements StatefulWidget,
 
     protected async confirmClose(): Promise<boolean> {
         const CLOSE = nls.localizeByDefault('Close');
+        // When the widget lives in a secondary window, open the dialog there so it is visible to the user.
+        const dialogOptions = this.secondaryWindow ? { node: this.secondaryWindow.document.createElement('div') } : undefined;
         const dialog = new ConfirmDialog({
             title: nls.localize('theia/terminal-manager/closeDialog/title', 'Do you want to close the terminal manager?'),
             msg: nls.localize(
@@ -287,7 +293,7 @@ export class TerminalManagerWidget extends BaseWidget implements StatefulWidget,
             ),
             ok: CLOSE,
             cancel: nls.localizeByDefault('Cancel'),
-        });
+        }, dialogOptions);
         const confirmed = await dialog.open();
         return confirmed === true;
     }


### PR DESCRIPTION
#### What it does

Fixes #16825: allows moving the Terminal Manager view to a secondary window.

- `TerminalManagerWidget` implements `ExtractableWidget`, so the "Move View to Secondary Window" toolbar action is offered for the view.
- The terminal-manager frontend module is registered as a `secondaryWindow` entry point so the manager's styles are loaded in secondary windows.
- The close confirmation dialog opens in the secondary window when the widget is extracted, instead of invisibly in the main window. For this, `ConfirmDialog` now forwards the optional `Widget.IOptions` of `AbstractDialog`, which allows opening the dialog in another document.

#### How to test

1. Set `terminal.grouping.mode` to `tree` and open the view via *View: Open Terminal Manager*.
2. Click *Move View to Secondary Window* in the view's toolbar: the whole manager (tree + terminals) moves to a new window and renders correctly.
3. In the secondary window: terminals stay connected, new pages/groups/terminals can be created, the tree's context menus render in the secondary window, and page switching works.
4. Click the tab's close button in the secondary window: the confirmation dialog opens in the secondary window. *Cancel* keeps the view; *Close* disposes it and the window closes.
5. Close the secondary window: the manager is restored to the bottom area with all pages and running terminals intact.

#### Follow-ups

None.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
