### PR TITLE
fix(ai-ide): reject malformed userInteraction arguments

### DIFF
--- a/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
@@ -554,7 +554,8 @@ export class UserInteractionToolRenderer implements ChatResponsePartRenderer<Too
     }
 
     render(response: ToolCallChatResponseContent, parentNode: ResponseNode): ReactNode {
-        const args = parseUserInteractionArgs(response.arguments);
+        const validation = parseUserInteractionArgs(response.arguments);
+        const args = validation.ok ? validation.args : undefined;
 
         if (!args || !response.id) {
             // The tool already returned a result but the args don't validate: this

--- a/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
+++ b/packages/ai-ide/src/browser/user-interaction-tool-renderer.tsx
@@ -494,8 +494,13 @@ const MalformedInteraction: React.FC<{ message: string }> = ({ message }) => (
     </div>
 );
 
-interface ToolErrorResult { error: string }
-function parseToolErrorResult(raw: unknown): ToolErrorResult | undefined {
+/**
+ * Extract the message to show for a tool result that the renderer cannot turn into an interaction.
+ * Covers both shapes the tool can produce for malformed arguments: the `{ error }` result of the
+ * handler, and the `{ denied: true, reason }` result of the auto-deny in `checkAutoAction`, which
+ * is what a validation failure produces before the handler ever runs.
+ */
+function extractErrorMessage(raw: unknown): string | undefined {
     let candidate: unknown = raw;
     if (typeof raw === 'string') {
         try {
@@ -504,8 +509,15 @@ function parseToolErrorResult(raw: unknown): ToolErrorResult | undefined {
             return undefined;
         }
     }
-    if (candidate && typeof candidate === 'object' && typeof (candidate as { error?: unknown }).error === 'string') {
-        return candidate as ToolErrorResult;
+    if (!candidate || typeof candidate !== 'object') {
+        return undefined;
+    }
+    const error = (candidate as { error?: unknown }).error;
+    if (typeof error === 'string') {
+        return error;
+    }
+    if (ToolCallChatResponseContent.isDenialResult(candidate) && typeof candidate.reason === 'string') {
+        return candidate.reason;
     }
     return undefined;
 }
@@ -563,8 +575,7 @@ export class UserInteractionToolRenderer implements ChatResponsePartRenderer<Too
             // rejected, or arguments that fail shared parsing). Show an error state
             // instead of a perpetual loading spinner.
             if (response.result !== undefined) {
-                const error = parseToolErrorResult(response.result);
-                const message = error?.error
+                const message = extractErrorMessage(response.result)
                     ?? nls.localize('theia/ai-ide/userInteractionMalformedFallback', 'The arguments could not be parsed.');
                 return <MalformedInteraction message={message} />;
             }

--- a/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
@@ -119,13 +119,57 @@ describe('UserInteractionTool', () => {
     it('should return error when no interactions are provided', async () => {
         const handler = tool.getTool().handler;
         const result = await handler(JSON.stringify({ interactions: [] }), { toolCallId: 'x' });
-        expect(JSON.parse(result as string).error).to.equal('No interactions provided');
+        expect(JSON.parse(result as string).error).to.match(/at least one step/);
     });
 
     it('should return error when arguments are invalid JSON', async () => {
         const handler = tool.getTool().handler;
         const result = await handler('not-json', { toolCallId: 'x' });
-        expect(JSON.parse(result as string).error).to.equal('Invalid arguments');
+        expect(JSON.parse(result as string).error).to.match(/valid JSON/i);
+    });
+
+    it('should reject a single step whose options are malformed instead of auto-completing it', async () => {
+        const handler = tool.getTool().handler;
+        const args = JSON.stringify({
+            interactions: [{
+                title: 'Apply fix?',
+                message: 'Should I apply this change?',
+                options: '[{"text":"Yes","value":"yes"}]'
+            }]
+        });
+        const result = JSON.parse(await handler(args, { toolCallId: 'malformed-options' }) as string);
+        expect(result.error).to.match(/step 1: "options" must be an array/i);
+        expect(result.completed).to.be.undefined;
+    });
+
+    it('should reject a single step with a partially malformed options array instead of silently dropping the bad option', async () => {
+        const handler = tool.getTool().handler;
+        const args = JSON.stringify({
+            interactions: [{
+                title: 'Apply fix?',
+                message: 'Should I apply this change?',
+                options: [{ text: 'Approve', value: 'approve' }, { text: 'Reject', value: 'reject' }, { label: 'Defer', value: 'defer' }]
+            }]
+        });
+        const result = JSON.parse(await handler(args, { toolCallId: 'partial-options' }) as string);
+        expect(result.error).to.match(/step 1, option 3: "text" and "value" are required strings/i);
+        expect(result.completed).to.be.undefined;
+    });
+
+    it('should reject a JSON-encoded interactions string with an actionable message', async () => {
+        const handler = tool.getTool().handler;
+        const args = JSON.stringify({ interactions: '[{"title":"T","message":"M"}]' });
+        const result = JSON.parse(await handler(args, { toolCallId: 'encoded-interactions' }) as string);
+        expect(result.error).to.match(/"interactions" must be an array of step objects, received string/);
+        expect(result.error).to.match(/do not JSON-encode nested values/i);
+    });
+
+    it('should auto-complete a single step that genuinely has no options', async () => {
+        const handler = tool.getTool().handler;
+        const args = JSON.stringify({ interactions: [{ title: 'FYI', message: 'Heads up' }] });
+        const result = parseResult(await handler(args, { toolCallId: 'informational' }));
+        expect(result.completed).to.be.true;
+        expect(result.steps).to.deep.equal([{ title: 'FYI' }]);
     });
 
     it('should return error when no tool call ID is available', async () => {

--- a/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.spec.ts
@@ -172,6 +172,22 @@ describe('UserInteractionTool', () => {
         expect(result.steps).to.deep.equal([{ title: 'FYI' }]);
     });
 
+    describe('checkAutoAction', () => {
+
+        it('should auto-deny malformed arguments so the model receives the validation error', () => {
+            const args = JSON.stringify({
+                interactions: [{ title: 'Apply fix?', message: 'Confirm?', options: '[{"text":"Yes","value":"yes"}]' }]
+            });
+            const autoAction = tool.getTool().checkAutoAction!(args);
+            expect(autoAction?.action).to.equal('deny');
+            expect(autoAction?.reason).to.match(/step 1: "options" must be an array/i);
+        });
+
+        it('should not auto-deny well-formed arguments, leaving confirmation to the user', () => {
+            expect(tool.getTool().checkAutoAction!(singleStepArgs())).to.be.undefined;
+        });
+    });
+
     it('should return error when no tool call ID is available', async () => {
         const handler = tool.getTool().handler;
         const result = await handler(singleStepArgs(), undefined);

--- a/packages/ai-ide/src/browser/user-interaction-tool.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.ts
@@ -103,8 +103,9 @@ const STEP_SCHEMA: ToolRequestParameterProperty = {
                 },
                 required: ['text', 'value']
             },
-            description: 'Optional buttons offered to the user for this step. Omit for purely informational steps; '
-                + 'a hardcoded "Next"/"Finish" button is always shown to advance.'
+            description: 'Buttons offered to the user for this step. Must be a real array of objects, never a JSON-encoded string. '
+                + 'Omit it (or pass an empty array) only for purely informational steps: a step without options is never a confirmation, '
+                + 'so never use one to ask for approval. In a multi-step interaction a hardcoded "Next"/"Finish" button is always shown to advance.'
         },
         links: {
             type: 'array',
@@ -144,7 +145,8 @@ const TOOL_PARAMETERS: ToolRequestParameters = {
         interactions: {
             type: 'array',
             items: STEP_SCHEMA,
-            description: 'Ordered list of interaction steps. The user walks through them sequentially and can revisit previous steps.'
+            description: 'Ordered list of interaction steps, as a real JSON array of objects (never a JSON-encoded string). '
+                + 'The user walks through them sequentially and can revisit previous steps.'
         }
     },
     required: ['interactions']
@@ -161,7 +163,10 @@ const TOOL_DESCRIPTION = 'Present an interactive user interaction. Each step has
     + 'The tool returns a JSON string with { "completed": boolean, "steps": [{ "title", "value"?, "comments"?, "skipped"? }] }. '
     + 'If the user cancels mid-interaction, the tool returns whatever has been collected so far with "completed": false. '
     + 'Use this to walk users through a series of pre-determined findings or decisions in a single tool call, '
-    + 'or to surface a single message/diff that should be shown inline in the chat.';
+    + 'or to surface a single message/diff that should be shown inline in the chat. '
+    + 'Arguments are validated strictly: pass nested values as real JSON arrays and objects, never as JSON-encoded strings. '
+    + 'A malformed step or option is rejected with an error naming what to fix, rather than being dropped - '
+    + 'so a step that asks for a decision can never be silently downgraded to an informational one.';
 
 @injectable()
 export class UserInteractionTool implements ToolProvider {
@@ -310,18 +315,14 @@ export class UserInteractionTool implements ToolProvider {
     }
 
     protected async handleInteraction(argString: string, ctx: ToolInvocationContext | undefined): Promise<string> {
-        try {
-            JSON.parse(argString);
-        } catch {
-            return JSON.stringify({ error: 'Invalid arguments' });
-        }
         // Validate via the shared parser so the tool only ever waits for steps that
-        // the renderer would actually render. Otherwise the agent could send a
-        // step the UI filters out, leaving the tool blocked on input forever.
-        const validated = parseUserInteractionArgs(argString);
-        if (!validated || validated.interactions.length === 0) {
-            return JSON.stringify({ error: 'No interactions provided' });
+        // the renderer would actually render, and so that anything the agent got
+        // wrong is reported back to it verbatim instead of being silently dropped.
+        const validation = parseUserInteractionArgs(argString);
+        if (!validation.ok) {
+            return JSON.stringify({ error: validation.error });
         }
+        const validated = validation.args;
 
         const toolCallId = ToolInvocationContext.getToolCallId(ctx);
         if (!toolCallId) {

--- a/packages/ai-ide/src/browser/user-interaction-tool.ts
+++ b/packages/ai-ide/src/browser/user-interaction-tool.ts
@@ -15,7 +15,7 @@
 // *****************************************************************************
 
 import { ToolProvider, ToolRequest, ToolRequestParameterProperty, ToolRequestParameters } from '@theia/ai-core';
-import { ToolInvocationContext } from '@theia/ai-core/lib/common/language-model';
+import { AutoActionResult, ToolInvocationContext } from '@theia/ai-core/lib/common/language-model';
 import { ChatToolContext } from '@theia/ai-chat';
 import { DiffUris } from '@theia/core/lib/browser/diff-uris';
 import { open, OpenerService } from '@theia/core/lib/browser';
@@ -103,7 +103,7 @@ const STEP_SCHEMA: ToolRequestParameterProperty = {
                 },
                 required: ['text', 'value']
             },
-            description: 'Buttons offered to the user for this step. Must be a real array of objects, never a JSON-encoded string. '
+            description: 'Buttons offered to the user for this step. '
                 + 'Omit it (or pass an empty array) only for purely informational steps: a step without options is never a confirmation, '
                 + 'so never use one to ask for approval. In a multi-step interaction a hardcoded "Next"/"Finish" button is always shown to advance.'
         },
@@ -145,8 +145,7 @@ const TOOL_PARAMETERS: ToolRequestParameters = {
         interactions: {
             type: 'array',
             items: STEP_SCHEMA,
-            description: 'Ordered list of interaction steps, as a real JSON array of objects (never a JSON-encoded string). '
-                + 'The user walks through them sequentially and can revisit previous steps.'
+            description: 'Ordered list of interaction steps. The user walks through them sequentially and can revisit previous steps.'
         }
     },
     required: ['interactions']
@@ -164,9 +163,7 @@ const TOOL_DESCRIPTION = 'Present an interactive user interaction. Each step has
     + 'If the user cancels mid-interaction, the tool returns whatever has been collected so far with "completed": false. '
     + 'Use this to walk users through a series of pre-determined findings or decisions in a single tool call, '
     + 'or to surface a single message/diff that should be shown inline in the chat. '
-    + 'Arguments are validated strictly: pass nested values as real JSON arrays and objects, never as JSON-encoded strings. '
-    + 'A malformed step or option is rejected with an error naming what to fix, rather than being dropped - '
-    + 'so a step that asks for a decision can never be silently downgraded to an informational one.';
+    + 'Pass nested values as real JSON arrays and objects, never as JSON-encoded strings.';
 
 @injectable()
 export class UserInteractionTool implements ToolProvider {
@@ -199,8 +196,20 @@ export class UserInteractionTool implements ToolProvider {
             providerName: 'ai-ide',
             description: TOOL_DESCRIPTION,
             parameters: TOOL_PARAMETERS,
-            handler: (argString: string, ctx) => this.handleInteraction(argString, ctx)
+            handler: (argString: string, ctx) => this.handleInteraction(argString, ctx),
+            checkAutoAction: (argString: string) => this.checkArguments(argString)
         };
+    }
+
+    /**
+     * Auto-deny invocations whose arguments do not validate, handing the validation error back to
+     * the model. Without this the confirmation flow would stall: the renderer refuses to mount the
+     * interaction (and with it the Allow/Deny buttons) for arguments it cannot render, so a
+     * confirmation that nobody can give would be awaited indefinitely.
+     */
+    protected checkArguments(argString: string): AutoActionResult | undefined {
+        const validation = parseUserInteractionArgs(argString);
+        return validation.ok ? undefined : { action: 'deny', reason: validation.error };
     }
 
     /**

--- a/packages/ai-ide/src/common/user-interaction-tool.spec.ts
+++ b/packages/ai-ide/src/common/user-interaction-tool.spec.ts
@@ -15,205 +15,226 @@
 // *****************************************************************************
 
 import { expect } from 'chai';
-import { buildDiffLabel, parseUserInteractionArgs, parseUserInteractionInput } from './user-interaction-tool';
+import { UserInteractionArgs, buildDiffLabel, parseUserInteractionArgs, parseUserInteractionInput } from './user-interaction-tool';
+
+function expectRejected(input: string | undefined): string {
+    const result = parseUserInteractionArgs(input);
+    expect(result.ok, `expected a rejection but got: ${JSON.stringify(result)}`).to.be.false;
+    return (result as { ok: false, error: string }).error;
+}
+
+function expectAccepted(input: string): UserInteractionArgs {
+    const result = parseUserInteractionArgs(input);
+    expect(result.ok, `expected acceptance but got: ${JSON.stringify(result)}`).to.be.true;
+    return (result as { ok: true, args: UserInteractionArgs }).args;
+}
 
 describe('parseUserInteractionArgs', () => {
-    it('should return undefined for undefined input', () => {
-        expect(parseUserInteractionArgs(undefined)).to.be.undefined;
-    });
 
-    it('should return undefined for invalid JSON', () => {
-        expect(parseUserInteractionArgs('not json')).to.be.undefined;
-    });
+    describe('rejecting malformed arguments', () => {
 
-    it('should return undefined when interactions is missing', () => {
-        const input = JSON.stringify({ foo: 'bar' });
-        expect(parseUserInteractionArgs(input)).to.be.undefined;
-    });
-
-    it('should return undefined when interactions is not an array', () => {
-        const input = JSON.stringify({ interactions: 'nope' });
-        expect(parseUserInteractionArgs(input)).to.be.undefined;
-    });
-
-    it('should return undefined when no step is valid', () => {
-        const input = JSON.stringify({ interactions: [{ foo: 'bar' }, { title: 1 }] });
-        expect(parseUserInteractionArgs(input)).to.be.undefined;
-    });
-
-    it('should drop steps that are missing title or message', () => {
-        const input = JSON.stringify({
-            interactions: [
-                { title: 'Valid', message: 'Hello' },
-                { title: 'No message' },
-                { message: 'No title' }
-            ]
+        it('should reject undefined input', () => {
+            expect(expectRejected(undefined)).to.match(/no arguments/i);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result).to.not.be.undefined;
-        expect(result!.interactions).to.have.length(1);
-        expect(result!.interactions[0].title).to.equal('Valid');
-    });
 
-    it('should accept a step without options (informational)', () => {
-        const input = JSON.stringify({
-            interactions: [{ title: 'Info', message: 'Just so you know' }]
+        it('should reject input that is not valid JSON', () => {
+            expect(expectRejected('not json')).to.match(/valid JSON/i);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result).to.not.be.undefined;
-        expect(result!.interactions[0].options).to.be.undefined;
-    });
 
-    it('should filter out invalid options within a step', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                options: [{ text: 'A', value: 'a' }, { bad: true }, { text: 'B', value: 'b' }]
-            }]
+        it('should reject arguments without an interactions property', () => {
+            expect(expectRejected(JSON.stringify({ foo: 'bar' }))).to.match(/"interactions" must be an array of step objects/);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].options).to.have.length(2);
-    });
 
-    it('should drop options array if no options are valid', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                options: [{ bad: true }]
-            }]
+        it('should reject a JSON-encoded interactions string and name the received type', () => {
+            const error = expectRejected(JSON.stringify({ interactions: '[{"title":"T","message":"M"}]' }));
+            expect(error).to.match(/"interactions" must be an array of step objects, received string/);
+            expect(error).to.match(/do not JSON-encode nested values/i);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].options).to.be.undefined;
-    });
 
-    it('should normalize singular link into a links array on a step', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                options: [{ text: 'A', value: 'a' }],
-                link: { ref: 'src/index.ts' }
-            }]
+        it('should reject an empty interactions array', () => {
+            expect(expectRejected(JSON.stringify({ interactions: [] }))).to.match(/at least one step/);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].links).to.deep.equal([{ ref: 'src/index.ts' }]);
-    });
 
-    it('should accept a links array with multiple entries', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                options: [{ text: 'A', value: 'a' }],
-                links: [
-                    { ref: 'src/a.ts' },
-                    { ref: 'src/old.ts', rightRef: 'src/new.ts' }
-                ]
-            }]
+        it('should reject a step that is missing its message, naming the step position', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [{ title: 'Valid', message: 'Hello' }, { title: 'No message' }]
+            }));
+            expect(error).to.match(/step 2: "title" and "message" are required strings/i);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].links).to.have.length(2);
-    });
 
-    it('should filter out invalid links from a step', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                options: [{ text: 'A', value: 'a' }],
-                links: [
-                    { ref: 'src/a.ts' },
-                    { noRef: true },
-                    { ref: '' }
-                ]
-            }]
+        it('should reject a step that is missing its title, naming the step position', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [{ message: 'No title' }]
+            }));
+            expect(error).to.match(/step 1: "title" and "message" are required strings/i);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].links).to.have.length(1);
-    });
 
-    it('should ignore invalid rightRef placeholders and keep multi-step file links', () => {
-        const emptyRightRefPlaceholder = {
-            path: '',
-            gitRef: '',
-            line: 0,
-            empty: false,
-            label: ''
-        };
-        const input = JSON.stringify({
-            interactions: ['README.md', 'package.json', 'CONTRIBUTING.md'].map((path, index) => ({
-                title: `File link: ${path}`,
-                message: 'Open the file link.',
-                links: [{
-                    ref: { path, gitRef: '', line: 1, empty: false, label: '' },
-                    rightRef: emptyRightRefPlaceholder,
-                    label: `Open ${path}`,
-                    autoOpen: index === 0
+        it('should reject a step whose options are a JSON-encoded string', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [{ title: 'Apply fix?', message: 'M', options: '[{"text":"Yes","value":"yes"}]' }]
+            }));
+            expect(error).to.match(/step 1: "options" must be an array of \{text, value\} objects, received string/i);
+            expect(error).to.match(/do not JSON-encode nested values/i);
+        });
+
+        it('should reject a step when a single option is malformed, even though others are valid', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    options: [{ text: 'A', value: 'a' }, { label: 'B', value: 'b' }, { text: 'C', value: 'c' }]
                 }]
-            }))
+            }));
+            expect(error).to.match(/step 1, option 2: "text" and "value" are required strings/i);
         });
 
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions.map(step => step.links![0])).to.deep.equal([
-            { ref: { path: 'README.md', line: 1 }, label: 'Open README.md', autoOpen: true },
-            { ref: { path: 'package.json', line: 1 }, label: 'Open package.json', autoOpen: false },
-            { ref: { path: 'CONTRIBUTING.md', line: 1 }, label: 'Open CONTRIBUTING.md', autoOpen: false }
-        ]);
+        it('should reject plain string options', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [{ title: 'T', message: 'M', options: ['Yes', 'No'] }]
+            }));
+            expect(error).to.match(/step 1, option 1: "text" and "value" are required strings/i);
+        });
+
+        it('should report the offending option position within the offending step', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [
+                    { title: 'Fine', message: 'M', options: [{ text: 'A', value: 'a' }] },
+                    { title: 'Broken', message: 'M', options: [{ text: 'A', value: 'a' }, { text: 'B' }] }
+                ]
+            }));
+            expect(error).to.match(/step 2, option 2: "text" and "value" are required strings/i);
+        });
     });
 
-    it('should accept multiple steps in order', () => {
-        const input = JSON.stringify({
-            interactions: [
-                { title: 'Overview', message: 'PR summary' },
-                { title: 'Area 1', message: 'finding', options: [{ text: 'OK', value: 'approve' }] },
-                { title: 'Area 2', message: 'no findings' }
-            ]
+    describe('accepting well-formed arguments', () => {
+
+        it('should accept a step without options (informational)', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{ title: 'Info', message: 'Just so you know' }]
+            }));
+            expect(args.interactions[0].options).to.be.undefined;
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions).to.have.length(3);
-        expect(result!.interactions[1].options).to.have.length(1);
-        expect(result!.interactions[2].options).to.be.undefined;
+
+        it('should accept an explicitly empty options array as informational', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{ title: 'Info', message: 'Just so you know', options: [] }]
+            }));
+            expect(args.interactions[0].options).to.be.undefined;
+        });
+
+        it('should accept multiple steps in order', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [
+                    { title: 'Overview', message: 'PR summary' },
+                    { title: 'Area 1', message: 'finding', options: [{ text: 'OK', value: 'approve' }] },
+                    { title: 'Area 2', message: 'no findings' }
+                ]
+            }));
+            expect(args.interactions).to.have.length(3);
+            expect(args.interactions[1].options).to.have.length(1);
+            expect(args.interactions[2].options).to.be.undefined;
+        });
+
+        it('should preserve buttonLabel and description in options', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    options: [{ text: 'Confirm changes', value: 'confirm', description: 'Applies the patch', buttonLabel: '✅ Confirm' }]
+                }]
+            }));
+            expect(args.interactions[0].options![0].buttonLabel).to.equal('✅ Confirm');
+            expect(args.interactions[0].options![0].description).to.equal('Applies the patch');
+        });
     });
 
-    it('should preserve buttonLabel in options', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                options: [{ text: 'Confirm changes', value: 'confirm', buttonLabel: '✅ Confirm' }]
-            }]
-        });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].options![0].buttonLabel).to.equal('✅ Confirm');
-    });
+    describe('links remain leniently filtered', () => {
 
-    it('should reject step links with empty path in object ref', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                links: [{ ref: { path: '' } }]
-            }]
+        it('should normalize a singular link into a links array on a step', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    options: [{ text: 'A', value: 'a' }],
+                    link: { ref: 'src/index.ts' }
+                }]
+            }));
+            expect(args.interactions[0].links).to.deep.equal([{ ref: 'src/index.ts' }]);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].links).to.be.undefined;
-    });
 
-    it('should accept step links with EmptyContentRef', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                links: [{ ref: { empty: true, label: 'New file' } }]
-            }]
+        it('should accept a links array with multiple entries', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    links: [{ ref: 'a.ts' }, { ref: 'b.ts', label: 'B' }]
+                }]
+            }));
+            expect(args.interactions[0].links).to.have.length(2);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].links![0].ref).to.deep.equal({ empty: true, label: 'New file' });
-    });
 
-    it('should accept step links with EmptyContentRef as rightRef', () => {
-        const input = JSON.stringify({
-            interactions: [{
-                title: 'T', message: 'M',
-                links: [{ ref: 'src/old.ts', rightRef: { empty: true } }]
-            }]
+        it('should drop invalid links from a step without rejecting the step', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    links: [{ ref: 'a.ts' }, { nope: true }, { ref: 42 }]
+                }]
+            }));
+            expect(args.interactions[0].links).to.have.length(1);
         });
-        const result = parseUserInteractionArgs(input);
-        expect(result!.interactions[0].links![0].rightRef).to.deep.equal({ empty: true });
+
+        it('should ignore invalid rightRef placeholders and keep multi-step file links', () => {
+            const emptyRightRefPlaceholder = {
+                path: '',
+                gitRef: '',
+                line: 0,
+                empty: false,
+                label: ''
+            };
+            const args = expectAccepted(JSON.stringify({
+                interactions: ['README.md', 'package.json', 'CONTRIBUTING.md'].map((path, index) => ({
+                    title: `File link: ${path}`,
+                    message: 'Open the file link.',
+                    links: [{
+                        ref: { path, gitRef: '', line: 1, empty: false, label: '' },
+                        rightRef: emptyRightRefPlaceholder,
+                        label: `Open ${path}`,
+                        autoOpen: index === 0
+                    }]
+                }))
+            }));
+            expect(args.interactions.map(step => step.links![0])).to.deep.equal([
+                { ref: { path: 'README.md', line: 1 }, label: 'Open README.md', autoOpen: true },
+                { ref: { path: 'package.json', line: 1 }, label: 'Open package.json', autoOpen: false },
+                { ref: { path: 'CONTRIBUTING.md', line: 1 }, label: 'Open CONTRIBUTING.md', autoOpen: false }
+            ]);
+        });
+
+        it('should reject step links with empty path in object ref', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    links: [{ ref: { path: '' } }]
+                }]
+            }));
+            expect(args.interactions[0].links).to.be.undefined;
+        });
+
+        it('should accept step links with EmptyContentRef', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    links: [{ ref: { empty: true, label: 'New file' } }]
+                }]
+            }));
+            expect(args.interactions[0].links![0].ref).to.deep.equal({ empty: true, label: 'New file' });
+        });
+
+        it('should accept step links with EmptyContentRef as rightRef', () => {
+            const args = expectAccepted(JSON.stringify({
+                interactions: [{
+                    title: 'T', message: 'M',
+                    links: [{ ref: 'src/old.ts', rightRef: { empty: true } }]
+                }]
+            }));
+            expect(args.interactions[0].links![0].rightRef).to.deep.equal({ empty: true });
+        });
     });
 });
 
@@ -237,34 +258,34 @@ describe('parseUserInteractionInput', () => {
     });
 
     it('should fall back to regex-based title extraction for incomplete JSON', () => {
-        const input = '{"interactions": [{"title": "Streaming Title", "message": "incom';
-        expect(parseUserInteractionInput(input).title).to.equal('Streaming Title');
+        const partial = '{"interactions":[{"title":"Streaming ti';
+        expect(parseUserInteractionInput(partial)).to.deep.equal({ title: 'Streaming ti', stepCount: 0 });
     });
 
     it('should return empty title from incomplete JSON without title field', () => {
-        const input = '{"interactions": [{"message": "no title here';
-        expect(parseUserInteractionInput(input).title).to.equal('');
+        const partial = '{"interactions":[{"mes';
+        expect(parseUserInteractionInput(partial)).to.deep.equal({ title: '', stepCount: 0 });
     });
 });
 
 describe('buildDiffLabel', () => {
     it('formats two empty refs', () => {
-        expect(buildDiffLabel({ empty: true, label: 'New' }, { empty: true, label: 'Deleted' }))
-            .to.equal('New ⟷ Deleted');
+        expect(buildDiffLabel({ empty: true, label: 'before' }, { empty: true, label: 'after' }))
+            .to.equal('before ⟷ after');
     });
 
     it('formats empty left vs path with gitRef', () => {
-        expect(buildDiffLabel({ empty: true, label: 'New' }, { path: 'src/x.ts', gitRef: 'abcdef0123' }))
-            .to.equal('src/x.ts (New ⟷ abcdef0)');
+        expect(buildDiffLabel({ empty: true, label: 'new file' }, { path: 'src/a.ts', gitRef: 'abcdef1234567' }))
+            .to.equal('src/a.ts (new file ⟷ abcdef1)');
     });
 
     it('formats path with gitRef vs working copy of same path', () => {
-        expect(buildDiffLabel({ path: 'src/x.ts', gitRef: 'abcdef0123' }, { path: 'src/x.ts' }))
-            .to.equal('src/x.ts (abcdef0 ⟷ Working Copy)');
+        expect(buildDiffLabel({ path: 'src/a.ts', gitRef: 'abcdef1234567' }, { path: 'src/a.ts' }))
+            .to.equal('src/a.ts (abcdef1 ⟷ Working Copy)');
     });
 
     it('formats two different paths', () => {
-        expect(buildDiffLabel({ path: 'src/old.ts' }, { path: 'src/new.ts' }))
-            .to.equal('src/old.ts ⟷ src/new.ts');
+        expect(buildDiffLabel({ path: 'src/a.ts' }, { path: 'src/b.ts' }))
+            .to.equal('src/a.ts ⟷ src/b.ts');
     });
 });

--- a/packages/ai-ide/src/common/user-interaction-tool.spec.ts
+++ b/packages/ai-ide/src/common/user-interaction-tool.spec.ts
@@ -45,6 +45,20 @@ describe('parseUserInteractionArgs', () => {
             expect(expectRejected(JSON.stringify({ foo: 'bar' }))).to.match(/"interactions" must be an array of step objects/);
         });
 
+        it('should reject a JSON-encoded argument blob and name the received type', () => {
+            const error = expectRejected(JSON.stringify('{"interactions":[{"title":"T","message":"M"}]}'));
+            expect(error).to.match(/arguments must be an object with an "interactions" array, received string/i);
+            expect(error).to.match(/do not JSON-encode nested values/i);
+        });
+
+        it('should reject a top-level array', () => {
+            expect(expectRejected('[]')).to.match(/arguments must be an object with an "interactions" array, received array/i);
+        });
+
+        it('should reject top-level null', () => {
+            expect(expectRejected('null')).to.match(/arguments must be an object with an "interactions" array, received null/i);
+        });
+
         it('should reject a JSON-encoded interactions string and name the received type', () => {
             const error = expectRejected(JSON.stringify({ interactions: '[{"title":"T","message":"M"}]' }));
             expect(error).to.match(/"interactions" must be an array of step objects, received string/);
@@ -87,11 +101,27 @@ describe('parseUserInteractionArgs', () => {
             expect(error).to.match(/step 1, option 2: "text" and "value" are required strings/i);
         });
 
-        it('should reject plain string options', () => {
+        it('should reject options given as an object rather than an array', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [{ title: 'T', message: 'M', options: { text: 'Yes', value: 'yes' } }]
+            }));
+            expect(error).to.match(/step 1: "options" must be an array of \{text, value\} objects, received object/i);
+        });
+
+        it('should reject plain string options and name the received type', () => {
             const error = expectRejected(JSON.stringify({
                 interactions: [{ title: 'T', message: 'M', options: ['Yes', 'No'] }]
             }));
-            expect(error).to.match(/step 1, option 1: "text" and "value" are required strings/i);
+            expect(error).to.match(/step 1, option 1: "text" and "value" are required strings, received string/i);
+            expect(error).to.match(/do not JSON-encode nested values/i);
+        });
+
+        it('should reject a JSON-encoded links string', () => {
+            const error = expectRejected(JSON.stringify({
+                interactions: [{ title: 'T', message: 'M', links: '[{"ref":"a.ts"}]' }]
+            }));
+            expect(error).to.match(/step 1: "links" must be an array of link objects, received string/i);
+            expect(error).to.match(/do not JSON-encode nested values/i);
         });
 
         it('should report the offending option position within the offending step', () => {
@@ -206,7 +236,7 @@ describe('parseUserInteractionArgs', () => {
             ]);
         });
 
-        it('should reject step links with empty path in object ref', () => {
+        it('should drop a link whose object ref has an empty path', () => {
             const args = expectAccepted(JSON.stringify({
                 interactions: [{
                     title: 'T', message: 'M',
@@ -258,34 +288,39 @@ describe('parseUserInteractionInput', () => {
     });
 
     it('should fall back to regex-based title extraction for incomplete JSON', () => {
-        const partial = '{"interactions":[{"title":"Streaming ti';
-        expect(parseUserInteractionInput(partial)).to.deep.equal({ title: 'Streaming ti', stepCount: 0 });
+        const input = '{"interactions": [{"title": "Streaming Title", "message": "incom';
+        expect(parseUserInteractionInput(input).title).to.equal('Streaming Title');
+    });
+
+    it('should extract a partial title from JSON truncated mid-title', () => {
+        const input = '{"interactions":[{"title":"Streaming ti';
+        expect(parseUserInteractionInput(input)).to.deep.equal({ title: 'Streaming ti', stepCount: 0 });
     });
 
     it('should return empty title from incomplete JSON without title field', () => {
-        const partial = '{"interactions":[{"mes';
-        expect(parseUserInteractionInput(partial)).to.deep.equal({ title: '', stepCount: 0 });
+        const input = '{"interactions": [{"message": "no title here';
+        expect(parseUserInteractionInput(input).title).to.equal('');
     });
 });
 
 describe('buildDiffLabel', () => {
     it('formats two empty refs', () => {
-        expect(buildDiffLabel({ empty: true, label: 'before' }, { empty: true, label: 'after' }))
-            .to.equal('before ⟷ after');
+        expect(buildDiffLabel({ empty: true, label: 'New' }, { empty: true, label: 'Deleted' }))
+            .to.equal('New ⟷ Deleted');
     });
 
     it('formats empty left vs path with gitRef', () => {
-        expect(buildDiffLabel({ empty: true, label: 'new file' }, { path: 'src/a.ts', gitRef: 'abcdef1234567' }))
-            .to.equal('src/a.ts (new file ⟷ abcdef1)');
+        expect(buildDiffLabel({ empty: true, label: 'New' }, { path: 'src/x.ts', gitRef: 'abcdef0123' }))
+            .to.equal('src/x.ts (New ⟷ abcdef0)');
     });
 
     it('formats path with gitRef vs working copy of same path', () => {
-        expect(buildDiffLabel({ path: 'src/a.ts', gitRef: 'abcdef1234567' }, { path: 'src/a.ts' }))
-            .to.equal('src/a.ts (abcdef1 ⟷ Working Copy)');
+        expect(buildDiffLabel({ path: 'src/x.ts', gitRef: 'abcdef0123' }, { path: 'src/x.ts' }))
+            .to.equal('src/x.ts (abcdef0 ⟷ Working Copy)');
     });
 
     it('formats two different paths', () => {
-        expect(buildDiffLabel({ path: 'src/a.ts' }, { path: 'src/b.ts' }))
-            .to.equal('src/a.ts ⟷ src/b.ts');
+        expect(buildDiffLabel({ path: 'src/old.ts' }, { path: 'src/new.ts' }))
+            .to.equal('src/old.ts ⟷ src/new.ts');
     });
 });

--- a/packages/ai-ide/src/common/user-interaction-tool.ts
+++ b/packages/ai-ide/src/common/user-interaction-tool.ts
@@ -155,43 +155,91 @@ export function parseUserInteractionResult(raw: unknown): UserInteractionResult 
     return obj as unknown as UserInteractionResult;
 }
 
-export function parseUserInteractionArgs(args: string | undefined): UserInteractionArgs | undefined {
-    if (!args) {
-        return undefined;
+/**
+ * Outcome of validating the raw `userInteraction` tool arguments.
+ *
+ * Validation is strict for anything that determines whether — and how — the user is asked
+ * (`interactions`, each step, and each option), because silently discarding those turns a
+ * decision step into an auto-completed informational one and skips the confirmation gate.
+ * It stays lenient for `links`, which are decoration: an unresolvable link should not
+ * discard the surrounding findings.
+ */
+export type UserInteractionValidation =
+    | { ok: true, args: UserInteractionArgs }
+    | { ok: false, error: string };
+
+type StepValidation =
+    | { ok: true, step: UserInteractionStep }
+    | { ok: false, error: string };
+
+type OptionsValidation =
+    | { ok: true, options?: UserInteractionOption[] }
+    | { ok: false, error: string };
+
+const JSON_ENCODING_HINT = 'Do not JSON-encode nested values - pass real arrays and objects.';
+
+function describeType(value: unknown): string {
+    // eslint-disable-next-line no-null/no-null
+    if (value === null) {
+        return 'null';
     }
-    try {
-        const parsed = JSON.parse(args);
-        if (!Array.isArray(parsed.interactions)) {
-            return undefined;
-        }
-        const validSteps = parsed.interactions
-            .map(parseStep)
-            .filter((step: UserInteractionStep | undefined): step is UserInteractionStep => step !== undefined);
-        if (validSteps.length === 0) {
-            return undefined;
-        }
-        return { interactions: validSteps };
-    } catch {
-        return undefined;
+    if (Array.isArray(value)) {
+        return 'array';
     }
+    return typeof value;
 }
 
-function parseStep(raw: unknown): UserInteractionStep | undefined {
-    if (!raw || typeof raw !== 'object') {
-        return undefined;
+/**
+ * Describe the received type, adding the JSON-encoding hint when a string was received where
+ * a structured value was expected - by far the most common way agents get these arguments wrong.
+ */
+function describeReceived(value: unknown): string {
+    const type = describeType(value);
+    return type === 'string' ? `${type}. ${JSON_ENCODING_HINT}` : `${type}.`;
+}
+
+export function parseUserInteractionArgs(args: string | undefined): UserInteractionValidation {
+    if (!args) {
+        return { ok: false, error: 'No arguments were provided.' };
+    }
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(args);
+    } catch {
+        return { ok: false, error: 'Arguments are not valid JSON.' };
+    }
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return { ok: false, error: `Arguments must be an object with an "interactions" array, received ${describeReceived(parsed)}` };
+    }
+    const interactions = (parsed as Record<string, unknown>).interactions;
+    if (!Array.isArray(interactions)) {
+        return { ok: false, error: `"interactions" must be an array of step objects, received ${describeReceived(interactions)}` };
+    }
+    if (interactions.length === 0) {
+        return { ok: false, error: '"interactions" must contain at least one step.' };
+    }
+    const steps: UserInteractionStep[] = [];
+    for (let index = 0; index < interactions.length; index++) {
+        const step = parseStep(interactions[index], index + 1);
+        if (!step.ok) {
+            return step;
+        }
+        steps.push(step.step);
+    }
+    return { ok: true, args: { interactions: steps } };
+}
+
+function parseStep(raw: unknown, position: number): StepValidation {
+    if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+        return { ok: false, error: `Step ${position}: expected a step object, received ${describeReceived(raw)}` };
     }
     const obj = raw as Record<string, unknown>;
     if (typeof obj.title !== 'string' || typeof obj.message !== 'string') {
-        return undefined;
+        return { ok: false, error: `Step ${position}: "title" and "message" are required strings.` };
     }
-    let options: UserInteractionOption[] | undefined;
-    if (Array.isArray(obj.options)) {
-        const validOptions = obj.options.filter(
-            (opt: unknown) => !!opt && typeof opt === 'object'
-                && typeof (opt as Record<string, unknown>).text === 'string'
-                && typeof (opt as Record<string, unknown>).value === 'string'
-        ) as UserInteractionOption[];
-        options = validOptions.length > 0 ? validOptions : undefined;
+    const options = parseOptions(obj.options, position);
+    if (!options.ok) {
+        return options;
     }
     let links: UserInteractionLink[] | undefined;
     if (Array.isArray(obj.links)) {
@@ -206,11 +254,52 @@ function parseStep(raw: unknown): UserInteractionStep | undefined {
         }
     }
     return {
-        title: obj.title,
-        message: obj.message,
-        options,
-        links
+        ok: true,
+        step: {
+            title: obj.title,
+            message: obj.message,
+            options: options.options,
+            links
+        }
     };
+}
+
+/**
+ * Validate a step's `options`. An absent or explicitly empty list means the step is
+ * informational; anything else must be a fully well-formed array, since a partially
+ * dropped option would silently offer the user a different choice than the agent intended.
+ */
+function parseOptions(raw: unknown, stepPosition: number): OptionsValidation {
+    // eslint-disable-next-line no-null/no-null
+    if (raw === undefined || raw === null) {
+        return { ok: true, options: undefined };
+    }
+    if (!Array.isArray(raw)) {
+        return {
+            ok: false,
+            error: `Step ${stepPosition}: "options" must be an array of {text, value} objects, received ${describeReceived(raw)}`
+        };
+    }
+    const options: UserInteractionOption[] = [];
+    for (let index = 0; index < raw.length; index++) {
+        const candidate = raw[index];
+        if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
+            return { ok: false, error: `Step ${stepPosition}, option ${index + 1}: "text" and "value" are required strings.` };
+        }
+        const obj = candidate as Record<string, unknown>;
+        if (typeof obj.text !== 'string' || typeof obj.value !== 'string') {
+            return { ok: false, error: `Step ${stepPosition}, option ${index + 1}: "text" and "value" are required strings.` };
+        }
+        const option: UserInteractionOption = { text: obj.text, value: obj.value };
+        if (typeof obj.description === 'string') {
+            option.description = obj.description;
+        }
+        if (typeof obj.buttonLabel === 'string') {
+            option.buttonLabel = obj.buttonLabel;
+        }
+        options.push(option);
+    }
+    return { ok: true, options: options.length > 0 ? options : undefined };
 }
 
 function normalizeContentRef(ref: unknown): ContentRef | undefined {

--- a/packages/ai-ide/src/common/user-interaction-tool.ts
+++ b/packages/ai-ide/src/common/user-interaction-tool.ts
@@ -161,8 +161,10 @@ export function parseUserInteractionResult(raw: unknown): UserInteractionResult 
  * Validation is strict for anything that determines whether — and how — the user is asked
  * (`interactions`, each step, and each option), because silently discarding those turns a
  * decision step into an auto-completed informational one and skips the confirmation gate.
- * It stays lenient for `links`, which are decoration: an unresolvable link should not
- * discard the surrounding findings.
+ * Individual `links` stay lenient, because they are decoration: an unresolvable link should
+ * not discard the surrounding findings. The `links` container itself is still strict, since a
+ * JSON-encoded list drops every link at once and leaves the step without the content it is
+ * about — the same failure as a JSON-encoded `options` list, not an unresolvable entry.
  */
 export type UserInteractionValidation =
     | { ok: true, args: UserInteractionArgs }
@@ -242,11 +244,15 @@ function parseStep(raw: unknown, position: number): StepValidation {
         return options;
     }
     let links: UserInteractionLink[] | undefined;
-    if (Array.isArray(obj.links)) {
-        const filtered = obj.links
+    // eslint-disable-next-line no-null/no-null
+    const rawLinks = obj.links === null ? undefined : obj.links;
+    if (Array.isArray(rawLinks)) {
+        const filtered = rawLinks
             .map(normalizeUserInteractionLink)
             .filter((link: UserInteractionLink | undefined): link is UserInteractionLink => link !== undefined);
         links = filtered.length > 0 ? filtered : undefined;
+    } else if (rawLinks !== undefined) {
+        return { ok: false, error: `Step ${position}: "links" must be an array of link objects, received ${describeReceived(rawLinks)}` };
     } else {
         const link = normalizeUserInteractionLink(obj.link);
         if (link) {
@@ -283,12 +289,12 @@ function parseOptions(raw: unknown, stepPosition: number): OptionsValidation {
     const options: UserInteractionOption[] = [];
     for (let index = 0; index < raw.length; index++) {
         const candidate = raw[index];
-        if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) {
-            return { ok: false, error: `Step ${stepPosition}, option ${index + 1}: "text" and "value" are required strings.` };
-        }
-        const obj = candidate as Record<string, unknown>;
-        if (typeof obj.text !== 'string' || typeof obj.value !== 'string') {
-            return { ok: false, error: `Step ${stepPosition}, option ${index + 1}: "text" and "value" are required strings.` };
+        const obj = candidate as Record<string, unknown> | undefined;
+        if (!obj || typeof obj !== 'object' || Array.isArray(obj) || typeof obj.text !== 'string' || typeof obj.value !== 'string') {
+            return {
+                ok: false,
+                error: `Step ${stepPosition}, option ${index + 1}: "text" and "value" are required strings, received ${describeReceived(candidate)}`
+            };
         }
         const option: UserInteractionOption = { text: obj.text, value: obj.value };
         if (typeof obj.description === 'string') {


### PR DESCRIPTION
#### What it does

`parseUserInteractionArgs` silently dropped malformed steps and options from `userInteraction` tool calls. That degraded a decision step into an informational one and skipped the confirmation gate entirely:

```jsonc
// options sent as a JSON-encoded string (or with "label" instead of "text")
{"interactions": [{"title": "Apply fix?", "message": "…", "options": "[{\"text\":\"Yes\",\"value\":\"yes\"}]"}]}
```

The options were dropped, the step became a single step with no options, and `handleInteraction`'s auto-complete shortcut returned `{"completed": true, "steps": [{"title": "Apply fix?"}]}` without ever showing the user a choice. An agent asking for confirmation got back an apparent approval nobody gave. Partial degradation had the same flavour: `[Approve, {label: …}, Defer]` silently offered the user two buttons while the agent believed it had offered three.

Validation is now strict for everything that determines **whether and how the user is asked** — `interactions`, each step, and each option — and stays lenient for `links`, which are decoration: an unresolvable link should not discard the surrounding findings.

| Input | Before | After |
| --- | --- | --- |
| `interactions: "[…]"` | `error: No interactions provided` | `"interactions" must be an array of step objects, received string. Do not JSON-encode nested values …` |
| `options: "[…]"` (single step) | auto-completed, `completed: true` | `Step 1: "options" must be an array of {text, value} objects, received string. …` |
| `options: [ok, ok, {bad}]` | silently showed 2 of 3 buttons | `Step 1, option 3: "text" and "value" are required strings.` |
| `interactions: [ok, {no title}]` | step silently dropped | `Step 2: "title" and "message" are required strings.` |
| `options: []` / omitted | informational | unchanged |
| `links: [ok, {bad}]` | bad link dropped | unchanged |

Errors name the field, the step/option position, and the received type so the agent can correct the call rather than retry the same shape. The tool description and parameter schema now also state that nested values must be real JSON structures, and that a step without options is never a confirmation.

`UserInteractionToolRenderer` already had a `MalformedInteraction` state that prefers the error text from the tool result, so these messages surface in the UI with no renderer changes beyond adapting to the new return type.

##### API change

`parseUserInteractionArgs` now returns a `UserInteractionValidation` union (`{ok: true, args} | {ok: false, error}`) instead of `UserInteractionArgs | undefined`. It carries no stability tag, so it is experimental API per [doc/api-management.md](https://github.com/eclipse-theia/theia/blob/master/doc/api-management.md). Both in-tree callers are updated; no other package imports it.

#### How to test

1. `npx lerna run compile --scope @theia/ai-ide && npx lerna run test --scope @theia/ai-ide` — 455 passing.
2. In a chat with an agent that has `userInteraction` enabled, have it call the tool with `options` as a JSON-encoded string, e.g. `{"interactions": [{"title": "Apply fix?", "message": "Confirm?", "options": "[{\"text\":\"Yes\",\"value\":\"yes\"}]"}]}`.
   - Before: the step renders as informational and completes immediately; the agent proceeds as if confirmed.
   - After: the chat shows the malformed-interaction state with the specific error, and the agent gets a message telling it what to fix.
3. Verify well-formed interactions are unaffected: a multi-step PR-review walkthrough with per-step Confirm/Reject buttons still behaves as before, as do informational steps and steps with file/diff links.

#### Follow-ups

- The validation error text is agent-facing (it describes JSON argument shape so the model can self-correct) and is intentionally not run through `nls`. This matches the strings it replaces (`No interactions provided`, `Invalid arguments`), which were surfaced the same way. If the malformed state should be fully localized, that is a separate change covering the whole error path.
- A single informational step still returns `completed: true`. That is correct for its documented purpose, but an agent could in principle still misread it as approval. Marking such results explicitly (e.g. `informational: true`) would close that off; it changes the documented result shape, so it is left out here.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Review checklist

<!-- nls box left unchecked deliberately: see the first Follow-up. The new validation strings are agent-facing and not localized, matching the strings they replace. -->

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [ ] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
