### PR TITLE
[vscode] API bump and nls update to 1.134.0

### DIFF
--- a/dev-packages/application-package/src/api.ts
+++ b/dev-packages/application-package/src/api.ts
@@ -18,7 +18,7 @@
  * The default supported API version the framework supports.
  * The version should be in the format `x.y.z`.
  */
-export const DEFAULT_SUPPORTED_API_VERSION = '1.130.0';
+export const DEFAULT_SUPPORTED_API_VERSION = '1.134.0';
 
 /**
  * The default supported monaco editor version the framework supports.

--- a/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
+++ b/packages/ai-chat-ui/src/browser/chat-input-widget.tsx
@@ -1209,7 +1209,7 @@ export class AIChatInputWidget extends ReactWidget {
             percentage
         );
         const summarizeAction = nls.localize('theia/ai/chat-ui/tokenUsageWarningSummarizeAction', 'Summarize Current Session');
-        const newSessionAction = nls.localize('theia/ai/chat-ui/tokenUsageWarningNewSessionAction', 'Start New Chat');
+        const newSessionAction = nls.localizeByDefault('Start New Chat');
         const openSettingsAction = nls.localizeByDefault('Open Settings');
         const selected = await this.messageService.warn(message, summarizeAction, newSessionAction, openSettingsAction);
         if (selected === summarizeAction) {

--- a/packages/ai-claude-code/src/browser/renderers/multiedit-tool-renderer.tsx
+++ b/packages/ai-claude-code/src/browser/renderers/multiedit-tool-renderer.tsx
@@ -175,7 +175,7 @@ const MultiEditToolComponent: React.FC<{
             {input.edits.map((edit, index) => (
                 <div key={index} className="claude-code-tool edit-preview">
                     <div className="claude-code-tool edit-preview-header">
-                        <span className="claude-code-tool edit-preview-title">{nls.localize('theia/ai/claude-code/edit', 'Edit {0}', index + 1)}</span>
+                        <span className="claude-code-tool edit-preview-title">{nls.localizeByDefault('Edit {0}', index + 1)}</span>
                         {edit.replace_all && (
                             <span className="claude-code-tool edit-preview-badge">
                                 {nls.localizeByDefault('Replace All')}

--- a/packages/core/src/common/i18n/nls.metadata.json
+++ b/packages/core/src/common/i18n/nls.metadata.json
@@ -1216,6 +1216,7 @@
 			"defaultWindowTitleIncludesEditorState",
 			"editableDiffEditor",
 			"editableEditor",
+			"editorDictation",
 			"editorViewAccessibleLabel",
 			"focusNotifications",
 			"gotoLineActionLabel",
@@ -1939,6 +1940,11 @@
 			"tabShouldJumpToInlineEdit"
 		],
 		"vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController": [
+			"nextEditSuggestionAcceptNoKb",
+			"nextEditSuggestionAcceptWithKb",
+			"nextEditSuggestionJumpNoKb",
+			"nextEditSuggestionJumpWithKb",
+			"nextEditSuggestionNoAction",
 			"showAccessibleViewHint"
 		],
 		"vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant": [
@@ -2661,12 +2667,9 @@
 		"vs/platform/agentHost/browser/agentHostConnectionsService": [
 			"agentHost.connection.ambient"
 		],
-		"vs/platform/agentHost/browser/agentHostEnablementService": [
-			"chat.agentHost.enabled"
-		],
 		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
-			"agentHost.config.claudeUseCopilotProxy.description",
-			"agentHost.config.claudeUseCopilotProxy.title",
+			"agentHost.config.allowSignedOutWhenUsable.description",
+			"agentHost.config.allowSignedOutWhenUsable.title",
 			"agentHost.config.customizations.description",
 			"agentHost.config.customizations.descriptionField",
 			"agentHost.config.customizations.displayName",
@@ -2676,25 +2679,42 @@
 			"agentHost.config.defaultShell.description",
 			"agentHost.config.defaultShell.title",
 			"agentHost.config.githubEnterpriseUri.description",
-			"agentHost.config.githubEnterpriseUri.title"
+			"agentHost.config.githubEnterpriseUri.title",
+			"agentHost.config.sessionCustomizationDiscoveryMode.description",
+			"agentHost.config.sessionCustomizationDiscoveryMode.title"
 		],
 		"vs/platform/agentHost/common/agentHostEnablementService": [
 			"agentHostEnabled",
-			"chat.agentHost.enabled",
-			"chat.agents.copilotCli.hideExtensionHost",
 			"chat.defaultToCopilotHarness",
-			"chat.editor.copilotCli.hideExtensionHost",
 			"chat.editor.localAgent.enabled",
 			"chat.editor.preferCopilotHarness",
+			"chat.editor.preferCopilotHarness.policy",
 			"chatAgentHostConfigurationTitle"
 		],
 		"vs/platform/agentHost/common/agentHostSchema": [
+			"agentHost.config.activeAgentTitleGeneration.description",
+			"agentHost.config.activeAgentTitleGeneration.title",
+			"agentHost.config.autoApprovePolicyRestricted",
 			"agentHost.config.autoReplyEnabled.description",
 			"agentHost.config.autoReplyEnabled.title",
+			"agentHost.config.claudeMultiRootEnabled.description",
+			"agentHost.config.claudeMultiRootEnabled.title",
 			"agentHost.config.codexAgentEnabled.description",
 			"agentHost.config.codexAgentEnabled.title",
+			"agentHost.config.codexMultiRootEnabled.description",
+			"agentHost.config.codexMultiRootEnabled.title",
+			"agentHost.config.copilotMultiRootEnabled.description",
+			"agentHost.config.copilotMultiRootEnabled.title",
+			"agentHost.config.disableRepoInfoTelemetry.description",
+			"agentHost.config.disableRepoInfoTelemetry.title",
+			"agentHost.config.editAutoApprovePatterns.description",
+			"agentHost.config.editAutoApprovePatterns.title",
+			"agentHost.config.editTelemetryEnabled.description",
+			"agentHost.config.editTelemetryEnabled.title",
 			"agentHost.config.globalAutoApproveEnabled.description",
 			"agentHost.config.globalAutoApproveEnabled.title",
+			"agentHost.config.markdownPlanRichLinksEnabled.description",
+			"agentHost.config.markdownPlanRichLinksEnabled.title",
 			"agentHost.config.mcpServers.arg.title",
 			"agentHost.config.mcpServers.args.description",
 			"agentHost.config.mcpServers.args.title",
@@ -2714,10 +2734,12 @@
 			"agentHost.config.mcpServers.type.title",
 			"agentHost.config.mcpServers.url.description",
 			"agentHost.config.mcpServers.url.title",
-			"agentHost.config.preferLongContextEnabled.description",
-			"agentHost.config.preferLongContextEnabled.title",
+			"agentHost.config.migrateLegacyCopilotCliEnabled.description",
+			"agentHost.config.migrateLegacyCopilotCliEnabled.title",
 			"agentHost.config.sessionSyncEnabled.description",
 			"agentHost.config.sessionSyncEnabled.title",
+			"agentHost.config.showExternalSessions.description",
+			"agentHost.config.showExternalSessions.title",
 			"agentHost.config.systemProxyEnabled.description",
 			"agentHost.config.systemProxyEnabled.title",
 			"agentHost.config.telemetryLevel.description",
@@ -2749,14 +2771,30 @@
 			"agentHost.sessionConfig.permissionsDescription"
 		],
 		"vs/platform/agentHost/common/agentHostStarter.config.contribution": [
+			"chat.agentHost.agentMerge.addressReviews",
+			"chat.agentHost.agentMerge.enabled",
+			"chat.agentHost.agentMerge.fixCI",
+			"chat.agentHost.agentMerge.mergeMethod",
+			"chat.agentHost.agentMerge.mergeMethod.auto",
+			"chat.agentHost.agentMerge.mergeMethod.merge",
+			"chat.agentHost.agentMerge.mergeMethod.rebase",
+			"chat.agentHost.agentMerge.mergeMethod.squash",
+			"chat.agentHost.agentMerge.mergePullRequest",
+			"chat.agentHost.agentMerge.replyAttribution",
+			"chat.agentHost.agentMerge.resolveConflicts",
 			"chat.agentHost.byokModels.enabled",
 			"chat.agentHost.claudeAgent.enabled",
 			"chat.agentHost.claudeAgent.enabled.policy",
+			"chat.agentHost.claudeAgent.multiRootEnabled",
 			"chat.agentHost.codexAgent.binaryArgs",
 			"chat.agentHost.codexAgent.codexHome",
 			"chat.agentHost.codexAgent.enabled",
 			"chat.agentHost.codexAgent.enabled.policy",
+			"chat.agentHost.codexAgent.multiRootEnabled",
 			"chat.agentHost.codexAgent.sdkRoot",
+			"chat.agentHost.copilotAgent.multiRootEnabled",
+			"chat.agentHost.experimental.activeAgentTitleGeneration",
+			"chat.agentHost.experimental.markdownPlanRichLinks",
 			"chat.agentHost.otel.captureContent",
 			"chat.agentHost.otel.captureContent.policy",
 			"chat.agentHost.otel.dbSpanExporter.enabled",
@@ -2783,6 +2821,15 @@
 			"chat.agentHost.systemProxy.enabled",
 			"chatAgentHostStarterConfigurationTitle"
 		],
+		"vs/platform/agentHost/common/agentMerge": [
+			"agentMerge.config.addressReviews",
+			"agentMerge.config.enabled",
+			"agentMerge.config.fixCI",
+			"agentMerge.config.mergeMethod",
+			"agentMerge.config.mergePullRequest",
+			"agentMerge.config.replyAttribution",
+			"agentMerge.config.resolveConflicts"
+		],
 		"vs/platform/agentHost/common/changesetUri": [
 			"branchChangeset.label",
 			"compareTurnsChangeset.description",
@@ -2805,18 +2852,51 @@
 			"agentHost.config.copilotSdkLogLevel.trace",
 			"agentHost.config.enableCustomTerminalTool.description",
 			"agentHost.config.enableCustomTerminalTool.title",
+			"agentHost.config.modelCapabilityOverrides.availableTools.description",
+			"agentHost.config.modelCapabilityOverrides.availableTools.item.title",
+			"agentHost.config.modelCapabilityOverrides.availableTools.title",
 			"agentHost.config.modelCapabilityOverrides.description",
 			"agentHost.config.modelCapabilityOverrides.entry.description",
 			"agentHost.config.modelCapabilityOverrides.entry.title",
+			"agentHost.config.modelCapabilityOverrides.excludedTools.description",
+			"agentHost.config.modelCapabilityOverrides.excludedTools.item.title",
+			"agentHost.config.modelCapabilityOverrides.excludedTools.title",
 			"agentHost.config.modelCapabilityOverrides.family.description",
 			"agentHost.config.modelCapabilityOverrides.family.title",
+			"agentHost.config.modelCapabilityOverrides.modelCapabilities.description",
+			"agentHost.config.modelCapabilityOverrides.modelCapabilities.title",
+			"agentHost.config.modelCapabilityOverrides.reasoningEffort.description",
+			"agentHost.config.modelCapabilityOverrides.reasoningEffort.title",
 			"agentHost.config.modelCapabilityOverrides.title",
 			"agentHost.config.opus48Prompt.description",
 			"agentHost.config.opus48Prompt.title",
-			"agentHost.config.reasoningEffortOverride.description",
-			"agentHost.config.reasoningEffortOverride.title",
+			"agentHost.config.reasoningSummary.description",
+			"agentHost.config.reasoningSummary.title",
 			"agentHost.config.rubberDuck.description",
-			"agentHost.config.rubberDuck.title"
+			"agentHost.config.rubberDuck.title",
+			"agentHost.config.toolSearchDeferThreshold.description",
+			"agentHost.config.toolSearchDeferThreshold.title",
+			"agentHost.config.toolSearchEnabled.description",
+			"agentHost.config.toolSearchEnabled.title"
+		],
+		"vs/platform/agentHost/common/copilotConfigSlashCommands": [
+			"copilotConfigSlash.autopilot.on",
+			"copilotConfigSlash.autopilot.prompt",
+			"copilotConfigSlash.autopilotHint",
+			"copilotConfigSlash.default",
+			"copilotConfigSlash.exitAutopilot",
+			"copilotConfigSlash.plan.prompt",
+			"copilotConfigSlash.promptHint",
+			"copilotConfigSlash.yolo"
+		],
+		"vs/platform/agentHost/common/openSessionLink": [
+			"agentSessionLink.ariaLabel",
+			"agentSessionLink.completed",
+			"agentSessionLink.error",
+			"agentSessionLink.needsInput",
+			"agentSessionLink.notStarted",
+			"agentSessionLink.tooltip",
+			"agentSessionLink.working"
 		],
 		"vs/platform/agentHost/common/reasoningEffort": [
 			"reasoningEffort.high",
@@ -2831,8 +2911,20 @@
 			"reasoningEffort.minimalDescription",
 			"reasoningEffort.none",
 			"reasoningEffort.noneDescription",
+			"reasoningEffort.ultra",
+			"reasoningEffort.ultraDescription",
 			"reasoningEffort.xhigh",
 			"reasoningEffort.xhighDescription"
+		],
+		"vs/platform/agentHost/common/remoteAgentHostLocationPreferenceDialog": [
+			"remoteAgentHostLocation.changeCommandLabel",
+			"remoteAgentHostLocation.current",
+			"remoteAgentHostLocation.dedicated",
+			"remoteAgentHostLocation.dedicated.detail",
+			"remoteAgentHostLocation.editor",
+			"remoteAgentHostLocation.editor.detail",
+			"remoteAgentHostLocation.message",
+			"remoteAgentHostLocation.reminder"
 		],
 		"vs/platform/agentHost/common/sandboxConfigSchema": [
 			"agentHost.config.sandbox.advancedRuntime.title",
@@ -2849,7 +2941,56 @@
 			"agentHost.config.sandbox.windowsEnabled.title",
 			"agentHost.config.sandbox.windowsFileSystem.title"
 		],
+		"vs/platform/agentHost/common/streamingToolCallDisplay": [
+			"toolStream.create",
+			"toolStream.createFile",
+			"toolStream.createLines",
+			"toolStream.createLinesInFile",
+			"toolStream.createOneLine",
+			"toolStream.createOneLineInFile",
+			"toolStream.edit",
+			"toolStream.editFile",
+			"toolStream.editLines",
+			"toolStream.editLinesInFile",
+			"toolStream.editOneLine",
+			"toolStream.editOneLineInFile",
+			"toolStream.insert",
+			"toolStream.insertInFile",
+			"toolStream.insertLines",
+			"toolStream.insertLinesInFile",
+			"toolStream.insertOneLine",
+			"toolStream.insertOneLineInFile",
+			"toolStream.patch",
+			"toolStream.patchFiles",
+			"toolStream.patchLines",
+			"toolStream.patchLinesInFiles",
+			"toolStream.patchOneLine",
+			"toolStream.patchOneLineInFiles",
+			"toolStream.replaceLines",
+			"toolStream.replaceLinesInFile",
+			"toolStream.replaceLinesWithLines",
+			"toolStream.replaceLinesWithLinesInFile",
+			"toolStream.replaceLinesWithOneLine",
+			"toolStream.replaceLinesWithOneLineInFile",
+			"toolStream.replaceOneLine",
+			"toolStream.replaceOneLineInFile",
+			"toolStream.replaceOneLineWithLines",
+			"toolStream.replaceOneLineWithLinesInFile",
+			"toolStream.replaceOneLineWithOneLine",
+			"toolStream.replaceOneLineWithOneLineInFile"
+		],
 		"vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl": [
+			"sshEditorAgentHostReplacedByStandalone",
+			"sshHostKeyCancel",
+			"sshHostKeyCaOnlyDetail",
+			"sshHostKeyChanged",
+			"sshHostKeyChangedKnownHosts",
+			"sshHostKeyConnect",
+			"sshHostKeyForgetAction",
+			"sshHostKeyRevoked",
+			"sshHostKeyStrictUnknown",
+			"sshHostKeyUnknownDetail",
+			"sshHostKeyUnknownMessage",
 			"sshKbiDefaultPrompt"
 		],
 		"vs/platform/agentHost/electron-browser/wslRemoteAgentHostServiceImpl": [
@@ -2878,6 +3019,29 @@
 		],
 		"vs/platform/agentHost/node/agentHostMain": [
 			"agentHost"
+		],
+		"vs/platform/agentHost/node/agentHostMergeOperationHandler": [
+			"agentHost.changeset.merge.cancelled",
+			"agentHost.changeset.merge.commitLookupFailed",
+			"agentHost.changeset.merge.commitMessage",
+			"agentHost.changeset.merge.commitMissing",
+			"agentHost.changeset.merge.detachedTarget",
+			"agentHost.changeset.merge.failed",
+			"agentHost.changeset.merge.failedAfterCommit",
+			"agentHost.changeset.merge.merged",
+			"agentHost.changeset.merge.parentMissing",
+			"agentHost.changeset.merge.pullRequestExists",
+			"agentHost.changeset.merge.sameBranch",
+			"agentHost.changeset.merge.sourceBranchMissing",
+			"agentHost.changeset.merge.sourceBranchMissingInParent",
+			"agentHost.changeset.merge.targetBranchMissing",
+			"agentHost.changeset.merge.targetDirty",
+			"agentHost.changeset.merge.wrongTargetBranch"
+		],
+		"vs/platform/agentHost/node/agentHostMergeOperationProvider": [
+			"agentHost.changeset.merge",
+			"agentHost.changeset.merge.confirmation",
+			"agentHost.changeset.merge.description"
 		],
 		"vs/platform/agentHost/node/agentHostPullRequestOperationHandler": [
 			"agentHost.changeset.pr.authRequired",
@@ -2943,6 +3107,9 @@
 			"claude.exitPlanMode.deny",
 			"claude.exitPlanMode.title"
 		],
+		"vs/platform/agentHost/node/claude/claudeReplayMapper": [
+			"claude.replay.missingPrompt"
+		],
 		"vs/platform/agentHost/node/claude/claudeToolDisplay": [
 			"claude.permission.default.title",
 			"claude.permission.mcp.title",
@@ -2977,30 +3144,10 @@
 			"claude.toolComplete.bash",
 			"claude.toolComplete.bashCmd",
 			"claude.toolComplete.bashOutput",
-			"claude.toolComplete.edit",
-			"claude.toolComplete.editFile",
 			"claude.toolComplete.failed",
-			"claude.toolComplete.glob",
-			"claude.toolComplete.globPattern",
-			"claude.toolComplete.grep",
-			"claude.toolComplete.grepPattern",
-			"claude.toolComplete.killBash",
-			"claude.toolComplete.ls",
-			"claude.toolComplete.lsPath",
-			"claude.toolComplete.read",
-			"claude.toolComplete.readFile",
 			"claude.toolComplete.skill",
 			"claude.toolComplete.skillNamed",
 			"claude.toolComplete.task",
-			"claude.toolComplete.taskComplete",
-			"claude.toolComplete.taskCreate",
-			"claude.toolComplete.taskCreateNamed",
-			"claude.toolComplete.taskDelete",
-			"claude.toolComplete.taskGet",
-			"claude.toolComplete.taskList",
-			"claude.toolComplete.taskStart",
-			"claude.toolComplete.taskUpdate",
-			"claude.toolComplete.todoWrite",
 			"claude.toolComplete.webFetch",
 			"claude.toolComplete.webFetchGeneric",
 			"claude.toolInvoke.bash",
@@ -3054,14 +3201,13 @@
 		"vs/platform/agentHost/node/codex/codexAgent": [
 			"codex.modelThinkingLevel.description",
 			"codex.modelThinkingLevel.title",
+			"codex.serverToolConfirmation.title",
 			"codex.sessionConfig.additionalDirectories",
 			"codex.sessionConfig.additionalDirectories.item",
 			"codex.sessionConfig.additionalDirectoriesDescription",
 			"codex.sessionConfig.approvalPolicy",
 			"codex.sessionConfig.approvalPolicy.never",
 			"codex.sessionConfig.approvalPolicy.neverDescription",
-			"codex.sessionConfig.approvalPolicy.onFailure",
-			"codex.sessionConfig.approvalPolicy.onFailureDescription",
 			"codex.sessionConfig.approvalPolicy.onRequest",
 			"codex.sessionConfig.approvalPolicy.onRequestDescription",
 			"codex.sessionConfig.approvalPolicy.untrusted",
@@ -3109,6 +3255,39 @@
 			"codexAgent.description",
 			"codexAgent.displayName"
 		],
+		"vs/platform/agentHost/node/codex/codexMapAppServerEvents": [
+			"codex.compaction.completed",
+			"codex.compaction.displayName",
+			"codex.compaction.inProgress",
+			"codex.imageGeneration.completed",
+			"codex.imageGeneration.displayName",
+			"codex.imageGeneration.error",
+			"codex.imageGeneration.failed",
+			"codex.imageGeneration.inProgress",
+			"codex.webSearch.completed",
+			"codex.webSearch.inProgress"
+		],
+		"vs/platform/agentHost/node/codex/codexProviderConfiguration": [
+			"codex.configuration.autoReviewPolicy",
+			"codex.configuration.autoReviewPolicy.description",
+			"codex.configuration.description",
+			"codex.configuration.file.description",
+			"codex.configuration.file.docs",
+			"codex.configuration.file.open",
+			"codex.configuration.file.title",
+			"codex.configuration.personality",
+			"codex.configuration.personality.default",
+			"codex.configuration.personality.description",
+			"codex.configuration.personality.friendly",
+			"codex.configuration.personality.pragmatic",
+			"codex.configuration.personalization",
+			"codex.configuration.review",
+			"codex.configuration.review.save",
+			"codex.configuration.title"
+		],
+		"vs/platform/agentHost/node/codexCompactCommand": [
+			"codex.compact.description"
+		],
 		"vs/platform/agentHost/node/copilot/copilotAgent": [
 			"copilot.modelContextSize.default",
 			"copilot.modelContextSize.description",
@@ -3116,6 +3295,7 @@
 			"copilot.modelContextSize.title",
 			"copilot.modelThinkingLevel.description",
 			"copilot.modelThinkingLevel.title",
+			"copilotAgent.connectionClosed",
 			"copilotAgent.description",
 			"copilotAgent.pluginParseError"
 		],
@@ -3143,6 +3323,10 @@
 			"agentHost.copilot.systemNotification.agentCompleted",
 			"agentHost.copilot.systemNotification.agentFailed",
 			"agentHost.copilot.systemNotification.agentIdle",
+			"agentHost.copilot.systemNotification.factoryCancelled",
+			"agentHost.copilot.systemNotification.factoryCompleted",
+			"agentHost.copilot.systemNotification.factoryFailed",
+			"agentHost.copilot.systemNotification.factoryHalted",
 			"agentHost.copilot.systemNotification.instructionDiscovered",
 			"agentHost.copilot.systemNotification.newInboxMessage",
 			"agentHost.copilot.systemNotification.shellCompleted",
@@ -3160,40 +3344,15 @@
 			"copilot.permission.url.message",
 			"copilot.permission.url.title",
 			"copilot.permission.write.title",
-			"toolComplete.create",
-			"toolComplete.createFile",
-			"toolComplete.edit",
-			"toolComplete.editFile",
-			"toolComplete.exitPlanMode",
 			"toolComplete.failed",
-			"toolComplete.glob",
-			"toolComplete.globPattern",
-			"toolComplete.grep",
-			"toolComplete.grepPattern",
-			"toolComplete.listAgents",
-			"toolComplete.patch",
-			"toolComplete.patchFile",
-			"toolComplete.patchFiles",
-			"toolComplete.readAgent",
-			"toolComplete.readAgentGeneric",
 			"toolComplete.readTerminal",
 			"toolComplete.shell",
 			"toolComplete.shellCmd",
-			"toolComplete.skill",
-			"toolComplete.skillName",
-			"toolComplete.sql",
 			"toolComplete.task",
-			"toolComplete.view",
-			"toolComplete.viewFile",
-			"toolComplete.viewFileFromLine",
-			"toolComplete.viewFileLine",
-			"toolComplete.viewFileRange",
 			"toolComplete.webFetch",
 			"toolComplete.webFetchGeneric",
-			"toolComplete.writeAgent",
-			"toolComplete.writeAgentGeneric",
-			"toolComplete.writeShell",
-			"toolComplete.writeShellCmd",
+			"toolComplete.webSearch",
+			"toolComplete.webSearchQuery",
 			"toolInvoke.create",
 			"toolInvoke.createFile",
 			"toolInvoke.edit",
@@ -3203,14 +3362,20 @@
 			"toolInvoke.globPattern",
 			"toolInvoke.grep",
 			"toolInvoke.grepPattern",
+			"toolInvoke.insert",
+			"toolInvoke.insertFile",
+			"toolInvoke.listAgents",
 			"toolInvoke.patch",
 			"toolInvoke.patchFile",
 			"toolInvoke.patchFiles",
+			"toolInvoke.readAgent",
+			"toolInvoke.readAgentGeneric",
 			"toolInvoke.readTerminal",
+			"toolInvoke.searchCode",
+			"toolInvoke.searchCodeQuery",
 			"toolInvoke.shell",
 			"toolInvoke.shellCmd",
 			"toolInvoke.skill",
-			"toolInvoke.skillName",
 			"toolInvoke.sql",
 			"toolInvoke.task",
 			"toolInvoke.view",
@@ -3218,8 +3383,13 @@
 			"toolInvoke.viewFileFromLine",
 			"toolInvoke.viewFileLine",
 			"toolInvoke.viewFileRange",
+			"toolInvoke.viewToolOutput",
 			"toolInvoke.webFetch",
 			"toolInvoke.webFetchGeneric",
+			"toolInvoke.webSearch",
+			"toolInvoke.webSearchQuery",
+			"toolInvoke.writeAgent",
+			"toolInvoke.writeAgentGeneric",
 			"toolInvoke.writeShell",
 			"toolInvoke.writeShellCmd",
 			"toolMarkdown.taskComplete",
@@ -3286,40 +3456,44 @@
 			"sessionPermissions.skip"
 		],
 		"vs/platform/agentHost/node/shared/agentFeedbackServerTools": [
-			"toolComplete.addComment",
-			"toolComplete.deleteComments",
-			"toolComplete.listComments",
-			"toolComplete.listComments.many",
-			"toolComplete.listComments.one",
-			"toolComplete.resolveComments",
-			"toolComplete.viewUnreviewedComments",
 			"toolInvoke.addComment",
 			"toolInvoke.deleteComments",
 			"toolInvoke.listComments",
+			"toolInvoke.replyToComment",
 			"toolInvoke.resolveComments",
 			"toolInvoke.viewUnreviewedComments",
 			"toolName.addComment",
 			"toolName.deleteComments",
 			"toolName.listComments",
+			"toolName.replyToComment",
 			"toolName.resolveComments",
 			"toolName.viewUnreviewedComments"
 		],
+		"vs/platform/agentHost/node/shared/agentMergeServerTools": [
+			"agentMerge.tool.readCI",
+			"agentMerge.tool.readCI.complete",
+			"agentMerge.tool.readCI.failed",
+			"agentMerge.tool.readCI.running",
+			"agentMerge.tool.replyReview",
+			"agentMerge.tool.replyReview.complete",
+			"agentMerge.tool.replyReview.failed",
+			"agentMerge.tool.replyReview.running",
+			"agentMerge.tool.rerunWorkflow",
+			"agentMerge.tool.rerunWorkflow.complete",
+			"agentMerge.tool.rerunWorkflow.failed",
+			"agentMerge.tool.rerunWorkflow.running"
+		],
 		"vs/platform/agentHost/node/shared/sessionServerTools": [
-			"toolComplete.createChat",
 			"toolComplete.createSession",
 			"toolComplete.deleteSession",
-			"toolComplete.getCurrentSession",
-			"toolComplete.getSessionContext",
-			"toolComplete.listSessions",
-			"toolComplete.listSessions.many",
-			"toolComplete.listSessions.one",
-			"toolComplete.sendMessage",
+			"toolComplete.renameChat",
 			"toolInvoke.createChat",
 			"toolInvoke.createSession",
 			"toolInvoke.deleteSession",
 			"toolInvoke.getCurrentSession",
 			"toolInvoke.getSessionContext",
 			"toolInvoke.listSessions",
+			"toolInvoke.renameChat",
 			"toolInvoke.sendMessage",
 			"toolName.createChat",
 			"toolName.createSession",
@@ -3327,6 +3501,7 @@
 			"toolName.getCurrentSession",
 			"toolName.getSessionContext",
 			"toolName.listSessions",
+			"toolName.renameChat",
 			"toolName.sendMessage"
 		],
 		"vs/platform/agentHost/node/shared/worktreeIsolation": [
@@ -3340,12 +3515,23 @@
 			"agentHost.sessionConfig.isolationDescription",
 			"agentHost.sessionConfig.worktreeBranchPrefix",
 			"agentHost.sessionConfig.worktreeBranchPrefixDescription",
+			"agentHost.sessionConfig.worktreeBranchTrack",
+			"agentHost.sessionConfig.worktreeBranchTrackDescription",
 			"agentHost.sessionConfig.worktreeIncludeFiles",
 			"agentHost.sessionConfig.worktreeIncludeFilesDescription",
 			"agentHost.sessionConfig.worktreeIncludeFilesItem",
+			"agentHost.worktreeCheckingOut",
+			"agentHost.worktreeCheckingOutPercent",
+			"agentHost.worktreeCopyingIncludeFiles",
+			"agentHost.worktreeCopyingIncludeFilesPercent",
 			"agentHost.worktreeCreated",
+			"agentHost.worktreeCreating",
+			"agentHost.worktreeCreationFailed",
+			"agentHost.worktreeCreationFailedWithDiagnostic",
+			"agentHost.worktreeNamingBranch",
 			"sessionWorkingDirectoryMissing",
 			"sessionWorkingDirectoryMissingWithReason",
+			"worktreeIsolation.commitMessage",
 			"worktreeRecreateBranchMissing"
 		],
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
@@ -3353,6 +3539,8 @@
 			"ssh.keyFileAuthRequiresPath",
 			"sshKeyPassphraseName",
 			"sshKeyPassphrasePrompt",
+			"sshProgressAwaitingAgent",
+			"sshProgressAwaitingSelection",
 			"sshProgressCheckingAgent",
 			"sshProgressConnecting",
 			"sshProgressDownloadingCLI",
@@ -3361,7 +3549,9 @@
 			"sshProgressStartingAgent"
 		],
 		"vs/platform/agentHost/node/tunnelHostMainService": [
-			"tunnelHost.log"
+			"tunnelHost.log",
+			"tunnelHost.startFailed",
+			"tunnelHost.startTimeout"
 		],
 		"vs/platform/agentHost/node/wslRemoteAgentHostService": [
 			"wslProgressConnecting",
@@ -3396,7 +3586,18 @@
 			"browser.device.hid",
 			"browser.device.usb"
 		],
+		"vs/platform/browserView/electron-main/browserViewInspector": [
+			"browserView.addComment",
+			"browserView.addCommentPlaceholder",
+			"browserView.commentOnSelectedElement",
+			"browserView.elementComment",
+			"browserView.elementCommentWithBody",
+			"browserView.emptyElementComment",
+			"browserView.removeComment",
+			"browserView.removeElementComment"
+		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
+			"browser.contextMenu.addComment",
 			"browser.contextMenu.addElementToChat",
 			"browser.contextMenu.back",
 			"browser.contextMenu.copyImage",
@@ -3409,7 +3610,20 @@
 			"browser.contextMenu.openLinkInNewTab",
 			"browser.contextMenu.reload"
 		],
+		"vs/platform/chat/common/sessionArchiveActions": [
+			"chatSession.archive",
+			"chatSession.archiveAll",
+			"chatSession.markAllAsDone",
+			"chatSession.markAsDone",
+			"chatSession.restore",
+			"chatSession.restoreAll",
+			"chatSession.section.archived",
+			"chatSession.section.done",
+			"chatSession.unarchive",
+			"chatSession.unarchiveAll"
+		],
 		"vs/platform/configuration/common/configurationRegistry": [
+			"config.agentHost.duplicate",
 			"config.policy.bothPolicyAndReference",
 			"config.policy.duplicate",
 			"config.property.duplicate",
@@ -3475,7 +3689,7 @@
 			{
 				"key": "aboutDetail",
 				"comment": [
-					"Electron, Chromium, Node.js and V8 are product names that need no translation"
+					"Electron, Chromium, Node.js, V8 and Copilot are product names that need no translation"
 				]
 			}
 		],
@@ -4094,21 +4308,7 @@
 			"remoteTunnelLog"
 		],
 		"vs/platform/remoteTunnel/node/remoteTunnelService": [
-			{
-				"key": "remoteTunnelService.authorizing",
-				"comment": [
-					"{0} is a user account name, {1} a provider name (e.g. Github)"
-				]
-			},
-			"remoteTunnelService.building",
-			"remoteTunnelService.openTunnel",
-			{
-				"key": "remoteTunnelService.openTunnelWithName",
-				"comment": [
-					"{0} is a tunnel name"
-				]
-			},
-			"remoteTunnelService.serviceInstallFailed"
+			"remoteTunnelService.building"
 		],
 		"vs/platform/request/common/request": [
 			"electronFetch",
@@ -4744,6 +4944,10 @@
 		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
 			"incompatible sync data"
 		],
+		"vs/platform/webContentExtractor/electron-main/webPageLoader": [
+			"webPageLoader.invalidUri",
+			"webPageLoader.unsupportedUriScheme"
+		],
 		"vs/platform/windows/electron-main/windowImpl": [
 			"appGone",
 			"appGoneDetailEmptyWindow",
@@ -4852,6 +5056,8 @@
 			"accountSignedInAriaNameOnly",
 			"agentsSignedOut",
 			"agentsSignedOutAria",
+			"agentsSignInOptional",
+			"agentsSignInOptionalAria",
 			"copilotAllQuotaReachedAria",
 			"copilotChatQuotaReachedAria",
 			"copilotCompletionsQuotaReachedAria",
@@ -4871,8 +5077,10 @@
 			"agentSidebarToggleClosedIcon",
 			"agentSidebarToggleOpenIcon",
 			"closePanel",
+			"hidePanel",
 			"hideSecondarySideBar",
 			"openAndCloseSidebar",
+			"showPanel",
 			"showSecondarySideBar",
 			"sidebarHidden",
 			"sidebarVisible",
@@ -4888,6 +5096,13 @@
 			"deleteChat",
 			"renameChat",
 			"renameChat.aria"
+		],
+		"vs/sessions/browser/parts/chatGroupView": [
+			"chatGroupAriaLabel",
+			"chatGroupTabsAriaLabel",
+			"chatTabsAriaLabel",
+			"sessionReadOnlyBanner.archived",
+			"sessionReadOnlyBanner.message"
 		],
 		"vs/sessions/browser/parts/menubar.contribution": [
 			{
@@ -5010,24 +5225,28 @@
 			"mobileTopBar.singleFileChanged",
 			"mobileTopBar.singleFileChangedTooltip"
 		],
+		"vs/sessions/browser/parts/sessionConversationsActionViewItem": [
+			"sessionConversationGroup.chats",
+			"sessionConversationGroup.subagents"
+		],
 		"vs/sessions/browser/parts/sessionHeader": [
 			"renameSession.aria"
 		],
 		"vs/sessions/browser/parts/sessionReadOnlyBanner": [
 			"sessionReadOnlyBanner.message"
 		],
-		"vs/sessions/browser/parts/sessionView": [
-			"sessionReadOnlyBanner.archived",
-			"sessionReadOnlyBanner.message",
-			"sessionReadOnlyBanner.restore"
+		"vs/sessions/browser/sessionConversationGroups": [
+			"sessionConversationStatus.ariaLabel",
+			"sessionConversationStatus.completed",
+			"sessionConversationStatus.failed",
+			"sessionConversationStatus.inProgress",
+			"sessionConversationStatus.needsInput",
+			"sessionConversationStatus.new"
 		],
 		"vs/sessions/browser/sessionsSetUpService": [
 			"loading",
 			"sessions.aiDisabled.detail",
 			"sessions.aiDisabled.enable",
-			"sessions.signIn",
-			"sessions.signingIn",
-			"sessions.signingIn.detail",
 			"sessions.welcome.detail",
 			"sessions.welcome.getStarted",
 			"sessions.welcome.title",
@@ -5043,18 +5262,39 @@
 				]
 			}
 		],
+		"vs/sessions/browser/sessionsSignInDialog": [
+			"sessions.returnToVSCodeEditor",
+			"sessions.signIn",
+			"sessions.signingIn",
+			"sessions.signingIn.detail"
+		],
+		"vs/sessions/browser/singlePaneWorkbench": [
+			"sidePaneHidden",
+			"sidePaneVisible"
+		],
 		"vs/sessions/browser/widget/openInVSCodeWidget": [
 			"openInVSCodeHover"
+		],
+		"vs/sessions/browser/workbench": [
+			"auxiliaryBarHidden",
+			"auxiliaryBarVisible"
 		],
 		"vs/sessions/common/categories": [
 			"agents"
 		],
 		"vs/sessions/common/contextkeys": [
 			"activeSessions",
+			"agentHostSessionTypesAvailable",
 			"agentSessionsHasDockedDetails",
+			"agentSessionsSinglePaneChangesTabAvailable",
 			"agentSessionsSinglePaneChangesTabMissing",
+			"agentSessionsSinglePaneDiffEditorInputActive",
+			"agentSessionsSinglePaneFilesTabAvailable",
 			"agentSessionsSinglePaneFilesTabMissing",
 			"agentSessionsSinglePaneLayoutEnabled",
+			"automationsCustomViewFocus",
+			"automationsHasItems",
+			"customViewVisible",
 			"editorMaximized",
 			"isQuickChatSession",
 			"multipleSessionsVisible",
@@ -5066,11 +5306,13 @@
 			"sessionHasChanges",
 			"sessionHasGitRepository",
 			"sessionHasGitSyncActionRunning",
+			"sessionHasIssues",
 			"sessionHasMultipleCommittedChats",
 			"sessionHasMultipleOpenChats",
 			"sessionHasPullRequest",
 			"sessionHasWorkspace",
 			"sessionId",
+			"sessionIsActive",
 			"sessionIsArchived",
 			"sessionIsCreated",
 			"sessionIsMaximized",
@@ -5083,6 +5325,7 @@
 			"sessionsCanGoBack",
 			"sessionsCanGoForward",
 			"sessionsFocus",
+			"sessionsHasClosedItem",
 			"sessionShouldShowChatTabs",
 			"sessionsIsPhoneLayout",
 			"sessionsKeyboardVisible",
@@ -5092,6 +5335,7 @@
 			"sessionSupportsFork",
 			"sessionSupportsMultipleChats",
 			"sessionSupportsRename",
+			"sessionSupportsSideChat",
 			"sessionsVisible",
 			"sessionsWelcomeVisible",
 			"sessionType",
@@ -5122,6 +5366,8 @@
 			"agents.background",
 			"agentsBadge.background",
 			"agentsBadge.foreground",
+			"agentsBottomPanel.border",
+			"agentsCard.border",
 			"agentsChatInput.background",
 			"agentsChatInput.border",
 			"agentsChatInput.focusBorder",
@@ -5155,11 +5401,35 @@
 			"agenticSignOutDetail",
 			"agenticSignOutMessage",
 			"agentsAccountStatusTitleBar",
+			"chatGPTAccountName",
+			"chatGPTAccountSectionLabel",
+			"chatGPTDailyLimitUsed",
+			"chatGPTLimitReset",
+			"chatGPTLimitUsedLabel",
+			"chatGPTLimitUsedPercentage",
+			"chatGPTLimitUsedPercentageValue",
+			"chatGPTPlan",
+			"chatGPTSubscription",
+			"chatGPTUsageLimitUsed",
+			"chatGPTWeeklyLimitUsed",
+			"copilotAccountSectionLabel",
+			"copilotCreditsReset",
+			"copilotCreditsResetAt",
+			"copilotCreditsUsedLabel",
+			"copilotCreditsUsedPercentage",
+			"copilotCreditsUsedPercentageValue",
+			"copilotCreditsUsedRatio",
+			"copilotCreditsUsedRatioValue",
 			"loadingAccountHeader",
-			"sessionsAccountSubscriptionSectionLabel",
+			"manageChatGPTModels",
+			"manageCopilotModels",
+			"openCodexAgentCustomizations",
+			"openCopilotAgentCustomizations",
+			"sessionsAccountStatusSectionLabel",
 			"settings",
 			"signIn",
-			"signOut"
+			"signOut",
+			"signOutOfChatGPT"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution": [
 			"agentFeedback.submitFeedbackCount"
@@ -5171,6 +5441,12 @@
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackAttachmentWidget": [
 			"chat.agentFeedback",
 			"removeAttachment"
+		],
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackContextView": [
+			"agentFeedbackAttachment.viewComments",
+			"agentFeedbackContextView.remove",
+			"agentFeedbackContextView.removeAll",
+			"agentFeedbackContextView.tree"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions": [
 			"agentFeedback.clear",
@@ -5184,6 +5460,7 @@
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution": [
 			"agentFeedback.add",
+			"agentFeedback.addAction",
 			"agentFeedback.addAndSubmit",
 			"agentFeedback.addAtCurrentLine",
 			"agentFeedback.addComment",
@@ -5191,17 +5468,13 @@
 			"altEnter",
 			"enter"
 		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay": [
-			"agentFeedback.submitCountShort",
-			"nOfM",
-			"zero"
-		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution": [
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidget": [
 			"acceptAgentFeedbackTooltip",
 			"acceptFeedbackButton",
 			"acceptPRFeedbackTooltip",
 			"addReplyPlaceholder",
 			"addToComment",
+			"agentFeedback.replyFromAgent",
 			"agentReviewComment",
 			"collapse",
 			"deleteAgentFeedbackTooltip",
@@ -5209,6 +5482,7 @@
 			"deletePRFeedbackTooltip",
 			"editComment",
 			"expand",
+			"hideComment",
 			"lineNumber",
 			"lineRange",
 			"nComments",
@@ -5216,11 +5490,6 @@
 			"removeComment",
 			"suggestedChangeLine",
 			"suggestedChangeLines"
-		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackHover": [
-			"agentFeedbackHover.remove",
-			"agentFeedbackHover.removeAll",
-			"agentFeedbackHover.tree"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackOverviewRulerContribution": [
 			"editorOverviewRuler.agentFeedbackForeground"
@@ -5250,7 +5519,6 @@
 		],
 		"vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews": [
 			"aiCustomizationTree",
-			"automations",
 			"builtinWithCount",
 			"customAgents",
 			"extensionsWithCount",
@@ -5284,10 +5552,17 @@
 			"aquarium.simulateStreak.died",
 			"aquarium.simulateStreak.diedDetail",
 			"aquarium.simulateStreak.placeholder",
+			"aquarium.toggleActionVisibility",
 			"sessions.developerJoy.enabled"
 		],
 		"vs/sessions/contrib/aquarium/browser/aquariumOverlay": [
+			"aquarium.action.hidden",
+			"aquarium.action.shown",
 			"aquarium.hide",
+			"aquarium.hunger.happy",
+			"aquarium.hunger.neutral",
+			"aquarium.hunger.sad",
+			"aquarium.hunger.verySad",
 			"aquarium.reviveBadge",
 			"aquarium.reviveLabel.one",
 			"aquarium.reviveLabel.other",
@@ -5333,6 +5608,7 @@
 			"automation.form.promptRequired",
 			"automation.form.sessionTypeRequired",
 			"automation.form.time",
+			"automation.form.trustFolderMessage",
 			"automation.form.workspacePicker.action",
 			"automation.form.workspacePicker.pickAriaLabel",
 			"automation.form.workspacePicker.selectedAriaLabel",
@@ -5354,7 +5630,8 @@
 		"vs/sessions/contrib/automations/browser/automationRunner": [
 			"automationRunFailed",
 			"automationRunner.cancelled",
-			"automationRunner.sessionFailed"
+			"automationRunner.sessionFailed",
+			"automationTargetUnavailable"
 		],
 		"vs/sessions/contrib/automations/browser/automations.contribution": [
 			"chat.automations.enabled",
@@ -5363,6 +5640,49 @@
 		"vs/sessions/contrib/automations/browser/automationScheduler": [
 			"automation.timedOut",
 			"automations.crashRecoveryReason"
+		],
+		"vs/sessions/contrib/automations/browser/automationTools": [
+			"automation.tool.cancelled",
+			"automation.tool.configure.create.confirmationMessage",
+			"automation.tool.configure.create.confirmationTitle",
+			"automation.tool.configure.create.invocationMessage",
+			"automation.tool.configure.create.pastTenseMessage",
+			"automation.tool.configure.created",
+			"automation.tool.configure.displayName",
+			"automation.tool.configure.update.confirmationMessage",
+			"automation.tool.configure.update.confirmationTitle",
+			"automation.tool.configure.update.invocationMessage",
+			"automation.tool.configure.update.pastTenseMessage",
+			"automation.tool.configure.updated",
+			"automation.tool.configure.userDescription",
+			"automation.tool.delete.cancel",
+			"automation.tool.delete.cancelled",
+			"automation.tool.delete.confirm",
+			"automation.tool.delete.confirmationMessage",
+			"automation.tool.delete.confirmationTitle",
+			"automation.tool.delete.deleted",
+			"automation.tool.delete.displayName",
+			"automation.tool.delete.invocationMessage",
+			"automation.tool.delete.pastTenseMessage",
+			"automation.tool.delete.userDescription",
+			"automation.tool.error",
+			"automation.tool.list.displayName",
+			"automation.tool.list.invocationMessage",
+			"automation.tool.list.pastTenseMessage",
+			"automation.tool.list.result.plural",
+			"automation.tool.list.result.singular",
+			"automation.tool.list.userDescription",
+			"automation.tool.run.alreadyRunning",
+			"automation.tool.run.alreadyRunningResult",
+			"automation.tool.run.cancelled",
+			"automation.tool.run.confirmationMessage",
+			"automation.tool.run.confirmationTitle",
+			"automation.tool.run.displayName",
+			"automation.tool.run.invocationMessage",
+			"automation.tool.run.pastTenseMessage",
+			"automation.tool.run.started",
+			"automation.tool.run.userDescription",
+			"automation.tool.run.wasAlreadyRunning"
 		],
 		"vs/sessions/contrib/changes/browser/changes.contribution": [
 			"changes",
@@ -5461,6 +5781,7 @@
 		"vs/sessions/contrib/changes/browser/sessionsChangesAccessibilityHelp": [
 			"sessionsChanges.checks",
 			"sessionsChanges.diffView",
+			"sessionsChanges.operations",
 			"sessionsChanges.overview",
 			"sessionsChanges.sessionFiles",
 			"sessionsChanges.sessionFilesToggle",
@@ -5496,10 +5817,53 @@
 			"branchPicker.unavailable",
 			"branchPicker.unavailableAriaLabel"
 		],
+		"vs/sessions/contrib/chat/browser/btwSlashCommand.contribution": [
+			"btw",
+			"btw.createFailed",
+			"btw.missingPrompt",
+			"btw.noTurn",
+			"btw.sessionUnavailable",
+			"btw.unsupported"
+		],
 		"vs/sessions/contrib/chat/browser/chat.contribution": [
 			"chat.agentHost.runWorktreeCreatedTasks",
 			"chat.agentSessions.scopedInputHistory",
 			"sessions.newSession.label"
+		],
+		"vs/sessions/contrib/chat/browser/externalSessionBanner": [
+			"externalSessionBanner.actions.ariaLabel",
+			"externalSessionBanner.ariaLabel",
+			"externalSessionBanner.close",
+			"externalSessionBanner.confirm.daysAgo",
+			"externalSessionBanner.confirm.last7Days.detail",
+			"externalSessionBanner.confirm.lastDay.detail",
+			"externalSessionBanner.confirm.message",
+			"externalSessionBanner.confirm.none.detail",
+			"externalSessionBanner.confirm.oneDayAgo",
+			"externalSessionBanner.confirm.recent.detail",
+			"externalSessionBanner.confirm.recent.message",
+			{
+				"key": "externalSessionBanner.confirm.save",
+				"comment": [
+					"&& denotes a mnemonic"
+				]
+			},
+			"externalSessionBanner.description",
+			"externalSessionBanner.message",
+			"externalSessionBanner.save",
+			"externalSessionBanner.save.invalidState",
+			"externalSessionBanner.select.all",
+			"externalSessionBanner.select.all.description",
+			"externalSessionBanner.select.ariaLabel",
+			"externalSessionBanner.select.last24Hours",
+			"externalSessionBanner.select.last24Hours.description",
+			"externalSessionBanner.select.last7Days",
+			"externalSessionBanner.select.last7Days.description",
+			"externalSessionBanner.select.none",
+			"externalSessionBanner.select.none.description",
+			"externalSessionBanner.select.placeholder",
+			"externalSessionBanner.select.recent",
+			"externalSessionBanner.select.recent.description"
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
 			"mobileSessionTypePicker.title"
@@ -5517,11 +5881,11 @@
 			"sessionsModelPicker"
 		],
 		"vs/sessions/contrib/chat/browser/newChatContextAttachments": [
-			"attachAsContext",
 			"chatContext.attach.placeholder",
 			"files",
 			"imageFromClipboard",
 			"pastedImage",
+			"pastedLines",
 			"removeAttachment",
 			"selectFilesOrFolders"
 		],
@@ -5534,6 +5898,8 @@
 			"newChatInput.status.otel.learnMore",
 			"newChatInput.status.otel.manage",
 			"newChatInput.status.otel.title",
+			"newSessionPromptOptions.closed",
+			"newSessionPromptOptions.inserted",
 			"send",
 			"sendWithBackgroundHint",
 			"sessionsChatInput.placeholder.describeTheOutcome",
@@ -5551,9 +5917,11 @@
 			"sessionsChatInput.placeholder.whatWillYouLaunch",
 			"sessionsChatInput.placeholder.whatWillYouShipToday",
 			"sessionsChatInput.placeholder.whatWouldYouLikeToAutomate",
+			"sessionsChatInputHasDictationFocus",
+			"sessionsStt.cancelPreparing",
 			"sessionsStt.dictate",
-			"sessionsStt.preparing",
-			"sessionsStt.stop"
+			"sessionsStt.stop",
+			"voiceInputMode"
 		],
 		"vs/sessions/contrib/chat/browser/newChatInSessionWidget": [
 			"newChatInSessionPlaceholder",
@@ -5569,17 +5937,63 @@
 			"agentsVoice.startVoiceInChat"
 		],
 		"vs/sessions/contrib/chat/browser/newChatWidget": [
+			"aquariumAction",
 			"newChatHeader",
 			"newSessionChooseWorkspace",
+			"newSessionFeedback.many",
+			"newSessionFeedback.one",
+			"newSessionFeedback.reveal",
 			"newSessionIn",
 			"newSessionWith",
-			"trustFolderMessage"
+			"petAction",
+			"workspacePicker.signInGitHub"
+		],
+		"vs/sessions/contrib/chat/browser/newSessionFolderQuickPickAction": [
+			"sessions.newSession.pickFolderQuickPick.browse",
+			"sessions.newSession.pickFolderQuickPick.label",
+			"sessions.newSession.pickFolderQuickPick.placeholder",
+			"sessions.newSession.pickFolderQuickPick.recent"
+		],
+		"vs/sessions/contrib/chat/browser/newSessionPromptOptions": [
+			"newSessionPromptOptions.close",
+			"newSessionPromptOptions.optionAriaLabel",
+			"newSessionPromptOptions.title"
 		],
 		"vs/sessions/contrib/chat/browser/noAgentHostEmptyState": [
 			"noAgentHost.aria",
 			"noAgentHost.description",
 			"noAgentHost.learnMore",
 			"noAgentHost.title"
+		],
+		"vs/sessions/contrib/chat/browser/omniSessionRoutingAdapter.contribution": [
+			"omniSessionRouting.cancelled",
+			"omniSessionRouting.localWorkspaceProviderUnavailable",
+			"omniSessionRouting.localWorkspaceUnsupported",
+			"omniSessionRouting.selectLocalWorkspace",
+			"omniSessionRouting.selectWorkspace",
+			"omniSessionRouting.sessionConfigurationUnsupported",
+			"omniSessionRouting.sessionNotCreated",
+			"omniSessionRouting.sessionUnavailable",
+			"omniSessionRouting.toolsUnsupported",
+			"omniSessionRouting.variablesUnsupported",
+			"omniSessionRouting.workspaceBrowseFailed",
+			"omniSessionRouting.workspaceBrowseUnavailable",
+			"omniSessionRouting.workspaceNotTrusted",
+			"omniSessionRouting.workspaceProviderUnavailable"
+		],
+		"vs/sessions/contrib/chat/browser/promptTemplatePlaceholder": [
+			"sessions.promptTemplatePlaceholder.hover",
+			"sessionsPromptTemplatePlaceholderFocused"
+		],
+		"vs/sessions/contrib/chat/browser/responseSelectionSideChatController": [
+			"sessions.selectionSideChat.ariaLabel",
+			"sessions.selectionSideChat.ask",
+			"sessions.selectionSideChat.busy",
+			"sessions.selectionSideChat.createFailed",
+			"sessions.selectionSideChat.enter",
+			"sessions.selectionSideChat.placeholder",
+			"sessions.selectionSideChat.sessionUnavailable",
+			"sessions.selectionSideChat.unsupported"
 		],
 		"vs/sessions/contrib/chat/browser/runScriptAction": [
 			"addActionTooltip",
@@ -5656,20 +6070,22 @@
 			"workspaceStorageLabel",
 			"workspaceStorageTooltip"
 		],
+		"vs/sessions/contrib/chat/browser/sessionActivityPill": [
+			"sessionActivityPill.open"
+		],
 		"vs/sessions/contrib/chat/browser/sessionBackgroundActivitiesControl": [
-			"backgroundActivities.activeBrowsers",
 			"backgroundActivities.activeSubagents",
 			"backgroundActivities.ariaLabel",
-			"backgroundActivities.browser",
-			"backgroundActivities.browsers",
-			"backgroundActivities.mixed",
-			"backgroundActivities.open",
 			"backgroundActivities.show",
 			"backgroundActivities.subagent",
 			"backgroundActivities.subagents"
 		],
-		"vs/sessions/contrib/chat/browser/sessionChatInputToolbar": [
-			"sessions.lastTurnChanges.title"
+		"vs/sessions/contrib/chat/browser/sessionBrowsersControl": [
+			"browsers.activeBrowsers",
+			"browsers.ariaLabel",
+			"browsers.browser",
+			"browsers.browsers",
+			"browsers.show"
 		],
 		"vs/sessions/contrib/chat/browser/sessionChatInputToolbarDebug": [
 			"sessions.debug.chatPills.agentFeedback",
@@ -5698,27 +6114,55 @@
 			"untitledSession"
 		],
 		"vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp": [
+			"sessionsChat.aquariumAction",
 			"sessionsChat.backgroundActivities",
 			"sessionsChat.changes",
+			"sessionsChat.chatGroups",
 			"sessionsChat.closeChat",
 			"sessionsChat.contextReferences",
 			"sessionsChat.conversations",
 			"sessionsChat.customizations",
 			"sessionsChat.deleteChat",
+			"sessionsChat.dictation",
+			"sessionsChat.externalSessionBanner",
+			"sessionsChat.externalSessionFilter",
+			"sessionsChat.feedbackAttachment",
+			"sessionsChat.feedbackComments",
 			"sessionsChat.filesView",
+			"sessionsChat.find",
+			"sessionsChat.goBack",
+			"sessionsChat.goForward",
 			"sessionsChat.history",
 			"sessionsChat.input",
 			"sessionsChat.inputBackground",
+			"sessionsChat.micContextMenu",
 			"sessionsChat.mobileConfig",
 			"sessionsChat.navigateNextSession",
 			"sessionsChat.navigatePreviousSession",
 			"sessionsChat.openPullRequest",
 			"sessionsChat.overview",
+			"sessionsChat.pastedText",
+			"sessionsChat.pickFolderQuickPick",
+			"sessionsChat.promptOptions",
+			"sessionsChat.promptTemplatePlaceholder",
+			"sessionsChat.promptTimeline",
+			"sessionsChat.pullRequestSession",
 			"sessionsChat.quickChat",
+			"sessionsChat.renameSession",
 			"sessionsChat.sessionsView",
+			"sessionsChat.subagentPills",
 			"sessionsChat.toggleSidePanel",
 			"sessionsChat.viewAllChanges",
+			"sessionsChat.voiceMode",
+			"sessionsChat.vscodePet",
 			"sessionsChat.workspace"
+		],
+		"vs/sessions/contrib/chat/browser/sessionTurnChanges": [
+			"chatTurnPills.changes.title",
+			"historicalTurnChanges.description",
+			"historicalTurnChanges.label",
+			"lastTurnChanges.description",
+			"lastTurnChanges.label"
 		],
 		"vs/sessions/contrib/chat/browser/sessionTypePicker": [
 			"sessionTypePicker.ariaLabel",
@@ -5732,28 +6176,24 @@
 			"workspacePicker.browseSelectLocal",
 			"workspacePicker.connectingRemoteAgentHost",
 			"workspacePicker.connectRemoteAgentHostFailed",
-			"workspacePicker.experimental",
 			"workspacePicker.filter",
 			"workspacePicker.pickAriaLabel",
 			"workspacePicker.selectedAriaLabel"
+		],
+		"vs/sessions/contrib/chat/browser/sessionWorkspacePickerModel": [
+			"workspacePicker.experimental"
 		],
 		"vs/sessions/contrib/chat/browser/slashCommands": [
 			"slashCommand.agents",
 			"slashCommand.hooks",
 			"slashCommand.instructions",
 			"slashCommand.models",
-			"slashCommand.skills"
+			"slashCommand.skills",
+			"slashCommand.vscodePet"
 		],
 		"vs/sessions/contrib/chat/browser/variableCompletions": [
 			"activeFile",
 			"fileEntryDescription"
-		],
-		"vs/sessions/contrib/chat/browser/voiceInputDecorations": [
-			"voiceMode.bargeInHint",
-			"voiceMode.bargeInHintNoKb",
-			"voiceMode.clickMicOrBargeInHint",
-			"voiceMode.listening",
-			"voiceMode.pttOrBargeInHint"
 		],
 		"vs/sessions/contrib/chat/browser/webWorkspacePicker": [
 			"scopedWorkspacePicker.selectFolder"
@@ -5765,6 +6205,15 @@
 		"vs/sessions/contrib/codeReview/browser/codeReview.contributions": [
 			"sessions.runCodeReview",
 			"sessions.runCodeReview.tooltip"
+		],
+		"vs/sessions/contrib/customViewTest/browser/customViewTest.contribution": [
+			"hideTestCustomView",
+			"showTestCustomView",
+			"testCustomView.description",
+			"testCustomView.item",
+			"testCustomView.title",
+			"testCustomViewPing",
+			"testCustomViewPinged"
 		],
 		"vs/sessions/contrib/editor/browser/addTabActions": [
 			"newBrowserTab",
@@ -5779,7 +6228,8 @@
 			"maximizeMainEditorPart",
 			"openEditorInModal",
 			"openModalEditorInEditor",
-			"restoreMainEditorPart"
+			"restoreMainEditorPart",
+			"showMainEditorPart"
 		],
 		"vs/sessions/contrib/editor/browser/emptyFileEditor": [
 			"emptyFileEditor.description",
@@ -5814,12 +6264,54 @@
 		"vs/sessions/contrib/files/browser/workspaceFolderActions": [
 			"agentSessions.files",
 			"agentSessions.openFilesView.ariaLabel",
-			"agentSessions.openFilesView.tooltip"
+			"agentSessions.openFilesView.tooltip",
+			"agentSessions.openFilesView.worktreePending",
+			"agentSessions.openFilesView.worktreePendingAriaLabel"
+		],
+		"vs/sessions/contrib/github/browser/createSessionFromPullRequestAction": [
+			"createSessionFromPullRequest",
+			"createSessionFromPullRequest.error",
+			"createSessionFromPullRequest.fetching",
+			"createSessionFromPullRequest.groupLoadError",
+			"createSessionFromPullRequest.loadError",
+			"createSessionFromPullRequest.noGitHubRepository",
+			"createSessionFromPullRequest.placeholder",
+			"createSessionFromPullRequest.resolveGitHubRepositoryError",
+			"createSessionFromPullRequest.resolvingRepository",
+			"createSessionFromPullRequest.title",
+			"pullRequests.assignedToMe",
+			"pullRequests.waitingForMyReview"
+		],
+		"vs/sessions/contrib/github/browser/issueActions": [
+			"agentSessions.openIssue",
+			"agentSessions.openIssue.count",
+			"agentSessions.openIssue.tooltip",
+			"agentSessions.openIssue.tooltipMany",
+			"agentSessions.openIssue.tooltipWithNumber"
+		],
+		"vs/sessions/contrib/github/browser/issueHover": [
+			"agentSessions.issueHover.bodyFallback",
+			"agentSessions.issueHover.onDate",
+			"agentSessions.issueHover.titleFallback"
 		],
 		"vs/sessions/contrib/github/browser/pullRequestActions": [
+			"agentSessions.copyPullRequestUrl",
 			"agentSessions.openPullRequest",
+			"agentSessions.openPullRequest.count",
 			"agentSessions.openPullRequest.tooltip",
-			"agentSessions.openPullRequest.tooltipWithNumber"
+			"agentSessions.openPullRequest.tooltipMany",
+			"agentSessions.openPullRequest.tooltipWithNumber",
+			"agentSessions.pullRequestList.closed",
+			"agentSessions.pullRequestList.draft",
+			"agentSessions.pullRequestList.failingChecks",
+			"agentSessions.pullRequestList.failingChecksAndUnresolvedComments",
+			"agentSessions.pullRequestList.label",
+			"agentSessions.pullRequestList.labelWithAttention",
+			"agentSessions.pullRequestList.labelWithTitle",
+			"agentSessions.pullRequestList.merged",
+			"agentSessions.pullRequestList.open",
+			"agentSessions.pullRequestList.pullRequest",
+			"agentSessions.pullRequestList.unresolvedComments"
 		],
 		"vs/sessions/contrib/github/browser/pullRequestHover": [
 			"agentSessions.pullRequestHover.baseFallback",
@@ -5827,6 +6319,14 @@
 			"agentSessions.pullRequestHover.headFallback",
 			"agentSessions.pullRequestHover.onDate",
 			"agentSessions.pullRequestHover.titleFallback"
+		],
+		"vs/sessions/contrib/github/browser/pullRequestPicker": [
+			"pullRequest.ariaLabel",
+			"pullRequest.context.tooltip",
+			"pullRequest.detail",
+			"pullRequests.assignedToMe",
+			"pullRequests.other",
+			"pullRequests.waitingForMyReview"
 		],
 		"vs/sessions/contrib/layout/browser/baseSessionLayoutController": [
 			"agentSecondarySidebarToggleClosedIcon",
@@ -5840,8 +6340,32 @@
 			"sessions.layout.autoCollapseSessionsSidebar",
 			"sessions.layout.singlePaneDetailPanel"
 		],
-		"vs/sessions/contrib/layout/browser/singlePane/singlePaneResponsiveSidebarStrategy": [
+		"vs/sessions/contrib/layout/browser/singlePane/singlePaneExistingSessionStrategy": [
 			"toggleDetails"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/newSessionViewV3Prompt": [
+			"sessions.onboarding.newSessionViewV3.githubPrompt.ciFailure",
+			"sessions.onboarding.newSessionViewV3.githubPrompt.issue",
+			"sessions.onboarding.newSessionViewV3.githubPrompt.mergeConflict",
+			"sessions.onboarding.newSessionViewV3.githubPrompt.reviewComments",
+			"sessions.onboarding.newSessionViewV3.options.fixBug.description",
+			"sessions.onboarding.newSessionViewV3.options.fixBug.placeholder",
+			"sessions.onboarding.newSessionViewV3.options.fixBug.prompt",
+			"sessions.onboarding.newSessionViewV3.options.fixBug.title",
+			"sessions.onboarding.newSessionViewV3.options.fixCi.description",
+			"sessions.onboarding.newSessionViewV3.options.fixCi.placeholder",
+			"sessions.onboarding.newSessionViewV3.options.fixCi.prompt",
+			"sessions.onboarding.newSessionViewV3.options.fixCi.title",
+			"sessions.onboarding.newSessionViewV3.options.githubCi.title",
+			"sessions.onboarding.newSessionViewV3.options.githubConflicts.title",
+			"sessions.onboarding.newSessionViewV3.options.githubIssue.title",
+			"sessions.onboarding.newSessionViewV3.options.githubReview.title",
+			"sessions.onboarding.newSessionViewV3.options.implementFeature.description",
+			"sessions.onboarding.newSessionViewV3.options.implementFeature.placeholder",
+			"sessions.onboarding.newSessionViewV3.options.implementFeature.prompt",
+			"sessions.onboarding.newSessionViewV3.options.implementFeature.title",
+			"sessions.onboarding.newSessionViewV3.prompt.taskPlaceholder",
+			"sessions.onboarding.newSessionViewV3.prompt.text"
 		],
 		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour": [
 			"sessions.onboarding.isolation.description",
@@ -5856,6 +6380,16 @@
 			"sessions.onboarding.newSessionView.isolation.title",
 			"sessions.onboarding.newSessionView.workspace.description",
 			"sessions.onboarding.newSessionView.workspace.title"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTourShared": [
+			"sessions.onboarding.newSessionViewV2.workspace.description",
+			"sessions.onboarding.newSessionViewV2.workspace.title"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewV2Tour": [
+			"sessions.onboarding.newSessionViewV2.harness.description",
+			"sessions.onboarding.newSessionViewV2.harness.title",
+			"sessions.onboarding.newSessionViewV2.model.description",
+			"sessions.onboarding.newSessionViewV2.model.title"
 		],
 		"vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked": [
 			"accountGate.approvedOrgs",
@@ -5873,39 +6407,6 @@
 			"policyBlocked.openVSCode",
 			"policyBlocked.title"
 		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution": [
-			"sessions.promptTimeline.rail",
-			"sessions.promptTimeline.stickyHeader"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineActions": [
-			"promptTimeline.category",
-			"promptTimeline.emptyPrompt",
-			"promptTimeline.goToPrompt",
-			"promptTimeline.nFiles",
-			"promptTimeline.oneFile",
-			"promptTimeline.pickPlaceholder",
-			"promptTimeline.statDetail"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineCard": [
-			"promptTimeline.groupedCount",
-			"promptTimeline.nFiles",
-			"promptTimeline.noEdits",
-			"promptTimeline.oneFile",
-			"promptTimeline.reviewChangesForPrompt"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineModel": [
-			"promptTimeline.reviewTitle",
-			"promptTimeline.tick",
-			"promptTimeline.tickGrouped"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail": [
-			"promptTimeline.railLabel"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader": [
-			"promptTimeline.emptyPrompt",
-			"promptTimeline.stickyCount",
-			"promptTimeline.stickyLabel"
-		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker": [
 			"agentHostAgentPicker"
 		],
@@ -5919,6 +6420,11 @@
 			"agentHostCodexApprovalsPicker.triggerAriaLabel",
 			"codexApprovals.learnMore"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification": [
+			"agentHost.discoveredConfig.description",
+			"agentHost.discoveredConfig.message",
+			"agentHost.discoveredConfig.signIn"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
 			"agentHostModePicker.ariaLabel",
 			"agentHostModePicker.triggerAriaLabel"
@@ -5930,7 +6436,8 @@
 			"agentHostPermissionPicker.assistedHover",
 			"agentHostPermissionPicker.autoApproveHover",
 			"agentHostPermissionPicker.autopilotApprovalsHover",
-			"agentHostPermissionPicker.defaultApprovalsHover"
+			"agentHostPermissionPicker.defaultApprovalsHover",
+			"agentHostPermissionPicker.manual.label"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
 			"copySessionBranchName"
@@ -5982,6 +6489,22 @@
 			"agentSessions.runSkill.merge",
 			"agentSessions.runSkill.updatePR"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentMergeActions": [
+			"agentMerge.action.addressReviews",
+			"agentMerge.action.fixCI",
+			"agentMerge.action.mergePullRequest",
+			"agentMerge.action.reset",
+			"agentMerge.action.reset.complete",
+			"agentMerge.action.reset.description",
+			"agentMerge.action.resolveConflicts",
+			"agentMerge.action.select",
+			"agentMerge.action.updated",
+			"agentMerge.configure",
+			"agentMerge.disable",
+			"agentMerge.disabled",
+			"agentMerge.enable",
+			"agentMerge.enabled"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentSessionSettings.contribution": [
 			"agentSessionSettings.label",
 			"openSessionSettings"
@@ -6004,11 +6527,12 @@
 			"notConnectedSend",
 			"sessionNotCommitted"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/codexCustomizationSettings.contribution": [
+			"codexCustomizationSettings.navigationDescription",
+			"codexCustomizationSettings.navigationLabel"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
 			"exportAgentHostDebugLogs"
-		],
-		"vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution": [
-			"sessions.chat.agentHost.defaultSessionsProvider"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider": [
 			"localAgentHostLabel"
@@ -6016,37 +6540,17 @@
 		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
 			"openSessionEventsFile"
 		],
-		"vs/sessions/contrib/providers/agentHost/browser/openSubagentChat": [
-			"chat.subagent.openChat",
-			"chat.subagent.openChat.aria"
-		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker": [
 			"branchPicker.select",
 			"isolationMode.worktree",
 			"isolationPicker.checkboxAriaLabel",
 			"isolationPicker.noGitRepo"
 		],
-		"vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker": [
-			"claude.permissionMode.acceptEdits",
-			"claude.permissionMode.acceptEdits.description",
-			"claude.permissionMode.auto",
-			"claude.permissionMode.auto.description",
-			"claude.permissionMode.bypass",
-			"claude.permissionMode.bypass.description",
-			"claude.permissionMode.default",
-			"claude.permissionMode.default.description",
-			"claude.permissionMode.plan",
-			"claude.permissionMode.plan.description",
-			"claudePermissionModePicker.ariaLabel",
-			"claudePermissionModePicker.triggerAriaLabel"
-		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution": [
-			"sessions.chat.claudeAgent.enabled",
 			"sessions.github.copilot.multiChatSessions"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
 			"branchPicker",
-			"claudePermissionModePicker",
 			"modePicker",
 			"permissionPicker"
 		],
@@ -6062,7 +6566,6 @@
 			"uncommittedChangesDescription"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider": [
-			"claudeCode",
 			"copilotChatSessionsProvider",
 			"copilotCloud",
 			"deleteChat.confirm",
@@ -6070,8 +6573,7 @@
 			"deleteChat.detail",
 			"new chat",
 			"new session",
-			"repositories",
-			"sessionWorkspaceGroup.github"
+			"repositories"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/mobilePermissionPicker": [
 			"permissionPicker.title",
@@ -6099,17 +6601,8 @@
 			"permissions.learnMore",
 			"permissions.policyDescription"
 		],
-		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution": [
-			"sessions.chat.localAgent.enabled"
-		],
-		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider": [
-			"deleteChat.confirm",
-			"deleteChat.delete",
-			"deleteChat.detail",
-			"localChatSessionsProvider",
-			"localSession",
-			"newChat",
-			"newSession"
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxReadOnlySessionHandler": [
+			"cloudSandbox.truncatedHistory"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/manageRemoteAgentHosts": [
 			"manageHosts.actionsHeader",
@@ -6120,6 +6613,7 @@
 			"manageRemoteAgentHosts"
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution": [
+			"chat.agentHost.cloudSandbox.enabled",
 			"chat.agentHost.forwardSSHAgent",
 			"chat.agentHost.localFilePermissions",
 			"chat.agentHost.localFilePermissions.read",
@@ -6194,8 +6688,17 @@
 			"tunnelAuthFailed",
 			"tunnelConnectFailed",
 			"tunnelConnecting",
+			"tunnelDeleteButton",
+			"tunnelDeleteConfirmation",
+			"tunnelDeleteDetail",
+			"tunnelDeleteFailed",
+			"tunnelDeleteTooltip",
 			"tunnelListFailed",
 			"tunnelNoneFound",
+			"tunnelNoneFoundAfterDelete",
+			"tunnelOnlyLocalFound",
+			"tunnelPickOffline",
+			"tunnelPickOnline",
 			"tunnelPickPlaceholder",
 			"tunnelPickTitle",
 			"updateRemoteAgentHost",
@@ -6233,6 +6736,7 @@
 			"agentHostIncompatibleNotification",
 			"agentHostIncompatibleShowOptions",
 			"agentHostIncompatibleUpdate",
+			"workspacePicker.changeLocationPreference",
 			"workspacePicker.copyAddress",
 			"workspacePicker.hoverConnected",
 			"workspacePicker.hoverConnectedAddr",
@@ -6244,6 +6748,10 @@
 			"workspacePicker.hoverIncompatibleAddr",
 			"workspacePicker.incompatibleValidationClient",
 			"workspacePicker.incompatibleValidationServer",
+			"workspacePicker.locationPreferenceReconnectFailed",
+			"workspacePicker.locationPreferenceReconnecting",
+			"workspacePicker.locationPreferenceSavedNoProvider",
+			"workspacePicker.locationPreferenceUpdated",
 			"workspacePicker.openSettings",
 			"workspacePicker.reconnect",
 			"workspacePicker.remoteOptionsTitle",
@@ -6263,6 +6771,22 @@
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution": [
 			"tunnelConnecting"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/electron-browser/forgetSSHHostKeyCommand": [
+			"forgetSSHHostKey",
+			"forgetSSHHostKey.forgotMany",
+			"forgetSSHHostKey.forgotOne",
+			"forgetSSHHostKey.none",
+			"forgetSSHHostKey.placeholder"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/electron-browser/remoteAgentHostLocationPreferenceCommand": [
+			"changeRemoteAgentHostLocationPreference",
+			"remoteAgentHostLocation.noHosts",
+			"remoteAgentHostLocation.pickHost"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl": [
+			"tunnelAgentHostFailoverNotification",
+			"tunnelAgentHostRejectedEditorNotification"
 		],
 		"vs/sessions/contrib/search/browser/search.contribution": [
 			"findInFolder",
@@ -6305,6 +6829,7 @@
 			"oneSessionTerminalApproval"
 		],
 		"vs/sessions/contrib/sessions/browser/blockedSessionsList": [
+			"allInputNeededIgnored",
 			"ciFailureIgnored",
 			"ignoreCIFailure",
 			"ignoreInputNeeded",
@@ -6313,7 +6838,7 @@
 		],
 		"vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution": [
 			"agents",
-			"automations",
+			"harnessSettings",
 			"hooks",
 			"instructions",
 			"mcpServers",
@@ -6327,13 +6852,19 @@
 			"mobileOpenFileDiff",
 			"mobileOpenSessionChanges"
 		],
+		"vs/sessions/contrib/sessions/browser/sessionDetailsAction": [
+			"sessions.details.editorTitle",
+			"sessions.showSessionDetails"
+		],
 		"vs/sessions/contrib/sessions/browser/sessionHoverContent": [
 			"agentSessions.fileChanged",
-			"agentSessions.filesChanged"
+			"agentSessions.filesChanged",
+			"agentSessions.worktreePending"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"agentSessions.view.label",
 			"agentSessionsViewIcon",
+			"chat.toggleInputWindow",
 			{
 				"key": "miSessions",
 				"comment": [
@@ -6362,6 +6893,8 @@
 			"deleteActiveChat",
 			"focusActiveSession",
 			"focusLastSessionInGrid",
+			"focusNextChatGroup",
+			"focusPreviousChatGroup",
 			"focusSessionInGrid",
 			{
 				"key": "miSessionsBack",
@@ -6375,6 +6908,8 @@
 					"&& denotes a mnemonic"
 				]
 			},
+			"moveChatToNextGroup",
+			"moveChatToPreviousGroup",
 			"navigateNextChat",
 			"navigatePreviousChat",
 			"newChatButtonAriaLabel",
@@ -6393,49 +6928,147 @@
 			"quickSwitchPreviousChat",
 			"recentlyOpened",
 			"renameSessionHeader",
+			"reopenLastClosedItem",
 			"searchChats",
 			"searchSessions",
 			"sessionsGoBack",
 			"sessionsGoBackTooltip",
 			"sessionsGoForward",
 			"sessionsGoForwardTooltip",
+			"sessionsPickerNeedsInput",
+			"sessionsPickerUnread",
 			"showChatsPicker",
 			"showSessionsPicker",
+			"splitChatGroupDown",
+			"splitChatGroupRight",
 			"untitledChat"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget": [
 			"agentSessionsControl",
 			"agentSessionsShowSessions",
+			"closeBlockedSessions",
+			"ignoreAllInputNeeded",
 			"nSessionsApproved",
 			"oneSessionApproved",
 			"showAllSessions",
 			"showSessions"
 		],
+		"vs/sessions/contrib/sessions/browser/views/automationsAccessibility": [
+			"automationsAccessibleView.automation",
+			"automationsAccessibleView.automationDisabled",
+			"automationsAccessibleView.completed",
+			"automationsAccessibleView.daily",
+			"automationsAccessibleView.empty",
+			"automationsAccessibleView.failed",
+			"automationsAccessibleView.history",
+			"automationsAccessibleView.hourly",
+			"automationsAccessibleView.manual",
+			"automationsAccessibleView.noRuns",
+			"automationsAccessibleView.pending",
+			"automationsAccessibleView.prompt",
+			"automationsAccessibleView.run",
+			"automationsAccessibleView.runError",
+			"automationsAccessibleView.running",
+			"automationsAccessibleView.schedule",
+			"automationsAccessibleView.title",
+			"automationsAccessibleView.unknown",
+			"automationsAccessibleView.weekly",
+			"automationsCustomView.help.accessibleView",
+			"automationsCustomView.help.cards",
+			"automationsCustomView.help.history",
+			"automationsCustomView.help.overview",
+			"automationsCustomView.help.read"
+		],
+		"vs/sessions/contrib/sessions/browser/views/automationsView": [
+			"automationActions",
+			"automationAlreadyRunningStatus",
+			"automationCard",
+			"automationChangedDuringEdit",
+			"automationCreatedStatus",
+			"automationCreateFailed",
+			"automationDeletedDuringEdit",
+			"automationDeletedStatus",
+			"automationDeleteFailed",
+			"automationMarkAllReadFailed",
+			"automationNotStartedStatus",
+			"automationRunActionFailed",
+			"automationRunHistoryDeleteFailed",
+			"automationRunOpenFailed",
+			"automationRunSessionDeletedStatus",
+			"automationRunSessionDeleteFailed",
+			"automationRunSessionStopFailed",
+			"automationRunSessionStoppedStatus",
+			"automationRunWorking",
+			"automationRunWorkingAriaLabel",
+			"automationsDescription",
+			"automationsDisabledBeforeSave",
+			"automationsDisabledDetail",
+			"automationsDisabledTitle",
+			"automationStartedStatus",
+			"automationsTitle",
+			"automationUpdatedStatus",
+			"automationUpdateFailed",
+			"confirmDeleteAutomation",
+			"confirmDeleteAutomationRunSession",
+			"confirmDeleteAutomationRunSessionDetail",
+			"confirmDeleteDetail",
+			"createAutomation",
+			"delete",
+			"deleteAutomation",
+			"deleteAutomationRunSessionAction",
+			"disabled",
+			"editAutomationNamed",
+			"historyHeader",
+			"lastWeek",
+			"markAllRead",
+			"newAutomation",
+			"noAutomationsDesc",
+			"noAutomationsYet",
+			"quickChat",
+			"running",
+			"runNow",
+			"scheduleDailyAt",
+			"scheduleHourly",
+			"scheduleManual",
+			"scheduleWeeklyAt",
+			"stopAutomationRunSessionAction",
+			"today",
+			"unknownAutomation",
+			"yesterday"
+		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
 			"addToGroupAction",
 			"allowAction",
 			"allowActionOnce",
-			"archived",
+			"automations",
+			"automationsActiveAria",
+			"automationsNeedsInputAria",
+			"automationsUnreadRunAria",
 			"chatsSection",
 			"ci.blockedRow",
 			"ci.fixCI",
 			"ci.fixCITooltip",
 			"createGroupAction",
 			"deleteGroupAction",
-			"failed",
 			"moveToGroupAction",
-			"needsInput",
 			"newGroupName",
 			"noChats",
+			"noSessionInGroup",
+			"noSessionInGroupHover",
 			"older",
 			"pendingVoiceResponse",
 			"pinned",
+			"quickChatBadge",
 			"recent",
 			"removeFromGroupAction",
 			"renameGroupAction",
 			"secondsDuration",
 			"sessionGroupName",
 			"sessionItemAria",
+			"sessionItemQuickChatAria",
+			"sessionItemWorkspaceAria",
+			"sessionItemWorktreePendingAria",
+			"sessionPlaceholderAria",
 			"sessions.dragLabel",
 			"sessionsList",
 			"showLessAria",
@@ -6448,11 +7081,9 @@
 			"showMoreWorkspaceCompact",
 			"showMoreWorkspacesAria",
 			"showMoreWorkspacesCompact",
-			"unknown",
-			"working"
+			"unknown"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsView": [
-			"filterArchived",
 			"filterRead",
 			"groupByTime",
 			"groupByWorkspace",
@@ -6469,20 +7100,17 @@
 			"statusNeedsInput"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
-			"archiveGroupSessions.archive",
+			"archiveGroupSession.confirmSingle",
 			"archiveGroupSessions.confirm",
-			"archiveGroupSessions.confirmSingle",
 			"archiveGroupSessions.detail",
+			"archivePinnedSectionSession.confirmSingle",
 			"archivePinnedSectionSessions.confirm",
-			"archivePinnedSectionSessions.confirmSingle",
-			"archiveSection",
-			"archiveSectionSessions.archive",
+			"archiveSectionSession.confirmSingle",
 			"archiveSectionSessions.confirm",
-			"archiveSectionSessions.confirmSingle",
 			"archiveSectionSessions.detail",
-			"archiveSession",
 			"closeSession",
 			"collapseAllGroups",
+			"deleteEmptyGroup",
 			"deleteSession",
 			"deleteSession.confirm",
 			"deleteSession.delete",
@@ -6496,9 +7124,18 @@
 			"find",
 			"groupByTime",
 			"groupByWorkspace",
-			"markAllInGroupAsDone",
+			"manageAutomations",
+			"markAllAutomationRunsRead",
 			"markAllRead",
+			"markGroupSessionDone.confirmSingle",
+			"markGroupSessionsDone.confirm",
+			"markGroupSessionsDone.detail",
+			"markPinnedSectionSessionDone.confirmSingle",
+			"markPinnedSectionSessionsDone.confirm",
 			"markRead",
+			"markSectionSessionDone.confirmSingle",
+			"markSectionSessionsDone.confirm",
+			"markSectionSessionsDone.detail",
 			"markUnread",
 			"navigateNextSession",
 			"navigateNextSession.mnemonic",
@@ -6513,12 +7150,10 @@
 			"renameSession",
 			"renameSession.empty",
 			"renameSession.prompt",
-			"restore",
 			"showAllSessions",
 			"showRecentSessions",
 			"sortByCreated",
 			"sortByUpdated",
-			"unarchiveSession",
 			"unpinSession"
 		],
 		"vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner": [
@@ -6526,8 +7161,6 @@
 		],
 		"vs/sessions/contrib/terminal/browser/sessionsTerminalContribution": [
 			"dumpTerminalTracking",
-			"hideTerminal",
-			"openInTerminal",
 			"showAllTerminals"
 		],
 		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution": [
@@ -6535,7 +7168,9 @@
 		],
 		"vs/sessions/electron-browser/actions/vscodeActions": [
 			"openInVSCode",
-			"openVSCodeWindow"
+			"openVSCodeWindow",
+			"returnToVSCodeEditor",
+			"shouldShowReturnToVSCodeEditor"
 		],
 		"vs/sessions/electron-browser/parts/titlebarPart": [
 			"agentsWindowTitle"
@@ -6543,11 +7178,21 @@
 		"vs/sessions/electron-browser/sessions.main": [
 			"join.closeStorage"
 		],
+		"vs/sessions/services/sessions/browser/sessionsManagementService": [
+			"sessions.cancelCurrentRequest.loadFailed"
+		],
+		"vs/sessions/services/sessions/browser/sessionsService": [
+			"sessionsService.trustFolderMessage"
+		],
 		"vs/sessions/services/sessions/common/session": [
 			"agentSessions.newChat",
 			"agentSessions.newSession",
+			"failed",
+			"needsInput",
+			"sessionWorkspaceGroup.github",
 			"sessionWorkspaceGroup.local",
-			"sessionWorkspaceGroup.remote"
+			"sessionWorkspaceGroup.remote",
+			"working"
 		],
 		"vs/sessions/services/workspace/browser/workspaceContextService": [
 			"agentsWindow"
@@ -6600,6 +7245,12 @@
 		"vs/workbench/api/browser/mainThreadCustomEditors": [
 			"defaultEditLabel",
 			"vetoExtHostRestart"
+		],
+		"vs/workbench/api/browser/mainThreadDataChannels": [
+			"linkPresentation.ruleMismatch",
+			"linkPresentation.unavailable",
+			"linkPresentation.unavailableAriaLabel",
+			"linkPresentation.unavailableTooltip"
 		],
 		"vs/workbench/api/browser/mainThreadEditSessionIdentityParticipant": [
 			"timeout.onWillCreateEditSessionIdentity"
@@ -6816,6 +7467,7 @@
 		"vs/workbench/api/common/configurationExtensionPoint": [
 			"accessibility",
 			"advanced",
+			"config.property.agentHost.unsupported",
 			"config.property.agentsWindow.proposed",
 			"config.property.defaultConfiguration.warning",
 			"config.property.duplicate",
@@ -6934,9 +7586,16 @@
 			"contributes.jsonValidation",
 			"contributes.jsonValidation.fileMatch",
 			"contributes.jsonValidation.url",
+			"contributes.jsonValidationRegistry",
+			"contributes.jsonValidationRegistry.url",
 			"fileMatch",
 			"invalid.fileMatch",
 			"invalid.jsonValidation",
+			"invalid.jsonValidationRegistry",
+			"invalid.jsonValidationRegistry.fileschema",
+			"invalid.jsonValidationRegistry.path",
+			"invalid.jsonValidationRegistry.schema",
+			"invalid.jsonValidationRegistry.url",
 			"invalid.path.1",
 			"invalid.url",
 			"invalid.url.fileschema",
@@ -6971,6 +7630,10 @@
 			},
 			"machine",
 			"policyDiagnostics",
+			"policyDiagnostics.editorTitle",
+			"policyDiagnostics.previewError",
+			"policyDiagnostics.previewMissingResource",
+			"policyDiagnostics.progress",
 			"profile",
 			"removeLargeStorageDatabaseEntries",
 			{
@@ -7421,6 +8084,10 @@
 			"notebookCellOutputLabel",
 			"notebookCellOutputLabelSimple"
 		],
+		"vs/workbench/browser/layout": [
+			"auxiliaryBarHidden",
+			"auxiliaryBarVisible"
+		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"activity bar position",
 			"activity bar size",
@@ -7466,8 +8133,6 @@
 			"top"
 		],
 		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
-			"auxiliaryBarHidden",
-			"auxiliaryBarVisible",
 			"closeIcon",
 			"closeSecondarySideBar",
 			"closeSecondarySideBar",
@@ -8000,6 +8665,7 @@
 			"closeEditorsInOtherGroups",
 			"closeEditorsToTheLeft",
 			"closeOneEditor",
+			"closeOthers",
 			"confirmClearDetail",
 			"confirmClearEditorHistoryMessage",
 			"confirmClearRecentsMessage",
@@ -8234,6 +8900,11 @@
 				]
 			}
 		],
+		"vs/workbench/browser/parts/editor/editorHeaderControl": [
+			"ariaLabelEditorHeaderActions",
+			"ariaLabelEditorHeaderLayoutActions",
+			"ariaLabelEditorHeaderPrimaryActions"
+		],
 		"vs/workbench/browser/parts/editor/editorPanes": [
 			"editorOpenErrorDialog",
 			{
@@ -8333,6 +9004,8 @@
 			}
 		],
 		"vs/workbench/browser/parts/editor/editorTabsControl": [
+			"addTab",
+			"ariaLabelAddTab",
 			"ariaLabelEditorActions",
 			"ariaLabelEditorActionsLayout",
 			"draggedEditorGroup"
@@ -8354,7 +9027,8 @@
 			"toggleSidebar"
 		],
 		"vs/workbench/browser/parts/editor/multiEditorTabsControl": [
-			"addTab",
+			"altClick",
+			"altClickMac",
 			"ariaLabelTabActions"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
@@ -8790,6 +9464,7 @@
 			"unableToOpenWindowDetail"
 		],
 		"vs/workbench/browser/workbench.contribution": [
+			"accountsShowAvatar",
 			"activeEditorLanguageId",
 			"activeEditorLong",
 			"activeEditorMedium",
@@ -8906,6 +9581,12 @@
 			"menuBarVisibility.mac",
 			"mergeWindow",
 			"modernUI",
+			{
+				"key": "modernUIUppercaseViewHeaders",
+				"comment": [
+					"{0} is a placeholder for a setting identifier."
+				]
+			},
 			"mouseBackForwardToNavigate",
 			{
 				"key": "navigationControlEnabled",
@@ -9099,6 +9780,7 @@
 			"workbench.editor.splitSizingDistribute",
 			"workbench.editor.splitSizingSplit",
 			"workbench.editor.tabActionCloseVisibility",
+			"workbench.editor.tabActionReserveSpace",
 			"workbench.editor.tabActionUnpinVisibility",
 			{
 				"comment": [
@@ -9204,6 +9886,7 @@
 			"activeCustomEditorTextDiff",
 			"activeEditor",
 			"activeEditorAvailableEditorIds",
+			"activeEditorCannotClose",
 			"activeEditorCanRevert",
 			"activeEditorCanToggleReadonly",
 			"activeEditorGroupEmpty",
@@ -9231,6 +9914,7 @@
 			"editorPartModalNavigation",
 			"editorPartModalSidebar",
 			"editorPartModalSidebarVisible",
+			"editorPartModalVisible",
 			"editorPartMultipleEditorGroups",
 			"editorTabsVisible",
 			"embedderIdentifier",
@@ -9267,6 +9951,7 @@
 			"resourcePath",
 			"resourceScheme",
 			"resourceSet",
+			"secondarySideBarVisible",
 			"SelectedEditorsInGroupFileOrUntitledResourceContextKey",
 			"sideBarFocus",
 			"sideBarVisible",
@@ -9327,6 +10012,7 @@
 			"commandCenter-foreground",
 			"commandCenter-inactiveBorder",
 			"commandCenter-inactiveForeground",
+			"editorBorder",
 			"editorDragAndDropBackground",
 			"editorDropIntoPromptBackground",
 			"editorDropIntoPromptBorder",
@@ -9343,6 +10029,24 @@
 			"menubarSelectionBackground",
 			"menubarSelectionBorder",
 			"menubarSelectionForeground",
+			"modernActivityBarActiveBackground",
+			"modernActivityBarActiveForeground",
+			"modernActivityBarHoverBackground",
+			"modernActivityBarHoverForeground",
+			"modernEditorTabActiveActionBackground",
+			"modernEditorTabActiveBackground",
+			"modernEditorTabActiveForeground",
+			"modernEditorTabActiveHoverActionBackground",
+			"modernEditorTabActiveHoverBackground",
+			"modernEditorTabHoverActionBackground",
+			"modernEditorTabHoverBackground",
+			"modernEditorTabHoverForeground",
+			"modernEditorTabInactiveBackground",
+			"modernEditorTabSelectedActionBackground",
+			"modernTabActiveBackground",
+			"modernTabActiveForeground",
+			"modernTabHoverBackground",
+			"modernTabHoverForeground",
 			"notificationCenterBorder",
 			"notificationCenterHeaderBackground",
 			"notificationCenterHeaderForeground",
@@ -9424,6 +10128,9 @@
 			"statusBarWarningItemForeground",
 			"statusBarWarningItemHoverBackground",
 			"statusBarWarningItemHoverForeground",
+			"surfaceBackground",
+			"surfaceBorder",
+			"surfaceForeground",
 			"tabActiveBackground",
 			"tabActiveBorder",
 			"tabActiveBorderTop",
@@ -9613,6 +10320,7 @@
 			"speechLanguage.auto",
 			"terminal.integrated.accessibleView.closeOnKeyPress",
 			"verbosity.automations",
+			"verbosity.browserElementCommenting",
 			"verbosity.chat.description",
 			"verbosity.chatQuestionCarousel",
 			"verbosity.comments",
@@ -9707,6 +10415,7 @@
 			"openDiffEditorAnnouncement"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution": [
+			"agents.voice.agentProgress",
 			"agents.voice.backendUrl",
 			"agents.voice.enabled",
 			"agents.voice.handsFree",
@@ -9722,32 +10431,29 @@
 			"agents.voice.language.pt",
 			"agents.voice.language.zh",
 			"agents.voice.liveTranscript",
+			"agents.voice.showButton",
 			"agents.voice.showTranscript",
 			"agents.voice.speakResponses",
 			"agents.voice.turn.silenceMs",
 			"agents.voice.turn.silenceMs.disabled",
 			"agents.voice.turn.stopPhrases",
 			"agents.voice.voice",
-			"agents.voice.voice.daniel",
-			"agents.voice.voice.kevin",
-			"agents.voice.voice.maya",
-			"agents.voice.voice.victoria",
+			"agents.voice.voice.birch",
+			"agents.voice.voice.harper",
+			"agents.voice.voice.junho",
+			"agents.voice.voice.oak",
 			"agentsVoice.cancelActiveRequest",
 			"agentsVoice.connecting",
 			"agentsVoice.disconnect",
+			"agentsVoice.onboardingNeedsChat",
 			"agentsVoice.openSettings",
 			"agentsVoice.pttStopInChat",
-			"agentsVoice.selectMicrophone",
+			"agentsVoice.showOnboarding",
 			"agentsVoice.simulateConnection",
 			"agentsVoice.startVoiceInChat",
 			"agentsVoiceConfigurationTitle",
 			"agentsVoicePushToTalk",
-			"current",
-			"noMicrophones",
-			"resetAgentsVoiceOnboarding",
-			"selectMic",
-			"systemDefault",
-			"unknownDevice"
+			"resetAgentsVoiceOnboarding"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscripts.contribution": [
 			"agentsVoice.showTranscripts",
@@ -9772,6 +10478,41 @@
 			"voiceTranscripts.older",
 			"voiceTranscripts.today",
 			"voiceTranscripts.yesterday"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding": [
+			"voiceMode.onboarding.close",
+			{
+				"key": "voiceMode.onboarding.description",
+				"comment": [
+					"Preserve the double square brackets: they mark the text that becomes a link. Keep both links, in this order - the first opens Voice Mode settings, the second opens the voice.md customization file."
+				]
+			},
+			"voiceMode.onboarding.microphone",
+			"voiceMode.onboarding.microphoneSelected",
+			"voiceMode.onboarding.region",
+			"voiceMode.onboarding.regionDescription",
+			"voiceMode.onboarding.systemDefault",
+			"voiceMode.onboarding.title",
+			"voiceMode.onboarding.voice.ariaLabel",
+			"voiceMode.onboarding.voice.aruha",
+			"voiceMode.onboarding.voice.birch",
+			"voiceMode.onboarding.voice.david",
+			"voiceMode.onboarding.voice.eva",
+			"voiceMode.onboarding.voice.gil",
+			"voiceMode.onboarding.voice.harper",
+			"voiceMode.onboarding.voice.jiyon",
+			"voiceMode.onboarding.voice.junho",
+			"voiceMode.onboarding.voice.localizedPlaying",
+			"voiceMode.onboarding.voice.localizedStopped",
+			"voiceMode.onboarding.voice.marc",
+			"voiceMode.onboarding.voice.maria",
+			"voiceMode.onboarding.voice.oak",
+			"voiceMode.onboarding.voice.previewAriaLabel",
+			"voiceMode.onboarding.voice.previewStopped",
+			"voiceMode.onboarding.voice.selected",
+			"voiceMode.onboarding.voice.stopPreview",
+			"voiceMode.onboarding.voice.wuzhi",
+			"voiceMode.onboarding.voices"
 		],
 		"vs/workbench/contrib/agentsVoice/common/agentsVoiceColors": [
 			"agentsVoice.speakingBackground",
@@ -9915,7 +10656,19 @@
 			"browserCategory"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/browserView.contribution": [
-			"browser.editorLabel"
+			"browser.editorLabel",
+			"browser.htmlEditorLabel"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserAutoReloadFeatures": [
+			{
+				"comment": [
+					"This is the description for a setting."
+				],
+				"key": "browser.autoReloadOnFileChange"
+			},
+			"browser.refreshAutomatically",
+			"browser.reloadAutomaticRefreshEnabled",
+			"browser.reloadMenu"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserDataStorageFeatures": [
 			"browser.clearEphemeralStorageAction",
@@ -9960,6 +10713,7 @@
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures": [
 			"browser.addAreaScreenshotToChatAction",
 			"browser.addConsoleLogsToChatAction",
+			"browser.addElementCommentToChatAction",
 			"browser.addElementToChatAction",
 			"browser.addFullPageScreenshotToChatAction",
 			"browser.addScreenshotToChatAction",
@@ -9969,7 +10723,17 @@
 			"browser.agentSharingContentWarning.ok",
 			"browser.areaSelectionActive",
 			"browser.chatActionsSubmenu",
-			"browser.elementSelectionActive",
+			"browser.elementCommentingAccessibilityHelp.composer",
+			"browser.elementCommentingAccessibilityHelp.continuous",
+			"browser.elementCommentingAccessibilityHelp.navigation",
+			"browser.elementCommentingAccessibilityHelp.overview",
+			"browser.elementCommentingAccessibilityHelp.pins",
+			"browser.elementCommentingDisabled",
+			"browser.elementCommentingEnabled",
+			"browser.elementCommentingEnabledWithAccessibilityHelp",
+			"browser.elementSelectionDisabled",
+			"browser.elementSelectionEnabled",
+			"browser.elementSelectionMode",
 			"browser.enableChatTools",
 			{
 				"comment": [
@@ -9979,6 +10743,7 @@
 			},
 			"browser.shareWithAgent",
 			"browser.sharingWithAgent",
+			"browser.stopElementSelectionAction",
 			"browser.unshareWithAgent",
 			"browserAreaScreenshot",
 			"browserCategory",
@@ -10271,6 +11036,10 @@
 			"hoverElementTool.displayName",
 			"hoverElementTool.userDescription"
 		],
+		"vs/workbench/contrib/browserView/electron-browser/tools/listBrowserPagesTool": [
+			"listBrowserPagesTool.displayName",
+			"listBrowserPagesTool.userDescription"
+		],
 		"vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool": [
 			"browser.goBack.invocation",
 			"browser.goBack.past",
@@ -10362,6 +11131,9 @@
 			"typeBrowserTool.userDescription"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/widgets/browserUrlBarWidget": [
+			"browser.address",
+			"browser.addressLockedAriaLabel",
+			"browser.addressLockedTooltip",
 			"browser.goTo",
 			"browser.urlPlaceholder"
 		],
@@ -10478,6 +11250,8 @@
 			"notificationDetail"
 		],
 		"vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView": [
+			"automationConfigured.created",
+			"automationConfigured.updated",
 			"autoModeResolutionA11y",
 			"autoModeResolutionA11yFallback",
 			"autoModeResolutionA11yNonReasoning",
@@ -10512,23 +11286,38 @@
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"chat.agentHostApprovalsPicker",
 			"chat.announcement",
+			"chat.attachments.inlineReferenceHover",
+			"chat.attachments.inlineReferences",
+			"chat.attachments.pastedText",
 			"chat.attachments.removal",
+			"chat.completedResponseDisclosure",
 			"chat.differencePanel",
 			"chat.differenceQuick",
+			"chat.externalSessionFilter",
 			"chat.fileChangesDisclosure",
+			"chat.find",
 			"chat.focusMostRecentTerminal",
 			"chat.focusMostRecentTerminalOutput",
+			"chat.focusNotice",
 			"chat.focusQuestionCarousel",
-			"chat.focusTip",
 			"chat.inspectResponse",
 			"chat.inspectResponseThinkingToggle",
 			"chat.nextQuestionCarouselQuestion",
 			"chat.overview",
+			"chat.planReviewEditor",
 			"chat.previousQuestionCarouselQuestion",
 			"chat.progressVerbosity",
 			"chat.requestHistory",
 			"chat.showHiddenTerminals",
 			"chat.signals",
+			"chat.speechToText.contextMenu",
+			"chat.stickyPromptHeader",
+			"chat.subagentPill",
+			"chat.voiceInputMode.agentProgress",
+			"chat.voiceInputMode.holdToTalk",
+			"chat.voiceInputMode.segmented",
+			"chat.voiceMode.introduction",
+			"chat.vscodePet",
 			"chatAgent.acceptTool",
 			"chatAgent.autoApprove",
 			"chatAgent.focusTodosView",
@@ -10550,6 +11339,12 @@
 			"chatEditing.saveAllFiles",
 			"chatEditing.sections",
 			"chatEditing.undoKeepSounds",
+			"chatInputWindow.close",
+			"chatInputWindow.dictate",
+			"chatInputWindow.overview",
+			"chatInputWindow.requestHistory",
+			"chatInputWindow.routing",
+			"chatInputWindow.signals",
 			"inlineChat.access",
 			"inlineChat.contextActions",
 			"inlineChat.diff",
@@ -10558,6 +11353,9 @@
 			"inlineChat.overview",
 			"inlineChat.requestHistory",
 			"inlineChat.toolbar",
+			"sessions.requestOrigin",
+			"sessions.selectionSideChat",
+			"sessions.threadCoordinationResult",
 			"workbench.action.chat.announceConfirmation",
 			"workbench.action.chat.cancelSpeechToText",
 			"workbench.action.chat.editing.attachFiles",
@@ -10565,7 +11363,6 @@
 			"workbench.action.chat.focusAgentSessionsViewer",
 			"workbench.action.chat.focusInput",
 			"workbench.action.chat.focusLastFocusedItem",
-			"workbench.action.chat.history",
 			"workbench.action.chat.newChat",
 			"workbench.action.chat.nextCodeBlock",
 			"workbench.action.chat.nextUserPrompt",
@@ -10585,9 +11382,9 @@
 			"chat.category",
 			"chat.editToolApproval.description",
 			"chat.editToolApproval.label",
+			"chat.notice.focusUnavailable",
 			"chat.questionCarousel.focusUnavailable",
 			"chat.showContextUsage",
-			"chat.tip.focusUnavailable",
 			"chat.todoList.focusUnavailable",
 			"chat.toggleDefaultVisibility.label",
 			"chatAndCompletionsQuotaExceeded",
@@ -10614,9 +11411,9 @@
 			"interactiveSession.clearHistory.label",
 			"interactiveSession.compactAgentHostConversation.label",
 			"interactiveSession.focusInput.label",
+			"interactiveSession.focusNotice.label",
 			"interactiveSession.focusQuestionCarousel.label",
 			"interactiveSession.focusQuestionCarouselTerminal.label",
-			"interactiveSession.focusTip.label",
 			"interactiveSession.focusTodosView.label",
 			"interactiveSession.newChatWindow",
 			"interactiveSession.nextQuestion.label",
@@ -10663,7 +11460,9 @@
 			"chatContext.attachScreenshot.labelWeb",
 			"chatContext.editors",
 			"chatContext.sessions",
+			"chatContext.sessions.otherWorkspaces",
 			"chatContext.sessions.placeholder",
+			"chatContext.sessions.thisWorkspace",
 			"chatContext.tools",
 			"chatContext.tools.placeholder",
 			"imageFromClipboard",
@@ -10739,6 +11538,7 @@
 			"interactive.openSessionTargetPicker.label",
 			"interactive.openWorkspacePicker.label",
 			"interactive.submit.label",
+			"interactive.submitPending.label",
 			"interactive.submitWithoutDispatch.label",
 			"interactive.switchToNextModel.label",
 			"interactive.switchToNextPinnedModel.label",
@@ -10752,6 +11552,15 @@
 		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
 			"interactive.nextFileTree.label",
 			"interactive.previousFileTree.label"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatFindActions": [
+			"chat.find",
+			"chat.findNext",
+			"chat.findPrevious",
+			"chat.hideFind",
+			"chat.toggleFindCaseSensitive",
+			"chat.toggleFindRegex",
+			"chat.toggleFindWholeWord"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatForkActions": [
 			"chat.forkConversation.label",
@@ -10833,6 +11642,10 @@
 			"interactive.previousUserPrompt.label"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatQueueActions": [
+			"chat.askInSideChat",
+			"chat.askInSideChat.createFailed",
+			"chat.askInSideChat.tooltip",
+			"chat.askInSideChat.unsupported",
 			"chat.editPendingRequest",
 			"chat.queueMessage",
 			"chat.queueMessage.tooltip",
@@ -10854,16 +11667,18 @@
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions": [
 			"chat.speechToText.cancel",
+			"chat.speechToText.connecting",
 			"chat.speechToText.hold",
 			"chat.speechToText.preparing",
+			"chat.speechToText.resetIntroduction",
 			"chat.speechToText.selectMicrophone",
+			"chat.speechToText.showIntroduction",
 			"chat.speechToText.start",
 			"chat.speechToText.stop",
 			"chatStt.current",
+			"chatStt.introductionNeedsChat",
 			"chatStt.noMicrophones",
-			"chatStt.selectMic",
-			"chatStt.systemDefault",
-			"chatStt.unknownDevice"
+			"chatStt.selectMic"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"chat.retry.confirmation.checkbox",
@@ -10926,6 +11741,17 @@
 			"newUntitledFile",
 			"selectOption"
 		],
+		"vs/workbench/contrib/chat/browser/actions/configureVoiceInstructionsAction": [
+			"configureDictationInstructions",
+			"configureVoiceInstructions",
+			"selectSpeechInstructionsTarget",
+			"selectSpeechInstructionsTargetUntrusted",
+			"userSpeechInstructions",
+			"userSpeechInstructionsDetail",
+			"workspaceSpeechInstructions",
+			"workspaceSpeechInstructionsDetail",
+			"workspaceSpeechInstructionsNamed"
+		],
 		"vs/workbench/contrib/chat/browser/actions/createPluginAction": [
 			"agents",
 			"chat.createPlugin",
@@ -10965,6 +11791,13 @@
 			"openSessionEventsFile.unsupported"
 		],
 		"vs/workbench/contrib/chat/browser/agentPluginActions": [
+			"agentHostPluginDisable",
+			"agentHostPluginDisableSession",
+			"agentHostPluginDisableWorkspace",
+			"agentHostPluginEnable",
+			"agentHostPluginEnableContainer",
+			"agentHostPluginEnableSession",
+			"agentHostPluginEnableWorkspace",
 			"disable",
 			"disableForWorkspace",
 			"enable",
@@ -10974,6 +11807,13 @@
 			"openReadme",
 			"pluginPolicyBlocked",
 			"uninstall"
+		],
+		"vs/workbench/contrib/chat/browser/agentPluginCommands": [
+			"agentPlugins.checkForUpdates",
+			"agentPlugins.forceUpdate",
+			"agentPlugins.updateFailed",
+			"agentPlugins.upToDate",
+			"chat.category"
 		],
 		"vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor": [
 			"noReadme",
@@ -11002,8 +11842,11 @@
 			"agentPlugins",
 			"agentPlugins.browse",
 			"agentPlugins.browse.tooltip",
-			"agentPlugins.checkForUpdates",
-			"agentPlugins.forceUpdate",
+			"agentPlugins.marketplacesRefreshed",
+			"agentPlugins.marketplacesRefreshedWithErrors",
+			"agentPlugins.refreshingMarketplaces",
+			"agentPlugins.refreshMarketplaces",
+			"agentPlugins.refreshMarketplacesFailed",
 			"chat.category",
 			"manage",
 			"noAgentPlugins",
@@ -11019,7 +11862,9 @@
 			"agentHost.signInFailed"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution": [
-			"agentHostHarnessLabel.local"
+			"agentHostHarnessLabel.local",
+			"agentHostModelSource.chatGPT.description",
+			"agentHostModelSource.chatGPT.label"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
 			"agentHostChatInputPicker.approvalsHover",
@@ -11033,8 +11878,11 @@
 			"agentHostChatInputPicker.boolean.onLabel",
 			"agentHostChatInputPicker.boolean.true",
 			"agentHostChatInputPicker.defaultApprovalsHover",
+			"agentHostChatInputPicker.defaultSandboxToggle",
+			"agentHostChatInputPicker.defaultSandboxToggleTitle",
 			"agentHostChatInputPicker.filter",
 			"agentHostChatInputPicker.learnMorePermissions",
+			"agentHostChatInputPicker.manualSandboxedLabel",
 			"agentHostChatInputPicker.policyDisabledHover",
 			"agentHostChatInputPicker.triggerAria",
 			"agentHostChatInputPicker.triggerAriaReadOnly"
@@ -11063,6 +11911,10 @@
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem": [
 			"agentHost.selectFolder"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerTip": [
+			"chat.agentHost.folderPickerTip.learnMore",
+			"chat.agentHost.folderPickerTip.text"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider": [
 			"agentHost.auto.discount"
 		],
@@ -11075,8 +11927,20 @@
 			"agentHost.permission.read",
 			"agentHost.permission.write"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPromptCacheNotification": [
+			"promptCacheExpiration.description",
+			"promptCacheExpiration.dontShowAgain",
+			"promptCacheExpiration.startNewChat",
+			"promptCacheExpiration.title"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler": [
 			"agentHost.authRequired",
+			"agentHost.clientTool.badInput",
+			"agentHost.clientTool.beginFailed",
+			"agentHost.clientTool.pastTense",
+			"agentHost.clientTool.unclaimed",
+			"agentHost.clientTool.unclaimedError",
+			"agentHost.clientTool.unknown",
 			"agentHost.elicit.url.cancel",
 			"agentHost.elicit.url.open",
 			"agentHost.elicit.url.title",
@@ -11091,6 +11955,9 @@
 			"agentHost.turnError",
 			"agentHost.workspaceTrust"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectorySynchronizer": [
+			"agentHostWorkingDirectories.untrusted"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSettings.contribution": [
 			"agentHostSettings.label",
 			"openAgentHostSettings"
@@ -11100,6 +11967,12 @@
 			"agentHostSettings.notObject",
 			"agentHostSettings.parseError",
 			"agentHostSettings.saveHint"
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification": [
+			"agentHost.signedOutModels.addModels",
+			"agentHost.signedOutModels.description",
+			"agentHost.signedOutModels.message",
+			"agentHost.signedOutModels.signIn"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
 			"agentHostTerminal.local"
@@ -11124,12 +11997,15 @@
 			"agentFeedback.reveal",
 			"agentFeedback.reviewMessage",
 			"agentFeedback.reviewTitle",
+			"agentHost.askUser.asking",
+			"agentHost.askUser.waiting",
 			"agentHost.elicit.url.instruction",
 			"agentHost.elicit.url.title",
 			"agentHost.otherClientTool.running",
 			"agentHost.responseDetails.credit",
 			"agentHost.responseDetails.credits",
 			"agentHost.responseDetails.resolvedModel",
+			"agentHost.streaming.readingFile",
 			"chat.inputRequest.boolean.false",
 			"chat.inputRequest.boolean.true",
 			"contextAttribution.category.system",
@@ -11169,21 +12045,13 @@
 			"chat.session.providerLabel.local"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution": [
-			"agentSessionsQuickAccessHelp",
-			"agentSessionsQuickAccessPlaceholder",
 			"filterAgentSessions"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions": [
 			"agentSessions.deleteAll",
-			"agentSessions.open",
-			"archive",
-			"archiveAll.label",
-			"archiveAllSessions.archive",
 			"archiveAllSessions.confirm",
 			"archiveAllSessions.confirmSingle",
 			"archiveAllSessions.detail",
-			"archiveSection",
-			"archiveSectionSessions.archive",
 			"archiveSectionSessions.confirm",
 			"archiveSectionSessions.confirmSingle",
 			"archiveSectionSessions.detail",
@@ -11213,19 +12081,24 @@
 			"find",
 			"hideAgentSessionsSidebar",
 			"markAllRead.label",
+			"markAllSessionsDone.confirm",
+			"markAllSessionsDone.confirmSingle",
+			"markAllSessionsDone.detail",
 			"markRead",
 			"markSectionRead",
+			"markSectionSessionsDone.confirm",
+			"markSectionSessionsDone.confirmSingle",
+			"markSectionSessionsDone.detail",
+			"markSessionDone",
 			"markUnread",
 			"newChatTitle",
 			"pin",
 			"refresh",
 			"rename",
+			"restoreSectionSessions.confirm",
 			"showAgentSessionsSidebar",
 			"toggleAgentSessionsSidebar",
-			"unarchive",
-			"unarchiveSection",
 			"unarchiveSectionSessions.confirm",
-			"unarchiveSectionSessions.unarchive",
 			"unpin"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner": [
@@ -11253,14 +12126,9 @@
 			"chat.openSessionFailed"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker": [
-			"archiveSession",
 			"chatAgentPickerPlaceholder",
 			"deleteSession",
-			"renameSession",
-			"unarchiveSession"
-		],
-		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsQuickAccess": [
-			"noAgentSessionResults"
+			"renameSession"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer": [
 			"agentSessionCompleted",
@@ -11373,6 +12241,14 @@
 			"showCommandsQuickAccess",
 			"showFilesQuickAccess"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/externalSessionsFilterMenu": [
+			"agentSessions.filter.external",
+			"agentSessions.filter.external.all",
+			"agentSessions.filter.external.last24Hours",
+			"agentSessions.filter.external.last7Days",
+			"agentSessions.filter.external.none",
+			"agentSessions.filter.external.recent"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability": [
 			"chat.sessionType.noModels",
 			"chat.sessionType.noModelsHover",
@@ -11382,6 +12258,10 @@
 			"chat.sessionType.upgradeHover",
 			"chat.sessionType.upgradeLink",
 			"chat.sessionType.upgradeMobile"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/agentGlobalConfigurationSettingsWidget": [
+			"agentSettings.save",
+			"agentSettings.unavailable"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons": [
 			"aiCustomizationAddIcon",
@@ -11550,8 +12430,7 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor": [
 			"agents",
 			"agentsDesc",
-			"automations",
-			"automationsDesc",
+			"backToCustomizationMigration",
 			"backToList",
 			"backToListTooltip",
 			"backToMcpList",
@@ -11560,12 +12439,20 @@
 			"backToOverviewTooltip",
 			"backToPluginList",
 			"backToPluginListTooltip",
-			"backToPromptMigration",
-			"backToPromptMigrationTooltip",
 			"backToToolsList",
 			"backToToolsListTooltip",
 			"cancelSaveTarget",
+			"confirmDeleteCustomizationFile",
+			"confirmDeleteDetail",
+			"customizationMigrationPageButton",
+			"customizationMigrationPageButtonWithCount",
+			"customizationMigrationSearchPlaceholder",
+			"customizationMigrationSelectAriaLabel",
+			"customizationMigrationSelectGroupAriaLabel",
 			"customizationPreviewAriaLabel",
+			"delete",
+			"deleteCustomizationFile",
+			"deleteCustomizationFileTooltip",
 			"editorActionButtonFailed",
 			"editorEditRawButtonLabel",
 			"editorEditRawButtonTooltip",
@@ -11581,17 +12468,22 @@
 			"instructions",
 			"instructionsDesc",
 			"learnMoreModels",
-			"learnMoreSkills",
 			"localHarnessLabel",
 			"mcpServers",
 			"mcpServersDesc",
-			"migrationShortcutAriaLabel",
-			"migrationShortcutAriaLabelWithCount",
-			"migrationShortcutLabel",
-			"migrationShortcutTooltip",
+			"migrationNoGlobalAgentFolder",
+			"migrationNoGlobalInstructionsFolder",
+			"migrationNoGlobalSkillFolder",
+			"migrationNoWorkspaceAgentFolder",
+			"migrationNoWorkspaceInstructionsFolder",
+			"migrationNoWorkspaceSkillFolder",
+			"migrationPickAgentFolder",
+			"migrationPickInstructionsFolder",
+			"migrationPickSkillFolder",
 			"models",
 			"modelsDesc",
 			"modelsDescription",
+			"openCustomizationFile",
 			"plugins",
 			"pluginsDesc",
 			"previewFieldHelpAriaLabel",
@@ -11600,34 +12492,6 @@
 			"previewNoBody",
 			"previewNoFrontMatter",
 			"previewUnknownFieldDescription",
-			"promptMigrationConfirmButton",
-			"promptMigrationConfirmDetailUser",
-			"promptMigrationConfirmDetailWorkspace",
-			"promptMigrationConfirmDetailWorkspaceAndUser",
-			"promptMigrationConfirmMessage",
-			"promptMigrationConverted",
-			"promptMigrationConvertedWithReview",
-			"promptMigrationDeletePromptFilesCheckbox",
-			"promptMigrationFilesFailed",
-			"promptMigrationFilesFailedWithRemainder",
-			"promptMigrationNoFilesConverted",
-			"promptMigrationNoSkillFolders",
-			"promptMigrationPageButton",
-			"promptMigrationPageButtonTooltip",
-			"promptMigrationPageButtonWithCount",
-			"promptMigrationPageDescription",
-			"promptMigrationPageDescriptionUser",
-			"promptMigrationPageDescriptionWorkspace",
-			"promptMigrationPageDescriptionWorkspaceAndUser",
-			"promptMigrationPageEmpty",
-			"promptMigrationPageTitle",
-			"promptMigrationPickWorkspaceSkillFolder",
-			"promptMigrationSearchEmpty",
-			"promptMigrationSearchPlaceholder",
-			"promptMigrationSelectAriaLabel",
-			"promptMigrationSelectGroupAriaLabel",
-			"promptMigrationUserGroup",
-			"promptMigrationWorkspaceGroup",
 			"prompts",
 			"promptsDesc",
 			"saveBuiltinCopyAndChooseLocation",
@@ -11655,8 +12519,10 @@
 			"agentsDesc",
 			"browse",
 			"browseCategoryAriaLabel",
-			"convertPromptFilesAriaLabel",
-			"convertToSkills",
+			"configure",
+			"configureCategoryAriaLabel",
+			"dictationInstructions",
+			"dictationInstructionsDesc",
 			"gettingStartedDesc",
 			"gettingStartedTitle",
 			"hooks",
@@ -11665,19 +12531,17 @@
 			"instructionsDesc",
 			"mcpServers",
 			"mcpServersDesc",
-			"migratePromptFiles",
 			"new",
 			"newCategoryAriaLabel",
 			"plugins",
 			"pluginsDesc",
-			"promptMigrationCardDescriptionUser",
-			"promptMigrationCardDescriptionWorkspace",
-			"promptMigrationCardDescriptionWorkspaceAndUser",
 			"sentToChat",
 			"skills",
 			"skillsDesc",
 			"tools",
 			"toolsDesc",
+			"voiceModeInstructions",
+			"voiceModeInstructionsDesc",
 			"welcomeHeadingWithHarness",
 			"welcomeSubtitle",
 			"workflowInputAriaLabel",
@@ -11685,91 +12549,89 @@
 			"workflowSubmitAriaLabel",
 			"workflowSubmitTooltip"
 		],
-		"vs/workbench/contrib/chat/browser/aiCustomization/automationsAccessibilityHelp": [
-			"automations.help.actionDelete",
-			"automations.help.actionEdit",
-			"automations.help.actionHistory",
-			"automations.help.actionRun",
-			"automations.help.actionsHeader",
-			"automations.help.actionToggle",
-			"automations.help.closingDesc",
-			"automations.help.closingHeader",
-			"automations.help.dialogFields",
-			"automations.help.dialogHeader",
-			"automations.help.dialogValidation",
-			"automations.help.header",
-			"automations.help.historyDesc",
-			"automations.help.historyHeader",
-			"automations.help.intro",
-			"automations.help.layoutDesc",
-			"automations.help.layoutHeader",
-			"automations.help.settingsHeader",
-			"automations.help.settingVerbosity",
-			"automations.help.statusDesc",
-			"automations.help.statusHeader"
-		],
-		"vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget": [
-			"automationAriaLabel",
-			"automationAriaLabelDisabled",
-			"automationCreatedStatus",
-			"automationCreateFailed",
-			"automationDeletedStatus",
-			"automationDisabled",
-			"automationDisabledStatus",
-			"automationEnabledStatus",
-			"automationFolderLabel",
-			"automationQuickChatLabel",
-			"automationQuickChatTitle",
-			"automationsDisabledDetail",
-			"automationsDisabledTitle",
-			"automationsEmptyCta",
-			"automationsEmptyMessage",
-			"automationsEmptyTitle",
-			"automationsHeaderSubtitle",
-			"automationsHeaderTitle",
-			"automationsListAriaLabel",
-			"automationStartedStatus",
-			"automationUpdatedStatus",
-			"automationUpdateFailed",
-			"confirmDeleteAutomation",
-			"confirmDeleteAutomationDetail",
-			"delete",
-			"deleteAutomation",
-			"disableAutomation",
-			"editAutomation",
-			"enableAutomation",
-			"hideHistory",
-			"historyAriaLabel",
-			"historyMore",
-			"lastRun",
-			"newAutomation",
-			"newAutomationTooltip",
-			"nextRun",
-			"nextRunNever",
-			"noRunsYet",
-			"openRunSession",
-			"openRunSessionFailed",
-			"runHistory",
-			"runNow",
-			"runStarted",
-			"runStatusCompleted",
-			"runStatusFailed",
-			"runStatusPending",
-			"runStatusRunning",
-			"runTriggerCatchUp",
-			"runTriggerManual",
-			"runTriggerSchedule",
-			"scheduleDaily",
-			"scheduleHourly",
-			"scheduleManual",
-			"scheduleWeekly",
-			"showHistory"
-		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService": [
 			"generateName",
 			"generateNamePlaceholder",
 			"nameRequired",
 			"selectTargetDirectory"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/customizationMigrationCategories": [
+			"backToPromptMigration",
+			"backToUserDataMigration",
+			"promptMigrationCardAction",
+			"promptMigrationCardActionAriaLabel",
+			"promptMigrationCardDescriptionUser",
+			"promptMigrationCardDescriptionWorkspace",
+			"promptMigrationCardDescriptionWorkspaceAndUser",
+			"promptMigrationCardLabel",
+			"promptMigrationConfirmButton",
+			"promptMigrationConfirmDetailUser",
+			"promptMigrationConfirmDetailWorkspace",
+			"promptMigrationConfirmDetailWorkspaceAndUser",
+			"promptMigrationConfirmMessage",
+			"promptMigrationConverted",
+			"promptMigrationConvertedWithReview",
+			"promptMigrationDeletePromptFilesCheckbox",
+			"promptMigrationFilesFailed",
+			"promptMigrationFilesFailedWithRemainder",
+			"promptMigrationLearnMore",
+			"promptMigrationNoFilesConverted",
+			"promptMigrationPageButtonTooltip",
+			"promptMigrationPageDescription",
+			"promptMigrationPageDescriptionUser",
+			"promptMigrationPageDescriptionWorkspace",
+			"promptMigrationPageDescriptionWorkspaceAndUser",
+			"promptMigrationPageEmpty",
+			"promptMigrationPageTitle",
+			"promptMigrationSearchEmpty",
+			"promptMigrationShortcutAriaLabelWithCount",
+			"promptMigrationShortcutLabel",
+			"promptMigrationShortcutTooltip",
+			"promptMigrationUserGroup",
+			"promptMigrationWorkspaceGroup",
+			"userDataMigrationAgentsGroup",
+			"userDataMigrationBannerConsequence",
+			"userDataMigrationBannerMessage",
+			"userDataMigrationBannerTitle",
+			"userDataMigrationBannerTitleSingle",
+			"userDataMigrationCardAction",
+			"userDataMigrationCardActionAriaLabel",
+			"userDataMigrationCardDescriptionAgent",
+			"userDataMigrationCardDescriptionAgents",
+			"userDataMigrationCardDescriptionInstruction",
+			"userDataMigrationCardDescriptionInstructions",
+			"userDataMigrationCardDescriptionMixed",
+			"userDataMigrationCardLabel",
+			"userDataMigrationCompleted",
+			"userDataMigrationCompletedSingle",
+			"userDataMigrationConfirmButton",
+			"userDataMigrationConfirmDetailAgent",
+			"userDataMigrationConfirmDetailAgents",
+			"userDataMigrationConfirmDetailInstruction",
+			"userDataMigrationConfirmDetailInstructions",
+			"userDataMigrationConfirmDetailMixed",
+			"userDataMigrationConfirmMessage",
+			"userDataMigrationDeleteOriginalFilesCheckbox",
+			"userDataMigrationFileFailed",
+			"userDataMigrationFilesFailed",
+			"userDataMigrationFilesFailedWithRemainder",
+			"userDataMigrationInstructionsGroup",
+			"userDataMigrationLearnMore",
+			"userDataMigrationNoFilesMigrated",
+			"userDataMigrationPageButtonTooltip",
+			"userDataMigrationPageDescription",
+			"userDataMigrationPageDescriptionAgent",
+			"userDataMigrationPageDescriptionAgents",
+			"userDataMigrationPageDescriptionAgentsAndInstructions",
+			"userDataMigrationPageDescriptionInstruction",
+			"userDataMigrationPageDescriptionInstructions",
+			"userDataMigrationPageEmpty",
+			"userDataMigrationPageTitle",
+			"userDataMigrationSearchEmpty",
+			"userDataMigrationShortcutAriaLabelSingle",
+			"userDataMigrationShortcutAriaLabelWithCount",
+			"userDataMigrationShortcutLabel",
+			"userDataMigrationShortcutTooltip"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail": [
 			"pluginDetailEmpty",
@@ -11807,9 +12669,11 @@
 			"addServer",
 			"addServerTooltip",
 			"agentHostMcpServerDisable",
-			"agentHostMcpServerDisableForWorkspace",
+			"agentHostMcpServerDisableSession",
+			"agentHostMcpServerDisableWorkspace",
 			"agentHostMcpServerEnable",
-			"agentHostMcpServerEnableForWorkspace",
+			"agentHostMcpServerEnableSession",
+			"agentHostMcpServerEnableWorkspace",
 			"authRequired",
 			"backToInstalled",
 			"browseMarketplace",
@@ -11822,7 +12686,6 @@
 			"collapsed",
 			"confirmUninstallPluginMcp",
 			"confirmUninstallPluginMcpDetail",
-			"disabled",
 			"emptyGallery",
 			"error",
 			"expanded",
@@ -11850,8 +12713,6 @@
 			"running",
 			"searchGalleryPlaceholder",
 			"searchMcpPlaceholder",
-			"sessionMcpServerDisable",
-			"sessionMcpServerEnable",
 			"showMcpServerOutput",
 			"showPlugin",
 			"signIn",
@@ -11878,11 +12739,9 @@
 			"createPlugin",
 			"disabledGroup",
 			"disabledGroupDescription",
-			"disablePlugin",
 			"emptyMarketplace",
 			"enabledGroup",
 			"enabledGroupDescription",
-			"enablePlugin",
 			"expanded",
 			"installFromSource",
 			"learnMorePlugins",
@@ -11908,14 +12767,14 @@
 			"remoteHostGroup",
 			"remoteHostGroupDescription",
 			"remotePluginDegraded",
-			"remotePluginDisabled",
 			"remotePluginError",
 			"remotePluginLoaded",
 			"remotePluginLoading",
 			"searchMarketplacePlaceholder",
 			"searchPluginsPlaceholder",
 			"tryAgainLater",
-			"tryDifferentSearch"
+			"tryDifferentSearch",
+			"updatePlugins"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider": [
 			"alwaysAdded",
@@ -11977,11 +12836,15 @@
 		],
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets": [
 			"chat.attachment",
+			"chat.attachment.chatReference",
+			"chat.attachment.chatReference.hover",
 			"chat.attachment.clearButton",
 			"chat.attachment.saveFileButton",
 			"chat.attachment.saveFileError",
 			"chat.attachment.saveImageButton",
 			"chat.attachment.saveImageError",
+			"chat.attachment.transcriptContext",
+			"chat.attachment.transcriptContext.hover",
 			"chat.attachment.withDeleteHint",
 			"chat.autoImageAttachment",
 			"chat.autoImageAttachmentHover",
@@ -11992,7 +12855,6 @@
 			"chat.browserViewClosed.aria",
 			"chat.browserViewNotShared",
 			"chat.browserViewNotShared.aria",
-			"chat.clickToViewContents",
 			"chat.elementAttachment",
 			"chat.elementHover.attributes",
 			"chat.elementHover.computedStyles",
@@ -12000,6 +12862,8 @@
 			"chat.elementHover.htmlPath",
 			"chat.elementHover.innerText",
 			"chat.elementHover.positionSize",
+			"chat.elementHover.screenshot",
+			"chat.elementHover.screenshotAlt",
 			"chat.elementHover.showMore",
 			"chat.fileAttachment",
 			"chat.fileAttachmentHover",
@@ -12016,6 +12880,7 @@
 			"chat.omittedFileAttachment",
 			"chat.omittedImageAttachment",
 			"chat.omittedNotebookImageAttachment",
+			"chat.openImagePreview",
 			"chat.partiallyOmittedImageAttachment",
 			"chat.partiallyOmittedNotebookImageAttachment",
 			"chat.promptAttachment",
@@ -12053,13 +12918,10 @@
 		],
 		"vs/workbench/contrib/chat/browser/chat.shared.contribution": [
 			"agentPlugin",
-			"agentSandbox.allowedNetworkDomains.deprecated",
-			"agentSandbox.allowedNetworkDomains2.deprecated",
-			"agentSandbox.deniedNetworkDomains.deprecated",
-			"agentSandbox.deniedNetworkDomains2.deprecated",
 			"autoApprove3.description",
 			"chat",
 			"chat.agent.allowedNetworkDomains",
+			"chat.agent.collapseCompletedResponses",
 			"chat.agent.deniedNetworkDomains",
 			"chat.agent.enabled.description",
 			"chat.agent.maxRequests",
@@ -12080,20 +12942,30 @@
 			"chat.agentHost.agentDebugLog.enabled",
 			"chat.agentHost.agentDebugLog.maxEventsInMemory",
 			"chat.agentHost.ahpJsonlLogging",
+			"chat.agentHost.allowSignedOutWhenUsable",
+			"chat.agentHost.copilot.mapLegacySettingsToManagedSettings",
+			"chat.agentHost.copilot.modelCapabilityOverrides",
+			"chat.agentHost.copilot.modelCapabilityOverrides.availableTools",
+			"chat.agentHost.copilot.modelCapabilityOverrides.excludedTools",
+			"chat.agentHost.copilot.modelCapabilityOverrides.family",
+			"chat.agentHost.copilot.modelCapabilityOverrides.modelCapabilities",
+			"chat.agentHost.copilot.modelCapabilityOverrides.reasoningEffort",
+			"chat.agentHost.copilot.toolSearch.deferThreshold",
+			"chat.agentHost.copilot.toolSearch.enabled",
 			"chat.agentHost.copilotSdk.logLevel",
 			"chat.agentHost.copilotSdk.logLevel.info",
 			"chat.agentHost.copilotSdk.logLevel.trace",
 			"chat.agentHost.customTerminalTool.enabled",
-			"chat.agentHost.modelCapabilityOverrides",
-			"chat.agentHost.modelCapabilityOverrides.family",
 			"chat.agentHost.opus48Prompt.enabled",
 			"chat.agentHost.reasoningEffortOverride",
+			"chat.agentHost.reasoningSummary",
 			"chat.agentHost.sdkSandbox.enabled",
-			"chat.agentHost.sdkSandbox.enabled.allowNetwork",
 			"chat.agentHost.sdkSandbox.enabled.off",
 			"chat.agentHost.sdkSandbox.enabled.on",
+			"chat.agentHost.sdkSandbox.enabledWindows",
+			"chat.agentHost.sdkSandbox.enabledWindows.off",
+			"chat.agentHost.sdkSandbox.enabledWindows.on",
 			"chat.agentLocations.invalidPath",
-			"chat.agents.claude.preferAgentHost",
 			"chat.agents.config.locations.description",
 			"chat.agents.config.locations.title",
 			"chat.agentsControl.badge",
@@ -12101,6 +12973,13 @@
 			"chat.agentsControl.enabled",
 			"chat.agentsControl.hidden",
 			"chat.agentSessionProjection.enabled",
+			"chat.agentSessions.migrateLegacyCopilotCli",
+			"chat.agentSessions.showExternal",
+			"chat.agentSessions.showExternal.all",
+			"chat.agentSessions.showExternal.last24Hours",
+			"chat.agentSessions.showExternal.last7Days",
+			"chat.agentSessions.showExternal.none",
+			"chat.agentSessions.showExternal.recent",
 			"chat.agentsHandoffTip.mode",
 			"chat.agentsHandoffTip.mode.custom",
 			"chat.agentsHandoffTip.mode.default",
@@ -12136,11 +13015,14 @@
 			"chat.codeBlock.showProgressAnimation.description",
 			"chat.contextUsage.enabled",
 			"chat.customizations.promptMigration.enabled",
+			"chat.customizations.strictPluginOnlyCustomization",
+			"chat.customizations.strictPluginOnlyCustomization.policy",
 			"chat.customizations.structuredPreview.enabled",
+			"chat.customizations.userDataMigration.enabled",
 			"chat.defaultConfiguration.approvals.allowAll",
 			"chat.defaultConfiguration.approvals.assisted",
-			"chat.defaultConfiguration.approvals.default",
 			"chat.defaultConfiguration.approvals.description",
+			"chat.defaultConfiguration.approvals.manual",
 			"chat.defaultConfiguration.mode.autopilot",
 			"chat.defaultConfiguration.mode.description",
 			"chat.defaultConfiguration.mode.interactive",
@@ -12156,7 +13038,6 @@
 			"chat.editing.explainChanges.enabled",
 			"chat.editing.openChangedFileInDiffEditor",
 			"chat.editing.revealNextChangeOnResolve",
-			"chat.editor.claude.preferAgentHost",
 			"chat.editor.codex.preferAgentHost",
 			"chat.editorAssociations",
 			"chat.editRequests",
@@ -12178,6 +13059,10 @@
 			"chat.experimental.incrementalRendering.buffering.word",
 			"chat.experimental.incrementalRendering.enabled",
 			"chat.experimental.permissionsSandboxToggle.enabled",
+			"chat.experimental.richLinks.enabled",
+			"chat.experimental.sessionArchiveActionWording",
+			"chat.experimental.sessionArchiveActionWording.archive",
+			"chat.experimental.sessionArchiveActionWording.done",
 			"chat.experimentalSessionsWindowOverride",
 			"chat.exploreAgent.defaultModel.description",
 			"chat.extensionToolsEnabled",
@@ -12188,6 +13073,8 @@
 			"chat.hookFilesLocations.description",
 			"chat.hookFilesLocations.invalidPath",
 			"chat.hookFilesLocations.title",
+			"chat.hooks.allowManagedOnly",
+			"chat.hooks.allowManagedOnly.policy",
 			"chat.implicitContext.enabled.1",
 			"chat.implicitContext.includeActiveEditor",
 			"chat.implicitContext.suggestedContext",
@@ -12215,6 +13102,8 @@
 			"chat.mcp.allowedServers.serverCommand",
 			"chat.mcp.allowedServers.serverName",
 			"chat.mcp.allowedServers.serverUrl",
+			"chat.mcp.allowManagedServersOnly",
+			"chat.mcp.allowManagedServersOnly.policy",
 			"chat.mcp.assisted.nuget.enabled.description",
 			"chat.mcp.autostart",
 			"chat.mcp.autostart.never",
@@ -12246,6 +13135,7 @@
 			"chat.notifyWindowOnResponseReceived.always",
 			"chat.notifyWindowOnResponseReceived.off",
 			"chat.notifyWindowOnResponseReceived.windowNotFocused",
+			"chat.omni.enabled",
 			"chat.permissions.default.autoApprove.description",
 			"chat.permissions.default.autoApprove.label",
 			"chat.permissions.default.autopilot.description",
@@ -12253,9 +13143,7 @@
 			"chat.permissions.default.default.description",
 			"chat.permissions.default.default.label",
 			"chat.permissions.default.settingDescription",
-			"chat.persistentProgress.enabled",
 			"chat.planAgent.defaultModel.description",
-			"chat.planReview.inlineEditor.enabled",
 			"chat.pluginLocations",
 			"chat.plugins.enabled",
 			"chat.plugins.enabledPlugins",
@@ -12275,21 +13163,13 @@
 			"chat.restoreLastPanelSession",
 			"chat.reusablePrompts.config.locations.description",
 			"chat.reusablePrompts.config.locations.title",
+			"chat.saveBeforeSend",
 			"chat.sessionSync.enabled",
 			"chat.sessionSync.enabled.policy",
 			"chat.sessionSync.excludeRepositories",
-			"chat.speechToText.enabled",
-			"chat.speechToText.mode.auto",
-			"chat.speechToText.mode.description",
-			"chat.speechToText.mode.pushToTalk",
-			"chat.speechToText.mode.toggle",
-			"chat.speechToText.model",
-			"chat.speechToText.model.base",
-			"chat.speechToText.model.nemotron",
-			"chat.speechToText.model.small",
-			"chat.speechToText.model.tiny",
 			"chat.subagents.allowInvocationsFromSubagents",
 			"chat.subagents.allowInvocationsFromSubagents.md",
+			"chat.subagents.useRichRendering",
 			"chat.tips.enabled",
 			"chat.titleBar.openInAgentsWindow.enabled",
 			"chat.titleBar.signIn.enabled",
@@ -12342,6 +13222,16 @@
 			"chat.viewSessions.orientation.sideBySide",
 			"chat.viewSessions.orientation.stacked",
 			"chatDebug",
+			"dictation.enabled",
+			"dictation.enabled.policy",
+			"dictation.experimental.llmCleanup",
+			"dictation.model",
+			"dictation.model.mai",
+			"dictation.model.mai.label",
+			"dictation.model.nemotronMultilingual",
+			"dictation.model.nemotronMultilingual.label",
+			"dictation.showButton",
+			"dictation.showTranscript",
 			"interactiveSession.editor.fontFamily",
 			"interactiveSession.editor.fontSize",
 			"interactiveSession.editor.fontWeight",
@@ -12736,7 +13626,6 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView": [
 			"chatDebug.active",
-			"chatDebug.claudeCodeSessionWithId",
 			"chatDebug.copilotCliSessionWithId",
 			"chatDebug.disabled",
 			"chatDebug.homeSubtitle",
@@ -13041,6 +13930,30 @@
 			"chatImageCarousel.allImages",
 			"chatImageCarousel.currentInput"
 		],
+		"vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindow.contribution": [
+			"chat.closeInputWindow",
+			"chat.toggleInputWindow"
+		],
+		"vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService": [
+			"chatInputWindow.close.label",
+			"chatInputWindow.drag",
+			"chatInputWindow.inputPlaceholder",
+			"chatInputWindow.pending.allow",
+			"chatInputWindow.pending.allowAndReview",
+			"chatInputWindow.pending.ciDetail",
+			"chatInputWindow.pending.ciTitle",
+			"chatInputWindow.pending.count",
+			"chatInputWindow.pending.dismissCI",
+			"chatInputWindow.pending.fixCI",
+			"chatInputWindow.pending.fixCITooltip",
+			"chatInputWindow.pending.next",
+			"chatInputWindow.pending.previous",
+			"chatInputWindow.pending.skip",
+			"chatInputWindow.selectFolder",
+			"chatInputWindow.selectSessionFolder",
+			"chatInputWindow.title",
+			"chatInputWindow.titleWithProject"
+		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution": [
 			"enableChatForByok",
 			"enableChatForByokReason",
@@ -13131,6 +14044,7 @@
 			"models.showGroup",
 			"models.showModel",
 			"models.showModelsPlural",
+			"models.signInGitHubCopilot",
 			"models.toolCalling",
 			"models.tools",
 			"models.unpinModel",
@@ -13148,6 +14062,10 @@
 			"vendor.ariaLabel",
 			"vendor.hidden.ariaLabel",
 			"visible.ariaLabel"
+		],
+		"vs/workbench/contrib/chat/browser/chatOutline": [
+			"chatOutline",
+			"chatOutline.emptyRequest"
 		],
 		"vs/workbench/contrib/chat/browser/chatOutputItemRenderer": [
 			"chatOutputRenderer.codeBlockLanguageIdentifiers",
@@ -13193,8 +14111,15 @@
 			"showExtension",
 			"vscode.extension.contributes.chatParticipant"
 		],
+		"vs/workbench/contrib/chat/browser/chatPetService": [
+			"chatPet.disabled",
+			"chatPet.enabled",
+			"chatPet.onTheRun",
+			"chatPet.restored",
+			"chatPet.variant.insiders",
+			"chatPet.variant.stable"
+		],
 		"vs/workbench/contrib/chat/browser/chatPromoNotification": [
-			"chat.promo.endsAt",
 			"chat.promo.tryModel"
 		],
 		"vs/workbench/contrib/chat/browser/chatQuotaNotification": [
@@ -13362,6 +14287,7 @@
 		"vs/workbench/contrib/chat/browser/chatSetup/chatSetupRunner": [
 			"chatWorkspaceTrust",
 			"continueWith",
+			"continueWithoutSigningIn",
 			"enableMore",
 			{
 				"key": "settings",
@@ -13390,7 +14316,8 @@
 			"autoApprove",
 			"autopilot",
 			"chatSessionOption.slashCommand.detail",
-			"clear",
+			"clear.archive",
+			"clear.markDone",
 			"debug",
 			"disableAutoApprove",
 			"disableYolo",
@@ -13404,6 +14331,7 @@
 			"rename",
 			"skills",
 			"tools",
+			"vscodePet",
 			"yolo"
 		],
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard": [
@@ -13426,6 +14354,7 @@
 			"completions.snoozeTimeDescription",
 			"completionsLabel",
 			"creditsLabel",
+			"creditsUsedLabel",
 			"enableAIFeatures",
 			"enableCopilotButton",
 			"enableDescription",
@@ -13441,8 +14370,6 @@
 			"manageBudget",
 			"modelLabel",
 			"premiumChatsLabel",
-			"premiumCreditsUsed",
-			"premiumCreditsUsedCompact",
 			"premiumIncluded",
 			"premiumIncludedCompact",
 			"premiumLimitReached",
@@ -13542,6 +14469,9 @@
 			"defaultModelDescription",
 			"modelLabelWithVendor"
 		],
+		"vs/workbench/contrib/chat/browser/editorChatResponseFileChangesService": [
+			"chatTurnPills.changes.title"
+		],
 		"vs/workbench/contrib/chat/browser/enablementActions": [
 			"disable",
 			"disableForWorkspace",
@@ -13557,19 +14487,14 @@
 		"vs/workbench/contrib/chat/browser/languageModelsConfigurationService": [
 			"settings.perModelConfig"
 		],
-		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions": [
+		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorOverlay": [
 			"planReviewFeedback.clear",
 			"planReviewFeedback.clearAllTooltip",
-			"planReviewFeedback.navStatus.label",
+			"planReviewFeedback.navigationStatus",
 			"planReviewFeedback.next",
-			"planReviewFeedback.previous"
-		],
-		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution": [
-			"planReviewFeedback.add",
-			"planReviewFeedback.addFeedback",
-			"planReviewFeedback.enter",
-			"planReviewFeedback.navStatus.nOfM",
-			"planReviewFeedback.navStatus.zero"
+			"planReviewFeedback.previous",
+			"planReviewFeedback.submit",
+			"planReviewFeedback.submitShort"
 		],
 		"vs/workbench/contrib/chat/browser/pluginGitCommandService": [
 			"pluginsBrowserGitHubAccessRequired",
@@ -13592,6 +14517,7 @@
 			"selectPlugin",
 			"showOutput",
 			"strictMarketplaceBlockedInstall",
+			"strictMarketplaceBlockedUpdate",
 			{
 				"key": "trustAndInstall",
 				"comment": [
@@ -13856,20 +14782,165 @@
 			"configure-skills",
 			"configure-skills.short"
 		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimeline.contribution": [
+			"chat.stickyScroll.enabled",
+			"sessions.chatTimeline.display",
+			"sessions.chatTimeline.display.gutter",
+			"sessions.chatTimeline.display.off",
+			"sessions.chatTimeline.display.ruler"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineCard": [
+			"promptTimeline.groupedCount",
+			"promptTimeline.nFiles",
+			"promptTimeline.noEdits",
+			"promptTimeline.oneFile",
+			"promptTimeline.reviewChangesForPrompt"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineGutterRail": [
+			"promptTimeline.gutter.railLabel",
+			"promptTimeline.gutter.reviewChanges",
+			"promptTimeline.gutter.reviewNFiles",
+			"promptTimeline.gutter.reviewOneFile",
+			"promptTimeline.gutter.toggleLabel"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineModel": [
+			"promptTimeline.reviewTitle",
+			"promptTimeline.tick",
+			"promptTimeline.tickGrouped"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineRulerRail": [
+			"promptTimeline.railLabel"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineStickyHeader": [
+			"promptTimeline.emptyPrompt",
+			"promptTimeline.stickyCount",
+			"promptTimeline.stickyLabel"
+		],
+		"vs/workbench/contrib/chat/browser/sessionRouter/chatSessionRoutingController": [
+			"chatSessionRouting.bestMatchSessionModel",
+			"chatSessionRouting.changeHint",
+			"chatSessionRouting.completed",
+			"chatSessionRouting.completedWithResponse",
+			"chatSessionRouting.confirmNewSession",
+			"chatSessionRouting.currentSession",
+			"chatSessionRouting.deliveryResults",
+			"chatSessionRouting.dismiss",
+			"chatSessionRouting.dispatching",
+			"chatSessionRouting.failedIn",
+			"chatSessionRouting.fanoutResult",
+			"chatSessionRouting.findingDestination",
+			"chatSessionRouting.highConfidenceSessionModel",
+			"chatSessionRouting.inProgress",
+			"chatSessionRouting.needsInputIn",
+			"chatSessionRouting.newSession",
+			"chatSessionRouting.newSessionInFolder",
+			"chatSessionRouting.noLongerQueued",
+			"chatSessionRouting.open",
+			"chatSessionRouting.preparingRequest",
+			"chatSessionRouting.queueCancelled",
+			"chatSessionRouting.queuedFor",
+			"chatSessionRouting.queuedNotSent",
+			"chatSessionRouting.sendAllHint",
+			"chatSessionRouting.sendFailed",
+			"chatSessionRouting.sendFailedTo",
+			"chatSessionRouting.sendFailedToWithReason",
+			"chatSessionRouting.sendingIn",
+			"chatSessionRouting.sendingToIn",
+			"chatSessionRouting.sendNowHint",
+			"chatSessionRouting.sendTo",
+			"chatSessionRouting.sendToMany",
+			"chatSessionRouting.sentTo",
+			"chatSessionRouting.targetCancelled",
+			"chatSessionRouting.targetFailed",
+			"chatSessionRouting.targetFolderChanged",
+			"chatSessionRouting.targetNoLongerQueued",
+			"chatSessionRouting.targetQueued",
+			"chatSessionRouting.targetSent",
+			"chatSessionRouting.waiting"
+		],
+		"vs/workbench/contrib/chat/browser/sessionRouter/chatSessionRoutingFolderPicker": [
+			"chatSessionRouting.changeTargetFolder",
+			"chatSessionRouting.changeTargetFolderAria",
+			"chatSessionRouting.changeTargetFolderWithName",
+			"chatSessionRouting.chooseExternalFolder",
+			"chatSessionRouting.chooseFolder",
+			"chatSessionRouting.folderPickerItem",
+			"chatSessionRouting.searchFolders",
+			"chatSessionRouting.searchWorkspaces",
+			"chatSessionRouting.selectTargetFolder"
+		],
 		"vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService": [
 			"chatStt.audioError",
 			"chatStt.captureError",
 			"chatStt.connectError",
 			"chatStt.downloading",
 			"chatStt.downloadingPercent",
+			"chatStt.installFromPackage",
 			"chatStt.loadingModel",
+			"chatStt.maiBusy",
+			"chatStt.maiDisconnected",
+			"chatStt.maiEnterpriseUnavailable",
+			"chatStt.maiNotConfigured",
+			"chatStt.maiSignIn",
 			"chatStt.micError",
 			"chatStt.modelError",
+			"chatStt.modelErrorOffline",
 			"chatStt.notSupported",
-			"chatStt.preparingModel"
+			"chatStt.preparingModel",
+			"chatStt.requiresPaidPlan",
+			"chatStt.switchMicError"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/dictationDownloadRing": [
+			"chatStt.hover.connecting",
+			"chatStt.hover.connectingTitle",
+			"chatStt.hover.preparing",
+			"chatStt.hover.title",
+			"chatStt.preparing.connecting",
+			"chatStt.preparing.downloading",
+			"chatStt.preparing.preparing"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding": [
+			"dictation.onboarding.close",
+			"dictation.onboarding.defaultDevice",
+			"dictation.onboarding.denied",
+			{
+				"key": "dictation.onboarding.description",
+				"comment": [
+					"Preserve the double square brackets: they mark the text that becomes a link. Keep both links, in this order - the first opens settings, the second opens the customization file."
+				]
+			},
+			"dictation.onboarding.microphone",
+			"dictation.onboarding.microphoneSelected",
+			"dictation.onboarding.noDevice",
+			"dictation.onboarding.region",
+			"dictation.onboarding.regionDescription",
+			"dictation.onboarding.regionDescription.preview",
+			"dictation.onboarding.systemDefault",
+			"dictation.onboarding.title",
+			"dictation.onboarding.unavailable",
+			"dictation.onboarding.unknownDevice"
 		],
 		"vs/workbench/contrib/chat/browser/speechToText/dictationSession": [
 			"chatStt.listening"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/micButtonHovers": [
+			"dictation.hover.cloud",
+			"dictation.hover.nemotronMultilingual",
+			"dictation.hover.onDevice",
+			"voiceMode.hover"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions": [
+			"dictation.configureInstructions",
+			"dictation.disable",
+			"dictation.microphoneButton",
+			"dictation.openSettings",
+			"dictation.showIntroduction",
+			"mic.selectMicrophone",
+			"voiceMode.button",
+			"voiceMode.configureInstructions",
+			"voiceMode.disable",
+			"voiceMode.openSettings",
+			"voiceMode.showIntroduction"
 		],
 		"vs/workbench/contrib/chat/browser/tools/chatToolRiskAssessmentService": [
 			"riskDefaultGreen",
@@ -13877,6 +14948,8 @@
 			"riskDefaultRed"
 		],
 		"vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution": [
+			"clientToolSet.automations.description",
+			"clientToolSet.automations.detail",
 			"clientToolSet.browser.description",
 			"clientToolSet.browser.detail",
 			"clientToolSet.notebooks.description",
@@ -13937,7 +15010,7 @@
 				"comment": [
 					"{Locked='](https://github.com/features/codespaces)'}",
 					"{Locked='](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)'}",
-					"{Locked='](https://code.visualstudio.com/docs/copilot/security)'}",
+					"{Locked='](https://code.visualstudio.com/docs/agents/run/security)'}",
 					"{Locked='**'}",
 					"{Locked='[`chat.autoReply`](command:workbench.action.openSettings?%5B%22chat.autoReply%22%5D)'}"
 				]
@@ -14011,23 +15084,96 @@
 			"mic.hardwareMuted",
 			"mic.permissionDenied"
 		],
+		"vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations": [
+			"voiceMode.bargeInHint",
+			"voiceMode.bargeInHintNoKb",
+			"voiceMode.clickMicOrBargeInHint",
+			"voiceMode.listening",
+			"voiceMode.pttOrBargeInHint"
+		],
 		"vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController": [
-			"voice.connectFailed",
+			"voice.authentication.choices",
+			"voice.authentication.fallback",
+			"voice.authentication.message",
+			"voice.authentication.title",
+			"voice.authUnavailable",
+			"voice.confirmation.choiceDescription",
+			"voice.confirmation.choices",
+			"voice.confirmation.fallback",
+			"voice.confirmation.moreChoices",
+			"voice.confirmation.title",
+			"voice.confirmation.truncated",
+			"voice.elicitation.choices",
+			"voice.elicitation.fallback",
+			"voice.elicitation.title",
 			"voice.fatalDisconnect",
-			"voice.movedToAnotherWindow"
+			"voice.internalError",
+			"voice.movedToAnotherWindow",
+			"voice.noAccess",
+			"voice.notConfigured",
+			"voice.plan.choices",
+			"voice.plan.fallback",
+			"voice.plan.open",
+			"voice.plan.title",
+			"voice.questionnaire.context",
+			"voice.questionnaire.customOption",
+			"voice.questionnaire.description",
+			"voice.questionnaire.fallback",
+			"voice.questionnaire.freeform",
+			"voice.questionnaire.manyOmitted",
+			"voice.questionnaire.moreOptions",
+			"voice.questionnaire.multiple",
+			"voice.questionnaire.oneOmitted",
+			"voice.questionnaire.open",
+			"voice.questionnaire.options",
+			"voice.questionnaire.question",
+			"voice.questionnaire.single",
+			"voice.reconnecting",
+			"voice.reconnectingAuthUnavailable",
+			"voice.reconnectingBecause",
+			"voice.reconnectingBusy",
+			"voice.reconnectingInternal",
+			"voice.reconnectingUnreachable",
+			"voice.retryAction",
+			"voice.serverBusy",
+			"voice.sessionEnded",
+			"voice.signInAction",
+			"voice.signInRequired",
+			"voice.toolConfirmation.command",
+			"voice.toolConfirmation.fallback",
+			"voice.toolConfirmation.title",
+			"voice.unreachable",
+			"voice.unreachableToast",
+			"voiceMode.enterpriseUnavailable",
+			"voiceMode.requiresPaidPlan"
 		],
 		"vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService": [
-			"agentsVoice.action.approve",
 			"agentsVoice.action.autoApprove",
 			"agentsVoice.action.focusSession",
 			"agentsVoice.action.getSessionChanges",
 			"agentsVoice.action.getSessionInfo",
 			"agentsVoice.action.getSessionThread",
-			"agentsVoice.action.newSessions",
-			"agentsVoice.action.reject",
+			"agentsVoice.action.respond",
 			"agentsVoice.action.revokeAutoApprove",
 			"agentsVoice.action.sendToChat",
+			"agentsVoice.action.setModel",
 			"agentsVoice.action.working"
+		],
+		"vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputMode": [
+			"chatVoiceInputMode"
+		],
+		"vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem": [
+			"voiceInputMode",
+			"voiceInputMode.connecting",
+			"voiceInputMode.dictation",
+			"voiceInputMode.dictationPreparing",
+			"voiceInputMode.dictationPreparingCancelable",
+			"voiceInputMode.disconnect",
+			"voiceInputMode.holdToTalk",
+			"voiceInputMode.startListening",
+			"voiceInputMode.startOrHoldListening",
+			"voiceInputMode.stopListening",
+			"voiceInputMode.voice"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatAgentHover": [
 			"reservedName",
@@ -14186,8 +15332,6 @@
 			"chat.planReview.autopilot.confirm",
 			"chat.planReview.autopilot.detail",
 			"chat.planReview.autopilot.title",
-			"chat.planReview.cancelButtonLabel",
-			"chat.planReview.cancelTooltip",
 			"chat.planReview.clearAll",
 			"chat.planReview.clearAllConfirm",
 			"chat.planReview.clearAllConfirmPrimary",
@@ -14197,18 +15341,18 @@
 			"chat.planReview.commentRowAriaLabel",
 			"chat.planReview.commentRowLine",
 			"chat.planReview.expand",
-			"chat.planReview.expandSize",
 			"chat.planReview.feedbackLabel",
 			"chat.planReview.feedbackPlaceholder",
 			"chat.planReview.inlineCommentLocation",
 			"chat.planReview.inlineCommentLocationLine",
 			"chat.planReview.inlineCommentsHeading",
-			"chat.planReview.inlineCommentsHeadingNoFile",
 			"chat.planReview.openButtonLabel",
 			"chat.planReview.openTooltip",
+			"chat.planReview.outdated",
+			"chat.planReview.outdatedAnnouncement",
+			"chat.planReview.outdatedAriaLabel",
 			"chat.planReview.reject",
 			"chat.planReview.removeComment",
-			"chat.planReview.restoreSize",
 			"chat.planReview.reviewButtonLabel",
 			"chat.planReview.reviewTooltip",
 			"chat.planReview.submitFeedback",
@@ -14219,9 +15363,16 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart": [
 			"chat.questionCarousel.answered",
+			"chat.questionCarousel.answeredAutomatically",
+			"chat.questionCarousel.answeredQuestions",
+			"chat.questionCarousel.answerPrefix",
+			"chat.questionCarousel.autoReplyAnswer",
 			"chat.questionCarousel.collapseTitle",
 			"chat.questionCarousel.combinedFocusTerminalHint",
 			"chat.questionCarousel.combinedFocusTerminalHintNoKb",
+			"chat.questionCarousel.conversationAnswer",
+			"chat.questionCarousel.conversationNotAnswered",
+			"chat.questionCarousel.customAnswer",
 			"chat.questionCarousel.deferredToTerminal",
 			"chat.questionCarousel.enterCustomAnswer",
 			"chat.questionCarousel.enterText",
@@ -14235,12 +15386,17 @@
 			"chat.questionCarousel.navigation",
 			"chat.questionCarousel.notAnsweredYet",
 			"chat.questionCarousel.optionLabel",
+			"chat.questionCarousel.optionsTitle",
 			"chat.questionCarousel.questionAlertMulti",
+			"chat.questionCarousel.questionPrefix",
 			"chat.questionCarousel.required",
 			"chat.questionCarousel.roleDescription",
+			"chat.questionCarousel.selectedCustomAnswerAriaLabel",
+			"chat.questionCarousel.selectedOptionAriaLabel",
 			"chat.questionCarousel.singleQuestionLabel",
 			"chat.questionCarousel.skipAllTitle",
 			"chat.questionCarousel.skipped",
+			"chat.questionCarousel.skippedConversation",
 			"chat.questionCarousel.stepIndicator",
 			"chat.questionCarousel.submitHintMac",
 			"chat.questionCarousel.submitHintOther",
@@ -14273,12 +15429,24 @@
 			"usedReferencesPlural",
 			"usedReferencesSingular"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatRequestOriginPart": [
+			"chat.requestOrigin.delegation",
+			"chat.requestOrigin.delegationAriaLabel",
+			"chat.requestOrigin.openSource",
+			"chat.sideChatOrigin.ariaLabel",
+			"chat.sideChatOrigin.ariaLabelNoQuote",
+			"chat.sideChatOrigin.originalConversation"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatResourceGroupWidget": [
 			"chat.saveResources",
 			"chat.saveResources.error",
 			"chat.saveResources.progress",
 			"chat.saveResources.reveal",
 			"chat.saveResources.title"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatRichLink": [
+			"chat.richLink.loading",
+			"chat.richLink.loading.ariaLabel"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart": [
 			"chat.subagent.completedDefaultDescription",
@@ -14300,6 +15468,23 @@
 			"hook.subagent.warning",
 			"hook.subagent.warningGeneric"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentOpenChat": [
+			"chat.subagent.activeToolAria",
+			"chat.subagent.activeToolTooltip",
+			"chat.subagent.modelAria",
+			"chat.subagent.modelTooltip",
+			"chat.subagent.openChat",
+			"chat.subagent.openChat.aria",
+			"chat.subagent.openChat.confirmationsTooltip",
+			"chat.subagent.openChat.confirmationTooltip",
+			"chat.subagent.openChat.invalidResource",
+			"chat.subagent.status.completed",
+			"chat.subagent.status.waiting",
+			"chat.subagent.status.working",
+			"chat.subagent.workedDuration",
+			"chat.subagent.working",
+			"chat.subagent.workingDuration"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget": [
 			"chat.currentMode",
 			"chat.proceedFrom",
@@ -14313,6 +15498,7 @@
 			"editsSummary"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart": [
+			"chat.thinking.changes.title",
 			"chat.thinking.createdFile",
 			"chat.thinking.deletedFile",
 			"chat.thinking.deletions",
@@ -14349,6 +15535,8 @@
 			"chat.thinking.tool.3",
 			"chat.thinking.tool.4",
 			"chat.thinking.tool.5",
+			"chat.thinking.viewChanges",
+			"chat.thinking.viewChangesAccessible",
 			"chat.working.fun.1",
 			"chat.working.fun.2",
 			"chat.working.fun.3",
@@ -14394,9 +15582,9 @@
 			"chat.turnChanges.oneFile",
 			"chat.turnChanges.preview",
 			"chat.turnChanges.viewAllAccessible",
+			"chat.turnPreview.ariaLabel",
 			"chat.turnPreview.tooltip",
-			"chat.viewTurnFileChangesSummary",
-			"chatTurnPills.changes.title"
+			"chat.viewTurnFileChangesSummary"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatWorkspaceEditContentPart": [
 			"created",
@@ -14423,6 +15611,7 @@
 			"skip"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart": [
+			"agentFeedback.acceptFailed",
 			"agentFeedback.cancel",
 			"agentFeedback.collapseComment",
 			"agentFeedback.delete",
@@ -14431,6 +15620,11 @@
 			"agentFeedback.openFile",
 			"agentFeedback.reveal",
 			"agentFeedback.revealComment"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAutomationConfiguredResultSubPart": [
+			"automationConfigured.created",
+			"automationConfigured.open",
+			"automationConfigured.updated"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart": [
 			"allow",
@@ -14573,6 +15767,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatDragAndDrop": [
 			"attacAsContext",
+			"chat",
 			"dragAndDroppedImageName",
 			"file",
 			"folder",
@@ -14583,11 +15778,31 @@
 			"symbol",
 			"url"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatFind/chatFindAccessibilityHelp": [
+			"chatFind.context",
+			"chatFind.header",
+			"chatFind.keyboardHeader",
+			"chatFind.keyEnter",
+			"chatFind.keyEscape",
+			"chatFind.keyF3",
+			"chatFind.keyShiftEnter",
+			"chatFind.optionCase",
+			"chatFind.optionRegex",
+			"chatFind.optionsHeader",
+			"chatFind.optionWord",
+			"chatFind.revealDesc",
+			"chatFind.revealHeader",
+			"chatFind.settingsHeader",
+			"chatFind.settingVerbosity"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatForkActionViewItem": [
+			"chat.forkConversation.running",
+			"chat.forkConversation.runningStatus"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatListRenderer": [
 			"chat.planReview.approved",
 			"chat.planReview.autopilot",
 			"chat.planReview.feedback",
-			"chat.planReview.feedbackInline",
 			"chat.planReview.openFullPlan",
 			"chat.planReview.openFullPlanFile",
 			"chat.planReview.rejected",
@@ -14597,6 +15812,19 @@
 			"chat.questionCarouselNeedsInputSR",
 			"chat.questionCarouselSignalMany",
 			"chat.questionCarouselSignalOne",
+			"chat.responseCompletedOneStep",
+			"chat.responseCompletedOneStepIn",
+			"chat.responseCompletedSteps",
+			"chat.responseCompletedStepsIn",
+			"chat.responseTokenStats.modelAria",
+			"chat.responseTokenStats.modelAriaCached",
+			"chat.responseTokenStats.modelLine",
+			"chat.responseTokenStats.modelLineCached",
+			"chat.responseTokenStats.title",
+			"chat.restoreCheckpoint.cancelTooltip",
+			"chat.restoreCheckpoint.confirmTooltip",
+			"chat.startOver.cancelTooltip",
+			"chat.startOver.confirmTooltip",
 			"chatConfirmationAction",
 			"chatRequestSentAt",
 			"chatResponseCompletedAt",
@@ -14608,6 +15836,7 @@
 			"hook.thinking.blockedGeneric",
 			"hook.thinking.warning",
 			"hook.thinking.warningGeneric",
+			"openSubagentChat",
 			"queuedDivider",
 			"queuedDividerTooltip",
 			"renderFailMsg",
@@ -14620,13 +15849,48 @@
 			"usedAgentSlashCommand",
 			"working"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatListWidget": [
+			"chat.scrollToBottom"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatPetWidget": [
+			"chatPet.bouncedOffLeftWall",
+			"chatPet.bouncedOffLeftWallAndFell",
+			"chatPet.bouncedOffRightWall",
+			"chatPet.bouncedOffRightWallAndFell",
+			"chatPet.comeBack.action",
+			"chatPet.cool",
+			"chatPet.dizzy",
+			"chatPet.fellOff",
+			"chatPet.goOnTheRun.action",
+			"chatPet.grew",
+			"chatPet.grow.action",
+			"chatPet.interact",
+			"chatPet.landed",
+			"chatPet.loved",
+			"chatPet.movedLeft",
+			"chatPet.movedRight",
+			"chatPet.pressedButton",
+			"chatPet.respawned",
+			"chatPet.respawning",
+			"chatPet.restore",
+			"chatPet.shrank",
+			"chatPet.shrink.action",
+			"chatPet.singing",
+			"chatPet.speechless",
+			"chatPet.spun",
+			"chatPet.thrownLeft",
+			"chatPet.thrownRight",
+			"chatPet.variant.insiders.action",
+			"chatPet.variant.stable.action",
+			"chatPet.wokeUp",
+			"chatPet.worried",
+			"chatPet.yapping"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner": [
-			"chatReadOnlyBanner.message"
+			"chatReadOnlyBanner.archivedMessage"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatRestoreCheckpointActionViewItem": [
-			"chat.restoreCheckpoint.cancelTooltip",
-			"chat.restoreCheckpoint.confirm",
-			"chat.restoreCheckpoint.confirmTooltip"
+			"chat.restoreCheckpoint.confirm"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatTurnPills": [
 			"chatTurnPills.ariaLabel",
@@ -14648,6 +15912,7 @@
 			"chat.pendingRequests.steeringQueued",
 			"chatDescription",
 			"chatDisclaimer",
+			"chatReadOnlyBanner.message",
 			"chatWidget.instructions",
 			"codingAgentTitle",
 			"copilotCodingAgentMessage",
@@ -14669,7 +15934,12 @@
 			"chat.goalBanner.label",
 			"chat.goalBanner.loading"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatInputNoticeWidget": [
+			"chatInputNotice.dismiss",
+			"chatInputNotice.focusHint"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget": [
+			"chatInputNotificationRoleDescription",
 			"dismissNotification"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputPart": [
@@ -14691,6 +15961,8 @@
 			"chatPhoneInput.triggerAriaLabel"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem": [
+			"chat.askInSideChat",
+			"chat.askInSideChat.hover",
 			"chat.queueMessage",
 			"chat.queueMessage.hover",
 			"chat.queuePicker.moreActions",
@@ -14706,8 +15978,12 @@
 			"continueIn",
 			"continueInThirdParty"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions": [
+			"chatReferenceDescription"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions": [
 			"activeFile",
+			"attachedContext",
 			"fileEntryDescription",
 			"installLabel",
 			"mcp.prompt.error",
@@ -14720,10 +15996,13 @@
 			"chatInput.promptSlashCommand.open"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorHover": [
+			"chat.attachmentReference.imageHover",
+			"chat.attachmentReference.imageHoverAccessible",
 			"hoverAccessibilityChatAgent"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/editor/chatPasteProviders": [
 			"chat.pastedImageAttached",
+			"chat.pastedTextAttached",
 			"pastedAttachment.multiple",
 			"pastedAttachment.multipleLines",
 			"pastedAttachment.oneLine",
@@ -14732,6 +16011,10 @@
 			"pastedImageAttachment",
 			"pastedImageName",
 			"pastedSymbolReference",
+			"pastedTextArtifact",
+			"pastedTextArtifact.multipleLines",
+			"pastedTextArtifact.name",
+			"pastedTextArtifact.oneLine",
 			"pasteHtmlAsMarkdown"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerActionItem": [
@@ -14742,7 +16025,9 @@
 		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerConfiguration": [
 			"chat.config.cacheBreakHint",
 			"chat.effort.header",
+			"chat.modelPicker.configureLabel",
 			"chat.modelPicker.effortAriaLabel",
+			"chat.modelPicker.navigationAriaLabel",
 			"chat.modelPicker.tokensAriaLabel",
 			"chat.tokens.header",
 			"models.configDefault"
@@ -14752,7 +16037,6 @@
 			"chat.category.powerful",
 			"chat.category.versatile",
 			"chat.promo.discountBadge",
-			"chat.promo.endsAt",
 			"models.cacheCostLabel",
 			"models.cacheWriteCostLabel",
 			"models.configurable",
@@ -14765,33 +16049,38 @@
 			"models.longContext",
 			"models.outputCostLabel"
 		],
-		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItems": [
-			"chat.manageModels",
-			"chat.manageModels.tooltip",
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives": [
 			"chat.modelPicker.adminDescription",
 			"chat.modelPicker.adminHover",
 			"chat.modelPicker.adminLink",
-			"chat.modelPicker.auto",
 			"chat.modelPicker.checkUpdateHover",
-			"chat.modelPicker.copilotGroup",
 			"chat.modelPicker.downloadUpdateHover",
-			"chat.modelPicker.noModels",
-			"chat.modelPicker.otherModels",
 			"chat.modelPicker.pin",
-			"chat.modelPicker.pinned",
 			"chat.modelPicker.restartUpdateHover",
-			"chat.modelPicker.restrictedMode",
-			"chat.modelPicker.restrictedMode.trust",
-			"chat.modelPicker.restrictedMode.trustTooltip",
-			"chat.modelPicker.setupRequired",
-			"chat.modelPicker.setupRequired.signIn",
-			"chat.modelPicker.setupRequired.signInTooltip",
 			"chat.modelPicker.unpin",
 			"chat.modelPicker.updateDescription",
 			"chat.modelPicker.upgradeHover",
 			"chat.modelPicker.upgradeHoverProPlus",
 			"chat.modelPicker.upgradeLink",
 			"chat.promo.discount"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItems": [
+			"chat.manageModels",
+			"chat.manageModels.tooltip"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections": [
+			"chat.modelPicker.auto",
+			"chat.modelPicker.noModels",
+			"chat.modelPicker.otherModels",
+			"chat.modelPicker.pinned",
+			"chat.modelPicker.restrictedMode",
+			"chat.modelPicker.restrictedMode.trust",
+			"chat.modelPicker.restrictedMode.trustTooltip",
+			"chat.modelPicker.setupRequired",
+			"chat.modelPicker.setupRequired.signIn",
+			"chat.modelPicker.setupRequired.signInTooltip",
+			"chat.modelPicker.upgradeHover",
+			"chat.modelPicker.upgradeLink"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerPresentation": [
 			"chat.priceCategory.high",
@@ -14819,7 +16108,10 @@
 			"chatModelProviderCopilotIcon",
 			"chatModelProviderGeminiIcon",
 			"chatModelProviderGenericIcon",
-			"chatModelProviderOpenAIIcon"
+			"chatModelProviderKimiIcon",
+			"chatModelProviderMicrosoftIcon",
+			"chatModelProviderOpenAIIcon",
+			"chatModelProviderXAIIcon"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem": [
 			"built-in",
@@ -14915,7 +16207,12 @@
 			"voiceMode.bargeInHintNoKb",
 			"voiceMode.clickMicOrBargeInHint",
 			"voiceMode.listening",
-			"voiceMode.pttOrBargeInHint"
+			"voiceMode.pttHint",
+			"voiceMode.pttOrBargeInHint",
+			"voiceMode.simHint.buttonHold",
+			"voiceMode.simHint.clickToggle",
+			"voiceMode.simHint.handsFree",
+			"voiceMode.simHint.keyboardHold"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewTitleControl": [
 			"chat",
@@ -14928,6 +16225,7 @@
 			"agentSessionIsArchived",
 			"agentSessionIsPinned",
 			"agentSessionIsRead",
+			"agentSessionPullRequest",
 			"agentSessionSection",
 			"agentSessionsViewerFocused",
 			"agentSessionsViewerOrientation",
@@ -14935,6 +16233,7 @@
 			"agentSessionsViewerVisible",
 			"agentSessionType",
 			"agentSupportsAttachments",
+			"chatAgentHostHasImmutablePrimaryWorkingDirectory",
 			"chatAgentHostProviderId",
 			"chatAgentModeDisabledByPolicy",
 			"chatContextUsageHasBeenOpened",
@@ -14946,6 +16245,10 @@
 			"chatEditingHasToolConfirmation",
 			"chatEditingSentRequest",
 			"chatExtensionInvalid",
+			"chatFindInputFocused",
+			"chatFindSupported",
+			"chatFindWidgetFocused",
+			"chatFindWidgetVisible",
 			"chatFirstRequest",
 			"chatForegroundSessionCount",
 			"chatHasAgents",
@@ -14954,6 +16257,8 @@
 			"chatHasPendingDelegationTarget",
 			"chatHasPendingRequests",
 			"chatHasUsedCreateSlashCommands",
+			"chatInputRouting",
+			"chatInputSubmitPending",
 			"chatIsAgentHostSession",
 			"chatIsEnabled",
 			"chatIsKatexMathElement",
@@ -14999,7 +16304,9 @@
 			"inAgentSessionsWelcome",
 			"inAutomationsDialog",
 			"inChat",
+			"inChatComposer",
 			"inChatEditor",
+			"inChatInputWindow",
 			"inChatQuestionCarousel",
 			"inChatTerminalToolOutput",
 			"inChatTip",
@@ -15235,6 +16542,10 @@
 			"newChat"
 		],
 		"vs/workbench/contrib/chat/common/customizationHarnessService": [
+			"customizationDisabled",
+			"customizationDisabledPlugin",
+			"customizationDisabledSession",
+			"customizationDisabledWorkspace",
 			"harness.local"
 		],
 		"vs/workbench/contrib/chat/common/editing/chatEditingService": [
@@ -15246,6 +16557,10 @@
 			"autoModel.description",
 			"autoModel.discount",
 			"autoModel.learnMore",
+			"chat.languageModelNameWithProvider",
+			"chat.languageModelNameWithProviderAndGroup",
+			"chat.languageModelProvider.copilot",
+			"chat.promo.endsAt",
 			"chat.providerDeprecation.install",
 			"chat.providerDeprecation.message",
 			"configureLanguageModelGroup",
@@ -15830,7 +17145,10 @@
 			"agentStatusIndicator.background",
 			"chat.avatarBackground",
 			"chat.avatarForeground",
+			"chat.dictationActiveMicGlow",
 			"chat.editedFileForeground",
+			"chat.findMatchBackground",
+			"chat.findMatchHighlightBackground",
 			"chat.inputWorkingBorderColor1",
 			"chat.inputWorkingBorderColor2",
 			"chat.inputWorkingBorderColor3",
@@ -15844,6 +17162,9 @@
 			"chat.slashCommandBackground",
 			"chat.slashCommandForeground",
 			"chat.thinkingShimmer",
+			"chat.voiceGlowBaseColor",
+			"chat.voiceListeningGlow",
+			"chat.voiceSpeakingGlow",
 			"chatCheckpointSeparator"
 		],
 		"vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions": [
@@ -15867,6 +17188,17 @@
 			"exportAgentTracesDB.label",
 			"exportAgentTracesDB.notFound"
 		],
+		"vs/workbench/contrib/chat/electron-browser/actions/installDictationModelAction": [
+			"chat.installDictationModel",
+			"chat.installDictationModel.dialogTitle",
+			"chat.installDictationModel.error",
+			"chat.installDictationModel.filter",
+			"chat.installDictationModel.localOnly",
+			"chat.installDictationModel.openLabel",
+			"chat.installDictationModel.progress",
+			"chat.installDictationModel.success",
+			"chat.installDictationModel.unsupported"
+		],
 		"vs/workbench/contrib/chat/electron-browser/actions/networkDiagnosticsAction": [
 			"workbench.action.chat.agentHostNetworkDiagnostics.label"
 		],
@@ -15885,6 +17217,9 @@
 			"profileAgentHost.stop",
 			"profileAgentHost.stopFailed",
 			"stopAgentHostProfile"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/restartAgentHostAction": [
+			"restartLocalAgentHost"
 		],
 		"vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions": [
 			"keywordActivation.status.active",
@@ -15971,15 +17306,33 @@
 			"reloadTheWindow.detail",
 			"reloadTheWindow.message"
 		],
+		"vs/workbench/contrib/chat/electron-browser/codexCustomizationSettings.contribution": [
+			"codexCustomizationSettings.navigationDescription",
+			"codexCustomizationSettings.navigationLabel"
+		],
 		"vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem": [
+			"tunnelHost.ariaLabel.remoteTunnelAccess",
 			"tunnelHost.hover.connecting",
 			"tunnelHost.hover.enabled",
 			"tunnelHost.hover.idle",
+			"tunnelHost.hover.idle.ariaLabel",
+			"tunnelHost.hover.idle.ariaLabel.noWebUrl",
+			"tunnelHost.hover.idle.noWebUrl",
+			"tunnelHost.hover.learnMore",
+			"tunnelHost.hover.remoteTunnelAccess",
+			"tunnelHost.hover.renameTunnel",
 			"tunnelHost.hover.sharing",
 			"tunnelHost.hover.showOutput",
 			"tunnelHost.toast"
 		],
 		"vs/workbench/contrib/chat/electron-browser/tunnelHost.contribution": [
+			"renameTunnel",
+			"renameTunnel.error",
+			"renameTunnel.invalidName",
+			"renameTunnel.maxLength",
+			"renameTunnel.placeholder",
+			"renameTunnel.prompt",
+			"renameTunnel.title",
 			"showTunnelHostOutput",
 			"toggleSharing",
 			"tunnelHost.category",
@@ -16635,8 +17988,7 @@
 			"contributes.priority",
 			"contributes.priority.default",
 			"contributes.priority.diffEditor",
-			"contributes.priority.mergeEditor",
-			"contributes.priority.never",
+			"contributes.priority.explicit",
 			"contributes.priority.option",
 			"contributes.priority.textEditor",
 			"contributes.selector",
@@ -19599,6 +20951,7 @@
 		],
 		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			"dirtyCounter",
+			"dirtyCounterAriaLabel",
 			"flipLayout",
 			{
 				"key": "miToggleEditorLayout",
@@ -19614,7 +20967,8 @@
 					"Open is an adjective"
 				]
 			},
-			"openEditors"
+			"openEditors",
+			"openUnsavedEditor"
 		],
 		"vs/workbench/contrib/files/browser/workspaceWatcher": [
 			"enospcError",
@@ -20549,6 +21903,7 @@
 			"mcp.agentHost.disableSession",
 			"mcp.agentHost.disableWorkspace",
 			"mcp.agentHost.enable",
+			"mcp.agentHost.enablePlugin",
 			"mcp.agentHost.enableSession",
 			"mcp.agentHost.enableWorkspace",
 			"mcp.agentHost.noServers",
@@ -22046,6 +23401,7 @@
 		],
 		"vs/workbench/contrib/onboarding/browser/onboarding.contribution": [
 			"onboarding.developerMode",
+			"onboarding.developerModeVariations",
 			"onboarding.enabled",
 			"onboarding.resetShownState"
 		],
@@ -22788,6 +24144,9 @@
 			"remote.help.report",
 			"remotehelp"
 		],
+		"vs/workbench/contrib/remote/browser/remote.contribution": [
+			"remote.togglePortsView"
+		],
 		"vs/workbench/contrib/remote/browser/remoteConnectionHealth": [
 			{
 				"key": "allow",
@@ -23063,6 +24422,7 @@
 					"{0} will be the tunnel name, {1} will the link address to the web UI, {6} an extension name, {7} a link to the extension documentation. [label](command:commandId) is a markdown link. Only translate the label, do not modify the format"
 				]
 			},
+			"progress.turnOn.final.noLink",
 			{
 				"key": "recommend.remoteExtension",
 				"comment": [
@@ -25259,11 +26619,15 @@
 			"suggestCommandsMore",
 			"suggestConfigure",
 			"suggestLearnMore",
-			"suggestTrigger"
+			"suggestTrigger",
+			"terminalDictation"
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/common/terminalAccessibilityConfiguration": [
 			"terminal.integrated.accessibleViewFocusOnCommandExecution",
-			"terminal.integrated.accessibleViewPreserveCursorPosition"
+			"terminal.integrated.accessibleViewPreserveCursorPosition",
+			"terminal.integrated.accessibleViewPreserveCursorPosition.always",
+			"terminal.integrated.accessibleViewPreserveCursorPosition.false",
+			"terminal.integrated.accessibleViewPreserveCursorPosition.true"
 		],
 		"vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration": [
 			"terminal.integrated.autoReplies",
@@ -25402,14 +26766,9 @@
 			"runInTerminal.allowNetwork.confirmationMessage.defaultReason",
 			"runInTerminal.allowNetwork.disabled.invocation",
 			"runInTerminal.allowNetwork.disabled.result",
-			"runInTerminal.bubblewrap.applyFix",
-			"runInTerminal.bubblewrap.cancel",
-			"runInTerminal.bubblewrap.cancelled",
-			"runInTerminal.bubblewrap.message",
-			"runInTerminal.bubblewrap.repairFailed",
-			"runInTerminal.bubblewrap.repairUnknown",
-			"runInTerminal.bubblewrap.stillUnavailable",
-			"runInTerminal.bubblewrap.title",
+			"runInTerminal.bubblewrap.hostRestriction",
+			"runInTerminal.bubblewrap.unsupportedEnvironment",
+			"runInTerminal.bubblewrap.unsupportedEnvironmentWithSettingsLink",
 			"runInTerminal.bubblewrap.unusable",
 			"runInTerminal.confirmationMessage",
 			"runInTerminal.defaultExplanation",
@@ -25526,12 +26885,9 @@
 			"agentSandbox.allowAutoApprove",
 			"agentSandbox.allowNetwork",
 			"agentSandbox.allowUnsandboxedCommands",
-			"agentSandbox.enabled.deprecated",
 			"agentSandbox.enabledSetting",
 			"agentSandbox.enabledSetting.offDescription",
 			"agentSandbox.enabledSetting.onDescription",
-			"agentSandbox.fileSystemLinux.deprecated",
-			"agentSandbox.fileSystemMac.deprecated",
 			"agentSandbox.linuxFileSystemSetting",
 			"agentSandbox.linuxFileSystemSetting.allowRead",
 			"agentSandbox.linuxFileSystemSetting.allowWrite",
@@ -25818,6 +27174,9 @@
 			"vscode.extension.contributes.terminalQuickFixes.kind",
 			"vscode.extension.contributes.terminalQuickFixes.outputMatcher"
 		],
+		"vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminalResizeDimensionsOverlayConfiguration": [
+			"resizeDimensionsOverlay.enabled"
+		],
 		"vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution": [
 			"sendSequence",
 			"sendSequence.text.desc",
@@ -25993,6 +27352,8 @@
 			"terminal.integrated.localEchoStyle"
 		],
 		"vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice": [
+			"terminalVoice.stopDictationHover",
+			"terminalVoice.stopDictationHoverNoKeybinding",
 			"terminalVoiceTextInserted"
 		],
 		"vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions": [
@@ -27572,17 +28933,6 @@
 			"onboarding.personalize.tip.prefix",
 			"onboarding.personalize.tip.shift",
 			"onboarding.personalize.tip.suffix",
-			"onboarding.sessions.agentMode",
-			"onboarding.sessions.agentMode.desc",
-			"onboarding.sessions.agentsTutorial",
-			"onboarding.sessions.customize",
-			"onboarding.sessions.customize.desc",
-			"onboarding.sessions.group.chat",
-			"onboarding.sessions.group.more",
-			"onboarding.sessions.planMode",
-			"onboarding.sessions.planMode.desc",
-			"onboarding.sessions.runAnywhere",
-			"onboarding.sessions.runAnywhere.desc",
 			"onboarding.sessions.signInNudge",
 			"onboarding.signIn.apple",
 			"onboarding.signIn.disclaimer.copilotPrefix",
@@ -27611,7 +28961,6 @@
 			"onboarding.signIn.heroSubtitle",
 			"onboarding.signIn.heroTitle",
 			"onboarding.signIn.signedIn",
-			"onboarding.step.agentSessions.subtitle.before",
 			"onboarding.step.aria",
 			"onboarding.stepOf",
 			"onboarding.theme.selected.alert"
@@ -27626,8 +28975,6 @@
 			"onboarding.aiPref.balanced.desc",
 			"onboarding.aiPref.codeFirst",
 			"onboarding.aiPref.codeFirst.desc",
-			"onboarding.step.agentSessions",
-			"onboarding.step.agentSessions.subtitle",
 			"onboarding.step.aiPreference",
 			"onboarding.step.aiPreference.subtitle",
 			"onboarding.step.personalize",
@@ -28300,6 +29647,19 @@
 			"vscode.extension.contributes.submenus",
 			"webview.context"
 		],
+		"vs/workbench/services/agentEditorComments/browser/agentEditorCommentsOverlayWidget": [
+			"agentEditorComments.nOfM",
+			"agentEditorComments.submitCount",
+			"agentEditorComments.submitCountShort",
+			"agentEditorComments.zero"
+		],
+		"vs/workbench/services/agentHost/browser/codexAccountService": [
+			"chatGPTAccount",
+			"chatGPTAccountWithProvider",
+			"downloadingCodexAgent",
+			"signInToChatGPT",
+			"signOutOfChatGPT"
+		],
 		"vs/workbench/services/assignment/common/assignmentService": [
 			"workbench.enableExperiments"
 		],
@@ -28520,6 +29880,19 @@
 			"missingExtensionName",
 			"noValueForCommand"
 		],
+		"vs/workbench/services/dataChannel/browser/dataChannelService": [
+			"linkPresentation.unavailable",
+			"linkPresentation.unavailableAriaLabel",
+			"linkPresentation.unavailableTooltip",
+			"linkPresentationProvider.coreDuplicateId",
+			"linkPresentationProvider.duplicateId",
+			"linkPresentationProvider.enablement",
+			"linkPresentationProvider.id",
+			"linkPresentationProvider.initialKind",
+			"linkPresentationProvider.invalidPattern",
+			"linkPresentationProvider.uriPattern",
+			"linkPresentationProviderExtensionPoint"
+		],
 		"vs/workbench/services/decorations/browser/decorationsService": [
 			"bubbleTitle"
 		],
@@ -28596,6 +29969,7 @@
 		"vs/workbench/services/editor/common/editorResolverService": [
 			"editor.diffEditorAssociations",
 			"editor.editorAssociations",
+			"editor.hiddenEditorTypes",
 			"editor.markdownDefaultEditorInAgentsWindow"
 		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
@@ -29105,7 +30479,13 @@
 			"accountPolicy.notification.orgWithAccountNoList",
 			"accountPolicy.notification.signin",
 			"accountPolicy.notification.signin.action",
-			"accountPolicy.notification.signinWithOrgs"
+			"accountPolicy.notification.signinWithOrgs",
+			"managedSettingsUpdate.dialog.close",
+			"managedSettingsUpdate.dialog.learnMore",
+			"managedSettingsUpdate.dialog.title",
+			"managedSettingsUpdate.dialog.update",
+			"managedSettingsUpdate.notification",
+			"managedSettingsUpdate.notificationWithMinimumVersion"
 		],
 		"vs/workbench/services/policies/common/accountPolicyService": [
 			"chatAccountPolicyGateActive"
@@ -29441,7 +30821,8 @@
 			"schema.rootFolderNames",
 			"schema.rootFolderNamesExpanded",
 			"schema.showLanguageModeIcons",
-			"schema.src"
+			"schema.src",
+			"schema.usesCurrentColor"
 		],
 		"vs/workbench/services/themes/common/iconExtensionPoint": [
 			"contributes.icon.default",
@@ -30983,6 +32364,7 @@
 			"activeEditorState - such as modified, problems, and more, is included as a part of the window.title setting by default. Disable it with accessibility.windowTitleOptimized.",
 			"You are in a pane of a diff editor.",
 			"You are in a code editor.",
+			"Start or stop dictation in the editor{0}.",
 			"Editor content",
 			"Focus notification toasts{0} to navigate them with the keyboard. Accept the primary action of a focused notification{1}.",
 			"Go to Line/Column...",
@@ -31526,6 +32908,11 @@
 			"Whether tab should jump to an inline edit."
 		],
 		"vs/editor/contrib/inlineCompletions/browser/controller/inlineCompletionsController": [
+			"Next edit suggestion available on line {0}, accept it to apply",
+			"Next edit suggestion available on line {0}, press {1} to accept",
+			"Next edit suggestion available on line {0}",
+			"Next edit suggestion available on line {0}, press {1} to jump",
+			"Next edit suggestion available on line {0}",
 			"Inspect this in the accessible view ({0})"
 		],
 		"vs/editor/contrib/inlineCompletions/browser/hintsWidget/hoverParticipant": [
@@ -32117,12 +33504,9 @@
 		"vs/platform/agentHost/browser/agentHostConnectionsService": [
 			"Local"
 		],
-		"vs/platform/agentHost/browser/agentHostEnablementService": [
-			"When enabled, some agents run in a separate agent host process."
-		],
 		"vs/platform/agentHost/common/agentHostCustomizationConfig": [
-			"When enabled (the default), the Claude agent routes all requests through GitHub Copilot. When disabled, Claude talks to Anthropic directly using your own credentials (API key or Claude subscription).",
-			"Route Claude Through Copilot",
+			"Experimental. When enabled, Agent Host sessions remain available while signed out as long as the selected agent has a usable model and authentication (for example Codex with ChatGPT authentication or Claude in native mode with your own Anthropic credentials). When disabled (the default), GitHub sign-in is required.",
+			"Allow Signed-Out Agent Host",
 			"Plugins configured on this agent host and available to remote sessions.",
 			"Description",
 			"Name",
@@ -32132,25 +33516,42 @@
 			"Absolute path to the shell executable used by host-managed terminals. Normally pushed by the connected VS Code client from `terminal.integrated.agentHostProfile.<os>` (falling back to `terminal.integrated.defaultProfile.<os>`); when unset, the agent host falls back to the system shell. Only the path is supported; `args` and `env` from the workbench profile are not piped through yet. The workbench only pushes this for the local agent host — remote agent host operators should set this directly in the remote machine's `agent-host-config.json`.",
 			"Default Shell",
 			"Optional base URI of a GitHub Enterprise instance (for example \"https://ghe.example.com\" for GitHub Enterprise Server, or \"https://tenant.ghe.com\" for GitHub Enterprise Cloud). When set, the agent host authenticates and makes GitHub API calls against this instance instead of github.com. Normally pushed by the connected VS Code client from the `github-enterprise.uri` setting; remote agent host operators can set it directly in the remote `agent-host-config.json`.",
-			"GitHub Enterprise URI"
+			"GitHub Enterprise URI",
+			"Controls whether session-scoped customizations are populated from local file scanning or from Copilot SDK discovery.",
+			"Session Customization Discovery Mode"
 		],
 		"vs/platform/agentHost/common/agentHostEnablementService": [
-			"Whether the local agent host process is enabled.",
-			"When enabled, some agents run in a separate agent host process.",
-			"When enabled, hides the Extension Host Copilot CLI entry from the Agents window picker. Requires `#chat.agentHost.enabled#`.",
-			"When enabled, new editor and panel chat sessions default to the Agent Host Copilot CLI instead of the local harness. Requires `#{0}#`.",
-			"When enabled, hides the Extension Host Copilot CLI entry from the editor window chat picker.",
+			"Whether Agent Host features are available and AI features are enabled in this window.",
+			"When enabled, new editor and panel chat sessions default to the Agent Host Copilot SDK instead of the local harness.",
 			"When enabled, shows the VS Code local chat harness in the chat picker. This setting is ignored in virtual workspaces, where the local chat harness is always available.",
-			"When enabled, prefers the Agent Host Copilot CLI for new editor chat sessions. If the local harness is selected, it is replaced with Copilot once.",
+			"When enabled, uses the Agent Host Copilot SDK whenever the local harness would otherwise be selected for a new editor chat session. Claude and Codex selections are unaffected.",
+			"Configure whether VS Code uses the Agent Host Copilot SDK instead of the local harness for new editor chat sessions.",
 			"Chat Agent Host"
 		],
 		"vs/platform/agentHost/common/agentHostSchema": [
+			"Whether the active agent names sessions and chats with rename tools instead of utility-model title generation.",
+			"Active Agent Title Generation",
+			"Auto Approve Policy Restricted",
 			"Whether VS Code's auto-reply setting is enabled. When `true`, `ask_user` questions are auto-answered instead of blocking on the user, mirroring autopilot mode.",
 			"Auto Reply",
+			"Whether the Claude provider advertises support for multiple working directories, letting a session span every folder of a multi-root workspace.",
+			"Claude Multiple Working Directories",
 			"Whether the Codex provider is enabled.",
 			"Codex Agent",
+			"Whether the Codex provider advertises support for multiple working directories, letting a session span every folder of a multi-root workspace.",
+			"Codex Multiple Working Directories",
+			"Whether the Copilot provider advertises support for multiple working directories, letting a session span every folder of a multi-root workspace.",
+			"Copilot Multiple Working Directories",
+			"Whether repository information telemetry is disabled for Agent Host sessions.",
+			"Disable Repository Information Telemetry",
+			"Effective edit auto-approve patterns forwarded by the connected client for agent-host write permission checks.",
+			"Edit Auto Approve Patterns",
+			"Whether edit attribution telemetry is enabled for Agent Host sessions.",
+			"Edit Telemetry",
 			"Whether VS Code's global auto-approve setting is enabled. When `true`, every tool call is auto-approved, equivalent to a session using Allow all.",
 			"Global Auto Approve",
+			"Whether agents receive guidance for using rich links and running task markers in Markdown plan documents.",
+			"Markdown Plan Rich Links",
 			"Argument",
 			"For `stdio` servers, the arguments passed to the command.",
 			"Arguments",
@@ -32170,10 +33571,12 @@
 			"Server Type",
 			"For `http` servers, the endpoint URL of the MCP server.",
 			"URL",
-			"Whether Copilot Chat's prefer-long-context setting is enabled. When `true`, models with a free long context window only show the long context option in the picker. When `false` (default), the smaller default context option stays selectable.",
-			"Prefer Long Context",
+			"Whether un-adopted extension-host Copilot CLI sessions are surfaced as adoptable agent-host sessions and migrated in place when opened.",
+			"Migrate Legacy Copilot CLI Sessions",
 			"Whether remote session sync is enabled for the copilot-sdk CLI.",
 			"Session Sync",
+			"Controls whether sessions created outside the Agent Host are included in the session catalog.",
+			"Show External Agent Sessions",
 			"Whether Copilot sessions automatically discover and use the operating system's proxy configuration.",
 			"System Proxy Discovery",
 			"Most restrictive telemetry level requested by connected clients.",
@@ -32187,12 +33590,12 @@
 			"Evaluates risk before running tools",
 			"Allow all",
 			"Runs tool calls without asking",
-			"Default approvals",
+			"Manual permissions",
 			"Asks when approval settings don't apply",
 			"Tool approval behavior for this session",
 			"Agent Mode",
 			"Autopilot",
-			"Autonomously iterates from start to finish",
+			"Works autonomously within permissions",
 			"Interactive",
 			"Step-by-step collaboration",
 			"Plan",
@@ -32205,18 +33608,34 @@
 			"Per-tool session permissions. Updated automatically when approving a tool \"in this Session\"."
 		],
 		"vs/platform/agentHost/common/agentHostStarter.config.contribution": [
-			"When enabled, the agent host wires up the BYOK ('bring your own key') language-model bridge so extension-provided BYOK models can run in agent-host sessions. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
-			"When enabled, the agent host registers the Claude provider (subject to the Claude SDK being reachable). Independent of `#chat.agents.claude.preferAgentHost#` and `#chat.editor.claude.preferAgentHost#`, which choose which integration surfaces Claude. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
+			"Controls whether enabled Agent Merge sessions address unresolved review threads, changes-requested reviews, and new pull request comments from repository maintainers or the Copilot pull request reviewer.",
+			"Enables the experimental Agent Merge controller and its commands. Agent Merge can monitor an agent session's pull request, ask the agent to address selected blockers, and optionally merge the pull request when it is ready.",
+			"Controls whether enabled Agent Merge sessions ask the agent to fix failed required CI checks.",
+			"Controls the native merge method used by Agent Merge.",
+			"Uses the first repository-compatible method in this order: squash, merge commit, rebase.",
+			"Uses a merge commit when the repository permits it.",
+			"Uses rebase merge when the repository permits it.",
+			"Uses squash merge when the repository permits it.",
+			"Controls whether the Agent Host automatically merges or enqueues pull requests for enabled Agent Merge sessions after all selected maintenance work is complete.",
+			"Controls whether review-thread replies posted by Agent Merge include an automated-reply attribution note.",
+			"Controls whether enabled Agent Merge sessions ask the agent to update branches that are behind or resolve merge conflicts.",
+			"When enabled, the agent host wires up the BYOK ('bring your own key') language-model bridge so extension-provided BYOK models can run in agent-host sessions. The agent host process must be restarted for changes to take effect.",
+			"When enabled, the agent host registers the Claude provider, subject to the Claude SDK being reachable. The agent host process must be restarted for changes to take effect.",
 			"Enable Claude Agent sessions in VS Code. Start and resume agentic coding sessions powered by Anthropic Claude Agent SDK directly in the editor. Uses your existing Copilot subscription.",
+			"When enabled, Claude agent-host sessions advertise support for multiple working directories, so a session created in a multi-root workspace can span every workspace folder. Experimental; newly created sessions pick up a change without restarting the agent host.",
 			"Additional command-line arguments passed to `codex app-server`. Primarily useful for debugging (for example, `--log-level=debug`).",
 			"Optional override for `$CODEX_HOME`. Controls where the codex binary reads config and writes rollouts. When empty, codex uses its default (`~/.codex`).",
-			"When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
-			"Enable Codex Agent sessions in VS Code. Start and resume agentic coding sessions powered by OpenAI Codex SDK. Uses your existing Copilot subscription.",
-			"Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@openai/codex`. When set, the agent host spawns the Codex binary from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. Requires `#chat.agentHost.enabled#`. The agent host process must be restarted for changes to take effect.",
+			"When enabled, the agent host registers the Codex provider (subject to the Codex SDK being reachable). Enabling takes effect without restarting the agent host.",
+			"Enable Codex Agent sessions in VS Code. Start and resume agentic coding sessions powered by OpenAI Codex. Usage can be routed through GitHub Copilot or authenticated directly with an OpenAI account.",
+			"When enabled, Codex agent-host sessions advertise support for multiple working directories, so a session created in a multi-root workspace can span every workspace folder. Experimental; newly created sessions pick up a change without restarting the agent host.",
+			"Experimental, for local SDK development only. Absolute path to a directory containing `node_modules/@openai/codex`. When set, the agent host spawns the Codex binary from this tree instead of downloading the SDK. Empty (the default) falls through to the SDK distribution shipped with this build. The agent host process must be restarted for changes to take effect.",
+			"When enabled, Copilot agent-host sessions advertise support for multiple working directories, so a session created in a multi-root workspace can span every workspace folder. Experimental; newly created sessions pick up a change without restarting the agent host.",
+			"When enabled, the active agent names new sessions and chats using rename tools. When disabled, a utility model generates titles. Changes apply to sessions and chats created afterward.",
+			"When enabled, agents receive guidance for using rich links to issues, pull requests, commits, sessions, and chats, plus running task markers, when creating or editing Markdown plan documents.",
 			"When enabled, includes prompt and response content in OTel span attributes. Configurable in user settings only. Sets `OTEL_INSTRUMENTATION_GENAI_CAPTURE_MESSAGE_CONTENT`. Privacy-sensitive: do not enable in environments that ship spans to shared sinks.",
 			"Controls whether Copilot OpenTelemetry export captures prompt, response, and tool content.",
 			"When enabled, the agent host persists every emitted OTel span to a local SQLite database. Configurable in user settings only. Spans can be inspected via the `Export Agent Host Traces Database` command. Compatible with external exporters: spans are written to SQLite *and* forwarded to the user-configured sink.",
-			"When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Configurable in user settings only. Requires `#chat.agentHost.enabled#`. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally.",
+			"When enabled, the agent host emits OpenTelemetry traces from the Copilot SDK. Configurable in user settings only. Either configure `#chat.agentHost.otel.otlpEndpoint#` to ship traces to an external collector or enable `#chat.agentHost.otel.dbSpanExporter.enabled#` to capture them locally.",
 			"Controls whether Copilot OpenTelemetry export is enabled. When managed, users cannot override the enterprise value.",
 			"Exporter backend used by the Copilot SDK when `#chat.agentHost.otel.enabled#` is on. Configurable in user settings only. `otlp-grpc` is downgraded to `otlp-http` transparently in the CLI runtime.",
 			"Enterprise-managed OTLP exporter headers (e.g. auth tokens) for Copilot OpenTelemetry export. Policy-only and extension-only: applied directly to the Copilot Chat extension's OTLP exporter, never delivered to the agent host process.",
@@ -32238,6 +33657,15 @@
 			"Controls the enterprise-managed OTel `service.name` resource attribute for Copilot OpenTelemetry export.",
 			"When enabled, Copilot sessions automatically discover and use the operating system's proxy configuration when no proxy environment variable is set.",
 			"Chat Agent Host Starter"
+		],
+		"vs/platform/agentHost/common/agentMerge": [
+			"Address Reviews",
+			"Agent Merge",
+			"Fix CI Failures",
+			"Merge Method",
+			"Merge Pull Request",
+			"Reply Attribution",
+			"Resolve Conflicts"
 		],
 		"vs/platform/agentHost/common/changesetUri": [
 			"Branch Changes",
@@ -32261,18 +33689,51 @@
 			"Trace",
 			"When enabled, Copilot SDK sessions use Agent Host's terminal tool override instead of the SDK's default terminal behavior.",
 			"Use Agent Host Terminal Tool",
-			"Per-model capability overrides for Copilot SDK sessions, keyed by model id. Aliasing a model id to a known `family` routes it to that family's tuned system prompt without changing the model id sent to the runtime. Only affects Copilot SDK sessions; intended for experimentation.",
+			"When set, only matching tools are available to sessions on this model. Patterns: bare tool names, `builtin:*` or `builtin:<name>` (Copilot runtime tools), `mcp:*` or `mcp:<name>` (MCP server tools), and `custom:*` or `custom:<name>` (every tool VS Code registers with the SDK, including the agent host's own terminal tools); a bare `*` expands to all three sources. Applied when the session launches or resumes.",
+			"Tool Name or Pattern",
+			"Available Tools",
+			"Per-model capability overrides for Copilot SDK sessions, keyed by model id (`*` matches every model; a specific entry wins field-by-field). Aliasing a model id to a known `family` routes it to that family's tuned system prompt and tool profile without changing the model id sent to the runtime; the remaining fields override reasoning effort, tool enablement, and model capability limits per model. Only affects Copilot SDK sessions; intended for experimentation.",
 			"A single capability override. The property key is the model id.",
 			"Capability Override",
-			"Alias the model's family for prompt/capability routing (e.g. `claude-opus-4-8`).",
+			"Tools disabled for sessions on this model; same pattern syntax as `availableTools` and takes precedence over it. Note that `custom:*` and a bare `*` also disable the agent host's own terminal tools registered with the SDK. Applied when the session launches or resumes.",
+			"Tool Name or Pattern",
+			"Excluded Tools",
+			"Route the model to another family's tuned system prompt and tool profile (e.g. `claude-opus-4.8`). The model id sent to the runtime is unaffected, so the session still runs on the selected model.",
 			"Family",
+			"Per-property model capability overrides passed through to the Copilot SDK's `modelCapabilities` session field (e.g. `{ \"supports\": { \"vision\": false }, \"limits\": { \"max_context_window_tokens\": 64000 } }`), deep-merged over the runtime's resolved defaults for this model. Applied when the session launches or resumes.",
+			"Model Capabilities",
+			"Reasoning effort for sessions on this model; overrides the model picker's thinking level. Unrecognized values are ignored.",
+			"Reasoning Effort",
 			"Model Capability Overrides",
 			"When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message.",
 			"Opus 4.8 Agent Prompt",
-			"Overrides the reasoning effort for Copilot SDK sessions regardless of the per-model picker value. Set it to a level the selected model supports (e.g. `low`, `medium`, `high`, `xhigh`); a value that isn't a recognized effort level is ignored and the session falls back to the picker value. Only affects Copilot SDK sessions; intended for experimentation.",
-			"Reasoning Effort Override",
+			"When enabled, requests concise reasoning summaries for supported Copilot SDK sessions.",
+			"Reasoning Summary",
 			"When enabled, the coding agent uses a rubber duck critic subagent to review code changes using a complementary model.",
-			"Rubber Duck Agent"
+			"Rubber Duck Agent",
+			"Minimum number of tools before MCP and external tools are deferred behind tool search. Set to 0 to always defer external tools. Only effective when tool search is enabled.",
+			"Tool Search Defer Threshold",
+			"When enabled, Copilot SDK sessions defer MCP and non-core VS Code tools behind a tool-search tool so the model discovers them on demand instead of loading every tool definition up front.",
+			"Agent Host Tool Search"
+		],
+		"vs/platform/agentHost/common/copilotConfigSlashCommands": [
+			"Switch to autopilot mode",
+			"Switch to autopilot mode with an objective",
+			"objective",
+			"Set permissions back to default",
+			"Switch to interactive mode",
+			"Create an implementation plan before coding",
+			"Describe what you want to plan or research",
+			"Set permissions to bypass approvals"
+		],
+		"vs/platform/agentHost/common/openSessionLink": [
+			"Agent session {0}, {1}",
+			"Completed",
+			"Error",
+			"Needs input",
+			"Not started",
+			"{0} · {1}",
+			"Working"
 		],
 		"vs/platform/agentHost/common/reasoningEffort": [
 			"High",
@@ -32287,8 +33748,20 @@
 			"Minimal reasoning for fastest responses",
 			"None",
 			"No reasoning applied",
+			"Ultra",
+			"Maximum reasoning with automatic task delegation",
 			"Extra High",
 			"Highest reasoning depth but slowest"
+		],
+		"vs/platform/agentHost/common/remoteAgentHostLocationPreferenceDialog": [
+			"Chat: Change Preferred Remote Agent Location",
+			" (Current)",
+			"Keep My Agents Running in a Dedicated Process",
+			"Agents continue after you close {0} and stop when their work finishes.",
+			"Stop My Agents if I Close {0}",
+			"Agents are available only while the remote {0} window is open.",
+			"How long should agents keep running on {0}?",
+			"You can change this later with the **{0}** command."
 		],
 		"vs/platform/agentHost/common/sandboxConfigSchema": [
 			"Advanced Sandbox Runtime",
@@ -32305,7 +33778,56 @@
 			"Sandbox Enabled (Windows)",
 			"Windows Sandbox Filesystem"
 		],
+		"vs/platform/agentHost/common/streamingToolCallDisplay": [
+			"Creating file",
+			"Creating {0}",
+			"Creating file ({0} lines)",
+			"Creating {0} ({1} lines)",
+			"Creating file (1 line)",
+			"Creating {0} (1 line)",
+			"Editing file",
+			"Editing {0}",
+			"Editing {0} lines",
+			"Editing {0} lines in {1}",
+			"Editing 1 line",
+			"Editing 1 line in {0}",
+			"Inserting text",
+			"Inserting text in {0}",
+			"Inserting {0} lines",
+			"Inserting {0} lines in {1}",
+			"Inserting 1 line",
+			"Inserting 1 line in {0}",
+			"Generating patch",
+			"Generating patch in {0}",
+			"Generating patch ({0} lines)",
+			"Generating patch ({0} lines) in {1}",
+			"Generating patch (1 line)",
+			"Generating patch (1 line) in {0}",
+			"Replacing {0} lines",
+			"Replacing {0} lines in {1}",
+			"Replacing {0} lines with {1} lines",
+			"Replacing {0} lines with {1} lines in {2}",
+			"Replacing {0} lines with 1 line",
+			"Replacing {0} lines with 1 line in {1}",
+			"Replacing 1 line",
+			"Replacing 1 line in {0}",
+			"Replacing 1 line with {0} lines",
+			"Replacing 1 line with {0} lines in {1}",
+			"Replacing 1 line with 1 line",
+			"Replacing 1 line with 1 line in {0}"
+		],
 		"vs/platform/agentHost/electron-browser/sshRemoteAgentHostServiceImpl": [
+			"The editor agent host exited. Reconnected to a dedicated agent host. In-progress work may have been interrupted.",
+			"Cancel",
+			"{0} key fingerprint is {1}.\n\nThis host is configured to use a certificate authority, but certificate-based host keys cannot be verified here, so this key cannot be checked against it.",
+			"Host key verification failed for '{0}'. Its {1} host key has changed, which could mean someone is impersonating the host — or that the host was legitimately rebuilt. Received {2}.",
+			"Host key verification failed for '{0}'. Its {1} host key does not match the entry in your known_hosts file, which could mean someone is impersonating the host — or that the host was legitimately rebuilt. Received {2}. Update or remove the known_hosts entry if this change was expected.",
+			"&&Connect",
+			"Forget Saved Host Key",
+			"Host key verification failed for '{0}'. This host's {1} key has been marked as revoked in your known_hosts file. Remove the @revoked line from known_hosts if this key should be trusted again.",
+			"Can't connect to '{0}': its host key is not known, and StrictHostKeyChecking is set to \"yes\" in your SSH configuration.",
+			"{0} key fingerprint is {1}.\n\nVerify this fingerprint matches the host before continuing.",
+			"The authenticity of host '{0}' can't be established.",
 			"Authentication required for {0}@{1}"
 		],
 		"vs/platform/agentHost/electron-browser/wslRemoteAgentHostServiceImpl": [
@@ -32335,6 +33857,29 @@
 		"vs/platform/agentHost/node/agentHostMain": [
 			"Agent Host"
 		],
+		"vs/platform/agentHost/node/agentHostMergeOperationHandler": [
+			"Merge operation was cancelled.",
+			"Changes were merged into '{0}', but the resulting commit could not be recorded: {1}",
+			"Agent Host changes for {0}",
+			"Changes were merged into '{0}', but the resulting commit could not be recorded.",
+			"Check out '{0}' in the parent repository before merging.",
+			"Failed to merge changes into '{0}'. Open the parent repository and merge manually. Git reported: {1}",
+			"The worktree changes were committed, but merging into '{0}' failed. Open the parent repository and merge manually. Git reported: {1}",
+			"Merged changes from '{0}' into '{1}'.",
+			"Could not resolve the parent repository for this worktree.",
+			"Merge Changes is no longer available because a pull request exists for branch '{0}'.",
+			"The worktree is already on the target branch '{0}'.",
+			"Could not determine the worktree branch.",
+			"The worktree branch '{0}' does not exist in the parent repository.",
+			"Could not determine the branch to merge into.",
+			"Commit or stash the changes in the parent repository before merging into '{0}'.",
+			"The parent repository is on '{0}'. Check out '{1}' there before merging."
+		],
+		"vs/platform/agentHost/node/agentHostMergeOperationProvider": [
+			"Merge Changes",
+			"Merge the worktree changes into the parent repository? Any uncommitted worktree changes will be committed first.",
+			"Commit any uncommitted changes and merge '{0}' into '{1}' in the parent repository."
+		],
 		"vs/platform/agentHost/node/agentHostPullRequestOperationHandler": [
 			"Sign in to GitHub with repository access to create a pull request.",
 			"merge",
@@ -32355,11 +33900,11 @@
 			"There are no branch changes to create a pull request for."
 		],
 		"vs/platform/agentHost/node/agentHostPullRequestOperationProvider": [
-			"Create Draft Pull Request",
-			"Create Pull Request",
-			"Create Pull Request (Auto-Merge)",
-			"Create Pull Request (Auto-Rebase)",
-			"Create Pull Request (Auto-Squash)"
+			"Create Draft PR",
+			"Create PR",
+			"Create PR (Auto-Merge)",
+			"Create PR (Auto-Rebase)",
+			"Create PR (Auto-Squash)"
 		],
 		"vs/platform/agentHost/node/agentHostRenameCommand": [
 			"Rename this chat"
@@ -32399,6 +33944,9 @@
 			"Deny",
 			"Ready to code?"
 		],
+		"vs/platform/agentHost/node/claude/claudeReplayMapper": [
+			"Message content could not be retrieved"
+		],
 		"vs/platform/agentHost/node/claude/claudeToolDisplay": [
 			"Allow tool call?",
 			"Allow tool from {0}?",
@@ -32433,57 +33981,37 @@
 			"Ran shell command",
 			"Ran {0}",
 			"Read shell output",
-			"Edited file",
-			"Edited {0}",
 			"\"{0}\" failed",
-			"Found files",
-			"Found files matching {0}",
-			"Searched files",
-			"Searched for {0}",
-			"Killed shell command",
-			"Listed directory",
-			"Listed {0}",
-			"Read file",
-			"Read {0}",
 			"Ran skill",
 			"Ran skill {0}",
 			"Ran subagent",
-			"Completed task",
-			"Created task",
-			"Created task: {0}",
-			"Deleted task",
-			"Read task",
-			"Read task list",
-			"Started task",
-			"Updated task",
-			"Updated todo list",
 			"Fetched {0}",
 			"Fetched URL",
 			"Running shell command",
 			"Running {0}",
 			"Reading shell output",
-			"Editing file",
-			"Editing {0}",
-			"Finding files",
-			"Finding files matching {0}",
-			"Searching files",
-			"Searching for {0}",
-			"Killing shell command",
-			"Listing directory",
-			"Listing {0}",
-			"Reading file",
-			"Reading {0}",
+			"Edit file",
+			"Edit {0}",
+			"Find files",
+			"Find files matching {0}",
+			"Search files",
+			"Search for {0}",
+			"Kill shell command",
+			"List directory",
+			"List {0}",
+			"Read file",
+			"Read {0}",
 			"Running skill",
 			"Running skill {0}",
-			"Completing task",
-			"Creating task",
-			"Creating task: {0}",
-			"Deleting task",
-			"Reading task",
-			"Reading task list",
-			"Starting task",
-			"Updating task",
-			"Updating todo list",
+			"Complete task",
+			"Create task",
+			"Create task: {0}",
+			"Delete task",
+			"Read task",
+			"Read task list",
+			"Start task",
+			"Update task",
+			"Update todo list",
 			"Fetching {0}",
 			"Fetching URL"
 		],
@@ -32510,14 +34038,13 @@
 		"vs/platform/agentHost/node/codex/codexAgent": [
 			"Controls how much reasoning effort Codex uses.",
 			"Thinking Level",
+			"Allow tool call?",
 			"Additional Writable Directories",
 			"Directory",
 			"Absolute paths the sandbox is allowed to write to, in addition to the workspace. Only applies when Sandbox is Workspace Write.",
 			"Approvals",
 			"No Escalations",
 			"Never ask for elevated permission; commands that cannot run in the sandbox are rejected.",
-			"Ask on Failure",
-			"Try commands in the sandbox first, then ask to retry with elevated permission if the sandbox blocks them.",
 			"Ask When Needed",
 			"Ask only when Codex determines a command needs elevated permission.",
 			"Ask More Often",
@@ -32562,8 +34089,41 @@
 			"Disabled",
 			"Live",
 			"Web-search tool availability for the model.",
-			"Codex agent backed by the OpenAI Codex app-server",
+			"Codex agent using session-selected model providers",
 			"Codex"
+		],
+		"vs/platform/agentHost/node/codex/codexMapAppServerEvents": [
+			"Compacted conversation",
+			"Compact conversation",
+			"Compacting conversation",
+			"Generated image",
+			"Generate image",
+			"Image generation {0}",
+			"Failed to generate image",
+			"Generating image",
+			"Searched the web for {0}",
+			"Searching the web for {0}"
+		],
+		"vs/platform/agentHost/node/codex/codexProviderConfiguration": [
+			"Auto-review policy",
+			"Updates auto_review.policy in config.toml. Leave empty to remove the auto_review section.",
+			"Configure Codex defaults stored in config.toml. Project and managed configuration can override these user values.",
+			"Open the Codex configuration file to customize additional agent behavior.",
+			"Codex configuration documentation",
+			"Open config.toml",
+			"Advanced configuration",
+			"Personality",
+			"Default",
+			"Controls the default communication style for Codex. Default leaves personality unset in config.toml.",
+			"Friendly",
+			"Pragmatic",
+			"Personalization",
+			"Review policy",
+			"Save Policy",
+			"Codex"
+		],
+		"vs/platform/agentHost/node/codexCompactCommand": [
+			"Compact this conversation's context"
 		],
 		"vs/platform/agentHost/node/copilot/copilotAgent": [
 			"Default",
@@ -32572,6 +34132,7 @@
 			"Context Size",
 			"Controls how much reasoning effort the model uses.",
 			"Thinking Level",
+			"Copilot stopped unexpectedly. Retry your request.",
 			"Copilot SDK agent running in the local agent host process",
 			"Error parsing plugin."
 		],
@@ -32599,6 +34160,10 @@
 			"Background agent {0} completed",
 			"Background agent {0} failed",
 			"Background agent {0} is complete",
+			"Factory {0} was cancelled",
+			"Factory {0} completed",
+			"Factory {0} failed",
+			"Factory {0} was halted",
 			"Instruction discovered: {0}",
 			"New inbox message from {0}",
 			"Shell completed",
@@ -32616,68 +34181,54 @@
 			"Allow fetching web content?",
 			"Fetch URL?",
 			"Write file?",
-			"Created file",
-			"Created {0}",
-			"Edited file",
-			"Edited {0}",
-			"Exited plan mode",
 			"\"{0}\" failed",
-			"Found files",
-			"Found files matching {0}",
-			"Searched files",
-			"Searched for {0}",
-			"Listed agents",
-			"Edited files",
-			"Edited {0}",
-			"Edited {0}",
-			"Read agent {0}",
-			"Read agent",
 			"Read Terminal",
 			"Ran {0} command",
 			"Ran {0}",
-			"Read skill {0}",
-			"Read skill {0}",
-			"Executed SQL query",
 			"Delegated task",
+			"Fetched {0}",
+			"Fetched URL",
+			"Searched the web",
+			"Searched the web for {0}",
+			"Create file",
+			"Create {0}",
+			"Edit file",
+			"Edit {0}",
+			"Present plan",
+			"Find files",
+			"Find files matching {0}",
+			"Search files",
+			"Search for {0}",
+			"Insert text",
+			"Insert text in {0}",
+			"List agents",
+			"Edit files",
+			"Edit {0}",
+			"Edit {0}",
+			"Read agent {0}",
+			"Read agent",
+			"Reading Terminal",
+			"Search code",
+			"Search code for {0}",
+			"Running {0} command",
+			"Running {0}",
+			"Read skill {0}",
+			"Execute SQL query",
+			"Delegating task",
 			"Read file",
 			"Read {0}",
 			"Read {0}, line {1} to the end",
 			"Read {0}, line {1}",
 			"Read {0}, lines {1} to {2}",
-			"Fetched {0}",
-			"Fetched URL",
-			"Wrote to agent {0}",
-			"Wrote to agent",
-			"Sent input to shell",
-			"Sent {0} to shell",
-			"Creating file",
-			"Creating {0}",
-			"Editing file",
-			"Editing {0}",
-			"Presenting plan",
-			"Finding files",
-			"Finding files matching {0}",
-			"Searching files",
-			"Searching for {0}",
-			"Editing files",
-			"Editing {0}",
-			"Editing {0}",
-			"Reading Terminal",
-			"Running {0} command",
-			"Running {0}",
-			"Reading skill {0}",
-			"Reading skill {0}",
-			"Executing SQL query",
-			"Delegating task",
-			"Reading file",
-			"Reading {0}",
-			"Reading {0}, line {1} to the end",
-			"Reading {0}, line {1}",
-			"Reading {0}, lines {1} to {2}",
+			"Read tool output",
 			"Fetching {0}",
 			"Fetching URL",
-			"Sending input to shell",
-			"Sending {0} to shell",
+			"Searching the web",
+			"Searching the web for {0}",
+			"Write to agent {0}",
+			"Write to agent",
+			"Send input to shell",
+			"Send {0} to shell",
 			"**Task completed:** {0}",
 			"Apply Patch",
 			"Ask User",
@@ -32742,47 +34293,52 @@
 			"Skip"
 		],
 		"vs/platform/agentHost/node/shared/agentFeedbackServerTools": [
-			"Added comment",
-			"Deleted comments",
-			"Checked comments",
-			"Checked {0} comments",
-			"Checked 1 comment",
-			"Resolved comments",
-			"Viewed comments",
-			"Adding comment",
-			"Deleting comments",
-			"Checking comments",
-			"Resolving comments",
-			"Viewing comments",
+			"Add comment",
+			"Delete comments",
+			"List comments",
+			"Reply to comment",
+			"Resolve comments",
+			"View comments",
 			"Add Comment",
 			"Delete Comments",
 			"List Comments",
+			"Reply to Comment",
 			"Resolve Comments",
 			"View Comments"
 		],
+		"vs/platform/agentHost/node/shared/agentMergeServerTools": [
+			"Read Agent Merge CI",
+			"Read failed required checks",
+			"Failed to read required checks",
+			"Reading failed required checks",
+			"Reply to Review Thread",
+			"Replied to review feedback",
+			"Failed to reply to review feedback",
+			"Replying to review feedback",
+			"Rerun Workflow",
+			"Reran failed workflow",
+			"Failed to rerun workflow",
+			"Rerunning failed workflow"
+		],
 		"vs/platform/agentHost/node/shared/sessionServerTools": [
-			"Created chat",
 			"Created session",
 			"Deleted session",
-			"Checked current session",
-			"Read session context",
-			"Checked sessions",
-			"Checked {0} sessions",
-			"Checked 1 session",
-			"Sent message",
-			"Creating chat",
+			"Updated chat name",
+			"Create chat",
 			"Creating session",
 			"Deleting session",
-			"Checking current session",
-			"Reading session context",
-			"Checking sessions",
-			"Sending message",
+			"Get current session",
+			"Read session context",
+			"List sessions",
+			"Renaming chat",
+			"Send message",
 			"Create Chat",
 			"Create Session",
 			"Delete Session",
 			"Get Current Session",
 			"Get Session Context",
 			"List Sessions",
+			"Rename Chat",
 			"Send Message"
 		],
 		"vs/platform/agentHost/node/shared/worktreeIsolation": [
@@ -32796,12 +34352,23 @@
 			"Where the agent should make changes",
 			"Worktree Branch Prefix",
 			"Prefix applied to the branch created for an isolated worktree.",
+			"Worktree Branch Tracking",
+			"Whether the branch created for an isolated worktree tracks its upstream.",
 			"Worktree Include Files",
 			"Glob patterns for git-ignored files to copy into the isolated worktree.",
 			"Pattern",
+			"Creating isolated worktree (checking out files)",
+			"Creating isolated worktree (checking out files, {0}%)",
+			"Creating isolated worktree (copying additional files)",
+			"Creating isolated worktree (copying additional files, {0}%)",
 			"Created isolated worktree for branch {0}",
+			"Creating isolated worktree",
+			"Couldn't create the isolated worktree. This session is continuing in the original folder.",
+			"Couldn't create the isolated worktree. This session is continuing in the original folder.\n\n{0}",
+			"Creating isolated worktree (naming branch)",
 			"This session couldn't be loaded because its working directory no longer exists: {0}",
 			"This session couldn't be loaded because its worktree is missing and could not be recreated: {0}",
+			"Saving uncommitted changes before archiving session",
 			"the branch '{0}' no longer exists"
 		],
 		"vs/platform/agentHost/node/sshRemoteAgentHostService": [
@@ -32809,7 +34376,9 @@
 			"Key file authentication requires a private key path.",
 			"SSH Key Passphrase",
 			"Enter passphrase for SSH key {0}.",
-			"Checking for existing agent host...",
+			"Waiting for the new agent host to register...",
+			"Waiting for endpoint selection...",
+			"Checking for existing agent hosts...",
 			"Establishing SSH connection...",
 			"Installing VS Code CLI on remote...",
 			"Connecting to remote agent host...",
@@ -32817,7 +34386,9 @@
 			"Starting remote agent host..."
 		],
 		"vs/platform/agentHost/node/tunnelHostMainService": [
-			"Remote Connections"
+			"Remote Connections",
+			"The agent host tunnel exited before it became ready.",
+			"Timed out waiting for the agent host tunnel to start."
 		],
 		"vs/platform/agentHost/node/wslRemoteAgentHostService": [
 			"Connecting to agent host in {0}...",
@@ -32852,7 +34423,18 @@
 			"HID Device {0}",
 			"USB Device {0}"
 		],
+		"vs/platform/browserView/electron-main/browserViewInspector": [
+			"Add Comment",
+			"Add a comment",
+			"Comment on selected element",
+			"Element comment {0}",
+			"Element comment {0}: {1}",
+			"Empty element comment {0}",
+			"Remove Comment",
+			"Remove element comment"
+		],
 		"vs/platform/browserView/electron-main/browserViewMainService": [
+			"Add Comment...",
 			"Add Element to Chat",
 			"Back",
 			"Copy Image",
@@ -32865,7 +34447,20 @@
 			"Open Link in New Tab",
 			"Reload"
 		],
+		"vs/platform/chat/common/sessionArchiveActions": [
+			"Archive",
+			"Archive All",
+			"Mark All as Done",
+			"Mark as Done",
+			"Restore",
+			"Restore All",
+			"Archived",
+			"Done",
+			"Unarchive",
+			"Unarchive All"
+		],
 		"vs/platform/configuration/common/configurationRegistry": [
+			"Cannot register '{0}'. The agent host configuration key '{1}' is already mirrored from '{2}'.",
 			"Cannot register '{0}'. A setting must not declare both 'policy' and 'policyReference'.",
 			"Cannot register '{0}'. The associated policy {1} is already registered with {2}. To attach another setting to the same policy, use 'policyReference'.",
 			"Cannot register '{0}'. This property is already registered.",
@@ -32918,7 +34513,7 @@
 			"&&Yes"
 		],
 		"vs/platform/dialogs/electron-browser/dialog": [
-			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\nOS: {8}"
+			"Version: {0}\nCommit: {1}\nDate: {2}\nElectron: {3}\nElectronBuildId: {4}\nChromium: {5}\nNode.js: {6}\nV8: {7}\n@github/copilot: {8}\n@github/copilot-sdk: {9}\nOS: {10}"
 		],
 		"vs/platform/dialogs/electron-main/dialogMainService": [
 			"Open",
@@ -33413,11 +35008,7 @@
 			"Remote Tunnel Service"
 		],
 		"vs/platform/remoteTunnel/node/remoteTunnelService": [
-			"Connecting as {0} ({1})",
-			"Building CLI from sources",
-			"Opening tunnel",
-			"Opening tunnel {0}",
-			"Failed to install tunnel as a service, starting in session..."
+			"Building CLI from sources"
 		],
 		"vs/platform/request/common/request": [
 			"Controls whether use of Electron's fetch implementation instead of Node.js' should be enabled. All local extensions will get Electron's fetch implementation for the global fetch API.",
@@ -33968,6 +35559,10 @@
 		"vs/platform/userDataSync/common/userDataSyncResourceProvider": [
 			"Cannot parse sync data as it is not compatible with the current version."
 		],
+		"vs/platform/webContentExtractor/electron-main/webPageLoader": [
+			"Navigation to an invalid URI is not allowed.",
+			"Navigation to the '{0}' URI scheme is not allowed."
+		],
 		"vs/platform/windows/electron-main/windowImpl": [
 			"The window terminated unexpectedly",
 			"We are sorry for the inconvenience. You can open a new empty window to start again.",
@@ -34021,6 +35616,8 @@
 			"Signed in as {0}",
 			"Agents Signed Out",
 			"Agents is signed out",
+			"Sign In",
+			"Sign in to GitHub to use more agents",
 			"GitHub Copilot chat and inline suggestion quota reached",
 			"GitHub Copilot chat quota reached",
 			"GitHub Copilot inline suggestion quota reached",
@@ -34040,8 +35637,10 @@
 			"Icon for the sessions sidebar when closed.",
 			"Icon for the sessions sidebar when open.",
 			"Hide Panel",
+			"Hide Panel",
 			"Hide Secondary Side Bar",
 			"Open/Show and Close/Hide Sidebar",
+			"Show Panel",
 			"Show Secondary Side Bar",
 			"Primary Side Bar hidden",
 			"Primary Side Bar shown",
@@ -34057,6 +35656,13 @@
 			"Delete Chat",
 			"Rename",
 			"Rename chat"
+		],
+		"vs/sessions/browser/parts/chatGroupView": [
+			"Chat Group {0} of {1}",
+			"Chats, Group {0} of {1}",
+			"Chats",
+			"Archived sessions are read-only.",
+			"This chat is read-only"
 		],
 		"vs/sessions/browser/parts/menubar.contribution": [
 			"&&Edit",
@@ -34139,58 +35745,85 @@
 			"1 file",
 			"1 file changed"
 		],
+		"vs/sessions/browser/parts/sessionConversationsActionViewItem": [
+			"Chats",
+			"Subagents"
+		],
 		"vs/sessions/browser/parts/sessionHeader": [
 			"Rename session"
 		],
 		"vs/sessions/browser/parts/sessionReadOnlyBanner": [
 			"This chat is read-only"
 		],
-		"vs/sessions/browser/parts/sessionView": [
-			"Archived sessions are read-only.",
-			"This chat is read-only",
-			"Restore"
+		"vs/sessions/browser/sessionConversationGroups": [
+			"State: {0}",
+			"Completed",
+			"Failed",
+			"In Progress",
+			"Input Needed",
+			"New"
 		],
 		"vs/sessions/browser/sessionsSetUpService": [
 			"Loading",
 			"Enable AI features to continue using Agents.",
 			"Enable AI Features",
-			"Sign in to use Agents",
-			"Signing in…",
-			"Please complete sign-in in the browser.",
 			"Your AI-powered coding experience where agents explore, build, and iterate with you.",
 			"Get Started",
 			"Welcome to {0}",
 			"{0} - Agents",
 			"By continuing, you agree to {0}'s [Terms]({1}) and [Privacy Statement]({2}). {3} Copilot may show [public code]({4}) suggestions and use your data to improve the product. You can change these [settings]({5}) anytime."
 		],
+		"vs/sessions/browser/sessionsSignInDialog": [
+			"Return to VS Code Editor",
+			"Sign in to use Agents",
+			"Signing in…",
+			"Please complete sign-in in the browser."
+		],
+		"vs/sessions/browser/singlePaneWorkbench": [
+			"Side pane hidden",
+			"Side pane shown"
+		],
 		"vs/sessions/browser/widget/openInVSCodeWidget": [
 			"Open in VS Code Editor Window"
+		],
+		"vs/sessions/browser/workbench": [
+			"Secondary Side Bar hidden",
+			"Secondary Side Bar shown"
 		],
 		"vs/sessions/common/categories": [
 			"Agents"
 		],
 		"vs/sessions/common/contextkeys": [
 			"The identifier of the active sessions panel",
+			"Whether at least one connected agent-host provider has advertised session types",
 			"Whether the single-pane active editor has a docked detail panel (a managed Changes/Files tab or a text file editor)",
+			"Whether the single-pane session supports a Changes editor",
 			"Whether the single-pane session supports a Changes editor but its tab is not currently open",
+			"Whether the active single-pane editor input is a diff, independent of the editor used to render it",
+			"Whether the single-pane session supports a Files editor",
 			"Whether the single-pane session supports a Files tab but its tab is not currently open",
 			"Whether the Agents window is using the single-pane (docked detail panel) layout. Single source of truth for gating single-pane behaviour — set once by the workbench from the layout it was constructed with; features must read this instead of the underlying setting",
+			"Whether the Automations custom view has keyboard focus",
+			"Whether there is at least one automation",
+			"Whether a custom view is shown in place of the sessions grid. The side panel and the panel are hidden while it is.",
 			"Whether the editor area is maximized",
 			"Whether the session in scope is a workspace-less quick chat",
 			"Whether more than one session is visible in the sessions part's grid",
-			"Whether the session view's currently-active chat has spawned subagent (tool-origin) chats, which are listed as a separate group in the Conversations menu",
+			"Whether the active chat has subagents, which are shown in the Chats dropdown",
 			"Whether the session's active chat can be closed (hidden) from the tab strip, i.e. it is not the main chat. Includes read-only subagent chats. Used to scope the close-chat keybinding so it closes the tab instead of the session",
 			"Whether the session's active chat can be permanently deleted from the tab strip, i.e. it is a real, user-created non-main chat (not the main chat and not a tool-spawned subagent chat, which are transient children). Used to scope the delete-chat keybinding",
 			"Whether the chats picker (chats within the active session) is visible",
 			"Whether the new-session view's harness (session type) picker is visible — it is hidden when at most one harness can serve the selected workspace",
 			"Whether the session view's session has pending changes (insertions or deletions)",
-			"Whether the session has an associated git repository",
+			"Whether the session has a usable git repository",
 			"Whether the session has a git sync action currently running",
-			"Whether the session view's session has more than one committed (non-draft) chat, which drives the Conversations menu visibility",
+			"Whether the session view's session references at least one GitHub issue",
+			"Whether the session view's session has more than one committed (non-draft) chat, which drives the Chats dropdown visibility",
 			"Whether the session view's session has more than one open chat (the tabs shown in the strip, including in-composer drafts). Used to scope chat-to-chat navigation (next/previous chat, the Ctrl+Tab chat switcher)",
 			"Whether the session view's session is associated with a GitHub pull request",
 			"Whether the session view's session has an associated workspace folder",
 			"The identifier of the session in scope (the active session globally, or a specific session within an isolated component such as the session view or a context menu overlay)",
+			"Whether the session in scope is in progress or needs input",
 			"Whether the session in scope is archived/marked as done (the active session globally, or a specific session within an isolated component such as the session view or a context menu overlay)",
 			"Whether the session view's session has been created (chat view shown, not new-session view)",
 			"Whether the session view is currently maximized in the sessions part's grid",
@@ -34203,7 +35836,8 @@
 			"Whether there is a previous session in the navigation history",
 			"Whether there is a next session in the navigation history",
 			"Whether the sessions part has keyboard focus",
-			"Whether the session view's chat tab strip is shown, i.e. the session has more than one chat (counting closed chats) or its single remaining chat's title diverged from the session title. Used to hide the header New Chat button, which the tab strip then offers instead",
+			"Whether a chat or session was closed recently and can be reopened with the Reopen Closed Chat or Session command",
+			"Whether the session view's chat tab strip is shown, i.e. the session has more than one chat actually showing as a tab. A single visible tab always hides the strip. Used to hide the header New Chat button, which the tab strip then offers instead",
 			"Whether the current layout is the phone layout",
 			"Whether the virtual keyboard is visible",
 			"Whether the sessions picker is visible",
@@ -34212,6 +35846,7 @@
 			"Whether the session view's session supports forking a chat from a turn into a new peer chat",
 			"Whether the session view's session supports multiple chats",
 			"Whether the session can be renamed",
+			"Whether the session view's session supports creating a side chat from a turn (via /btw)",
 			"Whether the sessions part is visible",
 			"Whether the sessions welcome overlay is visible",
 			"The session type of the session in scope (the active session globally, or a specific session within an isolated component such as the session view or a context menu overlay)",
@@ -34242,6 +35877,8 @@
 			"Background color of the agent sessions window shell and gradient base.",
 			"Background color of badges in the agent sessions window.",
 			"Foreground color of badges in the agent sessions window.",
+			"Border color of the bottom panel in the agent sessions window.",
+			"Border color of the floating content card (sessions grid and custom view grid) in the agent sessions window.",
 			"Background color of the chat input field in the agent sessions window.",
 			"Border color of the chat input field in the agent sessions window.",
 			"Border color of the chat input field when focused in the agent sessions window.",
@@ -34270,10 +35907,34 @@
 			"This will sign out '{0}' from the Agents window.",
 			"Sign out of the Agents window?",
 			"Agents Account and Status",
+			"ChatGPT",
+			"ChatGPT account",
+			"Daily limit",
+			"{0} resets {1}",
+			"Limit used",
+			"{0}% used",
+			"{0}%",
+			"ChatGPT {0}",
+			"ChatGPT subscription",
+			"Usage limit",
+			"Weekly limit",
+			"Copilot account",
+			"Resets {0}",
+			"Resets {0} at {1}",
+			"Credits used",
+			"{0}% credits used",
+			"{0}%",
+			"{0} / {1} credits used",
+			"{0} / {1}",
 			"Loading Account...",
-			"Subscription",
+			"Manage ChatGPT Models",
+			"Manage Copilot Models",
+			"Agent Customizations for Codex",
+			"Agent Customizations for Copilot",
+			"Account status",
 			"Settings",
-			"Sign In",
+			"Sign in to use GitHub Copilot",
+			"Sign Out",
 			"Sign Out"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedback.contribution": [
@@ -34287,6 +35948,12 @@
 			"Attached agent feedback, {0}",
 			"Remove"
 		],
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackContextView": [
+			"View comments",
+			"Remove",
+			"Remove All",
+			"Feedback Comments"
+		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorActions": [
 			"Clear",
 			"Clear All Feedback",
@@ -34299,24 +35966,21 @@
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorInputContribution": [
 			"Add Feedback",
-			"Add Feedback and Submit",
+			"Add",
+			"Add and Submit",
 			"Add Feedback at Current Line",
 			"Add Comment",
 			"Add Feedback",
 			"Alt+Enter",
 			"Enter"
 		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorOverlay": [
-			"Submit {0}",
-			"{0}/{1}",
-			"0/0"
-		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidgetContribution": [
+		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackEditorWidget": [
 			"Share comment with agent",
 			"Accept",
 			"Share PR comment with agent",
 			"Add a comment…",
 			"Add to Comment",
+			"Agent",
 			"Agent Review",
 			"Collapse",
 			"Remove agent comment",
@@ -34324,6 +35988,7 @@
 			"Remove and mark as resolved on GitHub",
 			"Edit",
 			"Expand",
+			"Hide",
 			"Line {0}",
 			"Lines {0}-{1}",
 			"{0} comments",
@@ -34331,11 +35996,6 @@
 			"Remove",
 			"Suggested Change • Line {0}",
 			"Suggested Change • Lines {0}-{1}"
-		],
-		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackHover": [
-			"Remove",
-			"Remove All",
-			"Feedback Comments"
 		],
 		"vs/sessions/contrib/agentFeedback/browser/agentFeedbackOverviewRulerContribution": [
 			"Editor overview ruler decoration color for agent feedback. This color should be opaque."
@@ -34365,7 +36025,6 @@
 		],
 		"vs/sessions/contrib/aiCustomizationTreeView/browser/aiCustomizationTreeViewViews": [
 			"Chat Customization Items",
-			"Automations",
 			"Built-in ({0})",
 			"Custom Agents",
 			"Extensions ({0})",
@@ -34399,16 +36058,23 @@
 			"Died streak (revivable)",
 			"Park a died streak and offer the revival prompt.",
 			"Pick a streak scenario to simulate",
+			"Toggle Aquarium Action Visibility",
 			"Adds an easter egg to the Agents window."
 		],
 		"vs/sessions/contrib/aquarium/browser/aquariumOverlay": [
+			"Aquarium action hidden",
+			"Aquarium action shown",
 			"Hide Aquarium",
-			"💔 {0} · Feed again to revive",
+			"fish is happy",
+			"fish is getting hungry",
+			"fish is hungry",
+			"fish is starving",
+			"{0} · Feed again to revive",
 			"{0} — feed a fish to revive your {1} day streak",
 			"{0} — feed a fish to revive your {1} day streak",
 			"Show Aquarium",
-			"{0} — 🔥 {1} day feeding streak",
-			"{0} — 🔥 {1} days feeding streak"
+			"{0} — {1} — {2} day feeding streak",
+			"{0} — {1} — {2} days feeding streak"
 		],
 		"vs/sessions/contrib/automations/browser/automationDialog": [
 			"Session capabilities are loading.",
@@ -34448,6 +36114,7 @@
 			"Prompt is required.",
 			"Session type is required.",
 			"Time",
+			"An agent session will be able to read files, run commands, and make changes in this folder.",
 			"Automations Workspace Picker",
 			"Pick a workspace for this automation",
 			"Automation target, {0}",
@@ -34460,7 +36127,7 @@
 		"vs/sessions/contrib/automations/browser/automationDialogService": [
 			"Cancel",
 			"Create",
-			"Define a prompt that Copilot will run on a schedule against the selected target.",
+			"Define a prompt that will run on a schedule against the selected target.",
 			"New automation",
 			"Update the schedule, prompt, or run target for this automation.",
 			"Edit automation",
@@ -34469,7 +36136,8 @@
 		"vs/sessions/contrib/automations/browser/automationRunner": [
 			"Automation '{0}' failed: {1}",
 			"Cancelled",
-			"Agent session failed."
+			"Agent session failed.",
+			"Automation '{0}' cannot start until its agent becomes available."
 		],
 		"vs/sessions/contrib/automations/browser/automations.contribution": [
 			"Enables the Automations feature: scheduling agent sessions to run on a cadence. When disabled, the Automations entry in the Customizations sidebar, the Automations section in the Customizations editor, and the Automation option in the new-session composer are hidden, and scheduled automations are not dispatched.",
@@ -34478,6 +36146,49 @@
 		"vs/sessions/contrib/automations/browser/automationScheduler": [
 			"Timed out after {0} minute(s).",
 			"Interrupted by app shutdown"
+		],
+		"vs/sessions/contrib/automations/browser/automationTools": [
+			"Automation change cancelled",
+			"Create the automation **{0}**?",
+			"Create Automation?",
+			"Configuring a new automation",
+			"Configured a new automation",
+			"Created automation {0}",
+			"Configure Automation",
+			"Apply the proposed changes to **{0}** (`{1}`)?",
+			"Update Automation?",
+			"Configuring automation",
+			"Configured automation",
+			"Updated automation {0}",
+			"Create or update an automation",
+			"Cancel",
+			"Automation deletion cancelled",
+			"Delete",
+			"Delete **{0}** (`{1}`)? Its saved configuration and run history will be permanently removed. Runs already in flight will continue.",
+			"Delete Automation?",
+			"Deleted automation {0}",
+			"Delete Automation",
+			"Deleting automation {0}",
+			"Deleted automation {0}",
+			"Delete a scheduled agent automation",
+			"Automation request failed",
+			"List Automations",
+			"Reading automations",
+			"Read automations",
+			"Listed {0} automations",
+			"Listed 1 automation",
+			"List scheduled agent automations",
+			"Automation {0} is already running",
+			"Automation {0} is already running",
+			"Automation run cancelled",
+			"Run **{0}** (`{1}`) now? This starts a new agent session using the automation's configured prompt and permissions.",
+			"Run Automation?",
+			"Run Automation",
+			"Running automation {0}",
+			"Started automation {0}",
+			"Started automation {0}",
+			"Run a configured agent automation now",
+			"Automation {0} was already running"
 		],
 		"vs/sessions/contrib/changes/browser/changes.contribution": [
 			"Changes",
@@ -34494,8 +36205,8 @@
 			"{0} files",
 			"Open File",
 			"{0}: {1}, +{2}, -{3}",
-			"View Changes",
-			"View Changes ({0})"
+			"View All Changes",
+			"View All Changes ({0})"
 		],
 		"vs/sessions/contrib/changes/browser/changesetReviewActions": [
 			"Viewed"
@@ -34571,6 +36282,7 @@
 		"vs/sessions/contrib/changes/browser/sessionsChangesAccessibilityHelp": [
 			"The Checks section lists the continuous integration checks for the session's pull request. Its header is a button: press Enter or Space to collapse or expand it{0}.",
 			"File diffs can be shown side by side or inline. Use the Toggle Diff View command to switch between them{0}.",
+			"When available, the toolbar also provides actions to commit, merge, sync, or create a pull request. Use Tab and Shift+Tab to move between the file list and toolbar actions.",
 			"You are in the Changes view. It shows the files changed by the current session as a tree, followed by two collapsible sections: Other Files and Checks.",
 			"The Other Files section lists files that were created, edited, or deleted outside the workspace during this session, such as configuration files in your home directory. These files are not part of the workspace and won't be committed.",
 			"The Other Files header is a button. Press Enter or Space to collapse or expand the list. When expanded, use the arrow keys to move through the files and press Enter to open one: created or deleted files open in an editor, while edited files open as a diff against their pre-session content.",
@@ -34583,8 +36295,8 @@
 			"Used by the Submit Feedback button in the Changes toolbar",
 			"Used by the Run Code Review button in the Changes view",
 			"Used by the Commit button in the Changes toolbar",
-			"Used by the Create Draft Pull Request button in the Changes toolbar",
-			"Used by the Create Pull Request button in the Changes toolbar",
+			"Used by the Create Draft PR button in the Changes toolbar",
+			"Used by the Create PR button in the Changes toolbar",
 			"Used by the Fix Checks button in the Changes toolbar",
 			"Used by the Run button in the title bar",
 			"Used by the Merge button in the Changes toolbar",
@@ -34606,10 +36318,48 @@
 			"Unavailable locally",
 			"{0}, unavailable locally"
 		],
+		"vs/sessions/contrib/chat/browser/btwSlashCommand.contribution": [
+			"Ask a side question without adding it to this conversation",
+			"The side chat could not be created.",
+			"Enter a question after `/btw`.",
+			"Send a message in this conversation before starting a side chat.",
+			"A side chat cannot be created from this conversation.",
+			"This conversation does not support side chats."
+		],
 		"vs/sessions/contrib/chat/browser/chat.contribution": [
 			"Whether to automatically run tasks tagged with `\"runOptions\": { \"runOn\": \"worktreeCreated\" }` when a new agent host session worktree is created. Manual `Run Task` invocations are unaffected.",
 			"Controls whether chat input history in the Agents Window is scoped to the current session. Disable this to use shared input history across sessions.",
 			"New Session"
+		],
+		"vs/sessions/contrib/chat/browser/externalSessionBanner": [
+			"External session banner actions",
+			"External session visibility",
+			"Close",
+			"{0} days ago",
+			"Only external sessions updated in the last 7 days will be shown. This session was last updated {0}. Are you sure you want to save this change?",
+			"Only external sessions updated in the last day will be shown. This session was last updated {0}. Are you sure you want to save this change?",
+			"This session will no longer appear in {0}",
+			"The option you selected hides sessions created in another application, including the session you currently have open. Are you sure you want to save this change?",
+			"1 day ago",
+			"Only the 2 most recently updated external sessions from the last 7 days will be shown. Are you sure you want to save this change?",
+			"This session may no longer appear in {0}",
+			"&&Save Anyway",
+			"Choose which external sessions you want to see in {0}. You can change this later in Settings.",
+			"{0} picked up this session, which was created in another application.",
+			"Save",
+			"Unable to save external session visibility because no option or session is selected.",
+			"All",
+			"Show all sessions created in another application.",
+			"External sessions to show",
+			"Last 24 Hours",
+			"Show external sessions updated in the last 24 hours.",
+			"Last 7 Days",
+			"Show external sessions updated in the last 7 days.",
+			"None",
+			"Do not show sessions created in another application.",
+			"Pick an option",
+			"Recent",
+			"Show the 2 most recently updated external sessions from the last 7 days."
 		],
 		"vs/sessions/contrib/chat/browser/mobile/mobileSessionTypePicker": [
 			"Session Type"
@@ -34627,11 +36377,11 @@
 			"Model"
 		],
 		"vs/sessions/contrib/chat/browser/newChatContextAttachments": [
-			"Attach as Context",
 			"Attach as context...",
 			"Files...",
 			"Image from Clipboard",
 			"Pasted Image",
+			"Pasted {0}",
 			"Remove",
 			"Select Files or Folders"
 		],
@@ -34644,6 +36394,8 @@
 			"Learn More",
 			"Manage",
 			"Monitoring with OpenTelemetry enabled",
+			"Prompt options closed",
+			"Inserted prompt: {0}",
 			"Send",
 			"Send (Alt-click to start in the background)",
 			"Describe the outcome you want",
@@ -34661,9 +36413,11 @@
 			"What will you launch?",
 			"What will you ship today?",
 			"What would you like to automate?",
+			"True when focus is in an Agents window chat composer that supports dictation.",
+			"Cancel Dictation. {0}",
 			"Dictate (Speech to Text)",
-			"Preparing Speech to Text Model…",
-			"Stop Dictation"
+			"Stop Dictation",
+			"Voice Input Mode"
 		],
 		"vs/sessions/contrib/chat/browser/newChatInSessionWidget": [
 			"Ask a follow-up question or start a new topic within this session...",
@@ -34679,17 +36433,63 @@
 			"Voice Mode"
 		],
 		"vs/sessions/contrib/chat/browser/newChatWidget": [
+			"Aquarium",
 			"New Chat",
 			"Start by picking a",
+			"{0} comments",
+			"1 comment",
+			"Reveal",
 			"New session in",
 			"with",
-			"An agent session will be able to read files, run commands, and make changes in this folder."
+			"Pet (/vscode-pet)",
+			"Sign in to GitHub"
+		],
+		"vs/sessions/contrib/chat/browser/newSessionFolderQuickPickAction": [
+			"Browse...",
+			"New Session in Folder...",
+			"Select a folder to start a new session in",
+			"Recent"
+		],
+		"vs/sessions/contrib/chat/browser/newSessionPromptOptions": [
+			"Close",
+			"{0}: {1}",
+			"Send your first prompt"
 		],
 		"vs/sessions/contrib/chat/browser/noAgentHostEmptyState": [
 			"No agent hosts available",
 			"Run ``{0}`` from any device, then return here to run agent tasks on it.",
 			"Learn more",
 			"Connect a host to get started"
+		],
+		"vs/sessions/contrib/chat/browser/omniSessionRoutingAdapter.contribution": [
+			"The request was cancelled.",
+			"No local workspace provider is available.",
+			"No Sessions provider can use the selected folder.",
+			"Select...",
+			"Select...",
+			"The selected Agent Host session configuration cannot be sent through Sessions.",
+			"The Sessions provider could not create the new session.",
+			"The selected session is no longer available.",
+			"The selected tool configuration cannot be sent through Sessions.",
+			"Resolved request variables cannot be sent through Sessions.",
+			"Unable to select a workspace.",
+			"The selected workspace browser is no longer available.",
+			"The selected workspace or folder is not trusted.",
+			"The selected workspace provider is no longer available."
+		],
+		"vs/sessions/contrib/chat/browser/promptTemplatePlaceholder": [
+			"Click or place the caret here and press Enter to describe the coding task",
+			"Whether the caret is inside an editable prompt template placeholder."
+		],
+		"vs/sessions/contrib/chat/browser/responseSelectionSideChatController": [
+			"Ask a question about the selected response text",
+			"Ask Question",
+			"Asking question…",
+			"The side chat could not be created.",
+			"Enter",
+			"Ask Question",
+			"A side chat cannot be created from this conversation.",
+			"This conversation does not support side chats."
 		],
 		"vs/sessions/contrib/chat/browser/runScriptAction": [
 			"Add a new task",
@@ -34766,20 +36566,22 @@
 			"Workspace",
 			"Save this task in the current workspace"
 		],
+		"vs/sessions/contrib/chat/browser/sessionActivityPill": [
+			"Open {0}"
+		],
 		"vs/sessions/contrib/chat/browser/sessionBackgroundActivitiesControl": [
-			"{0} Active Browsers",
 			"{0} Active Subagents",
 			"Background Activities",
-			"Browser",
-			"Browsers",
-			"{0} Background Activities",
-			"Open {0}",
 			"Show {0} background activities",
 			"Subagent",
 			"Subagents"
 		],
-		"vs/sessions/contrib/chat/browser/sessionChatInputToolbar": [
-			"Last Turn Changes"
+		"vs/sessions/contrib/chat/browser/sessionBrowsersControl": [
+			"{0} Active Browsers",
+			"Browsers",
+			"Browser",
+			"Browsers",
+			"Show {0} browsers"
 		],
 		"vs/sessions/contrib/chat/browser/sessionChatInputToolbarDebug": [
 			"Agent Feedback to Address",
@@ -34808,27 +36610,55 @@
 			"Untitled session"
 		],
 		"vs/sessions/contrib/chat/browser/sessionsChatAccessibilityHelp": [
-			"Press Shift+Tab from the chat input to reach status pills above it, then press Enter or Space to activate a pill. A pill with multiple background activities opens a picker; use the up and down arrows to navigate, Enter to open an activity, and Escape to dismiss the picker and return focus to the pill.",
+			"To show or hide the aquarium action on the new-session view, use the checked Aquarium item in the context menu outside the composer, or run the Toggle Aquarium Action Visibility command.",
+			"Press Shift+Tab from the chat input to reach status pills above it, then press Enter or Space to activate a pill. Live browsers appear in their own pill, and background activities such as running subagents in another. A pill with more than one entry opens a picker; use the up and down arrows to navigate, Enter to open an entry, and Escape to dismiss the picker and return focus to the pill.",
 			"Focus the Changes view{0}.",
-			"Activate a chat tab's close button to close (hide) that chat from the tab strip without deleting it; reopen it later from the Conversations menu. The session's main chat cannot be closed.",
+			"Chats can be arranged in groups. Focus the previous group{0} or next group{1}. Split the active chat into a group to the right{2} or below{3}, or move it to the previous group{4} or next group{5}.",
+			"Activate a chat tab's close button to close (hide) that chat from the tab strip without deleting it; reopen it later from the Chats menu. The session's main chat cannot be closed.",
 			"Type # in the chat input to attach context. Use #file to reference a file or folder, or #session to reference another agent session. Referencing a session together with the /troubleshoot command analyzes that session's logs instead of the current one. Accept a suggestion with Tab or Enter; the reference appears as a pill above the input that you can remove.",
-			"When a session supports multiple chats, a New Chat button is always shown: as a labeled button in the session header while the session has a single open chat, and as a compact button at the end of the chat tab strip once the session has more than one open chat. Activate it to start a new chat. Once the session has more than one committed chat, a Conversations menu is also shown: in the session header while the tab strip is hidden, and at the end of the chat tab strip once it is shown. Open it to reopen a closed chat: each chat is listed with a checkbox, where checked chats are shown as tabs and unchecked chats are closed (hidden).",
+			"When a session supports multiple chats, a New Chat button is always shown: as a labeled button in the session header while the session has a single visible chat tab, and as a compact button at the end of the chat tab strip once the session has more than one visible chat tab. Activate it to start a new chat. A Chats dropdown is also shown in the session header meta row, at the end of the pills, once the session has more than one committed chat or the active chat has subagents. Side chats appear as first-level chats. A Subagents group lists work delegated by the active chat, and every item announces its state. When there is one first-level chat, only its Subagents are listed. The active chat or subagent is selected when the dropdown opens. Select an item to open or focus it.",
 			"Focus the Chat Customizations view{0}.",
 			"To permanently delete a chat, open the chat tab's context menu and choose Delete Chat. This is destructive and cannot be undone.",
+			"When dictation is configured, dictate your message into the input{0}. Tap to start and stop, or hold to dictate only while pressed. If the speech-to-text model is still preparing, activate the dictation control again to cancel.",
+			"When you first open a session created in another application, a banner appears at the top of the chat. Use Tab to reach its external-session picker, choose an option, and activate Save. The Close action dismisses the banner without changing the setting. Saving or closing permanently dismisses the banner.",
+			"The Sessions list Filter menu includes an External submenu. Use it to choose whether external sessions from another application are shown for the last 24 hours, the last 7 days, always, or not at all.",
+			"When a feedback comments attachment appears above the input, focus it and press Enter or Space. A single comment opens directly. Multiple comments open a tree grouped by file; use the arrow keys to navigate, Enter to reveal a comment, and Escape to close the tree.",
+			"When feedback comments are available for a new session, a comments banner appears above the input. You can send the comments without typing a message, or focus the Reveal button to open the first comment in its editor.",
 			"Focus the Files Explorer view{0}.",
+			"To search the chat transcript, invoke Find in Chat{0}. Find Next{1} and Find Previous{2} move between results, scrolling each one into view.",
+			"Go back through visited sessions{0}.",
+			"Go forward through visited sessions{0}.",
 			"Use up and down arrows to navigate your request history in the input box.",
 			"You are in the chat input. Type a message and press Enter to send it.",
 			"Press Alt+Enter to start the session in the background without navigating into it. The started session appears in the Chat Sessions view.",
+			"To choose a microphone or turn off dictation or Voice Mode, focus the microphone button in the input toolbar and open its context menu (for example Shift+F10).",
 			"On mobile, the mode and model pickers appear as tappable chips below the input. Tap a chip to open a bottom sheet where you can change the selection.",
 			"Navigate to the next session in the list{0}.",
 			"Navigate to the previous session in the list{0}.",
 			"When the session is associated with a GitHub pull request, the session header shows the pull request number as a button. Activate it to open the pull request on GitHub{0}.",
 			"You are in the Agents window. The Agents window is a dedicated workspace for working with AI agents. It provides a chat interface, a changes view for reviewing agent-generated changes, a file explorer, and customization options.",
+			"Long pasted text is stored as an attached text item and replaced in the input with a numbered inline reference.",
+			"To choose a folder from a searchable list instead, use the New Session in Folder command{0}.",
+			"When prompt options appear above the new-session input, use Tab and Shift+Tab to move between them, then press Enter or Space to insert one. You can select a different option while the input is empty, exactly matches the inserted prompt, or only has its editable placeholder removed; other edits disable the options without hiding them. Clearing the input also clears the selected option. Use the Close action to hide the options and return focus to the input.",
+			"When the new-session prompt contains a highlighted task placeholder, place the caret inside it and replace it{0} to type your task.",
+			"When the prompt timeline is enabled, a handle on the left edge of the transcript lists your prompts. Activate it to expand the list, use the up and down arrows (or Home and End) to move between prompts, Enter or Space to jump to a prompt, and Escape to dismiss the list and return focus to the handle. When a prompt title is pinned above the transcript, activate its title to jump to that prompt, or use the Previous Prompt and Next Prompt buttons to jump between prompts.",
+			"In a repository section of the sessions list, activate Create Session from Pull Request to open a searchable pull request picker. Pull requests are grouped by review and assignment status. Use the arrow keys to navigate, Enter to create the session, and Escape to close the picker.",
 			"To start a workspace-less quick chat, use the New Quick Chat command{0} or the plus button on the Chats section in the sessions list. A quick chat has no workspace, so the workspace picker does not apply and the Toggle Side Panel command is disabled.",
+			"To rename a session, double-click its title in the sessions list. With the keyboard, focus the session, open its context menu (for example, with Shift+F10), and choose Rename.",
 			"Focus the Chat Sessions view{0}.",
+			"Subagent pills in the chat transcript can be dragged to a chat group's edge to open the subagent beside the current chat. With the keyboard, focus a subagent pill and press Alt+Enter to open it beside the current chat.",
 			"Toggle the side panel (the editor area together with the auxiliary bar) open or closed{0}.",
 			"The session header shows the diff stats (lines added and removed) as a button. Activate it to open the multi-file diff editor for all of the session's changes{0}.",
+			"Start or stop Voice Mode to interact with the agent using your microphone{0}.",
+			"Use the checked Pet item in the new-session view context menu, or type /vscode-pet, to show or hide the VS Code pet above the input. Drag it horizontally to reposition it, or use Tab to focus it and the left and right arrow keys to move it. Press Enter or Space to show it some love.",
 			"Shift+Tab to navigate to the workspace picker and choose a workspace for your session."
+		],
+		"vs/sessions/contrib/chat/browser/sessionTurnChanges": [
+			"Turn File Changes",
+			"Changes from the selected chat turn.",
+			"Turn Changes",
+			"Changes from the viewed chat's last turn.",
+			"Turn Changes"
 		],
 		"vs/sessions/contrib/chat/browser/sessionTypePicker": [
 			"Session Type",
@@ -34842,28 +36672,24 @@
 			"Select...",
 			"Connecting to {0}...",
 			"Failed to connect to {0}.",
-			"Experimental",
 			"Search Workspaces...",
 			"Start by picking a workspace",
 			"New session in {0}"
+		],
+		"vs/sessions/contrib/chat/browser/sessionWorkspacePickerModel": [
+			"Experimental"
 		],
 		"vs/sessions/contrib/chat/browser/slashCommands": [
 			"View and manage custom agents",
 			"View and manage hooks",
 			"View and manage instructions",
 			"Open the model picker",
-			"View and manage skills"
+			"View and manage skills",
+			"Toggle an interactive VS Code pet (Experimental)"
 		],
 		"vs/sessions/contrib/chat/browser/variableCompletions": [
 			"Active file",
 			"{0} ({1})"
-		],
-		"vs/sessions/contrib/chat/browser/voiceInputDecorations": [
-			"Press {0} to barge in",
-			"Speak to barge in",
-			"Click voice mode to talk or barge in",
-			"Listening...",
-			"Press {0} to talk or barge in"
 		],
 		"vs/sessions/contrib/chat/browser/webWorkspacePicker": [
 			"Select Folder..."
@@ -34875,6 +36701,15 @@
 		"vs/sessions/contrib/codeReview/browser/codeReview.contributions": [
 			"Run Code Review",
 			"Run Code Review"
+		],
+		"vs/sessions/contrib/customViewTest/browser/customViewTest.contribution": [
+			"Hide Test Custom View",
+			"Show Test Custom View",
+			"A placeholder view used to verify the custom view grid layout, header and scrolling.",
+			"Item {0}",
+			"Test Custom View",
+			"Ping Test Custom View",
+			"Test custom view action ran."
 		],
 		"vs/sessions/contrib/editor/browser/addTabActions": [
 			"Browser",
@@ -34889,7 +36724,8 @@
 			"Maximize Editor Area",
 			"Open in Modal Editor",
 			"Open in Editor Area",
-			"Restore Editor Area"
+			"Restore Editor Area",
+			"Show Editor"
 		],
 		"vs/sessions/contrib/editor/browser/emptyFileEditor": [
 			"Select a file from the Files view",
@@ -34919,12 +36755,54 @@
 		"vs/sessions/contrib/files/browser/workspaceFolderActions": [
 			"Files",
 			"Open Files: {0}",
-			"Open Files"
+			"Open Files",
+			"Creating worktree… Its folder and branch are shown once ready.",
+			"Open Files: {0}, creating worktree"
+		],
+		"vs/sessions/contrib/github/browser/createSessionFromPullRequestAction": [
+			"Create Session from Pull Request",
+			"Failed to create a session from pull request #{0}: {1}",
+			"Fetching pull request...",
+			"Pull requests loaded, but the {0} group could not be resolved: {1}",
+			"Failed to load pull requests: {0}",
+			"No GitHub repository could be resolved for this workspace.",
+			"Choose a pull request",
+			"Failed to resolve the GitHub repository: {0}",
+			"Resolving GitHub repository...",
+			"Create Session from Pull Request",
+			"Assigned to Me",
+			"Waiting for My Review"
+		],
+		"vs/sessions/contrib/github/browser/issueActions": [
+			"Open Issue",
+			"{0} issues",
+			"Open Issue",
+			"Show the {0} Issues Referenced by This Session",
+			"Open Issue #{0}"
+		],
+		"vs/sessions/contrib/github/browser/issueHover": [
+			"No description provided.",
+			"on {0}",
+			"Issue #{0}"
 		],
 		"vs/sessions/contrib/github/browser/pullRequestActions": [
+			"Copy Pull Request URL",
 			"Open Pull Request",
+			"{0} Pull Requests",
 			"Open Pull Request",
-			"Open Pull Request #{0}"
+			"Show the {0} Pull Requests Associated with This Session",
+			"Open Pull Request #{0}",
+			"Closed Pull Request",
+			"Draft Pull Request",
+			"failing checks",
+			"failing checks and unresolved comments",
+			"{0} #{1}",
+			"{0}, {1}",
+			"{0} #{1}: {2}",
+			"Merged Pull Request",
+			"Open Pull Request",
+			"Pull Request",
+			"unresolved comments"
 		],
 		"vs/sessions/contrib/github/browser/pullRequestHover": [
 			"target",
@@ -34932,6 +36810,14 @@
 			"source",
 			"on {0}",
 			"Pull Request #{0}"
+		],
+		"vs/sessions/contrib/github/browser/pullRequestPicker": [
+			"Pull request #{0}, {1}, by {2}, updated {3}, {4} additions and {5} deletions",
+			"Pull request #{0} by @{1}",
+			"@{0} · updated {1} · +{2} -{3}",
+			"Assigned to Me",
+			"Other Pull Requests",
+			"Waiting for My Review"
 		],
 		"vs/sessions/contrib/layout/browser/baseSessionLayoutController": [
 			"Icon for the sessions secondary sidebar when closed.",
@@ -34945,8 +36831,32 @@
 			"Controls whether the sessions sidebar is automatically collapsed in a narrow Agents window while both the editor and the side panel are open, and shown again once either of them closes.",
 			"Controls whether the Agents window docks the detail panel inside the editor so a single editor tab bar spans across the editor and the detail panel. Requires a window reload to take effect."
 		],
-		"vs/sessions/contrib/layout/browser/singlePane/singlePaneResponsiveSidebarStrategy": [
+		"vs/sessions/contrib/layout/browser/singlePane/singlePaneExistingSessionStrategy": [
 			"Toggle Details"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/newSessionViewV3Prompt": [
+			"The following pull request has failing CI checks: \"{0}\" ({1}). Investigate the failures and resolve them.",
+			"Tackle the following issue and create a pull request for it: \"{0}\" ({1}).",
+			"The following pull request has merge conflicts: \"{0}\" ({1}). Resolve the conflicts and update the pull request.",
+			"The following pull request has unresolved review comments that have not been addressed by a newer commit: \"{0}\" ({1}). Address the review comments and update the pull request.",
+			"Describe the unexpected behavior",
+			"[describe the bug]",
+			"Help me fix {0} in this project. Ask me questions if anything is unclear regarding the bug or the intended behaviour.",
+			"Fix a bug",
+			"Describe a failing check or paste a link",
+			"[describe the CI failure or paste a link]",
+			"Help me fix the failing CI for {0} in this project. Ask me questions if anything is unclear regarding the CI failure or how it should be fixed.",
+			"Fix CI",
+			"Fix CI",
+			"Resolve conflicts",
+			"Tackle issue",
+			"Address PR comments",
+			"Describe what you want to build",
+			"[describe the feature]",
+			"Help me implement {0} in this project. Ask me questions if anything is unclear regarding the intended behaviour.",
+			"Implement a feature",
+			"[describe the coding task]",
+			"Help me complete {0} in this project. First, inspect the relevant files and explain your approach briefly. Then implement the solution using existing project conventions, avoid unrelated changes, and run the most relevant tests or checks. If anything is unclear, make a reasonable assumption and state it. When finished, summarize what changed and mention any remaining issues."
 		],
 		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionTour": [
 			"Use a worktree to work on multiple tasks in the same project without conflicts. Each task stays isolated, so you can experiment freely and safely.",
@@ -34961,6 +36871,16 @@
 			"Isolate Your Work",
 			"Choose between the folders and repositories you work in. Run multiple sessions at once in a single workspace, or across many.",
 			"Work Across Workspaces"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewTourShared": [
+			"A workspace is the folder or repository where your agent reads context and makes changes. Choose one so it can understand your project and work on the right files.",
+			"Choose a workspace"
+		],
+		"vs/sessions/contrib/onboardingTours/browser/tours/newSessionViewV2Tour": [
+			"A harness is the agent runtime that plans, uses tools, and carries out your task. Choose one based on the capabilities your work needs.",
+			"Choose a harness",
+			"The model powers your agent's reasoning. Choose one based on the balance of speed and capability your task needs.",
+			"Choose a model"
 		],
 		"vs/sessions/contrib/policyBlocked/browser/sessionsPolicyBlocked": [
 			"Allowed organizations:",
@@ -34978,39 +36898,6 @@
 			"Open VS Code",
 			"Agents Disabled"
 		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimeline.contribution": [
-			"Controls whether the prompt timeline is shown next to the chat transcript in the Agents window.",
-			"Controls whether the current prompt is pinned to the top of the chat transcript while scrolling in the Agents window."
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineActions": [
-			"Chat",
-			"(empty prompt)",
-			"Go to Prompt...",
-			"{0} files",
-			"1 file",
-			"Go to a prompt in this chat",
-			"+{0} −{1} · {2}"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineCard": [
-			"{0} prompts",
-			"{0} files",
-			"no edits",
-			"1 file",
-			"Review Changes for Prompt: {0}"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineModel": [
-			"Changes · {0}",
-			"Prompt: {0}",
-			"{0} prompts starting with: {1}"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineRulerRail": [
-			"Prompt timeline"
-		],
-		"vs/sessions/contrib/promptTimeline/browser/promptTimelineStickyHeader": [
-			"(empty prompt)",
-			"{0}/{1}",
-			"Go to prompt {0} of {1}: {2}"
-		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostAgentPicker": [
 			"Agent"
 		],
@@ -35024,6 +36911,11 @@
 			"Pick Approvals, {0}",
 			"Learn more about permissions"
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentHostDiscoveredConfigNotification": [
+			"If you intended to use a Copilot subscription, sign in to GitHub.",
+			"We've discovered your existing {0} configuration.",
+			"Sign in to GitHub"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostModePicker": [
 			"Agent Mode Picker",
 			"Pick Agent Mode, {0}"
@@ -35035,7 +36927,8 @@
 			"An LLM judge evaluates each tool call. Tools it doesn't approve require your approval.",
 			"Copilot runs all tools without asking for approval.",
 			"Copilot runs tools without asking for approval and continues until the task is done.",
-			"Copilot asks before running tools unless your configured settings allow the tool."
+			"Copilot asks before running tools unless your configured settings allow the tool.",
+			"Manual permissions"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSessionBranchActions": [
 			"Copy Session Branch Name"
@@ -35082,10 +36975,26 @@
 			"Edit values below and save to apply. Unknown properties are ignored."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentHostSkillButtons": [
-			"Create Draft Pull Request",
-			"Create Pull Request",
+			"Create Draft PR",
+			"Create PR",
 			"Merge Changes",
 			"Sync Pull Request"
+		],
+		"vs/sessions/contrib/providers/agentHost/browser/agentMergeActions": [
+			"Address Reviews",
+			"Fix CI Failures",
+			"Automatically Merge When Ready",
+			"Reset to Global Defaults",
+			"Agent Merge now follows the global action defaults for this session.",
+			"Remove all action overrides for this session",
+			"Resolve Conflicts and Behind Branches",
+			"Select actions Agent Merge may perform for this session",
+			"Agent Merge actions were updated for the active session.",
+			"Configure Agent Merge for Active Session",
+			"Disable Agent Merge for Active Session",
+			"Agent Merge is disabled for the active session.",
+			"Enable Agent Merge for Active Session",
+			"Agent Merge is enabled for the active session."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/agentSessionSettings.contribution": [
 			"Session Settings",
@@ -35109,21 +37018,18 @@
 			"Cannot send request: not connected to agent host.",
 			"Agent host session was not committed."
 		],
+		"vs/sessions/contrib/providers/agentHost/browser/codexCustomizationSettings.contribution": [
+			"Configure global behavior for this harness.",
+			"Codex"
+		],
 		"vs/sessions/contrib/providers/agentHost/browser/exportDebugLogsAction": [
 			"Export Agent Host Debug Logs..."
-		],
-		"vs/sessions/contrib/providers/agentHost/browser/localAgentHost.contribution": [
-			"When enabled, the local agent host is used as the default sessions provider and its session types are shown first in the Agents window. Requires `#chat.agentHost.enabled#`."
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/localAgentHostSessionsProvider": [
 			"Local Agent Host"
 		],
 		"vs/sessions/contrib/providers/agentHost/browser/openSessionEventsFileActions": [
-			"Open Copilot CLI State File"
-		],
-		"vs/sessions/contrib/providers/agentHost/browser/openSubagentChat": [
-			"Open Subagent",
-			"Open subagent chat: {0}"
+			"Open Copilot State File"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/branchPicker": [
 			"Branch",
@@ -35131,27 +37037,11 @@
 			"Worktree isolation",
 			"Git repository required for worktree isolation"
 		],
-		"vs/sessions/contrib/providers/copilotChatSessions/browser/claudePermissionModePicker": [
-			"Edit Automatically",
-			"Claude edits files without asking",
-			"Auto",
-			"A model classifier approves or denies tool operations automatically",
-			"Bypass Permissions",
-			"All tools run without any confirmation",
-			"Ask Before Edits",
-			"Claude asks for approval before making changes",
-			"Plan Mode",
-			"Claude creates a plan before making changes",
-			"Permission Mode",
-			"Pick Permission Mode, {0}"
-		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessions.contribution": [
-			"Enable Claude Agent sessions in the Agents window. Start and resume agentic coding sessions powered by Anthropic's Claude Agent SDK directly. Uses your existing Copilot subscription.",
 			"Whether to enable multiple chats within a single session in the Copilot Chat sessions provider."
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsActions": [
 			"Branch",
-			"Permission Mode",
 			"Mode",
 			"Permissions"
 		],
@@ -35167,7 +37057,6 @@
 			"Show uncommitted changes in this session"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/copilotChatSessionsProvider": [
-			"Claude",
 			"Copilot Chat",
 			"Cloud",
 			"Are you sure you want to delete this chat?",
@@ -35175,8 +37064,7 @@
 			"This action cannot be undone.",
 			"New Chat",
 			"New Session",
-			"Repositories",
-			"GitHub"
+			"Repositories"
 		],
 		"vs/sessions/contrib/providers/copilotChatSessions/browser/mobilePermissionPicker": [
 			"Approvals",
@@ -35198,23 +37086,14 @@
 			"Runs tool calls without asking",
 			"Autopilot (Preview)",
 			"Auto-approve all tool calls and continue until the task is done. Autopilot may increase costs.",
-			"Autonomously iterates from start to finish",
-			"Default approvals",
+			"Works autonomously within permissions",
+			"Default permissions",
 			"Asks when approval settings don't apply",
 			"Learn more about permissions",
 			"Disabled by enterprise policy"
 		],
-		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessions.contribution": [
-			"Enable Local VS Code chat sessions in the Agents Window. Reload the window for changes to take effect."
-		],
-		"vs/sessions/contrib/providers/localChatSessions/browser/localChatSessionsProvider": [
-			"Are you sure you want to delete this chat?",
-			"Delete",
-			"This action cannot be undone.",
-			"Copilot Chat",
-			"Local",
-			"New Chat",
-			"New Session"
+		"vs/sessions/contrib/providers/remoteAgentHost/browser/cloudSandboxReadOnlySessionHandler": [
+			"This conversation is incomplete. Its recorded history ends mid-response, so the last exchange may be missing."
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/manageRemoteAgentHosts": [
 			"Add or Manage",
@@ -35225,6 +37104,7 @@
 			"Manage Remote Agent Hosts..."
 		],
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/remoteAgentHost.contribution": [
+			"Enable connecting to Copilot cloud sandbox sessions over a live Agent Host Protocol relay. When enabled, opening a Copilot cloud session connects to its sandbox for slash commands and a responsive, steerable experience instead of only polling logs.",
 			"When enabled, forwards the local SSH agent to the remote machine during SSH agent host connections to hosts whose SSH config has `ForwardAgent yes`. Only enable this for trusted hosts. The remote agent host process must be restarted for this setting to take effect.",
 			"Per-host filesystem grants for remote agent hosts. Maps a remote agent host address to URI strings and the access mode the host has been granted (`r` for read, `rw` for read and write). Hosts cannot read or write any files outside the granted URIs without prompting; a URI grant covers descendants. This setting is normally maintained by the agent-host permission prompts and rarely edited by hand.",
 			"Read-only access.",
@@ -35299,8 +37179,17 @@
 			"Authentication failed. Please try again.",
 			"Failed to connect to tunnel '{0}': {1}",
 			"Connecting to tunnel '{0}'...",
+			"&&Delete",
+			"Are you sure you want to delete dev tunnel '{0}'?",
+			"The tunnel may be recreated if a machine starts hosting it again.",
+			"Failed to delete dev tunnel '{0}': {1}",
+			"Delete Dev Tunnel",
 			"Failed to list dev tunnels: {0}",
 			"No dev tunnels with agent host support were found. Start a tunnel with 'code tunnel' on another machine.",
+			"No dev tunnels with agent host support were found. Start a tunnel with 'code tunnel' on another machine.",
+			"This machine is already hosting the only available dev tunnel.",
+			"{0} · Offline",
+			"{0} · Online",
 			"Select a dev tunnel to connect to",
 			"Connect via Dev Tunnel",
 			"Update Remote Agent Host Server...",
@@ -35338,6 +37227,7 @@
 			"Cannot connect to {0}: {1}",
 			"Show Options",
 			"Update Server",
+			"Change Preferred Agent Location",
 			"Copy Address",
 			"Remote agent host is connected and ready.",
 			"Remote agent host is connected and ready.\n\nAddress: {0}",
@@ -35349,6 +37239,10 @@
 			"Cannot connect to remote agent host: {0}\n\nThis client speaks protocol version {1}.\n\nAddress: {2}",
 			"Incompatible protocol version. We speak {0}. Error from {1}: {2}\n\n Ensure {3} and {1} are both up to date.",
 			"Incompatible protocol version. We speak {0}, but {1} speaks {2}. Ensure {3} and {1} are both up to date.",
+			"Preference saved for {0}, but reconnection failed: {1}",
+			"Reconnecting to {0}...",
+			"Preference saved for {0}, but no active connection was found. This takes effect the next time it connects.",
+			"Preference updated for {0}.",
 			"Open Settings",
 			"Reconnect",
 			"Options for {0}",
@@ -35369,6 +37263,22 @@
 		"vs/sessions/contrib/providers/remoteAgentHost/browser/tunnelAgentHost.contribution": [
 			"Connecting to tunnel '{0}'..."
 		],
+		"vs/sessions/contrib/providers/remoteAgentHost/electron-browser/forgetSSHHostKeyCommand": [
+			"Forget SSH Host Key",
+			"Forgot saved SSH host keys for {0} hosts. You'll be asked to verify them the next time you connect.",
+			"Forgot the saved SSH host key for '{0}'. You'll be asked to verify it the next time you connect.",
+			"No SSH host keys have been saved yet.",
+			"Select the hosts whose saved SSH host keys should be forgotten"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/electron-browser/remoteAgentHostLocationPreferenceCommand": [
+			"Change Preferred Remote Agent Location",
+			"No remote agent hosts are configured yet. Connect to one first, then change its preferred agent run location.",
+			"Select a remote host to change its preferred agent run location"
+		],
+		"vs/sessions/contrib/providers/remoteAgentHost/electron-browser/tunnelAgentHostServiceImpl": [
+			"The editor agent host exited. Reconnected to a dedicated agent host. In-progress work may have been interrupted.",
+			"The editor agent host is no longer running. Connected to a dedicated agent host instead."
+		],
 		"vs/sessions/contrib/search/browser/search.contribution": [
 			"Find in Folder...",
 			"&&Search",
@@ -35380,7 +37290,7 @@
 			"Hide for this session",
 			"Fix Checks",
 			"1 check failed",
-			"Reveal Checks",
+			"Reveal",
 			"Address Comments",
 			"{0} agent comments",
 			"1 agent comment",
@@ -35389,7 +37299,7 @@
 			"1 comment",
 			"{0} PR comments",
 			"1 PR comment",
-			"Reveal Comments"
+			"Reveal"
 		],
 		"vs/sessions/contrib/sessions/browser/aiCustomizationShortcutsWidget": [
 			"Customizations"
@@ -35405,6 +37315,7 @@
 			"1 session requires terminal approval"
 		],
 		"vs/sessions/contrib/sessions/browser/blockedSessionsList": [
+			"All current blocked sessions were ignored.",
 			"CI failure ignored until this session has another CI failure.",
 			"Ignore CI Failure",
 			"Ignore Input Needed",
@@ -35413,7 +37324,7 @@
 		],
 		"vs/sessions/contrib/sessions/browser/customizationsToolbar.contribution": [
 			"Agents",
-			"Automations",
+			"Codex",
 			"Hooks",
 			"Instructions",
 			"MCP Servers",
@@ -35427,13 +37338,19 @@
 			"Open File Diff",
 			"Open Session Changes"
 		],
+		"vs/sessions/contrib/sessions/browser/sessionDetailsAction": [
+			"Session Details",
+			"Show Session Details"
+		],
 		"vs/sessions/contrib/sessions/browser/sessionHoverContent": [
 			"1 file changed",
-			"{0} files changed"
+			"{0} files changed",
+			"Creating worktree…"
 		],
 		"vs/sessions/contrib/sessions/browser/sessions.contribution": [
 			"Sessions",
 			"Icon for Agent Sessions View",
+			"Toggle Floating Chat Input Window",
 			"&&Sessions",
 			"Controls whether the Chats group is shown in the sessions list even when it is empty."
 		],
@@ -35441,7 +37358,7 @@
 			"New Chat",
 			"New Chat",
 			"Close",
-			"Conversations",
+			"Chats",
 			"Maximize Session",
 			"Pin Session",
 			"Pin View",
@@ -35457,9 +37374,13 @@
 			"Delete Chat",
 			"Focus Active Session",
 			"Focus Last Session in Grid",
+			"Focus Next Chat Group",
+			"Focus Previous Chat Group",
 			"Focus Session {0} in Grid",
 			"&&Back",
 			"&&Forward",
+			"Move Chat to Next Group",
+			"Move Chat to Previous Group",
 			"Go to Next Chat",
 			"Go to Previous Chat",
 			"New Chat ({0})",
@@ -35478,49 +37399,147 @@
 			"Quick Switch to Previous Chat",
 			"recently opened",
 			"Rename...",
+			"Reopen Closed Chat or Session",
 			"Search chats by name",
 			"Search sessions by name or folder",
 			"Go Back",
 			"Go Back One Session",
 			"Go Forward",
 			"Go Forward One Session",
+			"needs input",
+			"unread",
 			"Go to Chat in Session",
 			"Show Sessions Picker",
+			"Split Chat Group Down",
+			"Split Chat Group Right",
 			"Untitled Chat"
 		],
 		"vs/sessions/contrib/sessions/browser/sessionsTitleBarWidget": [
 			"Agent Sessions",
 			"Show Sessions",
+			"Close",
+			"Ignore All Input Needed",
 			"Approved {0} sessions",
 			"Approved 1 session",
 			"Show All Sessions",
 			"Show Sessions"
 		],
+		"vs/sessions/contrib/sessions/browser/views/automationsAccessibility": [
+			"{0}, enabled",
+			"{0}, disabled",
+			"Completed",
+			"Daily at {0}",
+			"No automations.",
+			"Failed",
+			"Run history",
+			"Hourly",
+			"Manual",
+			"No runs.",
+			"Pending",
+			"Prompt: {0}",
+			"{0}, {1}, started {2}",
+			"Error: {0}",
+			"Running",
+			"Schedule: {0}",
+			"Automations",
+			"Unknown automation",
+			"{0} at {1}",
+			"Use Open Accessible View to read the current automations and run history as text.",
+			"Tab to a card's Edit control and action buttons. Use Left Arrow and Right Arrow to move between Run now and Delete. Press Enter or Space to activate a control. Edit, or clicking anywhere else on the card, opens the automation dialog. Run now starts a session immediately. Delete asks for confirmation.",
+			"Run history is grouped by date. While a run is waiting for its session, a lightweight row shows the automation name with a Working... description. Once the session is available, use Up Arrow and Down Arrow to navigate the Sessions list, Enter to open, and Tab to reach Stop or Delete actions when available. Delete permanently deletes the session and removes it from run history after confirmation.",
+			"You are in the Automations view. It contains automation cards followed by run history.",
+			"Completed and failed runs that have not been opened are announced as unread. Use Mark all as read to clear all available unread runs."
+		],
+		"vs/sessions/contrib/sessions/browser/views/automationsView": [
+			"Actions for {0}",
+			"Automation {0} is already running",
+			"{0} — {1}",
+			"This automation changed while the dialog was open. Reopen it to review the latest values.",
+			"Created automation {0}",
+			"Failed to create automation.",
+			"This automation was deleted while the dialog was open.",
+			"Deleted automation {0}",
+			"Failed to delete automation.",
+			"Failed to mark automation runs as read.",
+			"Automation {0} did not start",
+			"Failed to run automation.",
+			"The session was deleted, but its run history item could not be removed.",
+			"Failed to open automation run.",
+			"Deleted the session for {0}",
+			"Failed to delete the automation run session.",
+			"Failed to stop the automation run session.",
+			"Stopped the session for {0}",
+			"Working...",
+			"{0}, Working...",
+			"Schedule agent sessions to run automatically on a cadence you choose.",
+			"Automations were disabled before the change could be saved.",
+			"Enable “{0}” to make changes.",
+			"Automations are disabled.",
+			"Started automation {0}",
+			"Automations",
+			"Updated automation {0}",
+			"Failed to update automation.",
+			"Delete automation \"{0}\"?",
+			"Delete the session for \"{0}\"?",
+			"This will permanently delete the session and remove this item from run history. This action cannot be undone.",
+			"This will permanently delete the automation and its run history.",
+			"Create Automation",
+			"Delete",
+			"Delete",
+			"Delete",
+			"Disabled",
+			"Edit automation {0}",
+			"History",
+			"Last week",
+			"Mark all as read",
+			"New Automation",
+			"Create an automation to schedule an agent session to run on a cadence you choose.",
+			"No automations yet",
+			"Quick Chat",
+			"Running",
+			"Run now",
+			"Daily at {0}",
+			"Hourly",
+			"Manual",
+			"{0} at {1}",
+			"Stop",
+			"Today",
+			"Unknown",
+			"Yesterday"
+		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsList": [
 			"Add to Group",
 			"Allow",
 			"Allow once",
-			"Done",
+			"Automations",
+			"{0}, run in progress",
+			"{0}, run needs input",
+			"{0}, unread run",
 			"Chats",
 			"{0} checks failed, {1} pending",
 			"Fix CI",
 			"Fix failing CI checks",
 			"Create Group",
 			"Delete Group",
-			"Failed",
 			"Move to Group",
-			"Input needed",
 			"New Group",
 			"No chats",
+			"No session",
+			"Use Add to Group from a session's context menu, or drag it into this group.",
 			"Older",
 			"Voice response ready",
 			"Pinned",
+			"Chat",
 			"Recent",
 			"Remove from Group",
 			"Rename...",
 			"now",
 			"Group name",
 			"{0}, updated {1}",
+			"{0}, chat, updated {1}",
+			"{0}, in {1}",
+			"{0}, creating worktree, updated {1}",
+			"{0}. {1}",
 			"{0} sessions",
 			"Sessions",
 			"Show fewer sessions",
@@ -35533,11 +37552,9 @@
 			"+{0} more workspace",
 			"Show {0} more workspaces",
 			"+{0} more workspaces",
-			"Unknown",
-			"Working..."
+			"Unknown"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsView": [
-			"Done",
 			"Read",
 			"Group by Time",
 			"Group by Workspace",
@@ -35554,20 +37571,17 @@
 			"Input Needed"
 		],
 		"vs/sessions/contrib/sessions/browser/views/sessionsViewActions": [
-			"Mark All as Done",
-			"Are you sure you want to mark {0} sessions from '{1}' as done?",
-			"Are you sure you want to mark 1 session from '{0}' as done?",
-			"You can restore sessions later if needed from the sessions view.",
-			"Are you sure you want to mark {0} pinned sessions as done?",
-			"Are you sure you want to mark 1 pinned session as done?",
-			"Mark All as Done",
-			"Mark All as Done",
-			"Are you sure you want to mark {0} sessions from '{1}' as done?",
-			"Are you sure you want to mark 1 session from '{0}' as done?",
-			"You can restore sessions later if needed from the sessions view.",
-			"Mark as Done",
+			"Are you sure you want to archive 1 session from '{0}'?",
+			"Are you sure you want to archive {0} sessions from '{1}'?",
+			"You can unarchive sessions later if needed from the sessions view.",
+			"Are you sure you want to archive 1 pinned session?",
+			"Are you sure you want to archive {0} pinned sessions?",
+			"Are you sure you want to archive 1 session from '{0}'?",
+			"Are you sure you want to archive {0} sessions from '{1}'?",
+			"You can unarchive sessions later if needed from the sessions view.",
 			"Close Session",
 			"Collapse All Groups",
+			"Delete Group",
 			"Delete...",
 			"Are you sure you want to delete this session?",
 			"Delete",
@@ -35581,9 +37595,18 @@
 			"Find Session",
 			"Group by Time",
 			"Group by Workspace",
-			"Mark All as Done",
+			"Manage Automations",
 			"Mark All as Read",
+			"Mark All as Read",
+			"Are you sure you want to mark 1 session from '{0}' as done?",
+			"Are you sure you want to mark {0} sessions from '{1}' as done?",
+			"You can restore sessions later if needed from the sessions view.",
+			"Are you sure you want to mark 1 pinned session as done?",
+			"Are you sure you want to mark {0} pinned sessions as done?",
 			"Mark as Read",
+			"Are you sure you want to mark 1 session from '{0}' as done?",
+			"Are you sure you want to mark {0} sessions from '{1}' as done?",
+			"You can restore sessions later if needed from the sessions view.",
 			"Mark as Unread",
 			"Go to Next Session",
 			"&&Next Session",
@@ -35598,12 +37621,10 @@
 			"Rename...",
 			"Title cannot be empty",
 			"New agent session title",
-			"Restore",
 			"Show All Sessions",
 			"Show Recent Sessions",
 			"Sort by Created",
 			"Sort by Updated",
-			"Restore",
 			"Unpin"
 		],
 		"vs/sessions/contrib/terminal/browser/agentHostSessionTaskRunner": [
@@ -35611,8 +37632,6 @@
 		],
 		"vs/sessions/contrib/terminal/browser/sessionsTerminalContribution": [
 			"Dump Terminal Tracking",
-			"Hide Terminal",
-			"Open Terminal",
 			"Show All Terminals"
 		],
 		"vs/sessions/contrib/tunnelHost/electron-browser/tunnelHost.contribution": [
@@ -35620,7 +37639,9 @@
 		],
 		"vs/sessions/electron-browser/actions/vscodeActions": [
 			"Open in Editor",
-			"Open VS Code Window"
+			"Open VS Code Window",
+			"Return to VS Code Editor",
+			"Check Whether to Show Return to VS Code Editor"
 		],
 		"vs/sessions/electron-browser/parts/titlebarPart": [
 			"Agents"
@@ -35628,11 +37649,21 @@
 		"vs/sessions/electron-browser/sessions.main": [
 			"Saving UI state"
 		],
+		"vs/sessions/services/sessions/browser/sessionsManagementService": [
+			"Failed to load chat session for cancellation."
+		],
+		"vs/sessions/services/sessions/browser/sessionsService": [
+			"An agent session will be able to read files, run commands, and make changes in this folder."
+		],
 		"vs/sessions/services/sessions/common/session": [
 			"New Chat",
 			"New Session",
+			"Failed",
+			"Input needed",
+			"GitHub",
 			"Local",
-			"Remote"
+			"Remote",
+			"Working..."
 		],
 		"vs/sessions/services/workspace/browser/workspaceContextService": [
 			"Agents Window"
@@ -35680,6 +37711,12 @@
 		"vs/workbench/api/browser/mainThreadCustomEditors": [
 			"Edit",
 			"An extension provided editor for '{0}' is still open that would close otherwise."
+		],
+		"vs/workbench/api/browser/mainThreadDataChannels": [
+			"The selected link presentation provider does not accept this resource.",
+			"Not available",
+			"Link presentation is not available",
+			"The link presentation provider failed to load."
 		],
 		"vs/workbench/api/browser/mainThreadEditSessionIdentityParticipant": [
 			"Aborted onWillCreateEditSessionIdentity-event after 10000ms"
@@ -35846,6 +37883,7 @@
 		"vs/workbench/api/common/configurationExtensionPoint": [
 			"Accessibility settings",
 			"Advanced settings are hidden by default in the Settings editor unless the user chooses to show advanced settings.",
+			"Extension '{0}' CANNOT use the 'agentHost' property on configuration '{1}'.",
 			"Extension '{0}' CANNOT use 'agentsWindow' property on configuration '{1}' without enabling the 'agentsWindowConfiguration' API proposal.",
 			"Cannot register configuration defaults for '{0}'. Only defaults for machine-overridable, window, resource and language overridable scoped settings are supported.",
 			"Cannot register '{0}'. This property is already registered.",
@@ -35959,9 +37997,16 @@
 			"Contributes json schema configuration.",
 			"The file pattern (or an array of patterns) to match, for example \"package.json\" or \"*.launch\". Exclusion patterns start with '!'",
 			"A schema URL ('http:', 'https:') or relative path to the extension folder ('./').",
+			"Contributes a JSON validation registry. The registry can be a dynamic resource from a filesystem provider and allows associations to change at runtime.",
+			"A registry URI or relative path to the extension folder ('./').",
 			"File Match",
 			"'configuration.jsonValidation.fileMatch' must be defined as a string or an array of strings.",
 			"'configuration.jsonValidation' must be a array",
+			"'configuration.jsonValidationRegistry' must be an array",
+			"'configuration.jsonValidationRegistry.url' is an invalid relative URI: {0}",
+			"Expected `contributes.{0}.url` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
+			"'configuration.jsonValidationRegistry.url' must be an absolute URI or start with './' to reference a registry located in the extension.",
+			"'configuration.jsonValidationRegistry.url' must be a URI or relative path",
 			"Expected `contributes.{0}.url` ({1}) to be included inside extension's folder ({2}). This might make the extension non-portable.",
 			"'configuration.jsonValidation.url' must be a URL or relative path",
 			"'configuration.jsonValidation.url' is an invalid relative URL: {0}",
@@ -35986,6 +38031,10 @@
 			"Log Working Copies",
 			"Machine",
 			"Policy Diagnostics",
+			"Policy Diagnostics",
+			"Policy diagnostics opened as Markdown source because the rendered preview could not be opened: {0}",
+			"Policy diagnostics opened as Markdown source because the rendered preview could not be initialized.",
+			"Generating policy diagnostics...",
 			"Profile",
 			"Remove Large Storage Database Entries...",
 			"&&Remove",
@@ -36271,6 +38320,10 @@
 			"{0} • Cell {1} • Output {2}",
 			"{0} • Cell {1} • Output"
 		],
+		"vs/workbench/browser/layout": [
+			"Secondary Side Bar hidden",
+			"Secondary Side Bar shown"
+		],
 		"vs/workbench/browser/parts/activitybar/activitybarPart": [
 			"Activity Bar Position",
 			"Activity Bar Size",
@@ -36296,8 +38349,6 @@
 			"Top"
 		],
 		"vs/workbench/browser/parts/auxiliarybar/auxiliaryBarActions": [
-			"Secondary Side Bar hidden",
-			"Secondary Side Bar shown",
 			"Icon to close the secondary side bar.",
 			"Hide Secondary Side Bar",
 			"Hide Secondary Side Bar",
@@ -36595,6 +38646,7 @@
 			"Close Editors in Other Groups",
 			"Close Editors to the Left in Group",
 			"Close",
+			"Close Others",
 			"This action is irreversible!",
 			"Do you want to clear the history of recently opened editors?",
 			"Do you want to clear all recently opened files and workspaces?",
@@ -36784,6 +38836,11 @@
 			"Start Debugging",
 			"Toggle Terminal"
 		],
+		"vs/workbench/browser/parts/editor/editorHeaderControl": [
+			"Editor actions",
+			"Editor layout actions",
+			"Editor primary actions"
+		],
 		"vs/workbench/browser/parts/editor/editorPanes": [
 			"Unable to open '{0}'",
 			"&&OK"
@@ -36873,6 +38930,8 @@
 			"Tab Size: {0}"
 		],
 		"vs/workbench/browser/parts/editor/editorTabsControl": [
+			"Add Tab",
+			"Add Tab",
 			"Editor actions",
 			"Editor layout actions",
 			"{0} (+{1})"
@@ -36894,7 +38953,8 @@
 			"Toggle Sidebar"
 		],
 		"vs/workbench/browser/parts/editor/multiEditorTabsControl": [
-			"Add Tab",
+			"Alt+Click",
+			"⌥+Click",
 			"Tab actions"
 		],
 		"vs/workbench/browser/parts/editor/sideBySideEditor": [
@@ -37210,6 +39270,7 @@
 			"Please allow pop-ups for this website in your [browser settings]({0})."
 		],
 		"vs/workbench/browser/workbench.contribution": [
+			"Controls whether signed-in account profile images (avatars) are shown in account-related UI, such as the Accounts item in the Activity Bar.",
 			"`${activeEditorLanguageId}`: the language identifier of the active editor (e.g. typescript).",
 			"`${activeEditorLong}`: the full path of the file (e.g. /Users/Development/myFolder/myFileFolder/myFile.txt).",
 			"`${activeEditorMedium}`: the path of the file relative to the workspace folder (e.g. myFolder/myFileFolder/myFile.txt).",
@@ -37275,7 +39336,8 @@
 			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and a single press of the Alt key will show it. A setting of 'compact' will move the menu into the side bar.",
 			"Control the visibility of the menu bar. A setting of 'toggle' means that the menu bar is hidden and executing `Focus Application Menu` will show it. A setting of 'compact' will move the menu into the side bar.",
 			"Configure an interval in seconds during which the last entry in local file history is replaced with the entry that is being added. This helps reduce the overall number of entries that are added, for example when auto save is enabled. This setting is only applied to entries that have the same source of origin. Changing this setting has no effect on existing local file history entries.",
-			"Controls whether the experimental Modern UI Update is enabled. When on, the side bars and bottom panel are shown as floating cards with rounded corners and gaps, and a set of refreshed workbench styles is applied, matching the Agents window design.",
+			"Controls whether the Modern UI Update is enabled. When on, the side bars and bottom panel are shown as floating cards with rounded corners and gaps, and a set of refreshed workbench styles is applied, matching the Agents window design.",
+			"Controls whether view headers, side bar titles, and panel tabs use uppercase text when {0} is enabled.",
 			"Enables the use of mouse buttons four and five for commands 'Go Back' and 'Go Forward'.",
 			"Controls whether the navigation control is shown in the custom title bar. This setting only has an effect when {0} is not set to {1}.",
 			"Controls whether the navigation control in the title bar is shown.",
@@ -37414,6 +39476,7 @@
 			"Splits all the editor groups to equal parts.",
 			"Splits the active editor group to equal parts.",
 			"Controls the visibility of the tab close action button.",
+			"Controls whether Modern UI editor tabs always reserve space for tab action buttons. When disabled, clean tabs stay compact; tabs with persistent dirty or pinned indicators reserve space regardless.",
 			"Controls the visibility of the tab unpin action button.",
 			"Controls the height of editor tabs. Also applies to the title control bar when {0} is not set to {1}.",
 			"Always keep tabs large enough to show the full editor label.",
@@ -37494,6 +39557,7 @@
 			"Whether the active custom editor diff is backed by text documents",
 			"The identifier of the active editor",
 			"The available editor identifiers that are usable for the active editor",
+			"Whether the active editor cannot be closed through standard user actions",
 			"Whether the active editor can revert",
 			"Whether the active editor can toggle between being read-only or writeable",
 			"Whether the active editor group is empty",
@@ -37521,6 +39585,7 @@
 			"Whether the modal editor part has navigation context",
 			"Whether the modal editor part has a sidebar",
 			"Whether the modal editor part sidebar is visible",
+			"Whether a modal editor part is visible",
 			"Whether there are multiple editor groups opened in an editor part",
 			"Whether editor tabs are visible",
 			"The identifier of the embedder according to the product service, if one is defined",
@@ -37557,6 +39622,7 @@
 			"The full path of the resource",
 			"The scheme of the resource",
 			"Whether a resource is present or not",
+			"Whether the layout surface representing the secondary side bar is visible",
 			"Whether all selected editors in a group have a file or untitled resource associated",
 			"Whether the sidebar has keyboard focus",
 			"Whether the sidebar is visible",
@@ -37617,6 +39683,7 @@
 			"Foreground color of the command center",
 			"Border color of the command center when the window is inactive",
 			"Foreground color of the command center when the window is inactive",
+			"Border color of the editor surface in the modern layout.",
 			"Background color when dragging editors around. The color should have transparency so that the editor contents can still shine through.",
 			"Background color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
 			"Border color of text shown over editors when dragging files. This text informs the user that they can hold shift to drop into the editor.",
@@ -37633,6 +39700,24 @@
 			"Background color of the selected menu item in the menubar.",
 			"Border color of the selected menu item in the menubar.",
 			"Foreground color of the selected menu item in the menubar.",
+			"Background color of active Activity bar items in the default side position when the modern UI is enabled.",
+			"Foreground color of active Activity bar items in the default side position when the modern UI is enabled.",
+			"Background color of Activity bar items in the default side position when hovering and the modern UI is enabled.",
+			"Foreground color of Activity bar items in the default side position when hovering and the modern UI is enabled.",
+			"Opaque background color of tab actions on active editor tabs when the modern tab style is enabled.",
+			"Background color of active editor tabs when the modern tab style is enabled.",
+			"Foreground color of active editor tabs when the modern tab style is enabled.",
+			"Opaque background color of tab actions on active editor tabs when hovering and the modern tab style is enabled.",
+			"Background color of active editor tabs when hovering and the modern tab style is enabled.",
+			"Opaque background color of tab actions on editor tabs when hovering and the modern tab style is enabled.",
+			"Background color of editor tabs when hovering and the modern tab style is enabled.",
+			"Foreground color of editor tabs when hovering and the modern tab style is enabled.",
+			"Background color of inactive editor tabs when the modern tab style is enabled.",
+			"Opaque background color of tab actions on selected editor tabs when the modern tab style is enabled.",
+			"Background color of active tabs when the modern tab style is enabled.",
+			"Foreground color of active tabs when the modern tab style is enabled.",
+			"Background color of tabs when hovering and the modern tab style is enabled.",
+			"Foreground color of tabs when hovering and the modern tab style is enabled.",
 			"Notifications center border color. Notifications slide in from the bottom right of the window.",
 			"Notifications center header background color. Notifications slide in from the bottom right of the window.",
 			"Notifications center header foreground color. Notifications slide in from the bottom right of the window.",
@@ -37714,6 +39799,9 @@
 			"Status bar warning items foreground color. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
 			"Status bar warning items background color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
 			"Status bar warning items foreground color when hovering. Warning items stand out from other status bar entries to indicate warning conditions. The status bar is shown in the bottom of the window.",
+			"Background color of framed container surfaces (\"cards\"), such as the floating workbench panels in the modern layout.",
+			"Border color of framed container surfaces (\"cards\"), such as the floating workbench panels in the modern layout.",
+			"Foreground color of framed container surfaces (\"cards\"), such as the floating workbench panels in the modern layout.",
 			"Active tab background color in an active group. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
 			"Border on the bottom of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
 			"Border to the top of an active tab. Tabs are the containers for editors in the editor area. Multiple tabs can be opened in one editor group. There can be multiple editor groups.",
@@ -37902,7 +39990,8 @@
 			"Enable sound.",
 			"Auto (Use Display Language)",
 			"On keypress, close the Accessible View and focus the element from which it was invoked.",
-			"Provide information about how to use the Automations section of the Agent Customizations editor, including keyboard navigation and how to inspect scheduled runs.",
+			"Provide information about how to use Automations management views, including keyboard navigation and how to inspect scheduled runs.",
+			"Provide information about how to access element commenting accessibility help in the Integrated Browser.",
 			"Provide information about how to access the chat help menu when the chat input is focused.",
 			"Provide information about how to navigate and interact with the chat question carousel, including how to focus the terminal when applicable.",
 			"Provide information about actions that can be taken in the comment widget or in a file which contains comments.",
@@ -37997,10 +40086,11 @@
 			"Diff editor"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/agentsVoice.contribution": [
+			"Allow Agent mode to speak brief semantic progress updates while it investigates, plans, edits, validates, or recovers from a problem.",
 			"Voice backend WebSocket URL. Leave empty to use the default hosted backend. Set to e.g. `ws://localhost:8000/api/v1/realtime/voice` to point at a backend running on your machine.",
 			"Enable the Voice Mode panel in the chat view for voice-driven coding conversations.",
-			"When enabled, voice mode automatically re-enters listening after the assistant finishes speaking, so you can hold a hands-free back-and-forth conversation. When disabled, you start each turn manually. This controls only the auto-listen loop; how a turn ends is controlled by {0} and {1}.",
-			"The language used for speech recognition and spoken responses. The selectable languages support native voice output. Automatic follows the system or browser locale for speech recognition and uses English voice output when the detected language does not support native voice output. Changing this while voice mode is connected takes effect immediately.",
+			"When enabled, voice mode automatically re-enters listening after the assistant finishes speaking, so you can hold a hands-free back-and-forth conversation. When disabled, you start and end each turn manually, and ending the turn sends it. Turns are not ended automatically on trailing silence or a stop phrase unless {0} or {1} is explicitly configured.",
+			"The language used for speech recognition, dictation, and spoken responses. The selectable languages support native voice output. Automatic uses the configured display language for speech recognition and dictation when supported; otherwise, it follows the system or browser locale. English voice output is used when the detected language does not support native voice output. Changing this while voice mode is connected takes effect immediately.",
 			"Automatic",
 			"German",
 			"English",
@@ -38012,32 +40102,29 @@
 			"Portuguese",
 			"Chinese",
 			"Show your speech as a live, word-by-word transcript while you are speaking. When disabled, your transcript appears only once you finish speaking. Requires `#agents.voice.showTranscript#` to be enabled to be visible.",
+			"Controls whether the Voice Mode button is shown in the chat input. When hidden, Voice Mode can still be started with its keyboard shortcut.",
 			"Show the voice transcript overlay in the chat input area while voice mode is active. Enable this to read responses as text when `#agents.voice.speakResponses#` is disabled.",
 			"When enabled, the assistant reads responses aloud. When disabled, responses are not spoken; enable `#agents.voice.showTranscript#` to read them as a text transcript instead.",
-			"Trailing silence in milliseconds before the backend ends the turn automatically. Set to `-1` to disable ending the turn on silence, in which case the turn ends only via a stop phrase ({0}) or manually. When enabled, the backend clamps this to its supported range (currently 200-5000 ms) and is the source of truth.",
+			"Trailing silence in milliseconds before the backend ends the turn automatically. Set to `-1` to disable ending the turn on silence, in which case the turn ends only via a stop phrase ({0}) or manually. When enabled, the backend clamps this to its supported range (currently 200-5000 ms) and is the source of truth. When hands-free mode ({1}) is disabled, the turn is not ended on silence by default unless this setting is explicitly configured, so you keep manual control over when a turn is sent.",
 			"Do not end the turn on trailing silence.",
-			"Phrases that end the turn when spoken at the end of an utterance. Leave empty to disable ending the turn on a stop phrase, in which case the turn ends only on trailing silence ({0}) or manually. The backend strips the matched phrase from the transcript before it reaches the agent.",
-			"The voice used when the assistant reads responses aloud. Changing this while voice mode is connected takes effect immediately.",
-			"Daniel.",
-			"Kevin.",
-			"Maya.",
-			"Victoria.",
+			"Phrases that end the turn when spoken at the end of an utterance. Leave empty to disable ending the turn on a stop phrase, in which case the turn ends only on trailing silence ({0}) or manually. The backend strips the matched phrase from the transcript before it reaches the agent. When hands-free mode ({1}) is disabled, stop phrases do not end the turn by default unless this setting is explicitly configured, so you keep manual control over when a turn is sent.",
+			"The voice used when the assistant reads responses aloud. Changing this while voice mode is connected takes effect immediately. Use [Voice Mode instructions](command:{0}) to customize Voice Mode behavior and terminology.",
+			"Birch.",
+			"Harper.",
+			"Junho.",
+			"Oak.",
 			"Voice Mode: Cancel Request",
 			"Connecting...",
 			"Disconnect Voice Mode",
+			"Open a chat to see the Voice Mode introduction.",
 			"Voice Mode Settings",
 			"Voice Mode: Stop Recording",
-			"Voice: Select Microphone",
+			"Voice Mode: Show Introduction",
 			"Voice: Simulate Connection (Dev)",
 			"Voice Mode",
 			"Voice Mode",
 			"Voice Mode: Push to Talk",
-			"(current)",
-			"No microphones found",
-			"Voice: Reset Onboarding",
-			"Select a microphone for Voice Mode",
-			"System Default",
-			"Unknown Device ({0})"
+			"Voice: Reset Onboarding"
 		],
 		"vs/workbench/contrib/agentsVoice/browser/transcriptsView/voiceTranscripts.contribution": [
 			"Show Voice Transcripts",
@@ -38062,6 +40149,36 @@
 			"Older",
 			"Today",
 			"Yesterday"
+		],
+		"vs/workbench/contrib/agentsVoice/browser/voiceModeOnboarding": [
+			"Close the introduction",
+			"Choose how your agent speaks to you. Adjust [[settings]] or [[how it's written]] anytime.",
+			"Microphone",
+			"{0} selected.",
+			"Voice Mode introduction",
+			"Choose how your agent speaks to you. Adjust settings anytime.",
+			"System default",
+			"Welcome to Voice Mode",
+			"{0}. Hear this voice and use it for every conversation.",
+			"Aruha",
+			"Birch (Default)",
+			"David",
+			"Eva",
+			"Gil",
+			"Harper",
+			"Jiyon",
+			"Junho",
+			"Playing {0} preview.",
+			"{0} preview stopped.",
+			"Marc",
+			"Maria",
+			"Oak",
+			"{0}. Hear how your agent will sound.",
+			"{0} preview stopped.",
+			"{0} selected.",
+			"Stop {0} preview.",
+			"Wuzhi",
+			"Agent Voice:"
 		],
 		"vs/workbench/contrib/agentsVoice/common/agentsVoiceColors": [
 			"Background color for the speaking voice state row highlight",
@@ -38185,7 +40302,14 @@
 			"Browser"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/browserView.contribution": [
-			"Browser"
+			"Browser",
+			"Integrated Browser"
+		],
+		"vs/workbench/contrib/browserView/electron-browser/features/browserAutoReloadFeatures": [
+			"Controls whether the Integrated Browser automatically reloads by default when displaying local `file://` resources that change on disk.",
+			"Refresh Automatically",
+			"Reload (Automatic Refresh Enabled)",
+			"More Reload Actions"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/features/browserDataStorageFeatures": [
 			"Clear Storage (Ephemeral)",
@@ -38205,6 +40329,7 @@
 		"vs/workbench/contrib/browserView/electron-browser/features/browserEditorChatFeatures": [
 			"Add Area Screenshot to Chat",
 			"Add Console Logs to Chat",
+			"Comment on Elements",
 			"Add Element to Chat",
 			"Add Full Page Screenshot to Chat (Experimental)",
 			"Add Screenshot to Chat",
@@ -38214,11 +40339,22 @@
 			"&&OK",
 			"Whether area selection is currently active",
 			"Add to Chat",
-			"Whether element selection is currently active",
+			"In the comment input, press Enter to add the comment or Escape to cancel it.",
+			"Commenting mode remains active after adding a comment. Press Escape outside the comment input to stop commenting.",
+			"Use Tab and Shift+Tab to move through focusable page elements. Press Enter to comment on the focused element.",
+			"You are in Integrated Browser element commenting mode.",
+			"Numbered comment pins are in the page tab order. Focus a pin to preview its comment, then Tab to its Remove Comment button.",
+			"Element commenting disabled.",
+			"Element commenting enabled. Press Enter to comment on the focused element.",
+			"Element commenting enabled. Press Enter to comment on the focused element. {0}",
+			"Element selection disabled.",
+			"Element selection enabled. Press Enter to add the focused element to chat.",
+			"The active element selection mode",
 			"When enabled, chat agents can use browser tools to open and interact with pages in the Integrated Browser.",
 			"When enabled, experimental user-facing tools are available in the Integrated Browser's Add to Chat menu.",
 			"Share with Agent",
 			"Sharing with Agent",
+			"Stop Element Selection",
 			"Stop Sharing with Agent",
 			"Browser Area Screenshot",
 			"Browser",
@@ -38446,6 +40582,10 @@
 			"Hover Element",
 			"Hover over an element in a browser page"
 		],
+		"vs/workbench/contrib/browserView/electron-browser/tools/listBrowserPagesTool": [
+			"List Browser Pages",
+			"List browser pages that are shared with the agent"
+		],
 		"vs/workbench/contrib/browserView/electron-browser/tools/navigateBrowserTool": [
 			"Navigating backward in {0}",
 			"Navigated backward in {0}",
@@ -38525,6 +40665,9 @@
 			"Type text or press keys in a browser page"
 		],
 		"vs/workbench/contrib/browserView/electron-browser/widgets/browserUrlBarWidget": [
+			"Address",
+			"Address. This address cannot be changed because the browser is locked to a file resource.",
+			"The address is read-only because the browser is locked to a file resource.",
 			"Go to {0}",
 			"Enter a URL"
 		],
@@ -38636,6 +40779,8 @@
 			"New chat response."
 		],
 		"vs/workbench/contrib/chat/browser/accessibility/chatResponseAccessibleView": [
+			"Created an automation: {0}",
+			"Edited an automation: {0}",
 			"Routed to {0}. {1} - Confidence {2}%",
 			"Routed to {0}. Unable to resolve.",
 			"Non-reasoning",
@@ -38670,23 +40815,38 @@
 		"vs/workbench/contrib/chat/browser/actions/chatAccessibilityHelp": [
 			"When an agent session exposes approval presets, use Tab to reach the Approvals picker and choose how it handles workspace access, commands, and the internet.",
 			"Chat responses will be announced as they come in. A response will indicate the number of code blocks, if any, and then the rest of the response.",
+			"To inspect an inline attachment reference, place the cursor on it and invoke Show or Focus Hover{0}. Image references include a preview, while file and folder references include their path.",
+			"To mention an attached context item at a specific position without removing it from the attached context, type # or @ and select the attachment from the suggestions.",
+			"Long pasted text is stored as an attached text item and replaced in the input with a numbered inline reference.",
 			"To remove attached contexts, focus an attachment and press Delete or Backspace.",
+			"When completed response collapsing is enabled, the final response remains visible while earlier work is collapsed. Use Tab to focus the work disclosure and press Enter or Space to show or hide that work.",
 			"The chat view is a persistent interface that also supports navigating suggested follow-up questions, while the quick chat view is a transient interface for making and viewing requests.",
 			"The quick chat view is a transient interface for making and viewing requests, while the panel chat view is a persistent interface that also supports navigating suggested follow-up questions.",
-			"File change summaries show the total files, additions, and deletions. Focus the disclosure and press Enter or Space to show or hide the individual files.",
+			"The agent sessions filter includes an External submenu. Use it to choose whether external sessions from another application are shown for the last 24 hours, the last 7 days, always, or not at all.",
+			"File change summaries show the total files, additions, and deletions. Focus the disclosure and press Enter or Space to show or hide the individual files. Focus an additions and deletions label and press Enter or Space to open the changes in a diff editor.",
+			"To search the chat transcript, invoke Find in Chat{0}. Find Next{1} and Find Previous{2} move between results, scrolling each one into view.",
 			"To focus the last chat terminal that ran a tool, invoke the Focus Most Recent Chat Terminal command{0}.",
 			"To focus the output from the last chat terminal tool, invoke the Focus Most Recent Chat Terminal Output command{0}.",
+			"When a tip, notification or introduction appears above the input, toggle focus between it and the chat input{0}.",
 			"When a chat question appears, toggle focus between the question and the chat input{0}.",
-			"When a tip appears, toggle focus between the tip and the chat input{0}.",
 			"In the input box, inspect the last response in the accessible view{0}. Thinking content is included in order by default.",
 			"To include or exclude thinking content in the accessible view, run the Toggle Thinking Content in Accessible View command from the Command Palette.",
 			"When a chat question is focused, move to the next question{0}.",
 			"The quick chat view is comprised of an input box and a request/response list. The input box is used to make requests and the list is used to display responses.",
+			"When a plan is ready for review, open it from the chat response to edit the plan and add line comments. Use the editor toolbar to navigate, clear, or submit feedback. Choose an implementation action from the plan review in Chat.",
 			"When a chat question is focused, move to the previous question{0}.",
 			"As the chat request is being processed, you will hear verbose progress updates if the request takes more than 4 seconds. This includes information like searched text for <search term> with X results, created file <file_name>, or read file <file path>. This can be disabled with accessibility.verboseChatProgressUpdates.",
 			"In the input box, use up and down arrows to navigate your request history. Edit input and use enter or the submit button to run a new request.",
 			"If there are any hidden chat terminals, you can view them by invoking the View Hidden Chat Terminals command{0}.",
 			"Accessibility Signals can be changed via settings with a prefix of signals.chat. By default, if a request takes more than 4 seconds, you will hear a sound indicating that progress is still occurring.",
+			"To choose a microphone or turn off dictation or Voice Mode, focus the microphone button in the input toolbar and open its context menu{0} (for example Shift+F10).",
+			"The prompt you have scrolled past is pinned to the top of the transcript. Activate its title to jump back to that prompt.",
+			"When a subagent pill appears in a response, use Tab to focus it and press Enter or Space to open that subagent chat.",
+			"When the experimental agents.voice.agentProgress setting is enabled, Voice Mode Agent requests may speak brief progress updates while investigating, planning, editing, validating, or recovering from a problem.",
+			"In manual Voice Mode, the Start or Stop Listening button toggles listening when tapped, or you can press and hold it to talk and release to send. You can also hold the Voice Mode: Hold to Talk keybinding{0} to talk and release to send; this interrupts the assistant to barge in.",
+			"When the segmented voice input control is enabled, the input toolbar offers Dictation, Voice Mode, and, in manual Voice Mode, a Start or Stop Listening button. Stopping listening sends the completed turn. Each button can be focused and activated with Enter or Space.",
+			"The first time Voice Mode starts, an introduction appears above the input box. Tab to reach it, then use the arrow keys to move between the available voices; Enter or Space plays a voice and keeps it for future conversations. Its description also contains two links: Settings, which opens the Voice Mode settings, and How It Responds, which opens a file for customizing what the agent says back. Voice Mode stays connected but does not listen while the introduction is open. Press Escape, or activate the Close button, to dismiss it and return to the input box.",
+			"Type /vscode-pet to show or hide the VS Code pet above the input. One pet appears in whichever editor or Agents window is active. Drag it around the chat with the mouse and release it to drop it, or flick it in any direction to throw it along the gesture before gravity pulls it down. If it falls past the input, a despawn effect appears at the bottom and a respawn effect appears at the top before it automatically returns to the input. Moving the pointer rapidly between the pet’s left and right sides makes it dizzy. With the keyboard, use Tab to focus the pet, then the left and right arrows to make it hop along the input until it reaches an edge. Hold Shift with the left or right arrow to throw it toward a wall; rapidly alternate the unmodified arrows to make it dizzy. Press Enter or Space while it is resting to interact with it. Open its context menu{0} (for example Shift+F10), use the up and down arrow keys to choose Go on the Run, Come Back, Grow, Shrink, Stable Colors, or Insiders Colors, and press Enter to activate the choice. Grow and Shrink change its size in twenty-percent steps. The pet position and selected size are shared across chats and windows and remembered after you restart.",
 			"To accept a tool action, use the Accept Tool Confirmation command{0}.",
 			"To automatically approve tool actions without manual confirmation, set {0} to {1} in your settings.",
 			"To toggle focus between the Agent TODOs view and the chat input, use Agent TODOs: Toggle Focus{0}.",
@@ -38708,6 +40868,12 @@
 			"- Save All Files{0}.",
 			"Navigate between edits in the editor with navigate previous{0} and next{1}",
 			"Sounds will play when a change is accepted or undone. The sounds can be disabled with accessibility.signals.editsKept and accessibility.signals.editsUndone.",
+			"To close the floating chat input window, invoke the Close Floating Chat Input Window command, or toggle it with the Toggle Floating Chat Input Window command{0}.",
+			"To dictate your request using on-device speech-to-text, invoke the Dictate command{0}. Invoke it again to stop.",
+			"The floating chat input window is an input-only surface. It has no response list; instead each request you submit is routed to the coding session it best matches, and its response appears in that session rather than here.",
+			"In the input box, use up and down arrows to navigate your request history. Edit input and use Enter or the submit button to route a new request.",
+			"When no existing session is a confident match, a new session is started for the request. When an existing session matches, a destination picker appears with a countdown before sending. Press Escape from the input box to cancel, or use Tab to reach the picker, the arrow keys to move, Space to select more than one destination, and Enter to send. The picker also offers starting a new session.",
+			"Accessibility Signals can be changed via settings with a prefix of signals.chat. By default, if a request takes more than 4 seconds, you will hear a sound indicating that progress is still occurring.",
 			"It can be activated via code actions or directly using the command: Inline Chat: Start Inline Chat{0}.",
 			"Context menu actions may run a request prefixed with a /. Type / to discover such ready-made commands.",
 			"Once in the diff editor, enter review mode with{0}. Use up and down arrows to navigate lines with the proposed changes.",
@@ -38716,6 +40882,9 @@
 			"Inline chat occurs within a code editor and takes into account the current selection. It is useful for making changes to the current editor. For example, fixing diagnostics, documenting or refactoring code. Keep in mind that AI generated code may be incorrect.",
 			"In the input box, use Show Previous{0} and Show Next{1} to navigate your request history. Edit input and use enter or the submit button to run a new request.",
 			"Use tab to reach conditional parts like commands, status, message responses and more.",
+			"Some requests include a source chat button above the message. Use Tab to focus it, then Enter or Space to open the originating chat.",
+			"When you select text within an assistant response, an Ask Question input appears near the selection. Type a question and press Enter to start a new side chat scoped to that selection.",
+			"Completed create-chat and send-message operations can include a target chat button in the response. Use Tab to focus it, then Enter or Space to open that chat.",
 			"To focus pending chat confirmation dialogs, invoke the Focus Chat Confirmation Status command{0}.",
 			"While dictating, invoke the Cancel Dictation command{0} to stop and discard the dictated text.",
 			"- Attach Files{0}.",
@@ -38723,14 +40892,13 @@
 			"You can focus the agent sessions list by invoking the Focus Agent Sessions command{0}.",
 			"To focus the input box for chat requests, invoke the Focus Chat Input command{0}.",
 			"To return to the last chat response you focused, invoke the Focus Last Focused Chat Response command{0}.",
-			"To view all chat sessions, invoke the Show Chats command{0}.",
 			"To create a new chat session, invoke the New Chat command{0}.",
 			"To focus the next code block within a response, invoke the Chat: Next Code Block command{0}.",
 			"To navigate to the next user prompt in the conversation, invoke the Next User Prompt command{0}.",
 			"When starting an agent session in a multi-root workspace, you can choose which root folder it runs in by invoking the Folder command{0}, then selecting a folder from the list.",
 			"To navigate to the previous user prompt in the conversation, invoke the Previous User Prompt command{0}.",
 			"- Restore to Last Checkpoint{0}.",
-			"To dictate your request into the input box using on-device speech-to-text, invoke the Dictate command{0}. Invoke it again to stop; recording start and stop are indicated by accessibility signals.",
+			"To dictate your request into the input box, invoke the Dictate command{0}. Invoke it again to stop; recording start and stop are indicated by accessibility signals.",
 			"- Undo Edits{0}.",
 			"To open the Agents Window, invoke the Open Agents Window command{0}. In screen reader mode, this keybinding includes Alt to avoid conflicts with screen reader shortcuts."
 		],
@@ -38743,9 +40911,9 @@
 			"Chat",
 			"Edit/manage the tool approval and confirmation preferences for AI chat agents.",
 			"Manage Tool Approval",
+			"No chat notice.",
 			"No chat question to focus right now.",
 			"Show Context Usage",
-			"No chat tip.",
 			"No agent todos to focus right now.",
 			"Show View by Default",
 			"You've reached your monthly chat messages and inline suggestions quota.",
@@ -38772,9 +40940,9 @@
 			"Clear Input History",
 			"Compact Conversation",
 			"Focus Chat Input",
+			"Chat: Toggle Focus Between Notice and Input",
 			"Chat: Toggle Focus Between Question and Input",
 			"Chat: Focus Terminal from Question Carousel",
-			"Chat: Toggle Focus Between Tip and Input",
 			"Toggle Focus Between TODOs and Input",
 			"New Chat Window",
 			"Chat: Next Question",
@@ -38821,7 +40989,9 @@
 			"Screenshot",
 			"Open Editors",
 			"Sessions...",
+			"Other Workspaces",
 			"Select a session",
+			"This Workspace",
 			"Tools...",
 			"Select a tool",
 			"Image from Clipboard",
@@ -38897,6 +41067,7 @@
 			"Open Session Target Picker",
 			"Open Workspace Picker",
 			"Send",
+			"Routing Request…",
 			"Send",
 			"Switch to Next Model",
 			"Switch to Next Pinned Model",
@@ -38910,6 +41081,15 @@
 		"vs/workbench/contrib/chat/browser/actions/chatFileTreeActions": [
 			"Next File Tree",
 			"Previous File Tree"
+		],
+		"vs/workbench/contrib/chat/browser/actions/chatFindActions": [
+			"Find in Chat",
+			"Find Next in Chat",
+			"Find Previous in Chat",
+			"Hide Find in Chat",
+			"Toggle Find Case Sensitive in Chat",
+			"Toggle Find Using Regex in Chat",
+			"Toggle Find Using Whole Word in Chat"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatForkActions": [
 			"Fork Conversation",
@@ -38991,6 +41171,10 @@
 			"Previous User Prompt"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatQueueActions": [
+			"Ask in Side Chat",
+			"The side chat could not be created.",
+			"Ask this question in a side chat without adding it to this conversation",
+			"This conversation does not support side chats.",
 			"Edit",
 			"Add to Queue",
 			"Queue this message to send after the current request completes",
@@ -39012,16 +41196,18 @@
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatSpeechToTextActions": [
 			"Cancel Dictation (Speech to Text)",
+			"Connecting to Speech to Text…",
 			"Hold to Dictate (Speech to Text)",
 			"Preparing Speech to Text Model…",
-			"Dictate: Select Microphone",
+			"Dictate: Reset Onboarding",
+			"Select Microphone",
+			"Dictate: Show Introduction",
 			"Dictate (Speech to Text)",
 			"Stop Dictation",
 			"(current)",
+			"Open a chat to see the dictation introduction.",
 			"No microphones found",
-			"Select a microphone for dictation",
-			"System Default",
-			"Unknown Device ({0})"
+			"Select a microphone for dictation"
 		],
 		"vs/workbench/contrib/chat/browser/actions/chatTitleActions": [
 			"Don't ask again",
@@ -39084,6 +41270,17 @@
 			"New untitled editor",
 			"Select where to apply the code block"
 		],
+		"vs/workbench/contrib/chat/browser/actions/configureVoiceInstructionsAction": [
+			"Voice: Configure Dictation Instructions",
+			"Voice: Configure Voice Mode Instructions",
+			"Select where to configure {0}",
+			"Select where to configure {0}. Trust the workspace to configure workspace instructions.",
+			"User",
+			"Applies across all workspaces.",
+			"Workspace",
+			"Applies to this workspace and can be shared with your team.",
+			"Workspace: {0}"
+		],
 		"vs/workbench/contrib/chat/browser/actions/createPluginAction": [
 			"Agents",
 			"Create Plugin",
@@ -39116,13 +41313,20 @@
 			"Failed to save debug logs: {0}"
 		],
 		"vs/workbench/contrib/chat/browser/actions/openCopilotCliStateFileAction": [
-			"Open Copilot CLI State File",
+			"Open Copilot State File",
 			"Remote agent host '{0}' did not report a home directory.",
-			"No Copilot CLI session is active.",
+			"No Copilot session is active.",
 			"No active connection found for remote agent host '{0}'.",
-			"The active chat session is not a Copilot CLI session."
+			"The active chat session is not a Copilot session."
 		],
 		"vs/workbench/contrib/chat/browser/agentPluginActions": [
+			"Disable",
+			"Disable (Session)",
+			"Disable (Workspace)",
+			"Enable",
+			"Enable Plugin",
+			"Enable (Session)",
+			"Enable (Workspace)",
 			"Disable",
 			"Disable (Workspace)",
 			"Enable",
@@ -39132,6 +41336,13 @@
 			"Open README",
 			"The plugin \"{0}\" has been disabled by your organization and cannot be enabled.",
 			"Uninstall"
+		],
+		"vs/workbench/contrib/chat/browser/agentPluginCommands": [
+			"Update Plugins",
+			"Update Plugins (Force)",
+			"Failed to update plugins: {0}",
+			"Plugins are up to date.",
+			"Chat"
 		],
 		"vs/workbench/contrib/chat/browser/agentPluginEditor/agentPluginEditor": [
 			"No README available.",
@@ -39160,8 +41371,11 @@
 			"Agent Plugins",
 			"Agent Plugins",
 			"Browse Agent Plugins",
-			"Update Plugins",
-			"Update Plugins (Force)",
+			"Plugin marketplaces refreshed.",
+			"Refreshed plugin marketplaces, but {0} could not be read: {1}",
+			"Refreshing plugin marketplaces...",
+			"Refresh Plugin Marketplaces",
+			"Failed to refresh plugin marketplaces: {0}",
 			"Chat",
 			"Manage",
 			"No agent plugins found.",
@@ -39177,7 +41391,9 @@
 			"Failed to sign in to use GitHub Copilot."
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatContribution": [
-			"{0} [Agent Host]"
+			"{0} [Agent Host]",
+			"Models provided by your ChatGPT subscription",
+			"ChatGPT"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostChatInputPicker": [
 			"Controls whether the agent asks before running tools in this session.",
@@ -39191,8 +41407,11 @@
 			"On",
 			"On",
 			"Copilot asks before running tools unless your configured settings allow the tool.",
+			"Sandboxing for terminal",
+			"Run terminal commands inside a sandbox that restricts file system and network access",
 			"Filter...",
 			"Learn more about permissions",
+			"Manual permissions (sandboxed)",
 			"Disabled by your organization. Contact your administrator.",
 			"{0}: {1}",
 			"{0}: {1}, Read-Only"
@@ -39221,6 +41440,10 @@
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerActionItem": [
 			"Folder"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostFolderPickerTip": [
+			"Learn more",
+			"Select a primary directory"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostLanguageModelProvider": [
 			"{0}% discount"
 		],
@@ -39233,8 +41456,20 @@
 			"Remote agent host \"{0}\" wants to read {1}",
 			"Remote agent host \"{0}\" wants to write {1}"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostPromptCacheNotification": [
+			"The next prompt will incur increased cost. Consider starting a new chat. [Learn more]({0})",
+			"Don't Show Again",
+			"Start New Chat",
+			"This chat's prompt cache is stale"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionHandler": [
 			"Authentication is required to start a session. Please sign in and try again.",
+			"Invalid tool input for \"{0}\": expected JSON object parameters.",
+			"Could not create invocation for client tool \"{0}\".",
+			"Couldn't run {0}",
+			"Couldn't run {0}",
+			"{0} needs confirmation but no session was available to answer it.",
+			"Tool \"{0}\" is not available on this client.",
 			"Cancel",
 			"Open {0}",
 			"Authorization Required",
@@ -39249,6 +41484,9 @@
 			"Error: ({0}) {1}",
 			"AI features are currently only supported in trusted workspaces."
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSessionWorkingDirectorySynchronizer": [
+			"The workspace folder '{0}' is not trusted."
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSettings.contribution": [
 			"Host Settings",
 			"Open Host Settings"
@@ -39258,6 +41496,12 @@
 			"Agent host settings must be a JSON object.",
 			"Failed to parse agent host settings as JSON.",
 			"Edit values below and save to apply. Unknown properties are ignored."
+		],
+		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostSignedOutModelsNotification": [
+			"Add Models",
+			"Sign in to use GitHub Copilot models, or add a model with your own API key.",
+			"Choose how you want to use Copilot.",
+			"Sign In"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentHost/agentHostTerminalContribution": [
 			"Local"
@@ -39282,12 +41526,15 @@
 			"Reveal Selected",
 			"Choose which comments to reveal to the agent. Unchecked comments stay hidden.",
 			"Reveal unreviewed comments?",
+			"Asking a question...",
+			"Waiting for answer...",
 			"Open this URL?",
 			"Authorization Required",
 			"Running {0} on another client...",
 			"{0} credit",
 			"{0} credits",
 			"{0} ({1})",
+			"Reading file",
 			"False",
 			"True",
 			"System",
@@ -39327,21 +41574,13 @@
 			"Local"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessions.contribution": [
-			"Show All Agent Sessions",
-			"Search agent sessions by name",
 			"Filter Agent Sessions"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsActions": [
 			"Delete All Local Workspace Chat Sessions",
-			"Open Agent Session...",
-			"Archive",
-			"Archive All Workspace Agent Sessions",
-			"Archive",
 			"Are you sure you want to archive {0} agent sessions?",
 			"Are you sure you want to archive 1 agent session?",
 			"You can unarchive sessions later if needed from the sessions view.",
-			"Archive All",
-			"Archive All",
 			"Are you sure you want to archive {0} agent sessions from '{1}'?",
 			"Are you sure you want to archive 1 agent session from '{0}'?",
 			"You can unarchive sessions later if needed from the sessions view.",
@@ -39371,19 +41610,24 @@
 			"Find Agent Session",
 			"Hide Agent Sessions Sidebar",
 			"Mark All as Read",
+			"Are you sure you want to mark {0} agent sessions as done?",
+			"Are you sure you want to mark 1 agent session as done?",
+			"You can restore sessions later if needed from the sessions view.",
 			"Mark as Read",
 			"Mark All as Read",
+			"Are you sure you want to mark {0} agent sessions from '{1}' as done?",
+			"Are you sure you want to mark 1 agent session from '{0}' as done?",
+			"You can restore sessions later if needed from the sessions view.",
+			"Mark chat as done with pending edits?",
 			"Mark as Unread",
 			"New agent session title",
 			"Pin",
 			"Refresh Agent Sessions",
 			"Rename...",
+			"Are you sure you want to restore {0} agent sessions?",
 			"Show Agent Sessions Sidebar",
 			"Toggle Agent Sessions Sidebar",
-			"Unarchive",
-			"Unarchive All",
 			"Are you sure you want to unarchive {0} agent sessions?",
-			"Unarchive All",
 			"Unpin"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsBanner": [
@@ -39411,14 +41655,9 @@
 			"Failed to open chat session: {0}"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsPicker": [
-			"Archive",
 			"Search agent sessions by name",
 			"Delete",
-			"Rename",
-			"Unarchive"
-		],
-		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsQuickAccess": [
-			"No matching agent sessions"
+			"Rename"
 		],
 		"vs/workbench/contrib/chat/browser/agentSessions/agentSessionsViewer": [
 			"Completed",
@@ -39531,6 +41770,14 @@
 			"Show Commands (Unified)",
 			"Show Files (Unified)"
 		],
+		"vs/workbench/contrib/chat/browser/agentSessions/externalSessionsFilterMenu": [
+			"External",
+			"All",
+			"Last 24 Hours",
+			"Last 7 Days",
+			"None",
+			"Recent"
+		],
 		"vs/workbench/contrib/chat/browser/agentSessions/sessionTypeAvailability": [
 			"No models available",
 			"No models are available for this agent.",
@@ -39540,6 +41787,10 @@
 			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan) to use this agent.",
 			"[Upgrade](command:workbench.action.chat.upgradePlan)",
 			"Requires GitHub Copilot Pro"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/agentGlobalConfigurationSettingsWidget": [
+			"Save",
+			"These harness settings are not available from the connected agent host."
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationIcons": [
 			"Icon for adding new items.",
@@ -39708,8 +41959,7 @@
 		"vs/workbench/contrib/chat/browser/aiCustomization/aiCustomizationManagementEditor": [
 			"Agents",
 			"Define custom agents with specialized personas, tool access, and instructions for specific tasks.",
-			"Automations",
-			"Schedule agent sessions to run on a cadence you choose.",
+			"Back to migration",
 			"Back to list",
 			"Back to list",
 			"Back to MCP servers",
@@ -39718,12 +41968,20 @@
 			"Back to overview",
 			"Back to plugins",
 			"Back to plugins",
-			"Back to Migrate Prompt Files",
-			"Back to Migrate Prompt Files",
 			"Back to tools",
 			"Back to tools",
 			"Cancel",
+			"Are you sure you want to delete '{0}'?",
+			"This action cannot be undone.",
+			"Migrate",
+			"Migrate ({0})",
+			"Type to search...",
+			"Select {0}",
+			"Select all customizations in {0}",
 			"Customization preview",
+			"Delete",
+			"Delete {0}",
+			"Delete",
 			"Failed to finish the prompt action.",
 			"Edit",
 			"Edit the raw markdown file",
@@ -39739,17 +41997,22 @@
 			"Instructions",
 			"Set always-on instructions that guide AI behavior across your workspace or user profile.",
 			"Learn more about language models",
-			"Learn more about agent skills",
 			"Local",
 			"MCP Servers",
 			"Connect external tool servers that extend AI capabilities with custom tools and data sources.",
-			"Migrate prompt files to skills",
-			"Prompts, {0} deprecated prompt files need migration",
-			"Migrate Prompts",
-			"Convert deprecated prompt files to skills",
+			"No global agents folder is configured for the active harness.",
+			"No global instructions folder is configured for the active harness.",
+			"No global skills folder is configured for the active harness.",
+			"No workspace agents folder is configured for the active harness.",
+			"No workspace instructions folder is configured for the active harness.",
+			"No workspace skills folder is configured for the active harness.",
+			"Select a destination folder for migrated agents",
+			"Select a destination folder for migrated instructions",
+			"Select a destination folder for migrated skills",
 			"Models",
 			"Configure and manage language models available for use.",
 			"Browse and manage language models from different providers. Select models for use in chat, code completion, and other AI features.",
+			"Open {0}, {1}",
 			"Plugins",
 			"Install and manage agent plugins that add additional tools, skills, and integrations.",
 			"Show help for '{0}'",
@@ -39758,34 +42021,6 @@
 			"No markdown body found in this file.",
 			"No metadata found in this file.",
 			"Custom metadata field `{0}`.",
-			"Convert to Skills",
-			"This converts {0} user prompt files into skills.",
-			"This converts {0} workspace prompt files into skills.",
-			"This converts {0} workspace prompt files and {1} user prompt files into skills.",
-			"Convert prompt files to skills?",
-			"Converted {0} prompt files to skills.",
-			"Converted {0} prompt files to skills. Review migrated skills that used unsupported prompt headers: {1}.",
-			"Delete original prompt files after migration",
-			"Failed to migrate {0} prompt files: {1}.",
-			"Failed to migrate {0} prompt files: {1}, and {2} more.",
-			"No prompt files were converted.",
-			"No skill folders are configured for the active harness.",
-			"Migrate",
-			"Convert selected prompt files to skills",
-			"Migrate ({0})",
-			"Select prompt files to convert into skills for the active harness.",
-			"Prompt files are not supported for this harness. Found {0} user prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
-			"Prompt files are not supported for this harness. Found {0} workspace prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
-			"Prompt files are not supported for this harness. Found {0} prompt files ({1} workspace, {2} user) that local VS Code can still run, but {3} ignores. Convert them to skills to keep them available.",
-			"No prompt files are available to migrate.",
-			"Migrate Prompt Files",
-			"Select a workspace skill folder for migrated prompts",
-			"No prompt files match your search.",
-			"Type to search...",
-			"Select {0}",
-			"Select all {0} prompt files",
-			"User",
-			"Workspace",
 			"Prompts",
 			"Reusable prompt templates that can be invoked as slash commands.",
 			"Save override",
@@ -39813,8 +42048,10 @@
 			"Define custom agents with specialized personas, tool access, and instructions for specific tasks.",
 			"Browse...",
 			"Browse {0}...",
-			"Convert prompt files to skills",
-			"Convert to Skills...",
+			"Configure...",
+			"Configure {0}...",
+			"Dictation Instructions",
+			"Customize Dictation terminology and transcript formatting with dictation.md.",
 			"Describe your preferences and conventions to draft agents, skills, and instructions.",
 			"Customize Your Agent",
 			"Hooks",
@@ -39823,19 +42060,17 @@
 			"Set always-on instructions that guide AI behavior across your workspace or user profile.",
 			"MCP Servers",
 			"Connect external tool servers that extend AI capabilities with custom tools and data sources.",
-			"Migrate",
 			"New...",
 			"New {0}...",
 			"Plugins",
 			"Install and manage agent plugins that add additional tools, skills, and integrations.",
-			"Prompt files are deprecated for this harness. Found {0} global prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
-			"Prompt files are deprecated for this harness. Found {0} workspace prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
-			"Prompt files are deprecated for this harness. Found {0} prompt files ({1} workspace, {2} global) that local VS Code can still run, but {3} ignores. Convert them to skills to keep them available.",
 			"Sent to chat ✓",
 			"Skills",
 			"Create reusable skill files that provide domain-specific knowledge and workflows.",
 			"Tools",
 			"Enable or disable the tools available to chat.",
+			"Voice Mode Instructions",
+			"Customize Voice Mode behavior and terminology with voice.md.",
 			"Agent Customizations for {0}",
 			"Tailor how agents work in your projects. Configure workspace customizations for the entire team, or create personal ones that follow you across projects.",
 			"Describe your preferences to customize your agent",
@@ -39843,91 +42078,89 @@
 			"Customize agent",
 			"Open in Chat"
 		],
-		"vs/workbench/contrib/chat/browser/aiCustomization/automationsAccessibilityHelp": [
-			"- Delete: removes the automation after a confirmation prompt. Runs already in flight continue to completion.",
-			"- Edit: opens the create/edit dialog with the current values prefilled.",
-			"- Show history: expands an inline list of recent runs for the automation, including their status and any error messages.",
-			"- Run now: spawns a new agent session immediately using the automation’s prompt. The trigger is recorded as Manual.",
-			"Row Actions (Tab between them):",
-			"- Toggle enabled: pauses or resumes scheduled runs. Disabled automations skip their scheduled tick but can still be run manually.",
-			"Press Escape to close this dialog and return focus to the Automations list.",
-			"Closing this dialog:",
-			"The dialog has a Name field, a multi-line Prompt field, a Schedule selector (Manual, Hourly, Daily, Weekly), Time and Day-of-Week fields that appear when relevant, a Workspace target selector, a Session type selector, an isolation selector, a branch selector for supported Worktree sessions, an Agent Mode selector (Use default, Agent, Ask, Edit), and a Permission Mode selector (Use default, Default Approvals, Bypass Approvals, Autopilot). Choose No workspace from the Workspace target selector to run without a backing workspace. Only workspace-less-capable session types are then offered, and the isolation and branch controls do not apply. Folder isolation follows the selected repository’s current branch. Worktree isolation lets you choose a local base branch. The selected configuration is replayed when the scheduler starts a run. Tab and Shift+Tab move between fields; Enter or Space opens a focused selector, and Escape closes an open selector before it closes the dialog.",
-			"Create/Edit Dialog:",
-			"Save is disabled until Name, Prompt, and Session type are set. Workspace-backed automations also require a Workspace folder, and Worktree isolation requires a branch. Activate Cancel or press Escape to dismiss without saving.",
-			"Accessibility Help: Automations",
-			"Each run records its status (Pending, Running, Completed, Failed), the trigger that started it (Schedule, Manual, or Catch-up after VS Code restarts), the time it started, and the time it took. Failed runs include the failure reason.",
-			"Run History:",
-			"Automations let you schedule agent sessions to run on a cadence you choose. When an automation is due, a fresh chat session is created in the background and the prompt is sent automatically.",
-			"The Automations section shows a list of all your automations. Each row displays the automation’s name, schedule (Manual, Hourly, Daily at a time, or Weekly on a day at a time), whether it targets a workspace folder or runs without a workspace, the next scheduled run, and a preview of the prompt. Row action buttons follow on the right.",
-			"Layout:",
-			"Settings ({0} opens Settings):",
-			"- `accessibility.verbosity.automations`: Controls whether this Accessibility Help hint is announced when the Automations section is focused.",
-			"The Automations list announces state changes when you create, update, delete, toggle, or manually run an automation. Verbose announcements can be turned off via the accessibility.verbosity.automations setting.",
-			"Screen Reader Announcements:"
-		],
-		"vs/workbench/contrib/chat/browser/aiCustomization/automationsListWidget": [
-			"{0}, {1}, {2}",
-			"{0}, disabled, {1}, {2}",
-			"Created automation {0}",
-			"Failed to create automation.",
-			"Deleted automation {0}",
-			"Disabled",
-			"Disabled automation {0}",
-			"Enabled automation {0}",
-			"in {0}",
-			"without a workspace",
-			"Runs as a workspace-less chat",
-			"Enable “{0}” to make changes.",
-			"Automations are disabled.",
-			"Create automation",
-			"Create an automation to schedule an agent session to run on a cadence you choose.",
-			"No automations yet",
-			"Schedule agent sessions to run on a cadence you choose.",
-			"Automations",
-			"Automations",
-			"Started automation {0}",
-			"Updated automation {0}",
-			"Failed to update automation.",
-			"Delete automation “{0}”?",
-			"Runs already in flight will continue. This cannot be undone.",
-			"Delete",
-			"Delete",
-			"Disable",
-			"Edit",
-			"Enable",
-			"Hide history",
-			"Run history for {0}",
-			"{0} more run(s) not shown.",
-			"Last run {0}",
-			"New automation",
-			"Create a new automation",
-			"Next run {0}",
-			"No scheduled run",
-			"No runs yet.",
-			"Open session",
-			"Failed to open automation session",
-			"Run history",
-			"Run now",
-			"Started {0}",
-			"Completed",
-			"Failed",
-			"Pending",
-			"Running",
-			"Catch-up",
-			"Manual",
-			"Scheduled",
-			"Daily at {0}",
-			"Hourly",
-			"Manual",
-			"Weekly on {0} at {1}",
-			"Show history"
-		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/customizationCreatorService": [
 			"Name for the new {0}",
 			"e.g., my-{0}",
 			"Name is required",
 			"Select a directory for the new customization file"
+		],
+		"vs/workbench/contrib/chat/browser/aiCustomization/customizationMigrationCategories": [
+			"Back to Migrate Prompt Files",
+			"Back to Migrate User Data Customizations",
+			"Convert to Skills...",
+			"Convert prompt files to skills",
+			"Prompt files are deprecated for this harness. Found {0} global prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are deprecated for this harness. Found {0} workspace prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are deprecated for this harness. Found {0} prompt files ({1} workspace, {2} global) that local VS Code can still run, but {3} ignores. Convert them to skills to keep them available.",
+			"Migrate Prompt Files",
+			"Convert to Skills",
+			"This converts {0} user prompt files into skills.",
+			"This converts {0} workspace prompt files into skills.",
+			"This converts {0} workspace prompt files and {1} user prompt files into skills.",
+			"Convert prompt files to skills?",
+			"Converted {0} prompt files to skills.",
+			"Converted {0} prompt files to skills. Review migrated skills that used unsupported prompt headers: {1}.",
+			"Delete original prompt files after migration",
+			"Failed to migrate {0} prompt files: {1}.",
+			"Failed to migrate {0} prompt files: {1}, and {2} more.",
+			"Learn more about agent skills",
+			"No prompt files were converted.",
+			"Convert selected prompt files to skills",
+			"Select prompt files to convert into skills for the active harness.",
+			"Prompt files are not supported for this harness. Found {0} user prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are not supported for this harness. Found {0} workspace prompt files that local VS Code can still run, but {1} ignores. Convert them to skills to keep them available.",
+			"Prompt files are not supported for this harness. Found {0} prompt files ({1} workspace, {2} user) that local VS Code can still run, but {3} ignores. Convert them to skills to keep them available.",
+			"No prompt files are available to migrate.",
+			"Migrate Prompt Files",
+			"No prompt files match your search.",
+			"Prompts, {0} deprecated prompt files need migration",
+			"Migrate Prompts",
+			"Convert deprecated prompt files to skills",
+			"User",
+			"Workspace",
+			"Agents",
+			"Migrated files won't use Settings Sync. Commit them to a repository to share them.",
+			"They are stored in user data, which only VS Code reads. Migrating moves them into the folders {0} reads, keeping their name, type, and content, so you can keep using them.",
+			"{0} customizations are not available to {1}",
+			"1 customization is not available to {0}",
+			"Migrate...",
+			"Migrate user data customizations to the active harness",
+			"User data customizations are only used by VS Code. Found 1 agent that {0} ignores. Move it to keep it available.",
+			"User data customizations are only used by VS Code. Found {0} agents that {1} ignores. Move them to keep them available.",
+			"User data customizations are only used by VS Code. Found 1 instruction file that {0} ignores. Move it to keep it available.",
+			"User data customizations are only used by VS Code. Found {0} instruction files that {1} ignores. Move them to keep them available.",
+			"User data customizations are only used by VS Code. Found {0} customizations that {1} ignores. Move them to keep them available.",
+			"Migrate User Data Customizations",
+			"Migrated {0} user data customizations.",
+			"Migrated 1 user data customization.",
+			"Migrate",
+			"This moves 1 agent out of user data.",
+			"This moves {0} agents out of user data.",
+			"This moves 1 instruction file out of user data.",
+			"This moves {0} instruction files out of user data.",
+			"This moves {0} customizations out of user data.",
+			"Migrate user data customizations to {0}?",
+			"Delete the original files from user data after migration",
+			"Failed to migrate 1 user data customization: {0}.",
+			"Failed to migrate {0} user data customizations: {1}.",
+			"Failed to migrate {0} user data customizations: {1}, and {2} more.",
+			"Instructions",
+			"Learn more about agent customizations",
+			"No user data customizations were migrated.",
+			"Move the selected user data customizations to the active harness",
+			"Select user data customizations to move to the active harness.",
+			"Found 1 agent in user data that local VS Code can still use, but {0} ignores. Move it to the harness agents folder to keep it available.",
+			"Found {0} agents in user data that local VS Code can still use, but {1} ignores. Move them to the harness agents folder to keep them available.",
+			"Found {0} customizations in user data that local VS Code can still use, but {1} ignores. Move them to the harness folders to keep their type and content.",
+			"Found 1 instruction file in user data that local VS Code can still use, but {0} ignores. Move it to the harness instructions folder to keep it available.",
+			"Found {0} instruction files in user data that local VS Code can still use, but {1} ignores. Move them to the harness instructions folder to keep them available.",
+			"No user data customizations are available to migrate.",
+			"Migrate User Data Customizations",
+			"No user data customizations match your search.",
+			"User data, 1 customization needs migration",
+			"User data, {0} customizations need migration",
+			"Migrate User Data",
+			"Move user data agents and instructions to the active harness"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/embeddedAgentPluginDetail": [
 			"No plugin selected.",
@@ -39965,8 +42198,10 @@
 			"Add Server",
 			"Add Server",
 			"Disable",
+			"Disable (Session)",
 			"Disable (Workspace)",
 			"Enable",
+			"Enable (Session)",
 			"Enable (Workspace)",
 			"Authentication required",
 			"Back to installed servers",
@@ -39980,7 +42215,6 @@
 			"collapsed",
 			"This MCP server is provided by the plugin '{0}'",
 			"Individual MCP servers from a plugin cannot be removed separately. Would you like to uninstall the entire plugin?",
-			"Disabled",
 			"No MCP servers available",
 			"Error",
 			"expanded",
@@ -40008,8 +42242,6 @@
 			"Running",
 			"Search MCP marketplace...",
 			"Type to search...",
-			"Disable (Session)",
-			"Enable (Session)",
 			"Show output for {0}",
 			"Show Plugin",
 			"Sign In",
@@ -40036,11 +42268,9 @@
 			"Create Plugin",
 			"Disabled Locally",
 			"Plugins installed in this client but currently disabled.",
-			"Disable {0} from sync",
 			"No plugins available",
 			"Enabled Locally",
 			"Plugins installed in this client and available for syncing to the remote session.",
-			"Enable {0} for sync",
 			"expanded",
 			"Install Plugin from Source",
 			"Learn more about agent plugins",
@@ -40066,14 +42296,14 @@
 			"Remote",
 			"Plugins configured directly on the remote agent host and available without local sync.",
 			"Warning",
-			"Disabled",
 			"Error",
 			"Loaded",
 			"Loading",
 			"Search plugin marketplace...",
 			"Type to search...",
 			"Check your connection and try again",
-			"Try a different search term"
+			"Try a different search term",
+			"Update Plugins"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/promptsServiceCustomizationItemProvider": [
 			"always added",
@@ -40083,8 +42313,8 @@
 			"UI Integration"
 		],
 		"vs/workbench/contrib/chat/browser/aiCustomization/toolsListWidget": [
-			"Copilot CLI",
-			"Built-in tools the Copilot CLI agent runs inside its own runtime.",
+			"Copilot",
+			"Built-in tools the Copilot agent runs inside its own runtime.",
 			"Do you want to uninstall the extension '{0}'?",
 			"This extension may contribute more than tools. Uninstalling it removes all of its contributions.",
 			"Apply patches (used by some models instead of edit/create)",
@@ -40114,7 +42344,7 @@
 			"No tool extensions match '{0}'",
 			"Search the Marketplace...",
 			"Check your connection and try again",
-			"Enable or disable the tools available to chat. Disabled tools are not advertised to the agent. Tools other than Copilot CLI run on the client and require it to be connected.",
+			"Enable or disable the tools available to chat. Disabled tools are not advertised to the agent. Tools other than Copilot's built-in tools run on the client and require it to be connected.",
 			"Tools",
 			"Tool extensions",
 			"No tools available.",
@@ -40135,11 +42365,15 @@
 		],
 		"vs/workbench/contrib/chat/browser/attachments/chatAttachmentWidgets": [
 			"Attached context, {0}",
+			"Link to chat {0}",
+			"Open chat \"{0}\"",
 			"Remove from context",
 			"Save As...",
 			"Failed to save file: {0}",
 			"Save Image As...",
 			"Failed to save image: {0}",
+			"Open {0} in Browser",
+			"Open {0} in Browser",
 			"{0} (Delete)",
 			"Attached image, {0}. Image support depends on the model selected by Auto.",
 			"Image support depends on the model selected by Auto.",
@@ -40150,7 +42384,6 @@
 			"Browser page unavailable, {0}",
 			"This browser page is not shared with the agent.",
 			"Browser page not shared with agent, {0}",
-			"Click to view the contents of: {0}",
 			"Attached element, {0}",
 			"ATTRIBUTES",
 			"KEY COMPUTED STYLES",
@@ -40158,6 +42391,8 @@
 			"HTML PATH",
 			"INNER TEXT",
 			"POSITION & SIZE",
+			"SCREENSHOT",
+			"Screenshot of attached element {0}",
 			"Show More...",
 			"Attached file, {0}",
 			"{0} does not support this file type.",
@@ -40174,6 +42409,7 @@
 			"Omitted this file: {0}",
 			"Omitted this image: {0}",
 			"Omitted this Notebook ouput: {0}",
+			"Open in Images Preview",
 			"Partially omitted this image: {0}",
 			"Partially omitted this Notebook output: {0}",
 			"Prompt file, {0}",
@@ -40211,13 +42447,10 @@
 		],
 		"vs/workbench/contrib/chat/browser/chat.shared.contribution": [
 			"Agent Plugin",
-			"Use {0} instead",
-			"Use {0} instead",
-			"Use {0} instead",
-			"Use {0} instead",
 			"Global auto approve also known as \"YOLO mode\" disables manual approval completely for all tools in all workspaces, allowing the agent to act fully autonomously. This is extremely dangerous and is *never* recommended, even containerized environments like Codespaces and Dev Containers have user keys forwarded into the container that could be compromised.\n\nThis feature disables critical security protections and makes it much easier for an attacker to compromise the machine.\n\nNote: This setting only controls tool approval and does not prevent the agent from asking questions. To automatically answer agent questions, use the `#chat.autoReply#` setting.",
 			"Chat",
 			"Allowed domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. When {2} is enabled, all domains are allowed. Supports wildcards like {3}. When both allowed and denied lists are empty, all domains are blocked. Denied domains (see {4}) take precedence.",
+			"Controls whether completed chat responses collapse intermediate work while keeping the final response visible.",
 			"Denied domains for network access by agent tools (fetch tool, integrated browser). Applies when {0} or {1} is enabled. This does not apply when {2} is enabled. Takes precedence over {3}. Supports wildcards like {4}.",
 			"When enabled, agent mode can be activated from chat and tools in agentic contexts with side effects can be used.",
 			"The maximum number of requests to allow per-turn when using an agent. When the limit is reached, will ask to confirm to continue.",
@@ -40238,32 +42471,49 @@
 			"Enable agent debug logging for agent host sessions: surface their debug events in the agent debug panel. Takes effect immediately; only sessions that run while this is enabled are captured.",
 			"Maximum number of debug events kept in memory per agent host session for the agent debug panel. Older events beyond this limit are dropped from the in-memory buffer, which also lowers the totals (such as token usage) shown in the panel overview.",
 			"When enabled, logs all AHP transport messages for agent host connections to JSONL files under the window's log directory.",
+			"When enabled, Agent Host sessions remain available while signed out. The Agents window opens without forcing GitHub sign-in, and editor chat lets you select the Copilot harness. Agents usable without GitHub (for example Codex with ChatGPT authentication or Claude in native mode with your own Anthropic credentials) work while signed out; agents that require GitHub prompt you to add a model or sign in. When disabled (the default), GitHub sign-in is required before the Agents window opens.",
+			"When enabled, maps supported legacy VS Code settings to equivalent Copilot SDK managed settings for local Agent Host sessions. This compatibility bridge is temporary and is not used for new settings.",
+			"Per-model capability overrides for Copilot SDK agent sessions, keyed by model id (`*` matches every model; a specific entry wins field-by-field), intended for evaluating models against an existing model's profile. Declare an aliased `family` (for example `claude-opus-4.8`) to route the model to that family's tuned system prompt and tool profile without changing the model id sent to the runtime — so a preview model can be evaluated against a known prompt while still running on its own endpoint — a `reasoningEffort` to pin its effort level, `availableTools`/`excludedTools` to filter its tool set, or `modelCapabilities` to override individual capability limits (e.g. vision support, context window size) passed through to the SDK. All overrides apply when a session launches or resumes. On a mid-session model change, only the new model's `reasoningEffort` is applied; the session keeps its launch-time family, tool filters, and model capabilities. Only affects Copilot agent sessions.\n\n**Note**: This is an advanced setting for experimentation.",
+			"When set, only matching tools are available to sessions on this model. Patterns: bare tool names, `builtin:*` or `builtin:<name>` (Copilot runtime tools), `mcp:*` or `mcp:<name>` (MCP server tools), and `custom:*` or `custom:<name>` (every tool VS Code registers with the SDK, including the agent host's own terminal tools); a bare `*` expands to all three sources.",
+			"Tools disabled for sessions on this model; same pattern syntax as `availableTools` and takes precedence over it. Note that `custom:*` and a bare `*` also disable the agent host's own terminal tools registered with the SDK.",
+			"Route the model to another family's tuned system prompt and tool profile (e.g. `claude-opus-4.8`). The model id sent to the runtime is unaffected, so the session still runs on the selected model.",
+			"Per-property model capability overrides passed through to the Copilot SDK's `modelCapabilities` session field (e.g. `{ \"supports\": { \"vision\": false }, \"limits\": { \"max_context_window_tokens\": 64000 } }`), deep-merged over the runtime's resolved defaults for this model. Applied when the session launches or resumes.",
+			"Reasoning effort for sessions on this model, overriding the model picker's thinking level. Use the `*` entry to set it for every model. Unrecognized values are ignored.",
+			"Minimum number of tools before MCP and external tools are deferred behind tool search. Set to 0 to always defer external tools. Only effective when tool search is enabled.",
+			"When enabled, Copilot SDK sessions defer MCP and non-core VS Code tools behind a tool-search tool so the model discovers them on demand instead of loading every tool definition up front.",
 			"Controls the log level for the Copilot SDK runtime used by the local agent host. Changing this setting restarts the Copilot SDK client; active sessions are reloaded when next used.",
 			"Log informational messages. Running VS Code with trace logging still enables all Copilot SDK runtime diagnostics.",
 			"Log all Copilot SDK runtime diagnostics.",
 			"When enabled, Copilot SDK sessions use the Agent Host terminal tool override instead of the SDK's default terminal behavior.",
-			"Per-model capability overrides for Copilot SDK agent sessions, keyed by model id, intended for evaluating preview models against an existing model's profile. For each model id, declare an aliased `family` (for example `claude-opus-4-8`) to route the model to that family's tuned system prompt without a code change; the model id sent to the runtime is unaffected. Only affects Copilot CLI agent sessions.\n\n**Note**: This is an advanced setting for experimentation.",
-			"Alias the model's family for prompt/capability routing (e.g. `claude-opus-4-8`).",
 			"When enabled, Copilot SDK sessions running a Claude Opus 4.8 model apply Opus 4.8-tuned system-prompt section overrides on top of the default system message.",
 			"Overrides the reasoning effort for Copilot SDK agent sessions regardless of the per-model picker value. Set it to a level the selected model supports (for example `low`, `medium`, `high`, or `xhigh`) — choosing a level the model does not support may be rejected by the model. A value that isn't a recognized effort level is ignored and the session falls back to the picker value. Applied when a session is created and when its model changes. Only affects Copilot CLI agent sessions.\n\n**Note**: This is an advanced setting for experimentation.",
-			"Sandbox mode for the Copilot SDK's built-in shell tool. Only takes effect when `#chat.agentHost.customTerminalTool.enabled#` is `false`; when the Agent Host's own terminal tool is enabled, the engine sandbox is controlled by `#chat.agent.sandbox.enabled#`. The sandbox applies only to requests that run with default approvals — not when approvals are bypassed — and is not supported on Windows yet.",
-			"The SDK's built-in shell tool runs inside a sandbox with unrestricted outbound network access.",
+			"When enabled, requests concise reasoning summaries for supported Copilot SDK agent sessions.",
+			"Sandbox mode for the Copilot SDK's built-in shell tool on macOS and Linux. Only takes effect when `#chat.agentHost.customTerminalTool.enabled#` is `false`; when the Agent Host's own terminal tool is enabled, the engine sandbox is controlled by `#chat.agent.sandbox.enabled#`. The sandbox applies only to requests that run with manual permissions — not when approvals are bypassed. Unrestricted network is controlled by `#chat.agent.sandbox.allowNetwork#`. Use `#chat.agentHost.sdkSandbox.enabledWindows#` on Windows.",
 			"No sandbox policy is forwarded for the SDK's built-in shell tool — commands run unsandboxed.",
-			"The SDK's built-in shell tool runs inside a sandbox using the configured filesystem policy and host-list-restricted network.",
+			"The SDK's built-in shell tool runs inside a sandbox using the configured filesystem policy with outbound network blocked.",
+			"Sandbox mode for the Copilot SDK's built-in shell tool on Windows. Only takes effect when `#chat.agentHost.customTerminalTool.enabled#` is `false`. This setting is independent of `#chat.agentHost.sdkSandbox.enabled#` so Windows sandbox support can be enabled separately. Unrestricted network is controlled by `#chat.agent.sandbox.allowNetwork#`.",
+			"No sandbox policy is forwarded for the SDK's built-in shell tool on Windows — commands run unsandboxed.",
+			"The SDK's built-in shell tool runs inside the Windows sandbox using the configured filesystem policy.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
-			"When enabled, Claude sessions opened from the Agents Window run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window. Requires `#chat.agentHost.enabled#`.",
-			"Specify location(s) of custom agent files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
+			"Specify location(s) of custom agent files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.\n\nThis setting is only used by the Local agent harness.",
 			"Agent File Locations",
 			"Shows the agent status as a badge next to the command center.",
 			"Replaces the command center search box with a compact agent status indicator and unified chat widget.",
 			"Controls how the 'Agent Status' indicator appears in the title bar command center. When set to `hidden`, the indicator is not shown. Other values show the indicator and automatically enable {0}. The unread and in-progress session indicators require {1} to be enabled.",
 			"The agent status indicator is hidden from the title bar.",
 			"Controls whether Agent Session Projection mode is enabled for reviewing agent sessions in a focused workspace.",
+			"Controls whether legacy extension host Copilot CLI chat sessions are migrated in place to the Agent host when opened, so their history becomes editable. When disabled, legacy sessions open as before.",
+			"Controls which external agent sessions, created outside VS Code's Agent Host, are shown.",
+			"Shows all sessions discovered from supported external agent applications.",
+			"Shows external sessions updated in the last 24 hours.",
+			"Shows external sessions updated in the last 7 days.",
+			"Only shows sessions created by the Agent Host.",
+			"Shows the 2 most recently updated external sessions from the last 7 days.",
 			"Controls the tip shown above the chat input offering to continue eligible agent sessions in the Agents Window.",
 			"Show the handoff tip with an alternate description.",
 			"Show the handoff tip with the default description.",
 			"Never show the handoff tip.",
-			"Specify location(s) of agent skills (`{0}`) that can be used in Chat Sessions. [Learn More]({1}).\n\nEach path should contain skill subfolders with SKILL.md files (e.g., add `my-skills` if you have `my-skills/skillA/SKILL.md`). Relative paths are resolved from the root folder(s) of your workspace.",
+			"Specify location(s) of agent skills (`{0}`) that can be used in Chat Sessions. [Learn More]({1}).\n\nEach path should contain skill subfolders with SKILL.md files (e.g., add `my-skills` if you have `my-skills/skillA/SKILL.md`). Relative paths are resolved from the root folder(s) of your workspace.\n\nThis setting is only used by the Local agent harness.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
 			"Agent Skills Locations",
 			"Controls whether anonymous access is allowed in chat.",
@@ -40293,17 +42543,20 @@
 			"Controls whether to show chat checkpoint file changes.",
 			"When applying edits, show a progress animation in the code block pill. If disabled, shows the progress percentage instead.",
 			"Show the context window usage indicator in the chat input.",
-			"Controls whether the Chat Customizations editor shows the prompt file migration affordances for agent-host harnesses. When disabled, the migration card and sidebar shortcut are hidden.",
+			"Controls whether the Chat Customizations editor offers to convert prompt files into skills for agent-host harnesses, which ignore prompt files. When disabled, the migration card and sidebar shortcut are hidden.",
+			"Blocks standalone user and workspace skills, agents, hooks, instructions, and MCP servers while keeping eligible plugin customizations available.",
+			"Blocks standalone user and workspace skills, agents, hooks, instructions, and MCP servers while keeping eligible plugin customizations available.",
 			"Controls whether the Chat Customizations editor shows a structured preview for markdown customization files (agents, skills, instructions, prompts). When disabled, the editor always opens the raw markdown in the embedded code editor.",
+			"Controls whether the Chat Customizations editor offers to move agents and instructions stored in user data to the active agent-host harness, which ignores the user data location. When disabled, the migration card and sidebar shortcut are hidden.",
 			"Allow All — runs tool calls without asking.",
 			"Assisted permissions — evaluates risk before running tools.",
-			"Ask When Needed — asks when approval settings don't apply.",
-			"The starting approval behavior for new agent sessions. If enterprise policy disables auto approval, new sessions use Ask When Needed.",
+			"The starting approval behavior for new agent sessions. If enterprise policy disables auto approval, new sessions use Manual permissions.",
+			"Manual permissions — asks when approval settings don't apply.",
 			"Autopilot — autonomously iterate from start to finish.",
 			"The starting mode for new agent sessions.",
 			"Interactive — step-by-step collaboration.",
 			"Plan — plan first, execute when ready.",
-			"Controls the default configuration for new agent sessions (such as Copilot CLI). You can still change the mode and approval behavior per session, and each session remembers what was used.",
+			"Controls the default configuration for new agent sessions (such as Copilot). You can still change the mode and approval behavior per session, and each session remembers what was used.",
 			"The default model for new chat conversations. Use \"auto\" to let Copilot pick a model, a model family name (such as \"opus\" or \"gemini\") to use the latest available model in that family, or a full model id. You can still switch the model within a conversation; each new conversation starts at this model.",
 			"Sets the default chat model for new conversations. Accepts \"auto\", a model family name (such as \"opus\" or \"gemini\"), or a full model id. Users can still switch the model within a conversation.",
 			"Enables chat participant autodetection for panel chat.",
@@ -40314,8 +42567,7 @@
 			"Controls whether the Explain button in the Chat panel and the Explain Changes context menu in the SCM view are shown. This is an experimental feature.",
 			"Controls whether selecting a file in the changed files list of a chat response opens it in a diff editor showing the changes made by chat, or in a regular editor. Holding `kbstyle(Alt)` while selecting the file opens it with the opposite behavior.",
 			"Controls whether the editor automatically reveals the next change after keeping or undoing a chat edit.",
-			"When enabled, Claude sessions opened from the regular workbench (sidebar chat) run inside the agent host process instead of the GitHub Copilot Chat extension. Only one Claude implementation surfaces per window.",
-			"When enabled, Codex sessions opened from the regular workbench (sidebar chat) run inside the agent host process using the Codex App Server instead of the OpenAI extension. Only one Codex implementation surfaces per window. Requires `#chat.agentHost.enabled#` and `#chat.agentHost.codexAgent.enabled#`.",
+			"When enabled, Codex sessions opened from the regular workbench (sidebar chat) run inside the agent host process using the Codex App Server instead of the OpenAI extension. Only one Codex implementation surfaces per window. Requires `#chat.agentHost.codexAgent.enabled#`.",
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for opening files from chat (for example `\"*.md\": \"vscode.markdown.preview.editor\"`).",
 			"Enables editing of requests in the chat. This allows you to change the request content and resubmit it to the model.",
 			"Controls whether the chat panel automatically exits after delegating a request to another session.",
@@ -40335,7 +42587,11 @@
 			"Buffers content until a paragraph break before rendering.",
 			"Reveals content word by word.",
 			"Enables incremental rendering with optional block-level animation when streaming chat responses.",
-			"Controls whether the permissions picker shows an inline \"Sandboxing for terminal\" toggle on the Default Approvals option. The toggle reflects and updates `#chat.agent.sandbox.enabled#`.",
+			"Controls whether the permissions picker shows an inline \"Sandboxing for terminal\" toggle on the Manual permissions option. For Copilot SDK sessions using the built-in shell tool, the toggle reflects and updates `#chat.agentHost.sdkSandbox.enabled#` or `#chat.agentHost.sdkSandbox.enabledWindows#`.",
+			"Controls whether supported links in chat are rendered as rich links with live metadata. Enabling this may make authenticated requests to services such as GitHub.",
+			"Controls the wording and icons used by actions that archive and unarchive chat sessions, as well as the label of the archived sessions section.",
+			"Use Archive, Archive All, Unarchive, and Unarchive All.",
+			"Use Mark as Done, Mark All as Done, Restore, and Restore All.",
 			"When true, enables sessions-window-specific behavior for extensions.",
 			"Select the default language model to use for the Explore subagent from the available providers.",
 			"Enable using tools contributed by third-party extensions.",
@@ -40343,36 +42599,40 @@
 			"Controls the font family in chat messages.",
 			"Controls the font size in pixels in chat messages.",
 			"Controls whether to show a growth notification in the agent sessions view to encourage new users to try Copilot.",
-			"Specify paths to hook configuration files that define custom shell commands to execute at strategic points in an agent's workflow. [Learn More]({0}).\n\nRelative paths are resolved from the root folder(s) of your workspace. Supports Copilot hooks (`*.json`) and Claude Code hooks (`settings.json`, `settings.local.json`).",
+			"Specify paths to hook configuration files that define custom shell commands to execute at strategic points in an agent's workflow. [Learn More]({0}).\n\nRelative paths are resolved from the root folder(s) of your workspace. Supports Copilot hooks (`*.json`) and Claude Code hooks (`settings.json`, `settings.local.json`).\n\nThis setting is only used by the Local agent harness.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported.",
 			"Hook File Locations",
+			"Allows hooks only from enterprise-managed sources and plugins force-enabled by policy.",
+			"Allows hooks only from enterprise-managed sources and plugins force-enabled by policy.",
 			"Enables automatically using the active editor as chat context for specified chat locations.",
-			"When enabled, the active editor is automatically forwarded as context, even when it would otherwise only be suggested. Selections and explicitly attached files are always included regardless of this setting.\n\nNote: this setting currently only applies to Agent Host sessions (such as the Copilot CLI).",
+			"When enabled, the active editor is automatically forwarded as context, even when it would otherwise only be suggested. Selections and explicitly attached files are always included regardless of this setting.\n\nNote: this setting currently only applies to Agent Host sessions (such as Copilot).",
 			"Controls whether the new implicit context flow is shown. In Ask and Edit modes, the context will automatically be included. When using an agent, context will be suggested as an attachment. Selections are always included as context.",
 			"The value for the implicit context.",
 			"Implicit context is always enabled.",
 			"Implicit context is enabled for the first interaction.",
 			"Implicit context is never enabled.",
-			"Controls whether instructions with a matching 'applyTo' attribute are automatically included in chat requests.",
+			"Controls whether instructions with a matching 'applyTo' attribute are automatically included in chat requests. This setting is only used by the Local agent harness.",
 			"Include Applying Instructions",
-			"Controls whether referenced instructions are automatically included in chat requests.",
+			"Controls whether referenced instructions are automatically included in chat requests. This setting is only used by the Local agent harness.",
 			"Include Referenced Instructions",
 			"Controls how file and symbol references are displayed in chat messages.",
 			"Display file and symbol references as boxed widgets with icons.",
 			"Display file and symbol references as simple blue links without icons.",
-			"Specify location(s) of instructions files (`*{0}`) that can be attached in Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
+			"Specify location(s) of instructions files (`*{0}`) that can be attached in Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.\n\nThis setting is only used by the Local agent harness.",
 			"Instructions File Locations",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported. Glob patterns are deprecated and will be removed in future versions.",
 			"Enable math rendering in chat responses using KaTeX.",
 			"Controls access to installed Model Context Protocol servers.",
 			"Allow access to any installed MCP server.",
 			"No access to MCP servers.",
-			"Allows access to MCP servers installed from the registry that VS Code is connected to.",
+			"Allows access to MCP servers listed in the registry that VS Code is connected to.",
 			"Enterprise-managed allowlist that controls which Model Context Protocol servers may be installed and run. When set, only servers matching an entry are permitted; any other server is blocked. Servers can be matched by name, remote URL pattern (with `*` wildcards), or local command invocation. Omit entirely to allow all servers (subject to the deny list). Delivered via enterprise policy for governance; this setting is not surfaced to end users.",
 			"Allowlist of Model Context Protocol servers. When set, only servers matching an entry may be installed or run; omit entirely to allow all servers (subject to the deny list).",
 			"Match a local server by its exact command invocation, given as the command followed by its arguments.",
 			"Match a server by its configured name.",
 			"Match a remote server by its URL. Supports `*` wildcards, for example `https://*.example.com/*`.",
+			"Use only the enterprise-managed MCP allowlist when deciding which servers may run.",
+			"Use only the enterprise-managed MCP allowlist when deciding which servers may run.",
 			"Enables NuGet packages for AI-assisted MCP server installation. Used to install MCP servers by name from the central registry for .NET packages (NuGet.org).",
 			"Controls whether MCP servers should be automatically started when the chat messages are submitted.",
 			"Never automatically start MCP servers.",
@@ -40393,7 +42653,7 @@
 			"A model the MCP server has access to.",
 			"Controls whether MCP servers can provide custom UI for tool invocations.",
 			"This setting is deprecated and will be removed in future releases. Chat modes are now called custom agents and are located in `.github/agents`",
-			"Specify location(s) of custom chat mode files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
+			"Specify location(s) of custom chat mode files (`*{0}`). [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.\n\nThis setting is only used by the Local agent harness.",
 			"Mode File Locations",
 			"The default mode for new chat sessions. When empty, the chat view's default mode is used.",
 			"Controls whether a chat session should present the user with an OS notification when a confirmation or question needs input. This includes a window badge as well as notification toast.",
@@ -40404,26 +42664,25 @@
 			"Always show OS notifications for responses, even when the window is focused.",
 			"Never show OS notifications for responses.",
 			"Show OS notifications for responses when the window is not focused.",
+			"Enables the floating chat input window and its entry points. Requests submitted from the window are scored against existing agent sessions and routed with an advisory badge.",
 			"Start new chat sessions in Bypass Approvals mode.",
 			"Bypass Approvals",
 			"Start new chat sessions in Autopilot mode.",
 			"Autopilot (Preview)",
-			"Start new chat sessions with Default Approvals.",
-			"Default Approvals",
-			"Controls the default permissions picker mode for new local chat sessions. You can still change the permission mode per session, and each session remembers the permission mode that was used. If enterprise policy disables auto approval, new sessions use Default Approvals.",
-			"Always show progress in chat.",
+			"Start new chat sessions with Default Permissions.",
+			"Default Permissions",
+			"Controls the default permissions picker mode for new local chat sessions. You can still change the permission mode per session, and each session remembers the permission mode that was used. If enterprise policy disables auto approval, new sessions use Default Permissions.",
 			"Select the default language model to use for the Plan agent from the available providers.",
-			"When enabled, the plan review widget mounts an editor inline, as opposed to in a separate editor tab.",
 			"Plugin directories to discover. Each key is a path that points directly to a plugin folder, and the value enables (`true`) or disables (`false`) it. Paths can be absolute, relative to the workspace root, or start with `~/` for the user's home directory.",
 			"Enable agent plugin integration in chat.",
 			"Controls which [agent plugins](https://aka.ms/vscode-agent-plugins) are enabled or disabled. Keys are plugin IDs in `<plugin>@<marketplace>` form (where marketplace is defined in {1}); values enable (`true`) or disable (`false`) the plugin. Discovered alongside the path-keyed entries in {0}. When set by policy, entries are additive: plugins mapped to `true` are enabled in addition to the user's own plugins, and only plugins mapped to `false` are blocked from loading.",
 			"Plugin enablement. Keys are plugin IDs in `{plugin}@{marketplace}` form; values enable or disable the plugin.",
-			"Enterprise-managed additional plugin marketplaces. Unioned with {0}.",
-			"Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`{url}[#ref]`).",
+			"Enterprise-managed additional plugin marketplaces. Unioned with {0}. An entry's `autoUpdate` value overrides {1} for plugins from that marketplace.",
+			"Additional plugin marketplaces to query. Keys are marketplace names; values are GitHub shorthand (`owner/repo[#ref]`) or Git URIs (`{url}[#ref]`), optionally with an enterprise-managed auto-update override.",
 			"Plugin marketplaces to query. Entries may be GitHub shorthand (`owner/repo` or `owner/repo#ref`), direct Git repository URIs (`https://...git`, `ssh://...git`, or `git@host:path.git`, each optionally suffixed with `#ref`), or local repository URIs (`file:///...`). Equivalent GitHub shorthand and URI entries are deduplicated.",
 			"Enterprise-managed allowlist of plugin marketplace sources. When set, only marketplaces matching one of these entries can be installed; an empty array blocks all marketplaces. This does not retroactively disable already-installed plugins. Each entry is an object with a `source` discriminator (`github`, `git`, `url`, `npm`, `file`, `directory`, `hostPattern`, or `pathPattern`) and the corresponding fields. Typically delivered via enterprise policy.",
 			"Allowlist of plugin marketplace sources. When set, only marketplaces matching an entry are trusted; an empty array blocks all marketplaces.",
-			"Show an animated gradient border around the chat input while the agent is working or thinking. When enabled and reduced motion is not enabled, this overrides {0} to be off. Has no effect when reduced motion is enabled.",
+			"Show an animated gradient border around the chat input while the agent is working or thinking. Has no effect when reduced motion is enabled.",
 			"Paths must be relative or start with '~/'. Absolute paths and '\\' separators are not supported. Glob patterns are deprecated and will be removed in future versions.",
 			"Configure which prompt files to recommend in the chat welcome view. Each key is a prompt file name, and the value can be `true` to always recommend, `false` to never recommend, or a [when clause](https://aka.ms/vscode-when-clause) expression like `resourceExtname == .js` or `resourceLangId == markdown`.",
 			"Prompt File Recommendations",
@@ -40431,29 +42690,21 @@
 			"Queue the message to send after the current request completes.",
 			"Steer the current request by sending the message immediately, signaling the current request to yield.",
 			"Controls whether the last session is restored in panel after restart.",
-			"Specify location(s) of reusable prompt files (`*{0}`) that can be run in Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.",
+			"Specify location(s) of reusable prompt files (`*{0}`) that can be run in Chat sessions. [Learn More]({1}).\n\nRelative paths are resolved from the root folder(s) of your workspace.\n\nThis setting is only used by the Local agent harness.",
 			"Prompt File Locations",
+			"Controls whether all dirty editors except untitled editors are saved before sending a chat message.",
 			"Enable session sync to GitHub.com. When enabled, Copilot session data is synced to your GitHub account for cross-device access and richer insights. Requires `#github.copilot.chat.localIndex.enabled#` to also be enabled.",
 			"Enable session sync to GitHub.com for cross-device Copilot session history. When disabled by organization policy, session data is kept local only.",
 			"Repository patterns to exclude from session sync. Use exact `owner/repo` names or glob patterns like `my-org/*`. Sessions from matching repositories will only be stored locally.",
-			"Enables dictating into the chat input using on-device speech-to-text. When enabled on a supported platform, a microphone button appears in the chat input; the transcription model is downloaded on first use and runs locally.",
-			"Tap the dictation shortcut to start and stop, or press and hold it to dictate only while held (push-to-talk).",
-			"Controls how the chat dictation shortcut ({0}) behaves.",
-			"Press and hold the dictation shortcut to dictate; dictation stops as soon as the shortcut is released.",
-			"Tap the dictation shortcut to start dictating and tap again to stop.",
-			"The on-device model used for chat dictation. The model is downloaded on first use and cached on disk. Larger models are more accurate but slower and take longer to download.",
-			"Balanced speed and accuracy (~145MB download).",
-			"NVIDIA Nemotron RNN-T: multilingual (35+ languages, auto-detected), high accuracy, matches the GitHub Copilot app (~800MB download).",
-			"Most accurate; slower and larger (~465MB download).",
-			"Smallest and fastest; lowest accuracy (~75MB download).",
 			"Allow subagents to invoke subagents.",
 			"Controls whether subagents can invoke other subagents. When enabled, nesting is limited to a maximum depth of 5.",
+			"Controls whether subagents in chat editors use a rich presentation that opens each subagent in its own editor instead of rendering its full activity inline in the parent chat.",
 			"Controls whether tips are shown above user messages in chat. New tips are added frequently, so this is a helpful way to stay up to date with the latest features.",
 			"Controls whether the Open in Agents Window button is shown in the title bar.",
 			"Controls whether the Copilot Sign In button is shown in the title bar when signed out. When disabled, the Sign In affordance falls back to the status bar.",
 			"{0} - {1}",
 			"Controls whether edits made by the agent are automatically approved. The default is to approve all edits except those made to certain files which have the potential to cause immediate unintended side-effects, such as `**/.vscode/*.json`.\n\nSet to `true` to automatically approve edits to matching files, `false` to always require explicit approval. The last pattern matching a given file will determine whether the edit is automatically approved.",
-			"When enabled, tool failures are automatically expanded in the chat UI to show error details.",
+			"When enabled, terminal tool failures are automatically expanded in the chat UI to show error details.",
 			"Post-process tool output (for example `git diff`, `ls -l`, or `npm install`) to reduce token usage before it is sent to the model.",
 			"When enabled, multiple tool confirmations are batched into a carousel above the input.",
 			"Controls which tools are eligible for automatic approval. Tools set to 'false' will always present a confirmation and will never offer the option to auto-approve. The default behavior (or setting a tool to 'true') may result in the tool offering auto-approval options.",
@@ -40475,21 +42726,21 @@
 			"No animation is shown.",
 			"Shows expanding pulse rings from the button.",
 			"Shows radiant lines emanating from the button.",
-			"Controls whether instructions from `AGENTS.md` file found in a workspace roots are attached to all chat requests.",
+			"Controls whether instructions from `AGENTS.md` file found in a workspace roots are attached to all chat requests. This setting is only used by the Local agent harness.",
 			"Use AGENTS.md file",
-			"Controls whether skills are provided as specialized capabilities to the chat requests. Skills are loaded from the folders configured in `#chat.agentSkillsLocations#`. The language model can load these skills on-demand if the `read` tool is available. Learn more about [Agent Skills](https://aka.ms/vscode-agent-skills).",
+			"Controls whether skills are provided as specialized capabilities to the chat requests. Skills are loaded from the folders configured in `#chat.agentSkillsLocations#`. The language model can load these skills on-demand if the `read` tool is available. Learn more about [Agent Skills](https://aka.ms/vscode-agent-skills). This setting is only used by the Local agent harness.",
 			"Use Agent skills",
-			"Controls whether hooks from Claude configuration files can execute. When disabled, only Copilot-format hooks are used. Hooks are loaded from the files configured in `#chat.hookFilesLocations#`.",
+			"Controls whether hooks from Claude configuration files can execute. When disabled, only Copilot-format hooks are used. Hooks are loaded from the files configured in `#chat.hookFilesLocations#`. This setting is only used by the Local agent harness.",
 			"Use Claude Hooks",
-			"Controls whether instructions from `CLAUDE.md` file found in workspace roots, .claude and ~/.claude folder are attached to all chat requests.",
+			"Controls whether instructions from `CLAUDE.md` file found in workspace roots, .claude and ~/.claude folder are attached to all chat requests. This setting is only used by the Local agent harness.",
 			"Use CLAUDE.md file",
-			"Controls whether to use chat customization files in parent repositories.",
+			"Controls whether to use chat customization files in parent repositories. This setting is only used by the Local agent harness.",
 			"Use Customizations in Parent Repositories",
-			"Controls whether chat hooks are executed at strategic points during an agent's workflow. Hooks are loaded from the files configured in `#chat.hookFilesLocations#`.",
+			"Controls whether chat hooks are executed at strategic points during an agent's workflow. Hooks are loaded from the files configured in `#chat.hookFilesLocations#`. This setting is only used by the Local agent harness.",
 			"Use Chat Hooks",
-			"Controls whether instructions from nested `AGENTS.md` files found in the workspace are listed in all chat requests. The language model can load these skills on-demand if the `read` tool is available.",
+			"Controls whether instructions from nested `AGENTS.md` files found in the workspace are listed in all chat requests. The language model can load these skills on-demand if the `read` tool is available. This setting is only used by the Local agent harness.",
 			"Use nested AGENTS.md files",
-			"Controls whether a stronger skill adherence prompt is used that encourages the model to immediately invoke skills when relevant rather than just announcing them.",
+			"Controls whether a stronger skill adherence prompt is used that encourages the model to immediately invoke skills when relevant rather than just announcing them. This setting is only used by the Local agent harness.",
 			"Use Skill Adherence Prompt",
 			"Override the language model used by built-in utility flows. Leave empty to use the configured default behavior.",
 			"Override the language model used by built-in small/fast utility flows. A fast and inexpensive model is recommended. Leave empty to use the configured default behavior.",
@@ -40500,6 +42751,16 @@
 			"Display chat sessions side by side if space is sufficient, otherwise fallback to stacked above the chat input unless a chat session is visible.",
 			"Display chat sessions vertically stacked above the chat input unless a chat session is visible.",
 			"Debug View",
+			"Enables dictation across the product (chat input, editor, and terminal). When enabled on a supported platform, a microphone button appears in the chat input and the dictation shortcut becomes available; the on-device transcription model is downloaded on first use and runs locally.",
+			"Controls whether dictation is available across the product (chat input, editor, and terminal).",
+			"Experimental: when dictation ends, the final transcript is passed through a small language model to restore punctuation, capitalization, paragraphs, and lists. Requires Copilot to be enabled; the transcript is sent to the language model for cleanup. Falls back to the raw transcript when no model is available. Use [dictation instructions](command:{0}) to customize terminology and formatting.",
+			"The model used for dictation. On-device models download on first use and run locally through Microsoft Foundry Local; the cloud option streams audio to the Microsoft AI voice service.",
+			"Cloud transcription through the same Microsoft AI voice service used by Voice Mode. Requires a network connection and GitHub sign-in; audio is streamed to the service.",
+			"MAI — Cloud",
+			"NVIDIA Nemotron 3.5 multilingual streaming RNN-T, run on-device through Microsoft Foundry Local. Works offline; no audio leaves the device. Automatic language selection follows the Voice Mode language setting; when that setting is Automatic, dictation uses the configured display language when supported, then the system or browser locale, with model detection as a fallback. Downloaded on first use and cached on disk.",
+			"Nemotron 3.5 ASR (Multilingual) — On-Device",
+			"Controls whether the dictation microphone button is shown in the chat input. When hidden, dictation can still be started with its keyboard shortcut.",
+			"Controls whether the transcript is shown while dictating. The final transcript is inserted when dictation ends.",
 			"Controls the font family in chat codeblocks.",
 			"Controls the font size in pixels in chat codeblocks.",
 			"Controls the font weight in chat codeblocks.",
@@ -40566,12 +42827,12 @@
 			"tokens: {0}",
 			"tool calls: {0}",
 			"Unknown error",
-			"Copilot CLI Session {0}",
+			"Copilot Session {0}",
 			"User Request"
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/agentHostLogSources": [
 			"{0} (Log)",
-			"Copilot CLI Logs",
+			"Copilot Logs",
 			"Session Events (events.jsonl)",
 			"Remote Agent Host Log (agenthost.log)",
 			"AHP Log",
@@ -40894,7 +43155,6 @@
 		],
 		"vs/workbench/contrib/chat/browser/chatDebug/chatDebugHomeView": [
 			"Active",
-			"Claude Code: {0}",
 			"Copilot CLI: {0}",
 			"Enable to view debug logs and investigate chat issues with /troubleshoot.",
 			"Select a chat session to debug",
@@ -41199,6 +43459,30 @@
 			"Conversation Images",
 			"Current Input"
 		],
+		"vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindow.contribution": [
+			"Close Floating Chat Input Window",
+			"Toggle Floating Chat Input Window"
+		],
+		"vs/workbench/contrib/chat/browser/chatInputWindow/chatInputWindowService": [
+			"Close",
+			"Drag to move",
+			"Send a request to any session or folder...",
+			"Allow Once",
+			"Allow and Review Once",
+			"{0} checks failed, {1} pending",
+			"CI is failing for {0}",
+			"Item {0} of {1}",
+			"Dismiss",
+			"Fix CI",
+			"Fix failing CI checks",
+			"Next Item",
+			"Previous Item",
+			"Skip",
+			"Select Folder",
+			"Select Folder for New Session",
+			"Chat Input",
+			"Chat Input — {0}"
+		],
 		"vs/workbench/contrib/chat/browser/chatManagement/chatManagement.contribution": [
 			"Enabling AI features…",
 			"Enabling AI features",
@@ -41289,6 +43573,7 @@
 			"Show All Models",
 			"Show Model",
 			"Show Models",
+			"GitHub Copilot",
 			"Tools",
 			"Tools",
 			"Unpin Model",
@@ -41306,6 +43591,10 @@
 			"{0} Models",
 			"{0} Models (hidden)",
 			"Visible Models"
+		],
+		"vs/workbench/contrib/chat/browser/chatOutline": [
+			"Chat Outline",
+			"Request {0}"
 		],
 		"vs/workbench/contrib/chat/browser/chatOutputItemRenderer": [
 			"Code block language identifiers that this renderer can handle",
@@ -41346,8 +43635,15 @@
 			"Show Extension",
 			"Contributes a chat participant"
 		],
+		"vs/workbench/contrib/chat/browser/chatPetService": [
+			"VS Code pet disabled",
+			"VS Code pet enabled. Click the pet to interact with it, or use the Left and Right Arrow keys to move it.",
+			"The VS Code pet is on the run. Click the pet to bring it back.",
+			"The VS Code pet is back",
+			"VS Code pet changed to the Insiders colors",
+			"VS Code pet changed to the Stable colors"
+		],
 		"vs/workbench/contrib/chat/browser/chatPromoNotification": [
-			"Ends {0}.",
 			"Try {0}"
 		],
 		"vs/workbench/contrib/chat/browser/chatQuotaNotification": [
@@ -41509,6 +43805,7 @@
 		"vs/workbench/contrib/chat/browser/chatSetup/chatSetupRunner": [
 			"AI features are currently only supported in trusted workspaces.",
 			"Continue with {0}",
+			"Continue Without Signing In",
 			"Enable more AI features",
 			"By continuing, you agree to {0}'s [Terms]({1}) and [Privacy Statement]({2}). {3} Copilot may show [public code]({4}) suggestions and use your data to improve the product. You can change these [settings]({5}) anytime.",
 			"By continuing, you agree to {0}'s [Terms]({1}) and [Privacy Statement]({2}).",
@@ -41522,6 +43819,7 @@
 			"Set permissions to autopilot mode",
 			"Switch to '{0}'",
 			"Start a new chat and archive the current one",
+			"Start a new chat and mark the current one as done",
 			"Show Chat Debug View",
 			"Set permissions back to default",
 			"Set permissions back to default",
@@ -41535,6 +43833,7 @@
 			"Rename this chat",
 			"Configure skills",
 			"Configure tools",
+			"Toggle an interactive VS Code pet (Experimental)",
 			"Set permissions to bypass approvals"
 		],
 		"vs/workbench/contrib/chat/browser/chatStatus/chatStatusDashboard": [
@@ -41551,6 +43850,7 @@
 			"Inline suggestions are hidden for the remaining duration",
 			"Inline Suggestions",
 			"Credits",
+			"Credits Used",
 			"Use AI Features",
 			"Enable AI Features",
 			"Enable Copilot to use AI features.",
@@ -41566,8 +43866,6 @@
 			"Manage Budget",
 			"Model",
 			"Premium requests",
-			"{0} used",
-			"{0} used",
 			"Included with your organization's plan.",
 			"{0} included with your organization's plan.",
 			"Organization limit reached.",
@@ -41632,7 +43930,7 @@
 			"Use [{0}](command:{1} \"Run /init\"){2} to generate or update a workspace instructions file for AI coding agents.",
 			"Ask the agent to draw an architectural diagram or flow chart. It can render Mermaid diagrams directly in chat.",
 			"Steer the agent mid-task by sending follow-up messages. They queue and apply in order.",
-			"Try the [{0}](command:workbench.action.chat.openPlan \"Start Plan Mode\"){1} to research and plan before implementing changes.",
+			"Try the [{0}](command:workbench.action.chat.open?%5B%7B%22mode%22%3A%22Plan%22%7D%5D \"Start Plan Mode\"){1} to research and plan before implementing changes.",
 			"Have another task to work on? Start a new session to run multiple agents at once.",
 			"Using GPT-4.1? Try switching to [Auto](command:workbench.action.chat.openModelPicker \"Open Model Picker\") in the model picker for better coding performance.",
 			"Customize the loading messages shown while the agent works with [{0}](command:workbench.action.openSettings?%5B%22{1}%22%5D \"Open Settings\").",
@@ -41667,6 +43965,9 @@
 			"Use the vendor's default model",
 			"{0} ({1})"
 		],
+		"vs/workbench/contrib/chat/browser/editorChatResponseFileChangesService": [
+			"Turn File Changes"
+		],
 		"vs/workbench/contrib/chat/browser/enablementActions": [
 			"Disable",
 			"Disable (Workspace)",
@@ -41682,19 +43983,14 @@
 		"vs/workbench/contrib/chat/browser/languageModelsConfigurationService": [
 			"Per-model settings"
 		],
-		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorActions": [
+		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorOverlay": [
 			"Clear",
 			"Clear All Feedback",
 			"Navigation Status",
 			"Go to Next Feedback Comment",
-			"Go to Previous Feedback Comment"
-		],
-		"vs/workbench/contrib/chat/browser/planReviewFeedback/planReviewFeedbackEditorContribution": [
-			"Add Feedback (Enter)",
-			"Add Feedback",
-			"Enter",
-			"{0}/{1}",
-			"0/0"
+			"Go to Previous Feedback Comment",
+			"Submit Feedback",
+			"Submit"
 		],
 		"vs/workbench/contrib/chat/browser/pluginGitCommandService": [
 			"GitHub authentication is required to install '{0}'. Sign in with an account that has access to this repository, then try again.",
@@ -41717,6 +44013,7 @@
 			"Select a plugin to install from '{0}'",
 			"Show Output",
 			"Plugins from '{0}' are blocked by your organization's policy.",
+			"Updates from '{0}' are blocked by your organization's policy.",
 			"&&Trust",
 			"Trust Plugins from '{0}'?",
 			"Plugins can run code on your machine. Only install plugins from sources you trust.\n\nSource: {0}",
@@ -41816,8 +44113,8 @@
 			"Hooks",
 			"Existing Hook Files",
 			"Existing Hooks",
-			"Copilot CLI Agents",
-			"Local/Copilot CLI Agents",
+			"Copilot Agents",
+			"Local/Copilot Agents",
 			"Local Agents"
 		],
 		"vs/workbench/contrib/chat/browser/promptSyntax/hookUtils": [
@@ -41956,20 +44253,160 @@
 			"Configure Skills...",
 			"Skills"
 		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimeline.contribution": [
+			"Controls whether the current prompt is pinned to the top of the chat transcript while scrolling.",
+			"Controls how the prompt timeline is displayed next to the chat transcript in the Agents window.",
+			"Show a minimal handle in the transcript's left gutter that opens a list of prompts on hover.",
+			"Do not show the prompt timeline.",
+			"Show an overview ruler beside the transcript scrollbar that fans into prompt pills on engagement."
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineCard": [
+			"{0} prompts",
+			"{0} files",
+			"no edits",
+			"1 file",
+			"Review Changes for Prompt: {0}"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineGutterRail": [
+			"Prompt timeline",
+			"Review Changes for Prompt: {0}, {1}",
+			"{0} files changed",
+			"1 file changed",
+			"Show prompts"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineModel": [
+			"Changes · {0}",
+			"Prompt: {0}",
+			"{0} prompts starting with: {1}"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineRulerRail": [
+			"Prompt timeline"
+		],
+		"vs/workbench/contrib/chat/browser/promptTimeline/promptTimelineStickyHeader": [
+			"(empty prompt)",
+			"{0}/{1}",
+			"Go to prompt {0} of {1}: {2}"
+		],
+		"vs/workbench/contrib/chat/browser/sessionRouter/chatSessionRoutingController": [
+			"Best Match · Session model",
+			"Tab to choose · Arrow keys move · Space selects several · Escape cancels",
+			"Completed {0}",
+			"Completed {0}:",
+			"No confident match. Choose a destination before sending.",
+			"Current session",
+			"Delivery results",
+			"Dismiss",
+			"Sending request…",
+			"Failed in {0}",
+			"{0} sent, {1} queued, {2} failed.",
+			"Finding the best chat for your request.",
+			"High Confidence · Session model",
+			"In progress: {0}",
+			"{0} needs your input",
+			"New session",
+			"New session in {0}",
+			"Request is no longer queued for {0}",
+			"Open",
+			"Preparing your request.",
+			"Queued request to {0} was cancelled",
+			"Queued for {0}",
+			"Queued request to {0} was not sent",
+			"Enter to send to all",
+			"Could not send the request. Your draft was preserved.",
+			"Could not send to {0}. Your draft was preserved.",
+			"Could not send to {0}: {1} Your draft was preserved.",
+			"sending in {0}s",
+			"Sending to {0} in {1} seconds. Press Escape to cancel.",
+			"Enter to send now",
+			"Send to",
+			"Send to {0} sessions",
+			"Sent to {0}",
+			"{0}: cancelled",
+			"{0}: failed",
+			"New session will use folder {0}.",
+			"{0}: no longer queued",
+			"{0}: queued",
+			"{0}: sent",
+			"waiting for you"
+		],
+		"vs/workbench/contrib/chat/browser/sessionRouter/chatSessionRoutingFolderPicker": [
+			"Choose Folder",
+			"Change target folder for new session",
+			"Change target folder ({0})",
+			"Choose Folder…",
+			"Choose Folder",
+			"{0}, {1}",
+			"Search folders",
+			"Search workspaces",
+			"Select the folder for the new session"
+		],
 		"vs/workbench/contrib/chat/browser/speechToText/chatSpeechToTextService": [
 			"Speech-to-text stopped because audio could not be sent for transcription: {0}",
 			"Could not start audio capture for speech-to-text: {0}",
 			"Could not start speech-to-text: {0}",
 			"Downloading…",
 			"Downloading… {0}%",
+			"Install from Local Package...",
 			"Loading model…",
+			"Cloud dictation is unavailable while Voice Mode is connected.",
+			"Cloud dictation was disconnected.",
+			"Cloud speech-to-text is not available for GitHub Copilot Enterprise accounts.",
+			"Cloud speech-to-text is not available: no voice service is configured.",
+			"Sign in to GitHub to use cloud dictation.",
 			"Could not access the microphone for speech-to-text: {0}",
 			"On-device speech-to-text model failed to load: {0}",
+			"Could not download the {0} speech-to-text model, which can happen on networks that block the model registry. You can install it from a downloaded package instead.",
 			"On-device speech-to-text is not available on this platform.",
+			"Preparing speech-to-text model…",
+			"Dictation requires a paid GitHub Copilot plan.",
+			"Could not switch the microphone for speech-to-text: {0}"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/dictationDownloadRing": [
+			"Establishing a connection. This happens each time you start cloud dictation. Click to cancel.",
+			"**Connecting to dictation service**",
+			"This happens only the first time you dictate. Click to cancel.",
+			"**Downloading local model**",
+			"Connecting to dictation service…",
+			"Downloading speech-to-text model… {0}%",
 			"Preparing speech-to-text model…"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/dictationOnboarding": [
+			"Close the introduction",
+			"{0} (System default)",
+			"No microphone access. Check your system privacy settings.",
+			"Speak and it becomes text. Adjust [[settings]] or [[how it's written]] any time.",
+			"Microphone",
+			"{0} selected.",
+			"No microphone found.",
+			"Dictation introduction",
+			"Speak and it becomes text.",
+			"Say anything to check your microphone.",
+			"System default",
+			"Dictation",
+			"Can't read the microphone level.",
+			"Unknown device ({0})"
 		],
 		"vs/workbench/contrib/chat/browser/speechToText/dictationSession": [
 			"Listening…"
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/micButtonHovers": [
+			"Types what you say into the input. Transcribes in the cloud with the MAI speech model.",
+			"Types what you say into the input. Transcribes on-device with the Nemotron 3.5 ASR multilingual model.",
+			"Types what you say into the input. Transcribes on-device with {0}.",
+			"Talk with the agent and hear it reply. Uses the online real-time voice model."
+		],
+		"vs/workbench/contrib/chat/browser/speechToText/micButtonMenuActions": [
+			"Configure Instructions",
+			"Disable",
+			"Microphone Button",
+			"Open Settings",
+			"Show Introduction",
+			"Select Microphone",
+			"Voice Mode Button",
+			"Configure Instructions",
+			"Disable",
+			"Open Settings",
+			"Show Introduction"
 		],
 		"vs/workbench/contrib/chat/browser/tools/chatToolRiskAssessmentService": [
 			"{0} appears to have no observable side effects.",
@@ -41977,6 +44414,8 @@
 			"{0} performs an action that is hard to undo."
 		],
 		"vs/workbench/contrib/chat/browser/tools/clientToolSetsContribution": [
+			"Automations",
+			"List, configure, run, and delete scheduled agent automations.",
 			"Integrated Browser",
 			"Open, navigate, and inspect pages in the built-in browser.",
 			"Jupyter Notebooks",
@@ -42032,7 +44471,7 @@
 			"Disable",
 			"Enable",
 			"Enable global auto approve?",
-			"Global auto approve also known as \"YOLO mode\" disables manual approval completely for _all tools in all workspaces_, allowing the agent to act fully autonomously. This is extremely dangerous and is *never* recommended, even containerized environments like [Codespaces](https://github.com/features/codespaces) and [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) have user keys forwarded into the container that could be compromised.\n\n**This feature disables [critical security protections](https://code.visualstudio.com/docs/copilot/security) and makes it much easier for an attacker to compromise the machine.**\n\nNote: This setting only controls tool approval and does not prevent the agent from asking questions. To automatically answer agent questions, use the [`chat.autoReply`](command:workbench.action.openSettings?%5B%22chat.autoReply%22%5D) setting.",
+			"Global auto approve also known as \"YOLO mode\" disables manual approval completely for _all tools in all workspaces_, allowing the agent to act fully autonomously. This is extremely dangerous and is *never* recommended, even containerized environments like [Codespaces](https://github.com/features/codespaces) and [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) have user keys forwarded into the container that could be compromised.\n\n**This feature disables [critical security protections](https://code.visualstudio.com/docs/agents/run/security) and makes it much easier for an attacker to compromise the machine.**\n\nNote: This setting only controls tool approval and does not prevent the agent from asking questions. To automatically answer agent questions, use the [`chat.autoReply`](command:workbench.action.openSettings?%5B%22chat.autoReply%22%5D) setting.",
 			"The action was assessed as potentially destructive or irreversible.",
 			"Autopilot skipped \"{0}\" because it was assessed as high-risk: {1}",
 			"Delegate tasks to other agents",
@@ -42102,23 +44541,96 @@
 			"Your microphone appears to be muted or disabled, possibly by a hardware switch. Voice Mode won't hear you until it's re-enabled.",
 			"Microphone access was denied. Grant microphone permission in your system settings to use Voice Mode."
 		],
+		"vs/workbench/contrib/chat/browser/voiceClient/voiceInputDecorations": [
+			"Speak or use {0}",
+			"Speak to barge in",
+			"Click voice mode to talk or barge in",
+			"Listening...",
+			"Press {0} to talk or barge in"
+		],
 		"vs/workbench/contrib/chat/browser/voiceClient/voiceSessionController": [
-			"Voice mode could not connect. Please try again.",
+			"choices: Authenticate; Cancel",
+			"GitHub Copilot needs authentication to continue.",
+			"The MCP server {0} requires authentication to continue this tool call.",
+			"authentication request: MCP authentication required",
+			"Can't reach GitHub to check your account. Try again in a moment.",
+			"{0} - {1}",
+			"choices: {0}",
+			"GitHub Copilot needs your approval to continue.",
+			"{0}; {1} more choices",
+			"confirmation: {0}",
+			"{0}...",
+			"choices: {0}",
+			"GitHub Copilot needs your input in the open request.",
+			"input request: {0}",
 			"Voice disconnected. Tap to start.",
-			"Voice moved to another window. Tap to start."
+			"The voice service hit an error. Try again in a moment.",
+			"Voice moved to another window. Tap to start.",
+			"Your GitHub account doesn't have access to Voice Mode.",
+			"Voice Mode has no backend URL configured.",
+			"choices: {0}",
+			"A plan is open in GitHub Copilot and needs your approval.",
+			"The plan is open in GitHub Copilot.",
+			"plan approval: {0}",
+			"context: {0}",
+			"{0}; a custom response is also available",
+			"details: {0}",
+			"I need your input in the open questionnaire.",
+			"response: enter a free-form answer in GitHub Copilot",
+			"{0} more questions are open in GitHub Copilot.",
+			"{0}; {1} more options",
+			"questionnaire: {0} questions",
+			"1 more question is open in GitHub Copilot.",
+			"The questionnaire is open in GitHub Copilot.",
+			"options: {0}",
+			"{0}. {1}",
+			"questionnaire: 1 question",
+			"Reconnecting...",
+			"Reconnecting - can't reach GitHub to check your account",
+			"Reconnecting - {0}",
+			"Reconnecting - voice service is at capacity",
+			"Reconnecting - the voice service hit an error",
+			"Reconnecting - can't reach the voice service",
+			"Retry",
+			"Voice Mode is at capacity right now. Try again in a moment.",
+			"Voice session ended. Tap to start.",
+			"Sign in",
+			"Sign in to GitHub to use Voice Mode.",
+			"command: {0}",
+			"GitHub Copilot needs your approval to continue.",
+			"tool approval: {0}",
+			"Couldn't reach the voice service. Check your connection and try again.",
+			"Couldn't reach the voice service. Check your connection and try again.",
+			"Voice Mode is not available for GitHub Copilot Enterprise accounts.",
+			"Voice Mode requires a paid GitHub Copilot plan."
 		],
 		"vs/workbench/contrib/chat/browser/voiceClient/voiceToolDispatchService": [
-			"Approving...",
 			"Auto-approving session...",
 			"Focusing session...",
 			"Checking changes...",
 			"Checking sessions...",
 			"Checking conversation...",
-			"Starting new sessions...",
-			"Rejecting...",
+			"Responding...",
 			"Revoking auto-approve...",
 			"Sending to chat...",
+			"Changing model...",
 			"Working..."
+		],
+		"vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputMode": [
+			"The currently selected voice input mode in the chat input (dictation or voice)."
+		],
+		"vs/workbench/contrib/chat/browser/voiceInputMode/voiceInputModeActionViewItem": [
+			"Voice Input Mode",
+			"Connecting to Voice Mode…",
+			"Dictation",
+			"Preparing Speech to Text Model…",
+			"Cancel Dictation. {0}",
+			"Turn Off Voice Mode",
+			"Voice Mode: Hold to Talk",
+			"Start Listening",
+			"Tap to start, or hold to talk",
+			"Stop Listening",
+			"Voice Mode"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatAgentHover": [
 			"This chat extension is using a reserved name.",
@@ -42257,8 +44769,6 @@
 			"Enable",
 			"Autopilot will auto-approve all tool calls and continue working autonomously until the task is complete. This includes terminal commands, file edits, and external tool calls. The agent will make decisions on your behalf without asking for confirmation.\n\nYou can stop the agent at any time by clicking the stop button. This applies to the current session only.",
 			"Enable Autopilot?",
-			"Cancel",
-			"Exit feedback mode",
 			"Clear All",
 			"Clear {0} inline comment(s)?",
 			"Clear All",
@@ -42268,19 +44778,19 @@
 			"Line {0}: {1}",
 			"Line {0}",
 			"Expand",
-			"Expand",
 			"Feedback",
 			"Add an overall comment for the agent...",
 			"Line {0}, Column {1}",
 			"Line {0}",
 			"Inline comments on `{0}`:",
-			"Inline comments:",
 			"Open Plan",
 			"Open {0}",
+			"Outdated",
+			"Plan summary is outdated",
+			"Plan summary is outdated",
 			"Reject",
 			"Remove comment on line {0}",
-			"Restore Size",
-			"Edit or Provide Feedback",
+			"Open Full Plan",
 			"Review {0}",
 			"Submit Feedback",
 			"Submit Feedback ({0})"
@@ -42290,9 +44800,16 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatQuestionCarouselPart": [
 			"Answered",
+			"Answered automatically",
+			"Answered chat questions",
+			"Answered:",
+			"The user is not available to answer your question. Choose a pragmatic option best aligned with the context of the request.",
 			"Collapse Questions",
 			"{0} Use {1} to focus the terminal.",
 			"{0} Use the Focus Terminal from Question Carousel command to focus the terminal.",
+			"{0} {1}",
+			"Not answered yet",
+			"Custom answer: {0}",
 			"Deferring to user's input in the terminal",
 			"Enter custom answer",
 			"Enter your answer",
@@ -42306,12 +44823,17 @@
 			"Question navigation",
 			"Not answered yet",
 			"Option {0}: {1}",
+			"Options",
 			"Question {0} of {1}: {2}",
+			"Question:",
 			"This field is required",
 			"chat question",
+			"Custom answer: {0}, selected",
+			"{0}, selected",
 			"Chat question: {0}",
 			"Skip all questions",
-			"Skipped",
+			"Skipped question",
+			"Skipped question",
 			"{0}/{1}",
 			"⌘⏎ to submit",
 			"Ctrl+Enter to submit",
@@ -42344,12 +44866,24 @@
 			"Used {0} references",
 			"Used {0} reference"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatRequestOriginPart": [
+			"Sent by Codex from another chat",
+			"Sent by Codex from another chat. Select to open the source chat.",
+			"Open source chat",
+			"Side chat about {0}: {1}. Select to show the original message.",
+			"Side chat about {0}. Select to show the original message.",
+			"Original conversation"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatResourceGroupWidget": [
 			"Save...",
 			"Failed to save {0}: {1}",
 			"Saving resources...",
 			"Saved resources to {0}",
 			"Pick folder to save resources"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatRichLink": [
+			"Loading",
+			"Link {0}, {1}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentContentPart": [
 			"Ran subagent",
@@ -42371,6 +44905,23 @@
 			"Warning for {0}",
 			"Hook warning"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSubagentOpenChat": [
+			"Active tool {0}",
+			"Active tool: {0}",
+			"Model {0}",
+			"Model: {0}",
+			"Open Subagent",
+			"Open subagent chat: {0}",
+			"Open subagent chat ({0} confirmations needed)",
+			"Open subagent chat (1 confirmation needed)",
+			"The subagent chat could not be opened.",
+			"Subagent completed",
+			"Subagent is waiting for input",
+			"Subagent is working",
+			"Worked for {0}",
+			"Working on it...",
+			"Working for {0}"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatSuggestNextWidget": [
 			"current mode",
 			"Proceed from {0}",
@@ -42384,6 +44935,7 @@
 			"Made changes."
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatThinkingContentPart": [
+			"Section File Changes",
 			"Created {0}",
 			"Deleted {0}",
 			"{0} deletions",
@@ -42420,6 +44972,8 @@
 			"Loading",
 			"Analyzing",
 			"Evaluating",
+			"View File Changes",
+			"View file changes, {0} lines added, {1} lines deleted",
 			"Bribing the hamster",
 			"Reticulating splines",
 			"Untangling the spaghetti",
@@ -42465,9 +45019,9 @@
 			"1 file changed",
 			"Preview",
 			"View all file changes, {0} lines added, {1} lines deleted",
-			"Open Preview: {0}",
-			"View All File Changes",
-			"Turn File Changes"
+			"Open File: {0}",
+			"{0} • Open File",
+			"View All File Changes"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/chatWorkspaceEditContentPart": [
 			"Created []({0})",
@@ -42494,6 +45048,7 @@
 			"Skip"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAgentFeedbackReviewConfirmationSubPart": [
+			"Failed to reveal the selected comments. Please try again.",
 			"Cancel",
 			"Show Less",
 			"Delete Comment",
@@ -42502,6 +45057,11 @@
 			"Open File and Reveal Comment",
 			"Reveal Selected",
 			"Reveal this comment to the agent"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatAutomationConfiguredResultSubPart": [
+			"Created an automation: {0}",
+			"Open automation {0}",
+			"Edited an automation: {0}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatContentParts/toolInvocationParts/chatExtensionsInstallToolSubPart": [
 			"Allow",
@@ -42644,6 +45204,7 @@
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatDragAndDrop": [
 			"Attach {0} as Context",
+			"Chat",
 			"Image from URL",
 			"File",
 			"Folder",
@@ -42654,11 +45215,31 @@
 			"Symbol",
 			"URL"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatFind/chatFindAccessibilityHelp": [
+			"You are in the Find input for the chat transcript. It searches the whole conversation, including turns that are scrolled out of view, not only what is on screen.",
+			"Accessibility Help: Chat Transcript Find",
+			"Keyboard Navigation Summary:",
+			"- Enter: Move to the next match.",
+			"- Escape: Close Find and return focus to where it was before Find was opened.",
+			"- F3 / Shift+F3: Move to the next / previous match from anywhere in the chat.",
+			"- Shift+Enter: Move to the previous match.",
+			"- Match Case: Only exact case matches are included.",
+			"- Regular Expression: Use pattern matching for advanced searches.",
+			"Find Options:",
+			"- Whole Word: Only full words are matched.",
+			"Moving to a match scrolls the transcript to it, expanding the completed-work disclosure when the match is inside it.",
+			"Navigating to a Match:",
+			"Settings You Can Adjust ({0} opens Settings):",
+			"- `accessibility.verbosity.find`: Controls whether Chat Find announces the Accessibility Help hint."
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatForkActionViewItem": [
+			"Forking conversation",
+			"Forking conversation"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatListRenderer": [
 			"Approved plan",
 			"Started implementation with Autopilot",
 			"Provided feedback",
-			"{0}: {1}",
 			"Open full plan file",
 			"Open full plan file ({0})",
 			"Rejected plan",
@@ -42668,6 +45249,19 @@
 			"Chat input required.",
 			"Chat needs your input ({0} questions).",
 			"Chat needs your input (1 question).",
+			"Completed 1 step",
+			"Completed 1 step in {0}",
+			"Completed {0} steps",
+			"Completed {0} steps in {1}",
+			"{0}: {1} input tokens, {2} output tokens",
+			"{0}: {1} input tokens, {2} output tokens, {3} cached tokens",
+			"{0} — {1} in, {2} out",
+			"{0} — {1} in, {2} out, {3} cached",
+			"Tokens used this turn",
+			"Cancel restoring this checkpoint",
+			"Confirm restoring this checkpoint and discarding later edits",
+			"Cancel starting over",
+			"Confirm starting over and discarding all edits",
 			"Selected \"{0}\"",
 			"Sent {0}",
 			"Completed {0}",
@@ -42679,6 +45273,7 @@
 			"Blocked by hook",
 			"Used {0}, but received a warning",
 			"Tool call received a warning",
+			"Open {0} Chat",
 			"Queued",
 			"Queued messages will be sent after the current request completes",
 			"Failed to render content",
@@ -42691,20 +45286,55 @@
 			"used {0} [[(rerun without)]]",
 			"Working"
 		],
+		"vs/workbench/contrib/chat/browser/widget/chatListWidget": [
+			"Scroll to Bottom"
+		],
+		"vs/workbench/contrib/chat/browser/widget/chatPetWidget": [
+			"The VS Code pet bounced off the left wall and landed on the chat input",
+			"The VS Code pet bounced off the left wall, fell off, and will respawn automatically",
+			"The VS Code pet bounced off the right wall and landed on the chat input",
+			"The VS Code pet bounced off the right wall, fell off, and will respawn automatically",
+			"Come Back",
+			"The VS Code pet put on sunglasses",
+			"The VS Code pet got dizzy",
+			"The VS Code pet fell off and will respawn automatically",
+			"Go on the Run",
+			"VS Code pet size: {0} percent",
+			"Grow",
+			"Interact with the VS Code pet. Drag it around the chat, or flick it toward either side to throw it. Use the left and right arrow keys to make it hop, or hold Shift to throw it toward a wall. Use the context menu to put it on the run.",
+			"The VS Code pet landed on the chat input",
+			"The VS Code pet feels loved",
+			"VS Code pet moved left",
+			"VS Code pet moved right",
+			"The VS Code pet pressed its button",
+			"The VS Code pet respawned",
+			"The VS Code pet is respawning",
+			"Bring back the VS Code pet",
+			"VS Code pet size: {0} percent",
+			"Shrink",
+			"The VS Code pet is singing",
+			"The VS Code pet is speechless",
+			"The VS Code pet did a rare spin",
+			"The VS Code pet was thrown toward the left wall",
+			"The VS Code pet was thrown toward the right wall",
+			"Insiders Colors",
+			"Stable Colors",
+			"The VS Code pet woke up",
+			"The VS Code pet is worried",
+			"The VS Code pet is yapping"
+		],
 		"vs/workbench/contrib/chat/browser/widget/chatReadOnlyBanner": [
 			"Archived sessions are read-only."
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatRestoreCheckpointActionViewItem": [
-			"Cancel restoring this checkpoint",
-			"Discard Edits",
-			"Confirm restoring this checkpoint and discarding later edits"
+			"Discard Edits"
 		],
 		"vs/workbench/contrib/chat/browser/widget/chatTurnPills": [
 			"Turn status",
-			"View Changes: {0}, +{1}, -{2}",
+			"View Current Turn Changes: {0}, +{1}, -{2}",
 			"{0} File",
 			"{0} Files",
-			"View Changes",
+			"View Current Turn Changes",
 			"Open Preview",
 			"Show All Previewable Files",
 			"Open Preview: {0}"
@@ -42719,6 +45349,7 @@
 			"Steering",
 			"Ask about your code",
 			"AI responses may be inaccurate",
+			"This chat is read-only",
 			"[Generate Agent Instructions]({0}) to onboard AI onto your codebase.",
 			"Delegate to {0}",
 			"This chat session will be forwarded to the {0} [coding agent]({1}) where work is completed in the background. ",
@@ -42734,7 +45365,12 @@
 			"Goal",
 			"Determining goal…"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/chatInputNoticeWidget": [
+			"Dismiss",
+			"{0}. Use Shift+Tab to reach the notice."
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputNotificationWidget": [
+			"notification",
 			"Dismiss notification"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatInputPart": [
@@ -42756,6 +45392,8 @@
 			"Pick Mode and Model, {0}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/chatQueuePickerActionItem": [
+			"Ask in Side Chat",
+			"Ask this question in a side chat. The current response continues uninterrupted and the question is answered alongside it, without being added to this conversation.",
 			"Add to Queue",
 			"Queue this message to send after the current request completes. The current response will finish uninterrupted before the queued message is sent.",
 			"More Actions...",
@@ -42771,8 +45409,12 @@
 			"Continue In",
 			"Continue In (Third Party)"
 		],
+		"vs/workbench/contrib/chat/browser/widget/input/editor/agentHostInputCompletions": [
+			"Chat"
+		],
 		"vs/workbench/contrib/chat/browser/widget/input/editor/chatInputCompletions": [
 			"Active file",
+			"Attached context",
 			"{0} ({1})",
 			"Install Chat Extensions...",
 			"Error resolving prompt: {0}",
@@ -42785,10 +45427,13 @@
 			"Click to open {0}"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/editor/chatInputEditorHover": [
+			"Image attachment reference, {0}",
+			"Image attachment reference, {0}",
 			"There is a chat agent hover part here."
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/editor/chatPasteProviders": [
 			"Attached image",
+			"Attached pasted text as {0}",
 			"{0} and {1} more",
 			"{0} lines",
 			"1 line",
@@ -42797,6 +45442,10 @@
 			"Pasted Image Attachment",
 			"Pasted Image",
 			"Pasted Symbol Reference",
+			"Pasted Text Attachment",
+			"{0} lines",
+			"Pasted text #{0}",
+			"1 line",
 			"Paste as Markdown"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerActionItem": [
@@ -42807,7 +45456,9 @@
 		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerConfiguration": [
 			"Changing these options mid-session resets the prompt cache and may increase cost.",
 			"Thinking Effort",
+			"Configure",
 			"Thinking Effort: {0}",
+			"{0}: {1}",
 			"Context Size: {0}",
 			"Context Size",
 			"Default"
@@ -42817,7 +45468,6 @@
 			"Powerful",
 			"Versatile",
 			"{0}% discount",
-			"Ends {0}.",
 			"Cache Read",
 			"Cache Write",
 			"Configurable",
@@ -42830,33 +45480,38 @@
 			"Long Context",
 			"Output"
 		],
-		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItems": [
-			"Manage Models...",
-			"Manage Language Models",
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemPrimitives": [
 			"Contact your admin",
 			"This model is not available. Contact your administrator to enable it.",
 			"[Contact your admin]({0})",
-			"Auto",
 			"This model requires a newer version of VS Code. [Update VS Code](command:update.checkForUpdate) to access it.",
-			"Copilot",
 			"This model requires a newer version of VS Code. [Download Update](command:update.downloadUpdate) to access it.",
-			"No models available",
-			"Other Models",
 			"Pin Model",
-			"Pinned",
 			"This model requires a newer version of VS Code. [Restart to Update](command:update.restartToUpdate) to access it.",
-			"Models unavailable while in Restricted mode",
-			"Trust Workspace to enable models...",
-			"Trust the workspace to enable models.",
-			"Sign in to use Copilot",
-			"Sign in to use Copilot...",
-			"Sign in to GitHub Copilot to choose a model.",
 			"Unpin Model",
 			"Update VS Code",
 			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
 			"[Upgrade to GitHub Copilot Pro+](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
 			"[Upgrade](command:workbench.action.chat.upgradePlan \" \")",
 			"{0}% discount"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItems": [
+			"Manage Models...",
+			"Manage Language Models"
+		],
+		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerItemSections": [
+			"Auto",
+			"No models available",
+			"Other Models",
+			"Pinned",
+			"Models unavailable while in Restricted mode",
+			"Trust Workspace to enable models...",
+			"Trust the workspace to enable models.",
+			"Sign in to use Copilot",
+			"Sign in to use Copilot...",
+			"Sign in to GitHub Copilot to choose a model.",
+			"[Upgrade to GitHub Copilot Pro](command:workbench.action.chat.upgradePlan \" \") to use the best models.",
+			"[Upgrade](command:workbench.action.chat.upgradePlan \" \")"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modelPicker/modelPickerPresentation": [
 			"High cost",
@@ -42884,7 +45539,10 @@
 			"Icon for Copilot models.",
 			"Icon for Gemini models.",
 			"Icon for other model providers.",
-			"Icon for OpenAI models."
+			"Icon for Kimi models.",
+			"Icon for Microsoft models.",
+			"Icon for OpenAI models.",
+			"Icon for xAI models."
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/modePickerActionItem": [
 			"Built-In",
@@ -42907,21 +45565,21 @@
 			"Autopilot (Preview)",
 			"Auto-approve all tool calls and continue until the task is done. Autopilot may increase costs.",
 			"Autopilot (Preview)",
-			"Autonomously iterates from start to finish",
-			"Default approvals",
+			"Works autonomously within permissions",
+			"Default permissions",
 			"Use configured approval settings",
-			"Default approvals",
+			"Default permissions",
 			"Sandboxing for terminal",
 			"Run terminal commands inside a sandbox that restricts file system and network access",
 			"Asks when approval settings don't apply",
-			"Default approvals (sandboxed)",
+			"Default permissions (sandboxed)",
 			"This option is locked",
 			"Learn more about permissions",
 			"Disabled by enterprise policy",
 			"Disabled by enterprise policy"
 		],
 		"vs/workbench/contrib/chat/browser/widget/input/sessionTargetPickerActionItem": [
-			"Learn about agent types...",
+			"Learn about harnesses...",
 			"{0}. {1}",
 			"Agent Types",
 			"Other"
@@ -42970,11 +45628,16 @@
 			"New Session",
 			"Agent Session in Progress",
 			"Sessions",
-			"Press {0} to barge in",
+			"Speak or use {0}",
 			"Speak to barge in",
 			"Click voice mode to talk or barge in",
 			"Listening...",
-			"Press {0} to talk or barge in"
+			"Hold {0} to talk",
+			"Press {0} to talk or barge in",
+			"Hold the button to talk, tap to turn off",
+			"Tap the button to start listening",
+			"Hands-free — just start talking",
+			"Hold Space to talk"
 		],
 		"vs/workbench/contrib/chat/browser/widgetHosts/viewPane/chatViewTitleControl": [
 			"Chat",
@@ -42987,6 +45650,7 @@
 			"True when the agent session item is archived.",
 			"True when the agent session item is pinned.",
 			"True when the agent session item is read.",
+			"Whether the current agent session item has an associated pull request: 'available' or 'none'. Unset when the pull request state is unknown.",
 			"The section of the current agent session section item.",
 			"If the agent sessions view in the chat view is focused.",
 			"Orientation of the agent sessions view in the chat view.",
@@ -42994,6 +45658,7 @@
 			"Visibility of the agent sessions view in the chat view.",
 			"The type of the current agent session item.",
 			"True when the chat agent supports attachments.",
+			"True when the locked Agent Host provider pins an immutable primary working directory.",
 			"The Agent Host provider ID when the chat widget is locked to an Agent Host session.",
 			"True when agent mode is disabled by organization policy.",
 			"True when the user has opened the context window usage details.",
@@ -43005,6 +45670,10 @@
 			"True when a tool confirmation is present.",
 			"The type of the current editing request.",
 			"True when the installed chat extension is invalid and needs to be updated.",
+			"True when the chat transcript Find widget's input box has focus.",
+			"True when the chat widget hosting the current focus supports transcript Find.",
+			"True when any part of the chat transcript Find widget has focus.",
+			"True when the chat transcript Find widget is visible.",
 			"The chat item is the first request in the session.",
 			"The number of foreground chat sessions visible across chat surfaces.",
 			"True when the chat has custom agents available.",
@@ -43013,6 +45682,8 @@
 			"True when a delegation (continue in) target is selected but the request has not been submitted yet.",
 			"True when there are pending requests in the queue.",
 			"True when the user has used any of the /create-* slash commands.",
+			"True while the destination for a submitted chat request is being resolved.",
+			"True when a submitted request is being routed or dispatched (e.g. omni-chat routing) and cannot be re-sent yet.",
 			"True when the chat widget is locked to an Agent Host session.",
 			"True when chat is enabled because a default chat participant is activated with an implementation.",
 			"True when focusing a KaTeX math element.",
@@ -43050,7 +45721,7 @@
 			"The type of the current chat session.",
 			"True when the chat request in progress message should be skipped.",
 			"True when on-device speech-to-text is available for dictating into the chat input.",
-			"True while the on-device speech-to-text model is downloading or loading (the preparation notification is shown).",
+			"True while the selected speech-to-text backend is preparing.",
 			"True while the chat input is recording audio for speech-to-text transcription.",
 			"Whether the remote coding agent prompt file overlay feature is enabled",
 			"True when the chat widget is within a file with an edit session.",
@@ -43058,7 +45729,9 @@
 			"True when the chat input is within the agent sessions welcome page.",
 			"True when the chat input is within the automations dialog.",
 			"True when focus is in the chat widget, false otherwise.",
+			"True when focus is in an Agents window chat composer or one of the notices above it.",
 			"Whether focus is in a chat editor.",
+			"True when focus is in the floating chat input window, false otherwise.",
 			"True when focus is in the chat question carousel.",
 			"True when focus is in the chat terminal output region.",
 			"True when focus is in a chat tip.",
@@ -43194,6 +45867,10 @@
 			"New Chat"
 		],
 		"vs/workbench/contrib/chat/common/customizationHarnessService": [
+			"Disabled",
+			"Disabled (Plugin)",
+			"Disabled (Session)",
+			"Disabled (Workspace)",
 			"Local"
 		],
 		"vs/workbench/contrib/chat/common/editing/chatEditingService": [
@@ -43205,6 +45882,10 @@
 			"Auto routes based on your task and real-time system health and model performance.",
 			"Models routed via auto receive a {0}% discount.",
 			"[Learn More]({0})",
+			"{0}/{1}",
+			"{0}/{1}/{2}",
+			"Copilot",
+			"Ends {0}.",
 			"Install Extension",
 			"The internal {0} language model provider is being deprecated. Please migrate to the official extension.",
 			"Group Name",
@@ -43726,7 +46407,7 @@
 			"Manage and track todo items for task planning"
 		],
 		"vs/workbench/contrib/chat/common/tools/builtinTools/reviewPlanTool": [
-			"Review plan",
+			"Plan summary",
 			"Asking you to review the plan",
 			"Asked you to review the plan",
 			"At least one approval action must be provided.",
@@ -43789,7 +46470,10 @@
 			"Background color of the agent status indicator in the titlebar.",
 			"The background color of a chat avatar.",
 			"The foreground color of a chat avatar.",
+			"Accent color of the glow shown on the microphone while dictation is listening.",
 			"The foreground color of a chat edited file in the edited file list.",
+			"Background color of the current search match in a chat transcript.",
+			"Background color of the other search matches in a chat transcript. The color must not be opaque so as not to hide underlying content.",
 			"First color stop of the animated chat input border shown while a request is in flight.",
 			"Secondary accent color used by other animated chat input affordances. Not used by the in-flight chat input border.",
 			"Tertiary accent color used by other animated chat input affordances. Not used by the in-flight chat input border.",
@@ -43803,6 +46487,9 @@
 			"The background color of a chat slash command.",
 			"The foreground color of a chat slash command.",
 			"Shimmer highlight for thinking/working labels.",
+			"Base accent the Voice Mode ambient glow is derived from. The listening and speaking glows are hue-shifted from this color.",
+			"Accent color of the Voice Mode glow while listening. Derived from {0} when unset.",
+			"Accent color of the Voice Mode glow while the agent is speaking. Derived from {0} when unset.",
 			"Chat checkpoint separator color."
 		],
 		"vs/workbench/contrib/chat/electron-browser/actions/chatDeveloperActions": [
@@ -43826,6 +46513,17 @@
 			"Export Agent Host Traces Database...",
 			"No agent host trace database found yet. Run an agent session with `#chat.agentHost.otel.dbSpanExporter.enabled#` turned on to populate it."
 		],
+		"vs/workbench/contrib/chat/electron-browser/actions/installDictationModelAction": [
+			"Install Dictation Model from Local Package...",
+			"Select the {0} CPU model package (.zip) or folder",
+			"Failed to install the dictation model: {0}",
+			"Foundry Local Model Package",
+			"The dictation model package must be on the local file system.",
+			"Install",
+			"Installing dictation model...",
+			"Installed {0} version {1}.",
+			"On-device dictation is not supported on this platform."
+		],
 		"vs/workbench/contrib/chat/electron-browser/actions/networkDiagnosticsAction": [
 			"Network Diagnostics"
 		],
@@ -43844,6 +46542,9 @@
 			"Stop",
 			"Failed to stop profiling the agent host: {0}",
 			"Stop Local Agent Host Profile"
+		],
+		"vs/workbench/contrib/chat/electron-browser/actions/restartAgentHostAction": [
+			"Restart Local Agent Host"
 		],
 		"vs/workbench/contrib/chat/electron-browser/actions/voiceChatActions": [
 			"Listening to 'Hey Code'...",
@@ -43876,8 +46577,8 @@
 			"Continue in Agents Window",
 			"Get a dedicated, multi-pane view alongside your workspace.",
 			"Free with your Copilot plan — get a dedicated, multi-pane view alongside your workspace.",
-			"Open the Agents Window to start a Copilot CLI session.",
-			"Copilot CLI [Agent Host] isn't available without an open folder",
+			"Open the Agents Window to start a Copilot session.",
+			"Copilot isn't available without an open folder",
 			"Continue this session in the Agents Window",
 			"Don't Show Again",
 			"Open Agents Window",
@@ -43920,15 +46621,33 @@
 			"The session will stop if you reload the window.",
 			"A session is in progress. Are you sure you want to reload the window?"
 		],
+		"vs/workbench/contrib/chat/electron-browser/codexCustomizationSettings.contribution": [
+			"Configure global behavior for this harness.",
+			"Codex"
+		],
 		"vs/workbench/contrib/chat/electron-browser/toggleRemoteConnectionsActionViewItem": [
+			"Remote session access provided by Remote Tunnel Access via tunnel '{0}'",
 			"Establishing tunnel connection...",
 			"Remote session access is enabled",
-			"Allow remote session access",
+			"Allow connections from other machines and {0}",
+			"Allow connections from other machines and {0}",
+			"Allow connections from other machines",
+			"Allow connections from other machines",
+			"Learn More",
+			"Remote session access is provided by Remote Tunnel Access via tunnel '{0}'. Turning off remote session access does not disable Remote Tunnel Access.",
+			"Rename Tunnel",
 			"Remote session access enabled via tunnel '{0}'",
 			"Show Output",
 			"Remote session access is now enabled"
 		],
 		"vs/workbench/contrib/chat/electron-browser/tunnelHost.contribution": [
+			"Rename Tunnel",
+			"Failed to rename tunnel: {0}",
+			"The name must only consist of letters, numbers, underscore and dash. It must not start with a dash.",
+			"The name must not be longer than {0} characters.",
+			"Leave blank to use this machine's host name.",
+			"Enter a name for this tunnel.",
+			"Rename Tunnel",
 			"Show Remote Connections Output",
 			"Allow Remote Connections",
 			"Remote Connections",
@@ -44490,13 +47209,12 @@
 		"vs/workbench/contrib/customEditor/common/extensionPoint": [
 			"Contributed custom editors.",
 			"Human readable name of the custom editor. This is displayed to users when selecting which editor to use.",
-			"Controls if the custom editor is enabled automatically when the user opens a file, diff, or merge editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting. When omitted, the custom editor defaults to `default` for the normal editor and `never` for diff and merge editors, so it is not used for diffs or merges unless it opts in.",
+			"Controls if the custom editor is enabled automatically when the user opens a file or diff editor. This may be overridden by users using the `workbench.editorAssociations` or `workbench.diffEditorAssociations` setting. When omitted, the custom editor defaults to `default` for the normal editor and `explicit` for diff editors, so it is not used for diffs unless it opts in.",
 			"The editor is automatically used when the user opens a resource, provided that no other default custom editors are registered for that resource.",
-			"Controls if the custom editor is enabled automatically when the user opens a diff. When not specified this defaults to `never`, so the custom editor is not used for diffs unless it opts in.",
-			"Controls if the custom editor is enabled automatically when the user opens a merge editor. When not specified this defaults to `never`, so the custom editor is not used for merges unless it opts in.",
-			"The editor is never automatically used, and it is also skipped when the user points a `workbench.editorAssociations` entry at it. It can still be opened via the `Reopen With` command or the specialized `workbench.diffEditorAssociations` setting.",
+			"Controls if the custom editor is enabled automatically when the user opens a diff. When not specified this defaults to `explicit`, so the custom editor is not used for diffs unless it opts in.",
+			"The editor is not automatically used or opted into by an association from another editor mode. It can still be opened using the `Reopen With` command or an association configured specifically for this editor mode.",
 			"The editor is not automatically used when the user opens a resource, but a user can switch to the editor using the `Reopen With` command.",
-			"Controls if the custom editor is enabled automatically when the user opens a file. `diffEditor` and `mergeEditor` do not inherit this value; when they are not specified they default to `never`.",
+			"Controls if the custom editor is enabled automatically when the user opens a file. `diffEditor` does not inherit this value; when it is not specified it defaults to `explicit`.",
 			"Set of globs that the custom editor is enabled for.",
 			"Glob that the custom editor is enabled for.",
 			"Identifier for the custom editor. This must be unique across all custom editors, so we recommend including your extension id as part of `viewType`. The `viewType` is used when registering custom editors with `vscode.registerCustomEditorProvider` and in the `onCustomEditor:${id}` [activation event](https://code.visualstudio.com/api/references/activation-events).",
@@ -46667,12 +49385,14 @@
 		],
 		"vs/workbench/contrib/files/browser/views/openEditorsView": [
 			"{0} unsaved",
+			"{0} unsaved, open unsaved editor",
 			"Toggle Vertical/Horizontal Editor Layout",
 			"Flip &&Layout",
 			"Flip Layout",
 			"New Untitled Text File",
 			"Open Editors",
-			"Open Editors"
+			"Open Editors",
+			"Open Unsaved Editor"
 		],
 		"vs/workbench/contrib/files/browser/workspaceWatcher": [
 			"Unable to watch for file changes. Please follow the instructions link to resolve this issue.",
@@ -47529,6 +50249,7 @@
 			"Disable (Session)",
 			"Disable (Workspace)",
 			"Enable",
+			"Enable Plugin",
 			"Enable (Session)",
 			"Enable (Workspace)",
 			"No MCP servers",
@@ -47851,7 +50572,7 @@
 			"Enable",
 			"This feature is currently in preview. You can disable it anytime using the setting {0}.",
 			"Enable MCP Servers Marketplace?",
-			"Browse and install [Model Context Protocol (MCP) servers](https://code.visualstudio.com/docs/copilot/customization/mcp-servers) directly from VS Code to extend agent mode with extra tools for connecting to databases, invoking APIs and performing specialized tasks.",
+			"Browse and install [Model Context Protocol (MCP) servers](https://code.visualstudio.com/docs/agent-customization/mcp-servers) directly from VS Code to extend agent mode with extra tools for connecting to databases, invoking APIs and performing specialized tasks.",
 			"Enable MCP Servers Marketplace",
 			"Open Settings",
 			"MCP Servers",
@@ -48625,7 +51346,7 @@
 			"Show available diagnostics for cell failures.",
 			"Enable experimental generate action to create code cell with inline chat enabled.",
 			"Where the cell toolbar should be shown, or whether it should be hidden.",
-			"Configure the cell toolbar position for for specific file types",
+			"Configure the cell toolbar position for specific file types",
 			"Whether the cell toolbar should appear on hover or click.",
 			"Control whether the notebook editor should be rendered in a compact form. For example, when turned on, it will decrease the left margin width.",
 			"Control whether a confirmation prompt is required to delete a running cell.",
@@ -48915,6 +51636,7 @@
 		],
 		"vs/workbench/contrib/onboarding/browser/onboarding.contribution": [
 			"Map of onboarding scenario/tour id to whether developer mode is enabled for it. When enabled for a scenario, that onboarding tour ignores usage-based eligibility checks (such as how many sessions you have started), previously persisted shown state, and any linked experiment (so it is shown even if the experiment is not running or you are in the control group). It does not override the {0} setting. The tour is still shown at most once per window session, so reload the window to show it again.",
+			"Map of onboarding scenario/tour id to the variation used while developer mode is enabled for that scenario. An empty value uses the experiment-selected or default variation.",
 			"When enabled, onboarding tours and hints may appear automatically to highlight features. Disabling this does not affect tours you start manually.",
 			"Reset Onboarding Shown State"
 		],
@@ -49555,6 +52277,9 @@
 			"Report Issue",
 			"Remote Help"
 		],
+		"vs/workbench/contrib/remote/browser/remote.contribution": [
+			"Toggle Forwarded Ports View"
+		],
 		"vs/workbench/contrib/remote/browser/remoteConnectionHealth": [
 			"&&Allow",
 			"Support for 32-bit ARM remote servers is deprecated and will be removed in a future release of {0}.",
@@ -49765,6 +52490,7 @@
 			"Others",
 			"Unable to turn on the remote tunnel access. Check the Remote Tunnel Service log for details.",
 			"You can now access this machine anywhere via the secure tunnel [{0}](command:{4}). To connect via a different machine, use the generated [{1}]({2}) link or use the [{6}]({7}) extension in the desktop or web. You can [configure](command:{3}) or [turn off](command:{5}) this access via the VS Code Accounts menu.",
+			"Remote Tunnel Access is enabled for {0}. You can [configure](command:{1}) or [turn off](command:{2}) this access via the VS Code Accounts menu.",
 			"Tunnel '{0}' is avaiable for remote access. The {1} extension can be used to connect to it.",
 			"Configure Tunnel Name...",
 			"Copy Browser URI to Clipboard",
@@ -51721,11 +54447,15 @@
 			"- Toggle between the widget and terminal<keybinding:{0}> and toggle details focus<keybinding:{1}> to learn more about the suggestion.",
 			"-Configure suggest settings<keybinding:{0}> ",
 			"- Learn more about the suggestion<keybinding:{0}>.",
-			"The terminal request completions command can be invoked manually<keybinding:{0}>, but also appears while typing."
+			"The terminal request completions command can be invoked manually<keybinding:{0}>, but also appears while typing.",
+			"Start or stop dictation in the terminal<keybinding:{0}>."
 		],
 		"vs/workbench/contrib/terminalContrib/accessibility/common/terminalAccessibilityConfiguration": [
 			"Focus the terminal accessible view when a command is executed.",
-			"Preserve the cursor position on reopen of the terminal's accessible view rather than setting it to the bottom of the buffer."
+			"Controls whether the cursor position is preserved in the terminal's accessible view.",
+			"Always preserve the cursor position, including when new terminal content arrives.",
+			"Always position the cursor at the bottom of the buffer.",
+			"Preserve the cursor position on reopen until new terminal content arrives."
 		],
 		"vs/workbench/contrib/terminalContrib/autoReplies/common/terminalAutoRepliesConfiguration": [
 			"A set of messages that, when encountered in the terminal, will be automatically responded to. Provided the message is specific enough, this can help automate away common responses.\n\nRemarks:\n\n- Use {0} to automatically respond to the terminate batch job prompt on Windows.\n- The message includes escape sequences so the reply might not happen with styled text.\n- Each reply can only happen once every second.\n- Use {1} in the reply to mean the enter key.\n- To unset a default key, set the value to null.\n- Restart VS Code if new don't apply.",
@@ -51854,7 +54584,7 @@
 		"vs/workbench/contrib/terminalContrib/chatAgentTools/browser/tools/runInTerminalTool": [
 			"Allow",
 			"Run `{0}` command?",
-			"Allow the sandbox to run `{0}` command with unrestricted network access.",
+			"Allow {0} command to access the network?",
 			"Retry `{0}` command in the sandbox by allowing network access?",
 			"`{0}`",
 			"Retry `{0}` command in the sandbox by allowing network access to {1}?",
@@ -51864,14 +54594,9 @@
 			"The model indicated that this sandboxed command needs unrestricted network access.",
 			"Not running `{0}` because unrestricted network access in the sandbox is disabled",
 			"The command was not executed because it requested unrestricted network access in the terminal sandbox, but per-command network access is disabled by chat.agent.sandbox.retryWithAllowNetworkRequests. Run the command with restricted network access instead, or enable the setting to allow network access requests.",
-			"Apply Fix and Retry",
-			"Cancel",
-			"Bubblewrap sandbox repair was cancelled by the user.",
-			"Bubblewrap cannot create the sandbox environment.",
-			"Bubblewrap repair failed (exit code {0}). The command was not executed.",
-			"Could not determine whether the bubblewrap repair succeeded. The command was not executed.",
-			"Bubblewrap still cannot create the required sandbox namespace after remediation. Reload the window and try running the command again.",
-			"Repair Bubblewrap Sandbox",
+			"Sandbox creation failed due to host restrictions. Sandboxing can be disabled by setting `{0}` to `off`.",
+			"Sandboxing is not supported in this environment. To disable sandboxing, set `{0}` to `off`. The command was not executed.",
+			"Sandboxing is not supported in this environment. [Open the `{0}` setting](command:workbench.action.openSettings?{1} \"Open Settings\") and set it to `off`. The command was not executed.",
 			"Bubblewrap is installed but cannot create the required sandbox namespace on this system. The command was not executed.",
 			"Explanation: {0}\n\nGoal: {1}",
 			"No explanation provided",
@@ -51988,12 +54713,9 @@
 			"Controls whether agent mode terminal commands that run inside the sandbox are auto-approved. When disabled, the run in terminal tool uses the existing approval flow. This applies only when {0} is enabled.",
 			"When {0} is enabled, controls whether to allow all network domains in the sandbox. When enabled, the sandbox preserves file system restrictions while relaxing all network restrictions.",
 			"Controls whether agent mode terminal commands can run outside the sandbox after user confirmation when a sandboxed command fails or when sandbox restrictions would block the command. This applies only when {0} is enabled.",
-			"Use {0} instead",
 			"Controls whether agent mode uses sandboxing to restrict what tools can do. When enabled, tools like the terminal are run in a sandboxed environment to limit access to the system. Use {0} to allow all network domains.",
 			"Disable sandboxing for agent mode tools.",
 			"Enable sandboxing for agent mode tools.",
-			"Use {0} instead",
-			"Use {0} instead",
 			"Note: this setting is applicable only when {0} is enabled. Controls file system access in sandbox on Linux. Paths do not support glob patterns, only literal paths (ex: ./src/, ~/.ssh, .env). **bubblewrap** and **socat** should be installed for this setting to work.",
 			"Array of paths to re-allow read access within denied regions. Takes precedence over denyRead.",
 			"Array of additional paths to allow write access. Leave empty to disallow writes outside the workspace folders, workspace storage folder, and sandbox temp directory.",
@@ -52255,6 +54977,9 @@
 			"The kind of the resulting quick fix. This changes how the quick fix is presented. Defaults to {0}.",
 			"A regular expression or string to match a single line of the output against, which provides groups to be referenced in terminalCommand and uri.\n\nFor example:\n\n `lineMatcher: /git push --set-upstream origin (?<branchName>[^s]+)/;`\n\n`terminalCommand: 'git push --set-upstream origin ${group:branchName}';`\n"
 		],
+		"vs/workbench/contrib/terminalContrib/resizeDimensionsOverlay/common/terminalResizeDimensionsOverlayConfiguration": [
+			"Whether to show a visual overlay with the terminal's columns and rows when it is resized."
+		],
 		"vs/workbench/contrib/terminalContrib/sendSequence/browser/terminal.sendSequence.contribution": [
 			"Send Sequence",
 			"The sequence of text to send to the terminal",
@@ -52425,6 +55150,8 @@
 			"Terminal style of locally echoed text; either a font style or an RGB color."
 		],
 		"vs/workbench/contrib/terminalContrib/voice/browser/terminalVoice": [
+			"Stop Dictation ({0})",
+			"Stop Dictation",
 			"{0} inserted"
 		],
 		"vs/workbench/contrib/terminalContrib/voice/browser/terminalVoiceActions": [
@@ -53784,17 +56511,6 @@
 			"Tip: Press ",
 			"Shift",
 			" to access all VS Code commands.",
-			"Agent",
-			"Describe a goal. The agent plans the approach, edits files, runs commands, and self-corrects. You review and approve along the way.",
-			"Agents tutorial",
-			"Customize Your Agents",
-			"Tailor Copilot to your project with custom instructions and agents, skills, reusable prompts, and MCP servers that connect to the tools and context you rely on.",
-			"Agents made for the task",
-			"Agents that work your way",
-			"Plan",
-			"Produce a structured implementation plan before any code changes, then hand it off to an agent to execute.",
-			"Run Agents Anywhere",
-			"Run agents locally for interactive work, in the background with Copilot CLI, or in the cloud with cloud agents that open a pull request your team can review.",
 			"Sign in to use GitHub Copilot",
 			"Continue with Apple",
 			". {0} Copilot may show ",
@@ -53823,7 +56539,6 @@
 			"Sign in to use GitHub Copilot.",
 			"Welcome to VS Code",
 			"You're signed in. You can continue to the next step.",
-			"Open Chat anytime with ",
 			"Step {0} of {1}: {2}",
 			"{0} of {1}",
 			"{0} theme selected"
@@ -53838,8 +56553,6 @@
 			"Inline suggestions plus a chat panel for deeper collaboration. A balance of writing and delegating.",
 			"I Write the Code",
 			"AI assists with suggestions and answers questions when you ask. You stay in control of every edit.",
-			"Build with AI Agents",
-			"Open Chat anytime with {0}",
 			"Your AI Style",
 			"Choose how much AI collaboration fits your workflow",
 			"Make It Yours",
@@ -54356,6 +57069,19 @@
 			"Contributes submenu items to the editor",
 			"The webview context menu"
 		],
+		"vs/workbench/services/agentEditorComments/browser/agentEditorCommentsOverlayWidget": [
+			"{0}/{1}",
+			"Submit Feedback ({0})",
+			"Submit {0}",
+			"0/0"
+		],
+		"vs/workbench/services/agentHost/browser/codexAccountService": [
+			"ChatGPT",
+			"{0} (ChatGPT)",
+			"Downloading Codex agent…",
+			"Sign in to ChatGPT",
+			"Sign Out"
+		],
 		"vs/workbench/services/assignment/common/assignmentService": [
 			"Fetches experiments to run from a Microsoft online service."
 		],
@@ -54516,6 +57242,19 @@
 			"Variable {0} can not be resolved because no extension name is given.",
 			"Variable {0} can not be resolved because the command has no value."
 		],
+		"vs/workbench/services/dataChannel/browser/dataChannelService": [
+			"Not available",
+			"Link presentation is not available",
+			"The link presentation provider failed to load.",
+			"Link presentation provider identifier '{0}' is already registered by the core.",
+			"Link presentation provider identifier '{0}' is already contributed.",
+			"Configuration key that must be enabled before this provider is selected.",
+			"Unique identifier used to register this link presentation provider.",
+			"The initial semantic kind shown while the provider resolves its first presentation.",
+			"Link presentation provider '{0}' must use a valid anchored URI regular expression of at most {1} characters.",
+			"Anchored regular expression matched against the canonical URI string before the extension is activated.",
+			"Contributes link presentation providers selected by URI regular expressions."
+		],
 		"vs/workbench/services/decorations/browser/decorationsService": [
 			"Contains emphasized items"
 		],
@@ -54577,6 +57316,7 @@
 		"vs/workbench/services/editor/common/editorResolverService": [
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors for diff views (for example `\"*.md\": \"vscode.markdown.preview.editor\"`). These override `workbench.editorAssociations` for diffs.",
 			"Configure [glob patterns](https://aka.ms/vscode-glob-patterns) to editors (for example `\"*.hex\": \"hexEditor.hexedit\"`). These have precedence over the default behavior.",
+			"Configure editor types that are hidden from the editor type picker. The active editor type remains visible.",
 			"Controls whether the Markdown editor is used as the default editor for Markdown files in the Agents window."
 		],
 		"vs/workbench/services/extensionManagement/browser/extensionBisect": [
@@ -54977,10 +57717,16 @@
 			"Your administrator restricts AI features to specific GitHub accounts. The account \"{0}\" does not qualify.",
 			"Your administrator restricts AI features to specific GitHub accounts.",
 			"Sign In",
-			"Your administrator restricts AI features to GitHub accounts in the following organizations: {0}."
+			"Your administrator restricts AI features to GitHub accounts in the following organizations: {0}.",
+			"Close",
+			"Learn More",
+			"Update Required",
+			"Check for Updates",
+			"Your version of {0} cannot enforce your organization's managed settings. Update {0} to continue using AI features.",
+			"Your version of {0} cannot enforce your organization's managed settings. Update {0} to version {1} or later to continue using AI features."
 		],
 		"vs/workbench/services/policies/common/accountPolicyService": [
-			"True when the 'Require Approved Account' policy is in effect and the user is not yet signed into an approved GitHub organization, so all AI features are disabled until they sign in."
+			"True when account or managed-settings compatibility policy prevents this client from using AI features."
 		],
 		"vs/workbench/services/preferences/browser/keybindingsEditorInput": [
 			"Icon of the keybindings editor label.",
@@ -55278,7 +58024,8 @@
 			"Associates root folder names to icons. The object key is the root folder name. No patterns or wildcards are allowed. Root folder name matching is case insensitive.",
 			"Associates root folder names to icons for expanded root folders. The object key is the root folder name. No patterns or wildcards are allowed. Root folder name matching is case insensitive.",
 			"Configures whether the default language icons should be used if the theme does not define an icon for a language.",
-			"The location of the font."
+			"The location of the font.",
+			"Whether image icons use their alpha channel as a mask filled with the current text color. When enabled, only the shape of an image icon is used, so any colors defined in the icon (including light and high contrast variants) are ignored."
 		],
 		"vs/workbench/services/themes/common/iconExtensionPoint": [
 			"The default of the icon. Either a reference to an existing ThemeIcon or an icon in an icon font.",

--- a/packages/debug/src/browser/debug-frontend-application-contribution.ts
+++ b/packages/debug/src/browser/debug-frontend-application-contribution.ts
@@ -271,7 +271,7 @@ export class DebugFrontendApplicationContribution extends AbstractViewContributi
             { ...DebugCommands.STOP, ...DebugSessionContextCommands.STOP },
             { ...DebugThreadContextCommands.TERMINATE, label: nls.localizeByDefault('Terminate Thread') }
         );
-        registerMenuActions(DebugThreadsWidget.OPEN_MENU, { ...DebugSessionContextCommands.REVEAL, label: nls.localize('theia/debug/reveal', 'Reveal') });
+        registerMenuActions(DebugThreadsWidget.OPEN_MENU, { ...DebugSessionContextCommands.REVEAL, label: nls.localizeByDefault('Reveal') });
 
         registerMenuActions(DebugStackFramesWidget.CONTEXT_MENU,
             DebugCommands.RESTART_FRAME,

--- a/packages/plugin/src/theia.d.ts
+++ b/packages/plugin/src/theia.d.ts
@@ -17475,7 +17475,7 @@ export module '@theia/plugin' {
          * until the cancellation is requested on the `token`.
          *
          * @param request Request information for the test run.
-         * @param cancellationToken Token that signals the used asked to abort the
+         * @param token Token that signals the used asked to abort the
          * test run. If cancellation is requested on this token, all {@link TestRun}
          * instances associated with the request will be
          * automatically cancelled as well.


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

- Bump API compatibility to 1.134.0
  - No public API changes in vscode.d.ts between 1.130.0 and 1.134.0
  - The bump unblocks extensions targeting 1.134.0
  - minor doc update in theia.d.ts:
    - `TestRunProfile.runHandler` JSDoc renamed `@param` to `token`
- Update nls metadata for VSCode API 1.134.0
   - fix suggestions to use nls.localizeByDefault

No public API changes: `src/vscode-dts/vscode.d.ts` is unchanged between 1.130.0 and 1.134.0, so no `theia.d.ts` updates are required this cycle.

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

- Check the filtered [vscode-theia-comparator/status](https://eclipse-theia.github.io/vscode-theia-comparator/status.html) with the current Theia master and VS Code 1.134.0
- Regarding nls update: CI Lint step is successful and no localization related warnings are shown on startup

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
