### PR TITLE
feat(ai-chat): support resuming delegation sessions via sessionId

### DIFF
--- a/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.spec.ts
@@ -47,6 +47,7 @@ function makeAgentDelegationTool(chatAgentService: ChatAgentService, chatService
     const tool = new AgentDelegationTool();
     Object.defineProperty(tool, 'getChatAgentService', { value: () => chatAgentService });
     Object.defineProperty(tool, 'getChatService', { value: () => chatService });
+    Object.defineProperty(tool, 'logger', { value: { error: sinon.stub(), warn: sinon.stub(), info: sinon.stub(), debug: sinon.stub() } });
     return tool;
 }
 
@@ -116,6 +117,36 @@ function makeChatContext(): {
         toolCallId: undefined,
         request: { session: makeParentSession() },
         response: {}
+    };
+}
+
+function makeExistingSession(contextManager = makeContextManager()): {
+    id: string;
+    pinnedAgent: { id: string; name: string };
+    rootSessionId: string;
+    parentSessionId: string;
+    model: {
+        status: string;
+        context: ReturnType<typeof makeContextManager>;
+        changeSet: ReturnType<typeof makeChangeSet>;
+        onDidChange: sinon.SinonStub;
+        rootSessionId: string;
+        parentSessionId: string;
+    };
+} {
+    return {
+        id: 'existing-session-id',
+        pinnedAgent: { id: 'test-agent', name: 'Test Agent' },
+        rootSessionId: 'original-root-id',
+        parentSessionId: 'original-parent-id',
+        model: {
+            status: 'idle',
+            context: contextManager,
+            changeSet: makeChangeSet(),
+            onDidChange: sinon.stub().returns({ dispose: sinon.stub() }),
+            rootSessionId: 'original-root-id',
+            parentSessionId: 'original-parent-id'
+        }
     };
 }
 
@@ -213,7 +244,7 @@ describe('AgentDelegationTool', () => {
             const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
             const result = await tool.getTool().handler(argString, ctx);
 
-            expect(result).to.equal('final answer');
+            expect(result).to.equal('final answer\n\n[delegation sessionId: new-session-id]');
             expect(result).to.not.include('thinking');
         });
 
@@ -230,10 +261,10 @@ describe('AgentDelegationTool', () => {
             const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
             const result = await tool.getTool().handler(argString, ctx);
 
-            expect(result).to.equal('final answer');
+            expect(result).to.equal('final answer\n\n[delegation sessionId: new-session-id]');
         });
 
