### PR TITLE
perf(ai-chat-ui): skip doomed JSON.parse on streaming tool arguments

### DIFF
--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.spec.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-part-renderer.spec.ts
@@ -40,6 +40,22 @@ describe('condenseArguments', () => {
         expect(condenseArguments('{invalid}')).to.equal('{invalid}');
     });
 
+    it('returns the raw string without attempting JSON.parse while an arguments object is still streaming', () => {
+        const originalParse = JSON.parse;
+        let parseCalls = 0;
+        JSON.parse = ((text: string, reviver?: Parameters<typeof originalParse>[1]) => {
+            parseCalls++;
+            return originalParse(text, reviver);
+        }) as typeof JSON.parse;
+        try {
+            const streaming = '{"path": "src/index.ts", "content": "partial';
+            expect(condenseArguments(streaming)).to.equal(streaming);
+            expect(parseCalls).to.equal(0);
+        } finally {
+            JSON.parse = originalParse;
+        }
+    });
+
     it('condenses single string parameter as value only', () => {
         const result = condenseArguments('{"query": "search term"}');
         expect(result).to.equal('search term');

--- a/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-utils.ts
+++ b/packages/ai-chat-ui/src/browser/chat-response-renderer/toolcall-utils.ts
@@ -15,6 +15,7 @@
 // *****************************************************************************
 
 import { MarkdownStringImpl } from '@theia/core/lib/common/markdown-rendering/markdown-string';
+import { mayBeCompleteJson } from '../../common/toolcall-utils';
 
 export { extractJsonStringField } from '../../common/toolcall-utils';
 
@@ -167,6 +168,10 @@ export function formatArgsForTooltip(args: string): MarkdownStringImpl {
 export function condenseArguments(args: string): string | undefined {
     if (!args || !args.trim() || args.trim() === '{}') {
         return undefined;
+    }
+    if (!mayBeCompleteJson(args)) {
+        // still streaming: parsing could only fail, so show the raw text right away
+        return truncateString(args, MAX_CONDENSED_LENGTH);
     }
     let parsed: unknown;
     try {

--- a/packages/ai-chat-ui/src/common/toolcall-utils.spec.ts
+++ b/packages/ai-chat-ui/src/common/toolcall-utils.spec.ts
@@ -115,4 +115,21 @@ describe('extractJsonStringField', () => {
             expect(result).to.equal('echo \\');
         });
     });
+
+    describe('parse/regex boundary', () => {
+        it('should unescape via JSON.parse when complete JSON has trailing whitespace', () => {
+            const result = extractJsonStringField('{"cmd": "echo \\"hello\\""}\n', 'cmd');
+            expect(result).to.equal('echo "hello"');
+        });
+
+        it('should extract via regex when JSON ends with a brace but is still incomplete', () => {
+            const result = extractJsonStringField('{"path": "src/index.ts", "meta": {"x": "y"}', 'path');
+            expect(result).to.equal('src/index.ts');
+        });
+
+        it('should return undefined for a complete array without the field', () => {
+            const result = extractJsonStringField('[{"path": "src/index.ts"}]', 'other');
+            expect(result).to.be.undefined;
+        });
+    });
 });

--- a/packages/ai-chat-ui/src/common/toolcall-utils.ts
+++ b/packages/ai-chat-ui/src/common/toolcall-utils.ts
@@ -16,21 +16,29 @@
 
 /**
  * Extracts a string field value from potentially incomplete JSON.
- * Tries JSON.parse first, then falls back to regex extraction for streaming scenarios.
+ * Uses JSON.parse for complete JSON, and regex extraction for streaming scenarios.
  */
 export function extractJsonStringField(json: string | undefined, fieldName: string): string | undefined {
     if (!json) {
         return undefined;
     }
-    try {
-        const parsed = JSON.parse(json);
-        if (parsed && typeof parsed === 'object' && fieldName in parsed && typeof parsed[fieldName] === 'string') {
-            return parsed[fieldName];
+    // This is called repeatedly while tool call arguments stream in, where the JSON is truncated:
+    // JSON.parse would scan the whole string only to throw, which gets quadratic as the arguments
+    // grow (noticeable with large payloads such as whole-file writes). An arguments object is only
+    // complete once it ends with '}', so attempt the exact parse just then and use the regex otherwise.
+    const trimmed = json.trim();
+    if (!trimmed.startsWith('{') || trimmed.endsWith('}')) {
+        try {
+            const parsed = JSON.parse(json);
+            if (parsed && typeof parsed === 'object' && fieldName in parsed && typeof parsed[fieldName] === 'string') {
+                return parsed[fieldName];
+            }
+            return undefined;
+        } catch {
+            // fall through to the regex extraction
         }
-    } catch {
-        const regex = new RegExp('"' + fieldName + '"\\s*:\\s*"([^"]*)"?');
-        const match = regex.exec(json);
-        return match?.[1];
     }
-    return undefined;
+    const regex = new RegExp('"' + fieldName + '"\\s*:\\s*"([^"]*)"?');
+    const match = regex.exec(json);
+    return match?.[1];
 }

--- a/packages/ai-chat-ui/src/common/toolcall-utils.ts
+++ b/packages/ai-chat-ui/src/common/toolcall-utils.ts
@@ -15,6 +15,20 @@
 // *****************************************************************************
 
 /**
+ * Tells whether `json` may already be complete, i.e. whether handing it to `JSON.parse` can succeed at all.
+ *
+ * Tool call arguments are rendered repeatedly while they stream in, and the arguments object is truncated
+ * until the last delta arrives: `JSON.parse` would scan the whole string only to throw, which gets quadratic
+ * as the arguments grow (noticeable with large payloads such as whole-file writes). An arguments object can
+ * only be complete once it ends with `}`, so callers skip the parse until then. Text that does not start
+ * with `{` is not a streaming arguments object and is always considered worth parsing.
+ */
+export function mayBeCompleteJson(json: string): boolean {
+    const trimmed = json.trim();
+    return !trimmed.startsWith('{') || trimmed.endsWith('}');
+}
+
+/**
  * Extracts a string field value from potentially incomplete JSON.
  * Uses JSON.parse for complete JSON, and regex extraction for streaming scenarios.
  */
@@ -22,12 +36,7 @@ export function extractJsonStringField(json: string | undefined, fieldName: stri
     if (!json) {
         return undefined;
     }
-    // This is called repeatedly while tool call arguments stream in, where the JSON is truncated:
-    // JSON.parse would scan the whole string only to throw, which gets quadratic as the arguments
-    // grow (noticeable with large payloads such as whole-file writes). An arguments object is only
-    // complete once it ends with '}', so attempt the exact parse just then and use the regex otherwise.
-    const trimmed = json.trim();
-    if (!trimmed.startsWith('{') || trimmed.endsWith('}')) {
+    if (mayBeCompleteJson(json)) {
         try {
             const parsed = JSON.parse(json);
             if (parsed && typeof parsed === 'object' && fieldName in parsed && typeof parsed[fieldName] === 'string') {


### PR DESCRIPTION
#### What it does

Refs #17974

`extractJsonStringField` tried `JSON.parse` first and used its regex fallback only when the parse threw. While tool call arguments stream in, the JSON is truncated, so the parse *always* throws — after scanning the entire string. Called per render from the tool-call label, this gets quadratic as the arguments grow (measured ~27 s of CPU for 2 MB of arguments at 64-char deltas).

Now the full parse is only attempted once the arguments object can actually be complete (trimmed string ends with `}`); otherwise the regex extraction runs directly. Complete JSON still goes through `JSON.parse`, so proper unescaping (e.g. `\"`, Windows paths with `\\`) is preserved — pinned by the existing tests. Inputs that never start with `{` behave exactly as before.

#### How to test

1. `cd packages/ai-chat-ui && npx mocha --config ../../configs/mocharc.yml "./lib/**/*.spec.js"` — 278 passing, including 3 new boundary tests.
2. In agent mode, have an agent call `writeFileContent` with a large `content` argument and profile the frontend while the arguments stream: `JSON.parse` under `extractJsonStringField` no longer shows up.

#### Follow-ups

The regex still matches the first `"<field>": "..."` occurrence anywhere in the string, so a `content` value that itself contains e.g. a `"path"` property can show a wrong label mid-stream (cosmetic, pre-existing; noted in #17974).

#### Breaking changes

- [ ] This PR introduces breaking changes and requires careful review. If yes, the breaking changes section in the [changelog](https://github.com/eclipse-theia/theia/blob/master/CHANGELOG.md) has been updated.

#### Attribution

#### Review checklist

- [x] As an author, I have thoroughly tested my changes and carefully followed [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#requesting-a-review)
- [x] User-facing text is internationalized using the `nls` service (for details, please see the [Internationalization/Localization section](https://github.com/theia-ide/theia/blob/master/doc/coding-guidelines.md#internationalizationlocalization) in the Coding Guidelines)

#### Reminder for reviewers

- As a reviewer, I agree to behave in accordance with [the review guidelines](https://github.com/theia-ide/theia/blob/master/doc/pull-requests.md#reviewing)
