### PR TITLE
feat(ai): add gemini-3.7-flash to default models

### DIFF
--- a/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
+++ b/packages/ai-core/src/browser/frontend-language-model-alias-registry.ts
@@ -67,7 +67,7 @@ export class DefaultLanguageModelAliasRegistry implements LanguageModelAliasRegi
             defaultModelIds: [
                 'anthropic/claude-haiku-4-5',
                 'openai/gpt-5.6-luna',
-                'google/gemini-3.6-flash'
+                'google/gemini-3.7-flash'
             ],
             description: nls.localize('theia/ai/core/defaultModelAliases/fast/description',
                 'Faster and cheaper models for simpler tasks like exploration or basic tool calling, where deep reasoning is not required.')

--- a/packages/ai-google/src/common/google-preferences.ts
+++ b/packages/ai-google/src/common/google-preferences.ts
@@ -36,7 +36,7 @@ export const GooglePreferencesSchema: PreferenceSchema = {
             type: 'array',
             description: nls.localize('theia/ai/google/models/description', 'Official Google Gemini models to use'),
             title: AI_CORE_PREFERENCES_TITLE,
-            default: ['gemini-3.1-pro-preview', 'gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3.5-flash-lite'],
+            default: ['gemini-3.1-pro-preview', 'gemini-3.7-flash', 'gemini-3.6-flash', 'gemini-3.5-flash', 'gemini-3.5-flash-lite'],
             items: {
                 type: 'string'
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

Bumps the Google model defaults to the newly released `gemini-3.7-flash`:

- add gemini-3.7-flash to the Google default model list
- point the default/fast alias at gemini-3.7-flash

Anthropic and OpenAI defaults are already current, so they are unchanged.

Sources:
- [Anthropic model list (BenchLM)](https://benchlm.ai/providers/anthropic)
- [OpenAI models](https://developers.openai.com/api/docs/models)
- [Google Gemini models](https://ai.google.dev/gemini-api/docs/models)

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

Open the AI model settings and confirm `gemini-3.7-flash` appears in the Google model list and that the `default/fast` alias resolves to it.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

Contributed on behalf of STMicroelectronics

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