-        it('returns empty string when all content is thinking', async () => {
+        it('returns only the session id marker when all content is thinking', async () => {
             const thinkingContent = new ThinkingChatResponseContentImpl('internal', 'sig');
 
             const newSession = makeNewSession();
@@ -245,7 +276,116 @@ describe('AgentDelegationTool', () => {
             const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
             const result = await tool.getTool().handler(argString, ctx);
 
-            expect(result).to.equal('');
+            expect(result).to.equal('[delegation sessionId: new-session-id]');
+        });
+    });
+
+    describe('delegateToAgent() — delegation session id in result', () => {
+        it('appends the delegation session id to the tool result', async () => {
+            const newSession = makeNewSession();
+            const agentService = makeChatAgentService();
+            const chatService = makeChatService(newSession);
+            const tool = makeAgentDelegationTool(agentService, chatService);
+            const ctx = makeChatContext();
+
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'do something' });
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect(result).to.equal('agent response\n\n[delegation sessionId: new-session-id]');
+        });
+    });
+
+    describe('delegateToAgent() — sessionId parameter (resume)', () => {
+        let contextManager: ReturnType<typeof makeContextManager>;
+        let existingSession: ReturnType<typeof makeExistingSession>;
+        let chatService: ChatService;
+        let tool: AgentDelegationTool;
+        let ctx: ReturnType<typeof makeChatContext>;
+
+        beforeEach(() => {
+            contextManager = makeContextManager();
+            existingSession = makeExistingSession(contextManager);
+            const newSession = makeNewSession();
+            const agentService = makeChatAgentService();
+            chatService = makeChatService(newSession);
+            (chatService.getSession as sinon.SinonStub).withArgs('existing-session-id').returns(existingSession);
+            tool = makeAgentDelegationTool(agentService, chatService);
+            ctx = makeChatContext();
+        });
+
+        it('sends the follow-up request into the existing session instead of creating a new one', async () => {
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'fix the findings', sessionId: 'existing-session-id' });
+
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect((chatService.createSession as sinon.SinonStub).called).to.be.false;
+            const sendRequest = chatService.sendRequest as sinon.SinonStub;
+            expect(sendRequest.calledOnce).to.be.true;
+            expect(sendRequest.firstCall.args[0]).to.equal('existing-session-id');
+            expect(result).to.equal('agent response\n\n[delegation sessionId: existing-session-id]');
+        });
+
+        it('re-establishes event bubbling from the resumed session to the parent', async () => {
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'fix the findings', sessionId: 'existing-session-id' });
+
+            await tool.getTool().handler(argString, ctx);
+
+            expect(existingSession.model.onDidChange.calledOnce).to.be.true;
+            expect(existingSession.model.changeSet.onDidChange.calledOnce).to.be.true;
+        });
+
+        it('does not modify rootSessionId or parentSessionId of the resumed session', async () => {
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'fix the findings', sessionId: 'existing-session-id' });
+
+            await tool.getTool().handler(argString, ctx);
+
+            expect(existingSession.rootSessionId).to.equal('original-root-id');
+            expect(existingSession.parentSessionId).to.equal('original-parent-id');
+            expect(existingSession.model.rootSessionId).to.equal('original-root-id');
+            expect(existingSession.model.parentSessionId).to.equal('original-parent-id');
+        });
+
+        it('adds the task context variable to the resumed session when taskContextId is provided', async () => {
+            const argString = JSON.stringify({
+                agentId: 'test-agent', prompt: 'fix the findings', sessionId: 'existing-session-id', taskContextId: 'follow-up-ctx-id'
+            });
+
+            await tool.getTool().handler(argString, ctx);
+
+            expect(contextManager.addVariables.calledOnce).to.be.true;
+            const callArg: AIVariableResolutionRequest = contextManager.addVariables.firstCall.args[0];
+            expect(callArg.variable).to.equal(TASK_CONTEXT_VARIABLE);
+            expect(callArg.arg).to.equal('follow-up-ctx-id');
+        });
+
+        it('returns an error when the sessionId is unknown', async () => {
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'fix the findings', sessionId: 'unknown-session-id' });
+
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect(result).to.include('not found');
+            expect((chatService.sendRequest as sinon.SinonStub).called).to.be.false;
+            expect((chatService.createSession as sinon.SinonStub).called).to.be.false;
+        });
+
+        it('returns an error when the resumed session is still processing a request', async () => {
+            existingSession.model.status = 'running';
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'fix the findings', sessionId: 'existing-session-id' });
+
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect(result).to.include('still processing');
+            expect((chatService.sendRequest as sinon.SinonStub).called).to.be.false;
+        });
+
+        it('returns an error when agentId does not match the pinned agent of the session', async () => {
+            existingSession.pinnedAgent = { id: 'other-agent', name: 'Other Agent' };
+            const argString = JSON.stringify({ agentId: 'test-agent', prompt: 'fix the findings', sessionId: 'existing-session-id' });
+
+            const result = await tool.getTool().handler(argString, ctx);
+
+            expect(result).to.include("belongs to agent 'other-agent'");
+            expect((chatService.sendRequest as sinon.SinonStub).called).to.be.false;
         });
     });
 

