### PR TITLE
 Fix small UI issues in walkthroughs, hover tooltips, AI config and themes

### DIFF
--- a/packages/ai-ide/src/browser/ai-configuration/ai-configuration-tree-widget.tsx
+++ b/packages/ai-ide/src/browser/ai-configuration/ai-configuration-tree-widget.tsx
@@ -451,8 +451,7 @@ export function createAiConfigurationTreeContainer(parent: interfaces.Container)
         props: {
             virtualized: false,
             search: false,
-            leftPadding: 8,
-            expandOnlyOnExpansionToggleClick: true
+            leftPadding: 8
         }
     });
 }

--- a/packages/ai-ide/src/browser/chat-session-item.tsx
+++ b/packages/ai-ide/src/browser/chat-session-item.tsx
@@ -187,15 +187,13 @@ export function ChatSessionItem(props: ChatSessionItemComponentProps): React.Rea
 
     const handleMouseLeave = React.useCallback(() => {
         hoverActiveRef.current = false;
-        hoverService.cancelHover();
-    }, [hoverService]);
+    }, []);
 
     const handleMouseOver = React.useCallback((e: React.MouseEvent) => {
         if ((e.target as Element).closest('.theia-chat-session-item-action')) {
             hoverActiveRef.current = false;
-            hoverService.cancelHover();
         }
-    }, [hoverService]);
+    }, []);
 
     const handleKeyDown = React.useCallback((e: React.KeyboardEvent) => {
         if (isActivationKey(e)) {

--- a/packages/core/src/browser/hover-service.ts
+++ b/packages/core/src/browser/hover-service.ts
@@ -157,6 +157,12 @@ export class HoverService {
         // resetting the position prevents that
         host.style.left = '0px';
         host.style.top = '0px';
+        // Keep the host hidden while it is parked at (0,0) for measurement. A visible popover there
+        // would, for a target in the upper-left of the viewport (e.g. a view docked in the left panel),
+        // flash over the target for one frame. That steals the pointer from the target, whose mouse-leave
+        // handler then cancels the hover, and the cycle repeats: the tooltip flickers and never settles.
+        // `visibility: hidden` still lays the host out (so it can be measured) but is not hit-tested.
+        host.style.visibility = 'hidden';
         document.body.append(host);
         if (!host.matches(':popover-open')) {
             host.showPopover();
@@ -184,6 +190,10 @@ export class HoverService {
 
         await animationFrame(); // Allow the browser to size the host
         const updatedPosition = this.setHostPosition(target, host, position);
+        // Reveal the host only once it sits at its final position, so it never overlaps the target while
+        // parked at (0,0). Dropping the declaration rather than assigning a value hands `visibility` back
+        // to the stylesheet, which is where it comes from for every hover but the one being measured.
+        host.style.removeProperty('visibility');
 
         this.disposeOnHide.push({
             dispose: () => {
@@ -280,5 +290,8 @@ export class HoverService {
         }
         this.hoverHost.remove();
         this.hoverHost.replaceChildren();
+        // The host is reused across hovers; drop the transient hidden state set during measurement so a
+        // hover cancelled before it was revealed does not leave the next one invisible.
+        this.hoverHost.style.removeProperty('visibility');
     }
 }

--- a/packages/getting-started/src/browser/getting-started-contribution.ts
+++ b/packages/getting-started/src/browser/getting-started-contribution.ts
@@ -226,6 +226,11 @@ export class GettingStartedContribution extends AbstractViewContribution<Getting
             label: GettingStartedCommand.label,
             order: 'a10'
         });
+        menus.registerMenuAction(CommonMenus.HELP, {
+            commandId: WalkthroughCommands.OPEN_WALKTHROUGH.id,
+            label: WalkthroughCommands.OPEN_WALKTHROUGH.label,
+            order: 'a20'
+        });
     }
 
     registerColors(colors: ColorRegistry): void {

--- a/packages/getting-started/src/browser/style/index.css
+++ b/packages/getting-started/src/browser/style/index.css
@@ -251,14 +251,20 @@ body {
 
 /* A selected walkthrough takes over the whole welcome view. */
 .gs-walkthrough-container {
+  /* `.gs-container` sets `height: 100%`, so the padding has to stay inside the box. */
+  box-sizing: border-box;
   padding: calc(var(--theia-ui-padding) * 6);
   overflow: auto;
 }
 
+/*
+ * Sized by its content rather than stretched to the full height: a percentage height resolves against the
+ * scroll container's content box, and its padding would then push the scroll extent past the client height,
+ * leaving a scrollbar even for content that fits.
+ */
 .gs-walkthrough-detail {
   display: flex;
   flex-direction: column;
-  height: 100%;
 }
 
 .gs-walkthrough-detail-header {

--- a/packages/monaco/src/browser/monaco-indexed-db.ts
+++ b/packages/monaco/src/browser/monaco-indexed-db.ts
@@ -90,7 +90,7 @@ export async function deleteTheme(id: string): Promise<void> {
 
 export function stateToTheme(state: MonacoThemeState): Theme {
     const { id, label, description, uiTheme, data } = state;
-    const type = uiTheme === 'vs' ? 'light' : uiTheme === 'vs-dark' ? 'dark' : 'hc';
+    const type = uiTheme === 'vs' ? 'light' : uiTheme === 'vs-dark' ? 'dark' : uiTheme === 'hc-light' ? 'hcLight' : 'hc';
     return {
         type,
         id,

--- a/packages/monaco/src/browser/monaco-theming-service.ts
+++ b/packages/monaco/src/browser/monaco-theming-service.ts
@@ -163,7 +163,7 @@ export class MonacoThemingService {
     protected updateBodyUiTheme(): void {
         this.toUpdateUiTheme.dispose();
         const type = this.themeService.getCurrentTheme().type;
-        const uiTheme: monaco.editor.BuiltinTheme = type === 'hc' ? 'hc-black' : type === 'light' ? 'vs' : 'vs-dark';
+        const uiTheme: monaco.editor.BuiltinTheme = type === 'hc' ? 'hc-black' : type === 'hcLight' ? 'hc-light' : type === 'light' ? 'vs' : 'vs-dark';
         document.body.classList.add(uiTheme);
         this.toUpdateUiTheme.push(Disposable.create(() => document.body.classList.remove(uiTheme)));
     }

--- a/packages/plugin-utils/src/common/contribution-types.ts
+++ b/packages/plugin-utils/src/common/contribution-types.ts
@@ -290,7 +290,7 @@ export interface PluginColorContribution {
     defaults?: { light?: string, dark?: string, highContrast?: string };
 }
 
-export type PluginUiTheme = 'vs' | 'vs-dark' | 'hc-black';
+export type PluginUiTheme = 'vs' | 'vs-dark' | 'hc-black' | 'hc-light';
 
 export interface PluginThemeContribution {
     id?: string;

--- a/packages/plugin-utils/src/node/normalize-contributions.spec.ts
+++ b/packages/plugin-utils/src/node/normalize-contributions.spec.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { CustomEditorPriority, type GrammarsContribution, type WalkthroughContribution } from '../common/contribution-types';
+import { CustomEditorPriority, type GrammarsContribution, type PluginUiTheme, type WalkthroughContribution } from '../common/contribution-types';
 import { PreferenceScope } from '../common/protocol-shims';
 import {
     deriveDefaultForType,
@@ -316,6 +316,29 @@ describe('normalize-contributions', () => {
                 description: undefined,
                 uiTheme: undefined
             }]);
+        });
+
+        // A `uiTheme` that does not survive normalization falls back to `vs-dark` in the frontend, which
+        // files the theme under the dark ones and resolves its colors through the dark path.
+        it('keeps every ui theme, including hc-light', () => {
+            const ctx = createNormalizeCtx(undefined, undefined);
+            const plugin = manifest({
+                name: 'themes',
+                contributes: {
+                    themes: [
+                        { id: 'light', label: 'Light', uiTheme: 'vs', path: './themes/light.json' },
+                        { id: 'dark', label: 'Dark', uiTheme: 'vs-dark', path: './themes/dark.json' },
+                        { id: 'hc', label: 'HC', uiTheme: 'hc-black', path: './themes/hc.json' },
+                        { id: 'hc-light', label: 'HC Light', uiTheme: 'hc-light', path: './themes/hc-light.json' },
+                        // Manifests are untyped JSON, so an unknown value has to be dropped rather than passed on.
+                        { id: 'bogus', label: 'Bogus', uiTheme: 'nonsense' as PluginUiTheme, path: './themes/bogus.json' }
+                    ]
+                }
+            });
+            ctx.plugin = plugin;
+
+            expect(readThemes(ctx, plugin)?.map(theme => theme.uiTheme))
+                .to.deep.equal(['vs', 'vs-dark', 'hc-black', 'hc-light', undefined]);
         });
 
         it('validates color contributions and reports invalid ids', () => {

--- a/packages/plugin-utils/src/node/normalize-contributions.ts
+++ b/packages/plugin-utils/src/node/normalize-contributions.ts
@@ -82,7 +82,7 @@ import { rawContributes, type PluginManifest } from '../common/manifest-types';
 import { UNPUBLISHED } from '../common/constants';
 
 function isPluginUiTheme(value: unknown): value is PluginUiTheme {
-    return value === 'vs' || value === 'vs-dark' || value === 'hc-black';
+    return value === 'vs' || value === 'vs-dark' || value === 'hc-black' || value === 'hc-light';
 }
 
 export const colorIdPattern = '^\\w+[.\\w+]*$';


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description and review
the requirements below.

Contributors guide: https://github.com/theia-ide/theia/blob/master/CONTRIBUTING.md

Note: Security vulnerabilities should not be disclosed on GitHub, through a PR or any
other means. See SECURITY.md at the root of this repository, to learn how to report
vulnerabilities.
-->

#### What it does

<!-- Include relevant issues and describe how they are addressed. -->

**feat(getting-started): add Open Walkthrough to the Help menu**

- register the command in Help, right after Welcome
- drop the fixed height that always left the walkthrough view scrollable

**fix(core): keep hover tooltips stable and interactive** 

Resolves #17930

- hide the hover host while it is measured at (0,0), where the one-frame
  flash overlapped targets in the upper-left and cancelled the hover
- stop the chat session item from cancelling on mouse-leave and mouse-over,
  so the pointer can move onto the tooltip to read or copy it

**fix(ai-ide): toggle an AI configuration category on single click** 

- drop `expandOnlyOnExpansionToggleClick`, so a click selects and toggles
  the category like a click in the explorer does
- opening the category page no longer needs a second click on the
  expansion toggle

**fix(plugin-utils): keep the hc-light ui theme of a plugin theme** 

`hc-light` was missing from the accepted `uiTheme` values, so a plugin
theme declaring it was normalized to `undefined`, fell back to `vs-dark`
and ended up listed under the dark themes.

- accept `hc-light` in `PluginUiTheme` and its type guard
- map `hc-light` to the `hcLight` theme type instead of `hc`
- set the `hc-light` body class for an `hcLight` theme instead of `vs-dark`

#### How to test

<!-- Explain how a reviewer can reproduce a bug, test new functionality or verify performance improvements. -->

1. `Help > Open Walkthrough...` opens a walkthrough. All walkthrough detail views show no scrollbar when the content fits.
2. Hover a session in the AI Sessions view (if it is in the left sidebar): the tooltip settles instead of flickering. This mostly happend for active sessions at the top of the list (as active sessions usually have more detailed and longer tooltips than the restored ones, this was the reason where the flickering happened). It can also be observed int he extensions view if you have a list of search results and hover the first search results on the very top of the card.
Also for the AI Sessions view: the pointer can move onto the tooltip content to be able to copy it for example.
3. In the AI configuration view, one click on expandable categories like `Agents` and verify it opens its page and toggles its expansion state as for other trees in Theia, like the explorer file tree.
4. `Preferences: Color Theme`: `Light High Contrast` sits again under `high contrast themes`.

#### Follow-ups

<!-- Please list potential follow-up work, including known issues, possible future work, identified technical debt, and potentially introduced technical debt. If the PR introduces technical debt, specify the reason why this is acceptable. Please create tickets and link them here. Please use the label "technical debt" for new issues when it applies. -->

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

<!-- If the changelog entry for this change should contain an attribution at the end (e.g. Contributed on behalf of x) add it in this section -->

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