--- a/packages/ai-chat/src/browser/agent-delegation-tool.ts
+++ b/packages/ai-chat/src/browser/agent-delegation-tool.ts
@@ -26,6 +26,8 @@ import {
     ChatResponseContent,
     ChatService,
     ChatServiceFactory,
+    ChatSession,
+    ChatSessionStatus,
     ChatToolContext,
     MutableChatModel,
     MutableChatRequestModel,
@@ -60,6 +62,9 @@ export class AgentDelegationTool implements ToolProvider {
                 'remember that each sub-agent operates solely within its specialized capabilities and tools and does not have access to previous conversation context ' +
                 ' or external systems. Therefore, it is crucial to provide all necessary context and detailed information directly within your request to ensure accurate ' +
                 'and effective task completion. ' +
+                'Each result ends with a "[delegation sessionId: <id>]" line. To send a follow-up request to the same agent with its previous conversation retained ' +
+                '(e.g. to request fixes after reviewing its result), pass that id as sessionId. Prefer resuming for follow-ups on the same task; ' +
+                'start a fresh session (omit sessionId) for unrelated tasks, as a resumed session grows with every round. ' +
                 'You may optionally pass a taskContextId to make a specific task context (e.g. a plan) available to the delegated agent via its system prompt.',
             parameters: {
                 type: 'object',
@@ -77,6 +82,11 @@ export class AgentDelegationTool implements ToolProvider {
                     taskContextId: {
                         type: 'string',
                         description: 'Optional task context ID to make available to the delegated agent. The agent will see the task context in its system prompt.',
+                    },
+                    sessionId: {
+                        type: 'string',
+                        description: 'Optional ID of a previous delegation session to continue, as reported in the "[delegation sessionId: <id>]" line of an earlier result. ' +
+                            'The delegated agent keeps its previous conversation context. The agentId must match the original delegation.',
                     },
                 },
                 required: ['agentId', 'prompt'],
@@ -102,7 +112,7 @@ export class AgentDelegationTool implements ToolProvider {
 
         try {
             const args = JSON.parse(arg_string);
-            const { agentId, prompt, taskContextId } = args;
+            const { agentId, prompt, taskContextId, sessionId } = args;
 
             if (!agentId || !prompt) {
                 const errorMsg = 'Both agentId and prompt parameters are required.';
@@ -121,50 +131,88 @@ export class AgentDelegationTool implements ToolProvider {
                 return errorMsg;
             }
 
-            let newSession;
+            let session: ChatSession;
             let childModelDisposable: Disposable | undefined;
-            try {
+            if (sessionId) {
                 const chatService = this.getChatService();
+                const existingSession = chatService.getSession(sessionId);
+                if (!existingSession) {
+                    const errorMsg = `Delegation session '${sessionId}' not found. It may have been deleted. ` +
+                        'Send the request again without sessionId to start a fresh session — the agent will not have any prior context.';
+                    this.logger.error(errorMsg);
+                    return errorMsg;
+                }
+                if (ChatSessionStatus.isInProgress(existingSession.model.status)) {
+                    const errorMsg = `Delegation session '${sessionId}' is still processing a previous request. ` +
+                        'Wait for its result before sending a follow-up, or omit sessionId to start a fresh session.';
+                    this.logger.error(errorMsg);
+                    return errorMsg;
+                }
+                if (existingSession.pinnedAgent && existingSession.pinnedAgent.id !== agentId) {
+                    const errorMsg = `Delegation session '${sessionId}' belongs to agent '${existingSession.pinnedAgent.id}', not '${agentId}'. ` +
+                        'Pass the matching agentId, or omit sessionId to start a fresh session.';
+                    this.logger.error(errorMsg);
+                    return errorMsg;
+                }
 
-                // Store the current active session to restore it after delegation
-                const currentActiveSession = chatService.getActiveSession();
-
-                newSession = chatService.createSession(
-                    undefined,
-                    { focus: false },
-                    agent
-                );
-
-                // Set root session ID to enable task context sharing across delegation chains
-                // Root is either the current root (for nested delegation) or current session (for first-level delegation)
-                const rootId = ctx.rootSessionId || ctx.request.session.id;
-                newSession.rootSessionId = rootId;
-                newSession.model.rootSessionId = rootId;
-
-                // Track the immediate parent (the delegating session) so the UI can render the full
-                // delegation hierarchy, not just a flat list under the root.
-                const parentId = ctx.request.session.id;
-                newSession.parentSessionId = parentId;
-                newSession.model.parentSessionId = parentId;
-
+                // Deliberately keep rootSessionId/parentSessionId as set at creation time; a resumed
+                // session stays attached to its original delegation hierarchy.
                 if (taskContextId) {
-                    newSession.model.context.addVariables({
+                    existingSession.model.context.addVariables({
                         variable: TASK_CONTEXT_VARIABLE,
                         arg: taskContextId
                     });
                 }
 
-                // Immediately restore the original active session to avoid confusing the user
-                if (currentActiveSession) {
-                    chatService.setActiveSession(currentActiveSession.id, { focus: false });
-                }
+                session = existingSession;
+                // Re-establish bubbling for this request; the previous disposable was disposed when the
+                // original delegation completed, and the parent request/response are new objects now.
+                childModelDisposable = this.setupChildSessionBubbling(existingSession.model as MutableChatModel, ctx.request.session, ctx.response);
+            } else {
+                try {
+                    const chatService = this.getChatService();
 
-                // Setup bubbling of child session events to parent session
-                childModelDisposable = this.setupChildSessionBubbling(newSession.model as MutableChatModel, ctx.request.session, ctx.response);
-            } catch (sessionError) {
-                const errorMsg = `Failed to create chat session for agent '${agentId}': ${sessionError instanceof Error ? sessionError.message : sessionError}`;
-                this.logger.error(errorMsg, sessionError);
-                return errorMsg;
+                    // Store the current active session to restore it after delegation
+                    const currentActiveSession = chatService.getActiveSession();
+
+                    const newSession = chatService.createSession(
+                        undefined,
+                        { focus: false },
+                        agent
+                    );
+
+                    // Set root session ID to enable task context sharing across delegation chains
+                    // Root is either the current root (for nested delegation) or current session (for first-level delegation)
+                    const rootId = ctx.rootSessionId || ctx.request.session.id;
+                    newSession.rootSessionId = rootId;
+                    newSession.model.rootSessionId = rootId;
+
+                    // Track the immediate parent (the delegating session) so the UI can render the full
+                    // delegation hierarchy, not just a flat list under the root.
+                    const parentId = ctx.request.session.id;
+                    newSession.parentSessionId = parentId;
+                    newSession.model.parentSessionId = parentId;
+
+                    if (taskContextId) {
+                        newSession.model.context.addVariables({
+                            variable: TASK_CONTEXT_VARIABLE,
+                            arg: taskContextId
+                        });
+                    }
+
+                    // Immediately restore the original active session to avoid confusing the user
+                    if (currentActiveSession) {
+                        chatService.setActiveSession(currentActiveSession.id, { focus: false });
+                    }
+
+                    // Setup bubbling of child session events to parent session
+                    childModelDisposable = this.setupChildSessionBubbling(newSession.model as MutableChatModel, ctx.request.session, ctx.response);
+                    session = newSession;
+                } catch (sessionError) {
+                    const errorMsg = `Failed to create chat session for agent '${agentId}': ${sessionError instanceof Error ? sessionError.message : sessionError}`;
+                    this.logger.error(errorMsg, sessionError);
+                    return errorMsg;
+                }
             }
 
             // Send the request
@@ -180,7 +228,7 @@ export class AgentDelegationTool implements ToolProvider {
 
                 const chatService = this.getChatService();
                 response = await chatService.sendRequest(
-                    newSession.id,
+                    session.id,
                     chatRequest
                 );
 
@@ -210,7 +258,7 @@ export class AgentDelegationTool implements ToolProvider {
                     const chatService = this.getChatService();
                     const toolCallId = ctx.toolCallId;
                     const sessionEventListener = chatService.onSessionEvent(event => {
-                        if (event.type === 'deleted' && event.sessionId === newSession.id) {
+                        if (event.type === 'deleted' && event.sessionId === session.id) {
                             this.pendingDelegations.delete(toolCallId);
                             sessionEventListener.dispose();
                         }
@@ -229,8 +277,10 @@ export class AgentDelegationTool implements ToolProvider {
                     // Clean up the parent-child link after completion (event bubbling is no longer needed)
                     childModelDisposable?.dispose();
 
-                    // Return the raw text to the top-level Agent, as a tool result
-                    return stringResult;
+                    // Return the raw text to the top-level Agent, as a tool result. The session id
+                    // allows the caller to send follow-up requests into the same session.
+                    const sessionIdSuffix = `[delegation sessionId: ${session.id}]`;
+                    return stringResult ? `${stringResult}\n\n${sessionIdSuffix}` : sessionIdSuffix;
                 } catch (completionError) {
                     if (
                         completionError instanceof Error &&


### PR DESCRIPTION
#### What it does

Every `delegateToAgent` call currently creates a fresh chat session, so a follow-up request to the same worker (e.g. asking it to fix findings after reviewing its result) re-pays the full context setup — the delegated agent re-reads files and re-derives context it already had.

This PR lets the orchestrating agent continue an existing delegation session:

- Each delegation result now ends with a `[delegation sessionId: <id>]` line.
- The tool accepts an optional `sessionId`; when provided, the follow-up request is sent into the existing session, so the delegated agent keeps its previous conversation context.
- The resume path validates the session and returns actionable errors instead of silently falling back to a fresh session: a session the calling session did not delegate itself, an unknown/deleted session id, a request still in progress, or an `agentId` that does not match the session's pinned agent. Sessions that are no longer in memory are restored from storage, so a resume still works after a reload.
- Parent/child event bubbling is re-established for each follow-up and released on every outcome; `rootSessionId`/`parentSessionId` stay as set at creation; a `taskContextId` passed on resume replaces a previously set one.

Note: the tool result string now carries the trailing session id marker in all cases; adopters post-processing the raw delegation result string may need to account for it.

#### How to test

- `npx lerna run test --scope @theia/ai-chat` — new specs in `agent-delegation-tool.spec.ts` cover the marker, the resume path (session reuse, restore from storage, event bubbling and its disposal, id preservation, task context replacement) and each error case.
- Manually: in a chat with an agent that delegates (e.g. via the orchestrator), observe that a delegation result ends with the `[delegation sessionId: <id>]` line. Then instruct the agent to send a follow-up to the same delegate passing that sessionId and verify in the delegated session's UI that the new request landed in the same session with prior context, and that the delegate answers with awareness of the earlier exchange.

#### Follow-ups

- Orchestrator prompt templates could explicitly encourage the resume flow for verify→fix loops; currently the behavior is discoverable through the tool description only.

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

Contributed on behalf of K2view

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)

